### PR TITLE
Use fallbackAddress tag

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
@@ -140,6 +140,7 @@ object PaymentRequest {
       tags = List(
         Some(PaymentHashTag(paymentHash)),
         Some(DescriptionTag(description)),
+        fallbackAddress.map(FallbackAddressTag(_)),
         expirySeconds.map(ExpiryTag)
       ).flatten ++ extraHops.map(RoutingInfoTag(_)),
       signature = BinaryData.empty)


### PR DESCRIPTION
Fallback on-chain address could be provided but was not used in payment request generation.