### PR TITLE
Better handling of force-closing of channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ java -Declair.datadir=/tmp/node1 -jar eclair-node-gui-<version>-<commit_id>.jar
   checkpayment | paymentRequest                                                                         | returns true if the payment has been received, false otherwise
   close        | channelId                                                                              | close a channel
   close        | channelId, scriptPubKey                                                                | close a channel and send the funds to the given scriptPubKey
+  forceclose   | channelId                                                                              | force-close a channel by publishing the local commitment tx (careful: this is more expensive than a regular close and will incur a delay before funds are spendable)"
   help         |                                                                                        | display available methods
 
 ## Docker

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -141,9 +141,13 @@ trait Service extends Logging {
                         case _ => reject(UnknownParamsRejection(req.id, s"[nodeId, fundingSatoshis], [nodeId, fundingSatoshis, pushMsat], [nodeId, fundingSatoshis, pushMsat, feerateSatPerByte] or [nodeId, fundingSatoshis, pushMsat, feerateSatPerByte, flag]"))
                       }
                       case "close"        => req.params match {
-                        case JString(identifier) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = None)).mapTo[String])
-                        case JString(identifier) :: JString(scriptPubKey) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = Some(scriptPubKey))).mapTo[String])
+                        case JString(identifier) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = None, closeType = MUTUAL)).mapTo[String])
+                        case JString(identifier) :: JString(scriptPubKey) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = Some(scriptPubKey), closeType = MUTUAL)).mapTo[String])
                         case _ => reject(UnknownParamsRejection(req.id, "[channelId] or [channelId, scriptPubKey]"))
+                      }
+                      case "forceclose"   => req.params match {
+                        case JString(identifier) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = None, closeType = FORCE)).mapTo[String])
+                        case _ => reject(UnknownParamsRejection(req.id, "[channelId]"))
                       }
 
                       // local network methods
@@ -273,6 +277,7 @@ trait Service extends Logging {
     "send (paymentRequest, amountMsat): send a payment to a lightning node using a BOLT11 payment request and a custom amount",
     "close (channelId): close a channel",
     "close (channelId, scriptPubKey): close a channel and send the funds to the given scriptPubKey",
+    "forceclose (channelId): force-close a channel by publishing the local commitment tx (careful: this is more expensive than a regular close and will incur a delay before funds are spendable)",
     "checkpayment (paymentHash): returns true if the payment has been received, false otherwise",
     "checkpayment (paymentRequest): returns true if the payment has been received, false otherwise",
     "getinfo: returns info about the blockchain and this node",

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -141,12 +141,12 @@ trait Service extends Logging {
                         case _ => reject(UnknownParamsRejection(req.id, s"[nodeId, fundingSatoshis], [nodeId, fundingSatoshis, pushMsat], [nodeId, fundingSatoshis, pushMsat, feerateSatPerByte] or [nodeId, fundingSatoshis, pushMsat, feerateSatPerByte, flag]"))
                       }
                       case "close"        => req.params match {
-                        case JString(identifier) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = None, closeType = MUTUAL)).mapTo[String])
-                        case JString(identifier) :: JString(scriptPubKey) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = Some(scriptPubKey), closeType = MUTUAL)).mapTo[String])
+                        case JString(identifier) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = None)).mapTo[String])
+                        case JString(identifier) :: JString(scriptPubKey) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = Some(scriptPubKey))).mapTo[String])
                         case _ => reject(UnknownParamsRejection(req.id, "[channelId] or [channelId, scriptPubKey]"))
                       }
                       case "forceclose"   => req.params match {
-                        case JString(identifier) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = None, closeType = FORCE)).mapTo[String])
+                        case JString(identifier) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_FORCECLOSE).mapTo[String])
                         case _ => reject(UnknownParamsRejection(req.id, "[channelId]"))
                       }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -141,12 +141,12 @@ trait Service extends Logging {
                         case _ => reject(UnknownParamsRejection(req.id, s"[nodeId, fundingSatoshis], [nodeId, fundingSatoshis, pushMsat], [nodeId, fundingSatoshis, pushMsat, feerateSatPerByte] or [nodeId, fundingSatoshis, pushMsat, feerateSatPerByte, flag]"))
                       }
                       case "close"        => req.params match {
-                        case JString(identifier) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = None)).mapTo[String])
-                        case JString(identifier) :: JString(scriptPubKey) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = Some(scriptPubKey))).mapTo[String])
+                        case JString(identifier) :: Nil => completeRpcFuture(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = None)).mapTo[String])
+                        case JString(identifier) :: JString(scriptPubKey) :: Nil => completeRpcFuture(req.id, sendToChannel(identifier, CMD_CLOSE(scriptPubKey = Some(scriptPubKey))).mapTo[String])
                         case _ => reject(UnknownParamsRejection(req.id, "[channelId] or [channelId, scriptPubKey]"))
                       }
                       case "forceclose"   => req.params match {
-                        case JString(identifier) :: Nil => completeRpc(req.id, sendToChannel(identifier, CMD_FORCECLOSE).mapTo[String])
+                        case JString(identifier) :: Nil => completeRpcFuture(req.id, sendToChannel(identifier, CMD_FORCECLOSE).mapTo[String])
                         case _ => reject(UnknownParamsRejection(req.id, "[channelId]"))
                       }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -175,7 +175,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
           goto(OFFLINE) using data
       }
 
-    case Event(c: CMD_CLOSE, _) => goto(CLOSED) replying "ok"
+    case Event(CMD_CLOSE(_), _) => goto(CLOSED) replying "ok"
   })
 
   when(WAIT_FOR_OPEN_CHANNEL)(handleExceptions {
@@ -222,7 +222,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
           goto(WAIT_FOR_FUNDING_CREATED) using DATA_WAIT_FOR_FUNDING_CREATED(open.temporaryChannelId, localParams, remoteParams, open.fundingSatoshis, open.pushMsat, open.feeratePerKw, open.firstPerCommitmentPoint, open.channelFlags, accept) sending accept
       }
 
-    case Event(c: CMD_CLOSE, _) => goto(CLOSED) replying "ok"
+    case Event(CMD_CLOSE(_), _) => goto(CLOSED) replying "ok"
 
     case Event(e: Error, d: DATA_WAIT_FOR_OPEN_CHANNEL) => handleRemoteError(e, d)
 
@@ -261,7 +261,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
           goto(WAIT_FOR_FUNDING_INTERNAL) using DATA_WAIT_FOR_FUNDING_INTERNAL(temporaryChannelId, localParams, remoteParams, fundingSatoshis, pushMsat, initialFeeratePerKw, accept.firstPerCommitmentPoint, open)
       }
 
-    case Event(c: CMD_CLOSE, _) =>
+    case Event(CMD_CLOSE(_), _) =>
       replyToUser(Right("closed"))
       goto(CLOSED) replying "ok"
 
@@ -300,7 +300,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
       replyToUser(Left(Left(t)))
       goto(CLOSED) sending error
 
-    case Event(c: CMD_CLOSE, _) =>
+    case Event(CMD_CLOSE(_), _) =>
       replyToUser(Right("closed"))
       goto(CLOSED) replying "ok"
 
@@ -354,7 +354,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
           goto(WAIT_FOR_FUNDING_CONFIRMED) using store(DATA_WAIT_FOR_FUNDING_CONFIRMED(commitments, None, Right(fundingSigned))) sending fundingSigned
       }
 
-    case Event(c: CMD_CLOSE, _) => goto(CLOSED) replying "ok"
+    case Event(CMD_CLOSE(_), _) => goto(CLOSED) replying "ok"
 
     case Event(e: Error, d: DATA_WAIT_FOR_FUNDING_CREATED) => handleRemoteError(e, d)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -988,7 +988,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx), d: DATA_SHUTDOWN) => handleRemoteSpentOther(tx, d)
 
-    case Event(c@CMD_CLOSE(_), d: DATA_SHUTDOWN) => handleCommandError(ClosingAlreadyInProgress(d.channelId), c)
+    case Event(c: CMD_CLOSE, d: DATA_SHUTDOWN) => handleCommandError(ClosingAlreadyInProgress(d.channelId), c)
 
     case Event(e: Error, d: DATA_SHUTDOWN) => handleRemoteError(e, d)
 
@@ -1037,7 +1037,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
 
     case Event(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx), d: DATA_NEGOTIATING) => handleRemoteSpentOther(tx, d)
 
-    case Event(c@CMD_CLOSE(_), d: DATA_NEGOTIATING) => handleCommandError(ClosingAlreadyInProgress(d.channelId), c)
+    case Event(c: CMD_CLOSE, d: DATA_NEGOTIATING) => handleCommandError(ClosingAlreadyInProgress(d.channelId), c)
 
     case Event(e: Error, d: DATA_NEGOTIATING) => handleRemoteError(e, d)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1480,7 +1480,10 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
   }
 
   def handleLocalError(cause: Throwable, d: HasCommitments, msg: Option[Any]) = {
-    log.error(s"${cause.getMessage} while processing msg=${msg.getOrElse("n/a").getClass.getSimpleName} in state=$stateName")
+    cause match {
+      case _: ForcedLocalCommit => log.warning(s"force-closing channel at user request")
+      case _ => log.error(s"${cause.getMessage} while processing msg=${msg.getOrElse("n/a").getClass.getSimpleName} in state=$stateName")
+    }
     cause match {
       case _: ChannelException => ()
       case _ => log.error(cause, s"msg=${msg.getOrElse("n/a")} stateData=$stateData ")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -22,6 +22,7 @@ case class ChannelReserveTooHigh               (override val channelId: BinaryDa
 case class ChannelFundingError                 (override val channelId: BinaryData) extends ChannelException(channelId, "channel funding error")
 case class NoMoreHtlcsClosingInProgress        (override val channelId: BinaryData) extends ChannelException(channelId, "cannot send new htlcs, closing in progress")
 case class ClosingAlreadyInProgress            (override val channelId: BinaryData) extends ChannelException(channelId, "closing already in progress")
+case class CannotCloseInThisState              (override val channelId: BinaryData, state: State, closeType: CloseType) extends ChannelException(channelId, s"cannot close in state=$state closeType=$closeType")
 case class CannotCloseWithUnsignedOutgoingHtlcs(override val channelId: BinaryData) extends ChannelException(channelId, "cannot close when there are unsigned outgoing htlcs")
 case class ChannelUnavailable                  (override val channelId: BinaryData) extends ChannelException(channelId, "channel is unavailable (offline or closing)")
 case class InvalidFinalScript                  (override val channelId: BinaryData) extends ChannelException(channelId, "invalid final script")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -22,7 +22,7 @@ case class ChannelReserveTooHigh               (override val channelId: BinaryDa
 case class ChannelFundingError                 (override val channelId: BinaryData) extends ChannelException(channelId, "channel funding error")
 case class NoMoreHtlcsClosingInProgress        (override val channelId: BinaryData) extends ChannelException(channelId, "cannot send new htlcs, closing in progress")
 case class ClosingAlreadyInProgress            (override val channelId: BinaryData) extends ChannelException(channelId, "closing already in progress")
-case class CannotCloseInThisState              (override val channelId: BinaryData, state: State, closeType: CloseType) extends ChannelException(channelId, s"cannot close in state=$state closeType=$closeType")
+case class CannotCloseInThisState              (override val channelId: BinaryData, state: State) extends ChannelException(channelId, s"cannot close in state=$state")
 case class CannotCloseWithUnsignedOutgoingHtlcs(override val channelId: BinaryData) extends ChannelException(channelId, "cannot close when there are unsigned outgoing htlcs")
 case class ChannelUnavailable                  (override val channelId: BinaryData) extends ChannelException(channelId, "channel is unavailable (offline or closing)")
 case class InvalidFinalScript                  (override val channelId: BinaryData) extends ChannelException(channelId, "invalid final script")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -33,7 +33,6 @@ case object WAIT_FOR_ACCEPT_CHANNEL extends State
 case object WAIT_FOR_FUNDING_INTERNAL extends State
 case object WAIT_FOR_FUNDING_CREATED extends State
 case object WAIT_FOR_FUNDING_SIGNED extends State
-case object WAIT_FOR_FUNDING_PUBLISHED extends State
 case object WAIT_FOR_FUNDING_CONFIRMED extends State
 case object WAIT_FOR_FUNDING_LOCKED extends State
 case object NORMAL extends State
@@ -96,14 +95,12 @@ final case class CMD_FULFILL_HTLC(id: Long, r: BinaryData, commit: Boolean = fal
 final case class CMD_FAIL_HTLC(id: Long, reason: Either[BinaryData, FailureMessage], commit: Boolean = false) extends Command
 final case class CMD_FAIL_MALFORMED_HTLC(id: Long, onionHash: BinaryData, failureCode: Int, commit: Boolean = false) extends Command
 final case class CMD_UPDATE_FEE(feeratePerKw: Long, commit: Boolean = false) extends Command
-case object CMD_SIGN extends Command
-sealed trait CloseType
-case object MUTUAL extends CloseType
-case object FORCE extends CloseType
-final case class CMD_CLOSE(scriptPubKey: Option[BinaryData], closeType: CloseType = MUTUAL) extends Command
-case object CMD_GETSTATE extends Command
-case object CMD_GETSTATEDATA extends Command
-case object CMD_GETINFO extends Command
+final case object CMD_SIGN extends Command
+final case class CMD_CLOSE(scriptPubKey: Option[BinaryData]) extends Command
+final case object CMD_FORCECLOSE extends Command
+final case object CMD_GETSTATE extends Command
+final case object CMD_GETSTATEDATA extends Command
+final case object CMD_GETINFO extends Command
 final case class RES_GETINFO(nodeId: BinaryData, channelId: BinaryData, state: State, data: Data)
 
 /*

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -63,7 +63,6 @@ case object ERR_INFORMATION_LEAK extends State
 case class INPUT_INIT_FUNDER(temporaryChannelId: BinaryData, fundingSatoshis: Long, pushMsat: Long, initialFeeratePerKw: Long, fundingTxFeeratePerKw: Long, localParams: LocalParams, remote: ActorRef, remoteInit: Init, channelFlags: Byte)
 case class INPUT_INIT_FUNDEE(temporaryChannelId: BinaryData, localParams: LocalParams, remote: ActorRef, remoteInit: Init)
 case object INPUT_CLOSE_COMPLETE_TIMEOUT // when requesting a mutual close, we wait for as much as this timeout, then unilateral close
-case object INPUT_PUBLISH_LOCALCOMMIT // used in tests
 case object INPUT_DISCONNECTED
 case class INPUT_RECONNECTED(remote: ActorRef)
 case class INPUT_RESTORED(data: HasCommitments)
@@ -98,7 +97,10 @@ final case class CMD_FAIL_HTLC(id: Long, reason: Either[BinaryData, FailureMessa
 final case class CMD_FAIL_MALFORMED_HTLC(id: Long, onionHash: BinaryData, failureCode: Int, commit: Boolean = false) extends Command
 final case class CMD_UPDATE_FEE(feeratePerKw: Long, commit: Boolean = false) extends Command
 case object CMD_SIGN extends Command
-final case class CMD_CLOSE(scriptPubKey: Option[BinaryData]) extends Command
+sealed trait CloseType
+case object MUTUAL extends CloseType
+case object FORCE extends CloseType
+final case class CMD_CLOSE(scriptPubKey: Option[BinaryData], closeType: CloseType = MUTUAL) extends Command
 case object CMD_GETSTATE extends Command
 case object CMD_GETSTATEDATA extends Command
 case object CMD_GETINFO extends Command

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -40,7 +40,7 @@ class WaitForFundingSignedStateSpec extends TestkitBaseClass with StateTestsHelp
     test((alice, alice2bob, bob2alice, alice2blockchain))
   }
 
-  test("recv FundingSigned with valid signature") { case (alice, alice2bob, bob2alice, alice2blockchain) =>
+  test("recv FundingSigned with valid signature") { case (alice, _, bob2alice, alice2blockchain) =>
     within(30 seconds) {
       bob2alice.expectMsgType[FundingSigned]
       bob2alice.forward(alice)
@@ -50,7 +50,7 @@ class WaitForFundingSignedStateSpec extends TestkitBaseClass with StateTestsHelp
     }
   }
 
-  test("recv FundingSigned with invalid signature") { case (alice, alice2bob, bob2alice, alice2blockchain) =>
+  test("recv FundingSigned with invalid signature") { case (alice, alice2bob, _, _) =>
     within(30 seconds) {
       // sending an invalid sig
       alice ! FundingSigned("00" * 32, BinaryData("00" * 64))
@@ -59,9 +59,16 @@ class WaitForFundingSignedStateSpec extends TestkitBaseClass with StateTestsHelp
     }
   }
 
-  test("recv CMD_CLOSE") { case (alice, alice2bob, bob2alice, _) =>
+  test("recv CMD_CLOSE") { case (alice, _, _, _) =>
     within(30 seconds) {
       alice ! CMD_CLOSE(None)
+      awaitCond(alice.stateName == CLOSED)
+    }
+  }
+
+  test("recv CMD_FORCECLOSE") { case (alice, _, _, _) =>
+    within(30 seconds) {
+      alice ! CMD_FORCECLOSE
       awaitCond(alice.stateName == CLOSED)
     }
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -105,18 +105,18 @@ class WaitForFundingConfirmedStateSpec extends TestkitBaseClass with StateTestsH
     }
   }
 
-  test("recv CMD_CLOSE (mutual)") { case (alice, _, _, _, _) =>
+  test("recv CMD_CLOSE") { case (alice, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
-      sender.send(alice, CMD_CLOSE(None, MUTUAL))
-      sender.expectMsg(Failure(CannotCloseInThisState(channelId(alice), WAIT_FOR_FUNDING_CONFIRMED, MUTUAL)))
+      sender.send(alice, CMD_CLOSE(None))
+      sender.expectMsg(Failure(CannotCloseInThisState(channelId(alice), WAIT_FOR_FUNDING_CONFIRMED)))
     }
   }
 
-  test("recv CMD_CLOSE (force)") { case (alice, _, _, _, alice2blockchain) =>
+  test("recv CMD_FORCECLOSE") { case (alice, _, _, _, alice2blockchain) =>
     within(30 seconds) {
       val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! CMD_CLOSE(None, FORCE)
+      alice ! CMD_FORCECLOSE
       awaitCond(alice.stateName == CLOSING)
       alice2blockchain.expectMsg(PublishAsap(tx))
       alice2blockchain.expectMsgType[PublishAsap] // claim-main-delayed

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingLockedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingLockedStateSpec.scala
@@ -96,18 +96,18 @@ class WaitForFundingLockedStateSpec extends TestkitBaseClass with StateTestsHelp
     }
   }
 
-  test("recv CMD_CLOSE (mutual)") { case (alice, _, _, _, _, _) =>
+  test("recv CMD_CLOSE") { case (alice, _, _, _, _, _) =>
     within(30 seconds) {
       val sender = TestProbe()
-      sender.send(alice, CMD_CLOSE(None, MUTUAL))
-      sender.expectMsg(Failure(CannotCloseInThisState(channelId(alice), WAIT_FOR_FUNDING_LOCKED, MUTUAL)))
+      sender.send(alice, CMD_CLOSE(None))
+      sender.expectMsg(Failure(CannotCloseInThisState(channelId(alice), WAIT_FOR_FUNDING_LOCKED)))
     }
   }
 
-  test("recv CMD_CLOSE (force)") { case (alice, _, _, _, alice2blockchain, _) =>
+  test("recv CMD_FORCECLOSE") { case (alice, _, _, _, alice2blockchain, _) =>
     within(30 seconds) {
       val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_LOCKED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! CMD_CLOSE(None, FORCE)
+      alice ! CMD_FORCECLOSE
       awaitCond(alice.stateName == CLOSING)
       alice2blockchain.expectMsg(PublishAsap(tx))
       alice2blockchain.expectMsgType[PublishAsap]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingLockedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingLockedStateSpec.scala
@@ -1,5 +1,7 @@
 package fr.acinq.eclair.channel.states.c
 
+import akka.actor.Status
+import akka.actor.Status.Failure
 import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
@@ -94,10 +96,18 @@ class WaitForFundingLockedStateSpec extends TestkitBaseClass with StateTestsHelp
     }
   }
 
-  test("recv CMD_CLOSE") { case (alice, _, alice2bob, bob2alice, alice2blockchain, router) =>
+  test("recv CMD_CLOSE (mutual)") { case (alice, _, _, _, _, _) =>
+    within(30 seconds) {
+      val sender = TestProbe()
+      sender.send(alice, CMD_CLOSE(None, MUTUAL))
+      sender.expectMsg(Failure(CannotCloseInThisState(channelId(alice), WAIT_FOR_FUNDING_LOCKED, MUTUAL)))
+    }
+  }
+
+  test("recv CMD_CLOSE (force)") { case (alice, _, _, _, alice2blockchain, _) =>
     within(30 seconds) {
       val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_LOCKED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! CMD_CLOSE(None)
+      alice ! CMD_CLOSE(None, FORCE)
       awaitCond(alice.stateName == CLOSING)
       alice2blockchain.expectMsg(PublishAsap(tx))
       alice2blockchain.expectMsgType[PublishAsap]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -1863,11 +1863,9 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     within(30 seconds) {
       val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
       val sender = TestProbe()
-      sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 42, 10))
-      assert(relayer.expectMsgType[LocalChannelUpdate].channelAnnouncement_opt === None)
+      sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
       val annSigsA = alice2bob.expectMsgType[AnnouncementSignatures]
-      sender.send(bob, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 42, 10))
-      assert(relayer.expectMsgType[LocalChannelUpdate].channelAnnouncement_opt === None)
+      sender.send(bob, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
       val annSigsB = bob2alice.expectMsgType[AnnouncementSignatures]
       import initialState.commitments.localParams
       import initialState.commitments.remoteParams

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -404,7 +404,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
       sender.expectMsgType[State] == OFFLINE
     }, max = 20 seconds, interval = 1 second)
     // we then have C unilateral close the channel (which will make F redeem the htlc onchain)
-    sender.send(nodes("C").register, Forward(htlc.channelId, CMD_CLOSE(None, FORCE)))
+    sender.send(nodes("C").register, Forward(htlc.channelId, CMD_FORCECLOSE))
     sender.expectMsg("ok")
     // we then wait for F to detect the unilateral close and go to CLOSING state
     awaitCond({
@@ -474,7 +474,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
       sender.expectMsgType[State] == OFFLINE
     }, max = 20 seconds, interval = 1 second)
     // then we have F unilateral close the channel
-    sender.send(nodes("F2").register, Forward(htlc.channelId, CMD_CLOSE(None, FORCE)))
+    sender.send(nodes("F2").register, Forward(htlc.channelId, CMD_FORCECLOSE))
     sender.expectMsg("ok")
     // we then fulfill the htlc (it won't be sent to C, and will be used to pull funds on-chain)
     sender.send(nodes("F2").register, Forward(htlc.channelId, CMD_FULFILL_HTLC(htlc.id, preimage)))
@@ -581,7 +581,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
     val res = sender.expectMsgType[JValue](10 seconds)
     val previouslyReceivedByC = res.filter(_ \ "address" == JString(finalAddressC)).flatMap(_ \ "txids" \\ classOf[JString])
     // then we ask F to unilaterally close the channel
-    sender.send(nodes("F4").register, Forward(htlc.channelId, CMD_CLOSE(None, FORCE)))
+    sender.send(nodes("F4").register, Forward(htlc.channelId, CMD_FORCECLOSE))
     sender.expectMsg("ok")
     // we then generate enough blocks to make the htlc timeout
     sender.send(bitcoincli, BitcoinReq("generate", 11))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -404,7 +404,8 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
       sender.expectMsgType[State] == OFFLINE
     }, max = 20 seconds, interval = 1 second)
     // we then have C unilateral close the channel (which will make F redeem the htlc onchain)
-    sender.send(nodes("C").register, Forward(htlc.channelId, INPUT_PUBLISH_LOCALCOMMIT))
+    sender.send(nodes("C").register, Forward(htlc.channelId, CMD_CLOSE(None, FORCE)))
+    sender.expectMsg("ok")
     // we then wait for F to detect the unilateral close and go to CLOSING state
     awaitCond({
       sender.send(nodes("F1").register, Forward(htlc.channelId, CMD_GETSTATE))
@@ -473,7 +474,8 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
       sender.expectMsgType[State] == OFFLINE
     }, max = 20 seconds, interval = 1 second)
     // then we have F unilateral close the channel
-    sender.send(nodes("F2").register, Forward(htlc.channelId, INPUT_PUBLISH_LOCALCOMMIT))
+    sender.send(nodes("F2").register, Forward(htlc.channelId, CMD_CLOSE(None, FORCE)))
+    sender.expectMsg("ok")
     // we then fulfill the htlc (it won't be sent to C, and will be used to pull funds on-chain)
     sender.send(nodes("F2").register, Forward(htlc.channelId, CMD_FULFILL_HTLC(htlc.id, preimage)))
     // we then generate one block so that the htlc success tx gets written to the blockchain
@@ -579,7 +581,8 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
     val res = sender.expectMsgType[JValue](10 seconds)
     val previouslyReceivedByC = res.filter(_ \ "address" == JString(finalAddressC)).flatMap(_ \ "txids" \\ classOf[JString])
     // then we ask F to unilaterally close the channel
-    sender.send(nodes("F4").register, Forward(htlc.channelId, INPUT_PUBLISH_LOCALCOMMIT))
+    sender.send(nodes("F4").register, Forward(htlc.channelId, CMD_CLOSE(None, FORCE)))
+    sender.expectMsg("ok")
     // we then generate enough blocks to make the htlc timeout
     sender.send(bitcoincli, BitcoinReq("generate", 11))
     sender.expectMsgType[JValue](10 seconds)

--- a/eclair-node-gui/src/main/resources/gui/main/channelPane.fxml
+++ b/eclair-node-gui/src/main/resources/gui/main/channelPane.fxml
@@ -24,11 +24,14 @@
             <RowConstraints minHeight="10.0" vgrow="SOMETIMES"/>
             <RowConstraints minHeight="10.0" vgrow="SOMETIMES"/>
         </rowConstraints>
+
         <HBox GridPane.columnSpan="4" GridPane.columnIndex="0" alignment="CENTER" spacing="5.0">
             <TextField fx:id="channelId" text="N/A" editable="false" styleClass="noteditable, text-strong"
                        HBox.hgrow="ALWAYS" GridPane.valignment="BOTTOM" focusTraversable="false"/>
-            <Button fx:id="close" GridPane.columnIndex="4" GridPane.halignment="RIGHT" alignment="CENTER_RIGHT"
-                    HBox.hgrow="NEVER" mnemonicParsing="false" styleClass="close-channel" text="Close"/>
+            <HBox GridPane.columnIndex="4" GridPane.halignment="RIGHT" alignment="CENTER_RIGHT" HBox.hgrow="NEVER" spacing="5">
+                <Button fx:id="close" mnemonicParsing="false" styleClass="close-channel" text="Close"/>
+                <Button fx:id="forceclose" mnemonicParsing="false" styleClass="forceclose-channel" text="Force close"/>
+            </HBox>
         </HBox>
 
         <ProgressBar fx:id="balanceBar" minHeight="4.0" prefHeight="4.0" maxWidth="1.7976931348623157E308"

--- a/eclair-node-gui/src/main/resources/gui/main/channelPane.fxml
+++ b/eclair-node-gui/src/main/resources/gui/main/channelPane.fxml
@@ -29,8 +29,8 @@
             <TextField fx:id="channelId" text="N/A" editable="false" styleClass="noteditable, text-strong"
                        HBox.hgrow="ALWAYS" GridPane.valignment="BOTTOM" focusTraversable="false"/>
             <HBox GridPane.columnIndex="4" GridPane.halignment="RIGHT" alignment="CENTER_RIGHT" HBox.hgrow="NEVER" spacing="5">
-                <Button fx:id="close" mnemonicParsing="false" styleClass="close-channel" text="Close"/>
-                <Button fx:id="forceclose" mnemonicParsing="false" styleClass="forceclose-channel" text="Force close"/>
+                <Button fx:id="close" mnemonicParsing="false" styleClass="close-channel" text="Close" visible="false"/>
+                <Button fx:id="forceclose" mnemonicParsing="false" styleClass="forceclose-channel" text="Force close" visible="false"/>
             </HBox>
         </HBox>
 

--- a/eclair-node-gui/src/main/resources/gui/main/main.css
+++ b/eclair-node-gui/src/main/resources/gui/main/main.css
@@ -78,6 +78,10 @@
 	-fx-faint-focus-color: transparent;
 }
 
+.button.forceclose-channel {
+    -fx-base: #f5dcd8;
+}
+
 /* ---------- Table ---------- */
 
 .table-view {

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -5,6 +5,8 @@ import java.util.function.Predicate
 import javafx.application.Platform
 import javafx.event.{ActionEvent, EventHandler}
 import javafx.fxml.FXMLLoader
+import javafx.scene.control.Alert.AlertType
+import javafx.scene.control.{Alert, ButtonType}
 import javafx.scene.layout.VBox
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Terminated}
@@ -16,7 +18,7 @@ import fr.acinq.eclair.blockchain.electrum.ElectrumClient.{ElectrumConnected, El
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.gui.controllers._
 import fr.acinq.eclair.payment.{PaymentReceived, PaymentRelayed, PaymentSent}
-import fr.acinq.eclair.router._
+import fr.acinq.eclair.router.{NORMAL => _, _}
 import fr.acinq.eclair.wire.NodeAnnouncement
 
 import scala.collection.JavaConversions._
@@ -26,6 +28,9 @@ import scala.collection.JavaConversions._
   * Created by PM on 16/08/2016.
   */
 class GUIUpdater(mainController: MainController) extends Actor with ActorLogging {
+
+  val STATE_MUTUAL_CLOSE = Set(WAIT_FOR_INIT_INTERNAL, WAIT_FOR_OPEN_CHANNEL, WAIT_FOR_ACCEPT_CHANNEL, WAIT_FOR_FUNDING_INTERNAL, WAIT_FOR_FUNDING_CREATED, WAIT_FOR_FUNDING_SIGNED, NORMAL)
+  val STATE_FORCE_CLOSE = Set(WAIT_FOR_FUNDING_CONFIRMED, WAIT_FOR_FUNDING_LOCKED, NORMAL, SHUTDOWN, NEGOTIATING, OFFLINE, SYNCING)
 
   /**
     * Needed to stop JavaFX complaining about updates from non GUI thread
@@ -48,7 +53,16 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
     channelPaneController.channelId.setText(temporaryChannelId.toString())
     channelPaneController.funder.setText(if (isFunder) "Yes" else "No")
     channelPaneController.close.setOnAction(new EventHandler[ActionEvent] {
-      override def handle(event: ActionEvent) = channel ! CMD_CLOSE(None)
+      override def handle(event: ActionEvent) = channel ! CMD_CLOSE(scriptPubKey = None)
+    })
+    channelPaneController.forceclose.setOnAction(new EventHandler[ActionEvent] {
+      override def handle(event: ActionEvent) = {
+        val alert = new Alert(AlertType.WARNING, "Careful: force-close is more expensive than a regular close and will incur a delay before funds are spendable.\n\nAre you sure you want to proceed?", ButtonType.YES, ButtonType.NO)
+        alert.showAndWait
+        if (alert.getResult eq ButtonType.YES) {
+          channel ! CMD_FORCECLOSE
+        }
+      }
     })
 
     // set the node alias if the node has already been announced
@@ -93,12 +107,8 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
     case ChannelStateChanged(channel, _, _, _, currentState, _) if m.contains(channel) =>
       val channelPaneController = m(channel)
       runInGuiThread { () =>
-        if (currentState == CLOSING || currentState == CLOSED) {
-          channelPaneController.close.setVisible(false)
-        } else {
-          channelPaneController.close.setVisible(true)
-        }
-        channelPaneController.close.setText(if (OFFLINE == currentState) "Force close" else "Close")
+        channelPaneController.close.setVisible(STATE_MUTUAL_CLOSE.contains(currentState))
+        channelPaneController.forceclose.setVisible(STATE_FORCE_CLOSE.contains(currentState))
         channelPaneController.state.setText(currentState.toString)
       }
 

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/ChannelPaneController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/ChannelPaneController.scala
@@ -25,6 +25,7 @@ class ChannelPaneController(val theirNodeIdValue: String) extends Logging {
   @FXML var funder: TextField = _
   @FXML var state: TextField = _
   @FXML var close: Button = _
+  @FXML var forceclose: Button = _
 
   var contextMenu: ContextMenu = _
 


### PR DESCRIPTION
As soon as we receive a valid closing signature, we will publishing the
resulting closing tx instead of our commitment tx if we need to
immediately close the channel (before end of negotiation, e.g. in case
of errors, or in case the counterparty goes OFFLINE).

When the closing signature didn't correspond to one we sent ourselves, we
weren't properly recognizing the publishing tx and went into
`ERR_INFORMATION_LEAK` state.