### PR TITLE
Publish a `ChannelSignatureSent` for each outgoing commitment sig

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -25,4 +25,6 @@ case class LocalChannelDown(channel: ActorRef, channelId: BinaryData, shortChann
 
 case class ChannelStateChanged(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, previousState: State, currentState: State, currentData: Data) extends ChannelEvent
 
+case class ChannelSignatureSent(channel: ActorRef, Commitments: Commitments) extends ChannelEvent
+
 case class ChannelSignatureReceived(channel: ActorRef, Commitments: Commitments) extends ChannelEvent


### PR DESCRIPTION
For consistency with existing `ChannelSignatureReceived`.