### PR TITLE
Channel id switch

### DIFF
--- a/eclair-node/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedStateSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedStateSpec.scala
@@ -79,10 +79,11 @@ class WaitForFundingCreatedStateSpec extends TestkitBaseClass with StateTestsHel
 
   test("recv FundingCreated (fee too low)", Tag("fee_too_low")) { case (bob, alice2bob, bob2alice, bob2blockchain) =>
     within(30 seconds) {
-      alice2bob.expectMsgType[FundingCreated]
+      val fundingCreated = alice2bob.expectMsgType[FundingCreated]
       alice2bob.forward(bob)
       val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === "local/remote feerates are too different: remoteFeeratePerKw=100 localFeeratePerKw=10000")
+      // we check that the error uses the temporary channel id
+      assert(error === Error(fundingCreated.temporaryChannelId, "local/remote feerates are too different: remoteFeeratePerKw=100 localFeeratePerKw=10000".getBytes("UTF-8")))
       awaitCond(bob.stateName == CLOSED)
     }
   }


### PR DESCRIPTION
As per lightningnetwork/lightning-rfc/pull/151

The implementation is simplistic, we don't really acknowledge the switch but rather keep both ids in memory. On node restart, only stored channels (=with a final channel id) will be restored, so the clean up will happen at that time.