### PR TITLE
Bugfix: regression in init

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/PortChecker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/PortChecker.scala
@@ -1,0 +1,26 @@
+package fr.acinq.eclair
+
+import java.net.{InetAddress, ServerSocket}
+
+import scala.util.{Failure, Success, Try}
+
+object PortChecker {
+
+  /**
+    * Tests if a port is open
+    * See https://stackoverflow.com/questions/434718/sockets-discover-port-availability-using-java#435579
+    *
+    * @return
+    */
+  def checkAvailable(host: String, port: Int): Unit = {
+    Try(new ServerSocket(port, 50, InetAddress.getByName(host))) match {
+      case Success(socket) =>
+        Try(socket.close())
+      case Failure(_) =>
+        throw TCPBindException(port)
+    }
+  }
+
+}
+
+case class TCPBindException(port: Int) extends RuntimeException


### PR DESCRIPTION
Eclair wasn't stopping anymore when two instances were started with the
same ports.

Note: we should probably go one step further and put a lock in the datadir
directory.