### PR TITLE
Add primary key to channel_updates table

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -19,7 +19,7 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
     statement.execute("PRAGMA foreign_keys = ON")
     statement.executeUpdate("CREATE TABLE IF NOT EXISTS nodes (node_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL)")
     statement.executeUpdate("CREATE TABLE IF NOT EXISTS channels (short_channel_id INTEGER NOT NULL PRIMARY KEY, data BLOB NOT NULL)")
-    statement.executeUpdate("CREATE TABLE IF NOT EXISTS channel_updates (short_channel_id INTEGER NOT NULL, node_flag INTEGER NOT NULL, data BLOB NOT NULL, FOREIGN KEY(short_channel_id) REFERENCES channels(short_channel_id))")
+    statement.executeUpdate("CREATE TABLE IF NOT EXISTS channel_updates (short_channel_id INTEGER NOT NULL, node_flag INTEGER NOT NULL, data BLOB NOT NULL, PRIMARY KEY(short_channel_id, node_flag), FOREIGN KEY(short_channel_id) REFERENCES channels(short_channel_id))")
     statement.executeUpdate("CREATE INDEX IF NOT EXISTS channel_updates_idx ON channel_updates(short_channel_id)")
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -27,9 +27,9 @@ class SqliteChannelsDbSpec extends FunSuite {
     assert(db.listChannels().toSet === Set.empty)
     db.addOrUpdateChannel(channel)
     db.addOrUpdateChannel(channel)
-    assert(db.listChannels().toSet === Set(channel))
+    assert(db.listChannels() === List(channel))
     db.removeChannel(channel.channelId)
-    assert(db.listChannels().toSet === Set.empty)
+    assert(db.listChannels() === Nil)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
@@ -7,6 +7,7 @@ import fr.acinq.bitcoin.{Block, Crypto}
 import fr.acinq.eclair.db.sqlite.SqliteNetworkDb
 import fr.acinq.eclair.randomKey
 import fr.acinq.eclair.router.Announcements
+import fr.acinq.eclair.wire.LightningMessageCodecs.channelAnnouncementCodec
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
@@ -33,6 +34,8 @@ class SqliteNetworkDbSpec extends FunSuite {
 
     assert(db.listNodes().toSet === Set.empty)
     db.addNode(node_1)
+    db.addNode(node_1) // duplicate is ignored
+    assert(db.listNodes().size === 1)
     db.addNode(node_2)
     db.addNode(node_3)
     assert(db.listNodes().toSet === Set(node_1, node_2, node_3))
@@ -53,6 +56,8 @@ class SqliteNetworkDbSpec extends FunSuite {
 
     assert(db.listChannels().toSet === Set.empty)
     db.addChannel(channel_1)
+    db.addChannel(channel_1) // duplicate is ignored
+    assert(db.listChannels().size === 1)
     db.addChannel(channel_2)
     db.addChannel(channel_3)
     assert(db.listChannels().toSet === Set(channel_1, channel_2, channel_3))
@@ -65,6 +70,8 @@ class SqliteNetworkDbSpec extends FunSuite {
 
     assert(db.listChannelUpdates().toSet === Set.empty)
     db.addChannelUpdate(channel_update_1)
+    db.addChannelUpdate(channel_update_1) // duplicate is ignored
+    assert(db.listChannelUpdates().size === 1)
     intercept[SQLiteException](db.addChannelUpdate(channel_update_2))
     db.addChannelUpdate(channel_update_3)
     db.removeChannel(channel_3.shortChannelId)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
@@ -31,6 +31,8 @@ class SqlitePeersDbSpec extends FunSuite {
 
     assert(db.listPeers().toSet === Set.empty)
     db.addOrUpdatePeer(peer_1._1, peer_1._2)
+    db.addOrUpdatePeer(peer_1._1, peer_1._2) // duplicate is ignored
+    assert(db.listPeers().size === 1)
     db.addOrUpdatePeer(peer_2._1, peer_2._2)
     db.addOrUpdatePeer(peer_3._1, peer_3._2)
     assert(db.listPeers().toSet === Set(peer_1, peer_2, peer_3))


### PR DESCRIPTION
This table was missing a primary key, which caused it to grow
indefinitely. It was deduped when loaded by the router but made
the startup time longer.

Also added duplication tests to other tables.