### PR TITLE
Make router not broadcast announcements back to sender

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -8,7 +8,7 @@ import fr.acinq.bitcoin.{BinaryData, MilliSatoshi, Satoshi}
 import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.channel.HasCommitments
 import fr.acinq.eclair.crypto.TransportHandler.HandshakeCompleted
-import fr.acinq.eclair.router.Router.Rebroadcast
+import fr.acinq.eclair.router.Rebroadcast
 
 /**
   * Ties network connections to peers.

--- a/eclair-node/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -53,8 +53,8 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
 
   import ExecutionContext.Implicits.global
 
-  context.system.scheduler.schedule(5 seconds, nodeParams.routerBroadcastInterval, self, 'tick_broadcast)
-  context.system.scheduler.schedule(5 seconds, nodeParams.routerValidateInterval, self, 'tick_validate)
+  setTimer("broadcast", 'tick_broadcast, nodeParams.routerBroadcastInterval, repeat = true)
+  setTimer("validate", 'tick_validate, nodeParams.routerValidateInterval, repeat = true)
 
   startWith(NORMAL, Data(Map(), Map(), Map(), Nil, Nil, Nil))
 
@@ -63,7 +63,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
     case Event('tick_validate, d) =>
       require(d.awaiting.size == 0)
       var i = 0
-      // we extract a batch of at most 50 channel announcements from the stash
+      // we extract a batch of channel announcements from the stash
       val (channelAnns: Seq[ChannelAnnouncement]@unchecked, otherAnns) = d.stash.partition {
         case _: ChannelAnnouncement =>
           i = i + 1


### PR DESCRIPTION
Currently router doesn't remember what peer sent each annoucement, and broadcasts new announcements to all peers, resulting in unnecessary spam.