### PR TITLE
Have channels subscribe to blockchain events at creation

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1011,7 +1011,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
     case Event(CMD_CLOSE(_), d: HasCommitments) => handleLocalError(ForcedLocalCommit(d.channelId, "can't do a mutual close while disconnected"), d) replying "ok"
 
     case Event(CurrentBlockCount(count), d: HasCommitments) if d.commitments.hasTimedoutOutgoingHtlcs(count) =>
-      // note: this cal only happen if state is NORMAL or SHUTDOWN
+      // note: this can only happen if state is NORMAL or SHUTDOWN
       // -> in NEGOTIATING there are no more htlcs
       // -> in CLOSING we either have mutual closed (so no more htlcs), or already have unilaterally closed (so no action required), and we can't be in OFFLINE state anyway
       handleLocalError(HtlcTimedout(d.channelId), d)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -36,6 +36,11 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
   // see https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#requirements
   val ANNOUNCEMENTS_MINCONF = 6
 
+  // this will be used to detect htlc timeouts
+  context.system.eventStream.subscribe(self, classOf[CurrentBlockCount])
+  // this will be used to make sure the current commitment fee is up-to-date
+  context.system.eventStream.subscribe(self, classOf[CurrentFeerate])
+
   /*
           8888888 888b    888 8888888 88888888888
             888   8888b   888   888       888
@@ -127,7 +132,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
               context.system.eventStream.publish(ShortChannelIdAssigned(self, d.channelId, shortChannelId))
               val channelUpdate = Announcements.makeChannelUpdate(nodeParams.chainHash, nodeParams.privateKey, remoteNodeId, shortChannelId, nodeParams.expiryDeltaBlocks, nodeParams.htlcMinimumMsat, nodeParams.feeBaseMsat, nodeParams.feeProportionalMillionth)
               relayer ! channelUpdate
-            case _ => ()
+            case _ =>
           }
           goto(OFFLINE) using d
       }
@@ -371,9 +376,6 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
   when(WAIT_FOR_FUNDING_LOCKED)(handleExceptions {
     case Event(FundingLocked(_, nextPerCommitmentPoint), d@DATA_WAIT_FOR_FUNDING_LOCKED(commitments, _)) =>
-      // this clock will be used to detect htlc timeouts
-      context.system.eventStream.subscribe(self, classOf[CurrentBlockCount])
-      context.system.eventStream.subscribe(self, classOf[CurrentFeerate])
       // NB: in spv mode we currently can't get the tx index in block (which is used to calculate the short id)
       // instead, we rely on a hack by trusting the index the counterparty sends us
       if (d.commitments.announceChannel && !nodeParams.spv) {
@@ -1009,6 +1011,9 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
     case Event(CMD_CLOSE(_), d: HasCommitments) => handleLocalError(ForcedLocalCommit(d.channelId, "can't do a mutual close while disconnected"), d) replying "ok"
 
     case Event(CurrentBlockCount(count), d: HasCommitments) if d.commitments.hasTimedoutOutgoingHtlcs(count) =>
+      // note: this cal only happen if state is NORMAL or SHUTDOWN
+      // -> in NEGOTIATING there are no more htlcs
+      // -> in CLOSING we either have mutual closed (so no more htlcs), or already have unilaterally closed (so no action required), and we can't be in OFFLINE state anyway
       handleLocalError(HtlcTimedout(d.channelId), d)
 
     case Event(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx: Transaction), d: HasCommitments) if tx.txid == d.commitments.remoteCommit.txid => handleRemoteSpentCurrent(tx, d)
@@ -1048,10 +1053,6 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
           forwarder ! localShutdown
       }
 
-      // this clock will be used to detect htlc timeouts
-      context.system.eventStream.subscribe(self, classOf[CurrentBlockCount])
-      context.system.eventStream.subscribe(self, classOf[CurrentFeerate])
-
       // we put back the watch (operation is idempotent) because the event may have been fired while we were in OFFLINE
       // NB: in spv mode we currently can't get the tx index in block (which is used to calculate the short id)
       // instead, we rely on a hack by trusting the index the counterparty sends us
@@ -1071,9 +1072,6 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
     case Event(channelReestablish: ChannelReestablish, d: DATA_SHUTDOWN) =>
       val commitments1 = handleSync(channelReestablish, d)
       forwarder ! d.localShutdown
-      // this clock will be used to detect htlc timeouts
-      context.system.eventStream.subscribe(self, classOf[CurrentBlockCount])
-      context.system.eventStream.subscribe(self, classOf[CurrentFeerate])
       goto(SHUTDOWN) using d.copy(commitments = commitments1)
 
     case Event(_: ChannelReestablish, d: DATA_NEGOTIATING) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1048,6 +1048,10 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
           forwarder ! localShutdown
       }
 
+      // this clock will be used to detect htlc timeouts
+      context.system.eventStream.subscribe(self, classOf[CurrentBlockCount])
+      context.system.eventStream.subscribe(self, classOf[CurrentFeerate])
+
       // we put back the watch (operation is idempotent) because the event may have been fired while we were in OFFLINE
       // NB: in spv mode we currently can't get the tx index in block (which is used to calculate the short id)
       // instead, we rely on a hack by trusting the index the counterparty sends us
@@ -1067,6 +1071,9 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
     case Event(channelReestablish: ChannelReestablish, d: DATA_SHUTDOWN) =>
       val commitments1 = handleSync(channelReestablish, d)
       forwarder ! d.localShutdown
+      // this clock will be used to detect htlc timeouts
+      context.system.eventStream.subscribe(self, classOf[CurrentBlockCount])
+      context.system.eventStream.subscribe(self, classOf[CurrentFeerate])
       goto(SHUTDOWN) using d.copy(commitments = commitments1)
 
     case Event(_: ChannelReestablish, d: DATA_NEGOTIATING) =>


### PR DESCRIPTION
~Channels only registered to `CurrentBlockCount` and `CurrentFeerate`
events at `WAIT_FOR_FUNDING_LOCKED`->`NORMAL` transitions.~

~We need to subscribe to those events upon reconnection, more precisely at
`SYNCING`->`NORMAL` and `SYNCING`->`SHUTDOWN` transitions.~

~Note: the `subscribe` method is idempotent, it will just return false if
sender has already subscribe to the same event.~

Instead of only subscribing to those events when we reach certain states,
we now always subscribe to them at startup. It doesn't cost a lot because
we receive an event only when a new block appears, and is much simpler.

Note that we previously didn't even bother unsubscribing when we weren't
interested anymore in the events, and were ignoring the messages in the
`whenUnhandled` block. So it is more consistent to have the same behavior
during the whole lifetime of the channel.

This fixes #187.