### PR TITLE
Fixed type cast issue with `peers` rpc service

### DIFF
--- a/eclair-node/src/main/resources/gui/main/main.fxml
+++ b/eclair-node/src/main/resources/gui/main/main.fxml
@@ -57,7 +57,7 @@
                                         <TableView fx:id="networkChannelsTable" minHeight="50.0" prefHeight="5000.0">
                                             <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY"/></columnResizePolicy>
                                             <columns>
-                                                <TableColumn fx:id="networkChannelsIdColumn" minWidth="120.0" prefWidth="170.0" maxWidth="300.0" text="Channel Id"/>
+                                                <TableColumn fx:id="networkChannelsIdColumn" minWidth="120.0" prefWidth="170.0" maxWidth="300.0" text="Short Channel Id"/>
                                                 <TableColumn fx:id="networkChannelsNode1Column" text="Node 1"/>
                                                 <TableColumn fx:id="networkChannelsNode2Column" text="Node 2"/>
                                             </columns>

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -67,10 +67,10 @@ trait Service extends Logging {
     `Cache-Control`(public, `no-store`, `max-age`(0)) ::
     `Access-Control-Allow-Headers`("x-requested-with") :: Nil
 
-  def getChannel(channelIdHex: String): Future[ActorRef] =
+  def getChannel(channelId: String): Future[ActorRef] =
     for {
       channels <- (register ? 'channels).mapTo[Map[BinaryData, ActorRef]]
-    } yield channels.get(BinaryData(channelIdHex)).getOrElse(throw new RuntimeException("unknown channel"))
+    } yield channels.get(BinaryData(channelId)).getOrElse(throw new RuntimeException("unknown channel"))
 
   val route =
     respondWithDefaultHeaders(customHeaders) {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/gui/controllers/MainController.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/gui/controllers/MainController.scala
@@ -335,7 +335,7 @@ class MainController(val handlers: Handlers, val setup: Setup, val hostServices:
     val copyChannelId = new MenuItem("Copy Channel Id")
     copyChannelId.setOnAction(new EventHandler[ActionEvent] {
       override def handle(event: ActionEvent) = Option(row.getItem) match {
-        case Some(pc) => ContextMenuUtils.copyToClipboard(pc.shortChannelId.toString)
+        case Some(pc) => ContextMenuUtils.copyToClipboard(pc.shortChannelId.toHexString)
         case None =>
       }
     })


### PR DESCRIPTION
* also renamed `channelIdHex` to `channelId`
* fixed inconsistency when copying channel id in gui