### PR TITLE
TCPException message error should be defined

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/PortChecker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/PortChecker.scala
@@ -23,4 +23,4 @@ object PortChecker {
 
 }
 
-case class TCPBindException(port: Int) extends RuntimeException
+case class TCPBindException(port: Int) extends RuntimeException(s"Could not bind to port $port")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/PortChecker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/PortChecker.scala
@@ -23,4 +23,4 @@ object PortChecker {
 
 }
 
-case class TCPBindException(port: Int) extends RuntimeException(s"Could not bind to port $port")
+case class TCPBindException(port: Int) extends RuntimeException(s"could not bind to port $port")

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -21,8 +21,9 @@ object Boot extends App with Logging {
   }
 
   def onError(t: Throwable): Unit = {
-    System.err.println(s"fatal error: ${t.getMessage}")
-    logger.error(s"fatal error: ${t.getMessage}")
+    val errorMsg = if (t.getMessage != null) t.getMessage else t.getClass.getSimpleName
+    System.err.println(s"fatal error: $errorMsg")
+    logger.error(s"fatal error: $errorMsg")
     System.exit(1)
   }
 }


### PR DESCRIPTION
When using eclair-node, a 'null' message is displayed to the user when TCPException is thrown. This PR sets a message so that a useful message is printed instead.

Added a last resort clause where the exception class name is displayed if the exception message is null.

fixes #399