### PR TITLE
Add server address in ElectrumReady object

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPool.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPool.scala
@@ -44,7 +44,7 @@ class ElectrumClientPool(serverAddresses: Set[InetSocketAddress])(implicit val e
   startWith(Disconnected, DisconnectedData)
 
   when(Disconnected) {
-    case Event(ElectrumClient.ElectrumReady(tip), _) if addresses.contains(sender) =>
+    case Event(ElectrumClient.ElectrumReady(tip, _), _) if addresses.contains(sender) =>
       sender ! ElectrumClient.HeaderSubscription(self)
       handleHeader(sender, tip, None)
 
@@ -60,7 +60,7 @@ class ElectrumClientPool(serverAddresses: Set[InetSocketAddress])(implicit val e
   }
 
   when(Connected) {
-    case Event(ElectrumClient.ElectrumReady(tip), d: ConnectedData) if addresses.contains(sender) =>
+    case Event(ElectrumClient.ElectrumReady(tip, _), d: ConnectedData) if addresses.contains(sender) =>
       sender ! ElectrumClient.HeaderSubscription(self)
       handleHeader(sender, tip, Some(d))
 
@@ -73,7 +73,7 @@ class ElectrumClientPool(serverAddresses: Set[InetSocketAddress])(implicit val e
 
     case Event(ElectrumClient.AddStatusListener(listener), d: ConnectedData) =>
       statusListeners += listener
-      listener ! ElectrumClient.ElectrumReady(d.tips(d.master))
+      listener ! ElectrumClient.ElectrumReady(d.tips(d.master), addresses(d.master))
       stay
 
     case Event(Terminated(actor), d: ConnectedData) =>
@@ -119,15 +119,15 @@ class ElectrumClientPool(serverAddresses: Set[InetSocketAddress])(implicit val e
 
   initialize()
 
-  private def handleHeader(connection: ActorRef, tip: ElectrumClient.Header, d: Option[ConnectedData]) = {
+  private def handleHeader(connection: ActorRef, tip: ElectrumClient.Header, data: Option[ConnectedData]) = {
     // we update our block count even if it doesn't come from our current master
     updateBlockCount(tip.block_height)
-    d match {
+    data match {
       case None =>
         // as soon as we have a connection to an electrum server, we select it as master
         log.info(s"selecting master ${addresses(connection)} at $tip")
-        statusListeners.foreach(_ ! ElectrumClient.ElectrumReady(tip))
-        context.system.eventStream.publish(ElectrumClient.ElectrumReady(tip))
+        statusListeners.foreach(_ ! ElectrumClient.ElectrumReady(tip, addresses(connection)))
+        context.system.eventStream.publish(ElectrumClient.ElectrumReady(tip, addresses(connection)))
         goto(Connected) using ConnectedData(connection, Map(connection -> tip))
       case Some(d) if tip.block_height >= d.blockHeight + 2L =>
         // we only switch to a new master if there is a significant difference with our current master, because
@@ -137,8 +137,8 @@ class ElectrumClientPool(serverAddresses: Set[InetSocketAddress])(implicit val e
         // so users (wallet, watcher, ...) will reset their subscriptions
         statusListeners.foreach(_ ! ElectrumClient.ElectrumDisconnected)
         context.system.eventStream.publish(ElectrumClient.ElectrumDisconnected)
-        statusListeners.foreach(_ ! ElectrumClient.ElectrumReady(tip))
-        context.system.eventStream.publish(ElectrumClient.ElectrumReady(tip))
+        statusListeners.foreach(_ ! ElectrumClient.ElectrumReady(tip, addresses(connection)))
+        context.system.eventStream.publish(ElectrumClient.ElectrumReady(tip, addresses(connection)))
         goto(Connected) using d.copy(master = connection, tips = d.tips + (connection -> tip))
       case Some(d) =>
         log.debug(s"received tip from ${addresses(connection)} $tip")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPool.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPool.scala
@@ -71,7 +71,7 @@ class ElectrumClientPool(serverAddresses: Set[InetSocketAddress])(implicit val e
       master forward request
       stay
 
-    case Event(ElectrumClient.AddStatusListener(listener), d: ConnectedData) =>
+    case Event(ElectrumClient.AddStatusListener(listener), d: ConnectedData) if addresses.contains(d.master) =>
       statusListeners += listener
       listener ! ElectrumClient.ElectrumReady(d.tips(d.master), addresses(d.master))
       stay

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
@@ -56,10 +56,10 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
 
   client ! ElectrumClient.AddStatusListener(self)
 
-  // disconnected --> waitingForTip --> running --
+  // disconnected --> waitingForTip --> running --+
   // ^                                            |
   // |                                            |
-  //  --------------------------------------------
+  // +--------------------------------------------+
 
   /**
     * Send a notification if the wallet is ready and its ready message has not
@@ -97,7 +97,7 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
   })
 
   when(DISCONNECTED) {
-    case Event(ElectrumClient.ElectrumReady(_), data) =>
+    case Event(ElectrumClient.ElectrumReady(_, _), data) =>
       client ! ElectrumClient.HeaderSubscription(self)
       goto(WAITING_FOR_TIP) using data
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
@@ -52,7 +52,7 @@ class ElectrumWatcher(client: ActorRef) extends Actor with Stash with ActorLoggi
   def receive = disconnected(Set.empty, Nil, SortedMap.empty)
 
   def disconnected(watches: Set[Watch], publishQueue: Seq[PublishAsap], block2tx: SortedMap[Long, Seq[Transaction]]): Receive = {
-    case ElectrumClient.ElectrumReady(_) =>
+    case ElectrumClient.ElectrumReady(_, _) =>
       client ! ElectrumClient.HeaderSubscription(self)
     case ElectrumClient.HeaderSubscriptionResponse(header) =>
       watches.map(self ! _)
@@ -220,7 +220,7 @@ object ElectrumWatcher extends App {
     }
 
     def receive = {
-      case ElectrumClient.ElectrumReady(_) =>
+      case ElectrumClient.ElectrumReady(_, _) =>
         log.info(s"starting watcher")
         context become running(context.actorOf(Props(new ElectrumWatcher(client)), "watcher"))
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSimulatedClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSimulatedClientSpec.scala
@@ -16,6 +16,8 @@
 
 package fr.acinq.eclair.blockchain.electrum
 
+import java.net.InetSocketAddress
+
 import akka.actor.{Actor, ActorSystem, Props}
 import akka.testkit.{TestFSMRef, TestKit, TestProbe}
 import fr.acinq.bitcoin.{BinaryData, Block, MnemonicCode, Satoshi}
@@ -58,7 +60,7 @@ class ElectrumWalletSimulatedClientSpec extends TestKit(ActorSystem("test")) wit
 
 
   test("wait until wallet is ready") {
-    sender.send(wallet, ElectrumClient.ElectrumReady(header1))
+    sender.send(wallet, ElectrumClient.ElectrumReady(header1, InetSocketAddress.createUnresolved("0.0.0.0", 9735)))
     sender.send(wallet, ElectrumClient.HeaderSubscriptionResponse(header1))
     awaitCond(wallet.stateName == ElectrumWallet.RUNNING)
     assert(listener.expectMsgType[WalletReady].timestamp == header1.timestamp)
@@ -77,7 +79,7 @@ class ElectrumWalletSimulatedClientSpec extends TestKit(ActorSystem("test")) wit
     awaitCond(wallet.stateName == ElectrumWallet.DISCONNECTED)
 
     // reconnect wallet
-    sender.send(wallet, ElectrumClient.ElectrumReady(header3))
+    sender.send(wallet, ElectrumClient.ElectrumReady(header3, InetSocketAddress.createUnresolved("0.0.0.0", 9735)))
     sender.send(wallet, ElectrumClient.HeaderSubscriptionResponse(header3))
     awaitCond(wallet.stateName == ElectrumWallet.RUNNING)
 


### PR DESCRIPTION
The `ElectrumReady` message is changed to contain the address of the electrum server which the eclair electrum client connects to. This will provide feedback to the user (esp. the eclair wallet app on android) as to which electrum server is currently used.