### PR TITLE
Invalidate ports below 0 and above 65535

### DIFF
--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/OpenChannelController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/OpenChannelController.scala
@@ -46,7 +46,7 @@ class OpenChannelController(val handlers: Handlers, val stage: Stage) extends Lo
 
     host.textProperty.addListener(new ChangeListener[String] {
       def changed(observable: ObservableValue[_ <: String], oldValue: String, newValue: String): Unit = {
-        GUIValidators.validate(newValue, hostError, "Please use a valid url (pubkey@host:port)", GUIValidators.hostRegex)
+        GUIValidators.validate(newValue, hostError, "Please use a valid uri (pubkey@host:port)", GUIValidators.hostRegex)
       }
     })
 
@@ -68,7 +68,7 @@ class OpenChannelController(val handlers: Handlers, val stage: Stage) extends Lo
 
   @FXML def handleOpen(event: ActionEvent) = {
     clearErrors()
-    if (GUIValidators.validate(host.getText, hostError, "Please use a valid url (pubkey@host:port)", GUIValidators.hostRegex)) {
+    if (GUIValidators.validate(host.getText, hostError, "Please use a valid uri (pubkey@host:port)", GUIValidators.hostRegex)) {
       val nodeUri = NodeURI.parse(host.getText)
       if (simpleConnection.isSelected) {
         handlers.open(nodeUri, None)

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/OpenChannelController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/OpenChannelController.scala
@@ -46,7 +46,7 @@ class OpenChannelController(val handlers: Handlers, val stage: Stage) extends Lo
 
     host.textProperty.addListener(new ChangeListener[String] {
       def changed(observable: ObservableValue[_ <: String], oldValue: String, newValue: String): Unit = {
-        GUIValidators.validate(newValue, hostError, "Please use a valid uri (pubkey@host:port)", GUIValidators.hostRegex)
+        GUIValidators.validateHost(newValue, hostError, "Please use a valid uri (pubkey@host:port)", GUIValidators.hostRegex)
       }
     })
 
@@ -68,7 +68,7 @@ class OpenChannelController(val handlers: Handlers, val stage: Stage) extends Lo
 
   @FXML def handleOpen(event: ActionEvent) = {
     clearErrors()
-    if (GUIValidators.validate(host.getText, hostError, "Please use a valid uri (pubkey@host:port)", GUIValidators.hostRegex)) {
+    if (GUIValidators.validateHost(host.getText, hostError, "Please use a valid uri (pubkey@host:port)", GUIValidators.hostRegex)) {
       val nodeUri = NodeURI.parse(host.getText)
       if (simpleConnection.isSelected) {
         handlers.open(nodeUri, None)

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/OpenChannelController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/OpenChannelController.scala
@@ -7,10 +7,10 @@ import javafx.fxml.FXML
 import javafx.scene.control._
 import javafx.stage.Stage
 
-import fr.acinq.bitcoin.Satoshi
+import fr.acinq.bitcoin.{Satoshi, _}
 import fr.acinq.eclair.channel.{Channel, ChannelFlags}
+import fr.acinq.eclair.gui.utils.CoinUtils
 import fr.acinq.eclair.gui.{FxApp, Handlers}
-import fr.acinq.eclair.gui.utils.{CoinUtils, GUIValidators}
 import fr.acinq.eclair.io.{NodeURI, Peer}
 import grizzled.slf4j.Logging
 
@@ -45,8 +45,9 @@ class OpenChannelController(val handlers: Handlers, val stage: Stage) extends Lo
     })
 
     host.textProperty.addListener(new ChangeListener[String] {
-      def changed(observable: ObservableValue[_ <: String], oldValue: String, newValue: String): Unit = {
-        GUIValidators.validateHost(newValue, hostError, "Please use a valid uri (pubkey@host:port)", GUIValidators.hostRegex)
+      def changed(observable: ObservableValue[_ <: String], oldValue: String, newValue: String): Unit = Try(NodeURI.parse(newValue)) match {
+        case Failure(t) => hostError.setText(t.getLocalizedMessage)
+        case _ => hostError.setText("")
       }
     })
 
@@ -68,50 +69,41 @@ class OpenChannelController(val handlers: Handlers, val stage: Stage) extends Lo
 
   @FXML def handleOpen(event: ActionEvent) = {
     clearErrors()
-    if (GUIValidators.validateHost(host.getText, hostError, "Please use a valid uri (pubkey@host:port)", GUIValidators.hostRegex)) {
-      val nodeUri = NodeURI.parse(host.getText)
-      if (simpleConnection.isSelected) {
+    Try(NodeURI.parse(host.getText)) match {
+      case Success(nodeUri) if simpleConnection.isSelected =>
         handlers.open(nodeUri, None)
         stage.close
-      } else {
-        import fr.acinq.bitcoin._
-        fundingSatoshis.getText match {
-          case GUIValidators.amountDecRegex(_*) =>
-            Try(CoinUtils.convertStringAmountToSat(fundingSatoshis.getText, unit.getValue)) match {
-              case Success(capacitySat) if capacitySat.amount <= 0 =>
-                fundingSatoshisError.setText("Capacity must be greater than 0")
-              case Success(capacitySat) if capacitySat.amount >= Channel.MAX_FUNDING_SATOSHIS =>
-                fundingSatoshisError.setText(s"Capacity must be less than ${CoinUtils.formatAmountInUnit(Satoshi(Channel.MAX_FUNDING_SATOSHIS), FxApp.getUnit, withUnit = true)}")
-              case Success(capacitySat) =>
-                pushMsatField.getText match {
-                  case "" =>
-                    handlers.open(nodeUri, Some(Peer.OpenChannel(nodeUri.nodeId, capacitySat, MilliSatoshi(0), None)))
-                    stage close()
-                  case GUIValidators.amountRegex(_*) =>
-                    Try(MilliSatoshi(pushMsatField.getText.toLong)) match {
-                      case Success(pushMsat) if pushMsat.amount > satoshi2millisatoshi(capacitySat).amount =>
-                        pushMsatError.setText("Push must be less or equal to capacity")
-                      case Success(pushMsat) =>
-                        val channelFlags = if (publicChannel.isSelected) ChannelFlags.AnnounceChannel else ChannelFlags.Empty
-                        handlers.open(nodeUri, Some(Peer.OpenChannel(nodeUri.nodeId, capacitySat, pushMsat, Some(channelFlags))))
-                        stage close()
-                      case Failure(t) =>
-                        logger.error("Could not parse push amount", t)
-                        pushMsatError.setText("Push amount is not valid")
-                    }
-                  case _ => pushMsatError.setText("Push amount is not valid")
-                }
+      case Success(nodeUri) => Try(CoinUtils.convertStringAmountToSat(fundingSatoshis.getText, unit.getValue)) match {
+        case Success(capacitySat) if capacitySat.amount <= 0 => fundingSatoshisError.setText("Capacity must be greater than 0")
+        case Success(capacitySat) if capacitySat.amount >= Channel.MAX_FUNDING_SATOSHIS =>
+          fundingSatoshisError.setText(s"Capacity must be less than ${CoinUtils.formatAmountInUnit(Satoshi(Channel.MAX_FUNDING_SATOSHIS), FxApp.getUnit, withUnit = true)}")
+        case Success(capacitySat) =>
+          pushMsatField.getText match {
+            case "" =>
+              handlers.open(nodeUri, Some(Peer.OpenChannel(nodeUri.nodeId, capacitySat, MilliSatoshi(0), None)))
+              stage close()
+            case _ => Try(MilliSatoshi(pushMsatField.getText.toLong)) match {
+              case Success(pushMsat) if pushMsat.amount > satoshi2millisatoshi(capacitySat).amount =>
+                pushMsatError.setText("Push must be less or equal to capacity")
+              case Success(pushMsat) =>
+                val channelFlags = if (publicChannel.isSelected) ChannelFlags.AnnounceChannel else ChannelFlags.Empty
+                handlers.open(nodeUri, Some(Peer.OpenChannel(nodeUri.nodeId, capacitySat, pushMsat, Some(channelFlags))))
+                stage close()
               case Failure(t) =>
-                logger.error("Could not parse capacity amount", t)
-                fundingSatoshisError.setText("Capacity is not valid")
+                logger.error(s"could not parse push amount with cause=${t.getLocalizedMessage}")
+                pushMsatError.setText("Push amount is not valid")
             }
-          case _ => fundingSatoshisError.setText("Capacity is not valid")
-        }
+          }
+        case Failure(t) =>
+          logger.error(s"could not parse capacity with cause=${t.getLocalizedMessage}")
+          fundingSatoshisError.setText("Capacity is not valid")
       }
+      case Failure(t) => logger.error(s"could not parse node uri with cause=${t.getLocalizedMessage}")
+        hostError.setText(t.getLocalizedMessage)
     }
   }
 
-  private def clearErrors() = {
+  private def clearErrors() {
     hostError.setText("")
     fundingSatoshisError.setText("")
     pushMsatError.setText("")

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
@@ -8,7 +8,7 @@ import scala.util.matching.Regex
   * Created by DPA on 27/09/2016.
   */
 object GUIValidators {
-  val hostRegex = """([a-fA-F0-9]{66})@([a-zA-Z0-9:\[\]%\/\.\-_]+)(:([0-9]+))?""".r
+  val hostRegex = """([a-fA-F0-9]{66})@([a-zA-Z0-9:\[\]%\/\.\-_]+)""".r
   val amountRegex = """\d+""".r
   val amountDecRegex = """(\d+)|(\d*\.[\d]{1,})""".r
   val hexRegex = """[0-9a-fA-F]+""".r

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
@@ -45,7 +45,7 @@ object GUIValidators {
   }
 
   /**
-    * Validate host field against a hostRegex.
+    * Validate host field against a regex.
     *
     * @param field            String content of the field to validate
     * @param validatorLabel   JFX label associated to the field.

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
@@ -8,11 +8,7 @@ import scala.util.matching.Regex
   * Created by DPA on 27/09/2016.
   */
 object GUIValidators {
-  val hostRegex = """([a-fA-F0-9]{66})@([a-zA-Z0-9:\[\]%\/\.\-_]+)""".r
-  val amountRegex = """\d+""".r
   val amountDecRegex = """(\d+)|(\d*\.[\d]{1,})""".r
-  val hexRegex = """[0-9a-fA-F]+""".r
-  val intRegex = """([\-]?\d+)""".r
 
   /**
     * Validate a field against a regex. If field does not match the regex, validatorLabel is shown.
@@ -42,50 +38,5 @@ object GUIValidators {
     errorLabel.setOpacity(if (validCondition) 0 else 1)
     errorLabel.setText(errorMessage)
     validCondition
-  }
-
-  /**
-    * Validate host field against a regex.
-    *
-    * @param field            String content of the field to validate
-    * @param validatorLabel   JFX label associated to the field.
-    * @param validatorMessage Message displayed if the field is invalid. It should describe the cause of
-    *                         the validation failure
-    * @param regex            Scala regex that the field must match
-    * @return true if field is valid, false otherwise
-    */
-  def validateHost(field: String, validatorLabel: Label, validatorMessage: String, regex: Regex): Boolean = {
-    return field match {
-      case regex(_*) => {
-        // Make sure port is a positive Int below 65536.
-        val split_field = field.split(":")
-        split_field.length match {
-          // No port
-          case 1 => {
-            validate(validatorLabel, validatorMessage, true)
-          }
-          case _ => {
-            // Port is at the end.
-            split_field.last match {
-              case intRegex(portString) => {
-                val portNumber = portString.toInt
-                if (portNumber < 0 || portNumber > 65535) {
-                  // Port out of range.
-                  validate(validatorLabel, validatorMessage, false)
-                } else {
-                  // Valid port.
-                  validate(validatorLabel, validatorMessage, true)
-                }
-              }
-              case _ => {
-                // Not an Int but possibly part of an IPv6 address.
-                validate(validatorLabel, validatorMessage, true)
-              }
-            }  
-          }
-        }
-      }
-      case _ => validate(validatorLabel, validatorMessage, false)
-    }
   }
 }

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/GUIValidators.scala
@@ -12,6 +12,7 @@ object GUIValidators {
   val amountRegex = """\d+""".r
   val amountDecRegex = """(\d+)|(\d*\.[\d]{1,})""".r
   val hexRegex = """[0-9a-fA-F]+""".r
+  val intRegex = """([\-]?\d+)""".r
 
   /**
     * Validate a field against a regex. If field does not match the regex, validatorLabel is shown.
@@ -41,5 +42,50 @@ object GUIValidators {
     errorLabel.setOpacity(if (validCondition) 0 else 1)
     errorLabel.setText(errorMessage)
     validCondition
+  }
+
+  /**
+    * Validate host field against a hostRegex.
+    *
+    * @param field            String content of the field to validate
+    * @param validatorLabel   JFX label associated to the field.
+    * @param validatorMessage Message displayed if the field is invalid. It should describe the cause of
+    *                         the validation failure
+    * @param regex            Scala regex that the field must match
+    * @return true if field is valid, false otherwise
+    */
+  def validateHost(field: String, validatorLabel: Label, validatorMessage: String, regex: Regex): Boolean = {
+    return field match {
+      case regex(_*) => {
+        // Make sure port is a positive Int below 65536.
+        val split_field = field.split(":")
+        split_field.length match {
+          // No port
+          case 1 => {
+            validate(validatorLabel, validatorMessage, true)
+          }
+          case _ => {
+            // Port is at the end.
+            split_field.last match {
+              case intRegex(portString) => {
+                val portNumber = portString.toInt
+                if (portNumber < 0 || portNumber > 65535) {
+                  // Port out of range.
+                  validate(validatorLabel, validatorMessage, false)
+                } else {
+                  // Valid port.
+                  validate(validatorLabel, validatorMessage, true)
+                }
+              }
+              case _ => {
+                // Not an Int but possibly part of an IPv6 address.
+                validate(validatorLabel, validatorMessage, true)
+              }
+            }  
+          }
+        }
+      }
+      case _ => validate(validatorLabel, validatorMessage, false)
+    }
   }
 }


### PR DESCRIPTION
- Replace "url" by "uri" in GUI

- Remove the port part of hostRegex
The ending of hostRegex does nothing since commit af7d7b1.
It also made negative port numbers valid.

- Invalidate ports below 0 and above 65535
Ports out of range cause errors in the console but do nothing in the
GUI.

**Here are some examples:**
`03da7b53368bbdbfe0d413d14237646897a1ac73a7687dfe0530240ed72cb65578@127.0.0.1:65536`
`03da7b53368bbdbfe0d413d14237646897a1ac73a7687dfe0530240ed72cb65578@127.0.0.1:-1`

**Both of these URIs cause these errors in the console:**
```
Exception in thread "JavaFX Application Thread" java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at javafx.fxml.FXMLLoader$MethodHandler.invoke(FXMLLoader.java:1774)
	at javafx.fxml.FXMLLoader$ControllerMethodEventHandler.handle(FXMLLoader.java:1657)
	at com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:238)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:191)
	at com.sun.javafx.event.CompositeEventDispatcher.dispatchBubblingEvent(CompositeEventDispatcher.java:59)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:49)
	at javafx.event.Event.fireEvent(Event.java:198)
	at javafx.scene.Node.fireEvent(Node.java:8411)
	at javafx.scene.control.Button.fire(Button.java:185)
	at com.sun.javafx.scene.control.behavior.ButtonBehavior.mouseReleased(ButtonBehavior.java:182)
	at com.sun.javafx.scene.control.skin.BehaviorSkinBase$1.handle(BehaviorSkinBase.java:96)
	at com.sun.javafx.scene.control.skin.BehaviorSkinBase$1.handle(BehaviorSkinBase.java:89)
	at com.sun.javafx.event.CompositeEventHandler$NormalEventHandlerRecord.handleBubblingEvent(CompositeEventHandler.java:218)
	at com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:80)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:238)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:191)
	at com.sun.javafx.event.CompositeEventDispatcher.dispatchBubblingEvent(CompositeEventDispatcher.java:59)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:56)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:54)
	at javafx.event.Event.fireEvent(Event.java:198)
	at javafx.scene.Scene$MouseHandler.process(Scene.java:3757)
	at javafx.scene.Scene$MouseHandler.access$1500(Scene.java:3485)
	at javafx.scene.Scene.impl_processMouseEvent(Scene.java:1762)
	at javafx.scene.Scene$ScenePeerListener.mouseEvent(Scene.java:2494)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.run(GlassViewEventHandler.java:352)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler$MouseEventNotification.run(GlassViewEventHandler.java:275)
	at java.security.AccessController.doPrivileged(Native Method)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler.lambda$handleMouseEvent$300(GlassViewEventHandler.java:388)
	at com.sun.javafx.tk.quantum.QuantumToolkit.runWithoutRenderLock(QuantumToolkit.java:389)
	at com.sun.javafx.tk.quantum.GlassViewEventHandler.handleMouseEvent(GlassViewEventHandler.java:387)
	at com.sun.glass.ui.View.handleMouseEvent(View.java:555)
	at com.sun.glass.ui.View.notifyMouse(View.java:937)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$null$450(GtkApplication.java:139)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.reflect.misc.Trampoline.invoke(MethodUtil.java:71)
	at sun.reflect.GeneratedMethodAccessor1.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sun.reflect.misc.MethodUtil.invoke(MethodUtil.java:275)
	at javafx.fxml.FXMLLoader$MethodHandler.invoke(FXMLLoader.java:1769)
	... 48 more
Caused by: java.lang.IllegalArgumentException: Invalid host:port
	at fr.acinq.eclair.io.NodeURI$.parse(NodeURI.scala:29)
	at fr.acinq.eclair.gui.controllers.OpenChannelController.handleOpen(OpenChannelController.scala:72)
	... 58 more
```

I also put the URI validation in a separate method. This avoids useless conditions especially for all the other regular expressions.

There are more ways to get the same errors as above, for instance, by setting the port to :%1 or :/1 but I think this is beyond the scope a single pull request and only makes reviewing harder.

TODO: More precise validation of node URIs. Verify if it's IPv6, IPv4, etc.