### PR TITLE
Update bitcoin-lib to 0.9.17

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
@@ -52,7 +52,7 @@ object ChannelStateSpec {
   val keyManager = new LocalKeyManager("01" * 32, Block.RegtestGenesisBlock.hash)
   val localParams = LocalParams(
     keyManager.nodeId,
-    channelKeyPath = DeterministicWallet.KeyPath(Seq(42)),
+    channelKeyPath = DeterministicWallet.KeyPath(Seq(42L)),
     dustLimitSatoshis = Satoshi(546).toLong,
     maxHtlcValueInFlightMsat = UInt64(50),
     channelReserveSatoshis = 10000,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
@@ -43,7 +43,7 @@ class ChannelCodecsSpec extends FunSuite {
   }
 
   test("encode/decode key paths (all 0s)") {
-    val keyPath = KeyPath(Seq(0, 0, 0, 0))
+    val keyPath = KeyPath(Seq(0L, 0L, 0L, 0L))
     val encoded = keyPathCodec.encode(keyPath).require
     val decoded = keyPathCodec.decode(encoded).require
     assert(keyPath === decoded.value)
@@ -59,7 +59,7 @@ class ChannelCodecsSpec extends FunSuite {
   test("encode/decode localparams") {
     val o = LocalParams(
       nodeId = randomKey.publicKey,
-      channelKeyPath = DeterministicWallet.KeyPath(Seq(42)),
+      channelKeyPath = DeterministicWallet.KeyPath(Seq(42L)),
       dustLimitSatoshis = Random.nextInt(Int.MaxValue),
       maxHtlcValueInFlightMsat = UInt64(Random.nextInt(Int.MaxValue)),
       channelReserveSatoshis = Random.nextInt(Int.MaxValue),

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <scala.version>2.11.11</scala.version>
         <scala.version.short>2.11</scala.version.short>
         <akka.version>2.4.20</akka.version>
-        <bitcoinlib.version>0.9.16</bitcoinlib.version>
+        <bitcoinlib.version>0.9.17</bitcoinlib.version>
         <guava.version>24.0-android</guava.version>
     </properties>
 


### PR DESCRIPTION
It provides additional key BIP32/44/49/84 related functions, including a method to check mnemonic codes checksum (see https://github.com/ACINQ/eclair-wallet/issues/52) 