### PR TITLE
Basic data loss protection

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -46,7 +46,7 @@ eclair {
   node-alias = "eclair"
   node-color = "49daaa"
   global-features = ""
-  local-features = "08" // initial_routing_sync
+  local-features = "0a" // initial_routing_sync and data_loss_protect
   channel-flags = 1 // announce channels
   dust-limit-satoshis = 542
   default-feerate-per-kb = 20000  // default bitcoin core value

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -10,6 +10,9 @@ import fr.acinq.bitcoin.BinaryData
   * Created by PM on 13/02/2017.
   */
 object Features {
+  val OPTION_DATA_LOSS_PROTECT_MANDATORY = 0
+  val OPTION_DATA_LOSS_PROTECT_OPTIONAL = 1
+
   // reserved but not used as per lightningnetwork/lightning-rfc/pull/178
   val INITIAL_ROUTING_SYNC_BIT_MANDATORY = 2
   val INITIAL_ROUTING_SYNC_BIT_OPTIONAL = 3
@@ -27,6 +30,21 @@ object Features {
     * @return true if an initial dump of the routing table is requested
     */
   def initialRoutingSync(features: BinaryData): Boolean = initialRoutingSync(BitSet.valueOf(features.reverse.toArray))
+
+  /**
+    *
+    * @param features feature bits
+    * @return true if data loss protection is supported
+    */
+  def dataLossProtect(features: BitSet): Boolean = features.get(OPTION_DATA_LOSS_PROTECT_OPTIONAL)
+
+  /**
+    *
+    * @param features feature bits
+    * @return true if data loss protection is supported
+    */
+  def dataLossProtect(features: BinaryData): Boolean = dataLossProtect(BitSet.valueOf(features.reverse.toArray))
+
 
   /**
     * Check that the features that we understand are correctly specified, and that there are no mandatory features that

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1106,8 +1106,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
         channelId = d.channelId,
         nextLocalCommitmentNumber = d.commitments.localCommit.index + 1,
         nextRemoteRevocationNumber = d.commitments.remoteCommit.index,
-        Some(Scalar(yourLastPerCommitmentSecret)),
-        Some(myCurrentPerCommitmentPoint)
+        yourLastPerCommitmentSecret = Some(Scalar(yourLastPerCommitmentSecret)),
+        myCurrentPerCommitmentPoint = Some(myCurrentPerCommitmentPoint)
       )
       goto(SYNCING) sending channelReestablish
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1486,6 +1486,23 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
       } else throw RevocationSyncError(d.channelId)
     }
 
+    channelReestablish match {
+      case ChannelReestablish(_, _, nextRemoteRevocationNumber, Some(yourLastPerCommitmentSecret), Some(myCurrentPerCommitmentPoint))
+        // if next_remote_revocation_number is greater than expected above
+        if commitments1.localCommit.index < nextRemoteRevocationNumber =>
+
+        // AND your_last_per_commitment_secret is correct for that next_remote_revocation_number minus 1
+        if (Generators.perCommitSecret(d.commitments.localParams.shaSeed, nextRemoteRevocationNumber - 1) == yourLastPerCommitmentSecret) {
+          // TODO: MUST NOT broadcast its commitment transaction.
+          // TODO: SHOULD fail the channel.
+          // TODO: SHOULD store my_current_per_commitment_point to retrieve funds should the sending node broadcast its commitment transaction onchain
+        } else {
+          // TODO: SHOULD fail the channel
+        }
+
+      case _ => // Fine so far...
+    }
+
     // re-sending sig/rev (in the right order)
     val htlcsIn = commitments1.remoteNextCommitInfo match {
       case Left(waitingForRevocation) if waitingForRevocation.nextRemoteCommit.index + 1 == channelReestablish.nextLocalCommitmentNumber =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -43,6 +43,9 @@ case object CLOSING extends State
 case object CLOSED extends State
 case object OFFLINE extends State
 case object SYNCING extends State
+
+case object REFUNDING extends State
+
 case object ERR_FUNDING_PUBLISH_FAILED extends State
 case object ERR_FUNDING_LOST extends State
 case object ERR_FUNDING_TIMEOUT extends State
@@ -143,6 +146,10 @@ final case class DATA_SHUTDOWN(commitments: Commitments,
                                localShutdown: Shutdown, remoteShutdown: Shutdown) extends Data with HasCommitments
 final case class DATA_NEGOTIATING(commitments: Commitments,
                                   localShutdown: Shutdown, remoteShutdown: Shutdown, localClosingSigned: ClosingSigned) extends Data with HasCommitments
+
+final case class DATA_REFUNDING(commitments: Commitments,
+                                startedAt: Long) extends Data with HasCommitments // `startedAt` may be used to remove channel if peer does not respond for a long time
+
 final case class DATA_CLOSING(commitments: Commitments,
                               mutualClosePublished: Option[Transaction] = None,
                               localCommitPublished: Option[LocalCommitPublished] = None,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -450,7 +450,6 @@ object Commitments extends Logging {
   }
 
   def makeLocalTxs(commitTxNumber: Long, localParams: LocalParams, remoteParams: RemoteParams, commitmentInput: InputInfo, localPerCommitmentPoint: Point, spec: CommitmentSpec): (CommitTx, Seq[HtlcTimeoutTx], Seq[HtlcSuccessTx]) = {
-    val localPaymentPubkey = Generators.derivePubKey(localParams.paymentBasepoint, localPerCommitmentPoint)
     val localDelayedPaymentPubkey = Generators.derivePubKey(localParams.delayedPaymentBasepoint, localPerCommitmentPoint)
     val localHtlcPubkey = Generators.derivePubKey(localParams.htlcBasepoint, localPerCommitmentPoint)
     val remotePaymentPubkey = Generators.derivePubKey(remoteParams.paymentBasepoint, localPerCommitmentPoint)
@@ -464,7 +463,6 @@ object Commitments extends Logging {
   def makeRemoteTxs(commitTxNumber: Long, localParams: LocalParams, remoteParams: RemoteParams, commitmentInput: InputInfo, remotePerCommitmentPoint: Point, spec: CommitmentSpec): (CommitTx, Seq[HtlcTimeoutTx], Seq[HtlcSuccessTx]) = {
     val localPaymentPubkey = Generators.derivePubKey(localParams.paymentBasepoint, remotePerCommitmentPoint)
     val localHtlcPubkey = Generators.derivePubKey(localParams.htlcBasepoint, remotePerCommitmentPoint)
-    val remotePaymentPubkey = Generators.derivePubKey(remoteParams.paymentBasepoint, remotePerCommitmentPoint)
     val remoteDelayedPaymentPubkey = Generators.derivePubKey(remoteParams.delayedPaymentBasepoint, remotePerCommitmentPoint)
     val remoteHtlcPubkey = Generators.derivePubKey(remoteParams.htlcBasepoint, remotePerCommitmentPoint)
     val remoteRevocationPubkey = Generators.revocationPubKey(localParams.revocationBasepoint, remotePerCommitmentPoint)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
@@ -116,7 +116,9 @@ object LightningMessageCodecs {
   val channelReestablishCodec: Codec[ChannelReestablish] = (
     ("channelId" | binarydata(32)) ::
       ("nextLocalCommitmentNumber" | uint64) ::
-      ("nextRemoteRevocationNumber" | uint64)).as[ChannelReestablish]
+      ("nextRemoteRevocationNumber" | uint64) ::
+      ("yourLastPerCommitmentSecret" | optional(bool, scalar)) ::
+      ("myCurrentPerCommitmentPoint" | optional(bool, point))).as[ChannelReestablish]
 
   val openChannelCodec: Codec[OpenChannel] = (
     ("chainHash" | binarydata(32)) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
@@ -31,10 +31,11 @@ case class Ping(pongLength: Int, data: BinaryData) extends SetupMessage
 
 case class Pong(data: BinaryData) extends SetupMessage
 
-case class ChannelReestablish(
-                               channelId: BinaryData,
-                               nextLocalCommitmentNumber: Long,
-                               nextRemoteRevocationNumber: Long) extends ChannelMessage with HasChannelId
+case class ChannelReestablish(channelId: BinaryData,
+                              nextLocalCommitmentNumber: Long,
+                              nextRemoteRevocationNumber: Long,
+                              yourLastPerCommitmentSecret: Option[Scalar],
+                              myCurrentPerCommitmentPoint: Option[Point]) extends ChannelMessage with HasChannelId
 
 case class OpenChannel(chainHash: BinaryData,
                        temporaryChannelId: BinaryData,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
@@ -18,9 +18,19 @@ class FeaturesSpec extends FunSuite {
     assert(initialRoutingSync("08"))
   }
 
+  test("'data_loss_protect' feature") {
+    assert(dataLossProtect("02"))
+  }
+
+  test("'initial_routing_sync' and 'data_loss_protect' feature") {
+    assert(areSupported("0a") && dataLossProtect("0a") && initialRoutingSync("0a"))
+  }
+
   test("features compatibility") {
     assert(!areSupported(Protocol.writeUInt64(1L << INITIAL_ROUTING_SYNC_BIT_MANDATORY, ByteOrder.BIG_ENDIAN)))
     assert(areSupported(Protocol.writeUInt64(1l << INITIAL_ROUTING_SYNC_BIT_OPTIONAL, ByteOrder.BIG_ENDIAN)))
+    assert(!areSupported(Protocol.writeUInt64(1L << OPTION_DATA_LOSS_PROTECT_MANDATORY, ByteOrder.BIG_ENDIAN)))
+    assert(areSupported(Protocol.writeUInt64(1l << OPTION_DATA_LOSS_PROTECT_OPTIONAL, ByteOrder.BIG_ENDIAN)))
     assert(areSupported("14") == false)
     assert(areSupported("0141") == false)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -53,9 +53,9 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     sender.send(bob, INPUT_RECONNECTED(bob2alice.ref))
 
     // a didn't receive any update or sig
-    val ab_reestablish = alice2bob.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0))
+    val ab_reestablish = alice2bob.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0, None, None))
     // b didn't receive the sig
-    val ba_reestablish = bob2alice.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0))
+    val ba_reestablish = bob2alice.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0, None, None))
 
     // reestablish ->b
     alice2bob.forward(bob, ab_reestablish)
@@ -129,9 +129,9 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     sender.send(bob, INPUT_RECONNECTED(bob2alice.ref))
 
     // a didn't receive the sig
-    val ab_reestablish = alice2bob.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0))
+    val ab_reestablish = alice2bob.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0, None, None))
     // b did receive the sig
-    val ba_reestablish = bob2alice.expectMsg(ChannelReestablish(ab_add_0.channelId, 2, 0))
+    val ba_reestablish = bob2alice.expectMsg(ChannelReestablish(ab_add_0.channelId, 2, 0, None, None))
 
     // reestablish ->b
     alice2bob.forward(bob, ab_reestablish)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -5,6 +5,7 @@ import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.TestkitBaseClass
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.channel.{Data, State, _}
+import fr.acinq.eclair.crypto.{Generators, Sphinx}
 import fr.acinq.eclair.wire._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -52,10 +53,16 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     sender.send(alice, INPUT_RECONNECTED(alice2bob.ref))
     sender.send(bob, INPUT_RECONNECTED(bob2alice.ref))
 
+    val bobCommitments = bob.stateData.asInstanceOf[HasCommitments].commitments
+    val aliceCommitments = alice.stateData.asInstanceOf[HasCommitments].commitments
+
+    val bobCurrentPerCommitmentPoint = Generators.perCommitPoint(bobCommitments.localParams.shaSeed, bobCommitments.localCommit.index)
+    val aliceCurrentPerCommitmentPoint = Generators.perCommitPoint(aliceCommitments.localParams.shaSeed, aliceCommitments.localCommit.index)
+
     // a didn't receive any update or sig
-    val ab_reestablish = alice2bob.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0, None, None))
+    val ab_reestablish = alice2bob.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0, Some(Sphinx zeroes 32), Some(aliceCurrentPerCommitmentPoint)))
     // b didn't receive the sig
-    val ba_reestablish = bob2alice.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0, None, None))
+    val ba_reestablish = bob2alice.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0, Some(Sphinx zeroes 32), Some(bobCurrentPerCommitmentPoint)))
 
     // reestablish ->b
     alice2bob.forward(bob, ab_reestablish)
@@ -128,10 +135,16 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     sender.send(alice, INPUT_RECONNECTED(alice2bob.ref))
     sender.send(bob, INPUT_RECONNECTED(bob2alice.ref))
 
+    val bobCommitments = bob.stateData.asInstanceOf[HasCommitments].commitments
+    val aliceCommitments = alice.stateData.asInstanceOf[HasCommitments].commitments
+
+    val bobCurrentPerCommitmentPoint = Generators.perCommitPoint(bobCommitments.localParams.shaSeed, bobCommitments.localCommit.index)
+    val aliceCurrentPerCommitmentPoint = Generators.perCommitPoint(aliceCommitments.localParams.shaSeed, aliceCommitments.localCommit.index)
+
     // a didn't receive the sig
-    val ab_reestablish = alice2bob.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0, None, None))
+    val ab_reestablish = alice2bob.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0, Some(Sphinx zeroes 32), Some(aliceCurrentPerCommitmentPoint)))
     // b did receive the sig
-    val ba_reestablish = bob2alice.expectMsg(ChannelReestablish(ab_add_0.channelId, 2, 0, None, None))
+    val ba_reestablish = bob2alice.expectMsg(ChannelReestablish(ab_add_0.channelId, 2, 0, Some(Sphinx zeroes 32), Some(bobCurrentPerCommitmentPoint)))
 
     // reestablish ->b
     alice2bob.forward(bob, ab_reestablish)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/LightningMessageCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/LightningMessageCodecsSpec.scala
@@ -189,7 +189,7 @@ class LightningMessageCodecsSpec extends FunSuite {
     val announcement_signatures = AnnouncementSignatures(randomBytes(32), 42, randomSignature, randomSignature)
     val ping = Ping(100, BinaryData("01" * 10))
     val pong = Pong(BinaryData("01" * 10))
-    val channel_reestablish = ChannelReestablish(randomBytes(32), 242842L, 42L)
+    val channel_reestablish = ChannelReestablish(randomBytes(32), 242842L, 42L, Some(scalar(0)), Some(point(1)))
 
     val msgs: List[LightningMessage] =
       open :: accept :: funding_created :: funding_signed :: funding_locked :: update_fee :: shutdown :: closing_signed ::


### PR DESCRIPTION
As of now it can detect when current channel state is outdated and main output refunding procedure should start. But handling is not implemented yet. 

Perhaps there should be a dedicated channel data like `REFUNDING_DATA(updated commitments)` which, upon receiving `WatchEventSpent` would initiate a special `claimRemoteLostCommitMainOutput` method instead of regular `claimRemoteCommitTxOutputs`?

`updated commitments` is our outdated commitments with `.remoteCommit.remotePerCommitmentPoint`updated to `myCurrentPerCommitmentPoint` taken from their `ChannelReestablish` upon receiving it.