### PR TITLE
Check that all UTXOS are p2sh on testnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ zmqpubrawblock=tcp://127.0.0.1:29000
 zmqpubrawtx=tcp://127.0.0.1:29000
 ```
 
+On **__testnet__**, you also need to make sure that all your UTXOs are `p2sh-of-p2wpkh`.
+To do this, use the debug console, create a new address with `getnewaddress`, import it as a witness address with `addwitnessaddress`, and
+send all your balance to this witness address. 
+If you need to create and send funds manually, don't forget to create and specify a witness address for the change output (this option is avaliable on the GUI once you set the `Enable coin control features` wallet option).
+
+
 ### Installing Eclair
 
 The released binaries can be downloaded [here](https://github.com/ACINQ/eclair/releases).

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -70,12 +70,17 @@ class Setup(datadir: File, overrideDefaults: Config = ConfigFactory.empty(), act
         progress = (json \ "verificationprogress").extract[Double]
         chainHash <- bitcoinClient.rpcClient.invoke("getblockhash", 0).map(_.extract[String]).map(BinaryData(_)).map(x => BinaryData(x.reverse))
         bitcoinVersion <- bitcoinClient.rpcClient.invoke("getnetworkinfo").map(json => (json \ "version")).map(_.extract[String])
-      } yield (progress, chainHash, bitcoinVersion)
+        unspentAddresses <- bitcoinClient.listUnspentAddresses
+      } yield (progress, chainHash, bitcoinVersion, unspentAddresses)
       // blocking sanity checks
-      val (progress, chainHash, bitcoinVersion) = Await.result(future, 10 seconds)
+      val (progress, chainHash, bitcoinVersion, unspentAddresses) = Await.result(future, 10 seconds)
       assert(chainHash == nodeParams.chainHash, s"chainHash mismatch (conf=${nodeParams.chainHash} != bitcoind=$chainHash)")
+      if (chainHash == Block.TestnetGenesisBlock.hash) {
+        assert(unspentAddresses.forall(isSegwitAddress), "In testnet mode, make sure that all your UTXOs are p2sh-of-p2wpkh (check out our README for more details)")
+      }
       assert(progress > 0.99, "bitcoind should be synchronized")
       // TODO: add a check on bitcoin version?
+
       Bitcoind(bitcoinClient)
     case BITCOINJ =>
       logger.warn("EXPERIMENTAL BITCOINJ MODE ENABLED!!!")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -64,4 +64,12 @@ package object eclair {
   def feerateByte2Kw(feeratePerByte: Long): Long = feeratePerByte * 1024 / 4
 
 
+  /**
+    *
+    * @param address bitcoin Base58 address
+    * @return true if the address is a segwit address i.e. a p2sh-of-p2wpkh address.
+    *         We approximate this be returning true if the address is a p2sh address, there is no
+    *         way to tell what the script is.
+    */
+  def isSegwitAddress(address: String) : Boolean = address.startsWith("2") || address.startsWith("3")
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -63,7 +63,7 @@ class BitcoinCoreWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLi
     val sender = TestProbe()
     sender.send(bitcoincli, BitcoinReq("stop"))
     sender.expectMsgType[JValue]
-    //bitcoind.destroy()
+    bitcoind.exitValue()
     //    logger.warn(s"starting bitcoin-qt")
     //    val PATH_BITCOINQT = new File(System.getProperty("buildDirectory"), "bitcoin-0.14.0/bin/bitcoin-qt").toPath
     //    bitcoind = s"$PATH_BITCOINQT -datadir=$PATH_BITCOIND_DATADIR".run()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -74,7 +74,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
     val sender = TestProbe()
     sender.send(bitcoincli, BitcoinReq("stop"))
     sender.expectMsgType[JValue]
-    //bitcoind.destroy()
+    bitcoind.exitValue()
     nodes.foreach {
       case (name, setup) =>
         logger.info(s"stopping node $name")


### PR DESCRIPTION
to avoid malleability issues, ask users to only have p2sh-of-p2wkh outputs.
on testnet, on startup we check that all UTXOs are p2sh (we cannot check that the
p2sh script is a p2wpkh script). it is not needed on regtest since there is no
chance that wallet tx will be malleated.