### PR TITLE
Add a custom json serializer for `OutPoint`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -1,11 +1,11 @@
 package fr.acinq.eclair.api
 
 import fr.acinq.bitcoin.Crypto.{Point, PrivateKey, PublicKey, Scalar}
-import fr.acinq.bitcoin.{BinaryData, Transaction}
+import fr.acinq.bitcoin.{BinaryData, OutPoint, Transaction}
 import fr.acinq.eclair.channel.State
 import fr.acinq.eclair.crypto.ShaChain
 import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo
-import org.json4s.CustomSerializer
+import org.json4s.{CustomKeySerializer, CustomSerializer}
 import org.json4s.JsonAST.{JNull, JString}
 
 /**
@@ -72,5 +72,14 @@ class TransactionWithInputInfoSerializer extends CustomSerializer[TransactionWit
     ???
 }, {
   case x: TransactionWithInputInfo => JString(Transaction.write(x.tx).toString())
+}
+))
+
+class OutPointKeySerializer extends CustomKeySerializer[OutPoint](format => ( {
+  case x: String =>
+    val Array(k, v) = x.split(":")
+    OutPoint(BinaryData(k), v.toLong)
+}, {
+  case x: OutPoint => s"${x.hash}:${x.index}"
 }
 ))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -46,7 +46,7 @@ trait Service extends Logging {
   implicit def ec: ExecutionContext = ExecutionContext.Implicits.global
 
   implicit val serialization = jackson.Serialization
-  implicit val formats = org.json4s.DefaultFormats + new BinaryDataSerializer + new StateSerializer + new ShaChainSerializer + new PublicKeySerializer + new PrivateKeySerializer + new ScalarSerializer + new PointSerializer + new TransactionWithInputInfoSerializer
+  implicit val formats = org.json4s.DefaultFormats + new BinaryDataSerializer + new StateSerializer + new ShaChainSerializer + new PublicKeySerializer + new PrivateKeySerializer + new ScalarSerializer + new PointSerializer + new TransactionWithInputInfoSerializer + new OutPointKeySerializer
   implicit val timeout = Timeout(30 seconds)
   implicit val shouldWritePretty: ShouldWritePretty = ShouldWritePretty.True
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
@@ -1,0 +1,33 @@
+package fr.acinq.eclair.api
+
+import fr.acinq.bitcoin.{BinaryData, OutPoint}
+import org.json4s.Formats
+import org.json4s.jackson.Serialization
+import org.scalatest.FunSuite
+
+class JsonSerializersSpec extends FunSuite {
+
+  def writeRead(map: Map[OutPoint, BinaryData])(implicit formats: Formats) = {
+    val ser = Serialization.write(map)
+    val check = Serialization.read[Map[OutPoint, BinaryData]](ser)
+    assert(check === map)
+  }
+
+  test("deserialize Map[OutPoint, BinaryData]") {
+    val map = Map(
+      OutPoint("11418a2d282a40461966e4f578e1fdf633ad15c1b7fb3e771d14361127233be1", 0) -> BinaryData("dead"),
+      OutPoint("3d62bd4f71dc63798418e59efbc7532380c900b5e79db3a5521374b161dd0e33", 1) -> BinaryData("beef")
+    )
+    implicit val formats = org.json4s.DefaultFormats
+
+    // it won't work without a custom key serializer
+    val error = intercept[org.json4s.MappingException] {
+      writeRead(map)(formats)
+    }
+    assert(error.msg.contains("Do not know how to serialize key of type class fr.acinq.bitcoin.OutPoint."))
+
+    // but it works with our custom key serializer
+    implicit val formats1 = formats + new OutPointKeySerializer
+    writeRead(map)(formats1)
+  }
+}


### PR DESCRIPTION
For some reason, eclair wasn't always able to serialize it correctly:

```
Error during processing of request: 'Do
not know how to serialize key of type class fr.acinq.bitcoin.OutPoint. Consider implementing a CustomKeySerializer.'. Completing with 500 Internal Server Err
or response. To change default exception handling behavior, provide a custom ExceptionHandler.
org.json4s.package$MappingException: Do not know how to serialize key of type class fr.acinq.bitcoin.OutPoint. Consider implementing a CustomKeySerializer.
```

Note: I wasn't able to reproduce.