### PR TITLE
Fixed race condition in `ElectrumClient`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -124,8 +124,9 @@ class ElectrumClient(serverAddress: InetSocketAddress)(implicit val ec: Executio
 
     case Tcp.Connected(remote, _) =>
       log.info(s"connected to $remote")
-      sender ! Tcp.Register(self)
-      val connection = context.actorOf(Props(new WriteAckSender(sender())), name = "electrum-sender")
+      val conn = sender()
+      conn ! Tcp.Register(self)
+      val connection = context.actorOf(Props(new WriteAckSender(conn)), name = "electrum-sender")
       send(connection, version)
       context become waitingForVersion(connection, remote)
 


### PR DESCRIPTION
This regression caused in 438d8e3d4b35e781ccb760199576f952f45c1b05 is what caused flaky tests during the past few days.

Calling `sender()` inside a `Props()` leads to undefined behavior.