### PR TITLE
Temporarily exclude channels from routes

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -59,6 +59,7 @@ eclair {
   // than this ratio.
   update-fee_min-diff-ratio = 0.1
 
+  channel-exclude-duration = 60 seconds // when a temporary channel failure is returned, we exclude the channel from our payment routes for this duration
   router-broadcast-interval = 10 seconds // this should be 60 seconds on mainnet
   router-validate-interval = 2 seconds // this should be high enough to have a decent level of parallelism
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -49,6 +49,7 @@ case class NodeParams(extendedPrivateKey: ExtendedPrivateKey,
                       autoReconnect: Boolean,
                       chainHash: BinaryData,
                       channelFlags: Byte,
+                      channelExcludeDuration: FiniteDuration,
                       spv: Boolean)
 
 object NodeParams {
@@ -127,6 +128,7 @@ object NodeParams {
       autoReconnect = config.getBoolean("auto-reconnect"),
       chainHash = chainHash,
       channelFlags = config.getInt("channel-flags").toByte,
+      channelExcludeDuration = FiniteDuration(config.getDuration("channel-exclude-duration").getSeconds, TimeUnit.SECONDS),
       spv = config.getBoolean("spv"))
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Relayer.scala
@@ -133,7 +133,7 @@ class Relayer(nodeSecret: PrivateKey, paymentHandler: ActorRef) extends Actor wi
         shortId <- shortIds.map(_.swap).get(channelId)
         update <- channelUpdates.get(shortId)
       } yield update
-      // detail errors should have been catched earlier (when relayer picks the next channel), so here we just answer with generic error messages
+      // detail errors are caught before relaying the htlc to the downstream channel, here we just return generic error messages
       channelUpdate_opt match {
         case None =>
           // TODO: clarify what we're supposed to do in the specs

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -1,6 +1,6 @@
 package fr.acinq.eclair.router
 
-import java.io.{File, StringWriter}
+import java.io.StringWriter
 
 import akka.actor.{ActorRef, FSM, Props}
 import akka.pattern.pipe
@@ -10,7 +10,6 @@ import fr.acinq.bitcoin.Script.{pay2wsh, write}
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel._
-import fr.acinq.eclair.db.NetworkDb
 import fr.acinq.eclair.io.Peer
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
@@ -29,6 +28,8 @@ case class ChannelDesc(id: Long, a: PublicKey, b: PublicKey)
 case class Hop(nodeId: PublicKey, nextNodeId: PublicKey, lastUpdate: ChannelUpdate)
 case class RouteRequest(source: PublicKey, target: PublicKey, ignoreNodes: Set[PublicKey] = Set.empty, ignoreChannels: Set[Long] = Set.empty)
 case class RouteResponse(hops: Seq[Hop], ignoreNodes: Set[PublicKey], ignoreChannels: Set[Long]) { require(hops.size > 0, "route cannot be empty") }
+case class ExcludeChannel(desc: ChannelDesc) // this is used when we get a TemporaryChannelFailure, to give time for the channel to recover (note that exclusions are directed)
+case class LiftChannelExclusion(desc: ChannelDesc)
 case class SendRoutingState(to: ActorRef)
 case class Rebroadcast(ann: Seq[RoutingMessage], origins: Map[RoutingMessage, ActorRef])
 
@@ -39,7 +40,8 @@ case class Data(nodes: Map[PublicKey, NodeAnnouncement],
                   stash: Seq[RoutingMessage],
                   awaiting: Seq[ChannelAnnouncement],
                   origins: Map[RoutingMessage, ActorRef],
-                  localChannels: Map[BinaryData, PublicKey])
+                  localChannels: Map[BinaryData, PublicKey],
+                  excludedChannels: Set[ChannelDesc]) // those channels are temporarily excluded from route calculation, because their node returned a TemporaryChannelFailure
 
 sealed trait State
 case object NORMAL extends State
@@ -72,7 +74,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
   setTimer("broadcast", 'tick_broadcast, nodeParams.routerBroadcastInterval, repeat = true)
   setTimer("validate", 'tick_validate, nodeParams.routerValidateInterval, repeat = true)
 
-  startWith(NORMAL, Data(Map.empty, Map.empty, Map.empty, Nil, Nil, Nil, Map.empty, Map.empty))
+  startWith(NORMAL, Data(Map.empty, Map.empty, Map.empty, Nil, Nil, Nil, Map.empty, Map.empty, Set.empty))
 
   when(NORMAL) {
 
@@ -147,7 +149,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
 
     case Event(c: ChannelStateChanged, _) => stay
 
-    case Event(SendRoutingState(remote), Data(nodes, channels, updates, _, _, _, _, _)) =>
+    case Event(SendRoutingState(remote), Data(nodes, channels, updates, _, _, _, _, _, _)) =>
       log.debug(s"info sending all announcements to $remote: channels=${channels.size} nodes=${nodes.size} updates=${updates.size}")
       channels.values.foreach(remote ! _)
       nodes.values.foreach(remote ! _)
@@ -259,6 +261,16 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
           stay using d.copy(rebroadcast = Nil, origins = Map.empty)
       }
 
+    case Event(ExcludeChannel(desc@ChannelDesc(channelId, nodeId, _)), d) =>
+      val banDuration = nodeParams.channelExcludeDuration
+      log.info(s"excluding channelId=$channelId from nodeId=$nodeId for duration=$banDuration")
+      context.system.scheduler.scheduleOnce(banDuration, self, LiftChannelExclusion(desc))
+      stay using d.copy(excludedChannels = d.excludedChannels + desc)
+
+    case Event(LiftChannelExclusion(desc@ChannelDesc(channelId, nodeId, _)), d) =>
+      log.info(s"reinstating channelId=$channelId from nodeId=$nodeId")
+      stay using d.copy(excludedChannels = d.excludedChannels - desc)
+
     case Event('nodes, d) =>
       sender ! d.nodes.values
       stay
@@ -279,18 +291,21 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
       val localNodeId = nodeParams.privateKey.publicKey
       // TODO: HACK!!!!! the following is a workaround to make our routing work with private/not-yet-announced channels, that do not have a channelUpdate
       val fakeUpdates = d.localChannels.map { case (channelId, remoteNodeId) =>
-        // note that this id is deterministic, so that filterUpdates method still works
+        // note that this id is deterministic, otherwise filterUpdates would not work
         val fakeShortId = BigInt(channelId.take(7).toArray).toLong
         val channelDesc = ChannelDesc(fakeShortId, localNodeId, remoteNodeId)
-        // note that we store the channelId in the sig, other values are not used because this will be the first channel in the route
+        // note that we store the channelId in the sig, other values are not used because if it is selected this will be the first channel in the route
         val channelUpdate = ChannelUpdate(signature = channelId, chainHash = nodeParams.chainHash, fakeShortId, 0, "0000", 0, 0, 0, 0)
         (channelDesc -> channelUpdate)
       }
-      // we replace local channelUpdates (we have them for regular public alread-announced channels) by the ones we just generated
+      // we replace local channelUpdates (we have them for regular public already-announced channels) by the ones we just generated
       val updates1 = d.updates.filterKeys(_.a != localNodeId) ++ fakeUpdates
-      val updates2 = filterUpdates(updates1, ignoreNodes, ignoreChannels)
+      // we then filter out the currently excluded channels
+      val updates2 = updates1.filterKeys(!d.excludedChannels.contains(_))
+      // we also filter out  excluded channels
+      val updates3 = filterUpdates(updates2, ignoreNodes, ignoreChannels)
       log.info(s"finding a route $start->$end with ignoreNodes=${ignoreNodes.map(_.toBin).mkString(",")} ignoreChannels=${ignoreChannels.mkString(",")}")
-      findRoute(start, end, updates2).map(r => RouteResponse(r, ignoreNodes, ignoreChannels)) pipeTo sender
+      findRoute(start, end, updates3).map(r => RouteResponse(r, ignoreNodes, ignoreChannels)) pipeTo sender
       stay
   }
 
@@ -323,6 +338,9 @@ object Router {
 
   def isRelatedTo(c: ChannelAnnouncement, n: NodeAnnouncement) = n.nodeId == c.nodeId1 || n.nodeId == c.nodeId2
 
+  /**
+    * This method is used after a payment failed, and we want to exclude some nodes/channels that we know are failing
+    */
   def filterUpdates(updates: Map[ChannelDesc, ChannelUpdate], ignoreNodes: Set[PublicKey], ignoreChannels: Set[Long]) =
     updates
       .filterNot(u => ignoreNodes.map(_.toBin).contains(u._1.a) || ignoreNodes.map(_.toBin).contains(u._1.b))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -54,6 +54,7 @@ object TestConstants {
       autoReconnect = false,
       chainHash = Block.RegtestGenesisBlock.hash,
       channelFlags = 1,
+      channelExcludeDuration = 5 seconds,
       spv = false)
     def id = nodeParams.privateKey.publicKey
     def channelParams = Peer.makeChannelParams(
@@ -101,6 +102,7 @@ object TestConstants {
       autoReconnect = false,
       chainHash = Block.RegtestGenesisBlock.hash,
       channelFlags = 1,
+      channelExcludeDuration = 5 seconds,
       spv = false)
     def id = nodeParams.privateKey.publicKey
     def channelParams = Peer.makeChannelParams(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -58,9 +58,13 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
   val chan_ef = channelAnnouncement(channelId_ef, priv_e, priv_f, priv_funding_e, priv_funding_f)
 
   val channelUpdate_ab = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, b, channelId_ab, cltvExpiryDelta = 7, 0, feeBaseMsat = 766000, feeProportionalMillionths = 10)
+  val channelUpdate_ba = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, a, channelId_ab, cltvExpiryDelta = 7, 0, feeBaseMsat = 766000, feeProportionalMillionths = 10)
   val channelUpdate_bc = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, c, channelId_bc, cltvExpiryDelta = 5, 0, feeBaseMsat = 233000, feeProportionalMillionths = 1)
+  val channelUpdate_cb = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_c, b, channelId_bc, cltvExpiryDelta = 5, 0, feeBaseMsat = 233000, feeProportionalMillionths = 1)
   val channelUpdate_cd = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_c, d, channelId_cd, cltvExpiryDelta = 3, 0, feeBaseMsat = 153000, feeProportionalMillionths = 4)
+  val channelUpdate_dc = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_d, c, channelId_cd, cltvExpiryDelta = 3, 0, feeBaseMsat = 153000, feeProportionalMillionths = 4)
   val channelUpdate_ef = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_e, f, channelId_ef, cltvExpiryDelta = 9, 0, feeBaseMsat = 786000, feeProportionalMillionths = 8)
+  val channelUpdate_fe = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_f, e, channelId_ef, cltvExpiryDelta = 9, 0, feeBaseMsat = 786000, feeProportionalMillionths = 8)
 
   override def withFixture(test: OneArgTest) = {
     // the network will be a --(1)--> b ---(2)--> c --(3)--> d and e --(4)--> f (we are a)
@@ -106,9 +110,13 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
       router ! ann_f
       // then channel updates
       router ! channelUpdate_ab
+      router ! channelUpdate_ba
       router ! channelUpdate_bc
+      router ! channelUpdate_cb
       router ! channelUpdate_cd
+      router ! channelUpdate_dc
       router ! channelUpdate_ef
+      router ! channelUpdate_fe
 
       val sender = TestProbe()
 
@@ -122,7 +130,7 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
 
       sender.send(router, 'updates)
       val updates = sender.expectMsgType[Iterable[ChannelUpdate]]
-      assert(updates.size === 4)
+      assert(updates.size === 8)
 
       test((router, watcher))
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -13,6 +13,7 @@ import fr.acinq.eclair.{randomKey, toShortId}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 /**
@@ -142,6 +143,24 @@ class RouterSpec extends BaseRouterSpec {
     sender.send(router, channelUpdate_cd1)
     sender.send(router, RouteRequest(a, d))
     sender.expectMsg(Failure(RouteNotFound))
+  }
+
+  test("temporary channel exclusion") { case (router, _) =>
+    val sender = TestProbe()
+    sender.send(router, RouteRequest(a, d))
+    sender.expectMsgType[RouteResponse]
+    val bc = ChannelDesc(channelId_bc, b, c)
+    // let's exclude channel b->c
+    sender.send(router, ExcludeChannel(bc))
+    sender.send(router, RouteRequest(a, d))
+    sender.expectMsg(Failure(RouteNotFound))
+    // note that cb is still available!
+    sender.send(router, RouteRequest(d, a))
+    sender.expectMsgType[RouteResponse]
+    // let's remove the exclusion
+    sender.send(router, LiftChannelExclusion(bc))
+    sender.send(router, RouteRequest(a, d))
+    sender.expectMsgType[RouteResponse]
   }
 
   test("export graph in dot format") { case (router, _) =>


### PR DESCRIPTION
When a node returns a `TemporaryChannelFailure` for its outgoing
channel, along with an unchanged `ChannelUpdate`, we temporarily
exclude this channel from route calculation.

Note that the exclusion is directed, as we expect this will mostly
happen when all funds are on one side of the channel and the channel
remains available in the other direction.

The duration of the exclusion can be configured by setting the
key `eclair.channel-exclude-duration`. Default value is 60s.