### PR TITLE
Use chain getblockchaininfo.chain to infer the magic value

### DIFF
--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -9,7 +9,6 @@ eclair {
     port = 8080
   }
   bitcoind {
-    network = "regtest"
     host = "localhost"
     port = 18333
     rpcport = 18332

--- a/eclair-node/src/main/scala/fr/acinq/eclair/blockchain/peer/PeerClient.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/blockchain/peer/PeerClient.scala
@@ -10,11 +10,11 @@ import fr.acinq.bitcoin._
 import scala.compat.Platform
 import scala.concurrent.duration._
 
-class PeerClient(socket: InetSocketAddress, magic: Long) extends Actor with ActorLogging {
+class PeerClient(socketAddress: InetSocketAddress, magic: Long) extends Actor with ActorLogging {
 
   val supervisor = BackoffSupervisor.props(
     Backoff.onStop(
-      Props(classOf[PeerHandler], socket, self),
+      Props(classOf[PeerHandler], socketAddress, self),
       childName = "peer-conn",
       minBackoff = 1 seconds,
       maxBackoff = 10 seconds,
@@ -68,7 +68,7 @@ class PeerClient(socket: InetSocketAddress, magic: Long) extends Actor with Acto
 }
 
 object PeerClient {
-  def props(socket: InetSocketAddress, magic: Long) = Props(new PeerClient(socket, magic))
+  def props(socketAddress: InetSocketAddress, magic: Long) = Props(new PeerClient(socketAddress, magic))
 }
 
 object PeerClientTest extends App {


### PR DESCRIPTION
Bug in #43 was caused by PeerClient not recognizing `testnet` conf parameter and failing to initialize, thus entering in an infinite loop caused by the supervisor's restart strategy.
