### PR TITLE
Skip `Wallet.isRelevant` when bitcoinj is used as a watcher

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/spv/BitcoinjKit.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/spv/BitcoinjKit.scala
@@ -59,6 +59,7 @@ class BitcoinjKit(chain: String, datadir: File, staticPeers: List[InetSocketAddr
     logger.info(s"peerGroup.getMinBroadcastConnections==${peerGroup().getMinBroadcastConnections}")
 
     peerGroup().setMinRequiredProtocolVersion(70015) // bitcoin core 0.13
+    wallet().watchMode = true
 
 //    setDownloadListener(new DownloadProgressTracker {
 //      override def doneDownload(): Unit = {

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <scala.version.short>2.11</scala.version.short>
         <akka.version>2.4.18</akka.version>
         <bitcoinlib.version>0.9.13</bitcoinlib.version>
-        <bitcoinj.version>0.15-rc2</bitcoinj.version>
+        <bitcoinj.version>0.15-rc3</bitcoinj.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Related to [this commit](https://github.com/ACINQ/bitcoinj/commit/aed15e067adae7b34aba04c5983d1a6f306490ec).