### PR TITLE
Future timeouts should not be handled as failures in frontend

### DIFF
--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -35,7 +35,7 @@ call() {
     # set password
     if [ -z ${PASSWORD} ]; then auth="eclair-cli";
     else auth="eclair-cli:"${PASSWORD}; fi
-    eval curl "--max-time 90 --user ${auth} --silent --show-error -X POST -H \"Content-Type: application/json\" -d '{ \"method\": \"'${1}'\", \"params\": '${2}' }' ${URL}" | jq -r "$jqexp"
+    eval curl "--user ${auth} --silent --show-error -X POST -H \"Content-Type: application/json\" -d '{ \"method\": \"'${1}'\", \"params\": '${2}' }' ${URL}" | jq -r "$jqexp"
 }
 
 # get script options

--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -35,7 +35,7 @@ call() {
     # set password
     if [ -z ${PASSWORD} ]; then auth="eclair-cli";
     else auth="eclair-cli:"${PASSWORD}; fi
-    eval curl "--user ${auth} --silent --show-error -X POST -H \"Content-Type: application/json\" -d '{ \"method\": \"'${1}'\", \"params\": '${2}' }' ${URL}" | jq -r "$jqexp"
+    eval curl "--max-time 90 --user ${auth} --silent --show-error -X POST -H \"Content-Type: application/json\" -d '{ \"method\": \"'${1}'\", \"params\": '${2}' }' ${URL}" | jq -r "$jqexp"
 }
 
 # get script options

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/FxApp.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/FxApp.scala
@@ -15,7 +15,7 @@ import fr.acinq.eclair.blockchain.bitcoind.zmq.ZMQActor._
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient.ElectrumEvent
 import fr.acinq.eclair.channel.ChannelEvent
 import fr.acinq.eclair.gui.controllers.{MainController, NotificationsController}
-import fr.acinq.eclair.payment.PaymentEvent
+import fr.acinq.eclair.payment.{PaymentEvent, PaymentResult}
 import fr.acinq.eclair.router.NetworkEvent
 import grizzled.slf4j.Logging
 
@@ -80,6 +80,7 @@ class FxApp extends Application with Logging {
           setup.system.eventStream.subscribe(guiUpdater, classOf[ChannelEvent])
           setup.system.eventStream.subscribe(guiUpdater, classOf[NetworkEvent])
           setup.system.eventStream.subscribe(guiUpdater, classOf[PaymentEvent])
+          setup.system.eventStream.subscribe(guiUpdater, classOf[PaymentResult])
           setup.system.eventStream.subscribe(guiUpdater, classOf[ZMQEvent])
           setup.system.eventStream.subscribe(guiUpdater, classOf[ElectrumEvent])
           pKit.completeWith(setup.bootstrap)

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
@@ -20,7 +20,7 @@ import scala.util.{Failure, Success}
   */
 class Handlers(fKit: Future[Kit])(implicit ec: ExecutionContext = ExecutionContext.Implicits.global) extends Logging {
 
-  implicit val timeout = Timeout(60 seconds) // futures will timeout after 2 minutes
+  implicit val timeout = Timeout(60 seconds)
 
   private var notifsController: Option[NotificationsController] = None
 

--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -1,4 +1,13 @@
 akka {
+
+  http {
+    server {
+      # Defines the default time period within which the API has to
+      # produce an HttpResponse for any given HttpRequest it received.
+      request-timeout = 120 s
+    }
+  }
+
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   loglevel = "INFO"
 

--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -1,13 +1,5 @@
 akka {
 
-  http {
-    server {
-      # Defines the default time period within which the API has to
-      # produce an HttpResponse for any given HttpRequest it received.
-      request-timeout = 120 s
-    }
-  }
-
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   loglevel = "INFO"
 

--- a/eclair-node/src/main/resources/logback_colors.xml
+++ b/eclair-node/src/main/resources/logback_colors.xml
@@ -81,7 +81,7 @@
         <appender-ref ref="CYAN"/>
     </logger>
 
-    <logger name="fr.acinq.eclair.gui" level="WARN" additivity="false">
+    <logger name="fr.acinq.eclair.gui" level="INFO" additivity="false">
         <appender-ref ref="MAGENTA"/>
     </logger>
 


### PR DESCRIPTION
Both the GUI and the API should handle AskTimeoutException failures as specific cases: GUI should ignore them, API should print a pretty response.

Increased ask timeout to 60s ; increased akka http server timeout to 120s. This fixes #414 where eclair-cli would fail to parse the server timeout response.