### PR TITLE
Updated username, password and port in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ rpcpassword=bar
 txindex=1
 zmqpubrawblock=tcp://127.0.0.1:29000
 zmqpubrawtx=tcp://127.0.0.1:29000
-rpcport=18332
 ```
 
 On **__testnet__**, you also need to make sure that all your UTXOs are `p2sh-of-p2wpkh`.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Run bitcoind with the following minimal `bitcoin.conf`:
 ```
 testnet=1
 server=1
-rpcuser=XXX
-rpcpassword=XXX
+rpcuser=foo
+rpcpassword=bar
 txindex=1
 zmqpubrawblock=tcp://127.0.0.1:29000
 zmqpubrawtx=tcp://127.0.0.1:29000

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ rpcpassword=bar
 txindex=1
 zmqpubrawblock=tcp://127.0.0.1:29000
 zmqpubrawtx=tcp://127.0.0.1:29000
+rpcport=18332
 ```
 
 On **__testnet__**, you also need to make sure that all your UTXOs are `p2sh-of-p2wpkh`.


### PR DESCRIPTION
Updated username and password so now you don't get the following error:
```
Could not connect to Bitcoin Core using JSON-RPC
Make sure that Bitcoin Core is up and running and RPC parameters are correct.
```

Also explicitly stated the port for testnet, this is redundant if you haven't got it set to anything but for those who have already defined `rpcport` they now know to change it.