### PR TITLE
Better handling of connection lifecycle in Peer

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -938,13 +938,11 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(e: Error, d: DATA_CLOSING) => stay // nothing to do, there is already a spending tx published
 
-    case Event(INPUT_DISCONNECTED, _) =>
-      log.info(s"we are disconnected, but it does not matter anymore")
-      stay
+    case Event(INPUT_DISCONNECTED, _) => stay // we are disconnected, but it doesn't matter anymoer
   })
 
-  when(CLOSED, stateTimeout = 10 seconds)(handleExceptions {
-    case Event(StateTimeout, _) =>
+  when(CLOSED)(handleExceptions {
+    case Event('shutdown, _) =>
       stateData match {
         case d: HasCommitments =>
           log.info(s"deleting database record for channelId=${d.channelId}")
@@ -954,7 +952,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
       log.info("shutting down")
       stop(FSM.Normal)
 
-    case Event(INPUT_DISCONNECTED, _) => stay
+    case Event(INPUT_DISCONNECTED, _) => stay // we are disconnected, but it doesn't matter anymoer
   })
 
   when(OFFLINE)(handleExceptions {
@@ -1057,10 +1055,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
     case Event(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx: Transaction), d: HasCommitments) => handleRemoteSpentOther(tx, d)
   })
 
-  when(ERR_INFORMATION_LEAK, stateTimeout = 10 seconds) {
-    case Event(StateTimeout, _) =>
-      log.info("shutting down")
-      stop(FSM.Normal)
+  when(ERR_INFORMATION_LEAK) {
+    case Event('nevermatches, _) => stay // we can't define a state with no event handler, so we put a dummy one here
   }
 
   whenUnhandled {
@@ -1099,6 +1095,10 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
     case WAIT_FOR_INIT_INTERNAL -> OFFLINE =>
       context.system.eventStream.publish(ChannelStateChanged(self, context.parent, remoteNodeId, WAIT_FOR_INIT_INTERNAL, OFFLINE, nextStateData))
     case state -> nextState if nextState != state =>
+      if (nextState == CLOSED) {
+        // channel is closed, scheduling this actor for self destruction
+        context.system.scheduler.scheduleOnce(10 seconds, self, 'shutdown)
+      }
       context.system.eventStream.publish(ChannelStateChanged(self, context.parent, remoteNodeId, state, nextState, nextStateData))
   }
 


### PR DESCRIPTION
This fixes two things:
- A peer  won't try to reconnect to a remote if there are no live/pending channels (e.g. if the last channel was closed).
- A peer won't set up reconnect timers if it does not have the ip address of the remote node

NB: 
There is a possible race condition when a new channel request arrives at the same time of a disconnection, resulting in the connection never being attempted again. However this is a corner case and not a huge concern.

Overall the connection handling is over-complicated and error prone. I think the `Switchboard` should probably not keep a map of `nodeId`->`connection`, it should delegate connection handling entirely to the corresponding `Peer`.