### PR TITLE
Limit the max TCP packet size to the longest lightning message 

### DIFF
--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -14,4 +14,20 @@ akka {
       max-open-requests = 64
     }
   }
+
+  io {
+    tcp {
+
+      # The maximum number of bytes delivered by a `Received` message. Before
+      # more data is read from the network the connection actor will try to
+      # do other work.
+      # The purpose of this setting is to impose a smaller limit than the
+      # configured receive buffer size. When using value 'unlimited' it will
+      # try to read all from the receive buffer.
+      # As per BOLT#8 lightning messages are at most 2 + 16 + 65535 + 16 = 65569bytes
+      max-received-message-size = 65569b
+
+    }
+  }
+
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -2,6 +2,8 @@ package fr.acinq.eclair
 
 import java.io.File
 
+import akka.actor.ActorSystem
+import com.typesafe.config.ConfigFactory
 import grizzled.slf4j.Logging
 
 /**
@@ -11,9 +13,13 @@ object Boot extends App with Logging {
 
   val datadir = new File(System.getProperty("eclair.datadir", System.getProperty("user.home") + "/.eclair"))
 
+  val eclairNodeConf =
+    ConfigFactory.parseFile(new File(datadir, "eclair.conf"))
+      .withFallback(ConfigFactory.load())
+  
   try {
     import scala.concurrent.ExecutionContext.Implicits.global
-    new Setup(datadir).bootstrap onFailure {
+    new Setup(datadir, actorSystem = ActorSystem("default", eclairNodeConf)).bootstrap onFailure {
       case t: Throwable => onError(t)
     }
   } catch {


### PR DESCRIPTION
As specified in [BOLT#8](https://github.com/lightningnetwork/lightning-rfc/blob/master/08-transport.md#lightning-message-specification) the lightning message MUST NOT exceed 65569 bytes, this pull request sets a hard the limit for a TCP packet because we don't want to read more than the maximum allowed bytes from the socket. Moreover the akka configuration is now exposed in <eclair_datadir>/eclair.conf for easy testing and fine tuning, by default the akka config is taken from  eclair-node/src/main/resources/application.conf. Please note this setting applies to the whole application thus also to HTTP APIs.