### PR TITLE
Added quotes to sample parameter value in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ name                         | description                                      
  eclair.api.password         | API password (BASIC)                                                                  | "" (must be set if the API is enabled)
  eclair.bitcoind.rpcuser     | Bitcoin Core RPC user                                                                 | foo
  eclair.bitcoind.rpcpassword | Bitcoin Core RPC password                                                             | bar
- eclair.bitcoind.zmq         | Bitcoin Core ZMQ address                                                              | tcp://127.0.0.1:29000
+ eclair.bitcoind.zmq         | Bitcoin Core ZMQ address                                                              | "tcp://127.0.0.1:29000"
  eclair.gui.unit             | Unit in which amounts are displayed (possible values: msat, sat, mbtc, btc)           | btc 
 
 Quotes are not required unless the value contains special characters. Full syntax guide [here](https://github.com/lightbend/config/blob/master/HOCON.md).


### PR DESCRIPTION
The sample value for eclair.bitcoind.zmq, used as is, with no quotes, throws an error:

2018-01-22 21:40:26,190 ERROR fr.acinq.eclair.gui.FxPreloader   - An error has occuredcom.typesafe.config.ConfigException$Parse: /Users/dimitris/.eclair/eclair.conf: 8: Expecting end of input or a comma, got ':' (if you intended ':' to be part of a key or string value, try enclosing the key or value in double quotes, or you may be able to rename the file .properties rather than .conf)
	at com.typesafe.config.impl.ConfigDocumentParser$ParseContext.parseError(ConfigDocumentParser.java:201)
	at com.typesafe.config.impl.ConfigDocumentParser$ParseContext.parseError(ConfigDocumentParser.java:197)
	at com.typesafe.config.impl.ConfigDocumentParser$ParseContext.parseObject(ConfigDocumentParser.java:482)
	at com.typesafe.config.impl.ConfigDocumentParser$ParseContext.parse(ConfigDocumentParser.java:595)
	at com.typesafe.config.impl.ConfigDocumentParser.parse(ConfigDocumentParser.java:14)
	at com.typesafe.config.impl.Parseable.rawParseValue(Parseable.java:260)
	at com.typesafe.config.impl.Parseable.rawParseValue(Parseable.java:248)
	at com.typesafe.config.impl.Parseable.parseValue(Parseable.java:180)
	at com.typesafe.config.impl.Parseable.parseValue(Parseable.java:174)
	at com.typesafe.config.impl.Parseable.parse(Parseable.java:299)
	at com.typesafe.config.ConfigFactory.parseFile(ConfigFactory.java:734)
	at com.typesafe.config.ConfigFactory.parseFile(ConfigFactory.java:748)
	at fr.acinq.eclair.NodeParams$.loadConfiguration(NodeParams.scala:80)
	at fr.acinq.eclair.Setup.<init>(Setup.scala:40)
	at fr.acinq.eclair.gui.FxApp$$anon$2.run(FxApp.scala:66)
	at java.lang.Thread.run(Thread.java:745)

Adding quotes solves this issue.