### PR TITLE
Docker support with repeatable builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+.dockerignore
+.git
+**/*.idea
+**/*.iml
+**/target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+FROM openjdk:8u121-jdk-alpine as BUILD
+
+# Setup maven, we don't use https://hub.docker.com/_/maven/ as it declare .m2 as volume, we loose all mvn cache
+# We can alternatively do as proposed by https://github.com/carlossg/docker-maven#packaging-a-local-repository-with-the-image
+# this was meant to make the image smaller, but we use multi-stage build so we don't care
+
+RUN apk add --no-cache curl tar bash
+
+ARG MAVEN_VERSION=3.5.2
+ARG USER_HOME_DIR="/root"
+ARG SHA=707b1f6e390a65bde4af4cdaf2a24d45fc19a6ded00fff02e91626e3e42ceaff
+ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+
+RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && echo "${SHA}  /tmp/apache-maven.tar.gz" | sha256sum -c - \
+  && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+
+# Let's fetch eclair dependencies, so that Docker can cache them
+# This way we won't have to fetch dependencies again if only the source code changes
+# The easiest way to reliably get dependencies is to build the project with no sources
+WORKDIR /usr/src
+COPY pom.xml pom.xml
+COPY eclair-core/pom.xml eclair-core/pom.xml
+COPY eclair-node/pom.xml eclair-node/pom.xml
+COPY eclair-node-gui/pom.xml eclair-node-gui/pom.xml
+RUN mkdir -p eclair-core/src/main/scala && touch eclair-core/src/main/scala/empty.scala
+# Blank build. We only care about eclair-node, and we use install because eclair-node depends on eclair-core
+RUN mvn install -pl eclair-node -am clean
+
+# Only then do we copy the sources
+COPY . .
+
+# And this time we can build in offline mode
+RUN mvn package -pl eclair-node -am -DskipTests -o
+# It might be good idea to run the tests here, so that the docker build fail if the code is bugged
+
+# We currently use a debian image for runtime because of some jni-related issue with sqlite
+FROM openjdk:8u151-jre-slim
+WORKDIR /app
+# Eclair only needs the eclair-node-*.jar to run
+COPY --from=BUILD /usr/src/eclair-node/target/eclair-node-*.jar .
+RUN ln `ls` eclair-node
+ENTRYPOINT [ "java", "-jar", "eclair-node" ]

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -16,17 +16,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>revision</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
                 <version>1.3.0</version>

--- a/eclair-node-gui/pom.xml
+++ b/eclair-node-gui/pom.xml
@@ -16,17 +16,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>revision</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -16,17 +16,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>revision</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- default tag used when building without git -->
+        <git.commit.id>notag</git.commit.id>
+        <git.commit.id.abbrev>notag</git.commit.id.abbrev>
         <scala.version>2.11.11</scala.version>
         <scala.version.short>2.11</scala.version.short>
         <akka.version>2.4.18</akka.version>
@@ -84,6 +87,21 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>2.3</version>
+            </plugin>
+            <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>2.2.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                        <configuration>
+                            <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>


### PR DESCRIPTION
Made by @pm47 , improve on https://github.com/ACINQ/eclair/pull/251.

--------------

Dependency to `git` has been removed, we now use `notag` when building without
a git directory.

In order to reliably fetch all dependencies, we do a first blank commit
(with no source files), then we copy the sources and do a real commit.

This is a simpler and more robust approach.

Also, fixed the .dockerignore to filter out IDE files.