### PR TITLE
Added more methods in API

### DIFF
--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -18,6 +18,9 @@ case $1 in
 "channels")
         eval curl "$CURL_OPTS -d '{ \"method\": \"channels\", \"params\" : [] }' $URL" | jq ".result[]"
         ;;
+"channelsto")
+        eval curl "$CURL_OPTS -d '{ \"method\": \"channelsto\", \"params\" : [\"${2?"missing node id"}\"] }' $URL" | jq ".result[]"
+        ;;
 "channel")
         eval curl "$CURL_OPTS -d '{ \"method\": \"channel\", \"params\" : [\"${2?"missing channel id"}\"] }' $URL" | jq ".result | { nodeid, channelId, state, balanceMsat: .data.commitments.localCommit.spec.toLocalMsat, capacitySat: .data.commitments.commitInput.txOut.amount.amount }"
         ;;

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -16,6 +16,7 @@ import de.heikoseeberger.akkahttpjson4s.Json4sSupport.ShouldWritePretty
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{BinaryData, MilliSatoshi, Satoshi}
 import fr.acinq.eclair.Kit
+import fr.acinq.eclair.channel.Register.ForwardShortId
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.io.Switchboard.{NewChannel, NewConnection}
 import fr.acinq.eclair.payment.{PaymentRequest, PaymentResult, ReceivePayment, SendPayment}
@@ -26,7 +27,7 @@ import org.json4s.{JValue, jackson}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 /**
   * Created by PM on 25/01/2016.
@@ -62,10 +63,19 @@ trait Service extends Logging {
     `Cache-Control`(public, `no-store`, `max-age`(0)) ::
     `Access-Control-Allow-Headers`("x-requested-with") :: Nil
 
-  def getChannel(channelId: String): Future[ActorRef] =
+  /**
+    * Sends a request to a channel and expects a response
+    * @param channelIdentifier can be a shortChannelId (8-byte hex encoded) or a channelId (32-byte hex encoded)
+    * @param request
+    * @return
+    */
+  def sendToChannel(channelIdentifier: String, request: Any): Future[Any] =
     for {
-      channels <- (appKit.register ? 'channels).mapTo[Map[BinaryData, ActorRef]]
-    } yield channels.get(BinaryData(channelId)).getOrElse(throw new RuntimeException("unknown channel"))
+      fwdReq <- Future(Register.ForwardShortId(java.lang.Long.parseLong(channelIdentifier, 16), request))
+          .recoverWith { case _ => Future(Register.Forward(BinaryData(channelIdentifier), request)) }
+          .recoverWith { case _ => Future.failed(new RuntimeException(s"invalid channel identifier")) }
+      res <- appKit.register ? fwdReq
+    } yield res
 
   val route =
     respondWithDefaultHeaders(customHeaders) {
@@ -89,8 +99,8 @@ trait Service extends Logging {
                   (switchboard ? 'peers).mapTo[Map[PublicKey, ActorRef]].map(_.map(_._1.toBin))
                 case JsonRPCBody(_, _, "channels", _) =>
                   (register ? 'channels).mapTo[Map[Long, ActorRef]].map(_.keys)
-                case JsonRPCBody(_, _, "channel", JString(channelId) :: Nil) =>
-                  getChannel(channelId).flatMap(_ ? CMD_GETINFO).mapTo[RES_GETINFO]
+                case JsonRPCBody(_, _, "channel", JString(identifier) :: Nil) =>
+                  sendToChannel(identifier, CMD_GETINFO).mapTo[RES_GETINFO]
                 case JsonRPCBody(_, _, "allnodes", _) =>
                   (router ? 'nodes).mapTo[Iterable[NodeAnnouncement]].map(_.map(_.nodeId))
                 case JsonRPCBody(_, _, "allchannels", _) =>
@@ -116,10 +126,10 @@ trait Service extends Logging {
                     }
                     res <- (paymentInitiator ? sendPayment).mapTo[PaymentResult]
                   } yield res
-                case JsonRPCBody(_, _, "close", JString(channelId) :: JString(scriptPubKey) :: Nil) =>
-                  getChannel(channelId).flatMap(_ ? CMD_CLOSE(scriptPubKey = Some(scriptPubKey))).mapTo[String]
-                case JsonRPCBody(_, _, "close", JString(channelId) :: Nil) =>
-                  getChannel(channelId).flatMap(_ ? CMD_CLOSE(scriptPubKey = None)).mapTo[String]
+                case JsonRPCBody(_, _, "close", JString(identifier) :: JString(scriptPubKey) :: Nil) =>
+                  sendToChannel(identifier, CMD_CLOSE(scriptPubKey = Some(scriptPubKey))).mapTo[String]
+                case JsonRPCBody(_, _, "close", JString(identifier) :: Nil) =>
+                  sendToChannel(identifier, CMD_CLOSE(scriptPubKey = None)).mapTo[String]
                 case JsonRPCBody(_, _, "help", _) =>
                   Future.successful(List(
                     "connect (nodeId, host, port): connect to another lightning node through a secure connection",

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -265,8 +265,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
         signature = localSigOfRemoteTx
       )
       val channelId = toLongId(fundingTx.hash, fundingTxOutputIndex)
-      context.parent ! ChannelIdAssigned(self, temporaryChannelId, channelId) // we notify the peer asap so it knows how to route messages
-      context.system.eventStream.publish(ChannelIdAssigned(self, temporaryChannelId, channelId))
+      context.parent ! ChannelIdAssigned(self, remoteNodeId, temporaryChannelId, channelId) // we notify the peer asap so it knows how to route messages
+      context.system.eventStream.publish(ChannelIdAssigned(self, remoteNodeId, temporaryChannelId, channelId))
       goto(WAIT_FOR_FUNDING_SIGNED) using DATA_WAIT_FOR_FUNDING_SIGNED(channelId, localParams, remoteParams, fundingTx, localSpec, localCommitTx, RemoteCommit(0, remoteSpec, remoteCommitTx.tx.txid, remoteFirstPerCommitmentPoint), open.channelFlags, fundingCreated) sending fundingCreated
 
     case Event(Status.Failure(t), d: DATA_WAIT_FOR_FUNDING_INTERNAL) =>
@@ -313,8 +313,8 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
             originChannels = Map.empty,
             remoteNextCommitInfo = Right(randomKey.publicKey), // we will receive their next per-commitment point in the next message, so we temporarily put a random byte array,
             commitInput, ShaChain.init, channelId = channelId)
-          context.parent ! ChannelIdAssigned(self, temporaryChannelId, channelId) // we notify the peer asap so it knows how to route messages
-          context.system.eventStream.publish(ChannelIdAssigned(self, temporaryChannelId, channelId))
+          context.parent ! ChannelIdAssigned(self, remoteNodeId, temporaryChannelId, channelId) // we notify the peer asap so it knows how to route messages
+          context.system.eventStream.publish(ChannelIdAssigned(self, remoteNodeId, temporaryChannelId, channelId))
           context.system.eventStream.publish(ChannelSignatureReceived(self, commitments))
           log.info(s"waiting for them to publish the funding tx for channelId=$channelId fundingTxid=${commitInput.outPoint.txid}")
           blockchain ! WatchSpent(self, commitInput.outPoint.txid, commitInput.outPoint.index.toInt, commitments.commitInput.txOut.publicKeyScript, BITCOIN_FUNDING_SPENT) // TODO: should we wait for an acknowledgment from the watcher?

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -14,7 +14,7 @@ case class ChannelCreated(channel: ActorRef, peer: ActorRef, remoteNodeId: Publi
 
 case class ChannelRestored(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, isFunder: Boolean, channelId: BinaryData, currentData: HasCommitments) extends ChannelEvent
 
-case class ChannelIdAssigned(channel: ActorRef, temporaryChannelId: BinaryData, channelId: BinaryData) extends ChannelEvent
+case class ChannelIdAssigned(channel: ActorRef, remoteNodeId: PublicKey, temporaryChannelId: BinaryData, channelId: BinaryData) extends ChannelEvent
 
 case class ShortChannelIdAssigned(channel: ActorRef, channelId: BinaryData, shortChannelId: Long) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -63,6 +63,6 @@ object Register {
   case class ForwardShortId[T](shortChannelId: Long, message: T)
 
   case class ForwardFailure[T](fwd: Forward[T]) extends RuntimeException(s"channel ${fwd.channelId} not found")
-  case class ForwardShortIdFailure[T](fwd: ForwardShortId[T]) extends RuntimeException(s"channel ${fwd.shortChannelId} not found")
+  case class ForwardShortIdFailure[T](fwd: ForwardShortId[T]) extends RuntimeException(s"channel ${fwd.shortChannelId.toHexString} not found")
   // @formatter:on
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -194,7 +194,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, address_opt: Option[
       }
       stay
 
-    case Event(ChannelIdAssigned(channel, temporaryChannelId, channelId), d@ConnectedData(_, _, channels)) if channels.contains(TemporaryChannelId(temporaryChannelId)) =>
+    case Event(ChannelIdAssigned(channel, _, temporaryChannelId, channelId), d@ConnectedData(_, _, channels)) if channels.contains(TemporaryChannelId(temporaryChannelId)) =>
       log.info(s"channel id switch: previousId=$temporaryChannelId nextId=$channelId")
       // NB: we keep the temporary channel id because the switch is not always acknowledged at this point (see https://github.com/lightningnetwork/lightning-rfc/pull/151)
       // we won't clean it up, but we won't remember the temporary id on channel termination

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -81,7 +81,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
       })
       context.become(main(m + (channel -> channelPaneController)))
 
-    case ChannelIdAssigned(channel, temporaryChannelId, channelId) if m.contains(channel) =>
+    case ChannelIdAssigned(channel, _, _, channelId) if m.contains(channel) =>
       val channelPaneController = m(channel)
       Platform.runLater(new Runnable() {
         override def run = {
@@ -89,7 +89,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
         }
       })
 
-    case ChannelStateChanged(channel, _, _, _, currentState, currentData) if m.contains(channel) =>
+    case ChannelStateChanged(channel, _, _, _, currentState, _) if m.contains(channel) =>
       val channelPaneController = m(channel)
       Platform.runLater(new Runnable() {
         override def run = {


### PR DESCRIPTION
- can now use `channelId` or `shortChannelId` in calls `channel`/`close`
- added a `channelsto` `nodeId` method