### PR TITLE
Replaced sqlite result iterators by lists

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -9,6 +9,6 @@ trait ChannelsDb {
 
   def removeChannel(channelId: BinaryData)
 
-  def listChannels(): Iterator[HasCommitments]
+  def listChannels(): List[HasCommitments]
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
@@ -11,7 +11,7 @@ trait NetworkDb {
 
   def removeNode(nodeId: PublicKey)
 
-  def listNodes(): Iterator[NodeAnnouncement]
+  def listNodes(): List[NodeAnnouncement]
 
   def addChannel(c: ChannelAnnouncement)
 
@@ -22,12 +22,12 @@ trait NetworkDb {
     */
   def removeChannel(shortChannelId: Long)
 
-  def listChannels(): Iterator[ChannelAnnouncement]
+  def listChannels(): List[ChannelAnnouncement]
 
   def addChannelUpdate(u: ChannelUpdate)
 
   def updateChannelUpdate(u: ChannelUpdate)
 
-  def listChannelUpdates(): Iterator[ChannelUpdate]
+  def listChannelUpdates(): List[ChannelUpdate]
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
@@ -10,6 +10,6 @@ trait PeersDb {
 
   def removePeer(nodeId: PublicKey)
 
-  def listPeers(): Iterator[(PublicKey, InetSocketAddress)]
+  def listPeers(): List[(PublicKey, InetSocketAddress)]
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -35,8 +35,8 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb {
     statement.executeUpdate()
   }
 
-  override def listChannels(): Iterator[HasCommitments] = {
+  override def listChannels(): List[HasCommitments] = {
     val rs = sqlite.createStatement.executeQuery("SELECT data FROM local_channels")
-    codecIterator(rs, stateDataCodec)
+    codecList(rs, stateDataCodec)
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -43,13 +43,13 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
     statement.executeUpdate()
   }
 
-  override def listNodes(): Iterator[NodeAnnouncement] = {
+  override def listNodes(): List[NodeAnnouncement] = {
     val rs = sqlite.createStatement.executeQuery("SELECT data FROM nodes")
-    codecIterator(rs, nodeAnnouncementCodec)
+    codecList(rs, nodeAnnouncementCodec)
   }
 
   override def addChannel(c: ChannelAnnouncement): Unit = {
-    val statement = sqlite.prepareStatement("INSERT INTO channels VALUES (?, ?)")
+    val statement = sqlite.prepareStatement("INSERT OR IGNORE INTO channels VALUES (?, ?)")
     statement.setLong(1, c.shortChannelId)
     statement.setBytes(2, channelAnnouncementCodec.encode(c).require.toByteArray)
     statement.executeUpdate()
@@ -63,13 +63,13 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
     statement.execute("COMMIT TRANSACTION")
   }
 
-  override def listChannels(): Iterator[ChannelAnnouncement] = {
+  override def listChannels(): List[ChannelAnnouncement] = {
     val rs = sqlite.createStatement.executeQuery("SELECT data FROM channels")
-    codecIterator(rs, channelAnnouncementCodec)
+    codecList(rs, channelAnnouncementCodec)
   }
 
   override def addChannelUpdate(u: ChannelUpdate): Unit = {
-    val statement = sqlite.prepareStatement("INSERT INTO channel_updates VALUES (?, ?, ?)")
+    val statement = sqlite.prepareStatement("INSERT OR IGNORE INTO channel_updates VALUES (?, ?, ?)")
     statement.setLong(1, u.shortChannelId)
     statement.setBoolean(2, Announcements.isNode1(u.flags))
     statement.setBytes(3, channelUpdateCodec.encode(u).require.toByteArray)
@@ -84,9 +84,9 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
     statement.executeUpdate()
   }
 
-  override def listChannelUpdates(): Iterator[ChannelUpdate] = {
+  override def listChannelUpdates(): List[ChannelUpdate] = {
     val rs = sqlite.createStatement.executeQuery("SELECT data FROM channel_updates")
-    codecIterator(rs, channelUpdateCodec)
+    codecList(rs, channelUpdateCodec)
   }
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
@@ -35,12 +35,12 @@ class SqlitePeersDb(sqlite: Connection) extends PeersDb {
     statement.executeUpdate()
   }
 
-  override def listPeers(): Iterator[(PublicKey, InetSocketAddress)] = {
+  override def listPeers(): List[(PublicKey, InetSocketAddress)] = {
     val rs = sqlite.createStatement.executeQuery("SELECT node_id, data FROM peers")
-    new Iterator[(PublicKey, InetSocketAddress)] {
-      override def hasNext: Boolean = rs.next()
-
-      override def next() = (PublicKey(rs.getBytes("node_id")), socketaddress.decode(BitVector(rs.getBytes("data"))).require.value)
+    var l: List[(PublicKey, InetSocketAddress)] = Nil
+    while (rs.next()) {
+      l = l :+ (PublicKey(rs.getBytes("node_id")), socketaddress.decode(BitVector(rs.getBytes("data"))).require.value)
     }
+    l
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
@@ -6,17 +6,22 @@ import scodec.Codec
 import scodec.bits.BitVector
 
 object SqliteUtils {
+
   /**
     * This helper assumes that there is a "data" column available, decodable with the provided codec
+    *
+    * TODO: we should use an [[scala.Iterator]] instead
     *
     * @param rs
     * @param codec
     * @tparam T
     * @return
     */
-  def codecIterator[T](rs: ResultSet, codec: Codec[T]): Iterator[T] = new Iterator[T] {
-    override def hasNext: Boolean = rs.next()
-
-    override def next(): T = codec.decode(BitVector(rs.getBytes("data"))).require.value
+  def codecList[T](rs: ResultSet, codec: Codec[T]): List[T] = {
+    var l: List[T] = Nil
+    while (rs.next()) {
+      l = l :+ codec.decode(BitVector(rs.getBytes("data"))).require.value
+    }
+    l
   }
 }


### PR DESCRIPTION
It is less performant but our `ResultSet`->`Iterator` implementation
was buggy due to java/scala iterators requiring look-ahead capabilities
when iterating over the result, which `ResultSet` does not support.

This is a quick fix in the meantime.