### PR TITLE
Pre-validation announcements pruning

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -69,7 +69,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
 
   setTimer(TickBroadcast.toString, TickBroadcast, nodeParams.routerBroadcastInterval, repeat = true)
   setTimer(TickValidate.toString, TickValidate, nodeParams.routerValidateInterval, repeat = true)
-  setTimer(TickPruneStaleChannels.toString, TickPruneStaleChannels, 1 minute, repeat = true)
+  setTimer(TickPruneStaleChannels.toString, TickPruneStaleChannels, 1 day, repeat = true)
 
   val db = nodeParams.networkDb
 
@@ -386,9 +386,8 @@ object Router {
     // (1) is older than 2 weeks (2*7*144 = 2016 blocks)
     //  AND
     // (2) didn't have an update during the last 2 weeks
-    // NOTE: RADICAL PRUNING WE FORGET ABOUT CHANNELS OLDER THAN 3 DAYS WITH NO UPDATE
-    val staleThresholdSeconds = Platform.currentTime / 1000 - 259200
-    val staleThresholdBlocks = Globals.blockCount.get() - 432
+    val staleThresholdSeconds = Platform.currentTime / 1000 - 1209600
+    val staleThresholdBlocks = Globals.blockCount.get() - 2016
     val staleChannels = channels
       .filterKeys(shortChannelId => fromShortId(shortChannelId)._1 < staleThresholdBlocks) // consider only channels older than 2 weeks
       .filterKeys(shortChannelId => !updates.values.exists(u => u.shortChannelId == shortChannelId && u.timestamp >= staleThresholdSeconds)) // no update in the past 2 weeks

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -415,7 +415,7 @@ object Router {
     val staleThresholdBlocks = Globals.blockCount.get() - 2016
     val staleChannels = channels
       .filter(c => fromShortId(c.shortChannelId)._1 < staleThresholdBlocks) // consider only channels older than 2 weeks
-      .filter(c => updates.filter(_.shortChannelId == c.shortChannelId).map(_.timestamp).max  < staleThresholdSeconds) // no update in the past 2 weeks (remember: there are 2 updates per channel)
+      .filter(c => (0L +: updates.filter(_.shortChannelId == c.shortChannelId).map(_.timestamp).toSeq).max  < staleThresholdSeconds) // no update in the past 2 weeks (remember: there are 2 updates per channel)
     staleChannels.map(_.shortChannelId)
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -69,7 +69,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
 
   setTimer(TickBroadcast.toString, TickBroadcast, nodeParams.routerBroadcastInterval, repeat = true)
   setTimer(TickValidate.toString, TickValidate, nodeParams.routerValidateInterval, repeat = true)
-  setTimer(TickPruneStaleChannels.toString, TickPruneStaleChannels, 1 day, repeat = true)
+  setTimer(TickPruneStaleChannels.toString, TickPruneStaleChannels, 1 minute, repeat = true)
 
   val db = nodeParams.networkDb
 
@@ -386,8 +386,9 @@ object Router {
     // (1) is older than 2 weeks (2*7*144 = 2016 blocks)
     //  AND
     // (2) didn't have an update during the last 2 weeks
-    val staleThresholdSeconds = Platform.currentTime / 1000 - 1209600
-    val staleThresholdBlocks = Globals.blockCount.get() - 2016
+    // NOTE: RADICAL PRUNING WE FORGET ABOUT CHANNELS OLDER THAN 3 DAYS WITH NO UPDATE
+    val staleThresholdSeconds = Platform.currentTime / 1000 - 259200
+    val staleThresholdBlocks = Globals.blockCount.get() - 432
     val staleChannels = channels
       .filterKeys(shortChannelId => fromShortId(shortChannelId)._1 < staleThresholdBlocks) // consider only channels older than 2 weeks
       .filterKeys(shortChannelId => !updates.values.exists(u => u.shortChannelId == shortChannelId && u.timestamp >= staleThresholdSeconds)) // no update in the past 2 weeks

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -78,11 +78,8 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
   // advertise invalid channels. We could optimize this (at least not fetch txes from the blockchain, and not check sigs)
   log.info(s"loading network announcements from db...")
   db.listChannels().map(self ! _)
-  println(db.listChannels().size)
   db.listNodes().map(self ! _)
-  println(db.listNodes().size)
   db.listChannelUpdates().map(self ! _)
-  println(db.listChannelUpdates().size)
   log.info(s"starting state machine")
 
   startWith(NORMAL, Data(Map.empty, Map.empty, Map.empty, Nil, Nil, Nil, Map.empty, Map.empty, Set.empty))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -85,8 +85,6 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
   startWith(NORMAL, Data(Map.empty, Map.empty, Map.empty, Nil, Nil, Nil, Map.empty, Map.empty, Set.empty))
 
   when(NORMAL) {
-    case Event(TickValidate, d) if d.stash.isEmpty => stay
-
     case Event(TickValidate, d) =>
       require(d.awaiting.size == 0)
       // first we partition the announcements

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -654,6 +654,9 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
     // then we make the announcements
     val announcements = channels.map(c => AnnouncementsBatchValidationSpec.makeChannelAnnouncement(c))
     announcements.foreach(ann => nodes("A").router ! ann)
+    // we need to send channel_update otherwise router won't validate the channels
+    val updates = channels.zip(announcements).map(x => AnnouncementsBatchValidationSpec.makeChannelUpdate(x._1, x._2.shortChannelId))
+    updates.foreach(update => nodes("A").router ! update)
     awaitCond({
       sender.send(nodes("D").router, 'channels)
       sender.expectMsgType[Iterable[ChannelAnnouncement]](5 seconds).size == channels.size + 6 // 6 remaining channels because  D->F{1-F4} have disappeared

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsBatchValidationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsBatchValidationSpec.scala
@@ -6,7 +6,7 @@ import fr.acinq.bitcoin.{BinaryData, Block, Satoshi, Script, Transaction}
 import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BitcoinJsonRPCClient, ExtendedBitcoinClient}
 import fr.acinq.eclair.transactions.Scripts
-import fr.acinq.eclair.wire.ChannelAnnouncement
+import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate}
 import fr.acinq.eclair.{randomKey, toShortId}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuite
@@ -82,4 +82,8 @@ object AnnouncementsBatchValidationSpec {
     val channelAnnouncement = Announcements.makeChannelAnnouncement(Block.RegtestGenesisBlock.hash, shortChannelId, c.node1Key.publicKey, c.node2Key.publicKey, c.node1FundingKey.publicKey, c.node2FundingKey.publicKey, channelAnnNodeSig1, channelAnnNodeSig2, channelAnnBitcoinSig1, channelAnnBitcoinSig2)
     channelAnnouncement
   }
+
+  def makeChannelUpdate(c: SimulatedChannel, shortChannelId: Long): ChannelUpdate =
+    Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, c.node1Key, c.node2Key.publicKey, shortChannelId, 10, 1000, 10, 100)
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -211,8 +211,8 @@ class RouteCalculationSpec extends FunSuite {
     val id_e = toShortId(daysAgoInBlocks(1), 0, 0)
     val chan_e = channelAnnouncement(id_e)
 
-    val channels = Map(id_a -> chan_a, id_b -> chan_b, id_c -> chan_c, id_d -> chan_d, id_e -> chan_e)
-    val updates = Map(desc(id_a) -> upd_a, desc(id_c) -> upd_c, desc(id_d) -> upd_d)
+    val channels = Set(chan_a, chan_b, chan_c, chan_d, chan_e)
+    val updates = Set(upd_a, upd_c, upd_d)
 
     val staleChannels = Router.getStaleChannels(channels, updates).toSet
 


### PR DESCRIPTION
Our current pruning logic is very basic, we just clean up channels once every day. It is not very effective, because inbetween two pruning operations nodes can send us the same stale announcements we just removed.

This change makes the `router` filter out stale channels *before* processing them. As a consequence, it only processes a `channel_anouncement` if there is at least a corresponding `channel_update`.
