### PR TITLE
Store channel funding txid with announcements db

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -109,9 +109,11 @@ object NodeParams {
     val sqlite = DriverManager.getConnection(s"jdbc:sqlite:${new File(datadir, "eclair.sqlite")}")
     val channelsDb = new SqliteChannelsDb(sqlite)
     val peersDb = new SqlitePeersDb(sqlite)
-    val networkDb = new SqliteNetworkDb(sqlite)
     val preimagesDb = new SqlitePreimagesDb(sqlite)
     val paymentsDb = new SqlitePaymentsDb(sqlite)
+
+    val sqliteNetwork = DriverManager.getConnection(s"jdbc:sqlite:${new File(datadir, "network.sqlite")}")
+    val networkDb = new SqliteNetworkDb(sqliteNetwork)
 
     val color = BinaryData(config.getString("node-color"))
     require(color.size == 3, "color should be a 3-bytes hex buffer")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
@@ -85,7 +85,7 @@ class ZmqWatcher(client: ExtendedBitcoinClient)(implicit ec: ExecutionContext = 
           // not: we assume parent tx was published, we just need to make sure this particular output has not been spent
           client.isTransactionOuputSpendable(txid.toString(), outputIndex, true).collect {
             case false =>
-              log.warning(s"output=$outputIndex of txid=$txid has already been spent")
+              log.info(s"output=$outputIndex of txid=$txid has already been spent")
               self ! TriggerEvent(w, WatchEventSpentBasic(w.event))
           }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
@@ -1,5 +1,6 @@
 package fr.acinq.eclair.db
 
+import fr.acinq.bitcoin.BinaryData
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement}
 
@@ -13,7 +14,7 @@ trait NetworkDb {
 
   def listNodes(): List[NodeAnnouncement]
 
-  def addChannel(c: ChannelAnnouncement)
+  def addChannel(c: ChannelAnnouncement, txid: BinaryData)
 
   /**
     * This method removes 1 channel announcement and 2 channel updates (at both ends of the same channel)
@@ -23,7 +24,7 @@ trait NetworkDb {
     */
   def removeChannel(shortChannelId: Long)
 
-  def listChannels(): List[ChannelAnnouncement]
+  def listChannels(): Map[ChannelAnnouncement, BinaryData]
 
   def addChannelUpdate(u: ChannelUpdate)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -2,11 +2,12 @@ package fr.acinq.eclair.db.sqlite
 
 import java.sql.Connection
 
-import fr.acinq.bitcoin.Crypto
+import fr.acinq.bitcoin.{BinaryData, Crypto}
 import fr.acinq.eclair.db.NetworkDb
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire.LightningMessageCodecs.{channelAnnouncementCodec, channelUpdateCodec, nodeAnnouncementCodec}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement}
+import scodec.bits.BitVector
 
 class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
 
@@ -15,7 +16,7 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
   using(sqlite.createStatement()) { statement =>
     statement.execute("PRAGMA foreign_keys = ON")
     statement.executeUpdate("CREATE TABLE IF NOT EXISTS nodes (node_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL)")
-    statement.executeUpdate("CREATE TABLE IF NOT EXISTS channels (short_channel_id INTEGER NOT NULL PRIMARY KEY, data BLOB NOT NULL)")
+    statement.executeUpdate("CREATE TABLE IF NOT EXISTS channels (short_channel_id INTEGER NOT NULL PRIMARY KEY, txid STRING NOT NULL, data BLOB NOT NULL)")
     statement.executeUpdate("CREATE TABLE IF NOT EXISTS channel_updates (short_channel_id INTEGER NOT NULL, node_flag INTEGER NOT NULL, data BLOB NOT NULL, PRIMARY KEY(short_channel_id, node_flag), FOREIGN KEY(short_channel_id) REFERENCES channels(short_channel_id))")
     statement.executeUpdate("CREATE INDEX IF NOT EXISTS channel_updates_idx ON channel_updates(short_channel_id)")
   }
@@ -50,10 +51,11 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
     }
   }
 
-  override def addChannel(c: ChannelAnnouncement): Unit = {
-    using(sqlite.prepareStatement("INSERT OR IGNORE INTO channels VALUES (?, ?)")) { statement =>
+  override def addChannel(c: ChannelAnnouncement, txid: BinaryData): Unit = {
+    using(sqlite.prepareStatement("INSERT OR IGNORE INTO channels VALUES (?, ?, ?)")) { statement =>
       statement.setLong(1, c.shortChannelId)
-      statement.setBytes(2, channelAnnouncementCodec.encode(c).require.toByteArray)
+      statement.setString(2, txid.toString())
+      statement.setBytes(3, channelAnnouncementCodec.encode(c).require.toByteArray)
       statement.executeUpdate()
     }
   }
@@ -67,10 +69,14 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
     }
   }
 
-  override def listChannels(): List[ChannelAnnouncement] = {
+  override def listChannels(): Map[ChannelAnnouncement, BinaryData] = {
     using(sqlite.createStatement()) { statement =>
-      val rs = statement.executeQuery("SELECT data FROM channels")
-      codecList(rs, channelAnnouncementCodec)
+      val rs = statement.executeQuery("SELECT data, txid FROM channels")
+      var l: Map[ChannelAnnouncement, BinaryData] = Map()
+      while (rs.next()) {
+        l = l + (channelAnnouncementCodec.decode(BitVector(rs.getBytes("data"))).require.value -> BinaryData(rs.getString("txid")))
+      }
+      l
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/NetworkEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/NetworkEvents.scala
@@ -15,7 +15,7 @@ case class NodeUpdated(ann: NodeAnnouncement) extends NetworkEvent
 
 case class NodeLost(nodeId: PublicKey) extends NetworkEvent
 
-case class ChannelDiscovered(ann: ChannelAnnouncement, capacity: Satoshi) extends NetworkEvent
+case class ChannelDiscovered(ann: ChannelAnnouncement) extends NetworkEvent
 
 case class ChannelLost(channelId: Long) extends NetworkEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -77,28 +77,41 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSM[State, Data]
 
   val db = nodeParams.networkDb
 
-  // Note: We go through the whole validation process instead of directly loading into memory, because the channels
-  // could have been closed while we were shutdown, and if someone connects to us right after startup we don't want to
-  // advertise invalid channels. We could optimize this (at least not fetch txes from the blockchain, and not check sigs)
+  // Note: It is possible that some channels have been closed while we were shutdown. Since we are directly loading channels
+  // in memory without checking they are still alive, we may advertise closed channels if someone connects to us right after
+  // startup. That being said, if we stay down long enough that a significant numbers of channels are closed, there is a chance
+  // other peers forgot about us in the meantime.
   {
     log.info(s"loading network announcements from db...")
     val channels = db.listChannels()
     val nodes = db.listNodes()
     val updates = db.listChannelUpdates()
-    val staleChannels = getStaleChannels(channels.map(_._1), updates)
+    // let's prune the db (maybe eclair was stopped for a long time)
+    val staleChannels = getStaleChannels(channels.keys, updates)
     if (staleChannels.size > 0) {
       log.info(s"dropping ${staleChannels.size} stale channels pre-validation")
       staleChannels.foreach(shortChannelId => db.removeChannel(shortChannelId)) // this also removes updates
     }
-    val remainingChannels = channels.filterNot(c => staleChannels.contains(c._1.shortChannelId))
+    val remainingChannels = channels.keys.filterNot(c => staleChannels.contains(c.shortChannelId))
     val remainingUpdates = updates.filterNot(c => staleChannels.contains(c.shortChannelId))
-    remainingChannels.map(self ! _)
-    nodes.map(self ! _)
-    remainingUpdates.map(self ! _)
-    log.info(s"loaded from db: channels=${remainingChannels.size} nodes=${nodes.size} updates=${remainingUpdates.size}")
-  }
+    val remainingNodes = nodes.filter(n => remainingChannels.exists(c => isRelatedTo(c, n.nodeId)))
 
-  startWith(NORMAL, Data(Map.empty, Map.empty, Map.empty, Stash(Map.empty, Map.empty, Map.empty), Queue.empty, Map.empty, Map.empty, Map.empty, Set.empty, Set.empty))
+    val initChannels = remainingChannels.map(c => (c.shortChannelId -> c)).toMap
+    val initChannelUpdates = remainingUpdates.map(u => (getDesc(u, initChannels(u.shortChannelId)) -> u)).toMap
+    val initNodes = remainingNodes.map(n => (n.nodeId -> n)).toMap
+
+    // we watches the funding tx of all these channels
+    // note: some of them may already have been spent, in that case we will receive the watchh event immediately
+    remainingChannels.foreach { c =>
+      val txid = channels(c)
+      val (_, _, outputIndex) = fromShortId(c.shortChannelId)
+      val fundingOutputScript = write(pay2wsh(Scripts.multiSig2of2(PublicKey(c.bitcoinKey1), PublicKey(c.bitcoinKey2))))
+      watcher ! WatchSpentBasic(self, txid, outputIndex, fundingOutputScript, BITCOIN_FUNDING_EXTERNAL_CHANNEL_SPENT(c.shortChannelId))
+    }
+
+    log.info(s"loaded from db: channels=${remainingChannels.size} nodes=${nodes.size} updates=${remainingUpdates.size}")
+    startWith(NORMAL, Data(initNodes, initChannels, initChannelUpdates, Stash(Map.empty, Map.empty, Map.empty), Queue.empty, awaiting = Map.empty, privateChannels = Map.empty, privateUpdates = Map.empty, excludedChannels = Set.empty, sendingState = Set.empty))
+  }
 
   when(NORMAL) {
     case Event(TickValidate, d) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
@@ -54,15 +54,19 @@ class SqliteNetworkDbSpec extends FunSuite {
     val channel_2 = Announcements.makeChannelAnnouncement(Block.RegtestGenesisBlock.hash, 43, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, sig, sig, sig, sig)
     val channel_3 = Announcements.makeChannelAnnouncement(Block.RegtestGenesisBlock.hash, 44, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, sig, sig, sig, sig)
 
+    val txid_1 = randomKey.toBin
+    val txid_2 = randomKey.toBin
+    val txid_3 = randomKey.toBin
+
     assert(db.listChannels().toSet === Set.empty)
-    db.addChannel(channel_1)
-    db.addChannel(channel_1) // duplicate is ignored
+    db.addChannel(channel_1, txid_1)
+    db.addChannel(channel_1, txid_1) // duplicate is ignored
     assert(db.listChannels().size === 1)
-    db.addChannel(channel_2)
-    db.addChannel(channel_3)
-    assert(db.listChannels().toSet === Set(channel_1, channel_2, channel_3))
+    db.addChannel(channel_2, txid_2)
+    db.addChannel(channel_3, txid_3)
+    assert(db.listChannels().toSet === Set((channel_1, txid_1), (channel_2, txid_2), (channel_3, txid_3)))
     db.removeChannel(channel_2.shortChannelId)
-    assert(db.listChannels().toSet === Set(channel_1, channel_3))
+    assert(db.listChannels().toSet === Set((channel_1, txid_1), (channel_3, txid_3)))
 
     val channel_update_1 = Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, randomKey, randomKey.publicKey, 42, 5, 7000000, 50000, 100, true)
     val channel_update_2 = Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, randomKey, randomKey.publicKey, 43, 5, 7000000, 50000, 100, true)
@@ -75,7 +79,7 @@ class SqliteNetworkDbSpec extends FunSuite {
     intercept[SQLiteException](db.addChannelUpdate(channel_update_2))
     db.addChannelUpdate(channel_update_3)
     db.removeChannel(channel_3.shortChannelId)
-    assert(db.listChannels().toSet === Set(channel_1))
+    assert(db.listChannels().toSet === Set((channel_1, txid_1)))
     assert(db.listChannelUpdates().toSet === Set(channel_update_1))
     db.updateChannelUpdate(channel_update_1)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -63,7 +63,7 @@ class RouterSpec extends BaseRouterSpec {
     watcher.expectMsgType[WatchSpentBasic]
     watcher.expectNoMsg(1 second)
 
-    eventListener.expectMsg(ChannelDiscovered(chan_ac, Satoshi(1000000)))
+    eventListener.expectMsg(ChannelDiscovered(chan_ac))
   }
 
   test("properly announce lost channels and nodes") { case (router, watcher) =>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -149,7 +149,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
         })
       }
 
-    case ChannelDiscovered(channelAnnouncement, _) =>
+    case ChannelDiscovered(channelAnnouncement) =>
       log.debug(s"peer channel discovered with channel id=${channelAnnouncement.shortChannelId}")
       if (!mainController.networkChannelsList.exists(c => c.announcement.shortChannelId == channelAnnouncement.shortChannelId)) {
         mainController.networkChannelsList.add(new ChannelInfo(channelAnnouncement, None, None))


### PR DESCRIPTION
We previously revalidated all channels on startup, which was very inefficient and took a long time.

With this pr, announcements are also stored in a separate sqlite database `network.db`.