### PR TITLE
fixing 'filename to long' bug when compiling on ubuntu with encrypted…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,8 @@
                         <arg>-language:implicitConversions</arg>
                         <arg>-Xfatal-warnings</arg>
                         <arg>-unchecked</arg>
+			<arg>-Xmax-classfile-name</arg>
+			<arg>140</arg>
                     </args>
                     <scalaCompatVersion>${scala.version.short}</scalaCompatVersion>
                 </configuration>


### PR DESCRIPTION
… home dir

There is an issue when compiling Scala projects on a encrypted file system. Basically the filename becomes to long. 

https://stackoverflow.com/questions/28565837/filename-too-long-sbt/28567927#28567927

Here is my attempt at building eclair: https://pastebin.com/PPx4qVzE

If add a compiler flag that says the max filename size should be `140` the build works.