### PR TITLE
Fix a comment

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/Textui.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Textui.scala
@@ -27,8 +27,8 @@ class Textui(kit: Kit) extends Logging {
   import com.googlecode.lanterna.gui2._
   import com.googlecode.lanterna.screen.TerminalScreen
   import com.googlecode.lanterna.terminal.DefaultTerminalFactory
-  // Setup terminal and screen layers// Setup terminal and screen layers
 
+  // Setup terminal and screen layers
   val terminal = new DefaultTerminalFactory().createTerminal
   val screen = new TerminalScreen(terminal)
   screen.startScreen()


### PR DESCRIPTION
Reference PR #381 
As requested, I applied the change to `wip-android`.

I didn't change the comment on this line (as requested) although I think it should mention `bitcoind`:
https://github.com/ACINQ/eclair/blob/e28ac3990ea86e16398538176a87652abee91663/eclair-core/src/main/resources/reference.conf#L18

The reason why I think it makes sense on `wip-android` but not in the `master` branch is because `watcher-type` is `bitcoind` by default.