### PR TITLE
Initial version of audit logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ java -Declair.datadir=/tmp/node1 -jar eclair-node-gui-<version>-<commit_id>.jar
   send         | amountMsat, paymentHash, nodeId                                                        | send a payment to a lightning node
   send         | paymentRequest                                                                         | send a payment to a lightning node using a BOLT11 payment request
   send         | paymentRequest, amountMsat                                                             | send a payment to a lightning node using a BOLT11 payment request and a custom amount
+  sendasync    | as per send above                                                                      | send a payment to a lightning node. Same parameters as send but returns an ID instantly. 
+  checksentpayment| sendpaymentid                                                                       | returns if id is valid and a result if there is one. If no result payment is still pending.
   checkpayment | paymentHash                                                                            | returns true if the payment has been received, false otherwise
   checkpayment | paymentRequest                                                                         | returns true if the payment has been received, false otherwise
   close        | channelId                                                                              | close a channel

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -78,4 +78,5 @@ eclair {
   max-pending-payment-requests = 10000000
   max-payment-fee = 0.03 // max total fee for outgoing payments, in percentage: sending a payment will not be attempted if the cheapest route found is more expensive than that
   min-funding-satoshis = 100000
+  audit-enabled = true // determins if we log to sql database every payment to/from/relayed through a channel.
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/DBCompatChecker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/DBCompatChecker.scala
@@ -43,4 +43,14 @@ object DBCompatChecker extends Logging {
       case Success(_) => {}
       case Failure(_) => throw IncompatibleNetworkDBException
     }
+    /**
+    * Tests if the audit database is readable.
+    *
+    * @param nodeParams
+    */
+  def checkAuditDBCompatibility(nodeParams: NodeParams): Unit =
+    Try(nodeParams.auditDb.channelBalances("42")) match {
+      case Success(_) => {}
+      case Failure(_) => throw IncompatibleAuditDBException
+    }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -21,7 +21,8 @@ import java.net.InetSocketAddress
 import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.Crypto.{Point, PrivateKey, PublicKey, Scalar}
 import fr.acinq.bitcoin.{BinaryData, OutPoint, Transaction}
-import fr.acinq.eclair.channel.State
+import fr.acinq.eclair.channel._
+
 import fr.acinq.eclair.crypto.ShaChain
 import fr.acinq.eclair.router.RouteResponse
 import fr.acinq.eclair.transactions.Direction
@@ -35,6 +36,12 @@ import org.json4s.{CustomKeySerializer, CustomSerializer}
   * JSON Serializers.
   * Note: in general, deserialization does not need to be implemented.
   */
+
+class State2Serializer extends CustomKeySerializer[State](format => ({ null }, {
+  case x: State => x.toString()
+}))
+
+
 class BinaryDataSerializer extends CustomSerializer[BinaryData](format => ({ null }, {
   case x: BinaryData => JString(x.toString())
 }))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/EclairWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/EclairWallet.scala
@@ -54,4 +54,4 @@ trait EclairWallet {
 
 }
 
-final case class MakeFundingTxResponse(fundingTx: Transaction, fundingTxOutputIndex: Int)
+final case class MakeFundingTxResponse(fundingTx: Transaction, fundingTxOutputIndex: Int, fundingFee: Long)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumEclairWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumEclairWallet.scala
@@ -38,7 +38,7 @@ class ElectrumEclairWallet(val wallet: ActorRef, chainHash: BinaryData)(implicit
   override def makeFundingTx(pubkeyScript: BinaryData, amount: Satoshi, feeRatePerKw: Long) = {
     val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(amount, pubkeyScript) :: Nil, lockTime = 0)
     (wallet ? CompleteTransaction(tx, feeRatePerKw)).mapTo[CompleteTransactionResponse].map(response => response match {
-      case CompleteTransactionResponse(tx1, None) => MakeFundingTxResponse(tx1, 0)
+      case CompleteTransactionResponse(tx1, None) => MakeFundingTxResponse(tx1, 0,0) //TODO add return of funding TX fee
       case CompleteTransactionResponse(_, Some(error)) => throw error
     })
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -32,7 +32,7 @@ case class ChannelCreated(channel: ActorRef, peer: ActorRef, remoteNodeId: Publi
 
 case class ChannelRestored(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, isFunder: Boolean, channelId: BinaryData, currentData: HasCommitments) extends ChannelEvent
 
-case class ChannelIdAssigned(channel: ActorRef, remoteNodeId: PublicKey, temporaryChannelId: BinaryData, channelId: BinaryData) extends ChannelEvent
+case class ChannelIdAssigned(channel: ActorRef, remoteNodeId: PublicKey, temporaryChannelId: BinaryData, channelId: BinaryData, fundingFee: Long) extends ChannelEvent
 
 case class ShortChannelIdAssigned(channel: ActorRef, channelId: BinaryData, shortChannelId: ShortChannelId) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -143,7 +143,7 @@ case class ClosingTxProposed(unsignedTx: Transaction, localClosingSigned: Closin
 
 case class LocalCommitPublished(commitTx: Transaction, claimMainDelayedOutputTx: Option[Transaction], htlcSuccessTxs: List[Transaction], htlcTimeoutTxs: List[Transaction], claimHtlcDelayedTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
 case class RemoteCommitPublished(commitTx: Transaction, claimMainOutputTx: Option[Transaction], claimHtlcSuccessTxs: List[Transaction], claimHtlcTimeoutTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
-case class RevokedCommitPublished(commitTx: Transaction, claimMainOutputTx: Option[Transaction], mainPenaltyTx: Option[Transaction], htlcPenaltyTxs: List[Transaction], claimHtlcDelayedPenaltyTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
+case class RevokedCommitPublished(commitTx: Transaction, claimMainOutputTx: Option[Transaction], mainPenaltyTx: Option[Transaction], htlcPenaltyTxs: List[Transaction], claimHtlcDelayedPenaltyTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData], remoteSuccessTimeoutHtlcTxs: List[Transaction])
 
 final case class DATA_WAIT_FOR_OPEN_CHANNEL(initFundee: INPUT_INIT_FUNDEE) extends Data
 final case class DATA_WAIT_FOR_ACCEPT_CHANNEL(initFunder: INPUT_INIT_FUNDER, lastSent: OpenChannel) extends Data

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -550,17 +550,17 @@ object Commitments {
        |  toLocal: ${commitments.localCommit.spec.toLocalMsat}
        |  toRemote: ${commitments.localCommit.spec.toRemoteMsat}
        |  htlcs:
-       |${commitments.localCommit.spec.htlcs.map(h => s"    ${h.direction} ${h.add.id} ${h.add.expiry}").mkString("\n")}
+       |${commitments.localCommit.spec.htlcs.map(h => s"   ${h.add.amountMsat} ${h.direction} ${h.add.id} ${h.add.expiry}").mkString("\n")}
        |remotecommit:
        |  toLocal: ${commitments.remoteCommit.spec.toLocalMsat}
        |  toRemote: ${commitments.remoteCommit.spec.toRemoteMsat}
        |  htlcs:
-       |${commitments.remoteCommit.spec.htlcs.map(h => s"    ${h.direction} ${h.add.id} ${h.add.expiry}").mkString("\n")}
+       |${commitments.remoteCommit.spec.htlcs.map(h => s"   ${h.add.amountMsat} ${h.direction} ${h.add.id} ${h.add.expiry}").mkString("\n")}
        |next remotecommit:
        |  toLocal: ${commitments.remoteNextCommitInfo.left.toOption.map(_.nextRemoteCommit.spec.toLocalMsat).getOrElse("N/A")}
        |  toRemote: ${commitments.remoteNextCommitInfo.left.toOption.map(_.nextRemoteCommit.spec.toRemoteMsat).getOrElse("N/A")}
        |  htlcs:
-       |${commitments.remoteNextCommitInfo.left.toOption.map(_.nextRemoteCommit.spec.htlcs.map(h => s"    ${h.direction} ${h.add.id} ${h.add.expiry}").mkString("\n")).getOrElse("N/A")}""".stripMargin
+       |${commitments.remoteNextCommitInfo.left.toOption.map(_.nextRemoteCommit.spec.htlcs.map(h => s"   ${h.add.amountMsat} ${h.direction} ${h.add.id} ${h.add.expiry}").mkString("\n")).getOrElse("N/A")}""".stripMargin
   }
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -45,7 +45,7 @@ class Register extends Actor with ActorLogging {
       context.watch(channel)
       context become main(channels + (channelId -> channel), shortIds, channelsTo + (channelId -> remoteNodeId))
 
-    case ChannelIdAssigned(channel, remoteNodeId, temporaryChannelId, channelId) =>
+    case ChannelIdAssigned(channel, remoteNodeId, temporaryChannelId, channelId,_) =>
       context become main(channels + (channelId -> channel) - temporaryChannelId, shortIds, channelsTo + (channelId -> remoteNodeId) - temporaryChannelId)
 
     case ShortChannelIdAssigned(_, channelId, shortChannelId) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -1,0 +1,45 @@
+package fr.acinq.eclair.db
+
+import fr.acinq.bitcoin.{BinaryData, MilliSatoshi}
+import fr.acinq.eclair.payment.DAILY_STATS
+/**
+  * Store audit of funds that pass through this node. Should enable debugging of any fund loss related issues.
+  * 
+  */
+trait AuditDb {
+  def addAuditEntry(a: AuditEntry)
+  def channelBalances(channelId: BinaryData): ChannelBalances
+  def checkChannelClosed(channelId: BinaryData, txid: BinaryData): Boolean
+  def checkRelayAdded(channelId: BinaryData, htlcId: Long, paymentHash: BinaryData): Boolean
+  def errorHtlc(channelId: BinaryData, htlcId: Long): Unit
+  def checkExists(channelId: BinaryData ,paymentTxHash: BinaryData): Boolean
+  def checkExists(a: AuditEntry): Boolean
+  def checkSentAdded(channelId: BinaryData, htlcId: Long, paymentHash: BinaryData): Boolean
+  def dailyData(): Seq[DAILY_STATS]
+  def updateRounding(channelId:BinaryData)
+}
+trait AuditEntryType
+
+case class AuditEntry(channel: BinaryData, otherChannel: BinaryData=BinaryData.empty, localHtlcId: Long = -1L, remoteHtlcId: Long = -1L, amountMsat: MilliSatoshi =MilliSatoshi(0), htlcMsat: MilliSatoshi =MilliSatoshi(0),
+    profitInMsat: MilliSatoshi =MilliSatoshi(0), profitOutMsat: MilliSatoshi=MilliSatoshi(0), feeMsat: MilliSatoshi=MilliSatoshi(0), entryType: AuditEntryType, 
+    paymentTxHash: BinaryData=BinaryData.empty, btcAmount: Long = 0L, btcFee: Long =0L, delayed: Long = 0L,  penalty: Long = 0L, roundingMsat: Long=0)
+
+//select quote(channelid),max(localhtlcid),max(remotehtlcid),sum(amountmsat),sum(profitmsat),sum(feemsat) from audit group by channelid;
+
+case class ChannelBalances(maxLocalHTLCId: Long= -1, maxRemoteHTLCId: Long= -1, amount:MilliSatoshi=MilliSatoshi(0), htlcAmount:MilliSatoshi=MilliSatoshi(0),
+    profitIn: MilliSatoshi=MilliSatoshi(0), profitOut: MilliSatoshi=MilliSatoshi(0), fees: MilliSatoshi=MilliSatoshi(0), 
+    btcAmount: Long=0, btcFee: Long=0, penalty: Long=0, delayed: Long=0, sentMsat:MilliSatoshi=MilliSatoshi(0), receivedMsat:MilliSatoshi = MilliSatoshi(0),
+    rounding:MilliSatoshi=MilliSatoshi(0),relaySentMsat:MilliSatoshi=MilliSatoshi(0), relayReceivedMsat:MilliSatoshi = MilliSatoshi(0)){
+  override def toString={
+    "(maxLocalHTLCId:" + maxLocalHTLCId + ", maxRemoteHTLCId:"+maxRemoteHTLCId+", amountMsat:"+amount.amount+", htlcAmountMsat:"+htlcAmount.amount+", profitInMsat:"+profitIn.amount+", profitOutMsat:"+profitOut.amount + 
+    ", feesMsat:" + fees.amount + ", btcAmount:"+btcAmount+", btcFee:"+btcFee+", penalty:"+penalty+", delayed:"+delayed+", sentMsat:"+sentMsat+", receivedMsat:"+receivedMsat+", roundingMsat:"+rounding+
+    ", relaySentMsat:"+relaySentMsat+", relayReceivedMsat:"+relayReceivedMsat+")"
+  }
+    import Math.max
+  def +(that: ChannelBalances)=
+    new ChannelBalances(max(this.maxLocalHTLCId,that.maxLocalHTLCId),max(this.maxRemoteHTLCId,that.maxRemoteHTLCId),this.amount + that.amount, this.htlcAmount+that.htlcAmount,this.profitIn+that.profitIn
+        ,this.profitOut+that.profitOut,this.fees+that.fees, this.btcAmount+that.btcAmount, this.btcFee+that.btcFee, this.penalty+that.penalty, this.delayed+that.delayed, this.sentMsat+that.sentMsat
+        ,this.receivedMsat+that.receivedMsat, this.rounding+that.rounding,this.relaySentMsat+that.relaySentMsat,this.relayReceivedMsat+that.relayReceivedMsat)
+  
+}
+

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -25,7 +25,9 @@ trait ChannelsDb {
 
   def removeChannel(channelId: BinaryData)
 
-  def listChannels(): Seq[HasCommitments]
+  def getChannel(channelId: BinaryData, deleted: Boolean=false): Option[HasCommitments]
+
+  def listChannels(includeDeleted: Boolean =false): Seq[HasCommitments]
 
   def addOrUpdateHtlcInfo(channelId: BinaryData, commitmentNumber: Long, paymentHash: BinaryData, cltvExpiry: Long)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -1,0 +1,235 @@
+package fr.acinq.eclair.db.sqlite
+
+import java.sql.Connection
+
+import fr.acinq.bitcoin.{BinaryData, MilliSatoshi}
+import fr.acinq.eclair.db.sqlite.SqliteUtils.{using,getVersion}
+import fr.acinq.eclair.db._
+import grizzled.slf4j.Logging
+import scala.compat.Platform
+import fr.acinq.eclair.db.ChannelBalances
+import fr.acinq.eclair.payment._
+
+import scala.collection.immutable.Queue
+
+/**
+  * Audit entries are stored in the audit table.
+  */
+class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
+  val DB_NAME = "audit"
+  val CURRENT_VERSION = 1
+
+  using(sqlite.createStatement()) { statement =>
+    require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
+    statement.executeUpdate("""
+      CREATE TABLE IF NOT EXISTS audit (timemsec INTEGER NOT NULL,channelid BLOB NOT NULL,otherchannelid BLOB NOT NULL,
+        localhtlcid INTEGER NOT NULL, remotehtlcid INTEGER NOT NULL, amountmsat INTEGER NOT NULL, htlcmsat INTEGER NOT NULL, profitinmsat INTEGER NOT NULL, profitoutmsat INTEGER NOT NULL,
+        feemsat INTEGER NOT NULL,entrytype TEXT NOT NULL, paymenttx_hash BLOB NOT NULL, btcamount INTEGER NOT NULL, btcfee INTEGER NOT NULL, delayed INTEGER NOT NULL, 
+        penalty INTEGER NOT NULL, roundingmsat INTEGER NOT NULL)
+      """)
+    statement.executeUpdate("CREATE INDEX IF NOT EXISTS audit_channel_idx ON audit(channelid)")
+    statement.executeUpdate("CREATE INDEX IF NOT EXISTS audit_channel_close_idx ON audit(channelid,paymenttx_hash)")
+  }
+
+//select timemsec ,quote(channelid),quote(otherchannelid),localhtlcid,remotehtlcid,amountmsat,profitmsat,feemsat,entrytype,quote(targetnodeid),quote(paymenttx_hash) from audit;
+  override def checkExists(a: AuditEntry): Boolean = {
+    if(a.entryType==CLOSE_REVOKED_COMMIT) {
+      //ignore amount and penalty for these entries as varies due to booking the local into penalty
+      using(sqlite.prepareStatement("SELECT * FROM audit WHERE channelid=? AND otherchannelid=? AND localhtlcid=? AND remotehtlcid=?  AND htlcmsat=? AND " + 
+          " profitinmsat=? AND Profitoutmsat=? AND feemsat=? AND entrytype=? AND paymenttx_hash=? AND btcamount=? AND btcfee=? AND delayed=? ")) { statement =>
+        statement.setBytes(1, a.channel)
+        statement.setBytes(2, a.otherChannel)
+        statement.setLong(3,a.localHtlcId)
+        statement.setLong(4,a.remoteHtlcId)
+        statement.setLong(5,a.htlcMsat.amount)
+        statement.setLong(6,a.profitInMsat.amount)
+        statement.setLong(7,a.profitOutMsat.amount)
+        statement.setLong(8,a.feeMsat.amount)
+        statement.setString(9,a.entryType.toString())
+        statement.setBytes(10, a.paymentTxHash)
+        statement.setLong(11, a.btcAmount)
+        statement.setLong(12, a.btcFee)
+        statement.setLong(13, a.delayed)
+        val rs=statement.executeQuery();
+        rs.next() // if we find a row then already logged this tx
+        // This is needed as in some closing cases we double trigger the message due to watcher being registered twice.
+        
+      }
+    } else {
+      
+      using(sqlite.prepareStatement("SELECT * FROM audit WHERE channelid=? AND otherchannelid=? AND localhtlcid=? AND remotehtlcid=? AND amountmsat=? AND htlcmsat=? AND " + 
+          " profitinmsat=? AND Profitoutmsat=? AND feemsat=? AND entrytype=? AND paymenttx_hash=? AND btcamount=? AND btcfee=? AND delayed=? AND penalty=? AND roundingmsat=?")) { statement =>
+        statement.setBytes(1, a.channel)
+        statement.setBytes(2, a.otherChannel)
+        statement.setLong(3,a.localHtlcId)
+        statement.setLong(4,a.remoteHtlcId)
+        statement.setLong(5,a.amountMsat.amount)
+        statement.setLong(6,a.htlcMsat.amount)
+        statement.setLong(7,a.profitInMsat.amount)
+        statement.setLong(8,a.profitOutMsat.amount)
+        statement.setLong(9,a.feeMsat.amount)
+        statement.setString(10,a.entryType.toString())
+        statement.setBytes(11, a.paymentTxHash)
+        statement.setLong(12, a.btcAmount)
+        statement.setLong(13, a.btcFee)
+        statement.setLong(14, a.delayed)
+        statement.setLong(15, a.penalty)
+        statement.setLong(16, a.roundingMsat)
+        val rs=statement.executeQuery();
+        rs.next() // if we find a row then already logged this tx
+        // This is needed as in some closing cases we double trigger the message due to watcher being registered twice.
+        
+      }
+    }
+  }
+  override def addAuditEntry(a: AuditEntry): Unit = {
+    using(sqlite.prepareStatement("INSERT INTO audit VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) { statement =>
+      statement.setLong(1,Platform.currentTime)
+      statement.setBytes(2, a.channel)
+      statement.setBytes(3, a.otherChannel)
+      statement.setLong(4,a.localHtlcId)
+      statement.setLong(5,a.remoteHtlcId)
+      statement.setLong(6,a.amountMsat.amount)
+      statement.setLong(7,a.htlcMsat.amount)
+      statement.setLong(8,a.profitInMsat.amount)
+      statement.setLong(9,a.profitOutMsat.amount)
+      statement.setLong(10,a.feeMsat.amount)
+      statement.setString(11,a.entryType.toString())
+      statement.setBytes(12, a.paymentTxHash)
+      statement.setLong(13, a.btcAmount)
+      statement.setLong(14, a.btcFee)
+      statement.setLong(15, a.delayed)
+      statement.setLong(16, a.penalty)
+      statement.setLong(17, a.roundingMsat)
+      val res = statement.executeUpdate()
+      logger.debug(s"inserted $res audit entry=${a} in DB")
+    }
+  }
+//select quote(channelid),max(htlcid),sum(amountmsat),sum(profitmsat),sum(feemsat) from audit group by channelid;
+
+  override def checkChannelClosed(channelId: BinaryData, txid: BinaryData): Boolean = {
+    using(sqlite.prepareStatement("SELECT * FROM audit WHERE channelid=? and paymenttx_hash=?")) { statement =>
+      statement.setBytes(1,channelId)
+      statement.setBytes(2,txid)
+      val rs=statement.executeQuery();
+
+      rs.next() // if we find a row then already closed with this TX
+    }
+  }
+
+
+  override def checkRelayAdded(channelId: BinaryData, htlcId: Long, paymentHash: BinaryData): Boolean = {
+    using(sqlite.prepareStatement("SELECT * FROM audit WHERE channelid=? and remotehtlcid=? and paymenttx_hash=?")) { statement =>
+      statement.setBytes(1,channelId)
+      statement.setLong(2,htlcId)
+      statement.setBytes(3,paymentHash)
+      val rs=statement.executeQuery();
+      rs.next() // if we find a row then already logged this tx
+      // This is needed as in some closing cases we double trigger the message due to watcher being registered twice.
+    }
+  }
+  
+  override def checkSentAdded(channelId: BinaryData, htlcId: Long, paymentHash: BinaryData): Boolean = {
+    using(sqlite.prepareStatement("SELECT * FROM audit WHERE channelid=? and localhtlcid=? and paymenttx_hash=? and entryType='"+LN_ADD_HTLC+"'")) { statement =>
+      statement.setBytes(1,channelId)
+      statement.setLong(2,htlcId)
+      statement.setBytes(3,paymentHash)
+      val rs=statement.executeQuery();
+      rs.next() // if we find a row then already logged this tx
+      // This is needed as in some closing cases we double trigger the message due to watcher being registered twice.
+    }
+  }
+
+  override def checkExists(channelId: BinaryData ,paymentTxHash: BinaryData): Boolean = {
+    using(sqlite.prepareStatement("SELECT * FROM audit WHERE channelid=? and paymenttx_hash=?")) { statement =>
+      statement.setBytes(1,channelId)
+      statement.setBytes(2,paymentTxHash)
+      val rs=statement.executeQuery();
+      rs.next() // if we find a row then already logged this tx
+      // This is needed as in some closing cases we double trigger the message due to watcher being registered twice.
+    }
+  }
+  
+  val checkSQL="SELECT * FROM audit WHERE channelid=? and localhtlcid=? and " + 
+    "( entrytype='"+LN_ERROR_HTLC+"' or entrytype='"+LN_PAYMENT+"' or entrytype='"+LN_RELAY+"')"
+  def checkExists(channelId: BinaryData , htlcId: Long): Boolean = {
+    using(sqlite.prepareStatement(checkSQL)) { statement =>
+      statement.setBytes(1,channelId)
+      statement.setLong(2,htlcId)
+      val rs=statement.executeQuery();
+      rs.next() // if we find a row then already logged this update
+    }
+  }
+  
+  val errorSQL="SELECT otherchannelid,amountmsat,htlcmsat,paymenttx_hash FROM audit WHERE channelid=? and localhtlcid=? and entrytype='"+LN_ADD_HTLC+"'"
+  override def errorHtlc(channelId: BinaryData, htlcId: Long): Unit = {
+    // check if same channel/channel/hash/htlcidl/htclidr has already been paid/errored 1st.
+    if(!checkExists(channelId,htlcId)) {
+    
+      using(sqlite.prepareStatement(errorSQL)) { statement =>
+        statement.setBytes(1,channelId)
+        statement.setLong(2,htlcId)
+        val rs=statement.executeQuery()
+        if (rs.next()){
+          val a=AuditEntry(channelId,rs.getBytes(1),htlcId,-1L,MilliSatoshi(-rs.getLong(2)),MilliSatoshi(-rs.getLong(3)),MilliSatoshi(0),
+              MilliSatoshi(0),MilliSatoshi(0),LN_ERROR_HTLC,rs.getBytes(4),0,0)
+          addAuditEntry(a)
+        }
+      }
+    }
+  }
+ // val balanceSql="SELECT max(localhtlcid),max(remotehtlcid),sum(amountmsat),sum(htlcmsat),sum(profitinmsat),sum(profitoutmsat),sum(feemsat),sum(btcamount),sum(btcfee), " + 
+ //      "sum(penalty), sum(delayed), sum(CASE WHEN entrytype in ('"+LN_PAYMENT+"','"+LN_RELAY+"') THEN htlcmsat ELSE 0 END), sum(CASE WHEN entrytype in ('"+LN_RECEIPT+"','"+LN_RELAY+"') THEN amountmsat ELSE 0 END) " + 
+ //       " , sum(roundingmsat) FROM audit WHERE channelid=? group by channelid"
+  
+  val balanceSql="SELECT max(localhtlcid),max(remotehtlcid),sum(amountmsat),sum(htlcmsat),sum(profitinmsat),sum(profitoutmsat),sum(feemsat),sum(btcamount),sum(btcfee), " + 
+        "sum(penalty), sum(delayed), sum(CASE WHEN entrytype in ('"+LN_PAYMENT+"','"+LN_RELAY+"') THEN htlcmsat ELSE 0 END), sum(CASE WHEN entrytype in ('"+LN_RECEIPT+"','"+LN_RELAY+"') THEN amountmsat ELSE 0 END) " + 
+        " , sum(roundingmsat), sum(CASE WHEN entrytype ='"+LN_RELAY+"' THEN htlcmsat ELSE 0 END), sum(CASE WHEN entrytype ='"+LN_RELAY+"' THEN amountmsat ELSE 0 END) " +
+        " FROM audit WHERE channelid=? group by channelid"
+        
+  override def channelBalances(channelId: BinaryData): ChannelBalances = {
+    using(sqlite.prepareStatement(balanceSql)) { statement =>
+      statement.setBytes(1,channelId)
+      val rs=statement.executeQuery();
+
+      if (!rs.next() ) ChannelBalances(0,0,MilliSatoshi(0),MilliSatoshi(0),MilliSatoshi(0),MilliSatoshi(0),MilliSatoshi(0),0,0,0,0,MilliSatoshi(0),MilliSatoshi(0)) else 
+        ChannelBalances(rs.getLong(1),rs.getLong(2),MilliSatoshi(rs.getLong(3)),MilliSatoshi(rs.getLong(4)),MilliSatoshi(rs.getLong(5)),
+            MilliSatoshi(rs.getLong(6)),MilliSatoshi(rs.getLong(7)), rs.getLong(8), rs.getLong(9),rs.getLong(10),rs.getLong(11),
+            MilliSatoshi(rs.getLong(12)), MilliSatoshi(rs.getLong(13)), MilliSatoshi(rs.getLong(14)), MilliSatoshi(rs.getLong(15)), MilliSatoshi(rs.getLong(16)) )
+    }
+  }
+  def updateRounding(channelId:BinaryData) {
+    val bal=channelBalances(channelId)
+
+    val a=AuditEntry(channel=channelId,entryType=ROUNDING_CLOSE, htlcMsat = -bal.htlcAmount,roundingMsat= -bal.htlcAmount.amount)
+    addAuditEntry(a)
+
+    // this is for trimmed outputs where receive a payment but is trimmed and they publish the previous commit where it was in fees rather than in toLocal
+    val a2=AuditEntry(channel=channelId,entryType=ROUNDING_CLOSE, amountMsat = -bal.amount,roundingMsat= -bal.amount.amount)
+    addAuditEntry(a2)
+    
+  }
+
+  val getDailyDataSql="""select timemsec/86400000,
+sum(case when entrytype='LN_PAYMENT' then 1 else 0 end) as sent,
+sum(case when entrytype='LN_RECEIPT' then 1 else 0 end) as receive,
+sum(case when entrytype='LN_RELAY' then 1 else 0 end)/2 as relay,
+sum(case when entrytype='OPEN_FUNDING_LOCKED' then 1 else 0 end) as channelopen,
+sum(case when entrytype='MUTUAL_CLOSE' or entrytype='COMMIT_CLOSE' or entrytype='CLOSE_REVOKED_COMMIT' then 1 else 0 end) as channelclose,
+sum(feemsat) as lnfeemsat,
+sum(profitinmsat+profitoutmsat) as lnprofitmsat,
+sum(btcfee) as btcfee
+from audit
+group by timemsec/86400000 order by timemsec/86400000"""
+
+  override def dailyData(): Seq[DAILY_STATS] = {
+    using(sqlite.prepareStatement(getDailyDataSql)) { statement =>
+      val rs=statement.executeQuery();
+      var s: Seq[DAILY_STATS] = Seq()
+      while (rs.next()) {
+        s = s :+ DAILY_STATS(rs.getLong(1),rs.getLong(2),rs.getLong(3),rs.getLong(4),rs.getLong(5),rs.getLong(6),rs.getLong(7),rs.getLong(8),rs.getLong(9))
+      }
+      s
+    }
+  }
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -208,7 +208,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
       }
       stay
 
-    case Event(ChannelIdAssigned(channel, _, temporaryChannelId, channelId), d@ConnectedData(_, _, _, channels)) if channels.contains(TemporaryChannelId(temporaryChannelId)) =>
+    case Event(ChannelIdAssigned(channel, _, temporaryChannelId, channelId,_), d@ConnectedData(_, _, _, channels)) if channels.contains(TemporaryChannelId(temporaryChannelId)) =>
       log.info(s"channel id switch: previousId=$temporaryChannelId nextId=$channelId")
       // NB: we keep the temporary channel id because the switch is not always acknowledged at this point (see https://github.com/lightningnetwork/lightning-rfc/pull/151)
       // we won't clean it up, but we won't remember the temporary id on channel termination

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/AuditBalances.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/AuditBalances.scala
@@ -1,0 +1,205 @@
+package fr.acinq.eclair.payment
+
+import akka.actor.{Actor, ActorLogging, ActorRef,Props}
+import akka.pattern.ask
+import akka.pattern.pipe
+import akka.util.Timeout
+import fr.acinq.bitcoin.{BinaryData,MilliSatoshi, Satoshi}
+import fr.acinq.eclair.db._
+import fr.acinq.eclair.db.ChannelsDb
+import fr.acinq.eclair.channel._
+import fr.acinq.eclair.NodeParams
+import fr.acinq.eclair.ShortChannelId
+import fr.acinq.eclair.transactions.{IN,OUT}
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.util.{Failure,Success}
+
+
+class AuditRequest(auditLogger: ActorRef, register: ActorRef, channelsDb: ChannelsDb) extends Actor with ActorLogging {
+
+  var channelCount: Int=0
+  var returnMessage: Seq[RECONCILE]=Seq.empty
+  var infoReturn: GET_INFO = GET_INFO()
+  var caller: ActorRef=self
+
+  override def receive: Receive = {
+    case CHANNEL_RECONCILE_ERRORS =>
+      caller=sender() //message forwarded so will be the serviceapi
+      // get all channels
+      val channels=channelsDb.listChannels(true)
+      channelCount=channels.size
+      channels.foreach{c=>
+        context.parent ! CHANNEL_RECONCILE(c.channelId)
+      }
+    case m: RECONCILE =>
+      log.info("RecReceived")
+      channelCount-=1
+      if(!m.all && m.state!=CLOSED) returnMessage = returnMessage :+ m
+
+      if(channelCount==0) {
+        caller ! returnMessage
+        context.stop(self)
+      }
+
+    case CHANNEL_GET_INFO =>
+      caller=sender() //message forwarded so will be the serviceapi
+      // get all channels
+      val channels=channelsDb.listChannels(true) 
+      channelCount=channels.size
+      channels.foreach{c=>
+        context.parent ! CHANNEL_BALANCE(c.channelId)
+      }
+
+    case a: AuditReturn =>
+      channelCount-=1
+      
+      infoReturn=new GET_INFO(channelBalances=infoReturn.channelBalances+a.channelBalances,
+          notNormalChannelBalances=if(a.state==NORMAL) infoReturn.notNormalChannelBalances else infoReturn.notNormalChannelBalances+a.channelBalances,
+          infoReturn.channelCount + (a.state -> (infoReturn.channelCount(a.state)+1)),
+          infoReturn.localCommitiment+a.localCommitiment
+          )
+
+      if(channelCount==0) {
+        caller ! infoReturn
+        context.stop(self)
+      }
+  }
+}
+object AuditRequest {
+  def props(auditLogger: ActorRef, register: ActorRef, channelsDb: ChannelsDb) = Props(classOf[AuditRequest], auditLogger, register,channelsDb)
+}
+
+class AuditBalances(auditLogger: ActorRef, register: ActorRef, channelsDb: ChannelsDb) extends Actor with ActorLogging {
+  implicit def ec: ExecutionContext = ExecutionContext.Implicits.global
+  implicit val timeout = Timeout(60 seconds)
+  var requestCount: Int=0
+  override def receive: Receive = {
+    case CHANNEL_BALANCE(channelId) =>
+      val result=getBalances(channelId: BinaryData)
+      result pipeTo sender()
+
+    case CHANNEL_RECONCILE(channelId) =>
+      val result=getBalances(channelId: BinaryData)
+      val returnMessage = result.map {
+        case a:AuditReturn =>
+          val local=a.channelBalances.amount.amount==a.localCommitiment.toLocalmSat
+          val htlc=a.channelBalances.htlcAmount.amount==a.localCommitiment.inflightOutHtlc
+          import a.channelBalances._
+          val dbRec=amount.amount + htlcAmount.amount - sentMsat.amount - receivedMsat.amount - rounding.amount + penalty*1000 == -(btcAmount-btcFee)*1000L
+          
+          val dbToCommitRec=if(a.state!=CLOSED){
+            amount.amount==a.localCommitiment.toLocalmSat &&
+              htlcAmount.amount==a.localCommitiment.inflightOutHtlc &&
+              maxLocalHTLCId < a.localCommitiment.nextHtlcId // Can't check equal as could be failed ones that we did not audit 
+          } else {
+            delayed==0 && amount.amount==0 && htlcAmount.amount==0
+          }
+          RECONCILE(channelId,a.state.toString(), dbRec && dbToCommitRec, dbRec, dbToCommitRec)
+        case _ =>
+          RECONCILE(channelId,"Unknown", false,false,false)
+      } recoverWith {case _ => Future(RECONCILE(channelId,"Unknown2", false,false,false)) }
+      returnMessage pipeTo sender()
+
+    case m@CHANNEL_RECONCILE_ERRORS =>
+      val request = context.actorOf(AuditRequest.props(auditLogger, register, channelsDb),"AuditRequest-"+requestCount.toString())
+      requestCount+=1
+      request forward m
+
+    case m@CHANNEL_GET_INFO =>
+      val request = context.actorOf(AuditRequest.props(auditLogger, register, channelsDb),"AuditRequest-"+requestCount.toString())
+      requestCount+=1
+      request forward m
+
+    case m@CHANNEL_GET_DAILY_STATS =>
+      auditLogger forward m
+  }
+
+  /**
+    * Sends a request to a channel and expects a response
+    *
+    * @param channelIdentifier can be a shortChannelId (8-byte hex encoded) or a channelId (32-byte hex encoded)
+    * @param request
+    * @return
+    */
+  def sendToChannel(channelIdentifier: String, request: Any): Future[Any] =
+    for {
+      fwdReq <- Future(Register.ForwardShortId(ShortChannelId(channelIdentifier), request))
+        .recoverWith { case _ => Future(Register.Forward(BinaryData(channelIdentifier), request)) }
+        .recoverWith { case _ => Future.failed(new RuntimeException(s"invalid channel identifier '$channelIdentifier'")) }
+      res <- register ? fwdReq
+    } yield res
+
+  def getBalances(channelId: BinaryData) :Future[AuditReturn] = {
+    val channelFut = sendToChannel(channelId.toString(), CMD_GETINFO)
+    val auditFut = auditLogger ? GET_BALANCES(channelId)
+
+    val result :Future[AuditReturn] = for {
+      channelInfo <- channelFut.recoverWith{case e=> Future {None}}
+      auditInfo <- auditFut.mapTo[ChannelBalances]
+    } yield {
+      (channelInfo,auditInfo) match {
+        case (RES_GETINFO(_,_,state: State,data: HasCommitments),cb: ChannelBalances ) =>
+          val com=data.commitments
+          val lhIn=com.localCommit.spec.htlcs.toSeq.filter(_.direction==IN).map(_.add.amountMsat).sum
+          val lhOut=com.localCommit.spec.htlcs.toSeq.filter(_.direction==OUT).map(_.add.amountMsat).sum
+          val rhIn=com.remoteCommit.spec.htlcs.toSeq.filter(_.direction==IN).map(_.add.amountMsat).sum
+          val rhOut=com.remoteCommit.spec.htlcs.toSeq.filter(_.direction==OUT).map(_.add.amountMsat).sum
+          // need the toSeq or duplicate amounts get filtered out!
+          AuditReturn( cb,
+               CommitmentInfo(com.localCommit.spec.toLocalMsat,com.localCommit.spec.toRemoteMsat, lhIn,lhOut ,com.localNextHtlcId),
+               CommitmentInfo(com.remoteCommit.spec.toLocalMsat,com.remoteCommit.spec.toRemoteMsat, rhIn,rhOut, com.remoteNextHtlcId),
+               state
+              )
+        case (None,cb: ChannelBalances) =>
+          // used for CLOSED channels that are only in DB now
+          channelsDb.getChannel(channelId,true) match {
+            case Some(c) =>
+              val com=c.commitments
+              val lhIn=com.localCommit.spec.htlcs.filter(_.direction==IN).map(_.add.amountMsat).sum
+              val lhOut=com.localCommit.spec.htlcs.filter(_.direction==OUT).map(_.add.amountMsat).sum
+              val rhIn=com.remoteCommit.spec.htlcs.filter(_.direction==IN).map(_.add.amountMsat).sum
+              val rhOut=com.remoteCommit.spec.htlcs.filter(_.direction==OUT).map(_.add.amountMsat).sum
+
+              AuditReturn( cb,
+                   CommitmentInfo(0,0,0,0,com.localNextHtlcId),
+                   CommitmentInfo(0,0,0,0, com.remoteNextHtlcId),
+                   CLOSED
+                  )
+            case e => throw new ChannelNotFoundException(channelId,"Error - either no entries for channel or AuditLogger is disabled. "+e.toString())
+          }
+
+        case a =>
+          throw new ChannelNotFoundException(channelId,"Error - either no entries for channel or AuditLogger is disabled. "+a.toString())
+      }
+    }
+    result
+  }
+
+}
+
+object AuditBalances {
+  def props(auditLogger: ActorRef, register: ActorRef, channelsDb: ChannelsDb) = Props(classOf[AuditBalances], auditLogger, register,channelsDb)
+}
+
+
+sealed trait BALANCE_MESSAGES
+
+case class CHANNEL_BALANCE(channelId: BinaryData) extends BALANCE_MESSAGES
+case class CHANNEL_RECONCILE(channelId: BinaryData) extends BALANCE_MESSAGES
+case class CHANNEL_RECONCILE_ERRORS() extends BALANCE_MESSAGES
+case class CHANNEL_GET_INFO() extends BALANCE_MESSAGES
+case class CHANNEL_GET_DAILY_STATS() extends BALANCE_MESSAGES
+
+
+
+case class RECONCILE(channelId: BinaryData,state: String, all: Boolean, dbRec: Boolean, dbToCommitRec: Boolean)
+case class GET_INFO(channelBalances :ChannelBalances = ChannelBalances(),notNormalChannelBalances :ChannelBalances = ChannelBalances(),
+    channelCount: Map[State,Long]= Map[State,Long]().withDefaultValue(0),localCommitiment: CommitmentInfo=CommitmentInfo() )
+    
+case class DAILY_STATS(date: Long, sentCount: Long, receivedCount: Long, relayedCount: Long, openCount: Long, closedCount: Long, lnFeesMsat: Long, LNprofitMsat: Long, BTCFees: Long)
+
+
+
+
+case class ChannelNotFoundException(val channelId: BinaryData, message: String) extends RuntimeException(message)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/AuditLogger.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/AuditLogger.scala
@@ -1,0 +1,170 @@
+package fr.acinq.eclair.payment
+
+import akka.actor.{Actor, ActorLogging, ActorRef,Props}
+import fr.acinq.bitcoin.{BinaryData,MilliSatoshi, Satoshi}
+import fr.acinq.eclair.NodeParams
+import fr.acinq.eclair.db._
+import fr.acinq.eclair.channel.{State,ChannelIdAssigned}
+
+class AuditLogger(nodeParams: NodeParams, enabled: Boolean) extends Actor with ActorLogging {
+
+  if(enabled) {
+    context.system.eventStream.subscribe(self, classOf[PaymentSent])
+    context.system.eventStream.subscribe(self, classOf[PaymentRelayed])
+    context.system.eventStream.subscribe(self, classOf[PaymentReceived])
+    context.system.eventStream.subscribe(self, classOf[PaymentHTLCSent])
+    context.system.eventStream.subscribe(self, classOf[PaymentHTLCErrored])
+    context.system.eventStream.subscribe(self, classOf[CHANNEL_FUNDING_LOCKED])
+    context.system.eventStream.subscribe(self, classOf[CHANNEL_MUTUAL_CLOSE])
+    context.system.eventStream.subscribe(self, classOf[CHANNEL_COMMIT_CLOSE])
+    context.system.eventStream.subscribe(self, classOf[CHANNEL_CLOSE])
+    
+    context.system.eventStream.subscribe(self, classOf[CHANNEL_CLOSE_ROUNDING])
+    
+    context.system.eventStream.subscribe(self, classOf[ChannelIdAssigned]) //We listen for this to get the fee paid on funding Tx.
+  }
+
+  var fundingFees = Map[BinaryData,Long]().withDefaultValue[Long](0)
+
+  val db = nodeParams.auditDb
+
+  override def receive: Receive = {
+
+    case s@PaymentSent(_,_,_,_,_,_,_) =>
+      db.addAuditEntry(AuditEntry(channel=s.channelId,localHtlcId=s.commitId,htlcMsat=MilliSatoshi(0)-s.amount-s.feesPaid,
+          feeMsat=s.feesPaid,entryType=LN_PAYMENT,paymentTxHash=s.paymentHash))
+
+    case r@PaymentReceived(_,_,_,_) =>
+      db.addAuditEntry(AuditEntry(channel=r.channelId, localHtlcId= -1L, remoteHtlcId=r.commitId, amountMsat=r.amount,entryType=LN_RECEIPT,paymentTxHash=r.paymentHash))
+
+    case rl@PaymentRelayed(_,_,_,_,_,_,_) =>
+      if(!db.checkRelayAdded(rl.channelIdIn,rl.commitIdIn, rl.paymentHash)){
+        db.addAuditEntry(AuditEntry(channel=rl.channelIdIn,otherChannel=rl.channelIdOut,localHtlcId = -1L,remoteHtlcId=rl.commitIdIn,
+            amountMsat=rl.amountIn,profitInMsat=MilliSatoshi(math.ceil((rl.amountIn-rl.amountOut).amount/2d).toLong),
+            entryType=LN_RELAY,paymentTxHash=rl.paymentHash))
+
+        db.addAuditEntry(AuditEntry(channel=rl.channelIdOut,otherChannel=rl.channelIdIn, localHtlcId=rl.commitIdOut,
+            htlcMsat=MilliSatoshi(0)-rl.amountOut, profitOutMsat=MilliSatoshi(math.floor((rl.amountIn-rl.amountOut).amount/2d).toLong),
+            entryType=LN_RELAY,paymentTxHash=rl.paymentHash))
+      }
+
+    case PaymentHTLCSent(amount, paymentHash, channelId, commitId) => 
+      if (!db.checkSentAdded(channelId,commitId,paymentHash))
+        db.addAuditEntry(AuditEntry(channel=channelId, localHtlcId=commitId,amountMsat=MilliSatoshi(0)-amount,  htlcMsat=amount, entryType=LN_ADD_HTLC, paymentTxHash=paymentHash))
+
+    case PaymentHTLCErrored(channelId, commitId, paymentHash) =>
+      db.errorHtlc(channelId,commitId)
+
+    case ChannelIdAssigned(_, _, _, channelId,fundingFee) =>
+      fundingFees += ( channelId -> fundingFee)
+
+    case CHANNEL_FUNDING_LOCKED(cid,local,remote) =>
+      val fee=fundingFees(cid)
+      if (fundingFees.contains(cid)) fundingFees -= cid
+      db.addAuditEntry(AuditEntry(channel=cid, amountMsat=local, entryType=OPEN_FUNDING_LOCKED,btcAmount = -local.toLong/1000-fee, btcFee= -fee))
+
+    case CHANNEL_MUTUAL_CLOSE(channelId, amountLocal, amountRemote, txid, btcFee) =>
+      val rounding=(amountLocal.amount/1000L).toLong*1000L-amountLocal.amount // put any rounding in roundingMsat Negative means we lost money due to rounding
+      val a=AuditEntry(channel=channelId, amountMsat=MilliSatoshi(0) - amountLocal, entryType=MUTUAL_CLOSE,btcAmount = amountLocal.toLong/1000 - btcFee,
+          roundingMsat=rounding, btcFee = -btcFee, paymentTxHash=txid)
+      if(!db.checkExists(a)) db.addAuditEntry(a)
+
+    case CHANNEL_COMMIT_CLOSE(channelId, amountLocal, amountRemote, txid, btcFee) =>
+      val rounding=(amountLocal.amount/1000L).toLong*1000L-amountLocal.amount // put any rounding in roundingMsat Negative means we lost money due to rounding
+      val a=AuditEntry(channel=channelId, amountMsat=MilliSatoshi(0) - amountLocal, entryType=COMMIT_CLOSE,delayed = amountLocal.toLong/1000 - btcFee, 
+          roundingMsat=rounding, btcFee = -btcFee, paymentTxHash=txid)
+      if(!db.checkExists(a)) db.addAuditEntry(a)
+
+    case CHANNEL_CLOSE(txType @ (CLOSE_DELAYED_MAIN|CLOSE_MAIN|CLOSE_HTLC_DELAYED), channelId, amount, txid, btcFee) =>
+      val a=AuditEntry(channel=channelId, delayed= -btcFee-amount, entryType=txType,btcAmount = amount, btcFee = -btcFee, paymentTxHash=txid)
+      if(!db.checkExists(a)) db.addAuditEntry(a)
+
+    case CHANNEL_CLOSE(txType @ CLOSE_HTLC_SUCCESS, channelId, amount, txid, btcFee) =>
+      val a=AuditEntry(channel=channelId, btcAmount= amount, entryType=txType, btcFee = -btcFee, paymentTxHash=txid)
+      if(!db.checkExists(a)) db.addAuditEntry(a)
+
+    case CHANNEL_CLOSE(txType @ (CLOSE_HTLC_SUCCESS_DELAYED), channelId, amount, txid, btcFee) =>
+      val a=AuditEntry(channel=channelId,delayed= -btcFee-amount, entryType=txType, btcFee = -btcFee, paymentTxHash=txid)
+      if(!db.checkExists(a)) db.addAuditEntry(a)
+
+    case CHANNEL_CLOSE(txType @ CLOSE_HTLC_TIMEOUT, channelId, amount, txid, btcFee) =>
+      val a=AuditEntry(channel=channelId, amountMsat=MilliSatoshi(0),htlcMsat= MilliSatoshi(-(+btcFee+amount)*1000), btcAmount=(amount), entryType=txType, btcFee = -btcFee, paymentTxHash=txid)
+      if(!db.checkExists(a)) db.addAuditEntry(a)
+
+    case CHANNEL_CLOSE(txType @ CLOSE_HTLC_TIMEOUT_DELAYED, channelId, amount, txid, btcFee) =>
+      val a=AuditEntry(channel=channelId, amountMsat=MilliSatoshi(0),htlcMsat= MilliSatoshi(-(+btcFee+amount)*1000), delayed=(amount), entryType=txType, 
+          btcFee = -btcFee, paymentTxHash=txid)
+      if(!db.checkExists(a)) db.addAuditEntry(a)
+ 
+    case CHANNEL_CLOSE(txType @ CLOSE_REVOKED_COMMIT, channelId, amount, txid, btcFee) =>
+      val cb=db.channelBalances(channelId)
+      val localBalance=cb.amount+cb.htlcAmount
+      val rounding=(localBalance.toLong/1000-amount)*1000-(localBalance.amount-amount*1000)
+      val a=AuditEntry(channel=channelId, amountMsat=MilliSatoshi(0)-localBalance,penalty=localBalance.amount/1000-amount-btcFee, entryType=txType,btcAmount = amount,
+          roundingMsat=rounding, btcFee = -btcFee, paymentTxHash=txid)
+      if(!db.checkExists(a)) db.addAuditEntry(a)
+      
+    case CHANNEL_CLOSE(txType @ (CLOSE_REVOKED_MAIN|CLOSE_REVOKED_MAIN_PENALTY|CLOSE_REVOKED_HTLC_PENALTY|CLOSE_REVOKED_HTLC_DELAYED_PENALTY|CLOSE_REVOKED_HTLC_REMOTE), channelId, amount, txid, btcFee) =>
+      val a=AuditEntry(channel=channelId,penalty= -(amount+btcFee), entryType=txType,btcAmount = amount, btcFee = -btcFee, paymentTxHash=txid)
+      if(!db.checkExists(a)) db.addAuditEntry(a)
+
+    case CHANNEL_CLOSE_ROUNDING(channelId) => db.updateRounding(channelId)
+      
+    case GET_BALANCES(channelId) =>
+      sender ! db.channelBalances(channelId)  
+
+    case CHANNEL_GET_DAILY_STATS =>
+      sender ! db.dailyData()
+  }
+}
+
+case class CHANNEL_FUNDING_LOCKED(channelId: BinaryData, amount: MilliSatoshi, pushAmount: MilliSatoshi)
+case class CHANNEL_MUTUAL_CLOSE(channelId: BinaryData, amountLocal: MilliSatoshi, amountRemote: MilliSatoshi, txid: BinaryData, btcFee: Long)
+case class CHANNEL_COMMIT_CLOSE(channelId: BinaryData, amountLocal: MilliSatoshi, amountRemote: MilliSatoshi, txid: BinaryData, btcFee: Long)
+case class CHANNEL_CLOSE(txType: TX_TYPE, channelId: BinaryData, amount: Long, txid: BinaryData, btcFee: Long)
+case class CHANNEL_CLOSE_ROUNDING(channelId: BinaryData)
+
+case object LN_PAYMENT extends AuditEntryType
+case object LN_RECEIPT extends AuditEntryType
+case object LN_RELAY extends AuditEntryType
+case object LN_ADD_HTLC extends AuditEntryType
+case object LN_ERROR_HTLC extends AuditEntryType
+
+case object OPEN_FUNDING_LOCKED extends AuditEntryType
+case object MUTUAL_CLOSE extends AuditEntryType
+case object COMMIT_CLOSE extends AuditEntryType
+case object ROUNDING_CLOSE extends AuditEntryType
+
+sealed trait TX_TYPE extends AuditEntryType
+case object CLOSE_DELAYED_MAIN extends TX_TYPE 
+case object CLOSE_MAIN extends TX_TYPE 
+case object CLOSE_HTLC_SUCCESS extends TX_TYPE
+case object CLOSE_HTLC_SUCCESS_DELAYED extends TX_TYPE
+case object CLOSE_HTLC_TIMEOUT extends TX_TYPE
+case object CLOSE_HTLC_TIMEOUT_DELAYED extends TX_TYPE
+case object CLOSE_HTLC_DELAYED extends TX_TYPE
+case object CLOSE_REVOKED_COMMIT extends TX_TYPE with AuditEntryType
+case object CLOSE_REVOKED_MAIN extends TX_TYPE with AuditEntryType
+case object CLOSE_REVOKED_MAIN_PENALTY extends TX_TYPE with AuditEntryType
+case object CLOSE_REVOKED_HTLC_PENALTY extends TX_TYPE with AuditEntryType
+case object CLOSE_REVOKED_HTLC_REMOTE extends TX_TYPE with AuditEntryType
+case object CLOSE_REVOKED_HTLC_DELAYED_PENALTY extends TX_TYPE with AuditEntryType
+case object CLOSE_ERROR_FUTURE_PUBLISHED extends TX_TYPE with AuditEntryType
+
+case class GET_BALANCES(channelId: BinaryData)
+
+case class CommitmentInfo(toLocalmSat: Long=0,toRemotemSat: Long=0, inflightInHtlc: Long=0, inflightOutHtlc: Long=0 ,nextHtlcId: Long=0) {
+  import Math.max
+  def +(that: CommitmentInfo)=
+    new CommitmentInfo(this.toLocalmSat+that.toLocalmSat,this.toRemotemSat+that.toRemotemSat,this.inflightInHtlc+that.inflightInHtlc
+        ,this.inflightOutHtlc+that.inflightOutHtlc,max(this.nextHtlcId,that.nextHtlcId))
+  
+}
+
+
+
+case class AuditReturn(channelBalances: ChannelBalances, localCommitiment: CommitmentInfo, remoteCommitment: CommitmentInfo, state:State)
+
+object AuditLogger {
+  def props(nodeParams: NodeParams, enabled: Boolean) = Props(classOf[AuditLogger], nodeParams, enabled)
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/LocalPaymentHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/LocalPaymentHandler.scala
@@ -88,7 +88,8 @@ class LocalPaymentHandler(nodeParams: NodeParams)(implicit ec: ExecutionContext 
               // amount is correct or was not specified in the payment request
               nodeParams.paymentsDb.addPayment(Payment(htlc.paymentHash, htlc.amountMsat, Platform.currentTime / 1000))
               sender ! CMD_FULFILL_HTLC(htlc.id, paymentPreimage, commit = true)
-              context.system.eventStream.publish(PaymentReceived(MilliSatoshi(htlc.amountMsat), htlc.paymentHash))
+              context.system.eventStream.publish(PaymentReceived(MilliSatoshi(htlc.amountMsat), htlc.paymentHash,
+                  htlc.channelId,htlc.id))
               context.become(run(hash2preimage - htlc.paymentHash))
           }
         case None =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -25,8 +25,14 @@ sealed trait PaymentEvent {
   val paymentHash: BinaryData
 }
 
-case class PaymentSent(amount: MilliSatoshi, feesPaid: MilliSatoshi, paymentHash: BinaryData, paymentPreimage: BinaryData) extends PaymentEvent
+case class PaymentSent(amount: MilliSatoshi, feesPaid: MilliSatoshi, paymentHash: BinaryData, paymentPreimage: BinaryData,
+    channelId: BinaryData, commitId: Long, targetNode: BinaryData) extends PaymentEvent
 
-case class PaymentRelayed(amountIn: MilliSatoshi, amountOut: MilliSatoshi, paymentHash: BinaryData) extends PaymentEvent
+case class PaymentRelayed(amountIn: MilliSatoshi, amountOut: MilliSatoshi, paymentHash: BinaryData,
+    channelIdIn: BinaryData, commitIdIn: Long, channelIdOut: BinaryData, commitIdOut: Long) extends PaymentEvent
 
-case class PaymentReceived(amount: MilliSatoshi, paymentHash: BinaryData) extends PaymentEvent
+case class PaymentReceived(amount: MilliSatoshi, paymentHash: BinaryData,
+    channelId: BinaryData, commitId: Long) extends PaymentEvent
+
+case class PaymentHTLCSent(amount: MilliSatoshi, paymentHash: BinaryData, channelId: BinaryData, commitId: Long) extends PaymentEvent
+case class PaymentHTLCErrored(channelId: BinaryData, commitId: Long, paymentHash: BinaryData) extends PaymentEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentInitiator.scala
@@ -18,17 +18,27 @@ package fr.acinq.eclair.payment
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.eclair.payment.PaymentLifecycle.SendPayment
+import fr.acinq.eclair.payment.PaymentLifecycle.{SendPayment,PaymentResult}
 
 /**
   * Created by PM on 29/08/2016.
   */
 class PaymentInitiator(sourceNodeId: PublicKey, router: ActorRef, register: ActorRef) extends Actor with ActorLogging {
+  override def receive: Receive = run(Map(),Map(),0)
 
-  override def receive: Receive = {
+  def run(actors: Map[ActorRef, Long],results: Map[Long,Option[PaymentResult]] , paymentCounterId: Long): Receive = {
     case c: SendPayment =>
       val payFsm = context.actorOf(PaymentLifecycle.props(sourceNodeId, router, register))
+      if (c.async) sender ! SendPaymentId(paymentCounterId)
       payFsm forward c
+      context.become(run(actors + (payFsm -> paymentCounterId), results +(paymentCounterId -> None), paymentCounterId+1))
+    case (state: PaymentResult) =>
+      val id=actors(sender)
+      log.info("got:"+id+" state:"+state.toString())
+      context.become(run(actors,results + (id -> Some(state)),paymentCounterId))
+    case SendPaymentId(id) =>
+      log.info(s"got: $id state2:"+results.get(id))
+      sender ! CheckSendPaymentResult(results.contains(id),results.get(id))
   }
 
 }
@@ -36,3 +46,7 @@ class PaymentInitiator(sourceNodeId: PublicKey, router: ActorRef, register: Acto
 object PaymentInitiator {
   def props(sourceNodeId: PublicKey, router: ActorRef, register: ActorRef) = Props(classOf[PaymentInitiator], sourceNodeId, router, register)
 }
+
+case class SendPaymentId(id: Long) // A reference for this payment to allow api to callback to get status. As payments can hang.
+
+case class CheckSendPaymentResult(validId: Boolean, result: Option[Option[PaymentResult]])

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -222,6 +222,8 @@ object Transactions {
     if (amount < localDustLimit) {
       throw AmountBelowDustLimit
     }
+    val rounding=MilliSatoshi((htlc.amountMsat/1000)*1000-htlc.amountMsat)
+    
     val input = InputInfo(OutPoint(commitTx, outputIndex), commitTx.txOut(outputIndex), write(redeemScript))
     HtlcTimeoutTx(input, Transaction(
       version = 2,
@@ -239,6 +241,7 @@ object Transactions {
     if (amount < localDustLimit) {
       throw AmountBelowDustLimit
     }
+    val rounding=MilliSatoshi((htlc.amountMsat/1000)*1000-htlc.amountMsat)
     val input = InputInfo(OutPoint(commitTx, outputIndex), commitTx.txOut(outputIndex), write(redeemScript))
     HtlcSuccessTx(input, Transaction(
       version = 2,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
@@ -219,7 +219,8 @@ object ChannelCodecs extends Logging {
       ("mainPenaltyTx" | optional(bool, txCodec)) ::
       ("htlcPenaltyTxs" | listOfN(uint16, txCodec)) ::
       ("claimHtlcDelayedPenaltyTxs" | listOfN(uint16, txCodec)) ::
-      ("spent" | spentMapCodec)).as[RevokedCommitPublished]
+      ("spent" | spentMapCodec) ::
+      ("remoteSuccessTimeoutHtlcTxs" | listOfN(uint16, txCodec))).as[RevokedCommitPublished]
 
   val DATA_WAIT_FOR_FUNDING_CONFIRMED_Codec: Codec[DATA_WAIT_FOR_FUNDING_CONFIRMED] = (
     ("commitments" | commitmentsCodec) ::

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -42,7 +42,7 @@
         </encoder>
     </appender-->
 
-    <!--logger name="fr.acinq.eclair.channel" level="DEBUG"/-->
+    <logger name="fr.acinq.eclair.channel" level="DEBUG"/>
     <logger name="fr.acinq.eclair.router" level="WARN"/>
 
     <root level="INFO">

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -81,7 +81,8 @@ object TestConstants {
       paymentRequestExpiry = 1 hour,
       maxPendingPaymentRequests = 10000000,
       maxPaymentFee = 0.03,
-      minFundingSatoshis = 1000L)
+      minFundingSatoshis = 1000L,
+      auditDb=new SqliteAuditDb(sqlite))
 
     def channelParams = Peer.makeChannelParams(
       nodeParams = nodeParams,
@@ -135,7 +136,8 @@ object TestConstants {
       paymentRequestExpiry = 1 hour,
       maxPendingPaymentRequests = 10000000,
       maxPaymentFee = 0.03,
-      minFundingSatoshis = 1000L)
+      minFundingSatoshis = 1000L,
+      auditDb=new SqliteAuditDb(sqlite))
 
     def channelParams = Peer.makeChannelParams(
       nodeParams = nodeParams,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/TestWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/TestWallet.scala
@@ -45,7 +45,7 @@ object TestWallet {
       txIn = TxIn(OutPoint("42" * 32, 42), signatureScript = Nil, sequence = TxIn.SEQUENCE_FINAL) :: Nil,
       txOut = TxOut(amount, pubkeyScript) :: Nil,
       lockTime = 0)
-    MakeFundingTxResponse(fundingTx, 0)
+    MakeFundingTxResponse(fundingTx, 0,feeRatePerKw) //fee just dummy for tests 
   }
 
   def malleateTx(tx: Transaction): Transaction = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -99,7 +99,7 @@ class BitcoinCoreWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLi
     val fundingTxes = for (i <- 0 to 3) yield {
       val pubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(randomKey.publicKey, randomKey.publicKey)))
       wallet.makeFundingTx(pubkeyScript, MilliBtc(50), 10000).pipeTo(sender.ref)
-      val MakeFundingTxResponse(fundingTx, _) = sender.expectMsgType[MakeFundingTxResponse]
+      val MakeFundingTxResponse(fundingTx, _, _) = sender.expectMsgType[MakeFundingTxResponse]
       fundingTx
     }
 
@@ -171,7 +171,7 @@ class BitcoinCoreWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLi
     sender.expectMsgType[JValue]
 
     wallet.makeFundingTx(pubkeyScript, MilliBtc(50), 10000).pipeTo(sender.ref)
-    val MakeFundingTxResponse(fundingTx, _) = sender.expectMsgType[MakeFundingTxResponse]
+    val MakeFundingTxResponse(fundingTx, _, _) = sender.expectMsgType[MakeFundingTxResponse]
 
     wallet.commit(fundingTx).pipeTo(sender.ref)
     assert(sender.expectMsgType[Boolean])

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
@@ -1,0 +1,40 @@
+package fr.acinq.eclair.db
+
+import java.sql.DriverManager
+
+import fr.acinq.bitcoin.{BinaryData, MilliSatoshi}
+import fr.acinq.eclair.db.sqlite.SqliteAuditDb
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+import fr.acinq.eclair.payment._
+
+@RunWith(classOf[JUnitRunner])
+class SqliteAuditDbSpec extends FunSuite {
+
+  def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")
+
+  test("init sqlite 2 times in a row") {
+    val sqlite = inmem
+    val db1 = new SqliteAuditDb(sqlite)
+    val db2 = new SqliteAuditDb(sqlite)
+  }
+
+  test("add and check balances") {
+    val sqlite = inmem
+    val db = new SqliteAuditDb(sqlite)
+    db.addAuditEntry(AuditEntry(channel="00"*32,otherChannel="01"*32,localHtlcId=0,remoteHtlcId=0,amountMsat=MilliSatoshi(1000000),
+        profitInMsat=MilliSatoshi(100),profitOutMsat=MilliSatoshi(200), entryType=LN_RECEIPT,paymentTxHash="42"*32))
+
+    db.addAuditEntry(AuditEntry(channel="00"*32,otherChannel="01"*32,localHtlcId=1,remoteHtlcId=0,amountMsat=MilliSatoshi(0)-MilliSatoshi(100000),entryType=LN_PAYMENT,paymentTxHash="42"*32))
+
+    assert(db.channelBalances("00"*32) ==  ChannelBalances(1,0,MilliSatoshi(900000),MilliSatoshi(0),MilliSatoshi(100),MilliSatoshi(200),MilliSatoshi(0),0,0,0,0,MilliSatoshi(0),MilliSatoshi(1000000)))
+
+    db.addAuditEntry(AuditEntry(channel="00"*32,otherChannel="01"*32,localHtlcId=2,remoteHtlcId=0,amountMsat=MilliSatoshi(0)-MilliSatoshi(100000),
+        htlcMsat=MilliSatoshi(100000),entryType=LN_ADD_HTLC,paymentTxHash="42"*32))
+    assert(db.channelBalances("00"*32) ==  ChannelBalances(2,0,MilliSatoshi(800000),MilliSatoshi(100000),MilliSatoshi(100),MilliSatoshi(200),MilliSatoshi(0),0,0,0,0,MilliSatoshi(0),MilliSatoshi(1000000))) //check entry added
+    db.errorHtlc("00"*32,2)
+    assert(db.channelBalances("00"*32) ==  ChannelBalances(2,0,MilliSatoshi(900000),MilliSatoshi(0),MilliSatoshi(100),MilliSatoshi(200),MilliSatoshi(0),0,0,0,0,MilliSatoshi(0),MilliSatoshi(1000000))) // check rolled back
+    
+  }
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/AuditLoggerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/AuditLoggerSpec.scala
@@ -1,0 +1,62 @@
+package fr.acinq.eclair.payment
+import akka.testkit.{TestKit, TestProbe}
+import akka.actor.{ActorSystem, Status}
+import org.junit.runner.RunWith
+import org.scalatest.FunSuiteLike
+import org.scalatest.junit.JUnitRunner
+import akka.actor.Status.Failure
+import akka.testkit.{TestKit, TestProbe}
+import fr.acinq.bitcoin.{MilliSatoshi, Satoshi}
+import fr.acinq.eclair.Globals
+import fr.acinq.eclair.TestConstants.Alice
+import fr.acinq.eclair.payment._
+import grizzled.slf4j.Logging
+import scala.concurrent.duration._
+import fr.acinq.eclair.db.ChannelBalances
+
+@RunWith(classOf[JUnitRunner])
+class AuditLoggerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with Logging {
+  test("relayed payments should split profit") {
+    val nodeParams = Alice.nodeParams
+    val handler = system.actorOf(AuditLogger.props(nodeParams, true))
+    val sender = TestProbe()
+    val db=nodeParams.auditDb
+    
+    handler ! PaymentRelayed(MilliSatoshi(100001),MilliSatoshi(100000),"00"*32, "01"*32, 1, "02"*32, 2)
+    
+    // This is to test that profit is rounded correctly and extra 1 mSat goes to the in channel.
+    awaitAssert({
+       assert(db.channelBalances("01"*32)==ChannelBalances(-1,1,MilliSatoshi(100001),MilliSatoshi(0),
+           MilliSatoshi(1),MilliSatoshi(0),MilliSatoshi(0),0,0,0,sentMsat=MilliSatoshi(0),receivedMsat=MilliSatoshi(100001),
+           relayReceivedMsat=MilliSatoshi(100001)))
+           
+        }, max = 2 seconds, interval = 1 second)
+    awaitAssert({
+       assert(db.channelBalances("02"*32)==ChannelBalances(2,-1,MilliSatoshi(0),MilliSatoshi(-100000),
+           sentMsat=MilliSatoshi(-100000),relaySentMsat=MilliSatoshi(-100000)))
+           
+        }, max = 2 seconds, interval = 1 second)
+  }
+  
+  test("relayed payments should split profit even when very big") {
+    val nodeParams = Alice.nodeParams
+    val handler = system.actorOf(AuditLogger.props(nodeParams, true))
+    val sender = TestProbe()
+    val db=nodeParams.auditDb
+    
+    handler ! PaymentRelayed(MilliSatoshi(100000000L*1000L*1000L+1),MilliSatoshi(100000000L*1000L*1000L),"00"*32, "03"*32, 1, "04"*32, 2)
+    
+    // This is to test that profit is rounded correctly and extra 1 mSat goes to the in channel.
+    awaitAssert({
+       assert(db.channelBalances("03"*32)==ChannelBalances(-1,1,MilliSatoshi(100000000L*1000L*1000L+1),MilliSatoshi(0),
+           MilliSatoshi(1),sentMsat=MilliSatoshi(0),receivedMsat=MilliSatoshi(100000000L*1000L*1000L+1),
+           relayReceivedMsat=MilliSatoshi(100000000000001L)))
+           
+        }, max = 2 seconds, interval = 1 second)
+    awaitAssert({
+       assert(db.channelBalances("04"*32)==ChannelBalances(2,-1,MilliSatoshi(0),MilliSatoshi(-100000000L*1000L*1000L),
+           sentMsat=MilliSatoshi(-100000000L*1000L*1000L),relaySentMsat=MilliSatoshi(-100000000000000L)))
+           
+        }, max = 2 seconds, interval = 1 second)
+  }
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
@@ -55,7 +55,7 @@ class PaymentHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
       val add = UpdateAddHtlc("11" * 32, 0, amountMsat.amount, pr.paymentHash, expiry, "")
       sender.send(handler, add)
       sender.expectMsgType[CMD_FULFILL_HTLC]
-      eventListener.expectMsg(PaymentReceived(amountMsat, add.paymentHash))
+      eventListener.expectMsg(PaymentReceived(amountMsat, add.paymentHash, "11" * 32, 0))
       sender.send(handler, CheckPayment(pr.paymentHash))
       assert(sender.expectMsgType[Boolean] === true)
     }
@@ -68,7 +68,7 @@ class PaymentHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
       val add = UpdateAddHtlc("11" * 32, 0, amountMsat.amount, pr.paymentHash, expiry, "")
       sender.send(handler, add)
       sender.expectMsgType[CMD_FULFILL_HTLC]
-      eventListener.expectMsg(PaymentReceived(amountMsat, add.paymentHash))
+      eventListener.expectMsg(PaymentReceived(amountMsat, add.paymentHash,"11" * 32, 0))
       sender.send(handler, CheckPayment(pr.paymentHash))
       assert(sender.expectMsgType[Boolean] === true)
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -19,7 +19,7 @@ package fr.acinq.eclair.payment
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.actor.Status
 import akka.testkit.{TestFSMRef, TestProbe}
-import fr.acinq.bitcoin.{BinaryData, MilliSatoshi}
+import fr.acinq.bitcoin.{BinaryData,MilliSatoshi}
 import fr.acinq.eclair.Globals
 import fr.acinq.eclair.channel.{AddHtlcFailed, ChannelUnavailable}
 import fr.acinq.eclair.channel.Register.ForwardShortId
@@ -252,7 +252,13 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
 
     val paymentOK = sender.expectMsgType[PaymentSucceeded]
     assert(paymentOK.amountMsat > request.amountMsat)
-    val PaymentSent(MilliSatoshi(request.amountMsat), feesPaid, request.paymentHash, paymentOK.paymentPreimage) = eventListener.expectMsgType[PaymentSent]
+
+    val PaymentSent(MilliSatoshi(request.amountMsat), feesPaid, request.paymentHash, paymentOK.paymentPreimage, channelId, id, targetNode) = eventListener.expectMsgType[PaymentSent]
+    
+    val t: BinaryData="00"*32
+    assert(channelId==t)
+    assert(id==0)
+    assert(targetNode==d.toBin)
     assert(feesPaid.amount > 0)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -339,7 +339,8 @@ class RelayerSpec extends TestkitBaseClass {
     assert(fwd.channelId === origin.originChannelId)
     assert(fwd.message.id === origin.originHtlcId)
 
-    eventListener.expectMsg(PaymentRelayed(MilliSatoshi(origin.amountMsatIn), MilliSatoshi(origin.amountMsatOut), Crypto.sha256(fulfill_ba.paymentPreimage)))
+    eventListener.expectMsg(PaymentRelayed(MilliSatoshi(origin.amountMsatIn), MilliSatoshi(origin.amountMsatOut), Crypto.sha256(fulfill_ba.paymentPreimage),
+        channelId_ab,150,channelId_bc,42))
   }
 
   test("relay an htlc-fail") { case (relayer, register, _) =>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -117,7 +117,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
       runInGuiThread(() => mainController.channelBox.getChildren.addAll(root))
       context.become(main(m + (channel -> channelPaneController)))
 
-    case ChannelIdAssigned(channel, _, _, channelId) if m.contains(channel) =>
+    case ChannelIdAssigned(channel, _, _, channelId, _) if m.contains(channel) =>
       val channelPaneController = m(channel)
       runInGuiThread(() => channelPaneController.channelId.setText(s"$channelId"))
 


### PR DESCRIPTION
This is an initial version of an actor that logs to the database every send/receive/relay through the node. It does this at a detailed level so one can then compare balances on each channel with expected balance.

Currently uses lot of database space - but given code is alpha quality think this is a worthwhile trade-off until we are doing 100k+ tx a day. And even then dumping out the history daily may still be worth it.

Also note additional asserts in integration tests. And post the integration test you can use the sqlite3 tool to directly see what happened to each node.

Plan to add more asserts to the integration tests. And also an API call to get the balance and compare that to what the actual channel balance is to highlight any missing funds.