### PR TITLE
Addition of API calls checkinvoice and findroute

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ java -Declair.datadir=/tmp/node1 -jar eclair-node-gui-<version>-<commit_id>.jar
   allupdates   | nodeId                                                                                 | list all channels updates for this nodeId
   receive      | description                                                                            | generate a payment request without a required amount (can be useful for donations)
   receive      | amountMsat, description                                                                | generate a payment request for a given amount
+  checkinvoice | paymentRequest                                                                         | returns node, amount and payment hash in an invoice/paymentRequest
+  findroute    | paymentRequest|nodeId                                                                  | given a payment request or nodeID checks if there is a valid payment route returns JSON with attempts, nodes and channels of route
   send         | amountMsat, paymentHash, nodeId                                                        | send a payment to a lightning node
   send         | paymentRequest                                                                         | send a payment to a lightning node using a BOLT11 payment request
   send         | paymentRequest, amountMsat                                                             | send a payment to a lightning node using a BOLT11 payment request and a custom amount

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -24,9 +24,10 @@ import fr.acinq.bitcoin.{BinaryData, OutPoint, Transaction}
 import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.channel.State
 import fr.acinq.eclair.crypto.ShaChain
+import fr.acinq.eclair.router.RouteResponse
 import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo
 import fr.acinq.eclair.wire.Color
-import org.json4s.JsonAST.{JNull, JString}
+import org.json4s.JsonAST.{JArray, JNull, JString}
 import org.json4s.{CustomKeySerializer, CustomSerializer}
 
 /**
@@ -87,4 +88,13 @@ class OutPointKeySerializer extends CustomKeySerializer[OutPoint](format => ({
 
 class ColorSerializer extends CustomSerializer[Color](format => ({ null }, {
   case c: Color => JString(c.toString)
+}))
+
+class RouteResponseSerializer extends CustomSerializer[RouteResponse](format => ({ null }, {
+  case route: RouteResponse =>
+    val nodeIds = route.hops match {
+      case rest :+ last => rest.map(_.nodeId) :+ last.nodeId :+ last.nextNodeId
+      case Nil => Nil
+    }
+    JArray(nodeIds.toList.map(n => JString(n.toString)))
 }))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -68,7 +68,7 @@ trait Service extends Logging {
   implicit def ec: ExecutionContext = ExecutionContext.Implicits.global
 
   implicit val serialization = jackson.Serialization
-  implicit val formats = org.json4s.DefaultFormats + new BinaryDataSerializer + new StateSerializer + new ShaChainSerializer + new PublicKeySerializer + new PrivateKeySerializer + new ScalarSerializer + new PointSerializer + new TransactionSerializer + new TransactionWithInputInfoSerializer + new InetSocketAddressSerializer + new OutPointKeySerializer + new ColorSerializer + new ShortChannelIdSerializer
+  implicit val formats = org.json4s.DefaultFormats + new BinaryDataSerializer + new StateSerializer + new ShaChainSerializer + new PublicKeySerializer + new PrivateKeySerializer + new ScalarSerializer + new PointSerializer + new TransactionSerializer + new TransactionWithInputInfoSerializer + new InetSocketAddressSerializer + new OutPointKeySerializer + new ColorSerializer + new ShortChannelIdSerializer + new RouteResponseSerializer
   implicit val timeout = Timeout(60 seconds)
   implicit val shouldWritePretty: ShouldWritePretty = ShouldWritePretty.True
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -36,7 +36,7 @@ import fr.acinq.eclair.io.Peer.{GetPeerInfo, PeerInfo}
 import fr.acinq.eclair.io.{NodeURI, Peer}
 import fr.acinq.eclair.payment.PaymentLifecycle.{CheckPayment, PaymentResult, ReceivePayment, SendPayment}
 import fr.acinq.eclair.payment.PaymentRequest
-import fr.acinq.eclair.router.ChannelDesc
+import fr.acinq.eclair.router.{ChannelDesc,RouteRequest,RouteResponse}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement}
 import fr.acinq.eclair.{Kit, ShortChannelId, feerateByte2Kw}
 import grizzled.slf4j.Logging
@@ -221,17 +221,33 @@ trait Service extends Logging {
                           completeRpcFuture(req.id, (paymentHandler ? ReceivePayment(Some(MilliSatoshi(amountMsat.toLong)), description)).mapTo[PaymentRequest].map(PaymentRequest.write))
                         case _ => reject(UnknownParamsRejection(req.id, "[description] or [amount, description]"))
                       }
-                      
+
                       case "checkinvoice" => req.params match {
                         case JString(paymentRequest) :: Nil  => Try(PaymentRequest.read(paymentRequest)) match {
                           case Success(pr) => {
                             completeRpc(req.id,pr)
                           }
-                            // setting the payment amount
-                          case _ => reject(RpcValidationRejection(req.id, s"payment request is not valid"))
+                          case Failure(f) => reject(RpcValidationRejection(req.id, s"Payment request is not valid - could not parse: "+f.toString()))
                         }
+                        case _ => reject(UnknownParamsRejection(req.id, "[payment_request]"))
                       }
-                      
+
+                      case "findroute" => req.params match {
+                        case JString(nodeId) :: Nil if nodeId.length()==66 =>
+                          Try(PublicKey(nodeId)) match {
+                            case Success(pk) =>  completeRpcFuture(req.id, (router ? RouteRequest(appKit.nodeParams.nodeId, pk)  ).mapTo[RouteResponse]  )
+                            case (Failure(_)) => reject(RpcValidationRejection(req.id, s"invalid nodeId hash: '$nodeId'"))
+                          }
+
+                        case JString(paymentRequest) :: Nil  => Try(PaymentRequest.read(paymentRequest)) match {
+                          case pr@Success(PaymentRequest(_,_,_,_,_,_)) =>
+                            completeRpcFuture(req.id, (router ? RouteRequest(appKit.nodeParams.nodeId, pr.get.nodeId)  ).mapTo[RouteResponse]  )
+                          case Failure(f) => reject(RpcValidationRejection(req.id, s"payment request is not valid: "+f.toString()))
+                        }
+                        case _ => reject(UnknownParamsRejection(req.id, "[payment_request|nodeId]"))
+
+                      }
+
                       case "send"         => req.params match {
                         // user manually sets the payment information
                         case JInt(amountMsat) :: JString(paymentHash) :: JString(nodeId) :: Nil =>
@@ -305,6 +321,7 @@ trait Service extends Logging {
     "allupdates (nodeId): list all channels updates for this nodeId",
     "receive (amountMsat, description): generate a payment request for a given amount",
     "checkinvoice (paymentRequest): returns node, amount and payment hash in an invoice/paymentRequest",
+    "findroute (paymentRequest|nodeId): given a payment request or nodeID checks if there is a valid payment route returns JSON with attempts, nodes and channels of route",
     "send (amountMsat, paymentHash, nodeId): send a payment to a lightning node",
     "send (paymentRequest): send a payment to a lightning node using a BOLT11 payment request",
     "send (paymentRequest, amountMsat): send a payment to a lightning node using a BOLT11 payment request and a custom amount",


### PR DESCRIPTION
checkinvoice parses an invoice/PaymentRequest and returns the JSON object. Usecase is that you need to be 100% sure that Eclair is paying the amount you expect! Easy to be factor of 1000 out if someone has a bug!

checkroute takes an invoice and checks if we have a route to pay at that moment. Is useful when you do not want to accept a request for payment you know you can not make.

Includes tests for checkroute.