### PR TITLE
Filter out non-spendable outputs from bitcoind 'listunspent' call during setup 

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -99,7 +99,11 @@ class Setup(datadir: File, overrideDefaults: Config = ConfigFactory.empty(), act
         progress = (json \ "verificationprogress").extract[Double]
         chainHash <- bitcoinClient.invoke("getblockhash", 0).map(_.extract[String]).map(BinaryData(_)).map(x => BinaryData(x.reverse))
         bitcoinVersion <- bitcoinClient.invoke("getnetworkinfo").map(json => (json \ "version")).map(_.extract[String])
-        unspentAddresses <- bitcoinClient.invoke("listunspent").collect { case JArray(values) => values.map(value => (value \ "address").extract[String]) }
+        unspentAddresses <- bitcoinClient.invoke("listunspent").collect { case JArray(values) =>
+          values
+            .filter(value => (value \ "spendable").extract[Boolean])
+            .map(value => (value \ "address").extract[String])
+        }
       } yield (progress, chainHash, bitcoinVersion, unspentAddresses)
       // blocking sanity checks
       val (progress, chainHash, bitcoinVersion, unspentAddresses) = Await.result(future, 30 seconds)


### PR DESCRIPTION
Fixes #599 . In this PR we make sure we don't consider watch-only addresses when performing initialization checks on bitcoind.