### PR TITLE
Handle corner case when relaying to an unknown channel

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Relayer.scala
@@ -100,7 +100,7 @@ class Relayer(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorR
           sender ! CMD_FAIL_MALFORMED_HTLC(add.id, Crypto.sha256(add.onionRoutingPacket), failureCode = FailureMessageCodecs.BADONION, commit = true)
       }
 
-    case Register.ForwardShortIdFailure(Register.ForwardShortId(shortChannelId, CMD_ADD_HTLC(_, _, _, _, Some(add), _))) =>
+    case Status.Failure(Register.ForwardShortIdFailure(Register.ForwardShortId(shortChannelId, CMD_ADD_HTLC(_, _, _, _, Some(add), _)))) =>
       log.warning(s"couldn't resolve downstream channel $shortChannelId, failing htlc #${add.id}")
       register ! Register.Forward(add.channelId, CMD_FAIL_HTLC(add.id, Right(UnknownNextPeer), commit = true))
 
@@ -145,6 +145,8 @@ class Relayer(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorR
     case ForwardFailMalformed(fail, Relayed(originChannelId, originHtlcId, _, _)) =>
       val cmd = CMD_FAIL_MALFORMED_HTLC(originHtlcId, fail.onionHash, fail.failureCode, commit = true)
       register ! Register.Forward(originChannelId, cmd)
+
+    case "ok" => () // ignoring responses from channels
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -1,9 +1,10 @@
 package fr.acinq.eclair.payment
 
-import akka.actor.ActorRef
+import akka.actor.{ActorRef, Status}
 import akka.testkit.TestProbe
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{BinaryData, Crypto, MilliSatoshi}
+import fr.acinq.eclair.randomBytes
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.PaymentLifecycle.buildCommand
@@ -37,12 +38,8 @@ class RelayerSpec extends TestkitBaseClass {
     }
   }
 
-  // node c is the next node in the route
-  val nodeId_a = PublicKey(a)
-  val nodeId_c = PublicKey(c)
-  val channelId_ab: BinaryData = "65514354" * 8
-  val channelId_bc: BinaryData = "64864544" * 8
-  val channel_flags = 0x00.toByte
+  val channelId_ab: BinaryData = randomBytes(32)
+  val channelId_bc: BinaryData = randomBytes(32)
 
   def makeCommitments(channelId: BinaryData) = Commitments(null, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, null, null, channelId)
 
@@ -78,6 +75,32 @@ class RelayerSpec extends TestkitBaseClass {
     val fail = sender.expectMsgType[CMD_FAIL_HTLC]
     assert(fail.id === add_ab.id)
     assert(fail.reason == Right(UnknownNextPeer))
+
+    register.expectNoMsg(500 millis)
+    paymentHandler.expectNoMsg(500 millis)
+  }
+
+  test("fail to relay an htlc-add when register returns an error") { case (relayer, register, paymentHandler) =>
+    val sender = TestProbe()
+
+    // we use this to build a valid onion
+    val (cmd, _) = buildCommand(finalAmountMsat, finalExpiry, paymentHash, hops)
+    // and then manually build an htlc
+    val add_ab = UpdateAddHtlc(channelId = channelId_ab, id = 123456, cmd.amountMsat, cmd.paymentHash, cmd.expiry, cmd.onion)
+    relayer ! channelUpdate_bc
+
+    sender.send(relayer, ForwardAdd(add_ab))
+
+    val fwd1 = register.expectMsgType[Register.ForwardShortId[CMD_ADD_HTLC]]
+    assert(fwd1.shortChannelId === channelUpdate_bc.shortChannelId)
+    assert(fwd1.message.upstream_opt === Some(add_ab))
+
+    sender.send(relayer, Status.Failure(Register.ForwardShortIdFailure(fwd1)))
+
+    val fwd2 = register.expectMsgType[Register.Forward[CMD_FAIL_HTLC]]
+    assert(fwd2.channelId === channelId_ab)
+    assert(fwd2.message.id === add_ab.id)
+    assert(fwd2.message.reason === Right(UnknownNextPeer))
 
     register.expectNoMsg(500 millis)
     paymentHandler.expectNoMsg(500 millis)


### PR DESCRIPTION
The `relayer` wasn't correctly handling failures from the `register`, which led to `htlc` lingering without being failed. Sender would see payments stuck in `PENDING` state until they eventually timeout and cause the channel to be unilaterally closed.