### PR TITLE
Maven command to build eclair-node only

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -8,14 +8,18 @@
 ## Build
 To build the project, simply run:
 ```shell
-$ mvn package
+$ mvn install
 ```
 To skip the tests, run:
 ```shell
-$ mvn package -DskipTests
+$ mvn install -DskipTests
+```
+To only build the `eclair-node` module
+```shell
+$ mvn install -pl eclair-node -am -DskipTests
 ```
 To generate the windows installer along with the build, run the following command:
 ```shell
-$ mvn package -DskipTests -Pinstaller
+$ mvn install -DskipTests -Pinstaller
 ```
 The generated installer will be located in `eclair-node-gui/target/jfx/installer`


### PR DESCRIPTION
Building the `eclair-node` module only is a valid use case and the maven command to do it is not obvious. Added it to BUILD.md.

Also the `install` goal should be favored instead of `package`.