### PR TITLE
Docker support with repeatable builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+.dockerignore
+target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+FROM openjdk:8u121-jdk-alpine as BUILD
+
+# Setup maven, we don't use https://hub.docker.com/_/maven/ as it declare .m2 as volume, we loose all mvn cache
+# We can alternatively do as proposed by https://github.com/carlossg/docker-maven#packaging-a-local-repository-with-the-image
+# this was meant to make the image smaller, but we use multi-stage build so we don't care
+
+# We can remove dependency on git by setting <failOnNoGitDirectory>false</failOnNoGitDirectory> is set on git-commit-id-plugin
+RUN apk add --no-cache curl tar bash git
+
+ARG MAVEN_VERSION=3.5.2
+ARG USER_HOME_DIR="/root"
+ARG SHA=707b1f6e390a65bde4af4cdaf2a24d45fc19a6ded00fff02e91626e3e42ceaff
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+# Let's fetch eclair dependencies by copying and running poms without sources first. 
+# Docker will not have to fetch dependencies again if only the source code change
+WORKDIR /usr/src
+COPY pom.xml pom.xml
+COPY eclair-core/pom.xml eclair-core/pom.xml
+COPY eclair-node/pom.xml eclair-node/pom.xml
+COPY eclair-node-gui/pom.xml eclair-node-gui/pom.xml
+
+# We can remove dependency on git by setting <failOnNoGitDirectory>false</failOnNoGitDirectory> is set on git-commit-id-plugin
+RUN git init && \
+    git config  user.email "you@example.com" && \
+    git config user.name "Your Name" && \
+    git commit --allow-empty-message -m "" --allow-empty && \
+    # Get offline dependencies
+    mvn dependency:go-offline --fail-never && \
+    # For some reasons mvn miss dependencies which can be downloaded automatically if there is something to build
+    mkdir eclair-core/src && mkdir eclair-core/src/main && mkdir eclair-core/src/main/scala && touch eclair-core/src/main/scala/dummy.scala && \
+    mvn install -DskipTests -f eclair-core/pom.xml --fail-never && \
+    rm -rf eclair-core/src && mvn clean && \
+    # Same stuff with eclair-node
+    mkdir eclair-node/src && mkdir eclair-node/src/main && mkdir eclair-node/src/main/scala && touch eclair-node/src/main/scala/dummy.scala && \
+    mvn install -DskipTests -f eclair-node/pom.xml --fail-never && \
+    rm -rf eclair-node/src && mvn clean && \
+    # For some reasons, this fetch more dependencies
+    mvn package -pl eclair-node -am -DskipTests && mvn clean && \
+    rm -rf .git
+
+# Phew, we have all the dependencies in local now. We can now copy sources and build offline
+COPY . .
+RUN mvn package -pl eclair-node -am -DskipTests -o
+# It might be good idea to run the tests here, so that the docker build fail if the code is bugged
+
+# Remove artifact unecessary to run
+RUN cd eclair-node/target && ls -1 | grep -v 'node-'  | xargs rm -rf
+
+# We are only interested into the target for running eclair
+FROM openjdk:8u151-jre-slim
+WORKDIR /app
+COPY --from=BUILD /usr/src/eclair-node/target .
+RUN ln `ls` eclair-node
+ENTRYPOINT [ "java", "-jar", "eclair-node" ]


### PR DESCRIPTION
This DockerFile will repeatably build `eclair-node` and publish the artifact in a slim image.

Due to comments in Line 38, you will get this error message.

```
[WARNING]: Empty continuation line found in:
    RUN git init &&     git config  user.email "you@example.com" &&     git config user.name "Your Name" &&     git commit --allow-empty-message -m "" --allow-empty &&     mvn dependency:go-offline --fail-never &&     mkdir eclair-core/src && mkdir eclair-core/src/main && mkdir eclair-core/src/main/scala && touch eclair-core/src/main/scala/dummy.scala &&     mvn install -DskipTests -f eclair-core/pom.xml --fail-never &&     rm -rf eclair-core/src && mvn clean &&     mkdir eclair-node/src && mkdir eclair-node/src/main && mkdir eclair-node/src/main/scala && touch eclair-node/src/main/scala/dummy.scala &&     mvn install -DskipTests -f eclair-node/pom.xml --fail-never &&     rm -rf eclair-node/src && mvn clean &&     mvn package -pl eclair-node -am -DskipTests && mvn clean &&     rm -rf .git
[WARNING]: Empty continuation lines will become errors in a future release.
```

This error is harmless and will be fixed in Docker 17.10 (See https://github.com/moby/moby/pull/35004)

The build is a bit difficult as I am doing it in two parts: Fetching all the online dependencies, then building. This is very useful for developers: If you modify sources, docker will use a cached layer just before the build, but after fetching the dependencies.

There is a build time dependency on git.
The reason is that in order to fetch dependencies before copying all the sources to the container, only the poms file are copied, not the `.git` folder. (if it was included, any change to this directory would invalidate the cache built after downloading the dependencies) 

The build time dependency on git can be removed by adding  `<failOnNoGitDirectory>false</failOnNoGitDirectory>` to the git plugin in all the poms.

slim image is used instead of alpine for the runtime image. Alpine would show the following exception:

```
Failed to load native library:sqlite-3.20.0-9227a29f-7f85-48af-894b-57f88019b72e-libsqlitejdbc.so. osinfo: Linux/x86_64
java.lang.UnsatisfiedLinkError: /tmp/sqlite-3.20.0-9227a29f-7f85-48af-894b-57f88019b72e-libsqlitejdbc.so: Error relocating /tmp/sqlite-3.20.0-9227a29f-7f85-48af-894b-57f88019b72e-libsqlitejdbc.so: __isnan: symbol not found
fatal error: org.sqlite.core.NativeDB._open_utf8([BI)V
```