### PR TITLE
Add json serializers for `NodeAddress` type

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -24,6 +24,7 @@ import fr.acinq.bitcoin.{BinaryData, OutPoint, Transaction}
 import fr.acinq.eclair.channel.State
 import fr.acinq.eclair.crypto.ShaChain
 import fr.acinq.eclair.router.RouteResponse
+import fr.acinq.eclair.transactions.Direction
 import fr.acinq.eclair.transactions.Transactions.{InputInfo, TransactionWithInputInfo}
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{ShortChannelId, UInt64}
@@ -122,3 +123,8 @@ class NodeAddressSerializer extends CustomSerializer[NodeAddress](format => ({ n
   case Tor2(b, p) => JString(s"${b.toString}:$p")
   case Tor3(b, p) => JString(s"${b.toString}:$p")
 }))
+
+class DirectionSerializer extends CustomSerializer[Direction](format => ({ null },{
+  case d: Direction => JString(d.toString)
+}))
+

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -25,7 +25,7 @@ import fr.acinq.eclair.channel.State
 import fr.acinq.eclair.crypto.ShaChain
 import fr.acinq.eclair.router.RouteResponse
 import fr.acinq.eclair.transactions.Transactions.{InputInfo, TransactionWithInputInfo}
-import fr.acinq.eclair.wire.{Color, FailureMessage}
+import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{ShortChannelId, UInt64}
 import org.json4s.JsonAST._
 import org.json4s.{CustomKeySerializer, CustomSerializer}
@@ -114,4 +114,11 @@ class ThrowableSerializer extends CustomSerializer[Throwable](format => ({ null 
 
 class FailureMessageSerializer extends CustomSerializer[FailureMessage](format => ({ null }, {
   case m: FailureMessage => JString(m.message)
+}))
+
+class NodeAddressSerializer extends CustomSerializer[NodeAddress](format => ({ null},{
+  case IPv4(a, p) => JString(HostAndPort.fromParts(a.getHostAddress, p).toString)
+  case IPv6(a, p) => JString(HostAndPort.fromParts(a.getHostAddress, p).toString)
+  case Tor2(b, p) => JString(s"${b.toString}:$p")
+  case Tor3(b, p) => JString(s"${b.toString}:$p")
 }))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -70,7 +70,7 @@ trait Service extends Logging {
   def scheduler: Scheduler
 
   implicit val serialization = jackson.Serialization
-  implicit val formats = org.json4s.DefaultFormats + new BinaryDataSerializer + new UInt64Serializer + new ShortChannelIdSerializer + new StateSerializer + new ShaChainSerializer + new PublicKeySerializer + new PrivateKeySerializer + new ScalarSerializer + new PointSerializer + new TransactionSerializer + new TransactionWithInputInfoSerializer + new InetSocketAddressSerializer + new OutPointSerializer + new OutPointKeySerializer + new InputInfoSerializer + new ColorSerializer +  new RouteResponseSerializer + new ThrowableSerializer + new FailureMessageSerializer
+  implicit val formats = org.json4s.DefaultFormats + new BinaryDataSerializer + new UInt64Serializer + new ShortChannelIdSerializer + new StateSerializer + new ShaChainSerializer + new PublicKeySerializer + new PrivateKeySerializer + new ScalarSerializer + new PointSerializer + new TransactionSerializer + new TransactionWithInputInfoSerializer + new InetSocketAddressSerializer + new OutPointSerializer + new OutPointKeySerializer + new InputInfoSerializer + new ColorSerializer +  new RouteResponseSerializer + new ThrowableSerializer + new FailureMessageSerializer + new NodeAddressSerializer
   implicit val timeout = Timeout(60 seconds)
   implicit val shouldWritePretty: ShouldWritePretty = ShouldWritePretty.True
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -70,7 +70,7 @@ trait Service extends Logging {
   def scheduler: Scheduler
 
   implicit val serialization = jackson.Serialization
-  implicit val formats = org.json4s.DefaultFormats + new BinaryDataSerializer + new UInt64Serializer + new ShortChannelIdSerializer + new StateSerializer + new ShaChainSerializer + new PublicKeySerializer + new PrivateKeySerializer + new ScalarSerializer + new PointSerializer + new TransactionSerializer + new TransactionWithInputInfoSerializer + new InetSocketAddressSerializer + new OutPointSerializer + new OutPointKeySerializer + new InputInfoSerializer + new ColorSerializer +  new RouteResponseSerializer + new ThrowableSerializer + new FailureMessageSerializer + new NodeAddressSerializer
+  implicit val formats = org.json4s.DefaultFormats + new BinaryDataSerializer + new UInt64Serializer + new ShortChannelIdSerializer + new StateSerializer + new ShaChainSerializer + new PublicKeySerializer + new PrivateKeySerializer + new ScalarSerializer + new PointSerializer + new TransactionSerializer + new TransactionWithInputInfoSerializer + new InetSocketAddressSerializer + new OutPointSerializer + new OutPointKeySerializer + new InputInfoSerializer + new ColorSerializer +  new RouteResponseSerializer + new ThrowableSerializer + new FailureMessageSerializer + new NodeAddressSerializer + new DirectionSerializer
   implicit val timeout = Timeout(60 seconds)
   implicit val shouldWritePretty: ShouldWritePretty = ShouldWritePretty.True
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
@@ -17,16 +17,22 @@
 package fr.acinq.eclair.api
 
 import fr.acinq.bitcoin.{BinaryData, OutPoint}
-import org.json4s.Formats
 import org.json4s.jackson.Serialization
+import org.junit.runner.RunWith
 import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
 
+@RunWith(classOf[JUnitRunner])
 class JsonSerializersSpec extends FunSuite {
 
   test("deserialize Map[OutPoint, BinaryData]") {
+    val output1 = OutPoint("11418a2d282a40461966e4f578e1fdf633ad15c1b7fb3e771d14361127233be1", 0)
+    val output2 = OutPoint("3d62bd4f71dc63798418e59efbc7532380c900b5e79db3a5521374b161dd0e33", 1)
+
+
     val map = Map(
-      OutPoint("11418a2d282a40461966e4f578e1fdf633ad15c1b7fb3e771d14361127233be1", 0) -> BinaryData("dead"),
-      OutPoint("3d62bd4f71dc63798418e59efbc7532380c900b5e79db3a5521374b161dd0e33", 1) -> BinaryData("beef")
+      output1 -> BinaryData("dead"),
+      output2 -> BinaryData("beef")
     )
 
     // it won't work with the default key serializer
@@ -37,6 +43,6 @@ class JsonSerializersSpec extends FunSuite {
 
     // but it works with our custom key serializer
     val json = Serialization.write(map)(org.json4s.DefaultFormats + new BinaryDataSerializer + new OutPointKeySerializer)
-    assert(json === """{"11418a2d282a40461966e4f578e1fdf633ad15c1b7fb3e771d14361127233be1:0":"dead","3d62bd4f71dc63798418e59efbc7532380c900b5e79db3a5521374b161dd0e33:1":"beef"}""")
+    assert(json === s"""{"${output1.txid}:0":"dead","${output2.txid}:1":"beef"}""")
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
@@ -16,14 +16,17 @@
 
 package fr.acinq.eclair.api
 
+import java.net.{InetAddress, InetSocketAddress}
+
 import fr.acinq.bitcoin.{BinaryData, OutPoint}
+import fr.acinq.eclair.wire.NodeAddress
 import org.json4s.jackson.Serialization
 import org.junit.runner.RunWith
-import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FunSuite, Matchers}
 
 @RunWith(classOf[JUnitRunner])
-class JsonSerializersSpec extends FunSuite {
+class JsonSerializersSpec extends FunSuite with Matchers {
 
   test("deserialize Map[OutPoint, BinaryData]") {
     val output1 = OutPoint("11418a2d282a40461966e4f578e1fdf633ad15c1b7fb3e771d14361127233be1", 0)
@@ -44,5 +47,13 @@ class JsonSerializersSpec extends FunSuite {
     // but it works with our custom key serializer
     val json = Serialization.write(map)(org.json4s.DefaultFormats + new BinaryDataSerializer + new OutPointKeySerializer)
     assert(json === s"""{"${output1.txid}:0":"dead","${output2.txid}:1":"beef"}""")
+  }
+
+  test("NodeAddress serialization") {
+    val ipv4 = NodeAddress(new InetSocketAddress(InetAddress.getByAddress(Array(10, 0, 0, 1)), 8888))
+    val ipv6LocalHost = NodeAddress(new InetSocketAddress(InetAddress.getByAddress(Array(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1)), 9735))
+
+    Serialization.write(ipv4)(org.json4s.DefaultFormats + new NodeAddressSerializer) shouldBe s""""10.0.0.1:8888""""
+    Serialization.write(ipv6LocalHost)(org.json4s.DefaultFormats + new NodeAddressSerializer) shouldBe s""""[0:0:0:0:0:0:0:1]:9735""""
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.api
 import java.net.{InetAddress, InetSocketAddress}
 
 import fr.acinq.bitcoin.{BinaryData, OutPoint}
+import fr.acinq.eclair.transactions.{IN, OUT}
 import fr.acinq.eclair.wire.NodeAddress
 import org.json4s.jackson.Serialization
 import org.junit.runner.RunWith
@@ -56,4 +57,10 @@ class JsonSerializersSpec extends FunSuite with Matchers {
     Serialization.write(ipv4)(org.json4s.DefaultFormats + new NodeAddressSerializer) shouldBe s""""10.0.0.1:8888""""
     Serialization.write(ipv6LocalHost)(org.json4s.DefaultFormats + new NodeAddressSerializer) shouldBe s""""[0:0:0:0:0:0:0:1]:9735""""
   }
+
+  test("Direction serialization") {
+    Serialization.write(IN)(org.json4s.DefaultFormats + new DirectionSerializer) shouldBe s""""IN""""
+    Serialization.write(OUT)(org.json4s.DefaultFormats + new DirectionSerializer) shouldBe s""""OUT""""
+  }
+
 }


### PR DESCRIPTION
Fixes #565

The rendering of addresses can be checked with: 

```curl -X POST -H 'content-type: application/json' -u :bar -d '{"jsonrpc": "2.0","method": "allnodes"}' http://127.0.0.1:8080```