### PR TITLE
Refactor Transactions methods

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
@@ -20,7 +20,7 @@ import akka.actor.ActorSystem
 import fr.acinq.bitcoin.{BinaryData, OutPoint, Satoshi, Script, Transaction, TxIn, TxOut}
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BitcoinJsonRPCClient, JsonRPCError}
-import fr.acinq.eclair.transactions.Transactions
+import fr.acinq.eclair.transactions.{PubKeyScriptIndexFinder, Transactions}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST._
 
@@ -82,7 +82,7 @@ class BitcoinCoreWallet(rpcClient: BitcoinJsonRPCClient)(implicit system: ActorS
       // now let's sign the funding tx
       SignTransactionResponse(fundingTx, _) <- signTransaction(unsignedFundingTx)
       // there will probably be a change output, so we need to find which output is ours
-      outputIndex = Transactions.findPubKeyScriptIndex(fundingTx, pubkeyScript, outputsAlreadyUsed = Set.empty, amount_opt = None)
+      outputIndex = new PubKeyScriptIndexFinder(fundingTx).findPubKeyScriptIndex(pubkeyScript, None)
       _ = logger.debug(s"created funding txid=${fundingTx.txid} outputIndex=$outputIndex fee=$fee")
     } yield MakeFundingTxResponse(fundingTx, outputIndex)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -324,11 +324,9 @@ object Transactions {
                         localFinalScriptPubKey: BinaryData, feeratePerKw: Long): HtlcPenaltyTx = {
 
     val pubkeyScript = write(pay2wsh(redeemScript))
-    val (input, tx) = makeClaimTx(feeratePerKw, htlcPenaltyWeight, redeemScript,
+    HtlcPenaltyTx tupled makeClaimTx(feeratePerKw, htlcPenaltyWeight, redeemScript,
       finder.tx, outputIndex = finder.findPubKeyScriptIndex(pubkeyScript, None),
       localDustLimit, localFinalScriptPubKey, sequence = 0xffffffffL, lockTime = 0L)
-
-    HtlcPenaltyTx(input, tx)
   }
 
   def makeClosingTx(commitTxInput: InputInfo, localScriptPubKey: BinaryData, remoteScriptPubKey: BinaryData, localIsFunder: Boolean, dustLimit: Satoshi, closingFee: Satoshi, spec: CommitmentSpec): ClosingTx = {


### PR DESCRIPTION
- hide mutable output counter in a special class
- use common methods for making tier 1-2 transactions