### PR TITLE
Support building payments with extra hops

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentHop.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentHop.scala
@@ -24,14 +24,14 @@ object PaymentHop {
     */
   type ChannelUpdateAndKey = (ChannelUpdate, PublicKey)
   def buildExtra(updates: Seq[ChannelUpdateAndKey], msat: Long): Seq[ExtraHop] =
-    (Vector.empty[ExtraHop] /: updates) {
-    case (vec, (update, key)) if vec.isEmpty =>
+    (List.empty[ExtraHop] /: updates) {
+    case (Nil, (update, key)) =>
       val fee = nodeFee(update.feeBaseMsat, update.feeProportionalMillionths, msat)
-      ExtraHop(key, update.shortChannelId, fee, update.cltvExpiryDelta) +: vec
+      ExtraHop(key, update.shortChannelId, fee, update.cltvExpiryDelta) :: Nil
 
-    case (vec, (update, key)) =>
-      val fee = nodeFee(update.feeBaseMsat, update.feeProportionalMillionths, msat + vec.head.fee)
-      ExtraHop(key, update.shortChannelId, fee, update.cltvExpiryDelta) +: vec
+    case (head :: rest, (update, key)) =>
+      val fee = nodeFee(update.feeBaseMsat, update.feeProportionalMillionths, msat + head.fee)
+      ExtraHop(key, update.shortChannelId, fee, update.cltvExpiryDelta) :: head :: rest
   }
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentHop.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentHop.scala
@@ -1,0 +1,65 @@
+package fr.acinq.eclair.payment
+
+import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.eclair.wire.ChannelUpdate
+import fr.acinq.bitcoin.Protocol
+import java.nio.ByteOrder
+
+
+object PaymentHop {
+  /**
+    *
+    * @param baseMsat     fixed fee
+    * @param proportional proportional fee
+    * @param msat         amount in millisatoshi
+    * @return the fee (in msat) that a node should be paid to forward an HTLC of 'amount' millisatoshis
+    */
+  def nodeFee(baseMsat: Long, proportional: Long, msat: Long): Long = baseMsat + (proportional * msat) / 1000000
+
+  /**
+    *
+    * @param updates sequence of channel updates and node public keys, direction should be from recipient nodeId
+    * @param msat an amount to send to a payment recipient
+    * @return a sequence of extra hops with a pre-calculated fee for a given msat amount
+    */
+  type ChannelUpdateAndKey = (ChannelUpdate, PublicKey)
+  def buildExtra(updates: Vector[ChannelUpdateAndKey], msat: Long): Seq[ExtraHop] =
+    (Vector.empty[ExtraHop] /: updates) {
+    case (vec, (update, key)) if vec.isEmpty =>
+      val fee = nodeFee(update.feeBaseMsat, update.feeProportionalMillionths, msat)
+      ExtraHop(key, update.shortChannelId, fee, update.cltvExpiryDelta) +: vec
+
+    case (vec, (update, key)) =>
+      val fee = nodeFee(update.feeBaseMsat, update.feeProportionalMillionths, msat + vec.head.fee)
+      ExtraHop(key, update.shortChannelId, fee, update.cltvExpiryDelta) +: vec
+  }
+}
+
+trait PaymentHop {
+  def nextFee(msat: Long): Long
+  def shortChannelId: Long
+  def cltvExpiryDelta: Int
+  def nodeId: PublicKey
+}
+
+/**
+  * Extra hop contained in RoutingInfoTag
+  *
+  * @param nodeId          node id
+  * @param shortChannelId  channel id
+  * @param fee             node fee
+  * @param cltvExpiryDelta node cltv expiry delta
+  */
+case class ExtraHop(nodeId: PublicKey, shortChannelId: Long, fee: Long, cltvExpiryDelta: Int) extends PaymentHop {
+  def pack: Seq[Byte] = nodeId.toBin ++ Protocol.writeUInt64(shortChannelId, ByteOrder.BIG_ENDIAN) ++
+    Protocol.writeUInt64(fee, ByteOrder.BIG_ENDIAN) ++ Protocol.writeUInt16(cltvExpiryDelta, ByteOrder.BIG_ENDIAN)
+
+  // Fee is already pre-calculated for extra hops
+  def nextFee(msat: Long): Long = fee
+}
+
+case class Hop(nodeId: PublicKey, nextNodeId: PublicKey, lastUpdate: ChannelUpdate) extends PaymentHop {
+  def nextFee(msat: Long): Long = PaymentHop.nodeFee(lastUpdate.feeBaseMsat, lastUpdate.feeProportionalMillionths, msat)
+  def cltvExpiryDelta: Int = lastUpdate.cltvExpiryDelta
+  def shortChannelId: Long = lastUpdate.shortChannelId
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentHop.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentHop.scala
@@ -1,9 +1,8 @@
 package fr.acinq.eclair.payment
 
 import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.wire.ChannelUpdate
-import fr.acinq.bitcoin.Protocol
-import java.nio.ByteOrder
 
 
 object PaymentHop {
@@ -33,22 +32,6 @@ trait PaymentHop {
   def shortChannelId: Long
   def cltvExpiryDelta: Int
   def nodeId: PublicKey
-}
-
-/**
-  * Extra hop contained in RoutingInfoTag
-  *
-  * @param nodeId          node id
-  * @param shortChannelId  channel id
-  * @param fee             node fee
-  * @param cltvExpiryDelta node cltv expiry delta
-  */
-case class ExtraHop(nodeId: PublicKey, shortChannelId: Long, fee: Long, cltvExpiryDelta: Int) extends PaymentHop {
-  def pack: Seq[Byte] = nodeId.toBin ++ Protocol.writeUInt64(shortChannelId, ByteOrder.BIG_ENDIAN) ++
-    Protocol.writeUInt64(fee, ByteOrder.BIG_ENDIAN) ++ Protocol.writeUInt16(cltvExpiryDelta, ByteOrder.BIG_ENDIAN)
-
-  // Fee is already pre-calculated for extra hops
-  def nextFee(msat: Long): Long = fee
 }
 
 case class Hop(nodeId: PublicKey, nextNodeId: PublicKey, lastUpdate: ChannelUpdate) extends PaymentHop {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentHop.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentHop.scala
@@ -23,7 +23,7 @@ object PaymentHop {
     * @return a sequence of extra hops with a pre-calculated fee for a given msat amount
     */
   type ChannelUpdateAndKey = (ChannelUpdate, PublicKey)
-  def buildExtra(updates: Vector[ChannelUpdateAndKey], msat: Long): Seq[ExtraHop] =
+  def buildExtra(updates: Seq[ChannelUpdateAndKey], msat: Long): Seq[ExtraHop] =
     (Vector.empty[ExtraHop] /: updates) {
     case (vec, (update, key)) if vec.isEmpty =>
       val fee = nodeFee(update.feeBaseMsat, update.feeProportionalMillionths, msat)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentHop.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentHop.scala
@@ -23,8 +23,8 @@ object PaymentHop {
     * @return a sequence of extra hops with a pre-calculated fee for a given msat amount
     */
   def buildExtra(reversePath: Seq[Hop], msat: Long): Seq[ExtraHop] = (List.empty[ExtraHop] /: reversePath) {
-    case (Nil, hop) => ExtraHop(hop.nextNodeId, hop.shortChannelId, hop.nextFee(msat), hop.cltvExpiryDelta) :: Nil
-    case (head :: rest, hop) => ExtraHop(hop.nextNodeId, hop.shortChannelId, hop.nextFee(msat + head.fee), hop.cltvExpiryDelta) :: head :: rest
+    case (Nil, hop) => ExtraHop(hop.nodeId, hop.shortChannelId, hop.nextFee(msat), hop.cltvExpiryDelta) :: Nil
+    case (head :: rest, hop) => ExtraHop(hop.nodeId, hop.shortChannelId, hop.nextFee(msat + head.fee), hop.cltvExpiryDelta) :: head :: rest
   }
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
@@ -159,15 +159,6 @@ object PaymentLifecycle {
 
   def props(sourceNodeId: PublicKey, router: ActorRef, register: ActorRef) = Props(classOf[PaymentLifecycle], sourceNodeId, router, register)
 
-  /**
-    *
-    * @param baseMsat     fixed fee
-    * @param proportional proportional fee
-    * @param msat         amount in millisatoshi
-    * @return the fee (in msat) that a node should be paid to forward an HTLC of 'amount' millisatoshis
-    */
-  def nodeFee(baseMsat: Long, proportional: Long, msat: Long): Long = baseMsat + (proportional * msat) / 1000000
-
   def buildOnion(nodes: Seq[PublicKey], payloads: Seq[PerHopPayload], associatedData: BinaryData): Sphinx.PacketAndSecrets = {
     require(nodes.size == payloads.size)
     val sessionKey = randomKey
@@ -184,18 +175,16 @@ object PaymentLifecycle {
     *
     * @param finalAmountMsat the final htlc amount in millisatoshis
     * @param finalExpiry     the final htlc expiry in number of blocks
-    * @param hops            the hops as computed by the router
+    * @param hops            the hops as computed by the router + extra routes from payment request
     * @return a (firstAmountMsat, firstExpiry, payloads) tuple where:
     *         - firstAmountMsat is the amount for the first htlc in the route
     *         - firstExpiry is the cltv expiry for the first htlc in the route
     *         - a sequence of payloads that will be used to build the onion
     */
-  def buildPayloads(finalAmountMsat: Long, finalExpiry: Int, hops: Seq[Hop]): (Long, Int, Seq[PerHopPayload]) =
+  def buildPayloads(finalAmountMsat: Long, finalExpiry: Int, hops: Seq[PaymentHop]): (Long, Int, Seq[PerHopPayload]) =
     hops.reverse.foldLeft((finalAmountMsat, finalExpiry, PerHopPayload(0L, finalAmountMsat, finalExpiry) :: Nil)) {
       case ((msat, expiry, payloads), hop) =>
-        val feeMsat = nodeFee(hop.lastUpdate.feeBaseMsat, hop.lastUpdate.feeProportionalMillionths, msat)
-        val expiryDelta = hop.lastUpdate.cltvExpiryDelta
-        (msat + feeMsat, expiry + expiryDelta, PerHopPayload(hop.lastUpdate.shortChannelId, msat, expiry) +: payloads)
+        (msat + hop.nextFee(msat), expiry + hop.cltvExpiryDelta, PerHopPayload(hop.shortChannelId, msat, expiry) +: payloads)
     }
 
   // TODO: set correct initial expiry

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
@@ -96,12 +96,16 @@ object PaymentRequest {
   // https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#adding-an-htlc-update_add_htlc
   val maxAmount = MilliSatoshi(4294967296L)
 
-  def apply(chainHash: BinaryData, amount: Option[MilliSatoshi], paymentHash: BinaryData, privateKey: PrivateKey, description: String, fallbackAddress: Option[String] = None, expirySeconds: Option[Long] = None, timestamp: Long = System.currentTimeMillis() / 1000L): PaymentRequest = {
+  def apply(chainHash: BinaryData, amount: Option[MilliSatoshi], paymentHash: BinaryData, privateKey: PrivateKey,
+            description: String, fallbackAddress: Option[String] = None, expirySeconds: Option[Long] = None,
+            extraHops: Seq[Seq[ExtraHop]] = Nil, timestamp: Long = System.currentTimeMillis() / 1000L): PaymentRequest = {
+
     val prefix = chainHash match {
       case Block.RegtestGenesisBlock.hash => "lntb"
       case Block.TestnetGenesisBlock.hash => "lntb"
       case Block.LivenetGenesisBlock.hash => "lnbc"
     }
+
     PaymentRequest(
       prefix = prefix,
       amount = amount,
@@ -110,7 +114,8 @@ object PaymentRequest {
       tags = List(
         Some(PaymentHashTag(paymentHash)),
         Some(DescriptionTag(description)),
-        expirySeconds.map(ExpiryTag(_))).flatten,
+        expirySeconds.map(ExpiryTag(_))
+      ).flatten ++ extraHops.map(RoutingInfoTag(_)),
       signature = BinaryData.empty)
       .sign(privateKey)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
@@ -205,6 +205,22 @@ object PaymentRequest {
   }
 
   /**
+    * Extra hop contained in RoutingInfoTag
+    *
+    * @param nodeId          node id
+    * @param shortChannelId  channel id
+    * @param fee             node fee
+    * @param cltvExpiryDelta node cltv expiry delta
+    */
+  case class ExtraHop(nodeId: PublicKey, shortChannelId: Long, fee: Long, cltvExpiryDelta: Int) extends PaymentHop {
+    def pack: Seq[Byte] = nodeId.toBin ++ Protocol.writeUInt64(shortChannelId, ByteOrder.BIG_ENDIAN) ++
+      Protocol.writeUInt64(fee, ByteOrder.BIG_ENDIAN) ++ Protocol.writeUInt16(cltvExpiryDelta, ByteOrder.BIG_ENDIAN)
+
+    // Fee is already pre-calculated for extra hops
+    def nextFee(msat: Long): Long = fee
+  }
+
+  /**
     * Routing Info Tag
     *
     * @param path one or more entries containing extra routing information for a private route

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
@@ -200,19 +200,6 @@ object PaymentRequest {
   }
 
   /**
-    * Hidden hop
-    *
-    * @param pubkey          node id
-    * @param shortChannelId  channel id
-    * @param fee             node fee
-    * @param cltvExpiryDelta node cltv expiry delta
-    */
-  case class ExtraHop(pubkey: PublicKey, shortChannelId: Long, fee: Long, cltvExpiryDelta: Int) {
-    def pack: Seq[Byte] = pubkey.toBin ++ Protocol.writeUInt64(shortChannelId, ByteOrder.BIG_ENDIAN) ++
-      Protocol.writeUInt64(fee, ByteOrder.BIG_ENDIAN) ++ Protocol.writeUInt16(cltvExpiryDelta, ByteOrder.BIG_ENDIAN)
-  }
-
-  /**
     * Routing Info Tag
     *
     * @param path one or more entries containing extra routing information for a private route

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -13,6 +13,7 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.io.Peer
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
+import fr.acinq.eclair.payment.Hop
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath
 import org.jgrapht.ext._
 import org.jgrapht.graph.{DefaultDirectedGraph, DefaultEdge, SimpleGraph}
@@ -25,7 +26,6 @@ import scala.util.{Random, Success, Try}
 // @formatter:off
 
 case class ChannelDesc(id: Long, a: PublicKey, b: PublicKey)
-case class Hop(nodeId: PublicKey, nextNodeId: PublicKey, lastUpdate: ChannelUpdate)
 case class RouteRequest(source: PublicKey, target: PublicKey, ignoreNodes: Set[PublicKey] = Set.empty, ignoreChannels: Set[Long] = Set.empty)
 case class RouteResponse(hops: Seq[Hop], ignoreNodes: Set[PublicKey], ignoreChannels: Set[Long]) { require(hops.size > 0, "route cannot be empty") }
 case class ExcludeChannel(desc: ChannelDesc) // this is used when we get a TemporaryChannelFailure, to give time for the channel to recover (note that exclusions are directed)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -11,7 +11,6 @@ import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.payment._
-import fr.acinq.eclair.router.Hop
 import fr.acinq.eclair.wire._
 import grizzled.slf4j.Logging
 import org.junit.runner.RunWith

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
@@ -7,7 +7,7 @@ import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.PaymentLifecycle
-import fr.acinq.eclair.router.Hop
+import fr.acinq.eclair.payment.Hop
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{Globals, TestConstants}
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -8,7 +8,7 @@ import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.channel.{Data, State, _}
 import fr.acinq.eclair.payment.PaymentLifecycle
-import fr.acinq.eclair.router.Hop
+import fr.acinq.eclair.payment.Hop
 import fr.acinq.eclair.wire.{CommitSig, Error, FailureMessageCodecs, PermanentChannelFailure, RevokeAndAck, Shutdown, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFee, UpdateFulfillHtlc}
 import fr.acinq.eclair.{Globals, TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/HtlcGenerationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/HtlcGenerationSpec.scala
@@ -5,7 +5,7 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.crypto.Sphinx.{PacketAndSecrets, ParsedPacket}
 import fr.acinq.eclair.payment.PaymentLifecycle._
 import fr.acinq.eclair.randomKey
-import fr.acinq.eclair.router.Hop
+import fr.acinq.eclair.payment.PaymentHop.nodeFee
 import fr.acinq.eclair.wire.{ChannelUpdate, LightningMessageCodecs, PerHopPayload}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
@@ -4,7 +4,7 @@ import java.nio.ByteOrder
 
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{BinaryData, Block, Btc, Crypto, MilliBtc, MilliSatoshi, Protocol, Satoshi}
-import fr.acinq.eclair.payment.PaymentRequest.{Amount, RoutingInfoTag}
+import fr.acinq.eclair.payment.PaymentRequest.{Amount, ExtraHop, RoutingInfoTag}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
@@ -4,7 +4,7 @@ import java.nio.ByteOrder
 
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{BinaryData, Block, Btc, Crypto, MilliBtc, MilliSatoshi, Protocol, Satoshi}
-import fr.acinq.eclair.payment.PaymentRequest.{Amount, ExtraHop, RoutingInfoTag}
+import fr.acinq.eclair.payment.PaymentRequest.{Amount, RoutingInfoTag}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -1,10 +1,10 @@
 package fr.acinq.eclair.router
 
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
-import fr.acinq.bitcoin.{BinaryData, Block, Crypto}
+import fr.acinq.bitcoin.{BinaryData, Block, Crypto, MilliSatoshi}
 import fr.acinq.eclair.randomKey
 import fr.acinq.eclair.wire.{ChannelUpdate, PerHopPayload}
-import fr.acinq.eclair.payment.{ExtraHop, Hop, PaymentHop, PaymentLifecycle}
+import fr.acinq.eclair.payment._
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -176,23 +176,46 @@ class RouteCalculationSpec extends FunSuite {
   }
 
   test("calculate route with extra hops") {
-    val DUMMY_SIG = BinaryData("3045022100e0a180fdd0fe38037cc878c03832861b40a29d32bd7b40b10c9e1efc8c1468a002205ae06d1624896d0d29f4b31e32772ea3cb1b4d7ed4e077e5da28dcc33c0e781201")
+    // E (sender) -> D - public -> C - private -> B - private -> A (receiver)
 
-    val uab = ChannelUpdate(DUMMY_SIG, Block.RegtestGenesisBlock.hash, 1L, 0L, "0000", 1, 42, 2500, 140)
-    val ubc = ChannelUpdate(DUMMY_SIG, Block.RegtestGenesisBlock.hash, 2L, 1L, "0000", 1, 44, 2502, 142)
-    val publicHops: Seq[Hop] = Hop(a, b, uab) :: Hop(b, c, ubc) :: Nil
+    val amount = MilliSatoshi(100000000L)
+    val paymentPreimage = BinaryData("0" * 32)
+    val paymentHash = Crypto.sha256(paymentPreimage)
+    val privateKey = PrivateKey("bb77027e3b6ef55f3b16eb6973d124f68e0c2afc16accc00a44ec6b3d1e58cc601")
 
-    val ucd = ChannelUpdate(DUMMY_SIG, Block.RegtestGenesisBlock.hash, 13390952114749440L, 1508747148L, BinaryData.empty, 144, 100, 546000, 10)
-    val ude = ChannelUpdate(DUMMY_SIG, Block.RegtestGenesisBlock.hash, 11091873301069824L, 1508752623L, BinaryData.empty, 144, 100, 546000, 10)
-    val d: PublicKey = PublicKey("0299439d988cbf31388d59e3d6f9e184e7a0739b8b8fcdc298957216833935f9d3")
-    val e: PublicKey = PublicKey("02f0b230e53723ccc331db140edc518be1ee5ab29a508104a4be2f5be922c928e8")
+    // Ask router for a route from 02f0b230e53723ccc331db140edc518be1ee5ab29a508104a4be2f5be922c928e8 (node C)
+    // to 0299439d988cbf31388d59e3d6f9e184e7a0739b8b8fcdc298957216833935f9d3 (node A)
+    val hopCB = Hop(PublicKey("02f0b230e53723ccc331db140edc518be1ee5ab29a508104a4be2f5be922c928e8"),
+      PublicKey("032b4af42b5e8089a7a06005ead9ac4667527390ee39c998b7b0307f0d81d7f4ac"),
+      ChannelUpdate("3044022075bc283539935b1bc126035ef98d0f9bcd5dd7b0832b0a6175dc14a5ee12d47102203d141a4da4f83fca9d65bddfb9ee6ea5cdfcdb364de062d1370500f511b8370701",
+        "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f", 24412456671576064L, 1509366313, BinaryData("0000"), 144, 1000, 546000, 10))
 
-    val reversePathFromRecipient = Hop(d, e, ude) :: Hop(c, d, ucd) :: Nil
-    val extraHops: Seq[ExtraHop] = PaymentHop.buildExtra(reversePathFromRecipient, 100000L)
+    val hopBA = Hop(PublicKey("032b4af42b5e8089a7a06005ead9ac4667527390ee39c998b7b0307f0d81d7f4ac"),
+      PublicKey("0299439d988cbf31388d59e3d6f9e184e7a0739b8b8fcdc298957216833935f9d3"),
+      ChannelUpdate("304402205e9b28e26add5417ad97f6eb161229dd7db0d7848e146a1856a8841238bc627902203cc59996ca490375fd76a3327adfb7c5150ee3288ad1663b8c4fbe8908eb489a01",
+        "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f", 23366821113626624L, 1509455356, BinaryData("0001"), 144, 1000, 546000, 10))
 
-    // (a -> b), (b -> c) ++ ((d -> e), (c -> d)).reverse
-    val (_, _, payloads) = PaymentLifecycle.buildPayloads(100000L, 6, publicHops ++ extraHops.reverse)
-    assert(payloads === List(PerHopPayload(1L, 1194678L, 295), PerHopPayload(2L, 1192007L, 294), PerHopPayload(11091873301069824L, 646006L, 150), PerHopPayload(13390952114749440L, 100000L, 6), PerHopPayload(0L, 100000L, 6)))
+    val reverseRoute = List(hopBA, hopCB)
+    val extraRoute = PaymentHop.buildExtra(reverseRoute, amount.amount)
+
+    assert(extraRoute === List(ExtraHop(PublicKey("02f0b230e53723ccc331db140edc518be1ee5ab29a508104a4be2f5be922c928e8"), 24412456671576064L, 547005, 144),
+      ExtraHop(PublicKey("032b4af42b5e8089a7a06005ead9ac4667527390ee39c998b7b0307f0d81d7f4ac") ,23366821113626624L, 547000, 144)))
+
+    // Receiver side
+
+    // Ask router for a route D -> C
+    val hopDC = Hop(PublicKey("03c1b07dbe10e178216150b49646ded556466ed15368857fa721cf1acd9d9a6f24"),
+      PublicKey("02f0b230e53723ccc331db140edc518be1ee5ab29a508104a4be2f5be922c928e8"),
+      ChannelUpdate("3044022060c1034092d4e41d75271eb619ef0a0f00d0b5a61c4245e0f14eeac91a3c823202200da9c8b8067e73c32aea41cb9eec050ce49cb944877d9abb3b08be2dea92497301",
+        "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f", 24403660578553856L, 1509456040, BinaryData("0001"), 144, 1000, 546000, 10))
+
+    val (amt, expiry, payloads) = PaymentLifecycle.buildPayloads(amount.amount, 10, Seq(hopDC) ++ extraRoute)
+
+    assert(payloads === List(PerHopPayload(24403660578553856L, 101094005L, 298),
+      PerHopPayload(24412456671576064L, 100547000L, 154), PerHopPayload(23366821113626624L, 100000000L, 10), PerHopPayload(0L, 100000000L, 10)))
+
+    assert(amt == 101641015L)
+    assert(expiry == 442)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -2,6 +2,7 @@ package fr.acinq.eclair.router
 
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{BinaryData, Block, Crypto, MilliSatoshi}
+import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.randomKey
 import fr.acinq.eclair.wire.{ChannelUpdate, PerHopPayload}
 import fr.acinq.eclair.payment._
@@ -201,7 +202,7 @@ class RouteCalculationSpec extends FunSuite {
     assert(extraRoute === List(ExtraHop(PublicKey("02f0b230e53723ccc331db140edc518be1ee5ab29a508104a4be2f5be922c928e8"), 24412456671576064L, 547005, 144),
       ExtraHop(PublicKey("032b4af42b5e8089a7a06005ead9ac4667527390ee39c998b7b0307f0d81d7f4ac") ,23366821113626624L, 547000, 144)))
 
-    // Receiver side
+    // Sender side
 
     // Ask router for a route D -> C
     val hopDC = Hop(PublicKey("03c1b07dbe10e178216150b49646ded556466ed15368857fa721cf1acd9d9a6f24"),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -184,12 +184,15 @@ class RouteCalculationSpec extends FunSuite {
 
     val ucd = ChannelUpdate(DUMMY_SIG, Block.RegtestGenesisBlock.hash, 13390952114749440L, 1508747148L, BinaryData.empty, 144, 100, 546000, 10)
     val ude = ChannelUpdate(DUMMY_SIG, Block.RegtestGenesisBlock.hash, 11091873301069824L, 1508752623L, BinaryData.empty, 144, 100, 546000, 10)
-    val pubkey1: PublicKey = PublicKey("0299439d988cbf31388d59e3d6f9e184e7a0739b8b8fcdc298957216833935f9d3")
-    val pubkey2: PublicKey = PublicKey("02f0b230e53723ccc331db140edc518be1ee5ab29a508104a4be2f5be922c928e8")
-    val extraHops: Seq[ExtraHop] = PaymentHop.buildExtra(Seq(ucd -> pubkey1, ude -> pubkey2), 100000L)
+    val d: PublicKey = PublicKey("0299439d988cbf31388d59e3d6f9e184e7a0739b8b8fcdc298957216833935f9d3")
+    val e: PublicKey = PublicKey("02f0b230e53723ccc331db140edc518be1ee5ab29a508104a4be2f5be922c928e8")
 
-    val (_, _, payloads) = PaymentLifecycle.buildPayloads(100000L, 6, publicHops ++ extraHops)
-    assert(payloads === Seq(PerHopPayload(1L, 1194678L, 295), PerHopPayload(2L, 1192007L, 294), PerHopPayload(11091873301069824L, 646001L, 150), PerHopPayload(13390952114749440L, 100000L, 6), PerHopPayload(0L, 100000L, 6)))
+    val reversePathFromRecipient = Hop(d, e, ude) :: Hop(c, d, ucd) :: Nil
+    val extraHops: Seq[ExtraHop] = PaymentHop.buildExtra(reversePathFromRecipient, 100000L)
+
+    // (a -> b), (b -> c) ++ ((d -> e), (c -> d)).reverse
+    val (_, _, payloads) = PaymentLifecycle.buildPayloads(100000L, 6, publicHops ++ extraHops.reverse)
+    assert(payloads === List(PerHopPayload(1L, 1194678L, 295), PerHopPayload(2L, 1192007L, 294), PerHopPayload(11091873301069824L, 646006L, 150), PerHopPayload(13390952114749440L, 100000L, 6), PerHopPayload(0L, 100000L, 6)))
   }
 
 }


### PR DESCRIPTION
Unlike `Hop` from `Router`, `ExtraHop` from `PaymentRequest` has a pre-calculated fee for a given amount, otherwise they are pretty similar so it makes sense for them to inherit a same `PaymentHop` trait and use it in `PaymentLifecycle.buildPayloads` instead of `Hop`. 

This way it's possible to build a payment by getting a `Seq[Hop]` from `Router` and then just `PaymentLifecycle.buildPayloads(..., Seq[Hop] ++ Seq[ExtraHop])`