### PR TITLE
(gui) fix issue with initial size of modals in ubuntu

### DIFF
--- a/eclair-node/src/main/resources/gui/main/main.fxml
+++ b/eclair-node/src/main/resources/gui/main/main.fxml
@@ -85,14 +85,14 @@
                         <Label fx:id="labelAlias" text="N/A"/>
                     </children>
                 </HBox>
-                <HBox alignment="CENTER_LEFT" HBox.hgrow="NEVER" minWidth="75.0">
+                <HBox alignment="CENTER_LEFT" HBox.hgrow="NEVER" minWidth="85.0">
                     <children>
                         <Separator orientation="VERTICAL"/>
                         <Label text="HTTP" styleClass="badge, badge-http"/>
                         <Label fx:id="labelApi" styleClass="value" text="N/A"/>
                     </children>
                 </HBox>
-                <HBox alignment="CENTER_LEFT" HBox.hgrow="NEVER" minWidth="75.0">
+                <HBox alignment="CENTER_LEFT" HBox.hgrow="NEVER" minWidth="85.0">
                     <children>
                         <Separator orientation="VERTICAL"/>
                         <Label text="TCP" styleClass="badge, badge-tcp"/>

--- a/eclair-node/src/main/resources/gui/modals/openChannel.fxml
+++ b/eclair-node/src/main/resources/gui/modals/openChannel.fxml
@@ -13,7 +13,7 @@
 <?import javafx.scene.layout.VBox?>
 
 <?import javafx.scene.control.Separator?>
-<GridPane styleClass="grid" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane styleClass="grid" prefWidth="550.0" prefHeight="350.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="180.0" minWidth="10.0" prefWidth="180.0" halignment="RIGHT" />
         <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="180.0" />

--- a/eclair-node/src/main/resources/gui/modals/receivePayment.fxml
+++ b/eclair-node/src/main/resources/gui/modals/receivePayment.fxml
@@ -6,7 +6,7 @@
 <?import java.net.URL?>
 <?import javafx.collections.FXCollections?>
 <?import java.lang.String?>
-<GridPane styleClass="grid" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane styleClass="grid" prefWidth="550.0" prefHeight="300.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>
         <ColumnConstraints halignment="RIGHT" hgrow="SOMETIMES" maxWidth="210.0" minWidth="10.0" prefWidth="200.0"/>
         <ColumnConstraints hgrow="ALWAYS" minWidth="10.0" prefWidth="120.0"/>

--- a/eclair-node/src/main/resources/gui/modals/sendPayment.fxml
+++ b/eclair-node/src/main/resources/gui/modals/sendPayment.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.layout.*?>
 <?import java.lang.String?>
 <?import java.net.URL?>
-<GridPane fx:id="nodeId" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<GridPane fx:id="nodeId" prefWidth="450.0" prefHeight="450.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>
         <ColumnConstraints halignment="LEFT" hgrow="SOMETIMES" minWidth="10.0" prefWidth="110.0"/>
         <ColumnConstraints halignment="LEFT" hgrow="ALWAYS" minWidth="10.0" prefWidth="250.0"/>


### PR DESCRIPTION
* Modals width/height must be set in FXML to prevent initial display issues in ubuntu