### PR TITLE
Client must die when transport dies

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/io/Client.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/io/Client.scala
@@ -50,11 +50,13 @@ class Client(nodeParams: NodeParams, switchboard: ActorRef, address: InetSocketA
       log.info(s"handshake completed with ${h.remoteNodeId}")
       origin ! "connected"
       switchboard ! h
-      context unwatch transport
       context become connected(transport)
   }
 
   def connected(transport: ActorRef): Receive = {
+    case Terminated(actor) if actor == transport =>
+      context stop self
+
     case msg => log.warning(s"unexpected message $msg")
   }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -75,10 +75,15 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, address_opt: Option[
 
     case Event(Rebroadcast(_), _) => stay // ignored
 
+    case Event("connected", _) => stay // ignored
+
+    case Event(StateTimeout, d: DisconnectedData) if d.offlineChannels.size == 0 => stay // ignored
+
     case Event(StateTimeout, _) =>
       log.info(s"attempting a reconnect")
       self ! Reconnect
       stay
+
   }
 
   when(INITIALIZING) {


### PR DESCRIPTION
This fixes a regression introduced in 75e4923002bdca8b04c2703cf6682a4b5da3ddf8 (#45).

Note:
- Supervisor strategy of `Client` should probably be `Escalate` instead of `Stop`
- client/server handling should be factored in one place