### PR TITLE
Rework preimage handling

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -11,7 +11,7 @@ import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.DeterministicWallet.ExtendedPrivateKey
 import fr.acinq.bitcoin.{BinaryData, Block, DeterministicWallet}
 import fr.acinq.eclair.db._
-import fr.acinq.eclair.db.sqlite.{SqliteChannelsDb, SqliteNetworkDb, SqlitePeersDb}
+import fr.acinq.eclair.db.sqlite.{SqliteChannelsDb, SqliteNetworkDb, SqlitePeersDb, SqlitePreimagesDb}
 
 import scala.collection.JavaConversions._
 import scala.concurrent.duration.FiniteDuration
@@ -41,6 +41,7 @@ case class NodeParams(extendedPrivateKey: ExtendedPrivateKey,
                       channelsDb: ChannelsDb,
                       peersDb: PeersDb,
                       networkDb: NetworkDb,
+                      preimagesDb: PreimagesDb,
                       routerBroadcastInterval: FiniteDuration,
                       routerValidateInterval: FiniteDuration,
                       pingInterval: FiniteDuration,
@@ -93,6 +94,7 @@ object NodeParams {
     val channelsDb = new SqliteChannelsDb(sqlite)
     val peersDb = new SqlitePeersDb(sqlite)
     val networkDb = new SqliteNetworkDb(sqlite)
+    val preimagesDb = new SqlitePreimagesDb(sqlite)
 
     val color = BinaryData(config.getString("node-color"))
     require(color.size == 3, "color should be a 3-bytes hex buffer")
@@ -120,6 +122,7 @@ object NodeParams {
       channelsDb = channelsDb,
       peersDb = peersDb,
       networkDb = networkDb,
+      preimagesDb = preimagesDb,
       routerBroadcastInterval = FiniteDuration(config.getDuration("router-broadcast-interval").getSeconds, TimeUnit.SECONDS),
       routerValidateInterval = FiniteDuration(config.getDuration("router-validate-interval").getSeconds, TimeUnit.SECONDS),
       pingInterval = FiniteDuration(config.getDuration("ping-interval").getSeconds, TimeUnit.SECONDS),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -125,7 +125,7 @@ class Setup(datadir: File, overrideDefaults: Config = ConfigFactory.empty(), act
       case "noop" => Props[NoopPaymentHandler]
     }, "payment-handler", SupervisorStrategy.Resume))
     val register = system.actorOf(SimpleSupervisor.props(Props(new Register), "register", SupervisorStrategy.Resume))
-    val relayer = system.actorOf(SimpleSupervisor.props(Relayer.props(nodeParams.privateKey, paymentHandler), "relayer", SupervisorStrategy.Resume))
+    val relayer = system.actorOf(SimpleSupervisor.props(Relayer.props(nodeParams, register, paymentHandler), "relayer", SupervisorStrategy.Resume))
     val router = system.actorOf(SimpleSupervisor.props(Router.props(nodeParams, watcher), "router", SupervisorStrategy.Resume))
     val switchboard = system.actorOf(SimpleSupervisor.props(Switchboard.props(nodeParams, watcher, router, relayer, wallet), "switchboard", SupervisorStrategy.Resume))
     val paymentInitiator = system.actorOf(SimpleSupervisor.props(PaymentInitiator.props(nodeParams.privateKey.publicKey, router, register), "payment-initiator", SupervisorStrategy.Restart))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -3,7 +3,7 @@ package fr.acinq.eclair.channel
 import akka.actor.{ActorRef, FSM, LoggingFSM, OneForOneStrategy, Props, Status, SupervisorStrategy}
 import akka.event.Logging.MDC
 import akka.pattern.pipe
-import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.bitcoin.Crypto.{PublicKey, ripemd160, sha256}
 import fr.acinq.bitcoin._
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
@@ -411,27 +411,18 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
    */
 
   when(NORMAL)(handleExceptions {
-    case Event(c: CMD_ADD_HTLC, d: DATA_NORMAL) if d.localShutdown.isDefined || d.remoteShutdown.isDefined => {
+    case Event(c: CMD_ADD_HTLC, d: DATA_NORMAL) if d.localShutdown.isDefined || d.remoteShutdown.isDefined =>
       // note: spec would allow us to keep sending new htlcs after having received their shutdown (and not sent ours)
       // but we want to converge as fast as possible and they would probably not route them anyway
       val error = ClosingInProgress(d.channelId)
-      relayer ! AddHtlcFailed(c, error)
-      handleCommandError(error)
-    }
+      handleCommandAddError(error, origin(c))
 
-    case Event(c@CMD_ADD_HTLC(_, _, _, _, downstream_opt, _), d: DATA_NORMAL) =>
-      Try(Commitments.sendAdd(d.commitments, c)) match {
+    case Event(c: CMD_ADD_HTLC, d: DATA_NORMAL) =>
+      Try(Commitments.sendAdd(d.commitments, c, origin(c))) match {
         case Success(Right((commitments1, add))) =>
-          val origin = downstream_opt match {
-            case Some(u) => Relayed(sender, u)
-            case None => Local(sender)
-          }
-          relayer ! AddHtlcSucceeded(add, origin)
           if (c.commit) self ! CMD_SIGN
           handleCommandSuccess(sender, d.copy(commitments = commitments1)) sending add
-        case Success(Left(error)) =>
-          relayer ! AddHtlcFailed(c, error)
-          handleCommandError(error)
+        case Success(Left(error)) => handleCommandAddError(error, origin(c))
         case Failure(cause) => handleCommandError(cause)
       }
 
@@ -451,8 +442,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(fulfill: UpdateFulfillHtlc, d: DATA_NORMAL) =>
       Try(Commitments.receiveFulfill(d.commitments, fulfill)) match {
-        case Success(Right(commitments1)) =>
-          relayer ! ForwardFulfill(fulfill)
+        case Success(Right((commitments1, origin))) =>
+          relayer ! ForwardFulfill(fulfill, origin)
           stay using d.copy(commitments = commitments1)
         case Success(Left(_)) => stay
         case Failure(cause) => handleLocalError(cause, d)
@@ -476,8 +467,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(fail: UpdateFailHtlc, d: DATA_NORMAL) =>
       Try(Commitments.receiveFail(d.commitments, fail)) match {
-        case Success(Right(commitments1)) =>
-          relayer ! ForwardFail(fail)
+        case Success(Right((commitments1, origin))) =>
+          relayer ! ForwardFail(fail, origin)
           stay using d.copy(commitments = commitments1)
         case Success(Left(_)) => stay
         case Failure(cause) => handleLocalError(cause, d)
@@ -485,8 +476,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(fail: UpdateFailMalformedHtlc, d: DATA_NORMAL) =>
       Try(Commitments.receiveFailMalformed(d.commitments, fail)) match {
-        case Success(Right(commitments1)) =>
-          relayer ! ForwardFailMalformed(fail)
+        case Success(Right((commitments1, origin))) =>
+          relayer ! ForwardFailMalformed(fail, origin)
           stay using d.copy(commitments = commitments1)
         case Success(Left(_)) => stay
         case Failure(cause) => handleLocalError(cause, d)
@@ -700,7 +691,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(INPUT_DISCONNECTED, d: DATA_NORMAL) =>
       d.commitments.localChanges.proposed.collect {
-        case add: UpdateAddHtlc => relayer ! AddHtlcDiscarded(add)
+        case add: UpdateAddHtlc => relayer ! ForwardLocalFail(ChannelUnavailable(d.channelId), d.commitments.originChannels(add.id))
       }
       d.shortChannelId match {
         case Some(shortChannelId) =>
@@ -730,11 +721,9 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
    */
 
   when(SHUTDOWN)(handleExceptions {
-    case Event(c: CMD_ADD_HTLC, d: DATA_SHUTDOWN) => {
+    case Event(c: CMD_ADD_HTLC, d: DATA_SHUTDOWN) =>
       val error = ClosingInProgress(d.channelId)
-      relayer ! AddHtlcFailed(c, error)
-      handleCommandError(error)
-    }
+      handleCommandAddError(error, origin(c))
 
     case Event(c: CMD_FULFILL_HTLC, d: DATA_SHUTDOWN) =>
       Try(Commitments.sendFulfill(d.commitments, c)) match {
@@ -746,8 +735,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(fulfill: UpdateFulfillHtlc, d: DATA_SHUTDOWN) =>
       Try(Commitments.receiveFulfill(d.commitments, fulfill)) match {
-        case Success(Right(commitments1)) =>
-          relayer ! ForwardFulfill(fulfill)
+        case Success(Right((commitments1, origin))) =>
+          relayer ! ForwardFulfill(fulfill, origin)
           stay using d.copy(commitments = commitments1)
         case Success(Left(_)) => stay
         case Failure(cause) => handleLocalError(cause, d)
@@ -771,8 +760,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(fail: UpdateFailHtlc, d: DATA_SHUTDOWN) =>
       Try(Commitments.receiveFail(d.commitments, fail)) match {
-        case Success(Right(commitments1)) =>
-          relayer ! ForwardFail(fail)
+        case Success(Right((commitments1, origin))) =>
+          relayer ! ForwardFail(fail, origin)
           stay using d.copy(commitments = commitments1)
         case Success(Left(_)) => stay
         case Failure(cause) => handleLocalError(cause, d)
@@ -780,8 +769,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(fail: UpdateFailMalformedHtlc, d: DATA_SHUTDOWN) =>
       Try(Commitments.receiveFailMalformed(d.commitments, fail)) match {
-        case Success(Right(commitments1)) =>
-          relayer ! ForwardFailMalformed(fail)
+        case Success(Right((commitments1, origin))) =>
+          relayer ! ForwardFailMalformed(fail, origin)
           stay using d.copy(commitments = commitments1)
         case Success(Left(_)) => stay
         case Failure(cause) => handleLocalError(cause, d)
@@ -947,6 +936,49 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
         case Failure(cause) => handleCommandError(cause)
       }
 
+    case Event(WatchEventSpent(BITCOIN_HTLC_SPENT, tx), d: DATA_CLOSING) =>
+      // when a remote or local commitment tx containing outgoing htlcs is published on the network,
+      // we watch it in order to extract payment preimage if funds are pulled by the counterparty
+      // we can then use these preimages to fulfill origin htlcs
+      log.warning(s"processing BITCOIN_HTLC_SPENT with txid=${tx.txid} tx=${Transaction.write(tx)}")
+      require(tx.txIn.size == 1, s"htlc tx should only have 1 input")
+      val witness = tx.txIn(0).witness
+      val extracted = witness match {
+        case ScriptWitness(Seq(localSig, paymentPreimage, htlcOfferedScript)) if paymentPreimage.size == 32 =>
+          log.warning(s"extracted preimage=$paymentPreimage from tx=${Transaction.write(tx)} (claim-htlc-success)")
+          paymentPreimage
+        case ScriptWitness(Seq(BinaryData.empty, remoteSig, localSig, paymentPreimage, htlcReceivedScript)) if paymentPreimage.size == 32 =>
+          log.warning(s"extracted preimage=$paymentPreimage from tx=${Transaction.write(tx)} (htlc-success)")
+          paymentPreimage
+        case ScriptWitness(Seq(BinaryData.empty, remoteSig, localSig, BinaryData.empty, htlcOfferedScript)) =>
+          val paymentHash160 = BinaryData(htlcOfferedScript.slice(109, 109 + 20))
+          log.warning(s"extracted paymentHash160=$paymentHash160 from tx=${Transaction.write(tx)} (htlc-timeout)")
+          paymentHash160
+        case ScriptWitness(Seq(remoteSig, BinaryData.empty, htlcReceivedScript)) =>
+          val paymentHash160 = BinaryData(htlcReceivedScript.slice(69, 69 + 20))
+          log.warning(s"extracted paymentHash160=$paymentHash160 from tx=${Transaction.write(tx)} (claim-htlc-timeout)")
+          paymentHash160
+      }
+      // we only consider htlcs in our local commitment, because we only care about outgoing htlcs, which disappear first in the remote commitment
+      // if an outgoing htlc is in the remote commitment, then:
+      // - either it is in the local commitment (it was never fulfilled)
+      // - or we have already received the fulfill and forwarded it upstream
+      val outgoingHtlcs = d.commitments.localCommit.spec.htlcs.filter(_.direction == OUT).map(_.add)
+      outgoingHtlcs.collect {
+        case add if add.paymentHash == sha256(extracted) =>
+          val origin = d.commitments.originChannels(add.id)
+          log.warning(s"found a match between preimage=$extracted and origin=$origin: htlc was fulfilled")
+          // let's just pretend we received the preimage from the counterparty
+          relayer ! ForwardFulfill(UpdateFulfillHtlc(add.channelId, add.id, extracted), origin)
+        case add if ripemd160(add.paymentHash) == extracted =>
+          val origin = d.commitments.originChannels(add.id)
+          log.warning(s"found a match between paymentHash160=$extracted and origin=$origin: htlc timed out")
+          relayer ! ForwardLocalFail(HtlcTimedout(d.channelId), origin)
+      }
+      // TODO: should we handle local htlcs here as well? currently timed out htlcs that we sent will never have an answer
+      // TODO: we do not handle the case where htlcs transactions end up being unconfirmed this can happen if an htlc-success tx is published right before a htlc timed out
+      stay
+
     case Event(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx: Transaction), d: DATA_CLOSING) if Some(tx.txid) == d.mutualClosePublished.map(_.txid) =>
       // we just published a mutual close tx, we are notified but it's alright
       stay
@@ -1018,8 +1050,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(c: CMD_ADD_HTLC, d: DATA_NORMAL) =>
       log.info(s"rejecting htlc (disconnected)")
-      relayer ! AddHtlcFailed(c, ChannelUnavailable(d.channelId))
-      handleCommandError(ChannelUnavailable(d.channelId))
+      val error = ChannelUnavailable(d.channelId)
+      handleCommandAddError(error, origin(c))
 
     case Event(CMD_CLOSE(_), d: HasCommitments) => handleLocalError(ForcedLocalCommit(d.channelId, "can't do a mutual close while disconnected"), d) replying "ok"
 
@@ -1093,8 +1125,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(c: CMD_ADD_HTLC, d: DATA_NORMAL) =>
       log.info(s"rejecting htlc (syncing)")
-      relayer ! AddHtlcFailed(c, ChannelUnavailable(d.channelId))
-      handleCommandError(ChannelUnavailable(d.channelId))
+      val error = ChannelUnavailable(d.channelId)
+      handleCommandAddError(error, origin(c))
 
     case Event(CMD_CLOSE(_), d: HasCommitments) => handleLocalError(ForcedLocalCommit(d.channelId, "can't do a mutual close while syncing"), d)
 
@@ -1170,6 +1202,15 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
     stay using newData replying "ok"
   }
 
+  def handleCommandAddError(cause: Throwable, origin: Origin) = {
+    relayer ! ForwardLocalFail(cause, origin)
+    cause match {
+      case _: ChannelException => log.error(s"$cause")
+      case _ => log.error(cause, "")
+    }
+    stay
+  }
+
   def handleCommandError(cause: Throwable) = {
     cause match {
       case _: ChannelException => log.error(s"$cause")
@@ -1227,7 +1268,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     // if there is a claim-main-delayed-output tx, we watch it, otherwise we watch the commit tx
     // NB: we do not watch for htlcs txes!!
-    // this may lead to some htlcs not been claimed because the channel will be considered close and deleted before the claiming txes are published
+    // this may lead to some htlcs not been claimed because the channel will be considered closed and deleted before the claiming txes are published
     localCommitPublished.claimMainDelayedOutputTx match {
       case Some(tx) =>
         if (nodeParams.spv) {
@@ -1258,7 +1299,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
         blockchain ! Hint(new BitcoinjScript(localCommitPublished.commitTx.txOut(outpoint.index.toInt).publicKeyScript))
       }
       log.info(s"watching output ${outpoint.index} of commit tx ${outpoint.txid}")
-      blockchain ! WatchSpent(relayer, outpoint.txid, outpoint.index.toInt, BITCOIN_HTLC_SPENT)
+      blockchain ! WatchSpent(self, outpoint.txid, outpoint.index.toInt, BITCOIN_HTLC_SPENT)
     })
   }
 
@@ -1323,7 +1364,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
         blockchain ! Hint(new BitcoinjScript(remoteCommitPublished.commitTx.txOut(outpoint.index.toInt).publicKeyScript))
       }
       log.info(s"watching output ${outpoint.index} of commit tx ${outpoint.txid}")
-      blockchain ! WatchSpent(relayer, outpoint.txid, outpoint.index.toInt, BITCOIN_HTLC_SPENT)
+      blockchain ! WatchSpent(self, outpoint.txid, outpoint.index.toInt, BITCOIN_HTLC_SPENT)
     })
   }
 
@@ -1483,6 +1524,11 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
             goto(CLOSED) sending error
         }
       }
+  }
+
+  def origin(c: CMD_ADD_HTLC): Origin = c.upstream_opt match {
+    case None => Local(Some(sender))
+    case Some(u) => Relayed(u.channelId, u.id)
   }
 
   def store[T](d: T)(implicit tp: T <:< HasCommitments): T = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -282,6 +282,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
             LocalCommit(0, localSpec, PublishableTxs(signedLocalCommitTx, Nil)), RemoteCommit(0, remoteSpec, remoteCommitTx.tx.txid, remoteFirstPerCommitmentPoint),
             LocalChanges(Nil, Nil, Nil), RemoteChanges(Nil, Nil, Nil),
             localNextHtlcId = 0L, remoteNextHtlcId = 0L,
+            originChannels = Map.empty,
             remoteNextCommitInfo = Right(randomKey.publicKey), // we will receive their next per-commitment point in the next message, so we temporarily put a random byte array,
             commitInput, ShaChain.init, channelId = channelId)
           log.info(s"waiting for them to publish the funding tx for channelId=$channelId fundingTxid=${commitInput.outPoint.txid}")
@@ -321,6 +322,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
             LocalCommit(0, localSpec, PublishableTxs(signedLocalCommitTx, Nil)), remoteCommit,
             LocalChanges(Nil, Nil, Nil), RemoteChanges(Nil, Nil, Nil),
             localNextHtlcId = 0L, remoteNextHtlcId = 0L,
+            originChannels = Map.empty,
             remoteNextCommitInfo = Right(randomKey.publicKey), // we will receive their next per-commitment point in the next message, so we temporarily put a random byte array
             commitInput, ShaChain.init, channelId = channelId)
           context.system.eventStream.publish(ChannelSignatureReceived(self, commitments))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1521,7 +1521,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
   def origin(c: CMD_ADD_HTLC): Origin = c.upstream_opt match {
     case None => Local(Some(sender))
-    case Some(u) => Relayed(u.channelId, u.id)
+    case Some(u) => Relayed(u.channelId, u.id, u.amountMsat, c.amountMsat)
   }
 
   def store[T](d: T)(implicit tp: T <:< HasCommitments): T = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -417,7 +417,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
       handleCommandError(error)
     }
 
-    case Event(c@CMD_ADD_HTLC(_, _, _, _, downstream_opt, do_commit), d: DATA_NORMAL) =>
+    case Event(c@CMD_ADD_HTLC(_, _, _, _, downstream_opt, _), d: DATA_NORMAL) =>
       Try(Commitments.sendAdd(d.commitments, c)) match {
         case Success(Right((commitments1, add))) =>
           val origin = downstream_opt match {
@@ -1447,7 +1447,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     // let's now fail all pending htlc for which we are the final payee
     val htlcsToFail = commitments1.remoteCommit.spec.htlcs.collect {
-      case Htlc(OUT, add, _) => add
+      case DirectedHtlc(OUT, add) => add
     }.filter {
       case add =>
         Try(Sphinx.parsePacket(nodeParams.privateKey, add.paymentHash, add.onionRoutingPacket))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PreimagesDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PreimagesDb.scala
@@ -1,0 +1,26 @@
+package fr.acinq.eclair.db
+
+import fr.acinq.bitcoin.BinaryData
+import fr.acinq.eclair.channel.HasCommitments
+
+/**
+  * This database stores the preimages that we have received from downstream
+  * (either directly via UpdateFulfillHtlc or by extracting the value from the
+  * blockchain).
+  *
+  * This means that this database is only used in the context of *relaying* payments.
+  *
+  * We need to be sure that if downstream is able to pulls funds from us, we can always
+  * do the same from upstream, otherwise we lose money. Hence the need for persistence
+  * to handle all corner cases.
+  *
+  */
+trait PreimagesDb {
+
+  def addPreimage(channelId: BinaryData, htlcId: Long, paymentPreimage: BinaryData)
+
+  def removePreimage(channelId: BinaryData, htlcId: Long)
+
+  def listPreimages(channelId: BinaryData): List[(BinaryData, Long, BinaryData)]
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -30,9 +30,13 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb {
   }
 
   override def removeChannel(channelId: BinaryData): Unit = {
-    val statement = sqlite.prepareStatement("DELETE FROM local_channels WHERE channel_id=?")
-    statement.setBytes(1, channelId)
-    statement.executeUpdate()
+    val statement1 = sqlite.prepareStatement("DELETE FROM preimages WHERE channel_id=?")
+    statement1.setBytes(1, channelId)
+    statement1.executeUpdate()
+
+    val statement2 = sqlite.prepareStatement("DELETE FROM local_channels WHERE channel_id=?")
+    statement2.setBytes(1, channelId)
+    statement2.executeUpdate()
   }
 
   override def listChannels(): List[HasCommitments] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePreimagesDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePreimagesDb.scala
@@ -1,0 +1,41 @@
+package fr.acinq.eclair.db.sqlite
+
+import java.sql.Connection
+
+import fr.acinq.bitcoin.BinaryData
+import fr.acinq.eclair.db.PreimagesDb
+
+class SqlitePreimagesDb(sqlite: Connection) extends PreimagesDb {
+
+  {
+    val statement = sqlite.createStatement
+    // note: should we use a foreign key to local_channels table here?
+    statement.executeUpdate("CREATE TABLE IF NOT EXISTS preimages (channel_id BLOB NOT NULL, htlc_id INTEGER NOT NULL, preimage BLOB NOT NULL, PRIMARY KEY(channel_id, htlc_id))")
+  }
+
+  override def addPreimage(channelId: BinaryData, htlcId: Long, paymentPreimage: BinaryData): Unit = {
+    val statement = sqlite.prepareStatement("INSERT OR IGNORE INTO preimages VALUES (?, ?, ?)")
+    statement.setBytes(1, channelId)
+    statement.setLong(2, htlcId)
+    statement.setBytes(3, paymentPreimage)
+    statement.executeUpdate()
+  }
+
+  override def removePreimage(channelId: BinaryData, htlcId: Long): Unit = {
+    val statement = sqlite.prepareStatement("DELETE FROM preimages WHERE channel_id=? AND htlc_id=?")
+    statement.setBytes(1, channelId)
+    statement.setLong(2, htlcId)
+    statement.executeUpdate()
+  }
+
+  override def listPreimages(channelId: BinaryData): List[(BinaryData, Long, BinaryData)] = {
+    val statement = sqlite.prepareStatement("SELECT htlc_id, preimage FROM preimages WHERE channel_id=?")
+    statement.setBytes(1, channelId)
+    val rs = statement.executeQuery()
+    var l: List[(BinaryData, Long, BinaryData)] = Nil
+    while (rs.next()) {
+      l = l :+ (channelId, rs.getLong("htlc_id"), BinaryData(rs.getBytes("preimage")))
+    }
+    l
+  }
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -11,6 +11,6 @@ sealed trait PaymentEvent {
 
 case class PaymentSent(amount: MilliSatoshi, feesPaid: MilliSatoshi, paymentHash: BinaryData) extends PaymentEvent
 
-case class PaymentRelayed(amount: MilliSatoshi, feesEarned: MilliSatoshi, paymentHash: BinaryData) extends PaymentEvent
+case class PaymentRelayed(amountIn: MilliSatoshi, amountOut: MilliSatoshi, paymentHash: BinaryData) extends PaymentEvent
 
 case class PaymentReceived(amount: MilliSatoshi, paymentHash: BinaryData) extends PaymentEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Relayer.scala
@@ -20,6 +20,10 @@ sealed trait Origin
 case class Local(sender: ActorRef) extends Origin
 case class Relayed(upstream: ActorRef, htlcIn: UpdateAddHtlc) extends Origin
 
+sealed trait Origin2
+case object Local2 extends Origin2
+case class Relayed2(originChannelId: BinaryData, originHtlcId: Long) extends Origin2
+
 case class AddHtlcSucceeded(add: UpdateAddHtlc, origin: Origin)
 case class AddHtlcFailed(add: CMD_ADD_HTLC, error: ChannelException)
 case class AddHtlcDiscarded(add: UpdateAddHtlc) // dropped because of disconnection

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Relayer.scala
@@ -1,13 +1,12 @@
 package fr.acinq.eclair.payment
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props, Status}
-import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{BinaryData, Crypto}
-import fr.acinq.eclair.Globals
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire._
+import fr.acinq.eclair.{Globals, NodeParams}
 import scodec.bits.BitVector
 import scodec.{Attempt, DecodeResult}
 
@@ -25,47 +24,41 @@ case class ForwardLocalFail(error: Throwable, to: Origin) // happens when the fa
 case class ForwardFail(fail: UpdateFailHtlc, to: Origin)
 case class ForwardFailMalformed(fail: UpdateFailMalformedHtlc, to: Origin)
 
+case class AckFulfillCmd(channelId: BinaryData, htlcId: Long)
+
 // @formatter:on
 
 
 /**
   * Created by PM on 01/02/2017.
   */
-class Relayer(nodeSecret: PrivateKey, paymentHandler: ActorRef) extends Actor with ActorLogging {
+class Relayer(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorRef) extends Actor with ActorLogging {
+
+  import nodeParams.preimagesDb
 
   context.system.eventStream.subscribe(self, classOf[ChannelStateChanged])
-  context.system.eventStream.subscribe(self, classOf[ShortChannelIdAssigned])
 
-  override def receive: Receive = main(Map(), Map(), Map())
+  override def receive: Receive = main(Map())
 
-  def shortId2Channel(channels: Map[BinaryData, ActorRef], shortIds: Map[Long, BinaryData], shortId: Long): Option[ActorRef] = shortIds.get(shortId).flatMap(channels.get(_))
+  def main(channelUpdates: Map[Long, ChannelUpdate]): Receive = {
 
-  def main(channels: Map[BinaryData, ActorRef], shortIds: Map[Long, BinaryData], channelUpdates: Map[Long, ChannelUpdate]): Receive = {
-
-    case ChannelStateChanged(channel, _, _, _, NORMAL, d: DATA_NORMAL) =>
-      import d.commitments.channelId
-      log.info(s"adding channel $channelId to available channels")
-      context become main(channels + (channelId -> channel), shortIds, channelUpdates)
-
-    case ChannelStateChanged(_, _, _, _, NEGOTIATING, d: DATA_NEGOTIATING) =>
-      import d.commitments.channelId
-      log.info(s"removing channel $channelId from available channels")
-      context become main(channels - channelId, shortIds, channelUpdates)
-
-    case ChannelStateChanged(_, _, _, _, CLOSING, d: DATA_CLOSING) =>
-      import d.commitments.channelId
-      log.info(s"removing channel $channelId from available channels")
-      context become main(channels - channelId, shortIds, channelUpdates)
-
-    case ShortChannelIdAssigned(_, channelId, shortChannelId) =>
-      context become main(channels, shortIds + (shortChannelId -> channelId), channelUpdates)
+    case ChannelStateChanged(channel, _, _, _, NORMAL | SHUTDOWN | CLOSING, d: HasCommitments) =>
+      import d.channelId
+      preimagesDb.listPreimages(channelId) match {
+        case Nil => {}
+        case preimages =>
+          log.info(s"re-sending ${preimages.size} unacked fulfills to channel $channelId")
+          preimages.map(p => CMD_FULFILL_HTLC(p._2, p._3, commit = false)).foreach(channel ! _)
+          // better to sign once instead of after each fulfill
+          channel ! CMD_SIGN
+      }
 
     case channelUpdate: ChannelUpdate =>
       log.info(s"updating relay parameters with channelUpdate=$channelUpdate")
-      context become main(channels, shortIds, channelUpdates + (channelUpdate.shortChannelId -> channelUpdate))
+      context become main(channelUpdates + (channelUpdate.shortChannelId -> channelUpdate))
 
     case ForwardAdd(add) =>
-      Try(Sphinx.parsePacket(nodeSecret, add.paymentHash, add.onionRoutingPacket))
+      Try(Sphinx.parsePacket(nodeParams.privateKey, add.paymentHash, add.onionRoutingPacket))
         .map {
           case Sphinx.ParsedPacket(payload, nextPacket, sharedSecret) => (LightningMessageCodecs.perHopPayloadCodec.decode(BitVector(payload.data)), nextPacket, sharedSecret)
         } match {
@@ -82,28 +75,22 @@ class Relayer(nodeSecret: PrivateKey, paymentHandler: ActorRef) extends Actor wi
               paymentHandler forward add
           }
         case Success((Attempt.Successful(DecodeResult(perHopPayload, _)), nextPacket, _)) =>
-          shortId2Channel(channels, shortIds, perHopPayload.channel_id) match {
-            case Some(downstream) =>
-              val channelUpdate_opt = channelUpdates.get(perHopPayload.channel_id)
-              channelUpdate_opt match {
-                case None =>
-                  // TODO: clarify what we're supposed to do in the specs
-                  sender ! CMD_FAIL_HTLC(add.id, Right(TemporaryNodeFailure), commit = true)
-                case Some(channelUpdate) if !Announcements.isEnabled(channelUpdate.flags) =>
-                  sender ! CMD_FAIL_HTLC(add.id, Right(ChannelDisabled(channelUpdate.flags, channelUpdate)), commit = true)
-                case Some(channelUpdate) if add.amountMsat < channelUpdate.htlcMinimumMsat =>
-                  sender ! CMD_FAIL_HTLC(add.id, Right(AmountBelowMinimum(add.amountMsat, channelUpdate)), commit = true)
-                case Some(channelUpdate) if add.expiry != perHopPayload.outgoingCltvValue + channelUpdate.cltvExpiryDelta =>
-                  sender ! CMD_FAIL_HTLC(add.id, Right(IncorrectCltvExpiry(add.expiry, channelUpdate)), commit = true)
-                case Some(channelUpdate) if add.expiry < Globals.blockCount.get() + 3 => // TODO: hardcoded value
-                  sender ! CMD_FAIL_HTLC(add.id, Right(ExpiryTooSoon(channelUpdate)), commit = true)
-                case _ =>
-                  log.info(s"forwarding htlc #${add.id} to downstream=$downstream")
-                  downstream forward CMD_ADD_HTLC(perHopPayload.amtToForward, add.paymentHash, perHopPayload.outgoingCltvValue, nextPacket.serialize, upstream_opt = Some(add), commit = true)
-              }
+          val channelUpdate_opt = channelUpdates.get(perHopPayload.channel_id)
+          channelUpdate_opt match {
             case None =>
-              log.warning(s"couldn't resolve downstream channel ${perHopPayload.channel_id}, failing htlc #${add.id}")
-              sender ! CMD_FAIL_HTLC(add.id, Right(UnknownNextPeer), commit = true)
+              // TODO: clarify what we're supposed to do in the specs
+              sender ! CMD_FAIL_HTLC(add.id, Right(TemporaryNodeFailure), commit = true)
+            case Some(channelUpdate) if !Announcements.isEnabled(channelUpdate.flags) =>
+              sender ! CMD_FAIL_HTLC(add.id, Right(ChannelDisabled(channelUpdate.flags, channelUpdate)), commit = true)
+            case Some(channelUpdate) if add.amountMsat < channelUpdate.htlcMinimumMsat =>
+              sender ! CMD_FAIL_HTLC(add.id, Right(AmountBelowMinimum(add.amountMsat, channelUpdate)), commit = true)
+            case Some(channelUpdate) if add.expiry != perHopPayload.outgoingCltvValue + channelUpdate.cltvExpiryDelta =>
+              sender ! CMD_FAIL_HTLC(add.id, Right(IncorrectCltvExpiry(add.expiry, channelUpdate)), commit = true)
+            case Some(channelUpdate) if add.expiry < Globals.blockCount.get() + 3 => // TODO: hardcoded value
+              sender ! CMD_FAIL_HTLC(add.id, Right(ExpiryTooSoon(channelUpdate)), commit = true)
+            case _ =>
+              log.info(s"forwarding htlc #${add.id} to shortChannelId=${perHopPayload.channel_id}")
+              register forward Register.ForwardShortId(perHopPayload.channel_id, CMD_ADD_HTLC(perHopPayload.amtToForward, add.paymentHash, perHopPayload.outgoingCltvValue, nextPacket.serialize, upstream_opt = Some(add), commit = true))
           }
         case Success((Attempt.Failure(cause), _, _)) =>
           log.error(s"couldn't parse payload: $cause")
@@ -114,13 +101,23 @@ class Relayer(nodeSecret: PrivateKey, paymentHandler: ActorRef) extends Actor wi
           sender ! CMD_FAIL_MALFORMED_HTLC(add.id, Crypto.sha256(add.onionRoutingPacket), failureCode = FailureMessageCodecs.BADONION, commit = true)
       }
 
+    case Register.ForwardShortIdFailure(Register.ForwardShortId(shortChannelId, CMD_ADD_HTLC(_, _, _, _, Some(add), _))) =>
+      log.warning(s"couldn't resolve downstream channel $shortChannelId, failing htlc #${add.id}")
+      register ! Register.Forward(add.channelId, CMD_FAIL_HTLC(add.id, Right(UnknownNextPeer), commit = true))
+
     case ForwardFulfill(fulfill, Local(Some(sender))) =>
       sender ! fulfill
 
     case ForwardFulfill(fulfill, Relayed(originChannelId, originHtlcId)) =>
       val cmd = CMD_FULFILL_HTLC(originHtlcId, fulfill.paymentPreimage, commit = true)
       //context.system.eventStream.publish(PaymentRelayed(MilliSatoshi(htlcIn.amountMsat), MilliSatoshi(htlcIn.amountMsat - htlcOut.amountMsat), htlcIn.paymentHash))
-      forward(cmd, originChannelId, channels)
+      register ! Register.Forward(originChannelId, cmd)
+      // we also store the preimage in a db (note that this happens *after* forwarding the fulfill to the channel, so we don't add latency)
+      preimagesDb.addPreimage(originChannelId, originHtlcId, fulfill.paymentPreimage)
+
+    case AckFulfillCmd(channelId, htlcId) =>
+      log.debug(s"fulfill acked for channelId=$channelId htlcId=$htlcId")
+      preimagesDb.removePreimage(channelId, htlcId)
 
     case ForwardLocalFail(error, Local(Some(sender))) =>
       sender ! Status.Failure(error)
@@ -129,45 +126,28 @@ class Relayer(nodeSecret: PrivateKey, paymentHandler: ActorRef) extends Actor wi
       // TODO: clarify what we're supposed to do in the specs depending on the error
       val failure = error match {
         case HtlcTimedout(_) => PermanentChannelFailure
-        case _ =>
-          val channelUpdate_opt = for {
-            channelId <- channels.map(_.swap).get(sender)
-            shortId <- shortIds.map(_.swap).get(channelId)
-            update <- channelUpdates.get(shortId)
-          } yield update
-          // detail errors are caught before relaying the htlc to the downstream channel, here we just return generic error messages
-          channelUpdate_opt match {
-            case None => TemporaryNodeFailure
-            case Some(channelUpdate) => TemporaryChannelFailure(channelUpdate)
-          }
+        case _ => TemporaryNodeFailure
       }
       val cmd = CMD_FAIL_HTLC(originHtlcId, Right(failure), commit = true)
-      forward(cmd, originChannelId, channels)
+      register ! Register.Forward(originChannelId, cmd)
 
     case ForwardFail(fail, Local(Some(sender))) =>
       sender ! fail
 
     case ForwardFail(fail, Relayed(originChannelId, originHtlcId)) =>
       val cmd = CMD_FAIL_HTLC(originHtlcId, Left(fail.reason), commit = true)
-      forward(cmd, originChannelId, channels)
+      register ! Register.Forward(originChannelId, cmd)
 
     case ForwardFailMalformed(fail, Local(Some(sender))) =>
       sender ! fail
 
     case ForwardFailMalformed(fail, Relayed(originChannelId, originHtlcId)) =>
       val cmd = CMD_FAIL_MALFORMED_HTLC(originHtlcId, fail.onionHash, fail.failureCode, commit = true)
-      forward(cmd, originChannelId, channels)
-
-    case 'channels => sender ! channels
-  }
-
-  def forward(cmd: Command, originChannelId: BinaryData, channels: Map[BinaryData, ActorRef]) = channels.get(originChannelId) match {
-    case Some(channel) => channel ! cmd
-    case None => log.warning(s"couldn't resolve originChannelId=$originChannelId")
+      register ! Register.Forward(originChannelId, cmd)
   }
 
 }
 
 object Relayer {
-  def props(nodeSecret: PrivateKey, paymentHandler: ActorRef) = Props(classOf[Relayer], nodeSecret: PrivateKey, paymentHandler)
+  def props(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorRef) = Props(classOf[Relayer], nodeParams, register, paymentHandler)
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/CommitmentSpec.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/CommitmentSpec.scala
@@ -13,9 +13,9 @@ case object IN extends Direction { def opposite = OUT }
 case object OUT extends Direction { def opposite = IN }
 // @formatter:on
 
-case class Htlc(direction: Direction, add: UpdateAddHtlc, val previousChannelId: Option[BinaryData])
+case class DirectedHtlc(direction: Direction, add: UpdateAddHtlc)
 
-final case class CommitmentSpec(htlcs: Set[Htlc], feeratePerKw: Long, toLocalMsat: Long, toRemoteMsat: Long) {
+final case class CommitmentSpec(htlcs: Set[DirectedHtlc], feeratePerKw: Long, toLocalMsat: Long, toRemoteMsat: Long) {
   val totalFunds = toLocalMsat + toRemoteMsat + htlcs.toSeq.map(_.add.amountMsat).sum
 }
 
@@ -26,7 +26,7 @@ object CommitmentSpec {
   })
 
   def addHtlc(spec: CommitmentSpec, direction: Direction, update: UpdateAddHtlc): CommitmentSpec = {
-    val htlc = Htlc(direction, update, previousChannelId = None)
+    val htlc = DirectedHtlc(direction, update)
     direction match {
       case OUT => spec.copy(toLocalMsat = spec.toLocalMsat - htlc.add.amountMsat, htlcs = spec.htlcs + htlc)
       case IN => spec.copy(toRemoteMsat = spec.toRemoteMsat - htlc.add.amountMsat, htlcs = spec.htlcs + htlc)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -73,7 +73,7 @@ object Transactions {
 
   def weight2fee(feeratePerKw: Long, weight: Int) = Satoshi((feeratePerKw * weight) / 1000)
 
-  def trimOfferedHtlcs(dustLimit: Satoshi, spec: CommitmentSpec): Seq[Htlc] = {
+  def trimOfferedHtlcs(dustLimit: Satoshi, spec: CommitmentSpec): Seq[DirectedHtlc] = {
     val htlcTimeoutFee = weight2fee(spec.feeratePerKw, htlcTimeoutWeight)
     spec.htlcs
       .filter(_.direction == OUT)
@@ -81,7 +81,7 @@ object Transactions {
       .toSeq
   }
 
-  def trimReceivedHtlcs(dustLimit: Satoshi, spec: CommitmentSpec): Seq[Htlc] = {
+  def trimReceivedHtlcs(dustLimit: Satoshi, spec: CommitmentSpec): Seq[DirectedHtlc] = {
     val htlcSuccessFee = weight2fee(spec.feeratePerKw, htlcSuccessWeight)
     spec.htlcs
       .filter(_.direction == IN)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
@@ -53,10 +53,9 @@ object ChannelCodecs {
     (wire: BitVector) => bool.decode(wire).map(_.map(b => if (b) IN else OUT))
   )
 
-  val htlcCodec: Codec[Htlc] = (
+  val htlcCodec: Codec[DirectedHtlc] = (
     ("direction" | directionCodec) ::
-      ("add" | updateAddHtlcCodec) ::
-      ("previousChannelId" | optional(bool, varsizebinarydata))).as[Htlc]
+      ("add" | updateAddHtlcCodec)).as[DirectedHtlc]
 
   def setCodec[T](codec: Codec[T]): Codec[Set[T]] = Codec[Set[T]](
     (elems: Set[T]) => listOfN(uint16, codec).encode(elems.toList),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
@@ -3,7 +3,7 @@ package fr.acinq.eclair.wire
 import fr.acinq.bitcoin.{OutPoint, Transaction, TxOut}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.ShaChain
-import fr.acinq.eclair.payment.{Local2, Origin2, Relayed2}
+import fr.acinq.eclair.payment.{Local, Origin, Relayed}
 import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.transactions._
 import fr.acinq.eclair.wire.LightningMessageCodecs._
@@ -130,14 +130,14 @@ object ChannelCodecs {
       ("sentAfterLocalCommitIndex" | uint64) ::
       ("reSignAsap" | bool)).as[WaitingForRevocation]
 
-  val origin: Codec[Origin2] = discriminated[Origin2].by(uint16)
-    .typecase(0x01, provide(Local2))
-    .typecase(0x02, (("originChannelId" | binarydata(32)) :: ("originHtlcId" | int64)).as[Relayed2])
+  val origin: Codec[Origin] = discriminated[Origin].by(uint16)
+    .typecase(0x01, provide(Local(None)))
+    .typecase(0x02, (("originChannelId" | binarydata(32)) :: ("originHtlcId" | int64)).as[Relayed])
 
-  val originsList: Codec[List[(Long, Origin2)]] = listOfN(uint16, int64 ~ origin)
+  val originsList: Codec[List[(Long, Origin)]] = listOfN(uint16, int64 ~ origin)
 
-  val originsMap: Codec[Map[Long, Origin2]] = Codec[Map[Long, Origin2]](
-    (map: Map[Long, Origin2]) => originsList.encode(map.toList),
+  val originsMap: Codec[Map[Long, Origin]] = Codec[Map[Long, Origin]](
+    (map: Map[Long, Origin]) => originsList.encode(map.toList),
     (wire: BitVector) => originsList.decode(wire).map(_.map(_.toMap))
   )
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -5,7 +5,8 @@ import java.sql.DriverManager
 
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{BinaryData, Block, DeterministicWallet, Script}
-import fr.acinq.eclair.db.sqlite.{SqliteChannelsDb, SqliteNetworkDb, SqlitePeersDb}
+import fr.acinq.eclair.TestConstants.Alice.sqlite
+import fr.acinq.eclair.db.sqlite.{SqliteChannelsDb, SqliteNetworkDb, SqlitePeersDb, SqlitePreimagesDb}
 import fr.acinq.eclair.io.Peer
 
 import scala.concurrent.duration._
@@ -46,6 +47,7 @@ object TestConstants {
       channelsDb = new SqliteChannelsDb(sqlite),
       peersDb = new SqlitePeersDb(sqlite),
       networkDb = new SqliteNetworkDb(sqlite),
+      preimagesDb = new SqlitePreimagesDb(sqlite),
       routerBroadcastInterval = 60 seconds,
       routerValidateInterval = 2 seconds,
       pingInterval = 30 seconds,
@@ -94,6 +96,7 @@ object TestConstants {
       channelsDb = new SqliteChannelsDb(sqlite),
       peersDb = new SqlitePeersDb(sqlite),
       networkDb = new SqliteNetworkDb(sqlite),
+      preimagesDb = new SqlitePreimagesDb(sqlite),
       routerBroadcastInterval = 60 seconds,
       routerValidateInterval = 2 seconds,
       pingInterval = 30 seconds,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzyPipe.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzyPipe.scala
@@ -56,6 +56,6 @@ class FuzzyPipe(fuzzy: Boolean) extends Actor with Stash with ActorLogging {
       log.debug("RECONNECTED")
       a ! INPUT_RECONNECTED(self)
       b ! INPUT_RECONNECTED(self)
-      context become connected(a, b, Random.nextInt(20))
+      context become connected(a, b, Random.nextInt(40))
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -36,8 +36,10 @@ class FuzzySpec extends TestkitBaseClass with StateTestsHelperMethods with Loggi
     val bob2blockchain = TestProbe()
     val paymentHandlerA = system.actorOf(Props(new LocalPaymentHandler(Alice.nodeParams)))
     val paymentHandlerB = system.actorOf(Props(new LocalPaymentHandler(Bob.nodeParams)))
-    val relayerA = system.actorOf(Relayer.props(Alice.nodeParams.privateKey, paymentHandlerA))
-    val relayerB = system.actorOf(Relayer.props(Bob.nodeParams.privateKey, paymentHandlerB))
+    val registerA = TestProbe()
+    val registerB = TestProbe()
+    val relayerA = system.actorOf(Relayer.props(Alice.nodeParams, registerA.ref, paymentHandlerA))
+    val relayerB = system.actorOf(Relayer.props(Bob.nodeParams, registerB.ref, paymentHandlerB))
     val router = TestProbe()
     val wallet = new TestWallet
     val alice: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(Alice.nodeParams, wallet, Bob.id, alice2blockchain.ref, router.ref, relayerA))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -30,7 +30,7 @@ class FuzzySpec extends TestkitBaseClass with StateTestsHelperMethods with Loggi
   type FixtureParam = Tuple7[TestFSMRef[State, Data, Channel], TestFSMRef[State, Data, Channel], ActorRef, ActorRef, ActorRef, ActorRef, ActorRef]
 
   override def withFixture(test: OneArgTest) = {
-    val fuzzy = tags.contains("fuzzy")
+    val fuzzy = test.tags.contains("fuzzy")
     val pipe = system.actorOf(Props(new FuzzyPipe(fuzzy)))
     val alice2blockchain = TestProbe()
     val bob2blockchain = TestProbe()
@@ -107,15 +107,9 @@ class FuzzySpec extends TestkitBaseClass with StateTestsHelperMethods with Loggi
       case Status.Failure(t) =>
         log.error(s"htlc error: ${t.getMessage}")
         initiatePayment(stopping)
-      case 'cancelled =>
-        log.warning(s"our htlc was cancelled!")
-        // htlc was dropped because of a disconnection
-        initiatePayment(stopping)
       case 'stop =>
         log.warning(s"stopping...")
         context become waitingForFulfill(true)
-
-
     }
 
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/ThroughputSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/ThroughputSpec.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicLong
 
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.testkit.TestProbe
 import fr.acinq.bitcoin.{BinaryData, Crypto}
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair._
@@ -52,8 +53,10 @@ class ThroughputSpec extends FunSuite {
           context.become(run(h2r - htlc.paymentHash))
       }
     }), "payment-handler")
-    val relayerA = system.actorOf(Relayer.props(Alice.nodeParams.privateKey, paymentHandler))
-    val relayerB = system.actorOf(Relayer.props(Bob.nodeParams.privateKey, paymentHandler))
+    val registerA = TestProbe()
+    val registerB = TestProbe()
+    val relayerA = system.actorOf(Relayer.props(Alice.nodeParams, registerA.ref, paymentHandler))
+    val relayerB = system.actorOf(Relayer.props(Bob.nodeParams, registerB.ref, paymentHandler))
     val wallet = new TestWallet
     val alice = system.actorOf(Channel.props(Alice.nodeParams, wallet, Bob.id, blockchain, ???, relayerA), "a")
     val bob = system.actorOf(Channel.props(Bob.nodeParams, wallet, Alice.id, blockchain, ???, relayerB), "b")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -84,7 +84,7 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
         commitments = initialState.commitments.copy(
           localNextHtlcId = 1,
           localChanges = initialState.commitments.localChanges.copy(proposed = htlc :: Nil),
-          originChannels = Map(0L -> Relayed(originHtlc.channelId, originHtlc.id))
+          originChannels = Map(0L -> Relayed(originHtlc.channelId, originHtlc.id, originHtlc.amountMsat, htlc.amountMsat))
         )))
     }
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -50,7 +50,8 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       awaitCond(alice.stateData == initialState.copy(
         commitments = initialState.commitments.copy(
           localNextHtlcId = 1,
-          localChanges = initialState.commitments.localChanges.copy(proposed = htlc :: Nil)
+          localChanges = initialState.commitments.localChanges.copy(proposed = htlc :: Nil),
+          originChannels = Map(0L -> Local2)
         )))
       relayer.expectMsg(AddHtlcSucceeded(htlc, origin = Local(sender.ref)))
     }
@@ -84,7 +85,8 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       awaitCond(alice.stateData == initialState.copy(
         commitments = initialState.commitments.copy(
           localNextHtlcId = 1,
-          localChanges = initialState.commitments.localChanges.copy(proposed = htlc :: Nil)
+          localChanges = initialState.commitments.localChanges.copy(proposed = htlc :: Nil),
+          originChannels = Map(0L -> Relayed2(originHtlc.channelId, originHtlc.id))
         )))
       relayer.expectMsg(AddHtlcSucceeded(htlc, origin = Relayed(sender.ref, originHtlc)))
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -7,8 +7,7 @@ import fr.acinq.bitcoin.{BinaryData, Crypto, Satoshi, ScriptFlags, Transaction}
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.channel.{Data, State, _}
-import fr.acinq.eclair.payment.PaymentLifecycle
-import fr.acinq.eclair.payment.Hop
+import fr.acinq.eclair.payment._
 import fr.acinq.eclair.wire.{CommitSig, Error, FailureMessageCodecs, PermanentChannelFailure, RevokeAndAck, Shutdown, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFee, UpdateFulfillHtlc}
 import fr.acinq.eclair.{Globals, TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
@@ -22,7 +21,7 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple6[TestFSMRef[State, Data, Channel], TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe, TestProbe]
+  type FixtureParam = Tuple7[TestFSMRef[State, Data, Channel], TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe, TestProbe, TestProbe]
 
   override def withFixture(test: OneArgTest) = {
     val setup = init()
@@ -38,6 +37,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       val cmd1 = PaymentLifecycle.buildCommand(amount1, expiry1, h1, Hop(null, TestConstants.Bob.nodeParams.privateKey.publicKey, null) :: Nil)._1.copy(commit = false)
       sender.send(alice, cmd1)
       sender.expectMsg("ok")
+      relayer.expectMsgType[AddHtlcSucceeded]
       val htlc1 = alice2bob.expectMsgType[UpdateAddHtlc]
       alice2bob.forward(bob)
       awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteChanges.proposed == htlc1 :: Nil)
@@ -49,6 +49,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       val cmd2 = PaymentLifecycle.buildCommand(amount2, expiry2, h2, Hop(null, TestConstants.Bob.nodeParams.privateKey.publicKey, null) :: Nil)._1.copy(commit = false)
       sender.send(alice, cmd2)
       sender.expectMsg("ok")
+      relayer.expectMsgType[AddHtlcSucceeded]
       val htlc2 = alice2bob.expectMsgType[UpdateAddHtlc]
       alice2bob.forward(bob)
       awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteChanges.proposed == htlc1 :: htlc2 :: Nil)
@@ -64,6 +65,8 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       bob2alice.forward(alice)
       alice2bob.expectMsgType[RevokeAndAck]
       alice2bob.forward(bob)
+      relayer.expectMsgType[ForwardAdd]
+      relayer.expectMsgType[ForwardAdd]
       // alice initiates a closing
       sender.send(alice, CMD_CLOSE(None))
       alice2bob.expectMsgType[Shutdown]
@@ -72,11 +75,23 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       bob2alice.forward(alice)
       awaitCond(alice.stateName == SHUTDOWN)
       awaitCond(bob.stateName == SHUTDOWN)
-      test((alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain))
+      test((alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer))
     }
   }
 
-  test("recv CMD_FULFILL_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _) =>
+  test("recv CMD_ADD_HTLC") { case (alice, _, alice2bob, _, _, _, relayer) =>
+    within(30 seconds) {
+      val sender = TestProbe()
+      val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 300000)
+      sender.send(alice, add)
+      val error = ClosingInProgress(channelId(alice))
+      sender.expectMsg(Failure(error))
+      relayer.expectMsg(AddHtlcFailed(add, error))
+      alice2bob.expectNoMsg(200 millis)
+    }
+  }
+
+  test("recv CMD_FULFILL_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -89,7 +104,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_FULFILL_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _) =>
+  test("recv CMD_FULFILL_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -99,7 +114,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_FULFILL_HTLC (invalid preimage)") { case (_, bob, _, _, _, _) =>
+  test("recv CMD_FULFILL_HTLC (invalid preimage)") { case (_, bob, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -109,7 +124,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFulfillHtlc") { case (alice, _, _, _, _, _) =>
+  test("recv UpdateFulfillHtlc") { case (alice, _, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -119,7 +134,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFulfillHtlc (unknown htlc id)") { case (alice, _, alice2bob, _, alice2blockchain, _) =>
+  test("recv UpdateFulfillHtlc (unknown htlc id)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
     within(30 seconds) {
       val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       val sender = TestProbe()
@@ -132,7 +147,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFulfillHtlc (invalid preimage)") { case (alice, _, alice2bob, _, alice2blockchain, _) =>
+  test("recv UpdateFulfillHtlc (invalid preimage)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
     within(30 seconds) {
       val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       val sender = TestProbe()
@@ -144,7 +159,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_FAIL_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _) =>
+  test("recv CMD_FAIL_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -157,7 +172,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_FAIL_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _) =>
+  test("recv CMD_FAIL_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -167,7 +182,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_FAIL_MALFORMED_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _) =>
+  test("recv CMD_FAIL_MALFORMED_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -180,7 +195,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_FAIL_MALFORMED_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _) =>
+  test("recv CMD_FAIL_MALFORMED_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -190,7 +205,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_FAIL_HTLC (invalid failure_code)") { case (_, bob, _, _, _, _) =>
+  test("recv CMD_FAIL_HTLC (invalid failure_code)") { case (_, bob, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -200,7 +215,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFailHtlc") { case (alice, _, _, _, _, _) =>
+  test("recv UpdateFailHtlc") { case (alice, _, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -210,7 +225,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFailHtlc (unknown htlc id)") { case (alice, _, alice2bob, _, alice2blockchain, _) =>
+  test("recv UpdateFailHtlc (unknown htlc id)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
     within(30 seconds) {
       val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       val sender = TestProbe()
@@ -222,7 +237,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFailMalformedHtlc") { case (alice, _, _, _, _, _) =>
+  test("recv UpdateFailMalformedHtlc") { case (alice, _, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -232,7 +247,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFailMalformedHtlc (invalid failure_code)") { case (alice, _, alice2bob, _, alice2blockchain, _) =>
+  test("recv UpdateFailMalformedHtlc (invalid failure_code)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
@@ -246,7 +261,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_SIGN") { case (alice, bob, alice2bob, bob2alice, _, _) =>
+  test("recv CMD_SIGN") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       // we need to have something to sign so we first send a fulfill and acknowledge (=sign) it
@@ -265,7 +280,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_SIGN (no changes)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _) =>
+  test("recv CMD_SIGN (no changes)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       sender.send(alice, CMD_SIGN)
@@ -274,7 +289,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_SIGN (while waiting for RevokeAndAck)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _) =>
+  test("recv CMD_SIGN (while waiting for RevokeAndAck)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
@@ -294,7 +309,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CommitSig") { case (alice, bob, alice2bob, bob2alice, _, _) =>
+  test("recv CommitSig") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
@@ -309,7 +324,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CommitSig (no changes)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain) =>
+  test("recv CommitSig (no changes)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
     within(30 seconds) {
       val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       val sender = TestProbe()
@@ -322,7 +337,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CommitSig (invalid signature)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain) =>
+  test("recv CommitSig (invalid signature)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
     within(30 seconds) {
       val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       val sender = TestProbe()
@@ -334,7 +349,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv RevokeAndAck (with remaining htlcs on both sides)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain) =>
+  test("recv RevokeAndAck (with remaining htlcs on both sides)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
     within(30 seconds) {
       fulfillHtlc(1, "22" * 32, bob, alice, bob2alice, alice2bob)
       // this will cause alice and bob to receive RevokeAndAcks
@@ -346,7 +361,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv RevokeAndAck (with remaining htlcs on one side)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain) =>
+  test("recv RevokeAndAck (with remaining htlcs on one side)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
     within(30 seconds) {
       fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
       fulfillHtlc(1, "22" * 32, bob, alice, bob2alice, alice2bob)
@@ -364,7 +379,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv RevokeAndAck (no more htlcs on either side)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain) =>
+  test("recv RevokeAndAck (no more htlcs on either side)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
     within(30 seconds) {
       fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
       fulfillHtlc(1, "22" * 32, bob, alice, bob2alice, alice2bob)
@@ -374,7 +389,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv RevokeAndAck (invalid preimage)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain) =>
+  test("recv RevokeAndAck (invalid preimage)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
     within(30 seconds) {
       val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       val sender = TestProbe()
@@ -396,7 +411,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv RevokeAndAck (unexpectedly)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _) =>
+  test("recv RevokeAndAck (unexpectedly)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
     within(30 seconds) {
       val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       val sender = TestProbe()
@@ -409,7 +424,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_UPDATE_FEE") { case (alice, _, alice2bob, _, _, _) =>
+  test("recv CMD_UPDATE_FEE") { case (alice, _, alice2bob, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -422,7 +437,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_UPDATE_FEE (when fundee)") { case (_, bob, _, _, _, _) =>
+  test("recv CMD_UPDATE_FEE (when fundee)") { case (_, bob, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -432,7 +447,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFee") { case (_, bob, _, _, _, _) =>
+  test("recv UpdateFee") { case (_, bob, _, _, _, _, _) =>
     within(30 seconds) {
       val initialData = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
       val fee = UpdateFee("00" * 32, 12000)
@@ -441,7 +456,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFee (when sender is not funder)") { case (alice, _, alice2bob, _, alice2blockchain, _) =>
+  test("recv UpdateFee (when sender is not funder)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
     within(30 seconds) {
       val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       val sender = TestProbe()
@@ -453,7 +468,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFee (sender can't afford it)") { case (_, bob, _, bob2alice, _, bob2blockchain) =>
+  test("recv UpdateFee (sender can't afford it)") { case (_, bob, _, bob2alice, _, bob2blockchain, _) =>
     within(30 seconds) {
       val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       val sender = TestProbe()
@@ -469,7 +484,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv UpdateFee (local/remote feerates are too different)") { case (_, bob, _, bob2alice, _, bob2blockchain) =>
+  test("recv UpdateFee (local/remote feerates are too different)") { case (_, bob, _, bob2alice, _, bob2blockchain, _) =>
     within(30 seconds) {
       val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       val sender = TestProbe()
@@ -482,7 +497,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CurrentBlockCount (no htlc timed out)") { case (alice, bob, alice2bob, bob2alice, _, _) =>
+  test("recv CurrentBlockCount (no htlc timed out)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -491,7 +506,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CurrentBlockCount (an htlc timed out)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _) =>
+  test("recv CurrentBlockCount (an htlc timed out)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -504,7 +519,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CurrentFeerate (when funder, triggers an UpdateFee)") { case (alice, _, alice2bob, _, _, _) =>
+  test("recv CurrentFeerate (when funder, triggers an UpdateFee)") { case (alice, _, alice2bob, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
@@ -514,7 +529,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CurrentFeerate (when funder, doesn't trigger an UpdateFee)") { case (alice, _, alice2bob, _, _, _) =>
+  test("recv CurrentFeerate (when funder, doesn't trigger an UpdateFee)") { case (alice, _, alice2bob, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val event = CurrentFeerate(10010)
@@ -523,7 +538,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are close)") { case (_, bob, _, bob2alice, _, _) =>
+  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are close)") { case (_, bob, _, bob2alice, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val event = CurrentFeerate(11000)
@@ -532,7 +547,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are very different)") { case (_, bob, _, bob2alice, _, bob2blockchain) =>
+  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are very different)") { case (_, bob, _, bob2alice, _, bob2blockchain, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       val event = CurrentFeerate(1000)
@@ -544,7 +559,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CurrentFeerate (ignore negative feerate)") { case (alice, _, alice2bob, _, _, _) =>
+  test("recv CurrentFeerate (ignore negative feerate)") { case (alice, _, alice2bob, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       // this happens when in regtest mode
@@ -554,7 +569,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (their commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _) =>
+  test("recv BITCOIN_FUNDING_SPENT (their commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
     within(30 seconds) {
       // bob publishes his current commit tx, which contains two pending htlcs alice->bob
       val bobCommitTx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
@@ -585,7 +600,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (their next commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _) =>
+  test("recv BITCOIN_FUNDING_SPENT (their next commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
     within(30 seconds) {
       // bob fulfills the first htlc
       fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
@@ -631,7 +646,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (revoked tx)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _) =>
+  test("recv BITCOIN_FUNDING_SPENT (revoked tx)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
     within(30 seconds) {
       val revokedTx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       // two main outputs + 2 htlc
@@ -666,7 +681,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv CMD_CLOSE") { case (alice, _, _, _, _, _) =>
+  test("recv CMD_CLOSE") { case (alice, _, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
       sender.send(alice, CMD_CLOSE(None))
@@ -674,7 +689,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("recv Error") { case (alice, _, _, _, alice2blockchain, _) =>
+  test("recv Error") { case (alice, _, _, _, alice2blockchain, _, _) =>
     within(30 seconds) {
       val aliceCommitTx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
       alice ! Error("00" * 32, "oops".getBytes)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -83,7 +83,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       val sender = TestProbe()
       val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 300000)
       sender.send(alice, add)
-      val error = ClosingInProgress(channelId(alice))
+      val error = ChannelUnavailable(channelId(alice))
       //sender.expectMsg(Failure(error))
       relayer.expectMsg(ForwardLocalFail(error, Local(Some(sender.ref))))
       alice2bob.expectNoMsg(200 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -8,7 +8,7 @@ import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.channel.{Data, State, _}
 import fr.acinq.eclair.payment.HtlcGenerationSpec.paymentPreimage
-import fr.acinq.eclair.payment.{ForwardAdd, ForwardFulfill}
+import fr.acinq.eclair.payment.{AckFulfillCmd, ForwardAdd, ForwardFulfill}
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
 import org.junit.runner.RunWith
@@ -38,6 +38,7 @@ class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
         fulfillHtlc(htlc.id, r, bob, alice, bob2alice, alice2bob)
         relayer.expectMsgType[ForwardFulfill]
         crossSign(bob, alice, bob2alice, alice2bob)
+        relayer.expectMsgType[AckFulfillCmd]
         val bobCommitTx2 = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
         bobCommitTx1 :: bobCommitTx2 :: Nil
       }).flatten

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
@@ -5,7 +5,7 @@ import fr.acinq.bitcoin.{BinaryData, Crypto, MilliSatoshi, Satoshi, Transaction}
 import fr.acinq.eclair.channel.Helpers.Funding
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.{ShaChain, Sphinx}
-import fr.acinq.eclair.payment.{Local2, Relayed2}
+import fr.acinq.eclair.payment.{Local, Relayed}
 import fr.acinq.eclair.{UInt64, randomKey}
 import fr.acinq.eclair.transactions.Transactions.CommitTx
 import fr.acinq.eclair.transactions._
@@ -90,7 +90,7 @@ object ChannelStateSpec {
   val commitments = Commitments(localParams, remoteParams, channelFlags = 0x01.toByte, localCommit, remoteCommit, LocalChanges(Nil, Nil, Nil), RemoteChanges(Nil, Nil, Nil),
     localNextHtlcId = 0L,
     remoteNextHtlcId = 0L,
-    originChannels = Map(42L -> Local2, 15000L -> Relayed2("42" * 32, 43)),
+    originChannels = Map(42L -> Local(None), 15000L -> Relayed("42" * 32, 43)),
     remoteNextCommitInfo = Right(randomKey.publicKey),
     commitInput = commitmentInput, remotePerCommitmentSecrets = ShaChain.init, channelId = "00" * 32)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
@@ -5,6 +5,7 @@ import fr.acinq.bitcoin.{BinaryData, Crypto, MilliSatoshi, Satoshi, Transaction}
 import fr.acinq.eclair.channel.Helpers.Funding
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.{ShaChain, Sphinx}
+import fr.acinq.eclair.payment.{Local2, Relayed2}
 import fr.acinq.eclair.{UInt64, randomKey}
 import fr.acinq.eclair.transactions.Transactions.CommitTx
 import fr.acinq.eclair.transactions._
@@ -88,8 +89,9 @@ object ChannelStateSpec {
   val remoteCommit = RemoteCommit(0, CommitmentSpec(htlcs.toSet, 1500, 50000, 700000), BinaryData("0303030303030303030303030303030303030303030303030303030303030303"), Scalar(BinaryData("04" * 32)).toPoint)
   val commitments = Commitments(localParams, remoteParams, channelFlags = 0x01.toByte, localCommit, remoteCommit, LocalChanges(Nil, Nil, Nil), RemoteChanges(Nil, Nil, Nil),
     localNextHtlcId = 0L,
-    remoteNextCommitInfo = Right(randomKey.publicKey), // TODO: we will receive their next per-commitment point in the next message, so we temporarily put an empty byte array
     remoteNextHtlcId = 0L,
+    originChannels = Map(42L -> Local2, 15000L -> Relayed2("42" * 32, 43)),
+    remoteNextCommitInfo = Right(randomKey.publicKey),
     commitInput = commitmentInput, remotePerCommitmentSecrets = ShaChain.init, channelId = "00" * 32)
 
   val normal = DATA_NORMAL(commitments, Some(42), None, None, None)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
@@ -73,11 +73,11 @@ object ChannelStateSpec {
   )
 
   val htlcs = Seq(
-    Htlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(1000000).amount, Crypto.sha256(paymentPreimages(0)), 500, BinaryData("00" * Sphinx.PacketLength)), None),
-    Htlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(2000000).amount, Crypto.sha256(paymentPreimages(1)), 501, BinaryData("00" * Sphinx.PacketLength)), None),
-    Htlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(2000000).amount, Crypto.sha256(paymentPreimages(2)), 502, BinaryData("00" * Sphinx.PacketLength)), None),
-    Htlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(3000000).amount, Crypto.sha256(paymentPreimages(3)), 503, BinaryData("00" * Sphinx.PacketLength)), None),
-    Htlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(4000000).amount, Crypto.sha256(paymentPreimages(4)), 504, BinaryData("00" * Sphinx.PacketLength)), None)
+    DirectedHtlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(1000000).amount, Crypto.sha256(paymentPreimages(0)), 500, BinaryData("00" * Sphinx.PacketLength))),
+    DirectedHtlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(2000000).amount, Crypto.sha256(paymentPreimages(1)), 501, BinaryData("00" * Sphinx.PacketLength))),
+    DirectedHtlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(2000000).amount, Crypto.sha256(paymentPreimages(2)), 502, BinaryData("00" * Sphinx.PacketLength))),
+    DirectedHtlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(3000000).amount, Crypto.sha256(paymentPreimages(3)), 503, BinaryData("00" * Sphinx.PacketLength))),
+    DirectedHtlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(4000000).amount, Crypto.sha256(paymentPreimages(4)), 504, BinaryData("00" * Sphinx.PacketLength)))
   )
 
   val fundingTx = Transaction.read("0200000001adbb20ea41a8423ea937e76e8151636bf6093b70eaff942930d20576600521fd000000006b48304502210090587b6201e166ad6af0227d3036a9454223d49a1f11839c1a362184340ef0240220577f7cd5cca78719405cbf1de7414ac027f0239ef6e214c90fcaab0454d84b3b012103535b32d5eb0a6ed0982a0479bbadc9868d9836f6ba94dd5a63be16d875069184ffffffff028096980000000000220020c015c4a6be010e21657068fc2e6a9d02b27ebe4d490a25846f7237f104d1a3cd20256d29010000001600143ca33c2e4446f4a305f23c80df8ad1afdcf652f900000000")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
@@ -90,7 +90,7 @@ object ChannelStateSpec {
   val commitments = Commitments(localParams, remoteParams, channelFlags = 0x01.toByte, localCommit, remoteCommit, LocalChanges(Nil, Nil, Nil), RemoteChanges(Nil, Nil, Nil),
     localNextHtlcId = 0L,
     remoteNextHtlcId = 0L,
-    originChannels = Map(42L -> Local(None), 15000L -> Relayed("42" * 32, 43)),
+    originChannels = Map(42L -> Local(None), 15000L -> Relayed("42" * 32, 43, 11000000L, 10000000L)),
     remoteNextCommitInfo = Right(randomKey.publicKey),
     commitInput = commitmentInput, remotePerCommitmentSecrets = ShaChain.init, channelId = "00" * 32)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -2,7 +2,7 @@ package fr.acinq.eclair.db
 
 import java.sql.DriverManager
 
-import fr.acinq.eclair.db.sqlite.SqliteChannelsDb
+import fr.acinq.eclair.db.sqlite.{SqliteChannelsDb, SqlitePreimagesDb}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -21,6 +21,7 @@ class SqliteChannelsDbSpec extends FunSuite {
   test("add/remove/list channels") {
     val sqlite = inmem
     val db = new SqliteChannelsDb(sqlite)
+    new SqlitePreimagesDb(sqlite) // needed by db.removeChannel
 
     val channel = ChannelStateSpec.normal
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePreimagesDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePreimagesDbSpec.scala
@@ -1,0 +1,42 @@
+package fr.acinq.eclair.db
+
+import java.sql.DriverManager
+
+import fr.acinq.eclair.db.sqlite.SqlitePreimagesDb
+import fr.acinq.eclair.randomBytes
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class SqlitePreimagesDbSpec extends FunSuite {
+
+  def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")
+
+  test("init sqlite 2 times in a row") {
+    val sqlite = inmem
+    val db1 = new SqlitePreimagesDb(sqlite)
+    val db2 = new SqlitePreimagesDb(sqlite)
+  }
+
+  test("add/remove/list preimages") {
+    val sqlite = inmem
+    val db = new SqlitePreimagesDb(sqlite)
+
+    val channelId = randomBytes(32)
+    val preimage0 = randomBytes(32)
+    val preimage1 = randomBytes(32)
+    val preimage2 = randomBytes(32)
+    val preimage3 = randomBytes(32)
+
+    assert(db.listPreimages(channelId).toSet === Set.empty)
+    db.addPreimage(channelId, 0, preimage0)
+    db.addPreimage(channelId, 0, preimage0) // duplicate
+    db.addPreimage(channelId, 1, preimage1)
+    db.addPreimage(channelId, 2, preimage2)
+    assert(db.listPreimages(channelId).sortBy(_._2) === (channelId, 0, preimage0) :: (channelId, 1, preimage1) :: (channelId, 2, preimage2) :: Nil)
+    db.removePreimage(channelId, 1)
+    assert(db.listPreimages(channelId).sortBy(_._2) === (channelId, 0, preimage0) :: (channelId, 2, preimage2) :: Nil)
+  }
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -46,7 +46,7 @@ class RelayerSpec extends TestkitBaseClass {
   val channelId_bc: BinaryData = "64864544" * 8
   val channel_flags = 0x00.toByte
   
-  def makeCommitments(channelId: BinaryData) = Commitments(null, null, 0.toByte, null, null, null, null, 0, 0, null, null, null, channelId)
+  def makeCommitments(channelId: BinaryData) = Commitments(null, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, null, null, channelId)
 
   test("add a channel") { case (relayer, _) =>
     val sender = TestProbe()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/CommitmentSpecSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/CommitmentSpecSpec.scala
@@ -15,15 +15,15 @@ class CommitmentSpecSpec extends FunSuite {
 
     val add1 = UpdateAddHtlc("00" * 32, 1, 2000 * 1000, H, 400, "")
     val spec1 = CommitmentSpec.reduce(spec, add1 :: Nil, Nil)
-    assert(spec1 === spec.copy(htlcs = Set(Htlc(OUT, add1, None)), toLocalMsat = 3000 * 1000))
+    assert(spec1 === spec.copy(htlcs = Set(DirectedHtlc(OUT, add1)), toLocalMsat = 3000 * 1000))
 
     val add2 = UpdateAddHtlc("00" * 32, 2, 1000 * 1000, H, 400, "")
     val spec2 = CommitmentSpec.reduce(spec1, add2 :: Nil, Nil)
-    assert(spec2 === spec1.copy(htlcs = Set(Htlc(OUT, add1, None), Htlc(OUT, add2, None)), toLocalMsat = 2000 * 1000))
+    assert(spec2 === spec1.copy(htlcs = Set(DirectedHtlc(OUT, add1), DirectedHtlc(OUT, add2)), toLocalMsat = 2000 * 1000))
 
     val ful1 = UpdateFulfillHtlc("00" * 32, add1.id, R)
     val spec3 = CommitmentSpec.reduce(spec2, Nil, ful1 :: Nil)
-    assert(spec3 === spec2.copy(htlcs = Set(Htlc(OUT, add2, None)), toRemoteMsat = 2000 * 1000))
+    assert(spec3 === spec2.copy(htlcs = Set(DirectedHtlc(OUT, add2)), toRemoteMsat = 2000 * 1000))
 
     val fail1 = UpdateFailHtlc("00" * 32, add2.id, R)
     val spec4 = CommitmentSpec.reduce(spec3, Nil, fail1 :: Nil)
@@ -37,15 +37,15 @@ class CommitmentSpecSpec extends FunSuite {
 
     val add1 = UpdateAddHtlc("00" * 32, 1, 2000 * 1000, H, 400, "")
     val spec1 = CommitmentSpec.reduce(spec, Nil, add1 :: Nil)
-    assert(spec1 === spec.copy(htlcs = Set(Htlc(IN, add1, None)), toRemoteMsat = 3000 * 1000))
+    assert(spec1 === spec.copy(htlcs = Set(DirectedHtlc(IN, add1)), toRemoteMsat = 3000 * 1000))
 
     val add2 = UpdateAddHtlc("00" * 32, 2, 1000 * 1000, H, 400, "")
     val spec2 = CommitmentSpec.reduce(spec1, Nil, add2 :: Nil)
-    assert(spec2 === spec1.copy(htlcs = Set(Htlc(IN, add1, None), Htlc(IN, add2, None)), toRemoteMsat = 2000 * 1000))
+    assert(spec2 === spec1.copy(htlcs = Set(DirectedHtlc(IN, add1), DirectedHtlc(IN, add2)), toRemoteMsat = 2000 * 1000))
 
     val ful1 = UpdateFulfillHtlc("00" * 32, add1.id, R)
     val spec3 = CommitmentSpec.reduce(spec2, ful1 :: Nil, Nil)
-    assert(spec3 === spec2.copy(htlcs = Set(Htlc(IN, add2, None)), toLocalMsat = 2000 * 1000))
+    assert(spec3 === spec2.copy(htlcs = Set(DirectedHtlc(IN, add2)), toLocalMsat = 2000 * 1000))
 
     val fail1 = UpdateFailHtlc("00" * 32, add2.id, R)
     val spec4 = CommitmentSpec.reduce(spec3, fail1 :: Nil, Nil)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TestVectorsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TestVectorsSpec.scala
@@ -140,11 +140,11 @@ class TestVectorsSpec extends FunSuite {
   )
 
   val htlcs = Seq(
-    Htlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(1000000).amount, Crypto.sha256(paymentPreimages(0)), 500, BinaryData("")), None),
-    Htlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(2000000).amount, Crypto.sha256(paymentPreimages(1)), 501, BinaryData("")), None),
-    Htlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(2000000).amount, Crypto.sha256(paymentPreimages(2)), 502, BinaryData("")), None),
-    Htlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(3000000).amount, Crypto.sha256(paymentPreimages(3)), 503, BinaryData("")), None),
-    Htlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(4000000).amount, Crypto.sha256(paymentPreimages(4)), 504, BinaryData("")), None)
+    DirectedHtlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(1000000).amount, Crypto.sha256(paymentPreimages(0)), 500, BinaryData(""))),
+    DirectedHtlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(2000000).amount, Crypto.sha256(paymentPreimages(1)), 501, BinaryData(""))),
+    DirectedHtlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(2000000).amount, Crypto.sha256(paymentPreimages(2)), 502, BinaryData(""))),
+    DirectedHtlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(3000000).amount, Crypto.sha256(paymentPreimages(3)), 503, BinaryData(""))),
+    DirectedHtlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(4000000).amount, Crypto.sha256(paymentPreimages(4)), 504, BinaryData("")))
   )
   val htlcScripts = htlcs.map(htlc => htlc.direction match {
     case OUT => Scripts.htlcOffered(Local.public_key, Remote.public_key, Local.revocation_key, Crypto.ripemd160(htlc.add.paymentHash))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -47,10 +47,10 @@ class TransactionsSpec extends FunSuite {
   test("compute fees") {
     // see BOLT #3 specs
     val htlcs = Set(
-      Htlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(5000000).amount, Hash.Zeroes, 552, BinaryData("")), None),
-      Htlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(1000000).amount, Hash.Zeroes, 553, BinaryData("")), None),
-      Htlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(7000000).amount, Hash.Zeroes, 550, BinaryData("")), None),
-      Htlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(800000).amount, Hash.Zeroes, 551, BinaryData("")), None)
+      DirectedHtlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(5000000).amount, Hash.Zeroes, 552, BinaryData(""))),
+      DirectedHtlc(OUT, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(1000000).amount, Hash.Zeroes, 553, BinaryData(""))),
+      DirectedHtlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(7000000).amount, Hash.Zeroes, 550, BinaryData(""))),
+      DirectedHtlc(IN, UpdateAddHtlc("00" * 32, 0, MilliSatoshi(800000).amount, Hash.Zeroes, 551, BinaryData("")))
     )
     val spec = CommitmentSpec(htlcs, feeratePerKw = 5000, toLocalMsat = 0, toRemoteMsat = 0)
     val fee = Transactions.commitTxFee(Satoshi(546), spec)
@@ -152,10 +152,10 @@ class TransactionsSpec extends FunSuite {
     val htlc4 = UpdateAddHtlc("00" * 32, 3, (localDustLimit + weight2fee(feeratePerKw, htlcSuccessWeight)).amount * 1000, sha256(paymentPreimage4), 300, BinaryData(""))
     val spec = CommitmentSpec(
       htlcs = Set(
-        Htlc(OUT, htlc1, None),
-        Htlc(IN, htlc2, None),
-        Htlc(OUT, htlc3, None),
-        Htlc(IN, htlc4, None)
+        DirectedHtlc(OUT, htlc1),
+        DirectedHtlc(IN, htlc2),
+        DirectedHtlc(OUT, htlc3),
+        DirectedHtlc(IN, htlc4)
       ),
       feeratePerKw = feeratePerKw,
       toLocalMsat = millibtc2satoshi(MilliBtc(400)).amount * 1000,
@@ -288,8 +288,8 @@ class TransactionsSpec extends FunSuite {
     case Failure(t) => fail(t)
   }
 
-  def htlc(direction: Direction, amount: Satoshi): Htlc =
-    Htlc(direction, UpdateAddHtlc("00" * 32, 0, amount.amount * 1000, "00" * 32, 144, ""), None)
+  def htlc(direction: Direction, amount: Satoshi): DirectedHtlc =
+    DirectedHtlc(direction, UpdateAddHtlc("00" * 32, 0, amount.amount * 1000, "00" * 32, 144, ""))
 
   test("BOLT 2 fee tests") {
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
@@ -80,8 +80,8 @@ class ChannelCodecsSpec extends FunSuite {
       expiry = Random.nextInt(Int.MaxValue),
       paymentHash = randomBytes(32),
       onionRoutingPacket = randomBytes(Sphinx.PacketLength))
-    val htlc1 = Htlc(direction = IN, add = add, previousChannelId = Some(randomBytes(32)))
-    val htlc2 = Htlc(direction = OUT, add = add, previousChannelId = None)
+    val htlc1 = DirectedHtlc(direction = IN, add = add)
+    val htlc2 = DirectedHtlc(direction = OUT, add = add)
     htlcCodec.decodeValue(htlcCodec.encode(htlc1).require).require == htlc1
     htlcCodec.decodeValue(htlcCodec.encode(htlc2).require).require == htlc2
   }
@@ -101,8 +101,8 @@ class ChannelCodecsSpec extends FunSuite {
       expiry = Random.nextInt(Int.MaxValue),
       paymentHash = randomBytes(32),
       onionRoutingPacket = randomBytes(Sphinx.PacketLength))
-    val htlc1 = Htlc(direction = IN, add = add1, previousChannelId = Some(randomBytes(32)))
-    val htlc2 = Htlc(direction = OUT, add = add2, previousChannelId = None)
+    val htlc1 = DirectedHtlc(direction = IN, add = add1)
+    val htlc2 = DirectedHtlc(direction = OUT, add = add2)
     val htlcs = Set(htlc1, htlc2)
     setCodec(htlcCodec).decodeValue(setCodec(htlcCodec).encode(htlcs).require).require == htlcs
     val o = CommitmentSpec(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
@@ -69,8 +69,8 @@ class ChannelCodecsSpec extends FunSuite {
   }
 
   test("encode/decode direction") {
-    directionCodec.decodeValue(directionCodec.encode(IN).require).require == IN
-    directionCodec.decodeValue(directionCodec.encode(OUT).require).require == OUT
+    assert(directionCodec.decodeValue(directionCodec.encode(IN).require).require === IN)
+    assert(directionCodec.decodeValue(directionCodec.encode(OUT).require).require === OUT)
   }
 
   test("encode/decode htlc") {
@@ -83,8 +83,8 @@ class ChannelCodecsSpec extends FunSuite {
       onionRoutingPacket = randomBytes(Sphinx.PacketLength))
     val htlc1 = DirectedHtlc(direction = IN, add = add)
     val htlc2 = DirectedHtlc(direction = OUT, add = add)
-    htlcCodec.decodeValue(htlcCodec.encode(htlc1).require).require == htlc1
-    htlcCodec.decodeValue(htlcCodec.encode(htlc2).require).require == htlc2
+    assert(htlcCodec.decodeValue(htlcCodec.encode(htlc1).require).require === htlc1)
+    assert(htlcCodec.decodeValue(htlcCodec.encode(htlc2).require).require === htlc2)
   }
 
   test("encode/decode commitment spec") {
@@ -105,7 +105,7 @@ class ChannelCodecsSpec extends FunSuite {
     val htlc1 = DirectedHtlc(direction = IN, add = add1)
     val htlc2 = DirectedHtlc(direction = OUT, add = add2)
     val htlcs = Set(htlc1, htlc2)
-    setCodec(htlcCodec).decodeValue(setCodec(htlcCodec).encode(htlcs).require).require == htlcs
+    assert(setCodec(htlcCodec).decodeValue(setCodec(htlcCodec).encode(htlcs).require).require === htlcs)
     val o = CommitmentSpec(
       htlcs = Set(htlc1, htlc2),
       feeratePerKw = Random.nextInt(Int.MaxValue),
@@ -118,20 +118,20 @@ class ChannelCodecsSpec extends FunSuite {
   }
 
   test("encode/decode origin") {
-    origin.decodeValue(origin.encode(Local(None)).require).require == Local(None)
-    val originChannelId = randomBytes(32)
-    origin.decodeValue(origin.encode(Relayed(originChannelId, 42)).require).require == Relayed(originChannelId, 42)
+    assert(originCodec.decodeValue(originCodec.encode(Local(None)).require).require === Local(None))
+    val relayed = Relayed(randomBytes(32), 4324, 12000000L, 11000000L)
+    assert(originCodec.decodeValue(originCodec.encode(relayed).require).require === relayed)
   }
 
   test("encode/decode map of origins") {
     val map = Map(
       1L -> Local(None),
-      42L -> Relayed(randomBytes(32), 4324),
-      130L -> Relayed(randomBytes(32), -45),
-      1000L -> Relayed(randomBytes(32), 10),
-      -32L -> Relayed(randomBytes(32), 54),
+      42L -> Relayed(randomBytes(32), 4324, 12000000L, 11000000L),
+      130L -> Relayed(randomBytes(32), -45, 13000000L, 12000000L),
+      1000L -> Relayed(randomBytes(32), 10, 14000000L, 13000000L),
+      -32L -> Relayed(randomBytes(32), 54, 15000000L, 14000000L),
       -4L -> Local(None))
-    originsMap.decodeValue(originsMap.encode(map).require).require == map
+    assert(originsMapCodec.decodeValue(originsMapCodec.encode(map).require).require === map)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
@@ -3,7 +3,7 @@ package fr.acinq.eclair.wire
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.channel.{LocalParams, RemoteParams}
 import fr.acinq.eclair.crypto.Sphinx
-import fr.acinq.eclair.payment.{Local2, Relayed2}
+import fr.acinq.eclair.payment.{Local, Relayed}
 import fr.acinq.eclair.transactions._
 import fr.acinq.eclair.wire.ChannelCodecs._
 import fr.acinq.eclair.{UInt64, randomKey}
@@ -118,19 +118,19 @@ class ChannelCodecsSpec extends FunSuite {
   }
 
   test("encode/decode origin") {
-    origin.decodeValue(origin.encode(Local2).require).require == Local2
+    origin.decodeValue(origin.encode(Local(None)).require).require == Local(None)
     val originChannelId = randomBytes(32)
-    origin.decodeValue(origin.encode(Relayed2(originChannelId, 42)).require).require == Relayed2(originChannelId, 42)
+    origin.decodeValue(origin.encode(Relayed(originChannelId, 42)).require).require == Relayed(originChannelId, 42)
   }
 
   test("encode/decode map of origins") {
     val map = Map(
-      1L -> Local2,
-      42L -> Relayed2(randomBytes(32), 4324),
-      130L -> Relayed2(randomBytes(32), -45),
-      1000L -> Relayed2(randomBytes(32), 10),
-      -32L -> Relayed2(randomBytes(32), 54),
-      -4L -> Local2)
+      1L -> Local(None),
+      42L -> Relayed(randomBytes(32), 4324),
+      130L -> Relayed(randomBytes(32), -45),
+      1000L -> Relayed(randomBytes(32), 10),
+      -32L -> Relayed(randomBytes(32), 54),
+      -4L -> Local(None))
     originsMap.decodeValue(originsMap.encode(map).require).require == map
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
@@ -3,6 +3,7 @@ package fr.acinq.eclair.wire
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.channel.{LocalParams, RemoteParams}
 import fr.acinq.eclair.crypto.Sphinx
+import fr.acinq.eclair.payment.{Local2, Relayed2}
 import fr.acinq.eclair.transactions._
 import fr.acinq.eclair.wire.ChannelCodecs._
 import fr.acinq.eclair.{UInt64, randomKey}
@@ -114,7 +115,23 @@ class ChannelCodecsSpec extends FunSuite {
     val encoded = commitmentSpecCodec.encode(o).require
     val decoded = commitmentSpecCodec.decode(encoded).require
     assert(o === decoded.value)
+  }
 
+  test("encode/decode origin") {
+    origin.decodeValue(origin.encode(Local2).require).require == Local2
+    val originChannelId = randomBytes(32)
+    origin.decodeValue(origin.encode(Relayed2(originChannelId, 42)).require).require == Relayed2(originChannelId, 42)
+  }
+
+  test("encode/decode map of origins") {
+    val map = Map(
+      1L -> Local2,
+      42L -> Relayed2(randomBytes(32), 4324),
+      130L -> Relayed2(randomBytes(32), -45),
+      1000L -> Relayed2(randomBytes(32), 10),
+      -32L -> Relayed2(randomBytes(32), 54),
+      -4L -> Local2)
+    originsMap.decodeValue(originsMap.encode(map).require).require == map
   }
 
 }

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -175,7 +175,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
       mainController.paymentReceivedList.prepend(new PaymentReceivedRecord(p, LocalDateTime.now()))
 
     case p: PaymentRelayed =>
-      log.debug(s"payment relayed with h=${p.paymentHash}, amount=${p.amount}, feesEarned=${p.feesEarned}")
+      log.debug(s"payment relayed with h=${p.paymentHash}, amount=${p.amountIn}, feesEarned=${p.amountOut}")
       mainController.paymentRelayedList.prepend(new PaymentRelayedRecord(p, LocalDateTime.now()))
 
     case ZMQConnected =>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/MainController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/MainController.scala
@@ -290,13 +290,13 @@ class MainController(val handlers: Handlers, val hostServices: HostServices) ext
       override def onChanged(c: Change[_ <: PaymentRelayedRecord]) = updateTabHeader(paymentRelayedTab, "Relayed", paymentRelayedList)
     })
     paymentRelayedAmountColumn.setCellValueFactory(new Callback[CellDataFeatures[PaymentRelayedRecord, Number], ObservableValue[Number]]() {
-      def call(p: CellDataFeatures[PaymentRelayedRecord, Number]) = new SimpleLongProperty(p.getValue.event.amount.amount)
+      def call(p: CellDataFeatures[PaymentRelayedRecord, Number]) = new SimpleLongProperty(p.getValue.event.amountIn.amount)
     })
     paymentRelayedAmountColumn.setCellFactory(new Callback[TableColumn[PaymentRelayedRecord, Number], TableCell[PaymentRelayedRecord, Number]]() {
       def call(pn: TableColumn[PaymentRelayedRecord, Number]) = buildMoneyTableCell
     })
     paymentRelayedFeesColumn.setCellValueFactory(new Callback[CellDataFeatures[PaymentRelayedRecord, Number], ObservableValue[Number]]() {
-      def call(p: CellDataFeatures[PaymentRelayedRecord, Number]) = new SimpleLongProperty(p.getValue.event.feesEarned.amount)
+      def call(p: CellDataFeatures[PaymentRelayedRecord, Number]) = new SimpleLongProperty(p.getValue.event.amountIn.amount - p.getValue.event.amountOut.amount)
     })
     paymentRelayedFeesColumn.setCellFactory(new Callback[TableColumn[PaymentRelayedRecord, Number], TableCell[PaymentRelayedRecord, Number]]() {
       def call(pn: TableColumn[PaymentRelayedRecord, Number]) = buildMoneyTableCell


### PR DESCRIPTION
This PR changes the way we manage the storage/forwarding of payment preimages from downstream channels to upstream channels. The goal is to make sure that we never lose a preimage, because that means losing money.

Note that the handling of unilateral closing (local or remote) needs to be reworked too. We currently consider the channel CLOSED when the commitment transactions has been buried deep enough; this is wrong because it doesn't give us time to extract payment preimages in certain cases. This will be done separately.

The overall change is quite significant, and this PR is best reviewed commit by commit.