### PR TITLE
Use `min_final_cltv_expiry` included in payment request (if any)

### DIFF
--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/SendPaymentController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/SendPaymentController.scala
@@ -66,7 +66,7 @@ class SendPaymentController(val handlers: Handlers, val stage: Stage) extends Lo
   @FXML def handleSend(event: ActionEvent) = {
     Try(PaymentRequest.read(paymentRequest.getText)) match {
       case Success(pr) =>
-        Try(handlers.send(pr.nodeId, pr.paymentHash, pr.amount.get.amount)) match {
+        Try(handlers.send(pr.nodeId, pr.paymentHash, pr.amount.get.amount, pr.minFinalCltvExpiry)) match {
           case Success(s) => stage.close
           case Failure(f) => GUIValidators.validate(paymentRequestError, s"Invalid Payment Request: ${f.getMessage}", false)
         }


### PR DESCRIPTION
when sending an HTLC, we now use the optional min expiry that is specified in the BOLT11 payment request 