### PR TITLE
bitcoin rpc client: increase the number of concurrent requests

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -95,7 +95,7 @@ akka {
 
   http {
     host-connection-pool {
-      max-open-requests = 64
+      max-open-requests = 256
     }
   }
 }


### PR DESCRIPTION
this is a workaround for Exceeded configured max-open-requests errors when
sending too many rpc requests to bitcoin core.
see  http://doc.akka.io/docs/akka-http/current/scala/http/client-side/pool-overflow.html
for more information