### PR TITLE
Re-send htlc/sigs after `funding_locked`

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -30,18 +30,20 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("discard lost sig") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
+  /**
+    * This test checks the case where a disconnection occurs *right before* the counterparty receives a new sig
+    */
+  test("re-send update+sig after first commitment") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
     val sender = TestProbe()
 
     sender.send(alice, CMD_ADD_HTLC(1000000, BinaryData("42" * 32), 400144))
     val ab_add_0 = alice2bob.expectMsgType[UpdateAddHtlc]
     // add ->b
-    alice2bob.forward(bob, ab_add_0)
+    alice2bob.forward(bob)
 
     sender.send(alice, CMD_SIGN)
     val ab_sig_0 = alice2bob.expectMsgType[CommitSig]
-
-    // bob didn't receive the sig
+    // bob doesn't receive the sig
 
     sender.send(alice, INPUT_DISCONNECTED)
     sender.send(bob, INPUT_DISCONNECTED)
@@ -50,9 +52,9 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     sender.send(alice, INPUT_RECONNECTED(alice2bob.ref))
     sender.send(bob, INPUT_RECONNECTED(bob2alice.ref))
 
-    // a didn't receive the sig
+    // a didn't receive any update or sig
     val ab_reestablish = alice2bob.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0))
-    // b did receive the sig
+    // b didn't receive the sig
     val ba_reestablish = bob2alice.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0))
 
     // reestablish ->b
@@ -64,17 +66,42 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     alice2bob.expectMsgType[FundingLocked]
     bob2alice.expectMsgType[FundingLocked]
 
+    // a will re-send the update and the sig
+    val ab_add_0_re = alice2bob.expectMsg(ab_add_0)
+    val ab_sig_0_re = alice2bob.expectMsg(ab_sig_0)
+
+    // add ->b
+    alice2bob.forward(bob, ab_add_0_re)
+    // sig ->b
+    alice2bob.forward(bob, ab_sig_0_re)
+
+    // and b will reply with a revocation
+    val ba_rev_0 = bob2alice.expectMsgType[RevokeAndAck]
+    // rev ->a
+    bob2alice.forward(alice, ba_rev_0)
+
+    // then b sends a sig
+    bob2alice.expectMsgType[CommitSig]
+    // sig -> a
+    bob2alice.forward(alice)
+
+    // and a answers with a rev
+    alice2bob.expectMsgType[RevokeAndAck]
+    // sig -> a
+    alice2bob.forward(bob)
+
     alice2bob.expectNoMsg(500 millis)
     bob2alice.expectNoMsg(500 millis)
 
-    // alice will discard the update and the sig
-    alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localNextHtlcId == 0
+    alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localNextHtlcId == 1
 
     awaitCond(alice.stateName == NORMAL)
     awaitCond(bob.stateName == NORMAL)
-
   }
 
+  /**
+    * This test checks the case where a disconnection occurs *right after* the counterparty receives a new sig
+    */
   test("re-send lost revocation") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
     val sender = TestProbe()
 


### PR DESCRIPTION
We previously skipped the `handleSync` function when we had to re-send
`funding_locked` messages on reconnection. This didn't take into account
the fact that we might have been disconnected right after sending the
very first `commit_sig` in the channel. In that case we need to first
re-send `funding_locked`, then re-send whatever updates were included in
the lost signature, and finally re-send the same `commit_sig`.

Note that the specification doesn't require to re-send the exact same
updates and signatures on reconnection. But doing this allows for a single
commitment history and allows us not to keep track of all signatures
sent to the other party.

This was reported in #165.