### PR TITLE
[README] Added help for options syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please see the latest [release note](https://github.com/ACINQ/eclair/releases) f
 
 ## Installation
 
-:warning: **Those are valid for the most up-to-date, unreleased, version of eclair. Here are the [instructions for Eclair 0.2-alpha4](https://github.com/ACINQ/eclair/blob/v0.2-alpha4/README.md#installation)**.
+:warning: **Those are valid for the most up-to-date, unreleased, version of eclair. Here are the [instructions for Eclair 0.2-alpha5](https://github.com/ACINQ/eclair/blob/v0.2-alpha5/README.md#installation)**.
 
 ### Configuring Bitcoin Core
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ name                         | description               | default value
  eclair.bitcoind.rpcpassword | Bitcoin Core RPC password | bar
  eclair.bitcoind.zmq         | Bitcoin Core ZMQ address  | tcp://127.0.0.1:29000
 
-The options syntax follows [the HOCON format](https://github.com/lightbend/config/blob/master/HOCON.md). Quotes are not required unless the value contains special characters.
+Quotes are not required unless the value contains special characters. Full syntax guide [here](https://github.com/lightbend/config/blob/master/HOCON.md).
 
 &rarr; see [`reference.conf`](eclair-core/src/main/resources/reference.conf) for full reference. There are many more options!
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ name                         | description               | default value
  eclair.bitcoind.rpcpassword | Bitcoin Core RPC password | bar
  eclair.bitcoind.zmq         | Bitcoin Core ZMQ address  | tcp://127.0.0.1:29000
 
+The options syntax follows [the HOCON format](https://github.com/lightbend/config/blob/master/HOCON.md). Quotes are not required unless the value contains special characters.
+
 &rarr; see [`reference.conf`](eclair-core/src/main/resources/reference.conf) for full reference. There are many more options!
 
 #### Java Environment Variables

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -1,6 +1,6 @@
 eclair {
 
-  chain = "test"
+  chain = "test" // "regtest" for regtest, "test" for testnet. Livenet is not supported.
   spv = false // experimental!! do not use
 
   server {


### PR DESCRIPTION
* Options in eclair configuration follow the HOCON syntax and it should be mentioned in the README file.

* the `chain` option should mention the available values: `test` and `regtest`. See https://github.com/ACINQ/eclair/issues/209