### PR TITLE
Improved reconnection logic and fuzzy tests

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
@@ -128,6 +128,7 @@ object ChannelCodecs {
   val waitingForRevocationCodec: Codec[WaitingForRevocation] = (
     ("nextRemoteCommit" | remoteCommitCodec) ::
       ("sent" | commitSigCodec) ::
+      ("sentAfterLocalCommitIndex" | uint64) ::
       ("reSignAsap" | bool)).as[WaitingForRevocation]
 
   val commitmentsCodec: Codec[Commitments] = (

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -26,9 +26,6 @@
         </encoder>
     </appender-->
 
-    <logger name="fr.acinq.eclair.Pipe" level="DEBUG" />
-    <logger name="fr.acinq.eclair.crypto.TransportHandler" level="DEBUG" />
-
     <root level="INFO">
         <!--appender-ref ref="FILE"/>
         <appender-ref ref="CONSOLEWARN"/-->

--- a/eclair-core/src/test/scala/fr/acinq/eclair/Pipe.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/Pipe.scala
@@ -18,7 +18,7 @@ class Pipe extends Actor with Stash with ActorLogging {
       unstashAll()
       context become connected(a, b)
 
-    case msg => stash()
+    case _ => stash()
   }
 
   def connected(a: ActorRef, b: ActorRef): Receive = {
@@ -28,27 +28,5 @@ class Pipe extends Actor with Stash with ActorLogging {
     case msg: LightningMessage if sender() == b =>
       log.debug(f"A <--${msg2String(msg)}%-6s--- B")
       a forward msg
-    case msg@INPUT_DISCONNECTED =>
-      log.debug("DISCONNECTED")
-      // used for fuzzy testing (eg: send Disconnected messages)
-      a forward msg
-      b forward msg
-      context become disconnected(a, b)
-  }
-
-  def disconnected(a: ActorRef, b: ActorRef): Receive = {
-    case msg: LightningMessage if sender() == a =>
-      // dropped
-      log.info(f"A ---${msg2String(msg)}%-6s-X")
-    case msg: LightningMessage if sender() == b =>
-      // dropped
-      log.debug(f"  X-${msg2String(msg)}%-6s--- B")
-    case msg@INPUT_RECONNECTED(r) =>
-      log.debug(s"RECONNECTED with $r")
-      // used for fuzzy testing (eg: send Disconnected messages)
-      a forward msg
-      b forward msg
-      r ! (a, b)
-
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/FuzzyPipe.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/FuzzyPipe.scala
@@ -1,0 +1,61 @@
+package fr.acinq.eclair.channel.states
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Stash}
+import fr.acinq.eclair.channel.Commitments.msg2String
+import fr.acinq.eclair.channel.{INPUT_DISCONNECTED, INPUT_RECONNECTED}
+import fr.acinq.eclair.wire.LightningMessage
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+/**
+  * A Fuzzy [[fr.acinq.eclair.Pipe]] which randomly disconnects/reconnects peers.
+  */
+class FuzzyPipe extends Actor with Stash with ActorLogging {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  def receive = {
+    case (a: ActorRef, b: ActorRef) =>
+      unstashAll()
+      context become connected(a, b, 10)
+
+    case _ => stash()
+  }
+
+  def stayOrDisconnect(a: ActorRef, b: ActorRef, countdown: Int) = {
+    if (countdown > 1) context become connected(a, b, countdown - 1)
+    else {
+      log.debug("DISCONNECTED")
+      a ! INPUT_DISCONNECTED
+      b ! INPUT_DISCONNECTED
+      context.system.scheduler.scheduleOnce(100 millis, self, 'reconnect)
+      context become disconnected(a, b)
+    }
+  }
+
+  def connected(a: ActorRef, b: ActorRef, countdown: Int): Receive = {
+    case msg: LightningMessage if sender() == a =>
+      log.debug(f"A ---${msg2String(msg)}%-6s--> B")
+      b forward msg
+      stayOrDisconnect(a, b, countdown)
+    case msg: LightningMessage if sender() == b =>
+      log.debug(f"A <--${msg2String(msg)}%-6s--- B")
+      a forward msg
+      stayOrDisconnect(a, b, countdown)
+  }
+
+  def disconnected(a: ActorRef, b: ActorRef): Receive = {
+    case msg: LightningMessage if sender() == a =>
+      // dropped
+      log.info(f"A ---${msg2String(msg)}%-6s-X")
+    case msg: LightningMessage if sender() == b =>
+      // dropped
+      log.debug(f"  X-${msg2String(msg)}%-6s--- B")
+    case 'reconnect =>
+      log.debug("RECONNECTED")
+      a ! INPUT_RECONNECTED(self)
+      b ! INPUT_RECONNECTED(self)
+      context become connected(a, b, Random.nextInt(20))
+  }
+}


### PR DESCRIPTION
Most notably, *we do not anymore discard previously signed updates*.
Instead, we re-send them and re-send the exact same signature. For that to
work, we had to be careful to re-send rev/sig in the same order, because
that impacts whatever is signed. OTOH, we still discard unsigned updates, but
we do it explicitly by sending a new `AddHtlcDiscarded` message.

This makes fuzzy testing far easier because now we know what updates were discarded.
Fuzzy testing has also been improved by disconnecting every x messages 
instead of every x seconds (which is unreliable on slow boxes).

NB: this breaks storage serialization backward compatibility