### PR TITLE
Validity of remote final script is not checked when a Shutdown was already sent

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -571,8 +571,8 @@ class Channel(val nodeParams: NodeParams, remoteNodeId: PublicKey, blockchain: A
       handleLocalError(new RuntimeException("it is illegal to send a shutdown while having unsigned changes"), d)
 
     case Event(remoteShutdown@Shutdown(_, remoteScriptPubKey), d@DATA_NORMAL(commitments, _)) =>
+      require(Closing.isValidFinalScriptPubkey(remoteScriptPubKey), "invalid final script")
       Try(d.commitments.unackedShutdown().map(s => (s, commitments)).getOrElse {
-        require(Closing.isValidFinalScriptPubkey(remoteScriptPubKey), "invalid final script")
         // first if we have pending changes, we need to commit them
         val commitments2 = if (Commitments.localHasChanges(commitments)) {
           val (commitments1, commit) = Commitments.sendCommit(d.commitments)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -90,8 +90,8 @@ object Transactions {
   }
 
   def commitTxFee(dustLimit: Satoshi, spec: CommitmentSpec): Satoshi = {
-    val trimmedOfferedHtlcs = trimOfferedHtlcs(dustLimit, spec).map(htlc => MilliSatoshi(htlc.add.amountMsat))
-    val trimmedReceivedHtlcs = trimReceivedHtlcs(dustLimit, spec).map(htlc => MilliSatoshi(htlc.add.amountMsat))
+    val trimmedOfferedHtlcs = trimOfferedHtlcs(dustLimit, spec)
+    val trimmedReceivedHtlcs = trimReceivedHtlcs(dustLimit, spec)
     val weight = commitWeight + 172 * (trimmedOfferedHtlcs.size + trimmedReceivedHtlcs.size)
     weight2fee(spec.feeratePerKw, weight)
   }


### PR DESCRIPTION
`remoteScriptPubKey` validity is only checked if we don't have a previously sent `Shutdown`, should not it be moved one line up?