### PR TITLE
Extend penalty to stealing HTLC outputs

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -614,7 +614,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
                 case u: UpdateFailMalformedHtlc => relayer ! CommandBuffer.CommandAck(u.channelId, u.id)
               }
               // TODO: be smarter and only consider commitments1.localChanges.signed and commitments1.remoteChanges.signed
-              htlcTxs.map {
+              htlcTxs.foreach {
                 case tx: TransactionWithInputInfo =>
                   val pubKeyScript = tx.input.txOut.publicKeyScript
                   val redeemScript = tx.input.redeemScript
@@ -1745,7 +1745,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
     watchConfirmedIfNeeded(watchConfirmedQueue, irrevocablySpent)
 
     // we watch outputs of the commitment tx that both parties may spend
-    val watchSpentQueue = mainPenaltyTx ++ htlcPenaltyTxs ++ claimHtlcDelayedPenaltyTxs
+    val watchSpentQueue = mainPenaltyTx ++ htlcPenaltyTxs
     watchSpentIfNeeded(commitTx, watchSpentQueue, irrevocablySpent)
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -606,7 +606,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
           stay
         case Right(_) =>
           Try(Commitments.sendCommit(d.commitments, keyManager)) match {
-            case Success((commitments1, commit, htlcTxs)) =>
+            case Success((commitments1, commit)) =>
               log.debug(s"sending a new sig, spec:\n${Commitments.specs2String(commitments1)}")
               commitments1.localChanges.signed.collect {
                 case u: UpdateFulfillHtlc => relayer ! CommandBuffer.CommandAck(u.channelId, u.id)
@@ -923,7 +923,7 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
           stay
         case Right(_) =>
           Try(Commitments.sendCommit(d.commitments, keyManager)) match {
-            case Success((commitments1, commit, _)) =>
+            case Success((commitments1, commit)) =>
               log.debug(s"sending a new sig, spec:\n${Commitments.specs2String(commitments1)}")
               commitments1.localChanges.signed.collect {
                 case u: UpdateFulfillHtlc => relayer ! CommandBuffer.CommandAck(u.channelId, u.id)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -42,6 +42,6 @@ case class LocalChannelDown(channel: ActorRef, channelId: BinaryData, shortChann
 
 case class ChannelStateChanged(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, previousState: State, currentState: State, currentData: Data) extends ChannelEvent
 
-case class ChannelSignatureSent(channel: ActorRef, Commitments: Commitments) extends ChannelEvent
+case class ChannelSignatureSent(channel: ActorRef, commitments: Commitments) extends ChannelEvent
 
-case class ChannelSignatureReceived(channel: ActorRef, Commitments: Commitments) extends ChannelEvent
+case class ChannelSignatureReceived(channel: ActorRef, commitments: Commitments) extends ChannelEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -140,9 +140,9 @@ trait HasCommitments extends Data {
 
 case class ClosingTxProposed(unsignedTx: Transaction, localClosingSigned: ClosingSigned)
 
-case class LocalCommitPublished(commitTx: Transaction, claimMainDelayedOutputTx: Option[Transaction], htlcSuccessTxs: List[Transaction], htlcTimeoutTxs: List[Transaction], claimHtlcDelayedTx: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
+case class LocalCommitPublished(commitTx: Transaction, claimMainDelayedOutputTx: Option[Transaction], htlcSuccessTxs: List[Transaction], htlcTimeoutTxs: List[Transaction], claimHtlcDelayedTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
 case class RemoteCommitPublished(commitTx: Transaction, claimMainOutputTx: Option[Transaction], claimHtlcSuccessTxs: List[Transaction], claimHtlcTimeoutTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
-case class RevokedCommitPublished(commitTx: Transaction, claimMainOutputTx: Option[Transaction], mainPenaltyTx: Option[Transaction], claimHtlcTimeoutTxs: List[Transaction], htlcTimeoutTxs: List[Transaction], htlcPenaltyTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
+case class RevokedCommitPublished(commitTx: Transaction, claimMainOutputTx: Option[Transaction], mainPenaltyTx: Option[Transaction], claimHtlcDelayedTxs: List[Transaction], htlcPenaltyTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
 
 final case class DATA_WAIT_FOR_OPEN_CHANNEL(initFundee: INPUT_INIT_FUNDEE) extends Data
 final case class DATA_WAIT_FOR_ACCEPT_CHANNEL(initFunder: INPUT_INIT_FUNDER, lastSent: OpenChannel) extends Data

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -142,7 +142,7 @@ case class ClosingTxProposed(unsignedTx: Transaction, localClosingSigned: Closin
 
 case class LocalCommitPublished(commitTx: Transaction, claimMainDelayedOutputTx: Option[Transaction], htlcSuccessTxs: List[Transaction], htlcTimeoutTxs: List[Transaction], claimHtlcDelayedTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
 case class RemoteCommitPublished(commitTx: Transaction, claimMainOutputTx: Option[Transaction], claimHtlcSuccessTxs: List[Transaction], claimHtlcTimeoutTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
-case class RevokedCommitPublished(commitTx: Transaction, claimMainOutputTx: Option[Transaction], mainPenaltyTx: Option[Transaction], claimHtlcDelayedTxs: List[Transaction], htlcPenaltyTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
+case class RevokedCommitPublished(commitTx: Transaction, claimMainOutputTx: Option[Transaction], mainPenaltyTx: Option[Transaction], htlcPenaltyTxs: List[Transaction], claimHtlcDelayedPenaltyTxs: List[Transaction], irrevocablySpent: Map[OutPoint, BinaryData])
 
 final case class DATA_WAIT_FOR_OPEN_CHANNEL(initFundee: INPUT_INIT_FUNDEE) extends Data
 final case class DATA_WAIT_FOR_ACCEPT_CHANNEL(initFunder: INPUT_INIT_FUNDER, lastSent: OpenChannel) extends Data

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -362,7 +362,7 @@ object Commitments {
 
   def revocationHash(seed: BinaryData, index: Long): BinaryData = Crypto.sha256(revocationPreimage(seed, index))
 
-  def sendCommit(commitments: Commitments, keyManager: KeyManager): (Commitments, CommitSig) = {
+  def sendCommit(commitments: Commitments, keyManager: KeyManager): (Commitments, CommitSig, Seq[TransactionWithInputInfo]) = {
     import commitments._
     commitments.remoteNextCommitInfo match {
       case Right(_) if !localHasChanges(commitments) =>
@@ -387,7 +387,7 @@ object Commitments {
           remoteNextCommitInfo = Left(WaitingForRevocation(RemoteCommit(remoteCommit.index + 1, spec, remoteCommitTx.tx.txid, remoteNextPerCommitmentPoint), commitSig, commitments.localCommit.index)),
           localChanges = localChanges.copy(proposed = Nil, signed = localChanges.proposed),
           remoteChanges = remoteChanges.copy(acked = Nil, signed = remoteChanges.acked))
-        (commitments1, commitSig)
+        (commitments1, commitSig, htlcTimeoutTxs ++ htlcSuccessTxs)
       case Left(_) =>
         throw CannotSignBeforeRevocation(commitments.channelId)
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -362,7 +362,7 @@ object Commitments {
 
   def revocationHash(seed: BinaryData, index: Long): BinaryData = Crypto.sha256(revocationPreimage(seed, index))
 
-  def sendCommit(commitments: Commitments, keyManager: KeyManager): (Commitments, CommitSig, Seq[TransactionWithInputInfo]) = {
+  def sendCommit(commitments: Commitments, keyManager: KeyManager): (Commitments, CommitSig) = {
     import commitments._
     commitments.remoteNextCommitInfo match {
       case Right(_) if !localHasChanges(commitments) =>
@@ -387,7 +387,7 @@ object Commitments {
           remoteNextCommitInfo = Left(WaitingForRevocation(RemoteCommit(remoteCommit.index + 1, spec, remoteCommitTx.tx.txid, remoteNextPerCommitmentPoint), commitSig, commitments.localCommit.index)),
           localChanges = localChanges.copy(proposed = Nil, signed = localChanges.proposed),
           remoteChanges = remoteChanges.copy(acked = Nil, signed = remoteChanges.acked))
-        (commitments1, commitSig, htlcTimeoutTxs ++ htlcSuccessTxs)
+        (commitments1, commitSig)
       case Left(_) =>
         throw CannotSignBeforeRevocation(commitments.channelId)
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -333,11 +333,9 @@ object Helpers {
       val (remoteCommitTx, _, _) = Commitments.makeRemoteTxs(keyManager, remoteCommit.index, localParams, remoteParams, commitInput, remoteCommit.remotePerCommitmentPoint, remoteCommit.spec)
       require(remoteCommitTx.tx.txid == tx.txid, "txid mismatch, cannot recompute the current remote commit tx")
 
-      val localPaymentPubkey = Generators.derivePubKey(keyManager.paymentPoint(localParams.channelKeyPath).publicKey, remoteCommit.remotePerCommitmentPoint)
       val localHtlcPubkey = Generators.derivePubKey(keyManager.htlcPoint(localParams.channelKeyPath).publicKey, remoteCommit.remotePerCommitmentPoint)
       val remoteHtlcPubkey = Generators.derivePubKey(remoteParams.htlcBasepoint, remoteCommit.remotePerCommitmentPoint)
       val localPerCommitmentPoint = keyManager.commitmentPoint(localParams.channelKeyPath, commitments.localCommit.index.toInt)
-      val localRevocationPubKey = Generators.revocationPubKey(remoteParams.revocationBasepoint, localPerCommitmentPoint)
       val remoteRevocationPubkey = Generators.revocationPubKey(keyManager.revocationPoint(localParams.channelKeyPath).publicKey, remoteCommit.remotePerCommitmentPoint)
 
       // we need to use a rather high fee for htlc-claim because we compete with the counterparty
@@ -427,9 +425,8 @@ object Helpers {
         .map(d => Scalar(d))
         .map { remotePerCommitmentSecret =>
           val remotePerCommitmentPoint = remotePerCommitmentSecret.toPoint
-
           val remoteDelayedPaymentPubkey = Generators.derivePubKey(remoteParams.delayedPaymentBasepoint, remotePerCommitmentPoint)
-          val remoteRevocationPubkey = Generators.revocationPubKey(keyManager.revocationPoint(localParams.channelKeyPath).publicKey, remotePerCommitmentSecret.toPoint)
+          val remoteRevocationPubkey = Generators.revocationPubKey(keyManager.revocationPoint(localParams.channelKeyPath).publicKey, remotePerCommitmentPoint)
           val localPubkey = Generators.derivePubKey(keyManager.paymentPoint(localParams.channelKeyPath).publicKey, remotePerCommitmentPoint)
 
           // no need to use a high fee rate for our main output (we are the only one who can spend it)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -510,9 +510,9 @@ object Helpers {
             val feeratePerKwPenalty = Globals.feeratesPerKw.get.block_1
 
             generateTx("claim-htlc-delayed-penalty")(Try {
-              val txinfo = Transactions.makeClaimDelayedOutputTx(htlcTx, Satoshi(localParams.dustLimitSatoshis), remoteRevocationPubkey, localParams.toSelfDelay, remoteDelayedPaymentPubkey, localParams.defaultFinalScriptPubKey, feeratePerKwPenalty)
+              val txinfo = Transactions.makeClaimDelayedOutputPenaltyTx(htlcTx, Satoshi(localParams.dustLimitSatoshis), remoteRevocationPubkey, localParams.toSelfDelay, remoteDelayedPaymentPubkey, localParams.defaultFinalScriptPubKey, feeratePerKwPenalty)
               val sig = keyManager.sign(txinfo, keyManager.revocationPoint(localParams.channelKeyPath), remotePerCommitmentSecret)
-              val signedTx = Transactions.addSigsRev(txinfo, sig)
+              val signedTx = Transactions.addSigs(txinfo, sig)
               // we need to make sure that the tx is indeed valid
               Transaction.correctlySpends(signedTx.tx, Seq(htlcTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
               signedTx

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -22,6 +22,7 @@ import fr.acinq.bitcoin.Script._
 import fr.acinq.bitcoin.{OutPoint, _}
 import fr.acinq.eclair.blockchain.EclairWallet
 import fr.acinq.eclair.crypto.{Generators, KeyManager}
+import fr.acinq.eclair.db.ChannelsDb
 import fr.acinq.eclair.transactions.Scripts._
 import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.transactions._
@@ -317,7 +318,7 @@ object Helpers {
         claimMainDelayedOutputTx = mainDelayedTx.map(_.tx),
         htlcSuccessTxs = htlcTxes.collect { case c: HtlcSuccessTx => c.tx },
         htlcTimeoutTxs = htlcTxes.collect { case c: HtlcTimeoutTx => c.tx },
-        claimHtlcDelayedTx = htlcDelayedTxes.map(_.tx),
+        claimHtlcDelayedTxs = htlcDelayedTxes.map(_.tx),
         irrevocablySpent = Map.empty)
     }
 
@@ -420,7 +421,7 @@ object Helpers {
       *
       * @return a [[RevokedCommitPublished]] object containing penalty transactions if the tx is a revoked commitment
       */
-    def claimRevokedRemoteCommitTxOutputs(keyManager: KeyManager, commitments: Commitments, tx: Transaction)(implicit log: LoggingAdapter): Option[RevokedCommitPublished] = {
+    def claimRevokedRemoteCommitTxOutputs(keyManager: KeyManager, commitments: Commitments, tx: Transaction, db: ChannelsDb)(implicit log: LoggingAdapter): Option[RevokedCommitPublished] = {
       import commitments._
       require(tx.txIn.size == 1, "commitment tx should have 1 input")
       val obscuredTxNumber = Transactions.decodeTxNumber(tx.txIn(0).sequence, tx.lockTime)
@@ -457,7 +458,15 @@ object Helpers {
             Transactions.addSigs(txinfo, sig)
           })
 
-          // TODO: we don't claim htlcs outputs yet for revoked transactions
+          // and finally we steal all the htlcs
+          val htlcPenalyTxs = tx.txOut.map(txOut => db.getHtlcScript(commitments.channelId, txOut.publicKeyScript)).collect {
+            case Some(htlcRedeemScript) =>
+              generateTx("htlc-penalty")(Try {
+                val txinfo = Transactions.makeHtlcPenaltyTx(tx, htlcRedeemScript, Satoshi(localParams.dustLimitSatoshis), localParams.defaultFinalScriptPubKey, feeratePerKwPenalty)
+                val sig = keyManager.sign(txinfo, keyManager.revocationPoint(localParams.channelKeyPath), remotePerCommitmentSecret)
+                Transactions.addSigs(txinfo, sig, remoteRevocationPubkey)
+              })
+          }.flatten.toList
 
           // OPTIONAL: let's check transactions are actually spendable
           //val txes = mainDelayedRevokedTx :: Nil
@@ -467,9 +476,8 @@ object Helpers {
             commitTx = tx,
             claimMainOutputTx = mainTx.map(_.tx),
             mainPenaltyTx = mainPenaltyTx.map(_.tx),
-            claimHtlcTimeoutTxs = Nil,
-            htlcTimeoutTxs = Nil,
-            htlcPenaltyTxs = Nil,
+            claimHtlcDelayedTxs = Nil,
+            htlcPenaltyTxs = htlcPenalyTxs.map(_.tx),
             irrevocablySpent = Map.empty
           )
         }
@@ -560,6 +568,42 @@ object Helpers {
         }).toSet.flatten
       }
 
+    def spendDelayedHtlcTxOutputs(keyManager: KeyManager, commitments: Commitments, revokedCommitPublished: RevokedCommitPublished, htlcTx: Transaction)(implicit log: LoggingAdapter): (RevokedCommitPublished, Option[Transaction]) = {
+      // Let's assume that htlcTx is an HtlcSuccessTx or HtlcTimeoutTx and try to generate a tx spending its output using a revocation key
+      import commitments._
+      val tx = revokedCommitPublished.commitTx
+      val obscuredTxNumber = Transactions.decodeTxNumber(tx.txIn(0).sequence, tx.lockTime)
+      // this tx has been published by remote, so we need to invert local/remote params
+      val txnumber = Transactions.obscuredCommitTxNumber(obscuredTxNumber, !localParams.isFunder, remoteParams.paymentBasepoint, keyManager.paymentPoint(localParams.channelKeyPath).publicKey)
+      // now we know what commit number this tx is referring to, we can derive the commitment point from the shachain
+      remotePerCommitmentSecrets.getHash(0xFFFFFFFFFFFFL - txnumber)
+        .map(d => Scalar(d))
+        .flatMap { remotePerCommitmentSecret =>
+          val remotePerCommitmentPoint = remotePerCommitmentSecret.toPoint
+          val remoteDelayedPaymentPubkey = Generators.derivePubKey(remoteParams.delayedPaymentBasepoint, remotePerCommitmentPoint)
+          val remoteRevocationPubkey = Generators.revocationPubKey(keyManager.revocationPoint(localParams.channelKeyPath).publicKey, remotePerCommitmentSecret.toPoint)
+
+          // we need to use a high fee here for punishment txes because after a delay they can be spent by the counterparty
+          val feeratePerKwPenalty = Globals.feeratesPerKw.get.block_1
+
+          Try {
+            val txinfo = Transactions.makeClaimDelayedOutputTx(htlcTx, Satoshi(localParams.dustLimitSatoshis), remoteRevocationPubkey, localParams.toSelfDelay, remoteDelayedPaymentPubkey, localParams.defaultFinalScriptPubKey, feeratePerKwPenalty)
+            val sig = keyManager.sign(txinfo, keyManager.revocationPoint(localParams.channelKeyPath), remotePerCommitmentSecret)
+            val signedTx = Transactions.addSigs(txinfo, sig)
+            // we need to make sure that the tx is indeed valid
+            Transaction.correctlySpends(signedTx.tx, Seq(htlcTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+            log.info(s"generated penalty tx spending output of HtlcSuccess/HtlcTimeout txid=${htlcTx.txid}")
+            signedTx
+          }.toOption
+        }  match {
+        case Some(tx) =>
+          val revokedCommitPublished1 = revokedCommitPublished.copy(claimHtlcDelayedTxs = revokedCommitPublished.claimHtlcDelayedTxs :+ tx.tx)
+          (revokedCommitPublished1, Some(tx.tx))
+        case None =>
+          (revokedCommitPublished, None)
+      }
+    }
+
     /**
       * In CLOSING state, when we are notified that a transaction has been confirmed, we check if this tx belongs in the
       * local commit scenario and keep track of it.
@@ -581,7 +625,7 @@ object Helpers {
         val spendsTheCommitTx = localCommitPublished.commitTx.txid == outPoint.txid
         // is the tx one of our 3rd stage delayed txes? (a 3rd stage tx is a tx spending the output of an htlc tx, which
         // is itself spending the output of the commitment tx)
-        val is3rdStageDelayedTx = localCommitPublished.claimHtlcDelayedTx.map(_.txid).contains(outPoint.txid)
+        val is3rdStageDelayedTx = localCommitPublished.claimHtlcDelayedTxs.map(_.txid).contains(outPoint.txid)
         isCommitTx || spendsTheCommitTx || is3rdStageDelayedTx
       }
       // then we add the relevant outpoints to the map keeping track of which txid spends which outpoint
@@ -632,8 +676,10 @@ object Helpers {
         val isCommitTx = revokedCommitPublished.commitTx.txid == tx.txid
         // does the tx spend an output of the local commitment tx?
         val spendsTheCommitTx = revokedCommitPublished.commitTx.txid == outPoint.txid
-        // TODO: we don't claim htlcs outputs yet for revoked transactions
-        isCommitTx || spendsTheCommitTx
+        // is the tx one of our 3rd stage delayed txes? (a 3rd stage tx is a tx spending the output of an htlc tx, which
+        // is itself spending the output of the commitment tx)
+        val is3rdStageDelayedTx = revokedCommitPublished.claimHtlcDelayedTxs.map(_.txid).contains(outPoint.txid)
+        isCommitTx || spendsTheCommitTx || is3rdStageDelayedTx
       }
       // then we add the relevant outpoints to the map keeping track of which txid spends which outpoint
       revokedCommitPublished.copy(irrevocablySpent = revokedCommitPublished.irrevocablySpent ++ relevantOutpoints.map(o => (o -> tx.txid)).toMap)
@@ -648,13 +694,13 @@ object Helpers {
       * @return
       */
     def isLocalCommitDone(localCommitPublished: LocalCommitPublished) = {
-      // is the commitment tx buried? (we need to check this because we may not have nay outputs)
+      // is the commitment tx buried? (we need to check this because we may not have any outputs)
       val isCommitTxConfirmed = localCommitPublished.irrevocablySpent.values.toSet.contains(localCommitPublished.commitTx.txid)
       // are there remaining spendable outputs from the commitment tx? we just subtract all known spent outputs from the ones we control
       val commitOutputsSpendableByUs = (localCommitPublished.claimMainDelayedOutputTx.toSeq ++ localCommitPublished.htlcSuccessTxs ++ localCommitPublished.htlcTimeoutTxs)
         .flatMap(_.txIn.map(_.outPoint)).toSet -- localCommitPublished.irrevocablySpent.keys
       // which htlc delayed txes can we expect to be confirmed?
-      val unconfirmedHtlcDelayedTxes = localCommitPublished.claimHtlcDelayedTx
+      val unconfirmedHtlcDelayedTxes = localCommitPublished.claimHtlcDelayedTxs
         .filter(tx => (tx.txIn.map(_.outPoint.txid).toSet -- localCommitPublished.irrevocablySpent.values).isEmpty) // only the txes which parents are already confirmed may get confirmed (note that this also eliminates outputs that have been double-spent by a competing tx)
         .filterNot(tx => localCommitPublished.irrevocablySpent.values.toSet.contains(tx.txid)) // has the tx already been confirmed?
       isCommitTxConfirmed && commitOutputsSpendableByUs.isEmpty && unconfirmedHtlcDelayedTxes.isEmpty
@@ -668,7 +714,7 @@ object Helpers {
       * @return
       */
     def isRemoteCommitDone(remoteCommitPublished: RemoteCommitPublished) = {
-      // is the commitment tx buried? (we need to check this because we may not have nay outputs)
+      // is the commitment tx buried? (we need to check this because we may not have any outputs)
       val isCommitTxConfirmed = remoteCommitPublished.irrevocablySpent.values.toSet.contains(remoteCommitPublished.commitTx.txid)
       // are there remaining spendable outputs from the commitment tx?
       val commitOutputsSpendableByUs = (remoteCommitPublished.claimMainOutputTx.toSeq ++ remoteCommitPublished.claimHtlcSuccessTxs ++ remoteCommitPublished.claimHtlcTimeoutTxs)
@@ -684,13 +730,16 @@ object Helpers {
       * @return
       */
     def isRevokedCommitDone(revokedCommitPublished: RevokedCommitPublished) = {
-      // is the commitment tx buried? (we need to check this because we may not have nay outputs)
+      // is the commitment tx buried? (we need to check this because we may not have any outputs)
       val isCommitTxConfirmed = revokedCommitPublished.irrevocablySpent.values.toSet.contains(revokedCommitPublished.commitTx.txid)
       // are there remaining spendable outputs from the commitment tx?
-      val commitOutputsSpendableByUs = (revokedCommitPublished.claimMainOutputTx.toSeq ++ revokedCommitPublished.mainPenaltyTx)
+      val commitOutputsSpendableByUs = (revokedCommitPublished.claimMainOutputTx.toSeq ++ revokedCommitPublished.mainPenaltyTx ++ revokedCommitPublished.htlcPenaltyTxs)
         .flatMap(_.txIn.map(_.outPoint)).toSet -- revokedCommitPublished.irrevocablySpent.keys
-      // TODO: we don't claim htlcs outputs yet for revoked transactions
-      isCommitTxConfirmed && commitOutputsSpendableByUs.isEmpty
+      // which htlc delayed txes can we expect to be confirmed?
+      val unconfirmedHtlcDelayedTxes = revokedCommitPublished.claimHtlcDelayedTxs
+        .filter(tx => (tx.txIn.map(_.outPoint.txid).toSet -- revokedCommitPublished.irrevocablySpent.values).isEmpty) // only the txes which parents are already confirmed may get confirmed (note that this also eliminates outputs that have been double-spent by a competing tx)
+        .filterNot(tx => revokedCommitPublished.irrevocablySpent.values.toSet.contains(tx.txid)) // has the tx already been confirmed?
+      isCommitTxConfirmed && commitOutputsSpendableByUs.isEmpty && unconfirmedHtlcDelayedTxes.isEmpty
     }
 
     /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -27,4 +27,8 @@ trait ChannelsDb {
 
   def listChannels(): Seq[HasCommitments]
 
+  def addOrUpdateHtlcScript(channelId: BinaryData, scriptHash: BinaryData, script: BinaryData)
+
+  def getHtlcScript(channelId: BinaryData, scriptHash: BinaryData): Option[BinaryData]
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -27,8 +27,8 @@ trait ChannelsDb {
 
   def listChannels(): Seq[HasCommitments]
 
-  def addOrUpdateHtlcScript(channelId: BinaryData, scriptHash: BinaryData, script: BinaryData)
+  def addOrUpdateHtlcInfo(channelId: BinaryData, commitmentNumber: Long, paymentHash: BinaryData, cltvExpiry: Long)
 
-  def getHtlcScript(channelId: BinaryData, scriptHash: BinaryData): Option[BinaryData]
+  def listHtlcHtlcInfos(channelId: BinaryData, commitmentNumber: Long): Seq[(BinaryData, Long)]
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
@@ -264,9 +264,10 @@ object Scripts {
     ScriptWitness(localSig :: BinaryData.empty :: htlcReceivedScript :: Nil)
 
   /**
-    * Spends an HTLC output using a revocation sig. Htlc script can be htlcOfferedScript or htlcReceivedScript
+    * This witness script spends (steals) a [[htlcOffered]] or [[htlcReceived]] output using a revocation key as a punishment
+    * for having published a revoked transaction
     */
-  def witnessHtlcWithRevocationSig(revocationSig: BinaryData, revocationPubkey: BinaryData, htlcScript: BinaryData) =
-    ScriptWitness(revocationSig :: revocationPubkey :: htlcScript :: Nil)
+  def witnessHtlcWithRevocationSig(revocationSig: BinaryData, revocationPubkey: PublicKey, htlcScript: BinaryData) =
+    ScriptWitness(revocationSig :: revocationPubkey.toBin :: htlcScript :: Nil)
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
@@ -263,4 +263,10 @@ object Scripts {
   def witnessClaimHtlcTimeoutFromCommitTx(localSig: BinaryData, htlcReceivedScript: BinaryData) =
     ScriptWitness(localSig :: BinaryData.empty :: htlcReceivedScript :: Nil)
 
+  /**
+    * Spends an HTLC output using a revocation sig. Htlc script can be htlcOfferedScript or htlcReceivedScript
+    */
+  def witnessHtlcWithRevocationSig(revocationSig: BinaryData, revocationPubkey: BinaryData, htlcScript: BinaryData) =
+    ScriptWitness(revocationSig :: revocationPubkey :: htlcScript :: Nil)
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
@@ -217,8 +217,8 @@ object ChannelCodecs extends Logging {
     ("commitTx" | txCodec) ::
       ("claimMainOutputTx" | optional(bool, txCodec)) ::
       ("mainPenaltyTx" | optional(bool, txCodec)) ::
-      ("claimHtlcDelayedTxs" | listOfN(uint16, txCodec)) ::
       ("htlcPenaltyTxs" | listOfN(uint16, txCodec)) ::
+      ("claimHtlcDelayedPenaltyTxs" | listOfN(uint16, txCodec)) ::
       ("spent" | spentMapCodec)).as[RevokedCommitPublished]
 
   val DATA_WAIT_FOR_FUNDING_CONFIRMED_Codec: Codec[DATA_WAIT_FOR_FUNDING_CONFIRMED] = (

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
@@ -217,8 +217,7 @@ object ChannelCodecs extends Logging {
     ("commitTx" | txCodec) ::
       ("claimMainOutputTx" | optional(bool, txCodec)) ::
       ("mainPenaltyTx" | optional(bool, txCodec)) ::
-      ("claimHtlcTimeoutTxs" | listOfN(uint16, txCodec)) ::
-      ("htlcTimeoutTxs" | listOfN(uint16, txCodec)) ::
+      ("claimHtlcDelayedTxs" | listOfN(uint16, txCodec)) ::
       ("htlcPenaltyTxs" | listOfN(uint16, txCodec)) ::
       ("spent" | spentMapCodec)).as[RevokedCommitPublished]
 

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -43,6 +43,7 @@
     </appender-->
 
     <!--logger name="fr.acinq.eclair.channel" level="DEBUG"/-->
+    <logger name="fr.acinq.eclair.router" level="WARN"/>
 
     <root level="INFO">
         <!--appender-ref ref="FILE"/>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -722,18 +722,26 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       alice2bob.expectMsgType[Error]
 
       val mainTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      val penaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
+      val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
+      val htlc1PenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
+      val htlc2PenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(revokedTx))
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(mainTx))
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // main-penalty
+      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // htlc1-penalty
+      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // htlc2-penalty
       alice2blockchain.expectNoMsg(1 second)
 
       Transaction.correctlySpends(mainTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(penaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+      Transaction.correctlySpends(mainPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+      Transaction.correctlySpends(htlc1PenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+      Transaction.correctlySpends(htlc2PenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
-      // two main outputs are 300 000 and 200 000
+      // two main outputs are 300 000 and 200 000, htlcs are 300 000 and 200 000
       assert(mainTx.txOut(0).amount == Satoshi(284950))
-      assert(penaltyTx.txOut(0).amount == Satoshi(195170))
+      assert(mainPenaltyTx.txOut(0).amount == Satoshi(195170))
+      assert(htlc1PenaltyTx.txOut(0).amount == Satoshi(194230))
+      assert(htlc2PenaltyTx.txOut(0).amount == Satoshi(294230))
 
       awaitCond(alice.stateName == CLOSING)
       assert(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 1)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -43,7 +43,8 @@ class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
   override def withFixture(test: OneArgTest) = {
     val setup = init()
     import setup._
-    within(30 seconds) {
+
+    val bobCommitTxes = within(30 seconds) {
       reachNormal(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer)
       val bobCommitTxes: List[PublishableTxs] = (for (amt <- List(100000000, 200000000, 300000000)) yield {
         val (r, htlc) = addHtlc(amt, alice, bob, alice2bob, bob2alice)
@@ -69,9 +70,9 @@ class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       // - revoked commit
       // and we want to be able to test the different scenarii.
       // Hence the NORMAL->CLOSING transition will occur in the individual tests.
-
-      test((alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer, bobCommitTxes))
+      bobCommitTxes
     }
+    test((alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer, bobCommitTxes))
   }
 
   def mutualClose(alice: TestFSMRef[State, Data, Channel],

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -25,8 +25,8 @@ import akka.pattern.pipe
 import akka.testkit.{TestKit, TestProbe}
 import com.google.common.net.HostAndPort
 import com.typesafe.config.{Config, ConfigFactory}
-import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{Base58, Base58Check, BinaryData, Block, Crypto, MilliSatoshi, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHDATA, Satoshi, Script}
+import fr.acinq.bitcoin.Crypto.{PublicKey, sha256}
+import fr.acinq.bitcoin.{Base58, Base58Check, BinaryData, Block, Crypto, MilliSatoshi, OP_CHECKSIG, OP_DUP, OP_EQUAL, OP_EQUALVERIFY, OP_HASH160, OP_PUSHDATA, Satoshi, Script, ScriptFlags, Transaction}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, BitcoinJsonRPCClient, ExtendedBitcoinClient}
 import fr.acinq.eclair.blockchain.{Watch, WatchConfirmed}
 import fr.acinq.eclair.channel.Register.Forward
@@ -35,8 +35,10 @@ import fr.acinq.eclair.crypto.Sphinx.ErrorPacket
 import fr.acinq.eclair.io.Peer.Disconnect
 import fr.acinq.eclair.io.{NodeURI, Peer}
 import fr.acinq.eclair.payment.PaymentLifecycle.{State => _, _}
-import fr.acinq.eclair.payment.PaymentRequest
+import fr.acinq.eclair.payment.{LocalPaymentHandler, PaymentRequest}
 import fr.acinq.eclair.router.{Announcements, AnnouncementsBatchValidationSpec}
+import fr.acinq.eclair.transactions.Transactions
+import fr.acinq.eclair.transactions.Transactions.{HtlcSuccessTx, HtlcTimeoutTx}
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{Globals, Kit, Setup}
 import grizzled.slf4j.Logging
@@ -138,14 +140,18 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
     val commonConfig = ConfigFactory.parseMap(Map("eclair.chain" -> "regtest", "eclair.spv" -> false, "eclair.server.public-ips.1" -> "localhost", "eclair.bitcoind.port" -> 28333, "eclair.bitcoind.rpcport" -> 28332, "eclair.bitcoind.zmq" -> "tcp://127.0.0.1:28334", "eclair.router-broadcast-interval" -> "2 second", "eclair.auto-reconnect" -> false))
     instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.node-alias" -> "A", "eclair.delay-blocks" -> 130, "eclair.server.port" -> 29730, "eclair.api.port" -> 28080, "eclair.channel-flags" -> 0)).withFallback(commonConfig)) // A's channels are private
     instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.node-alias" -> "B", "eclair.delay-blocks" -> 131, "eclair.server.port" -> 29731, "eclair.api.port" -> 28081)).withFallback(commonConfig))
-    instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.delay-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082)).withFallback(commonConfig))
+    instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.delay-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
     instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.node-alias" -> "D", "eclair.delay-blocks" -> 133, "eclair.server.port" -> 29733, "eclair.api.port" -> 28083)).withFallback(commonConfig))
     instantiateEclairNode("E", ConfigFactory.parseMap(Map("eclair.node-alias" -> "E", "eclair.delay-blocks" -> 134, "eclair.server.port" -> 29734, "eclair.api.port" -> 28084)).withFallback(commonConfig))
     instantiateEclairNode("F1", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F1", "eclair.delay-blocks" -> 135, "eclair.server.port" -> 29735, "eclair.api.port" -> 28085, "eclair.payment-handler" -> "noop")).withFallback(commonConfig)) // NB: eclair.payment-handler = noop allows us to manually fulfill htlcs
     instantiateEclairNode("F2", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F2", "eclair.delay-blocks" -> 136, "eclair.server.port" -> 29736, "eclair.api.port" -> 28086, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
     instantiateEclairNode("F3", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F3", "eclair.delay-blocks" -> 137, "eclair.server.port" -> 29737, "eclair.api.port" -> 28087, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
     instantiateEclairNode("F4", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F4", "eclair.delay-blocks" -> 138, "eclair.server.port" -> 29738, "eclair.api.port" -> 28088, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
-    instantiateEclairNode("F5", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F5", "eclair.delay-blocks" -> 139, "eclair.server.port" -> 29739, "eclair.api.port" -> 28089)).withFallback(commonConfig))
+    instantiateEclairNode("F5", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F5", "eclair.delay-blocks" -> 139, "eclair.server.port" -> 29739, "eclair.api.port" -> 28089, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
+
+    // by default C has a normal payment handler, but this can be overriden in tests
+    val paymentHandlerC = nodes("C").system.actorOf(LocalPaymentHandler.props(nodes("C").nodeParams))
+    nodes("C").paymentHandler ! paymentHandlerC
   }
 
   def connect(node1: Kit, node2: Kit, fundingSatoshis: Long, pushMsat: Long) = {
@@ -386,6 +392,9 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
 
   test("propagate a fulfill upstream when a downstream htlc is redeemed on-chain (local commit)") {
     val sender = TestProbe()
+    // we subscribe to C's channel state transitions
+    val stateListener = TestProbe()
+    nodes("C").system.eventStream.subscribe(stateListener.ref, classOf[ChannelStateChanged])
     // first we make sure we are in sync with current blockchain height
     sender.send(bitcoincli, BitcoinReq("getblockcount"))
     val currentBlockCount = sender.expectMsgType[JValue](10 seconds).extract[Long]
@@ -451,11 +460,19 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
       val receivedByC = res.filter(_ \ "address" == JString(finalAddressC)).flatMap(_ \ "txids" \\ classOf[JString])
       (receivedByC diff previouslyReceivedByC).size == 1
     }, max = 30 seconds, interval = 1 second)
+    // we generate blocks to make tx confirm
+    sender.send(bitcoincli, BitcoinReq("generate", 2))
+    sender.expectMsgType[JValue](10 seconds)
+    // and we wait for C'channel to close
+    awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     awaitAnnouncements(nodes.filter(_._1 == "A"), 8, 9, 20)
   }
 
   test("propagate a fulfill upstream when a downstream htlc is redeemed on-chain (remote commit)") {
     val sender = TestProbe()
+    // we subscribe to C's channel state transitions
+    val stateListener = TestProbe()
+    nodes("C").system.eventStream.subscribe(stateListener.ref, classOf[ChannelStateChanged])
     // first we make sure we are in sync with current blockchain height
     sender.send(bitcoincli, BitcoinReq("getblockcount"))
     val currentBlockCount = sender.expectMsgType[JValue](10 seconds).extract[Long]
@@ -517,11 +534,19 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
       val receivedByC = res.filter(_ \ "address" == JString(finalAddressC)).flatMap(_ \ "txids" \\ classOf[JString])
       (receivedByC diff previouslyReceivedByC).size == 1
     }, max = 30 seconds, interval = 1 second)
+    // we generate blocks to make tx confirm
+    sender.send(bitcoincli, BitcoinReq("generate", 2))
+    sender.expectMsgType[JValue](10 seconds)
+    // and we wait for C'channel to close
+    awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     awaitAnnouncements(nodes.filter(_._1 == "A"), 7, 8, 18)
   }
 
   test("propagate a failure upstream when a downstream htlc times out (local commit)") {
     val sender = TestProbe()
+    // we subscribe to C's channel state transitions
+    val stateListener = TestProbe()
+    nodes("C").system.eventStream.subscribe(stateListener.ref, classOf[ChannelStateChanged])
     // first we make sure we are in sync with current blockchain height
     sender.send(bitcoincli, BitcoinReq("getblockcount"))
     val currentBlockCount = sender.expectMsgType[JValue](10 seconds).extract[Long]
@@ -569,11 +594,19 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
       val receivedByC = res.filter(_ \ "address" == JString(finalAddressC)).flatMap(_ \ "txids" \\ classOf[JString])
       (receivedByC diff previouslyReceivedByC).size == 2
     }, max = 30 seconds, interval = 1 second)
+    // we generate blocks to make tx confirm
+    sender.send(bitcoincli, BitcoinReq("generate", 2))
+    sender.expectMsgType[JValue](10 seconds)
+    // and we wait for C'channel to close
+    awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     awaitAnnouncements(nodes.filter(_._1 == "A"), 6, 7, 16)
   }
 
   test("propagate a failure upstream when a downstream htlc times out (remote commit)") {
     val sender = TestProbe()
+    // we subscribe to C's channel state transitions
+    val stateListener = TestProbe()
+    nodes("C").system.eventStream.subscribe(stateListener.ref, classOf[ChannelStateChanged])
     // first we make sure we are in sync with current blockchain height
     sender.send(bitcoincli, BitcoinReq("getblockcount"))
     val currentBlockCount = sender.expectMsgType[JValue](10 seconds).extract[Long]
@@ -624,37 +657,97 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
       val receivedByC = res.filter(_ \ "address" == JString(finalAddressC)).flatMap(_ \ "txids" \\ classOf[JString])
       (receivedByC diff previouslyReceivedByC).size == 2
     }, max = 30 seconds, interval = 1 second)
+    // we generate blocks to make tx confirm
+    sender.send(bitcoincli, BitcoinReq("generate", 2))
+    sender.expectMsgType[JValue](10 seconds)
+    // and we wait for C'channel to close
+    awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     awaitAnnouncements(nodes.filter(_._1 == "A"), 5, 6, 14)
   }
 
   test("punish a node that has published a revoked commit tx") {
     val sender = TestProbe()
-    val listener = TestProbe()
+    // we subscribe to C's channel state transitions
+    val stateListener = TestProbe()
+    nodes("C").system.eventStream.subscribe(stateListener.ref, classOf[ChannelStateChanged])
     // we use this to get commitments
-    nodes("F5").system.eventStream.subscribe(listener.ref, classOf[ChannelSignatureReceived])
+    val sigListener = TestProbe()
+    nodes("F5").system.eventStream.subscribe(sigListener.ref, classOf[ChannelSignatureReceived])
+    // we use this to control when to fulfill htlcs, setup is as follow : noop-handler ---> forward-handler ---> payment-handler
+    val forwardHandlerC = TestProbe()
+    nodes("C").paymentHandler ! forwardHandlerC.ref
+    val forwardHandlerF = TestProbe()
+    nodes("F5").paymentHandler ! forwardHandlerF.ref
+    // this is the actual payment handler that we will forward requests to
+    val paymentHandlerC = nodes("C").system.actorOf(LocalPaymentHandler.props(nodes("C").nodeParams))
+    val paymentHandlerF = nodes("F5").system.actorOf(LocalPaymentHandler.props(nodes("F5").nodeParams))
     // first we make sure we are in sync with current blockchain height
     sender.send(bitcoincli, BitcoinReq("getblockcount"))
     val currentBlockCount = sender.expectMsgType[JValue](10 seconds).extract[Long]
     awaitCond(Globals.blockCount.get() == currentBlockCount, max = 20 seconds, interval = 1 second)
     // first we send 3 mBTC to F so that it has a balance
     val amountMsat = MilliSatoshi(300000000L)
-    sender.send(nodes("F5").paymentHandler, ReceivePayment(Some(amountMsat), "1 coffee"))
+    sender.send(paymentHandlerF, ReceivePayment(Some(amountMsat), "1 coffee"))
     val pr = sender.expectMsgType[PaymentRequest]
-    val sendReq = SendPayment(300000000L, pr.paymentHash, nodes("F5").nodeParams.nodeId)
+    val sendReq = SendPayment(300000000L, pr.paymentHash, pr.nodeId)
     sender.send(nodes("A").paymentInitiator, sendReq)
+    // we forward the htlc to the payment handler
+    forwardHandlerF.expectMsgType[UpdateAddHtlc]
+    forwardHandlerF.forward(paymentHandlerF)
+    sigListener.expectMsgType[ChannelSignatureReceived]
+    sigListener.expectMsgType[ChannelSignatureReceived]
     sender.expectMsgType[PaymentSucceeded]
-    // we now send some more money to F so that it creates a new commitment tx
-    val amountMsat1 = MilliSatoshi(100000000L)
-    sender.send(nodes("F5").paymentHandler, ReceivePayment(Some(amountMsat1), "1 coffee"))
-    val pr1 = sender.expectMsgType[PaymentRequest]
-    val sendReq1 = SendPayment(100000000L, pr1.paymentHash, nodes("F5").nodeParams.nodeId)
-    sender.send(nodes("A").paymentInitiator, sendReq1)
-    sender.expectMsgType[PaymentSucceeded]
-    // F5 must have received exactly 4 signatures
-    val commitmentsF = for (_ <- 0 until 4) yield listener.expectMsgType[ChannelSignatureReceived].commitments
-    listener.expectNoMsg(1 second)
+    // we now send a few htlcs C->F and F->C in order to obtain a commitments with multiple htlcs
+    def send(amountMsat: Long, paymentHandler: ActorRef, paymentInitiator: ActorRef) = {
+      sender.send(paymentHandler, ReceivePayment(Some(MilliSatoshi(amountMsat)), "1 coffee"))
+      val pr = sender.expectMsgType[PaymentRequest]
+      val sendReq = SendPayment(amountMsat, pr.paymentHash, pr.nodeId)
+      sender.send(paymentInitiator, sendReq)
+    }
+    val buffer = TestProbe()
+    send(100000000, paymentHandlerF, nodes("C").paymentInitiator) // will be left pending
+    forwardHandlerF.expectMsgType[UpdateAddHtlc]
+    forwardHandlerF.forward(buffer.ref)
+    sigListener.expectMsgType[ChannelSignatureReceived]
+    send(110000000, paymentHandlerF, nodes("C").paymentInitiator) // will be left pending
+    forwardHandlerF.expectMsgType[UpdateAddHtlc]
+    forwardHandlerF.forward(buffer.ref)
+    sigListener.expectMsgType[ChannelSignatureReceived]
+    send(120000000, paymentHandlerC, nodes("F5").paymentInitiator)
+    forwardHandlerC.expectMsgType[UpdateAddHtlc]
+    forwardHandlerC.forward(buffer.ref)
+    sigListener.expectMsgType[ChannelSignatureReceived]
+    send(130000000, paymentHandlerC, nodes("F5").paymentInitiator)
+    forwardHandlerC.expectMsgType[UpdateAddHtlc]
+    forwardHandlerC.forward(buffer.ref)
+    val commitmentsF = sigListener.expectMsgType[ChannelSignatureReceived].commitments
+    sigListener.expectNoMsg(1 second)
+    // in this commitment, both parties should have a main output, and there are four pending htlcs
+    val localCommitF = commitmentsF.localCommit.publishableTxs
+    assert(localCommitF.commitTx.tx.txOut.size === 6)
+    val htlcTimeoutTxs = localCommitF.htlcTxsAndSigs.collect { case h@HtlcTxAndSigs(_: HtlcTimeoutTx, _, _) => h }
+    val htlcSuccessTxs = localCommitF.htlcTxsAndSigs.collect { case h@HtlcTxAndSigs(_: HtlcSuccessTx, _, _) => h }
+    assert(htlcTimeoutTxs.size === 2)
+    assert(htlcSuccessTxs.size === 2)
+    // we fulfill htlcs to get the preimagse
+    buffer.expectMsgType[UpdateAddHtlc]
+    buffer.forward(paymentHandlerF)
+    sigListener.expectMsgType[ChannelSignatureReceived]
+    val preimage1 = sender.expectMsgType[PaymentSucceeded].paymentPreimage
+    buffer.expectMsgType[UpdateAddHtlc]
+    buffer.forward(paymentHandlerF)
+    sigListener.expectMsgType[ChannelSignatureReceived]
+    sender.expectMsgType[PaymentSucceeded].paymentPreimage
+    buffer.expectMsgType[UpdateAddHtlc]
+    buffer.forward(paymentHandlerC)
+    sigListener.expectMsgType[ChannelSignatureReceived]
+    sender.expectMsgType[PaymentSucceeded].paymentPreimage
+    buffer.expectMsgType[UpdateAddHtlc]
+    buffer.forward(paymentHandlerC)
+    sigListener.expectMsgType[ChannelSignatureReceived]
+    sender.expectMsgType[PaymentSucceeded].paymentPreimage
     // this also allows us to get the channel id
-    val channelId = commitmentsF.head.channelId
+    val channelId = commitmentsF.channelId
     // we also retrieve C's default final address
     sender.send(nodes("C").register, Forward(channelId, CMD_GETSTATEDATA))
     val finalAddressC = scriptPubKeyToAddress(sender.expectMsgType[DATA_NORMAL].commitments.localParams.defaultFinalScriptPubKey)
@@ -662,18 +755,34 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
     sender.send(bitcoincli, BitcoinReq("listreceivedbyaddress", 0))
     val res = sender.expectMsgType[JValue](10 seconds)
     val previouslyReceivedByC = res.filter(_ \ "address" == JString(finalAddressC)).flatMap(_ \ "txids" \\ classOf[JString])
-    // then we publish F's 3rd commitment (both parties have a main output and there is also a pending htlc)
-    val localCommitF = commitmentsF(2).localCommit.publishableTxs
-    assert(localCommitF.commitTx.tx.txOut.size == 3)
-    sender.send(bitcoincli, BitcoinReq("sendrawtransaction", localCommitF.commitTx.tx.toString()))
+    // F will publish the commitment above, which is now revoked
+    val revokedCommitTx = localCommitF.commitTx.tx
+    val htlcSuccess = Transactions.addSigs(htlcSuccessTxs.head.txinfo.asInstanceOf[HtlcSuccessTx], htlcSuccessTxs.head.localSig, htlcSuccessTxs.head.remoteSig, preimage1).tx
+    val htlcTimeout = Transactions.addSigs(htlcTimeoutTxs.head.txinfo.asInstanceOf[HtlcTimeoutTx], htlcTimeoutTxs.head.localSig, htlcTimeoutTxs.head.remoteSig).tx
+    Transaction.correctlySpends(htlcSuccess, Seq(revokedCommitTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(htlcTimeout, Seq(revokedCommitTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    // we then generate blocks to make the htlc timeout (nothing will happen in the channel because all of them have already been fulfilled)
+    sender.send(bitcoincli, BitcoinReq("generate", 20))
+    sender.expectMsgType[JValue](10 seconds)
+    // then we publish F's revoked transactions
+    sender.send(bitcoincli, BitcoinReq("sendrawtransaction", revokedCommitTx.toString()))
+    sender.expectMsgType[JValue](10000 seconds)
+    sender.send(bitcoincli, BitcoinReq("sendrawtransaction", htlcSuccess.toString()))
+    sender.expectMsgType[JValue](10000 seconds)
+    sender.send(bitcoincli, BitcoinReq("sendrawtransaction", htlcTimeout.toString()))
     sender.expectMsgType[JValue](10000 seconds)
     // at this point C should have 3 recv transactions: its previous main output, and F's main and htlc output (taken as punishment)
     awaitCond({
       sender.send(bitcoincli, BitcoinReq("listreceivedbyaddress", 0))
       val res = sender.expectMsgType[JValue](10 seconds)
       val receivedByC = res.filter(_ \ "address" == JString(finalAddressC)).flatMap(_ \ "txids" \\ classOf[JString])
-      (receivedByC diff previouslyReceivedByC).size == 3
+      (receivedByC diff previouslyReceivedByC).size == 6
     }, max = 30 seconds, interval = 1 second)
+    // we generate blocks to make tx confirm
+    sender.send(bitcoincli, BitcoinReq("generate", 2))
+    sender.expectMsgType[JValue](10 seconds)
+    // and we wait for C'channel to close
+    awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     // this will remove the channel
     awaitAnnouncements(nodes.filter(_._1 == "A"), 4, 5, 12)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -119,6 +119,20 @@ class TransactionsSpec extends FunSuite {
     }
 
     {
+      // HtlcPenaltyTx
+      // first we create a fake commitTx tx, containing only the output that will be spent by the ClaimHtlcSuccessTx
+      val paymentPreimage = BinaryData("42" * 32)
+      val htlc = UpdateAddHtlc("00" * 32, 0, Satoshi(20000).amount * 1000, sha256(paymentPreimage), expiry = 400144, BinaryData.empty)
+      val redeemScript = htlcReceived(localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, localRevocationPriv.publicKey, ripemd160(htlc.paymentHash), htlc.expiry)
+      val pubKeyScript = write(pay2wsh(redeemScript))
+      val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(htlc.amountMsat / 1000), pubKeyScript) :: Nil, lockTime = 0)
+      val htlcPenaltyTx = makeHtlcPenaltyTx(commitTx, Script.write(redeemScript), localDustLimit, finalPubKeyScript, feeratePerKw)
+      // we use dummy signatures to compute the weight
+      val weight = Transaction.weight(addSigs(htlcPenaltyTx, "bb" * 71, localRevocationPriv.publicKey).tx)
+      assert(htlcPenaltyWeight == weight)
+    }
+
+    {
       // ClaimHtlcSuccessTx
       // first we create a fake commitTx tx, containing only the output that will be spent by the ClaimHtlcSuccessTx
       val paymentPreimage = BinaryData("42" * 32)
@@ -276,30 +290,20 @@ class TransactionsSpec extends FunSuite {
 
     {
       // remote spends offered HTLC output with revocation key
-      val script = Scripts.htlcOffered(localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, localRevocationPriv.publicKey, Crypto.ripemd160(htlc1.paymentHash))
-      val index = commitTx.tx.txOut.indexWhere(_.publicKeyScript == Script.write(Script.pay2wsh(script)))
-      val tx = Transaction(
-        version = 2,
-        txIn = TxIn(OutPoint(commitTx.tx, index), signatureScript = Nil, sequence = TxIn.SEQUENCE_FINAL) :: Nil,
-        txOut = TxOut(commitTx.tx.txOut(index).amount, Script.pay2wpkh(remotePaymentPriv.publicKey)) :: Nil,
-        lockTime = 0)
-      val sig = Transaction.signInput(tx, 0, script, SIGHASH_ALL, commitTx.tx.txOut(index).amount, SigVersion.SIGVERSION_WITNESS_V0, localRevocationPriv)
-      val tx1 = tx.updateWitness(0, ScriptWitness(sig :: localRevocationPriv.publicKey.toBin :: Script.write(script) :: Nil))
-      Transaction.correctlySpends(tx1, Seq(commitTx.tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+      val script = Script.write(Scripts.htlcOffered(localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, localRevocationPriv.publicKey, Crypto.ripemd160(htlc1.paymentHash)))
+      val htlcPenaltyTx = makeHtlcPenaltyTx(commitTx.tx, script, localDustLimit, finalPubKeyScript, feeratePerKw)
+      val sig = sign(htlcPenaltyTx, localRevocationPriv)
+      val signed = addSigs(htlcPenaltyTx, sig, localRevocationPriv.publicKey)
+      assert(checkSpendable(signed).isSuccess)
     }
 
     {
       // remote spends received HTLC output with revocation key
-      val script = Scripts.htlcReceived(localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, localRevocationPriv.publicKey, Crypto.ripemd160(htlc2.paymentHash), htlc2.expiry)
-      val index = commitTx.tx.txOut.indexWhere(_.publicKeyScript == Script.write(Script.pay2wsh(script)))
-      val tx = Transaction(
-        version = 2,
-        txIn = TxIn(OutPoint(commitTx.tx, index), signatureScript = Nil, sequence = TxIn.SEQUENCE_FINAL) :: Nil,
-        txOut = TxOut(commitTx.tx.txOut(index).amount, Script.pay2wpkh(remotePaymentPriv.publicKey)) :: Nil,
-        lockTime = 0)
-      val sig = Transaction.signInput(tx, 0, script, SIGHASH_ALL, commitTx.tx.txOut(index).amount, SigVersion.SIGVERSION_WITNESS_V0, localRevocationPriv)
-      val tx1 = tx.updateWitness(0, ScriptWitness(sig :: localRevocationPriv.publicKey.toBin :: Script.write(script) :: Nil))
-      Transaction.correctlySpends(tx1, Seq(commitTx.tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+      val script = Script.write(Scripts.htlcReceived(localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, localRevocationPriv.publicKey, Crypto.ripemd160(htlc2.paymentHash), htlc2.expiry))
+      val htlcPenaltyTx = makeHtlcPenaltyTx(commitTx.tx, script, localDustLimit, finalPubKeyScript, feeratePerKw)
+      val sig = sign(htlcPenaltyTx, localRevocationPriv)
+      val signed = addSigs(htlcPenaltyTx, sig, localRevocationPriv.publicKey)
+      assert(checkSpendable(signed).isSuccess)
     }
 
   }


### PR DESCRIPTION
Previously we were only stealing the remote's main output when they publish a revoked commit, and were relying on a sufficiently high `channel_reserve` do deincentivize cheating.

In order to also steal the htlc outputs, we need to handle both cases:
- they only publish their revoked commit tx => we claim the htlc outputs directly from the commit tx
- they publish their revoked commit tx, and their 2nd-stage HTLCSuccessTx and HtlcTimeout txes => we claim the output of these htlcs tx

To do that, we need to be able to reconstruct htlc scripts (`htlcOffered` and `htlcReceived`), therefore we need to store `paymentHash` and `cltvExpiry` for each htlc we sign. Note that this won't be needed in the future when we have MAST.