### PR TITLE
[WIP] Shrink README and add detailed help to the Wiki

### DIFF
--- a/CONFIGURE.md
+++ b/CONFIGURE.md
@@ -1,0 +1,38 @@
+# Configure Eclair
+
+Eclair reads its configuration from the `eclair.conf` file in the `datadir` directory. By default, `datadir` is `~/.eclair`, you can override this through a parameters when launching eclair. Detailed information is available in this page.
+
+## Change your node's configuration
+
+The first step is to actually create the configuration file. Go to `datadir` and create a file name `eclair.conf`. Encoding should be UTF-8.
+
+Options are set as key-value pairs. The syntax follows the <TODO link>. Value do not need to be surrounded by quotes, except if they contain special characters.
+
+This is a common configuration file which overrides the default server port, node's label and node's color:
+
+```shell
+
+# server port
+eclair.server.port=9737
+
+# node's label
+eclair.node-alias="my node"
+
+# rgb node's color
+eclair.node-color=49daaa
+
+```
+
+## Options reference
+
+Here are some of the most common options:
+
+name                         | description               | default value
+-----------------------------|---------------------------|--------------
+ eclair.server.port          | Lightning TCP port        | 9735
+ eclair.api.port             | API HTTP port             | 8080
+ eclair.bitcoind.rpcuser     | Bitcoin Core RPC user     | foo
+ eclair.bitcoind.rpcpassword | Bitcoin Core RPC password | bar
+ eclair.bitcoind.zmq         | Bitcoin Core ZMQ address  | tcp://127.0.0.1:29000
+
+&rarr; see [`reference.conf`](eclair-core/src/main/resources/reference.conf) for full reference. There are many more options!

--- a/RUN.md
+++ b/RUN.md
@@ -1,0 +1,115 @@
+# Run a full eclair node on desktop
+
+## Supported platforms
+
+Eclair is supported on the following platforms:
+
+* Linux - as a self executable JAR file
+* Mac OS - as a self executable JAR file
+* Windows - as a self executable JAR file. An installer is also available.
+
+## Prerequisites
+
+* Java [JRE 1.8](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html). Note that if you are using the windows installer, the JRE is included in the package.
+* [Bitcoin Core](https://github.com/bitcoin/bitcoin) 0.14+: _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node. This means that on Windows you will need Bitcoin Core 0.14+. See below for the required bitcoin configuration.
+
+```
+testnet=1
+server=1
+rpcuser=XXX
+rpcpassword=XXX
+txindex=1
+zmqpubrawblock=tcp://127.0.0.1:29000
+zmqpubrawtx=tcp://127.0.0.1:29000
+```
+
+## Installation
+
+### Manual installation (Linux, MacOS, Windows)
+
+Download the latest JAR files available in https://github.com/ACINQ/eclair/releases.
+
+The eclair node JAR file are named as follows:
+
+```shell
+# Without a user interface
+eclair-node-<version>.jar
+
+# With a User Interface
+eclair-node-gui-<version>.jar
+```
+
+:warning: On linux if you are using the OpenJDK JRE and want to run Eclair with a GUI, you will need to build OpenJFX yourself.
+
+Then move the JAR to your preferred folder.
+
+### Autoinstaller (Windows only)
+
+The installer is available for Windows only. It will install Eclair in your Windows user's `AppData` folder and create a shortcut on your desktop pointing to the Eclair node `.exe` file.
+
+## Run your node
+
+For the Windows autoinstall version, running the node is pretty straightforward. The following instructions will assume that you are using a manual installation.
+
+Go to the folder containing the Eclair JAR file and run the following command:
+
+
+```shell
+# Without a user interface
+java -jar eclair-node-<version>.jar
+
+# With a User Interface
+java -jar eclair-node-gui-<version>.jar
+```
+
+## Run Eclair node with advanced options
+
+For advanced used case, some options are available, they can be changed through Java environment variables. Most users won't need this and can skip this section.
+
+For users with the autoinstall version, you can set Java parameter by right clicking on the Eclair shortcut and add the parameter at the end of the target input field.
+
+### Run Eclair GUI in headless mode
+
+You can run a GUI version of eclair without the GUI by providing the `eclair.headless` parameter.
+
+```shell
+# Headless mode with the GUI JaR
+java -jar eclair-node-gui-<version>.jar -Declair.headless
+```
+
+### Change the data directory
+
+The default data directory is `~/.eclair`. You can change this with the `eclair.datadir` parameter.
+
+```shell
+java -jar eclair-node-<version>.jar -Declair.datadir="/path/to/custom/eclair/data/folder"
+```
+
+### Run several instances of Eclair on the same host
+
+If you want to run several instance of eclair on the same machine, you'll have to use a separate `datadir` for each node. Use the `eclair.datadir` parameter as seen above.
+
+You'll also have to use different ports for each running instance of Eclair. To do so, please take a look at the Eclair options page.
+
+### Print to stdout when running
+
+If you wish to log in the console in addition to `eclair.log`, add the `eclair.printToConsole` parameter.
+
+
+## Eclair logs
+
+Eclair logs are found in the `datadir` directory.
+
+## Eclair JSON-RPC API
+
+Eclair API listens API on the `eclair.api.port` port set in the configuration. This API exposes all the necessary methods to read the current state of the node, open/close channels and send/receive payments.
+
+Please take a look a the Eclair API page.
+
+## Configuring Eclair
+
+Please take a look at the Eclair options page
+
+## Use Eclair GUI
+
+Please take a look at the Eclair usage page.

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,106 @@
+# Usage instructions
+
+## Your node's informations
+
+### With a GUI
+
+The GUI displays a status bar on the bottom on the window with the following data:
+
+* Node's public key. Right click on this node to copy the node's public key or the node's URI.
+* Node's server port
+* Node's API port
+* Bitcoin core's version
+* Current chain (regtest, testnet, livenet)
+
+### Command line
+
+```shell
+
+./eclair.cli openchannel <node_pubkey> <ip> <port> <capacity_in_satoshi> <push_in_millisatoshi>
+
+```
+
+## Open a channel
+
+A channel is a bitcoin transaction between two parties, funded by one party and signed by both the funder and the fundee. To establish a channel between two nodes, the funder must set the address of the fundee and the amount of money he wants to lock in the channel.
+
+* URI of the targeted node. This URI looks like this:
+
+```shell
+
+target_node_public_key@host:ip
+
+```
+
+Note: a node's public key is the unique identifier or the node on the network.
+
+* Channel's capacity: this is the amount in Bitcoin that the funder wants to lock in the channel. When opening the channel, the balance will be equal to the capacity (unless the funder set a `push` amount)
+
+* (optional) Push amount: This amount is sent by the funder to the fundee. Default value is 0. The `push` amount is deducted from the balance of the channel on the funder side. This behaviour is akin to opening a channel with a 0 `push` amount and send a payment to the fundee as soon as the channel reaches a ready state, and should be used by advanced users only.
+
+### Dual funding
+
+A channel can not be funded by the two parties yet. This feature will be available in the 1.1 version of the Lightning Network specifications.
+
+### Channel's lifecycle
+
+This are the possible states of the channel:
+
+* **WAIT_FOR_INIT_INTERNAL**: 
+* **WAIT_FOR_OPEN_CHANNEL**: channel is initializing, internal operations only
+* **WAIT_FOR_ACCEPT_CHANNEL**: waiting for the fundee to accept the channel
+* **WAIT_FOR_FUNDING_CREATED**: the funding transaction is being created by the two parties
+* **WAIT_FOR_FUNDING_SIGNED**: both parties must sign the transaction
+* **WAIT_FOR_FUNDING_LOCKED**: the transaction must have at least 1 confirmation
+* **NORMAL**: the channel is opened and ready to receive, forward or send payments
+
+### With the GUI
+
+* Click on `File` > `Open Channel`.
+* Enter the URI of the node you want to open a channel with.
+* Enter the capacity of the channel. This amount must be lower than 0,167 Bitcoins.
+* (optional) Enter a push amount
+* Click OK
+* Wait for 6 confirmations. Your channel should reach the `NORMAL` state.
+* You can now send/receive/forward payments
+
+### Command line (Linux only)
+
+Run the following command:
+
+```shell
+
+./eclair.cli openchannel <node_pubkey> <ip> <port> <capacity_in_satoshi> <push_in_millisatoshi>
+
+```
+
+### WIth the JSON-RPC API
+
+Link to the API.
+
+## Close a channel
+
+
+
+### With the GUI
+
+### Command line
+
+### WIth the JSON-RPC API
+
+## Receive a payment
+
+### With the GUI
+
+### Command line
+
+### WIth the JSON-RPC API
+
+## Send a payment
+
+### With the GUI
+
+### Command line
+
+### WIth the JSON-RPC API
+


### PR DESCRIPTION
The README file should be briefer, with a short presentation of the project, a short Getting Started section for users and a few links to the Wiki for more advanced users.

Detailed help should be found in the project's Wiki where it can be edited by anyone without having to create a Pull request.
This detailed help should contain at least these pages:

* How to **install** and **run** a node? With a section for advanced use cases (such as multiple instances)
* How to **configure** my node? With reasonable explanations for the possible parameters in `eclair.conf`
* How to **use** eclair ? Be it with the GUI, command line or with the JSON RPC API
