### PR TITLE
Handle ipv6 addresses

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -3,12 +3,13 @@ package fr.acinq.eclair.api
 import java.net.InetSocketAddress
 
 import fr.acinq.bitcoin.Crypto.{Point, PrivateKey, PublicKey, Scalar}
-import fr.acinq.bitcoin.{BinaryData, OutPoint, Transaction}
+import fr.acinq.bitcoin.{BinaryData, OutPoint}
 import fr.acinq.eclair.channel.State
 import fr.acinq.eclair.crypto.ShaChain
+import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo
-import org.json4s.{CustomKeySerializer, CustomSerializer}
 import org.json4s.JsonAST.{JNull, JString}
+import org.json4s.{CustomKeySerializer, CustomSerializer}
 
 /**
   * Created by PM on 28/01/2016.
@@ -81,7 +82,7 @@ class InetSocketAddressSerializer extends CustomSerializer[InetSocketAddress](fo
   case JString(x) if (false) => // NOT IMPLEMENTED
     ???
 }, {
-  case x: InetSocketAddress => JString(s"${x.getHostString}:${x.getPort}")
+  case x: InetSocketAddress => JString(NodeURI.getHostAndPort(x))
 }
 ))
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -2,11 +2,11 @@ package fr.acinq.eclair.api
 
 import java.net.InetSocketAddress
 
+import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.Crypto.{Point, PrivateKey, PublicKey, Scalar}
 import fr.acinq.bitcoin.{BinaryData, OutPoint}
 import fr.acinq.eclair.channel.State
 import fr.acinq.eclair.crypto.ShaChain
-import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo
 import org.json4s.JsonAST.{JNull, JString}
 import org.json4s.{CustomKeySerializer, CustomSerializer}
@@ -82,7 +82,7 @@ class InetSocketAddressSerializer extends CustomSerializer[InetSocketAddress](fo
   case JString(x) if (false) => // NOT IMPLEMENTED
     ???
 }, {
-  case x: InetSocketAddress => JString(NodeURI.getHostAndPort(x))
+  case address: InetSocketAddress => JString(HostAndPort.fromParts(address.getHostString, address.getPort).toString)
 }
 ))
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Client.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Client.scala
@@ -20,7 +20,7 @@ class Client(nodeParams: NodeParams, authenticator: ActorRef, address: InetSocke
   import Tcp._
   import context.system
 
-  log.info(s"connecting to $remoteNodeId@${address.getHostString}:${address.getPort}")
+  log.info(s"connecting to pubkey=$remoteNodeId host=${address.getHostString} port=${address.getPort}")
   IO(Tcp) ! Connect(address, timeout = Some(5 seconds), options = KeepAlive(true) :: Nil)
 
   def receive = {
@@ -29,7 +29,7 @@ class Client(nodeParams: NodeParams, authenticator: ActorRef, address: InetSocke
       context stop self
 
     case Connected(remote, _) =>
-      log.info(s"connected to $remoteNodeId@${remote.getHostString}:${remote.getPort}")
+      log.info(s"connected to pubkey=$remoteNodeId host=${remote.getHostString} port=${remote.getPort}")
       val connection = sender
       authenticator ! Authenticator.PendingAuth(connection, origin_opt = Some(origin), outgoingConnection_opt = Some(Authenticator.OutgoingConnection(remoteNodeId, address)))
       // TODO: shutdown?

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/NodeURI.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/NodeURI.scala
@@ -2,7 +2,6 @@ package fr.acinq.eclair.io
 
 import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.Crypto.PublicKey
-import grizzled.slf4j.Logging
 
 import scala.util.{Failure, Success, Try}
 
@@ -10,7 +9,7 @@ case class NodeURI(nodeId: PublicKey, address: HostAndPort) {
   override def toString: String = s"$nodeId@$address"
 }
 
-object NodeURI extends Logging {
+object NodeURI {
 
   val DEFAULT_PORT = 9735
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/NodeURI.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/NodeURI.scala
@@ -1,24 +1,18 @@
 package fr.acinq.eclair.io
 
-import java.net.{Inet6Address, InetSocketAddress}
-
 import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.Crypto.PublicKey
 import grizzled.slf4j.Logging
-import org.spongycastle.util.encoders.DecoderException
 
-import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
 
-case class NodeURI(nodeId: PublicKey, address: InetSocketAddress) {
-  override def toString: String = s"$nodeId@$getHostAndPort"
-  def getHostAndPort = NodeURI.getHostAndPort(address)
+case class NodeURI(nodeId: PublicKey, address: HostAndPort) {
+  override def toString: String = s"$nodeId@$address"
 }
 
 object NodeURI extends Logging {
 
   val DEFAULT_PORT = 9735
-  val regex: Regex = """([a-fA-F0-9]{66})@([a-zA-Z0-9:\[\]%\/\.\-_]+):([0-9]+)""".r
 
   /**
     * Extracts the PublicKey and InetAddress from a string URI (format pubkey@host:port). Port is optional, default is 9735.
@@ -30,31 +24,12 @@ object NodeURI extends Logging {
   @throws[IllegalArgumentException]
   def parse(uri: String): NodeURI = {
     uri.split("@") match {
-      case Array(nodeId, address) => Try(PublicKey(nodeId), HostAndPort.fromString(address).withDefaultPort(DEFAULT_PORT)) match {
-        case Success((pk, hostPort)) =>
-          logger.debug(s"parsed uri=$uri to pk=$pk host=$hostPort")
-          NodeURI(PublicKey(nodeId), new InetSocketAddress(hostPort.getHost, hostPort.getPort))
-        case Failure(t) if t.isInstanceOf[scala.MatchError] || t.isInstanceOf[DecoderException] =>
-          logger.debug(s"could not parse uri=$uri with cause=${t.getMessage}")
-          throw new IllegalArgumentException("Public key is not valid")
-        case Failure(t) =>
-          logger.error(s"could not parse uri=$uri with cause = ${t.getMessage}")
-          throw new IllegalArgumentException("URI is not valid. Should be pubkey@host:port")
+      case Array(nodeId, address) => (Try(PublicKey(nodeId)), Try(HostAndPort.fromString(address).withDefaultPort(DEFAULT_PORT))) match {
+        case (Success(pk), Success(hostAndPort)) => NodeURI(pk, hostAndPort)
+        case (Failure(_), _) => throw new IllegalArgumentException("Invalid node id")
+        case (_, Failure(_)) => throw new IllegalArgumentException("Invalid host:port")
       }
-      case _ => throw new IllegalArgumentException("URI is not valid. Should be pubkey@host:port")
-    }
-  }
-
-  /**
-    * Returns host of address. If address is IPV6 and not bracketed, surrounds host with brackets.
-    *
-    * @param address Inet address
-    * @return a formatted host preventing issue with ipv6 addresses when parsing host and port
-    */
-  def getHostAndPort(address: InetSocketAddress): String = {
-    address.getAddress match {
-      case a: Inet6Address if !a.getHostAddress.startsWith("[") && !a.getHostAddress.endsWith("]") => s"[${a.getHostAddress}]:${address.getPort}"
-      case _ => s"${address.getHostString}:${address.getPort}"
+      case _ => throw new IllegalArgumentException("Invalid uri, should be nodeId@host:port")
     }
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/NodeURI.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/NodeURI.scala
@@ -1,20 +1,60 @@
 package fr.acinq.eclair.io
 
-import java.net.InetSocketAddress
+import java.net.{Inet6Address, InetSocketAddress}
 
+import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.Crypto.PublicKey
+import grizzled.slf4j.Logging
+import org.spongycastle.util.encoders.DecoderException
+
+import scala.util.matching.Regex
+import scala.util.{Failure, Success, Try}
 
 case class NodeURI(nodeId: PublicKey, address: InetSocketAddress) {
-  override def toString: String = s"$nodeId@${address.getHostString}:${address.getPort}"
+  override def toString: String = s"$nodeId@$getHostAndPort"
+  def getHostAndPort = NodeURI.getHostAndPort(address)
 }
 
-object NodeURI {
+object NodeURI extends Logging {
 
-  val regex = """([a-fA-F0-9]{66})@([a-zA-Z0-9:\.\-_]+):([0-9]+)""".r
+  val DEFAULT_PORT = 9735
+  val regex: Regex = """([a-fA-F0-9]{66})@([a-zA-Z0-9:\[\]%\/\.\-_]+):([0-9]+)""".r
 
-
+  /**
+    * Extracts the PublicKey and InetAddress from a string URI (format pubkey@host:port). Port is optional, default is 9735.
+    *
+    * @param uri uri of a node, as a String
+    * @throws IllegalArgumentException if the uri is not valid and can not be read
+    * @return a NodeURI
+    */
+  @throws[IllegalArgumentException]
   def parse(uri: String): NodeURI = {
-    val regex(nodeid, host, port) = uri
-    NodeURI(PublicKey(nodeid), new InetSocketAddress(host, port.toInt))
+    uri.split("@") match {
+      case Array(nodeId, address) => Try(PublicKey(nodeId), HostAndPort.fromString(address).withDefaultPort(DEFAULT_PORT)) match {
+        case Success((pk, hostPort)) =>
+          logger.debug(s"parsed uri=$uri to pk=$pk host=$hostPort")
+          NodeURI(PublicKey(nodeId), new InetSocketAddress(hostPort.getHost, hostPort.getPort))
+        case Failure(t) if t.isInstanceOf[scala.MatchError] || t.isInstanceOf[DecoderException] =>
+          logger.debug(s"could not parse uri=$uri with cause=${t.getMessage}")
+          throw new IllegalArgumentException("Public key is not valid")
+        case Failure(t) =>
+          logger.error(s"could not parse uri=$uri with cause = ${t.getMessage}")
+          throw new IllegalArgumentException("URI is not valid. Should be pubkey@host:port")
+      }
+      case _ => throw new IllegalArgumentException("URI is not valid. Should be pubkey@host:port")
+    }
+  }
+
+  /**
+    * Returns host of address. If address is IPV6 and not bracketed, surrounds host with brackets.
+    *
+    * @param address Inet address
+    * @return a formatted host preventing issue with ipv6 addresses when parsing host and port
+    */
+  def getHostAndPort(address: InetSocketAddress): String = {
+    address.getAddress match {
+      case a: Inet6Address if !a.getHostAddress.startsWith("[") && !a.getHostAddress.endsWith("]") => s"[${a.getHostAddress}]:${address.getPort}"
+      case _ => s"${address.getHostString}:${address.getPort}"
+    }
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -31,7 +31,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, previousKnownAddress
   when(DISCONNECTED) {
     case Event(Peer.Connect(NodeURI(_, address)), _) =>
       // even if we are in a reconnection loop, we immediately process explicit connection requests
-      context.actorOf(Client.props(nodeParams, authenticator, address, remoteNodeId, origin = sender()))
+      context.actorOf(Client.props(nodeParams, authenticator, new InetSocketAddress(address.getHost, address.getPort), remoteNodeId, origin = sender()))
       stay
 
     case Event(Reconnect, d@DisconnectedData(address_opt, channels, attempts)) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/BasicBitcoinjIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/BasicBitcoinjIntegrationSpec.scala
@@ -7,6 +7,7 @@ import java.util.{Properties, UUID}
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.pipe
 import akka.testkit.{TestKit, TestProbe}
+import com.google.common.net.HostAndPort
 import com.typesafe.config.{Config, ConfigFactory}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{Base58, Base58Check, BinaryData, Block, Crypto, MilliSatoshi, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHDATA, Satoshi, Script}
@@ -17,7 +18,7 @@ import fr.acinq.eclair.channel.Register.Forward
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.Sphinx.ErrorPacket
 import fr.acinq.eclair.io.Peer.Disconnect
-import fr.acinq.eclair.io.{NodeURI, Peer, Switchboard}
+import fr.acinq.eclair.io.{NodeURI, Peer}
 import fr.acinq.eclair.payment.{State => _, _}
 import fr.acinq.eclair.router.{Announcements, AnnouncementsBatchValidationSpec}
 import fr.acinq.eclair.wire._
@@ -165,9 +166,10 @@ class BasicIntegrationSpvSpec extends TestKit(ActorSystem("test")) with FunSuite
     node1.system.eventStream.subscribe(eventListener1.ref, classOf[ChannelStateChanged])
     node2.system.eventStream.subscribe(eventListener2.ref, classOf[ChannelStateChanged])
     val sender = TestProbe()
+    val address = node2.nodeParams.publicAddresses.head
     sender.send(node1.switchboard, Peer.Connect(NodeURI(
       nodeId = node2.nodeParams.privateKey.publicKey,
-      address = node2.nodeParams.publicAddresses.head)))
+      address = HostAndPort.fromParts(address.getHostString, address.getPort))))
     sender.expectMsgAnyOf(10 seconds, "connected", "already connected")
       sender.send(node1.switchboard, Peer.OpenChannel(
         remoteNodeId = node2.nodeParams.privateKey.publicKey,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -7,9 +7,10 @@ import java.util.{Properties, UUID}
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.pipe
 import akka.testkit.{TestKit, TestProbe}
+import com.google.common.net.HostAndPort
 import com.typesafe.config.{Config, ConfigFactory}
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{Base58, Base58Check, BinaryData, Block, Crypto, MilliSatoshi, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHDATA, Satoshi, Script, Transaction}
+import fr.acinq.bitcoin.{Base58, Base58Check, BinaryData, Block, Crypto, MilliSatoshi, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHDATA, Satoshi, Script}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BitcoinJsonRPCClient, ExtendedBitcoinClient}
 import fr.acinq.eclair.blockchain.{Watch, WatchConfirmed}
 import fr.acinq.eclair.channel.Register.Forward
@@ -132,9 +133,10 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
 
   def connect(node1: Kit, node2: Kit, fundingSatoshis: Long, pushMsat: Long) = {
     val sender = TestProbe()
+    val address = node2.nodeParams.publicAddresses.head
     sender.send(node1.switchboard, Peer.Connect(NodeURI(
       nodeId = node2.nodeParams.privateKey.publicKey,
-      address = node2.nodeParams.publicAddresses.head)))
+      address = HostAndPort.fromParts(address.getHostString, address.getPort))))
     sender.expectMsgAnyOf(10 seconds, "connected", "already connected")
     sender.send(node1.switchboard, Peer.OpenChannel(
       remoteNodeId = node2.nodeParams.privateKey.publicKey,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/NodeURISpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/NodeURISpec.scala
@@ -1,0 +1,121 @@
+package fr.acinq.eclair.io
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class NodeURISpec extends FunSuite {
+
+  val PUBKEY = "03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134"
+  val SHORT_PUB_KEY = "03933884aaf1d6b108397e5efe5c86bcf2d8ca"
+  val NOT_HEXA_PUB_KEY = "03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fcghijklmn"
+
+  val IPV4_ENDURANCE = "34.250.234.192"
+  val NAME_ENDURANCE = "endurance.acinq.co"
+  val IPV6 = "[2405:204:66a9:536c:873f:dc4a:f055:a298]"
+  val IPV6_NO_BRACKETS = "2001:db8:a0b:12f0::1"
+  val IPV6_PREFIX = "[2001:db8:a0b:12f0::1/64]"
+  val IPV6_ZONE_IDENTIFIER = "[2001:db8:a0b:12f0::1%eth0]"
+
+  // ---------- IPV4
+
+  test("parse NodeURI with IPV4 and port") {
+    val uri = s"$PUBKEY@$IPV4_ENDURANCE:9737"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.nodeId.toString() == PUBKEY)
+    assert(nodeUri.address.getPort == 9737)
+  }
+
+  test("parse NodeURI with IPV4 and NO port") {
+    val uri = s"$PUBKEY@$IPV4_ENDURANCE"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.address.getPort == NodeURI.DEFAULT_PORT)
+  }
+
+  test("parse NodeURI with named host and port") {
+    val uri = s"$PUBKEY@$IPV4_ENDURANCE:9737"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.nodeId.toString() == PUBKEY)
+    assert(nodeUri.address.getPort == 9737)
+  }
+
+  // ---------- IPV6 / regular with brackets
+
+  test("parse NodeURI with IPV6 with brackets and port") {
+    val uri = s"$PUBKEY@$IPV6:9737"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.address.getPort == 9737)
+  }
+
+  test("parse NodeURI with IPV6 with brackets and NO port") {
+    val uri = s"$PUBKEY@$IPV6"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.address.getPort == NodeURI.DEFAULT_PORT)
+  }
+
+  // ---------- IPV6 / regular without brackets
+
+  test("fail to parse NodeURI with IPV6 without brackets and port, and use default port") {
+    // this can not be parsed because we can not tell what the port is (brackets are required) and the port is the default
+    val uri = s"$PUBKEY@$IPV6_NO_BRACKETS:9737"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.address.getPort == NodeURI.DEFAULT_PORT)
+  }
+
+  test("parse NodeURI with IPV6 without brackets and NO port") {
+    val uri = s"$PUBKEY@$IPV6_NO_BRACKETS"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.address.getPort == NodeURI.DEFAULT_PORT)
+  }
+
+  // ---------- IPV6 / prefix
+
+  test("parse NodeURI with IPV6 with prefix and port") {
+    val uri = s"$PUBKEY@$IPV6_PREFIX:9737"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.address.getPort == 9737)
+  }
+
+  test("parse NodeURI with IPV6 with prefix and NO port") {
+    val uri = s"$PUBKEY@$IPV6_PREFIX"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.address.getPort == NodeURI.DEFAULT_PORT)
+  }
+
+  // ---------- IPV6 / zone identifier
+
+  test("parse NodeURI with IPV6 with a zone identifier and port") {
+    val uri = s"$PUBKEY@$IPV6_ZONE_IDENTIFIER:9737"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.address.getPort == 9737)
+  }
+
+  test("parse NodeURI with IPV6 with a zone identifier and NO port") {
+    val uri = s"$PUBKEY@$IPV6_ZONE_IDENTIFIER"
+    val nodeUri = NodeURI.parse(uri)
+    assert(nodeUri.address.getPort == NodeURI.DEFAULT_PORT)
+  }
+
+  // ---------- fail if public key is not valid
+
+  test("parsing should fail if the public key is not correct") {
+    intercept[IllegalArgumentException](NodeURI.parse(s"$SHORT_PUB_KEY@$IPV4_ENDURANCE"))
+    intercept[IllegalArgumentException](NodeURI.parse(s"$NOT_HEXA_PUB_KEY@$IPV4_ENDURANCE"))
+  }
+
+  test("parsing should fail if the uri is malformed") {
+    intercept[IllegalArgumentException](NodeURI.parse("03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134@"))
+    intercept[IllegalArgumentException](NodeURI.parse("03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134@123.45@654321"))
+    intercept[IllegalArgumentException](NodeURI.parse("loremipsum"))
+    intercept[IllegalArgumentException](NodeURI.parse(IPV6))
+    intercept[IllegalArgumentException](NodeURI.parse(IPV4_ENDURANCE))
+    intercept[IllegalArgumentException](NodeURI.parse(PUBKEY))
+    intercept[IllegalArgumentException](NodeURI.parse(""))
+    intercept[IllegalArgumentException](NodeURI.parse("@"))
+    intercept[IllegalArgumentException](NodeURI.parse(":"))
+  }
+}
+
+
+

--- a/eclair-node-gui/src/main/resources/gui/main/main.fxml
+++ b/eclair-node-gui/src/main/resources/gui/main/main.fxml
@@ -216,8 +216,7 @@
                         </HBox>
                         <HBox alignment="CENTER_RIGHT" HBox.hgrow="SOMETIMES" minWidth="195.0">
                             <children>
-                                <Label text="Bitcoin-core" textAlignment="RIGHT" textOverrun="CLIP"/>
-                                <Label fx:id="bitcoinVersion" text="N/A" textOverrun="CLIP"/>
+                                <Label fx:id="bitcoinWallet" text="N/A" textAlignment="RIGHT" textOverrun="CLIP"/>
                                 <Label fx:id="bitcoinChain" styleClass="chain" text="(N/A)" textOverrun="CLIP"/>
                             </children>
                         </HBox>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
@@ -40,18 +40,18 @@ class Handlers(fKit: Future[Kit])(implicit ec: ExecutionContext = ExecutionConte
   def open(nodeUri: NodeURI, channel: Option[Peer.OpenChannel]) = {
     logger.info(s"opening a connection to nodeUri=$nodeUri")
     (for {
-          kit <- fKit
-          conn <- kit.switchboard ? Peer.Connect(nodeUri)
-          _ <- channel match {
-            case Some(o) =>
-              logger.info(s"opening a channel with remoteNodeId=${o.remoteNodeId}")
-              kit.switchboard ? o
-            case None => Future.successful(0) // nothing to do
-          }
+      kit <- fKit
+      conn <- kit.switchboard ? Peer.Connect(nodeUri)
+      _ <- channel match {
+        case Some(o) =>
+          logger.info(s"opening a channel with remoteNodeId=${o.remoteNodeId}")
+          kit.switchboard ? o
+        case None => Future.successful(0) // nothing to do
+      }
     } yield conn) onFailure {
-          case t: Throwable =>
-            t.printStackTrace()
-            notification("Connection failed", nodeUri.getHostAndPort, NOTIFICATION_ERROR)
+      case t: Throwable =>
+        logger.error("Could not open channel ", t)
+        notification("Connection failed", nodeUri.address.toString, NOTIFICATION_ERROR)
     }
   }
 

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
@@ -51,7 +51,7 @@ class Handlers(fKit: Future[Kit])(implicit ec: ExecutionContext = ExecutionConte
     } yield conn) onFailure {
           case t: Throwable =>
             t.printStackTrace()
-            notification("Connection failed", s"${nodeUri.address.getHostString}:${nodeUri.address.getPort}", NOTIFICATION_ERROR)
+            notification("Connection failed", nodeUri.getHostAndPort, NOTIFICATION_ERROR)
     }
   }
 

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/MainController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/MainController.scala
@@ -24,12 +24,12 @@ import javafx.stage.FileChooser.ExtensionFilter
 import javafx.stage._
 import javafx.util.{Callback, Duration}
 
+import com.google.common.net.HostAndPort
 import fr.acinq.eclair.NodeParams.{BITCOIND, BITCOINJ, ELECTRUM}
 import fr.acinq.eclair.Setup
 import fr.acinq.eclair.gui.Handlers
 import fr.acinq.eclair.gui.stages._
 import fr.acinq.eclair.gui.utils.{ContextMenuUtils, CopyAction}
-import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.{PaymentEvent, PaymentReceived, PaymentRelayed, PaymentSent}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, NodeAnnouncement}
 import grizzled.slf4j.Logging
@@ -169,7 +169,7 @@ class MainController(val handlers: Handlers, val hostServices: HostServices) ext
     })
     networkNodesIPColumn.setCellValueFactory(new Callback[CellDataFeatures[NodeAnnouncement, String], ObservableValue[String]]() {
       def call(pn: CellDataFeatures[NodeAnnouncement, String]) = {
-        val address = pn.getValue.addresses.map(a => NodeURI.getHostAndPort(a)).mkString(",")
+        val address = pn.getValue.addresses.map(a => HostAndPort.fromParts(a.getHostString, a.getPort)).mkString(",")
         new SimpleStringProperty(address)
       }
     })
@@ -329,7 +329,7 @@ class MainController(val handlers: Handlers, val hostServices: HostServices) ext
     bitcoinChain.getStyleClass.add(setup.chain)
 
     val nodeURI_opt = setup.nodeParams.publicAddresses.headOption.map(address => {
-      s"${setup.nodeParams.privateKey.publicKey}@${NodeURI.getHostAndPort(address)}"
+      s"${setup.nodeParams.privateKey.publicKey}@${HostAndPort.fromParts(address.getHostString, address.getPort)}"
     })
 
     contextMenu = ContextMenuUtils.buildCopyContext(List(CopyAction("Copy Pubkey", setup.nodeParams.privateKey.publicKey.toString())))
@@ -408,7 +408,7 @@ class MainController(val handlers: Handlers, val hostServices: HostServices) ext
     copyURI.setOnAction(new EventHandler[ActionEvent] {
       override def handle(event: ActionEvent): Unit = Option(row.getItem) match {
         case Some(pn) => ContextMenuUtils.copyToClipboard(
-          if (pn.addresses.nonEmpty) s"${pn.nodeId.toString}@${NodeURI.getHostAndPort(pn.addresses.head)}"
+          if (pn.addresses.nonEmpty) s"${pn.nodeId.toString}@${HostAndPort.fromParts(pn.addresses.head.getHostString, pn.addresses.head.getPort)}"
           else "no URI Known")
         case None =>
       }

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/ContextMenuUtils.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/ContextMenuUtils.scala
@@ -30,13 +30,17 @@ object ContextMenuUtils {
   def buildCopyContext(actions: List[CopyAction]): ContextMenu = {
     val context = new ContextMenu()
     for (action <- actions) {
-      val copyItem = new MenuItem(action.label)
-      copyItem.setOnAction(new EventHandler[ActionEvent] {
-        override def handle(event: ActionEvent) = copyToClipboard(action.value)
-      })
-      context.getItems.addAll(copyItem)
+      context.getItems.addAll(buildCopyMenuItem(action))
     }
     context
+  }
+
+  def buildCopyMenuItem(action: CopyAction): MenuItem = {
+    val copyItem = new MenuItem(action.label)
+    copyItem.setOnAction(new EventHandler[ActionEvent] {
+      override def handle(event: ActionEvent): Unit = copyToClipboard(action.value)
+    })
+    copyItem
   }
 
   def copyToClipboard(value: String) = {

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
@@ -2,15 +2,13 @@ package fr.acinq.eclair.gui.utils
 
 import javafx.scene.control.Label
 
-import fr.acinq.eclair.io.NodeURI
-
 import scala.util.matching.Regex
 
 /**
   * Created by DPA on 27/09/2016.
   */
 object GUIValidators {
-  val hostRegex = NodeURI.regex
+  val hostRegex = """([a-fA-F0-9]{66})@([a-zA-Z0-9:\[\]%\/\.\-_]+):([0-9]+)""".r
   val amountRegex = """\d+""".r
   val amountDecRegex = """(\d+)|(\d*\.[\d]{1,})""".r
   val paymentRequestRegex =


### PR DESCRIPTION
The IP address of a lightning node can be IPV6 which has a different validation ruleset than IPV4.
NodeURI is updated to be able to parse IPV6 adresses.

Note: the host should be enclosed with brackets `[` `]` if the address is IPV6 and it doesn't have brackets.
This is compliant with [RFC 3986, section 3.2.2](https://tools.ietf.org/html/rfc3986#section-3.2.2)

Thanks to @Sgt-Miller for pointing this out in #343 