### PR TITLE
Added more checks on `open`/`accept` messages

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -48,7 +48,7 @@ eclair {
   global-features = ""
   local-features = "08" // initial_routing_sync
   channel-flags = 1 // announce channels
-  dust-limit-satoshis = 542
+  dust-limit-satoshis = 546
   default-feerate-per-kb = 20000  // default bitcoin core value
 
   max-htlc-value-in-flight-msat = 100000000000 // 1 BTC ~= unlimited

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -11,6 +11,7 @@ import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.DeterministicWallet.ExtendedPrivateKey
 import fr.acinq.bitcoin.{BinaryData, Block, DeterministicWallet}
 import fr.acinq.eclair.NodeParams.WatcherType
+import fr.acinq.eclair.channel.Channel
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.db.sqlite.{SqliteChannelsDb, SqliteNetworkDb, SqlitePeersDb, SqlitePreimagesDb}
 
@@ -114,6 +115,12 @@ object NodeParams {
       case _ => BITCOIND
     }
 
+    val dustLimitSatoshis = config.getLong("dust-limit-satoshis")
+    require(dustLimitSatoshis >= Channel.MIN_DUSTLIMIT, s"dust limit must be greater than ${Channel.MIN_DUSTLIMIT}")
+
+    val maxAcceptedHtlcs = config.getInt("max-accepted-htlcs")
+    require(maxAcceptedHtlcs <= Channel.MAX_ACCEPTED_HTLCS, s"max-accepted-htlcs must be lower than ${Channel.MAX_ACCEPTED_HTLCS}")
+
     NodeParams(
       extendedPrivateKey = extendedPrivateKey,
       privateKey = extendedPrivateKey.privateKey,
@@ -122,9 +129,9 @@ object NodeParams {
       publicAddresses = config.getStringList("server.public-ips").toList.map(ip => new InetSocketAddress(ip, config.getInt("server.port"))),
       globalFeatures = BinaryData(config.getString("global-features")),
       localFeatures = BinaryData(config.getString("local-features")),
-      dustLimitSatoshis = config.getLong("dust-limit-satoshis"),
+      dustLimitSatoshis = dustLimitSatoshis,
       maxHtlcValueInFlightMsat = UInt64(config.getLong("max-htlc-value-in-flight-msat")),
-      maxAcceptedHtlcs = config.getInt("max-accepted-htlcs"),
+      maxAcceptedHtlcs = maxAcceptedHtlcs,
       expiryDeltaBlocks = config.getInt("expiry-delta-blocks"),
       htlcMinimumMsat = config.getInt("htlc-minimum-msat"),
       delayBlocks = config.getInt("delay-blocks"),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -10,6 +10,11 @@ import fr.acinq.eclair.UInt64
 class ChannelException(channelId: BinaryData, message: String) extends RuntimeException(message)
 // @formatter:off
 case class DebugTriggeredException             (channelId: BinaryData) extends ChannelException(channelId, "debug-mode triggered failure")
+case class InvalidChainHash                    (channelId: BinaryData, local: BinaryData, remote: BinaryData) extends ChannelException(channelId, s"invalid chain_hash (local=$local remote=$remote)")
+case class InvalidFundingAmount                (channelId: BinaryData, fundingSatoshis: Long, min: Long, max: Long) extends ChannelException(channelId, s"invalid funding_satoshis=$fundingSatoshis (min=$min max=$max)")
+case class InvalidPushAmount                   (channelId: BinaryData, pushMsat: Long, max: Long) extends ChannelException(channelId, s"invalid push_msat=$pushMsat (max=$max)")
+case class InvalidMaxAcceptedHtlcs             (channelId: BinaryData, maxAcceptedHtlcs: Int, max: Int) extends ChannelException(channelId, s"invalid max_accepted_htlcs=$maxAcceptedHtlcs (max=$max)")
+case class InvalidDustLimit                    (channelId: BinaryData, dustLimitSatoshis: Long, min: Long) extends ChannelException(channelId, s"invalid dust_limit_satoshis=$dustLimitSatoshis (min=$min)")
 case class ChannelReserveTooHigh               (channelId: BinaryData, channelReserveSatoshis: Long, reserveToFundingRatio: Double, maxReserveToFundingRatio: Double) extends ChannelException(channelId, s"channelReserveSatoshis too high: reserve=$channelReserveSatoshis fundingRatio=$reserveToFundingRatio maxFundingRatio=$maxReserveToFundingRatio")
 case class ClosingInProgress                   (channelId: BinaryData) extends ChannelException(channelId, "cannot send new htlcs, closing in progress")
 case class ClosingAlreadyInProgress            (channelId: BinaryData) extends ChannelException(channelId, "closing already in progress")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -7,7 +7,7 @@ import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{MilliSatoshi, Satoshi}
 import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.blockchain.EclairWallet
-import fr.acinq.eclair.channel.HasCommitments
+import fr.acinq.eclair.channel.{Channel, HasCommitments}
 import fr.acinq.eclair.crypto.TransportHandler.HandshakeCompleted
 import fr.acinq.eclair.router.Rebroadcast
 
@@ -101,7 +101,10 @@ object Switchboard {
   def props(nodeParams: NodeParams, watcher: ActorRef, router: ActorRef, relayer: ActorRef, wallet: EclairWallet) = Props(new Switchboard(nodeParams, watcher, router, relayer, wallet))
 
   // @formatter:off
-  case class NewChannel(fundingSatoshis: Satoshi, pushMsat: MilliSatoshi, channelFlags: Option[Byte])
+  case class NewChannel(fundingSatoshis: Satoshi, pushMsat: MilliSatoshi, channelFlags: Option[Byte]) {
+    require(fundingSatoshis.amount < Channel.MAX_FUNDING_SATOSHIS, s"fundingSatoshis must be less than ${Channel.MAX_FUNDING_SATOSHIS}")
+    require(pushMsat.amount < 1000 * fundingSatoshis.amount, s"pushMsat must be less or equal to fundingSatoshis")
+  }
   case class NewConnection(remoteNodeId: PublicKey, address: InetSocketAddress, newChannel_opt: Option[NewChannel])
   // @formatter:on
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -103,7 +103,7 @@ object Switchboard {
   // @formatter:off
   case class NewChannel(fundingSatoshis: Satoshi, pushMsat: MilliSatoshi, channelFlags: Option[Byte]) {
     require(fundingSatoshis.amount < Channel.MAX_FUNDING_SATOSHIS, s"fundingSatoshis must be less than ${Channel.MAX_FUNDING_SATOSHIS}")
-    require(pushMsat.amount < 1000 * fundingSatoshis.amount, s"pushMsat must be less or equal to fundingSatoshis")
+    require(pushMsat.amount <= 1000 * fundingSatoshis.amount, s"pushMsat must be less or equal to fundingSatoshis")
   }
   case class NewConnection(remoteNodeId: PublicKey, address: InetSocketAddress, newChannel_opt: Option[NewChannel])
   // @formatter:on

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -65,7 +65,7 @@ class TransactionsSpec extends FunSuite {
     val remoteHtlcPriv = PrivateKey(BinaryData("eb" * 32), compressed = true)
     val localFinalPriv = PrivateKey(BinaryData("ff" * 32), compressed = true)
     val finalPubKeyScript = Script.write(Script.pay2wpkh(PrivateKey(BinaryData("fe" * 32), compressed = true).publicKey))
-    val localDustLimit = Satoshi(542)
+    val localDustLimit = Satoshi(546)
     val toLocalDelay = 144
     val feeratePerKw = 1000
 
@@ -141,7 +141,7 @@ class TransactionsSpec extends FunSuite {
     val finalPubKeyScript = Script.write(Script.pay2wpkh(PrivateKey(BinaryData("a9" * 32), true).publicKey))
     val commitInput = Funding.makeFundingInputInfo(BinaryData("a0" * 32), 0, Btc(1), localFundingPriv.publicKey, remoteFundingPriv.publicKey)
     val toLocalDelay = 144
-    val localDustLimit = Satoshi(542)
+    val localDustLimit = Satoshi(546)
     val feeratePerKw = 22000
 
 

--- a/eclair-node-gui/src/main/resources/gui/modals/openChannel.fxml
+++ b/eclair-node-gui/src/main/resources/gui/modals/openChannel.fxml
@@ -73,7 +73,7 @@
         </VBox>
         <TextField fx:id="pushMsat" prefWidth="313.0" GridPane.columnIndex="1" GridPane.rowIndex="4"/>
         <Label fx:id="pushMsatError" opacity="0.0" styleClass="text-error, text-error-downward"
-               text="Generic Invalid Push"
+               text="Generic Invalid Push" GridPane.columnSpan="2"
                GridPane.columnIndex="1" GridPane.rowIndex="4"/>
         <CheckBox fx:id="publicChannel" mnemonicParsing="true" selected="true" styleClass="text-sm"
                   text="Public Channel"


### PR DESCRIPTION
We check that channel parameters are compliant with [BOLT 2](https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md) (this fixes #236).

We make sure that the counterparty chooses a decent `dust_limit`
because we want them to be able to publish their commitment, e.g. in a
data loss scenario. We also make sure that our configurable `dust_limit` isn't too low (this
fixes #234).

Also fixed our min `dust_limit` (542->546).