### PR TITLE
Removed default values for commitid in pom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN mvn install -pl eclair-node -am clean
 # Only then do we copy the sources
 COPY . .
 
-# And this time we can build in offline mode
-RUN mvn package -pl eclair-node -am -DskipTests -o
+# And this time we can build in offline mode, specifying 'notag' instead of git commit
+RUN mvn package -pl eclair-node -am -DskipTests -Dgit.commit.id=notag -Dgit.commit.id.abbrev=notag -o
 # It might be good idea to run the tests here, so that the docker build fail if the code is bugged
 
 # We currently use a debian image for runtime because of some jni-related issue with sqlite

--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <!-- default tag used when building without git -->
-        <git.commit.id>notag</git.commit.id>
-        <git.commit.id.abbrev>notag</git.commit.id.abbrev>
         <scala.version>2.11.11</scala.version>
         <scala.version.short>2.11</scala.version.short>
         <akka.version>2.4.18</akka.version>


### PR DESCRIPTION
This is a regression caused by 0794fb8d5a289a3c4e5a180cc203b4f8565c04bb,
because default values provided for `git.commit.id` `git.commit.id.abbrev`
are not overriden by git-commit-id-plugin plugin.

Instead we specify these variables when doing the docker build.