### PR TITLE
Include payment preimage in PaymentSent event

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -9,7 +9,7 @@ sealed trait PaymentEvent {
   val paymentHash: BinaryData
 }
 
-case class PaymentSent(amount: MilliSatoshi, feesPaid: MilliSatoshi, paymentHash: BinaryData) extends PaymentEvent
+case class PaymentSent(amount: MilliSatoshi, feesPaid: MilliSatoshi, paymentHash: BinaryData, paymentPreimage: BinaryData) extends PaymentEvent
 
 case class PaymentRelayed(amountIn: MilliSatoshi, amountOut: MilliSatoshi, paymentHash: BinaryData) extends PaymentEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
@@ -73,7 +73,7 @@ class PaymentLifecycle(sourceNodeId: PublicKey, router: ActorRef, register: Acto
 
     case Event(fulfill: UpdateFulfillHtlc, w: WaitingForComplete) =>
       w.sender ! PaymentSucceeded(w.hops, fulfill.paymentPreimage)
-      context.system.eventStream.publish(PaymentSent(MilliSatoshi(w.c.amountMsat), MilliSatoshi(w.cmd.amountMsat - w.c.amountMsat), w.cmd.paymentHash))
+      context.system.eventStream.publish(PaymentSent(MilliSatoshi(w.c.amountMsat), MilliSatoshi(w.cmd.amountMsat - w.c.amountMsat), w.cmd.paymentHash, fulfill.paymentPreimage))
       stop(FSM.Normal)
 
     case Event(fail: UpdateFailHtlc, WaitingForComplete(s, c, _, failures, sharedSecrets, ignoreNodes, ignoreChannels, hops)) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -177,8 +177,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
 
     sender.send(paymentFSM, UpdateFulfillHtlc("00" * 32, 0, "42" * 32))
 
-    sender.expectMsgType[PaymentSucceeded]
-    val PaymentSent(MilliSatoshi(request.amountMsat), feesPaid, request.paymentHash) = eventListener.expectMsgType[PaymentSent]
+    val paymentOK = sender.expectMsgType[PaymentSucceeded]
+    val PaymentSent(MilliSatoshi(request.amountMsat), feesPaid, request.paymentHash, paymentOK.paymentPreimage) = eventListener.expectMsgType[PaymentSent]
     assert(feesPaid.amount > 0)
 
   }

--- a/eclair-node-gui/src/main/resources/gui/main/main.fxml
+++ b/eclair-node-gui/src/main/resources/gui/main/main.fxml
@@ -111,6 +111,8 @@
                                                                          maxWidth="150.0"/>
                                                             <TableColumn fx:id="paymentSentHashColumn"
                                                                          text="Payment Hash"/>
+                                                            <TableColumn fx:id="paymentSentPreimageColumn"
+                                                                         text="Payment Preimage"/>
                                                         </columns>
                                                     </TableView>
                                                 </Tab>


### PR DESCRIPTION
Payment preimage is important for the sender of the payment as it proves that he actually paid the request. 
This PR adds a `paymentPreimage` field to the `PaymentSent` event.

The GUI also shows a _payment preimage_ column in the _sent_ table in the Activity tab.