### PR TITLE
Electrum: add a `send all balance` method

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
@@ -19,7 +19,7 @@ package fr.acinq.eclair.blockchain.electrum
 import akka.actor.{ActorRef, FSM, Props}
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.DeterministicWallet.{ExtendedPrivateKey, derivePrivateKey, hardened}
-import fr.acinq.bitcoin.{Base58, Base58Check, BinaryData, Block, Crypto, DeterministicWallet, OP_PUSHDATA, OutPoint, SIGHASH_ALL, Satoshi, Script, ScriptWitness, SigVersion, Transaction, TxIn, TxOut}
+import fr.acinq.bitcoin.{Base58, Base58Check, BinaryData, Block, Crypto, DeterministicWallet, OP_PUSHDATA, OutPoint, SIGHASH_ALL, Satoshi, Script, ScriptElt, ScriptWitness, SigVersion, Transaction, TxIn, TxOut}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.Error
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient.{GetTransaction, GetTransactionResponse, TransactionHistoryItem, computeScriptHash}
 import fr.acinq.eclair.transactions.Transactions
@@ -226,6 +226,10 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
         case Failure(t) => stay replying CompleteTransactionResponse(tx, Some(t))
       }
 
+    case Event(SendAll(publicKeyScript, feeRatePerKw), data) =>
+      val (tx, fee) = data.spendAll(publicKeyScript, feeRatePerKw)
+      stay replying SendAllResponse(tx, fee)
+
     case Event(CommitTransaction(tx), data) =>
       log.info(s"committing txid=${tx.txid}")
       val data1 = data.commitTransaction(tx)
@@ -297,6 +301,9 @@ object ElectrumWallet {
 
   case class CompleteTransaction(tx: Transaction, feeRatePerKw: Long) extends Request
   case class CompleteTransactionResponse(tx: Transaction, error: Option[Throwable]) extends Response
+
+  case class SendAll(publicKeyScript: BinaryData, feeRatePerKw: Long) extends Request
+  case class SendAllResponse(tx: Transaction, fee: Satoshi) extends Response
 
   case class CommitTransaction(tx: Transaction) extends Request
   case class CommitTransactionResponse(tx: Transaction) extends Response
@@ -700,19 +707,24 @@ object ElectrumWallet {
       }
 
       // sign our tx
-      val tx3 = tx2.copy(txIn = tx2.txIn.zipWithIndex.map { case (txIn, i) =>
-        val key = utxos(i).key
-        val sig = Transaction.signInput(tx2, i, Script.pay2pkh(key.publicKey), SIGHASH_ALL, Satoshi(utxos(i).item.value), SigVersion.SIGVERSION_WITNESS_V0, key.privateKey)
-        val sigScript = Script.write(OP_PUSHDATA(Script.write(Script.pay2wpkh(key.publicKey))) :: Nil)
-        val witness = ScriptWitness(sig :: key.publicKey.toBin :: Nil)
-        txIn.copy(signatureScript = sigScript, witness = witness)
-      })
+      val tx3 = signTransaction(tx2)
       //Transaction.correctlySpends(tx3, utxos.map(utxo => utxo.outPoint -> TxOut(Satoshi(utxo.item.value), computePublicKeyScript(utxo.key.publicKey))).toMap, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
       // and add the completed tx to the lokcs
       val data1 = this.copy(locks = this.locks + tx3)
 
       (data1, tx3)
+    }
+
+    def signTransaction(tx: Transaction) : Transaction = {
+      tx.copy(txIn = tx.txIn.zipWithIndex.map { case (txIn, i) =>
+        val utxo = utxos.find(_.outPoint == txIn.outPoint).getOrElse(throw new RuntimeException(s"cannot sign input that spends from ${txIn.outPoint}"))
+        val key = utxo.key
+        val sig = Transaction.signInput(tx, i, Script.pay2pkh(key.publicKey), SIGHASH_ALL, Satoshi(utxos(i).item.value), SigVersion.SIGVERSION_WITNESS_V0, key.privateKey)
+        val sigScript = Script.write(OP_PUSHDATA(Script.write(Script.pay2wpkh(key.publicKey))) :: Nil)
+        val witness = ScriptWitness(sig :: key.publicKey.toBin :: Nil)
+        txIn.copy(signatureScript = sigScript, witness = witness)
+      })
     }
 
     /**
@@ -746,6 +758,28 @@ object ElectrumWallet {
         }
       this.copy(locks = this.locks - tx, transactions = this.transactions + (tx.txid -> tx), heights = this.heights + (tx.txid -> 0L), history = history1)
     }
+
+    /**
+      * spend all our balance, including unconfirmed utxos and locked utxos (i.e utxos
+      * that are used in funding transactions that have not been published yet
+      * @param publicKeyScript script to send all our funds to
+      * @param feeRatePerKw fee rate in satoshi per kiloweight
+      * @return a (tx, fee) tuple, tx is a signed transaction that spends all our balance and
+      *         fee is the associated bitcoin network fee
+      */
+    def spendAll(publicKeyScript: BinaryData, feeRatePerKw: Long) : (Transaction, Satoshi) = {
+      // use confirmed and unconfirmed balance
+      val amount = balance._1 + balance._2
+      val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(amount, publicKeyScript) :: Nil, lockTime = 0)
+      // use all uxtos, including locked ones
+      val tx1 = addUtxosWithDummySig(tx, utxos)
+      val fee = Transactions.weight2fee(feeRatePerKw, tx1.weight())
+      val tx2 = tx1.copy(txOut = TxOut(amount - fee, publicKeyScript) :: Nil)
+      val tx3 = signTransaction(tx2)
+      (tx3, fee)
+    }
+
+    def spendAll(publicKeyScript: Seq[ScriptElt], feeRatePerKw: Long) : (Transaction, Satoshi) = spendAll(Script.write(publicKeyScript), feeRatePerKw)
   }
 
   object Data {


### PR DESCRIPTION
It will use all available utxos, including unconfirmed and locked utxos, and return a signed transaction and fee it pays to the bitcoin network. 