### PR TITLE
Faster search of spending tx when using bitcoind

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/BasicBitcoinjIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/BasicBitcoinjIntegrationSpec.scala
@@ -503,7 +503,7 @@ class BasicIntegrationSpvSpec extends TestKit(ActorSystem("test")) with FunSuite
     awaitCond({
       sender.send(bitcoincli, BitcoinReq("generate", 1))
       sender.expectMsgType[JValue](10 seconds)
-      ext.getTxsSinceBlockHash(currentBlockHash).pipeTo(sender.ref)
+      //ext.getTxsSinceBlockHash(currentBlockHash).pipeTo(sender.ref)
       val txes = sender.expectMsgType[Seq[fr.acinq.bitcoin.Transaction]].filterNot(fr.acinq.bitcoin.Transaction.isCoinbase(_))
       // at this point F should have 1 recv transactions: the redeemed htlc and C will have its main output
       txes.count(tx => tx.txOut(0).publicKeyScript == finalScriptPubkeyF) == 1 &&
@@ -558,7 +558,7 @@ class BasicIntegrationSpvSpec extends TestKit(ActorSystem("test")) with FunSuite
     awaitCond({
       sender.send(bitcoincli, BitcoinReq("generate", 1))
       sender.expectMsgType[JValue](10 seconds)
-      ext.getTxsSinceBlockHash(currentBlockHash).pipeTo(sender.ref)
+      //ext.getTxsSinceBlockHash(currentBlockHash).pipeTo(sender.ref)
       val txes = sender.expectMsgType[Seq[fr.acinq.bitcoin.Transaction]].filterNot(fr.acinq.bitcoin.Transaction.isCoinbase(_))
       // at this point C should have 2 recv transactions: its main output and the htlc timeout
       txes.count(tx => tx.txOut(0).publicKeyScript == finalScriptPubkeyF) == 0 &&
@@ -615,7 +615,7 @@ class BasicIntegrationSpvSpec extends TestKit(ActorSystem("test")) with FunSuite
     awaitCond({
       sender.send(bitcoincli, BitcoinReq("generate", 1))
       sender.expectMsgType[JValue](10 seconds)
-      ext.getTxsSinceBlockHash(currentBlockHash).pipeTo(sender.ref)
+      //ext.getTxsSinceBlockHash(currentBlockHash).pipeTo(sender.ref)
       val txes = sender.expectMsgType[Seq[fr.acinq.bitcoin.Transaction]].filterNot(fr.acinq.bitcoin.Transaction.isCoinbase(_))
       // at this point C should have 2 recv transactions: its main output and the htlc timeout
       txes.count(tx => tx.txOut(0).publicKeyScript == finalScriptPubkeyF) == 0 &&


### PR DESCRIPTION
When a `WatchSpent` is set, and the `watcher` detects the tx has already been spent, it will try to find the spending tx.

We previously looked forward starting at the block in which the funding tx was confirmed.

We now look backward starting from now. It is faster because most of the time the spending tx was published recently and we just shutdown/restarted the node.