### PR TITLE
Reworked peer management

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ java -Declair.datadir=/tmp/node1 -jar eclair-node-gui-<version>-<commit_id>.jar
  method       |  params                                       | description
  -------------|-----------------------------------------------|-----------------------------------------------------------
   getinfo     |                                               | return basic node information (id, chain hash, current block height) 
-  connect     | nodeId, host, port                            | connect to another lightning node through a secure connection
-  open        | nodeId, host, port, fundingSatoshis, pushMsat | opens a channel with another lightning node
+  connect     | uri                                           | open a secure connection to a lightning node
+  open        | nodeId, fundingSatoshis, pushMsat             | open a channel with another lightning node
   peers       |                                               | list existing local peers
   channels    |                                               | list existing local channels
   channel     | channelId                                     | retrieve detailed information about a given channel

--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -24,8 +24,11 @@ case $1 in
 "channel")
         eval curl "$CURL_OPTS -d '{ \"method\": \"channel\", \"params\" : [\"${2?"missing channel id"}\"] }' $URL" | jq ".result | { nodeid, channelId, state, balanceMsat: .data.commitments.localCommit.spec.toLocalMsat, capacitySat: .data.commitments.commitInput.txOut.amount.amount }"
         ;;
+"connect")
+        eval curl "$CURL_OPTS -d '{ \"method\": \"open\", \"params\" : [\"${2?"missing uri"}\"] }' $URL" | jq -r "if .error == null then .result else .error.message end"
+        ;;
 "open")
-        eval curl "$CURL_OPTS -d '{ \"method\": \"open\", \"params\" : [\"${2?"missing node id"}\", \"${3?"missing ip"}\", ${4?"missing port"}, ${5?"missing amount (sat)"}, ${6?"missing push amount (msat)"}] }' $URL" | jq -r "if .error == null then .result else .error.message end"
+        eval curl "$CURL_OPTS -d '{ \"method\": \"open\", \"params\" : [\"${2?"missing node id"}\", ${3?"missing amount (sat)"}, ${4?"missing push amount (msat)"}] }' $URL" | jq -r "if .error == null then .result else .error.message end"
         ;;
 "close")
         eval curl "$CURL_OPTS -d '{ \"method\": \"close\", \"params\" : [\"${2?"missing channel id"}\"] }' $URL"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -1,5 +1,7 @@
 package fr.acinq.eclair.api
 
+import java.net.InetSocketAddress
+
 import fr.acinq.bitcoin.Crypto.{Point, PrivateKey, PublicKey, Scalar}
 import fr.acinq.bitcoin.{BinaryData, OutPoint, Transaction}
 import fr.acinq.eclair.channel.State
@@ -72,6 +74,14 @@ class TransactionWithInputInfoSerializer extends CustomSerializer[TransactionWit
     ???
 }, {
   case x: TransactionWithInputInfo => JString(x.tx.toString())
+}
+))
+
+class InetSocketAddressSerializer extends CustomSerializer[InetSocketAddress](format => ( {
+  case JString(x) if (false) => // NOT IMPLEMENTED
+    ???
+}, {
+  case x: InetSocketAddress => JString(s"${x.getHostString}:${x.getPort}")
 }
 ))
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -21,7 +21,6 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.io.Peer.{GetPeerInfo, PeerInfo}
 import fr.acinq.eclair.io.{NodeURI, Peer}
 import fr.acinq.eclair.payment.{PaymentRequest, PaymentResult, ReceivePayment, SendPayment}
-import fr.acinq.eclair.io.Switchboard.{NewChannel, NewConnection}
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.wire.{ChannelAnnouncement, NodeAnnouncement}
 import grizzled.slf4j.Logging

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -52,7 +52,7 @@ trait Service extends Logging {
   implicit def ec: ExecutionContext = ExecutionContext.Implicits.global
 
   implicit val serialization = jackson.Serialization
-  implicit val formats = org.json4s.DefaultFormats + new BinaryDataSerializer + new StateSerializer + new ShaChainSerializer + new PublicKeySerializer + new PrivateKeySerializer + new ScalarSerializer + new PointSerializer + new TransactionWithInputInfoSerializer + new OutPointKeySerializer
+  implicit val formats = org.json4s.DefaultFormats + new BinaryDataSerializer + new StateSerializer + new ShaChainSerializer + new PublicKeySerializer + new PrivateKeySerializer + new ScalarSerializer + new PointSerializer + new TransactionWithInputInfoSerializer + new InetSocketAddressSerializer + new OutPointKeySerializer
   implicit val timeout = Timeout(30 seconds)
   implicit val shouldWritePretty: ShouldWritePretty = ShouldWritePretty.True
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/TransportHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/TransportHandler.scala
@@ -77,7 +77,7 @@ class TransportHandler[T: ClassTag](keyPair: KeyPair, rs: Option[BinaryData], co
         reader.read(payload) match {
           case (writer, _, Some((dec, enc, ck))) =>
             val remoteNodeId = PublicKey(writer.rs)
-            context.parent ! HandshakeCompleted(self, remoteNodeId)
+            context.parent ! HandshakeCompleted(connection, self, remoteNodeId)
             val nextStateData = WaitingForListenerData(ExtendedCipherState(enc, ck), ExtendedCipherState(dec, ck), remainder)
             goto(WaitingForListener) using nextStateData
 
@@ -93,7 +93,7 @@ class TransportHandler[T: ClassTag](keyPair: KeyPair, rs: Option[BinaryData], co
               case (_, message, Some((enc, dec, ck))) => {
                 out ! buf(TransportHandler.prefix +: message)
                 val remoteNodeId = PublicKey(writer.rs)
-                context.parent ! HandshakeCompleted(self, remoteNodeId)
+                context.parent ! HandshakeCompleted(connection, self, remoteNodeId)
                 val nextStateData = WaitingForListenerData(ExtendedCipherState(enc, ck), ExtendedCipherState(dec, ck), remainder)
                 goto(WaitingForListener) using nextStateData
               }
@@ -131,16 +131,15 @@ class TransportHandler[T: ClassTag](keyPair: KeyPair, rs: Option[BinaryData], co
 
   whenUnhandled {
     case Event(ErrorClosed(cause), _) =>
-      // we transform connection closed events into application error so that it triggers a uniclose
-      log.warning(s"tcp connection error: $cause")
+      log.debug(s"tcp connection error: $cause")
       stop(FSM.Normal)
 
     case Event(PeerClosed, _) =>
-      log.warning(s"connection closed")
+      log.debug(s"connection closed")
       stop(FSM.Normal)
 
     case Event(Terminated(actor), _) if actor == connection =>
-      log.warning(s"connection terminated, stopping the transport")
+      log.debug(s"connection terminated, stopping the transport")
       // this can be the connection or the listener, either way it is a cause of death
       stop(FSM.Normal)
   }
@@ -216,7 +215,7 @@ object TransportHandler {
 
   case class Listener(listener: ActorRef)
 
-  case class HandshakeCompleted(transport: ActorRef, remoteNodeId: PublicKey)
+  case class HandshakeCompleted(connection: ActorRef, transport: ActorRef, remoteNodeId: PublicKey)
 
   sealed trait Data
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Authenticator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Authenticator.scala
@@ -1,0 +1,68 @@
+package fr.acinq.eclair.io
+
+import java.net.InetSocketAddress
+
+import akka.actor.{Actor, ActorLogging, ActorRef, Props, Status, Terminated}
+import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.eclair.NodeParams
+import fr.acinq.eclair.crypto.Noise.KeyPair
+import fr.acinq.eclair.crypto.TransportHandler
+import fr.acinq.eclair.crypto.TransportHandler.HandshakeCompleted
+import fr.acinq.eclair.io.Authenticator.{Authenticated, AuthenticationFailed, PendingAuth}
+import fr.acinq.eclair.wire.{LightningMessage, LightningMessageCodecs}
+
+/**
+  * The purpose of this class is to serve as a buffer for newly connection before they are authenticated
+  * (meaning that a crypto handshake as successfully been completed).
+  *
+  * All incoming/outgoing connections are processed here, before being sent to the switchboard
+  */
+class Authenticator(nodeParams: NodeParams) extends Actor with ActorLogging {
+
+  override def receive: Receive = {
+    case switchboard: ActorRef => context become ready(switchboard, Map.empty)
+  }
+
+  def ready(switchboard: ActorRef, authenticating: Map[ActorRef, PendingAuth]): Receive = {
+    case pending@PendingAuth(connection, _, outgoingConnection_opt) =>
+      val transport = context.actorOf(Props(
+        new TransportHandler[LightningMessage](
+          KeyPair(nodeParams.privateKey.publicKey.toBin, nodeParams.privateKey.toBin),
+          outgoingConnection_opt.map(_.remoteNodeId),
+          connection = connection,
+          codec = LightningMessageCodecs.lightningMessageCodec)))
+      context watch transport
+      context become (ready(switchboard, authenticating + (transport -> pending)))
+
+    case HandshakeCompleted(connection, transport, remoteNodeId) if authenticating.contains(transport) =>
+      val pendingAuth = authenticating(transport)
+      log.info(s"connection authenticated with $remoteNodeId address=${pendingAuth.outgoingConnection_opt.map(_.address).getOrElse("(incoming)")}")
+      switchboard ! Authenticated(connection, transport, remoteNodeId, pendingAuth.outgoingConnection_opt.map(_.address), pendingAuth.origin_opt)
+      context become ready(switchboard, authenticating - transport)
+
+    case Terminated(transport) =>
+      authenticating.get(transport) match {
+        case Some(pendingAuth) =>
+          // we send an error only when we are the initiator
+          pendingAuth.origin_opt.map(origin => pendingAuth.outgoingConnection_opt.map(_.address).map(address => origin ! Status.Failure(AuthenticationFailed(address))))
+          context become ready(switchboard, authenticating - transport)
+        case None => ()
+      }
+
+  }
+
+  override def unhandled(message: Any): Unit = log.warning(s"unhandled message=$message")
+}
+
+object Authenticator {
+
+  def props(nodeParams: NodeParams): Props = Props(new Authenticator(nodeParams))
+
+  // @formatter:off
+  case class OutgoingConnection(remoteNodeId: PublicKey, address: InetSocketAddress)
+  case class PendingAuth(connection: ActorRef, origin_opt: Option[ActorRef], outgoingConnection_opt: Option[OutgoingConnection])
+  case class Authenticated(connection: ActorRef, transport: ActorRef, remoteNodeId: PublicKey, address_opt: Option[InetSocketAddress], origin: Option[ActorRef])
+  case class AuthenticationFailed(address: InetSocketAddress) extends RuntimeException(s"connection failed to $address")
+  // @formatter:on
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/NodeURI.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/NodeURI.scala
@@ -1,0 +1,20 @@
+package fr.acinq.eclair.io
+
+import java.net.InetSocketAddress
+
+import fr.acinq.bitcoin.Crypto.PublicKey
+
+case class NodeURI(nodeId: PublicKey, address: InetSocketAddress) {
+  override def toString: String = s"$nodeId@${address.getHostString}:${address.getPort}"
+}
+
+object NodeURI {
+
+  val regex = """([a-fA-F0-9]{66})@([a-zA-Z0-9:\.\-_]+):([0-9]+)""".r
+
+
+  def parse(uri: String): NodeURI = {
+    val regex(nodeid, host, port) = uri
+    NodeURI(PublicKey(nodeid), new InetSocketAddress(host, port.toInt))
+  }
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -4,24 +4,22 @@ import java.net.InetSocketAddress
 
 import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, Status, SupervisorStrategy, Terminated}
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{MilliSatoshi, Satoshi}
 import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.blockchain.EclairWallet
-import fr.acinq.eclair.channel.{Channel, HasCommitments}
-import fr.acinq.eclair.crypto.TransportHandler.HandshakeCompleted
+import fr.acinq.eclair.channel.HasCommitments
 import fr.acinq.eclair.router.Rebroadcast
 
 /**
   * Ties network connections to peers.
   * Created by PM on 14/02/2017.
   */
-class Switchboard(nodeParams: NodeParams, watcher: ActorRef, router: ActorRef, relayer: ActorRef, wallet: EclairWallet) extends Actor with ActorLogging {
+class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: ActorRef, router: ActorRef, relayer: ActorRef, wallet: EclairWallet) extends Actor with ActorLogging {
 
-  import Switchboard._
+  authenticator ! self
 
   // we load peers and channels from database
   val initialPeers = {
-    val channels = nodeParams.channelsDb.listChannels().toList.groupBy(_.commitments.remoteParams.nodeId)
+    val channels = nodeParams.channelsDb.listChannels().groupBy(_.commitments.remoteParams.nodeId)
     val peers = nodeParams.peersDb.listPeers().toMap
     channels
       .map {
@@ -30,67 +28,69 @@ class Switchboard(nodeParams: NodeParams, watcher: ActorRef, router: ActorRef, r
       .map {
         case (remoteNodeId, states, address_opt) =>
           // we might not have an address if we didn't initiate the connection in the first place
-          val peer = createOrGetPeer(Map(), remoteNodeId, address_opt, states.toSet)
+          val peer = createOrGetPeer(Map(), remoteNodeId, previousKnownAddress = address_opt, offlineChannels = states.toSet)
           (remoteNodeId -> peer)
       }.toMap
   }
 
-  def receive: Receive = main(initialPeers, Map())
+  def receive: Receive = main(initialPeers)
 
-  def main(peers: Map[PublicKey, ActorRef], connections: Map[PublicKey, ActorRef]): Receive = {
+  def main(peers: Map[PublicKey, ActorRef]): Receive = {
 
-    case NewConnection(publicKey, _, _) if publicKey == nodeParams.privateKey.publicKey =>
+    case Peer.Connect(NodeURI(publicKey, _)) if publicKey == nodeParams.privateKey.publicKey =>
       sender ! Status.Failure(new RuntimeException("cannot open connection with oneself"))
 
-    case NewConnection(remoteNodeId, address, newChannel_opt) =>
-      val connection = connections.get(remoteNodeId) match {
-        case Some(connection) =>
-          log.info(s"already connected to nodeId=$remoteNodeId")
-          sender ! s"already connected to nodeId=$remoteNodeId"
-          connection
-        case None =>
-          log.info(s"connecting to $remoteNodeId @ $address on behalf of $sender")
-          val connection = context.actorOf(Client.props(nodeParams, self, address, remoteNodeId, sender))
-          context watch (connection)
-          connection
+    case c@Peer.Connect(NodeURI(remoteNodeId, _)) =>
+      // we create a peer if it doesn't exist
+      val peer = createOrGetPeer(peers, remoteNodeId, previousKnownAddress = None, offlineChannels = Set.empty)
+      peer forward c
+      context become main(peers + (remoteNodeId -> peer))
+
+    case o@Peer.OpenChannel(remoteNodeId, _, _, _) =>
+      peers.get(remoteNodeId) match {
+        case Some(peer) => peer forward o
+        case None => sender ! Status.Failure(new RuntimeException("no connection to peer"))
       }
-      val peer = createOrGetPeer(peers, remoteNodeId, Some(address), Set.empty)
-      newChannel_opt.foreach(peer forward _)
-      context become main(peers + (remoteNodeId -> peer), connections + (remoteNodeId -> connection))
 
-    case Terminated(actor) if connections.values.toSet.contains(actor) =>
-      log.info(s"$actor is dead, removing from connections")
-      val remoteNodeId = connections.find(_._2 == actor).get._1
-      context become main(peers, connections - remoteNodeId)
+    case Terminated(actor) =>
+      peers.collectFirst {
+        case (remoteNodeId, peer) if peer == actor =>
+          log.debug(s"$actor is dead, removing from peers")
+          nodeParams.peersDb.removePeer(remoteNodeId)
+          context become main(peers - remoteNodeId)
+      }
 
-    case Terminated(actor) if peers.values.toSet.contains(actor) =>
-      log.info(s"$actor is dead, removing from peers/connections/db")
-      val remoteNodeId = peers.find(_._2 == actor).get._1
-      nodeParams.peersDb.removePeer(remoteNodeId)
-      context become main(peers - remoteNodeId, connections - remoteNodeId)
-
-    case h@HandshakeCompleted(_, remoteNodeId) =>
-      val peer = createOrGetPeer(peers, remoteNodeId, None, Set.empty)
-      peer forward h
-      context become main(peers + (remoteNodeId -> peer), connections)
+    case auth@Authenticator.Authenticated(_, _, remoteNodeId, _, _) =>
+      // if this is an incoming connection, we might not yet have created the peer
+      val peer = createOrGetPeer(peers, remoteNodeId, previousKnownAddress = None, offlineChannels = Set.empty)
+      peer forward auth
+      context become main(peers + (remoteNodeId -> peer))
 
     case r: Rebroadcast => peers.values.foreach(_ forward r)
 
     case 'peers => sender ! peers
 
-    case 'connections => sender ! connections
-
   }
 
-  def createOrGetPeer(peers: Map[PublicKey, ActorRef], remoteNodeId: PublicKey, address_opt: Option[InetSocketAddress], offlineChannels: Set[HasCommitments]) = {
+  /**
+    *
+    * @param peers
+    * @param remoteNodeId
+    * @param previousKnownAddress only to be set if we know for sure that this ip worked in the past
+    * @param offlineChannels
+    * @return
+    */
+  def createOrGetPeer(peers: Map[PublicKey, ActorRef], remoteNodeId: PublicKey, previousKnownAddress: Option[InetSocketAddress], offlineChannels: Set[HasCommitments]) = {
     peers.get(remoteNodeId) match {
       case Some(peer) => peer
       case None =>
-        val peer = context.actorOf(Peer.props(nodeParams, remoteNodeId, address_opt, watcher, router, relayer, wallet, offlineChannels), name = s"peer-$remoteNodeId")
+        val peer = context.actorOf(Peer.props(nodeParams, remoteNodeId, previousKnownAddress, authenticator, watcher, router, relayer, wallet, offlineChannels), name = s"peer-$remoteNodeId")
         context watch (peer)
         peer
     }
   }
+
+  override def unhandled(message: Any): Unit = log.warning(s"unhandled message=$message")
 
   // we resume failing peers because they may have open channels that we don't want to close abruptly
   override val supervisorStrategy = OneForOneStrategy(loggingEnabled = true) { case _ => SupervisorStrategy.Resume }
@@ -98,14 +98,6 @@ class Switchboard(nodeParams: NodeParams, watcher: ActorRef, router: ActorRef, r
 
 object Switchboard {
 
-  def props(nodeParams: NodeParams, watcher: ActorRef, router: ActorRef, relayer: ActorRef, wallet: EclairWallet) = Props(new Switchboard(nodeParams, watcher, router, relayer, wallet))
-
-  // @formatter:off
-  case class NewChannel(fundingSatoshis: Satoshi, pushMsat: MilliSatoshi, channelFlags: Option[Byte]) {
-    require(fundingSatoshis.amount < Channel.MAX_FUNDING_SATOSHIS, s"fundingSatoshis must be less than ${Channel.MAX_FUNDING_SATOSHIS}")
-    require(pushMsat.amount <= 1000 * fundingSatoshis.amount, s"pushMsat must be less or equal to fundingSatoshis")
-  }
-  case class NewConnection(remoteNodeId: PublicKey, address: InetSocketAddress, newChannel_opt: Option[NewChannel])
-  // @formatter:on
+  def props(nodeParams: NodeParams, authenticator: ActorRef, watcher: ActorRef, router: ActorRef, relayer: ActorRef, wallet: EclairWallet) = Props(new Switchboard(nodeParams, authenticator, watcher, router, relayer, wallet))
 
 }

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
@@ -2,13 +2,15 @@ package fr.acinq.eclair.gui.utils
 
 import javafx.scene.control.Label
 
+import fr.acinq.eclair.io.NodeURI
+
 import scala.util.matching.Regex
 
 /**
   * Created by DPA on 27/09/2016.
   */
 object GUIValidators {
-  val hostRegex = """([a-fA-F0-9]{66})@([a-zA-Z0-9:\.\-_]+):([0-9]+)""".r
+  val hostRegex = NodeURI.regex
   val amountRegex = """\d+""".r
   val amountDecRegex = """(\d+)|(\d+\.[\d]{1,})""".r
   val paymentRequestRegex =


### PR DESCRIPTION
- connection and channel opening are now separated, simplified
  `switchboard`

- use a single authenticator for both incoming and outgoing connections

- `peers` api call now returns current state and channel count