### PR TITLE
(gui) Remove millisatoshis part from milli-bitcoin amounts

### DIFF
--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -13,6 +13,7 @@ import fr.acinq.bitcoin._
 import fr.acinq.eclair.blockchain.zmq.{ZMQConnected, ZMQDisconnected}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.gui.controllers._
+import fr.acinq.eclair.gui.utils.CoinFormat
 import fr.acinq.eclair.payment.{PaymentReceived, PaymentRelayed, PaymentSent}
 import fr.acinq.eclair.router._
 import fr.acinq.eclair.wire.NodeAnnouncement
@@ -50,8 +51,8 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
 
   def updateBalance(channelPaneController: ChannelPaneController, commitments: Commitments) = {
     val spec = commitments.localCommit.spec
-    channelPaneController.capacity.setText(s"${millisatoshi2millibtc(MilliSatoshi(spec.totalFunds)).amount}")
-    channelPaneController.amountUs.setText(s"${millisatoshi2millibtc(MilliSatoshi(spec.toLocalMsat)).amount}")
+    channelPaneController.capacity.setText(s"${CoinFormat.MILLI_BTC_FORMAT.format(millisatoshi2millibtc(MilliSatoshi(spec.totalFunds)).amount)}")
+    channelPaneController.amountUs.setText(s"${CoinFormat.MILLI_BTC_FORMAT.format(millisatoshi2millibtc(MilliSatoshi(spec.toLocalMsat)).amount)}")
     channelPaneController.balanceBar.setProgress(spec.toLocalMsat.toDouble / spec.totalFunds)
   }
 
@@ -91,7 +92,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
       val channelPaneController = m(channel)
       Platform.runLater(new Runnable() {
         override def run = {
-          channelPaneController.close.setText( if (OFFLINE == currentState) "Force close" else "Close")
+          channelPaneController.close.setText(if (OFFLINE == currentState) "Force close" else "Close")
           channelPaneController.state.setText(currentState.toString)
         }
       })
@@ -113,7 +114,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
 
     case NodeDiscovered(nodeAnnouncement) =>
       log.debug(s"peer node discovered with node id=${nodeAnnouncement.nodeId}")
-      if(!mainController.networkNodesList.exists(na => na.nodeId == nodeAnnouncement.nodeId)) {
+      if (!mainController.networkNodesList.exists(na => na.nodeId == nodeAnnouncement.nodeId)) {
         mainController.networkNodesList.add(nodeAnnouncement)
         m.foreach(f => if (nodeAnnouncement.nodeId.toString.equals(f._2.theirNodeIdValue)) {
           Platform.runLater(new Runnable() {
@@ -142,7 +143,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
 
     case ChannelDiscovered(channelAnnouncement, _) =>
       log.debug(s"peer channel discovered with channel id=${channelAnnouncement.shortChannelId}")
-      if(!mainController.networkChannelsList.exists(c => c.announcement.shortChannelId == channelAnnouncement.shortChannelId)) {
+      if (!mainController.networkChannelsList.exists(c => c.announcement.shortChannelId == channelAnnouncement.shortChannelId)) {
         mainController.networkChannelsList.add(new ChannelInfo(channelAnnouncement, None, None))
       }
 

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/CoinFormat.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/CoinFormat.scala
@@ -1,0 +1,28 @@
+package fr.acinq.eclair.gui.utils
+
+import java.text.{DecimalFormat, NumberFormat}
+import java.util.Locale
+
+object CoinFormat {
+  /**
+    * Always 3 decimals, maximum of 8
+    */
+  val BTC_PATTERN = "###,##0.000#####"
+
+  /**
+    * Always 5 decimals
+    */
+  val MILLI_BTC_PATTERN = "###,##0.00000"
+
+  /**
+    * Localized formatter for BTC amounts. Uses `BTC_PATTERN`.
+    */
+  val BTC_FORMAT: DecimalFormat = NumberFormat.getNumberInstance(Locale.getDefault).asInstanceOf[DecimalFormat]
+  BTC_FORMAT.applyPattern(BTC_PATTERN)
+
+  /**
+    * Localized formatter for milli-bitcoin amounts. Uses `MILLI_BTC_PATTERN`.
+    */
+  val MILLI_BTC_FORMAT: DecimalFormat = NumberFormat.getNumberInstance(Locale.getDefault).asInstanceOf[DecimalFormat]
+  MILLI_BTC_FORMAT.applyPattern(MILLI_BTC_PATTERN)
+}

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/CoinFormat.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/CoinFormat.scala
@@ -1,28 +1,15 @@
 package fr.acinq.eclair.gui.utils
 
-import java.text.{DecimalFormat, NumberFormat}
-import java.util.Locale
+import java.text.DecimalFormat
 
 object CoinFormat {
-  /**
-    * Always 3 decimals, maximum of 8
-    */
-  val BTC_PATTERN = "###,##0.000#####"
-
   /**
     * Always 5 decimals
     */
   val MILLI_BTC_PATTERN = "###,##0.00000"
 
   /**
-    * Localized formatter for BTC amounts. Uses `BTC_PATTERN`.
-    */
-  val BTC_FORMAT: DecimalFormat = NumberFormat.getNumberInstance(Locale.getDefault).asInstanceOf[DecimalFormat]
-  BTC_FORMAT.applyPattern(BTC_PATTERN)
-
-  /**
     * Localized formatter for milli-bitcoin amounts. Uses `MILLI_BTC_PATTERN`.
     */
-  val MILLI_BTC_FORMAT: DecimalFormat = NumberFormat.getNumberInstance(Locale.getDefault).asInstanceOf[DecimalFormat]
-  MILLI_BTC_FORMAT.applyPattern(MILLI_BTC_PATTERN)
+  val MILLI_BTC_FORMAT: DecimalFormat = new DecimalFormat(MILLI_BTC_PATTERN)
 }


### PR DESCRIPTION
The user interface does need to display the millisatoshis part in a channel's balance/capacity.
This PR fixes an issue where msat part was truncated but still displayed, with a value equals to `000`.

see #139 