### PR TITLE
Set a minimum feerate-per-kw of 253 (fixes #602)

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -35,7 +35,7 @@ eclair {
       72 = 20000
     }
   }
-  min-feerate = 1 // minimum feerate in satoshis per byte (same default value as bitcoin core's minimum relay fee)
+  min-feerate = 2 // minimum feerate in satoshis per byte
 
   node-alias = "eclair"
   node-color = "49daaa"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -45,6 +45,7 @@ case class InvalidFinalScript                  (override val channelId: BinaryDa
 case class FundingTxTimedout                   (override val channelId: BinaryData) extends ChannelException(channelId, "funding tx timed out")
 case class FundingTxSpent                      (override val channelId: BinaryData, spendingTx: Transaction) extends ChannelException(channelId, s"funding tx has been spent by txid=${spendingTx.txid}")
 case class HtlcTimedout                        (override val channelId: BinaryData) extends ChannelException(channelId, "one or more htlcs timed out")
+case class FeerateTooSmall                     (override val channelId: BinaryData, remoteFeeratePerKw: Long) extends ChannelException(channelId, s"remote fee rate is too small: remoteFeeratePerKw=$remoteFeeratePerKw")
 case class FeerateTooDifferent                 (override val channelId: BinaryData, localFeeratePerKw: Long, remoteFeeratePerKw: Long) extends ChannelException(channelId, s"local/remote feerates are too different: remoteFeeratePerKw=$remoteFeeratePerKw localFeeratePerKw=$localFeeratePerKw")
 case class InvalidCommitmentSignature          (override val channelId: BinaryData, tx: Transaction) extends ChannelException(channelId, s"invalid commitment signature: tx=$tx")
 case class InvalidHtlcSignature                (override val channelId: BinaryData, tx: Transaction) extends ChannelException(channelId, s"invalid htlc signature: tx=$tx")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -326,6 +326,10 @@ object Commitments {
       throw FundeeCannotSendUpdateFee(commitments.channelId)
     }
 
+    if (fee.feeratePerKw < fr.acinq.eclair.MinimumFeeratePerKw) {
+      throw FeerateTooSmall(commitments.channelId, remoteFeeratePerKw = fee.feeratePerKw)
+    }
+
     val localFeeratePerKw = Globals.feeratesPerKw.get.blocks_2
     if (Helpers.isFeeDiffTooHigh(fee.feeratePerKw, localFeeratePerKw, maxFeerateMismatch)) {
       throw FeerateTooDifferent(commitments.channelId, localFeeratePerKw = localFeeratePerKw, remoteFeeratePerKw = fee.feeratePerKw)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -83,6 +83,12 @@ package object eclair {
    */
   val MinimumFeeratePerKw = 253
 
+  /*
+    minimum relay fee rate, in satoshi per kilo
+    bitcoin core uses virtual size and not the actual size in bytes, see above
+   */
+  val MinimumRelayFeeRate = 1000
+
   /**
     * Converts feerate in satoshi-per-kilobytes to feerate in satoshi-per-kw
     *

--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -68,13 +68,28 @@ package object eclair {
     */
   def feerateKw2Byte(feeratesPerKw: Long): Long = feeratesPerKw / 250
 
+  /*
+    why 253 and not 250 since feerate-per-kw is feerate-per-kb / 250 and the minimum relay fee rate is 1000 satoshi/Kb ?
+
+    because bitcoin core uses neither the actual tx size in bytes or the tx weight to check fees, but a "virtual size"
+    which is (3 * weight) / 4 ...
+    so we want :
+    fee > 1000 * virtual size
+    feerate-per-kw * weight > 1000 * (3 * weight / 4)
+    feerate_per-kw > 250 + 3000 / (4 * weight)
+    with a conservative minimum weight of 400, we get a minimum feerate_per-kw of 253
+
+    see https://github.com/ElementsProject/lightning/pull/1251
+   */
+  val MinimumFeeratePerKw = 253
+
   /**
     * Converts feerate in satoshi-per-kilobytes to feerate in satoshi-per-kw
     *
     * @param feeratePerKB fee rate in satoshi-per-kilobytes
     * @return feerate in satoshi-per-kw
     */
-  def feerateKB2Kw(feeratePerKB: Long): Long = feeratePerKB / 4
+  def feerateKB2Kw(feeratePerKB: Long): Long = Math.max(feeratePerKB / 4, MinimumFeeratePerKw)
 
   /**
     *

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -274,7 +274,7 @@ object Transactions {
       txOut = TxOut(Satoshi(0), localFinalScriptPubKey) :: Nil,
       lockTime = 0)
 
-    val weight = Transactions.addSigs(ClaimHtlcTimeoutTx(input, tx), BinaryData("00" * 73)).tx.weight()
+    val weight = Transactions.addSigs(ClaimHtlcSuccessTx(input, tx), BinaryData("00" * 73), BinaryData("00" * 32)).tx.weight()
     val fee = weight2fee(feeratePerKw, weight)
     val amount = input.txOut.amount - fee
     if (amount < localDustLimit) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -41,6 +41,11 @@ object Transactions {
   sealed trait TransactionWithInputInfo {
     def input: InputInfo
     def tx: Transaction
+    def fee: Satoshi = input.txOut.amount - tx.txOut.map(_.amount).sum
+    def minRelayFee: Satoshi = {
+      val vsize = (tx.weight() + 3) / 4
+      Satoshi(fr.acinq.eclair.MinimumRelayFeeRate * vsize / 1000)
+    }
   }
 
   case class CommitTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -84,15 +84,22 @@ object Transactions {
     *   - [[HtlcPenaltyTx]] spends competes with [[HtlcSuccessTx]] and [[HtlcTimeoutTx]] for the same outputs (published by local)
     */
 
+  /**
+    * these values are defined in the RFC
+    */
   val commitWeight = 724
   val htlcTimeoutWeight = 663
   val htlcSuccessWeight = 703
-  val claimP2WPKHOutputWeight = 437
-  val claimHtlcDelayedWeight = 482
-  val claimHtlcSuccessWeight = 570
-  val claimHtlcTimeoutWeight = 544
-  val mainPenaltyWeight = 483
-  val htlcPenaltyWeight = 577 // based on spending an HTLC-Success output (would be 571 with HTLC-Timeout)
+
+  /**
+    * these values specific to us and used to estimate fees
+    */
+  val claimP2WPKHOutputWeight = 439
+  val claimHtlcDelayedWeight = 484
+  val claimHtlcSuccessWeight = 572
+  val claimHtlcTimeoutWeight = 546
+  val mainPenaltyWeight = 485
+  val htlcPenaltyWeight = 579 // based on spending an HTLC-Success output (would be 571 with HTLC-Timeout)
 
   def weight2fee(feeratePerKw: Long, weight: Int) = Satoshi((feeratePerKw * weight) / 1000)
 
@@ -251,124 +258,183 @@ object Transactions {
   }
 
   def makeClaimHtlcSuccessTx(commitTx: Transaction, outputsAlreadyUsed: Set[Int], localDustLimit: Satoshi, localHtlcPubkey: PublicKey, remoteHtlcPubkey: PublicKey, remoteRevocationPubkey: PublicKey, localFinalScriptPubKey: BinaryData, htlc: UpdateAddHtlc, feeratePerKw: Long): ClaimHtlcSuccessTx = {
-    val fee = weight2fee(feeratePerKw, claimHtlcSuccessWeight)
     val redeemScript = htlcOffered(remoteHtlcPubkey, localHtlcPubkey, remoteRevocationPubkey, ripemd160(htlc.paymentHash))
     val pubkeyScript = write(pay2wsh(redeemScript))
     val outputIndex = findPubKeyScriptIndex(commitTx, pubkeyScript, outputsAlreadyUsed, amount_opt = Some(Satoshi(htlc.amountMsat / 1000)))
     val input = InputInfo(OutPoint(commitTx, outputIndex), commitTx.txOut(outputIndex), write(redeemScript))
+
+    val tx = Transaction(
+      version = 2,
+      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0xffffffffL) :: Nil,
+      txOut = TxOut(Satoshi(0), localFinalScriptPubKey) :: Nil,
+      lockTime = 0)
+
+    val weight = Transactions.addSigs(ClaimHtlcTimeoutTx(input, tx), BinaryData("00" * 73)).tx.weight()
+    val fee = weight2fee(feeratePerKw, weight)
     val amount = input.txOut.amount - fee
     if (amount < localDustLimit) {
       throw AmountBelowDustLimit
     }
-    ClaimHtlcSuccessTx(input, Transaction(
-      version = 2,
-      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0xffffffffL) :: Nil,
-      txOut = TxOut(amount, localFinalScriptPubKey) :: Nil,
-      lockTime = 0))
+
+    val tx1 = tx.copy(txOut = tx.txOut(0).copy(amount = amount) :: Nil)
+    ClaimHtlcSuccessTx(input, tx1)
   }
 
   def makeClaimHtlcTimeoutTx(commitTx: Transaction, outputsAlreadyUsed: Set[Int], localDustLimit: Satoshi, localHtlcPubkey: PublicKey, remoteHtlcPubkey: PublicKey, remoteRevocationPubkey: PublicKey, localFinalScriptPubKey: BinaryData, htlc: UpdateAddHtlc, feeratePerKw: Long): ClaimHtlcTimeoutTx = {
-    val fee = weight2fee(feeratePerKw, claimHtlcTimeoutWeight)
     val redeemScript = htlcReceived(remoteHtlcPubkey, localHtlcPubkey, remoteRevocationPubkey, ripemd160(htlc.paymentHash), htlc.expiry)
     val pubkeyScript = write(pay2wsh(redeemScript))
     val outputIndex = findPubKeyScriptIndex(commitTx, pubkeyScript, outputsAlreadyUsed, amount_opt = Some(Satoshi(htlc.amountMsat / 1000)))
     val input = InputInfo(OutPoint(commitTx, outputIndex), commitTx.txOut(outputIndex), write(redeemScript))
+
+    // unsigned tx
+    val tx = Transaction(
+      version = 2,
+      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0x00000000L) :: Nil,
+      txOut = TxOut(Satoshi(0), localFinalScriptPubKey) :: Nil,
+      lockTime = htlc.expiry)
+
+    val weight = Transactions.addSigs(ClaimHtlcTimeoutTx(input, tx), BinaryData("00" * 73)).tx.weight()
+    val fee = weight2fee(feeratePerKw, weight)
+
     val amount = input.txOut.amount - fee
     if (amount < localDustLimit) {
       throw AmountBelowDustLimit
     }
-    ClaimHtlcTimeoutTx(input, Transaction(
-      version = 2,
-      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0x00000000L) :: Nil,
-      txOut = TxOut(amount, localFinalScriptPubKey) :: Nil,
-      lockTime = htlc.expiry))
+
+    val tx1 = tx.copy(txOut = tx.txOut(0).copy(amount = amount) :: Nil)
+    ClaimHtlcTimeoutTx(input, tx1)
   }
 
   def makeClaimP2WPKHOutputTx(delayedOutputTx: Transaction, localDustLimit: Satoshi, localPaymentPubkey: PublicKey, localFinalScriptPubKey: BinaryData, feeratePerKw: Long): ClaimP2WPKHOutputTx = {
-    val fee = weight2fee(feeratePerKw, claimP2WPKHOutputWeight)
     val redeemScript = Script.pay2pkh(localPaymentPubkey)
     val pubkeyScript = write(pay2wpkh(localPaymentPubkey))
     val outputIndex = findPubKeyScriptIndex(delayedOutputTx, pubkeyScript, outputsAlreadyUsed = Set.empty, amount_opt = None)
     val input = InputInfo(OutPoint(delayedOutputTx, outputIndex), delayedOutputTx.txOut(outputIndex), write(redeemScript))
+
+    // unsigned tx
+    val tx = Transaction(
+      version = 2,
+      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0x00000000L) :: Nil,
+      txOut = TxOut(Satoshi(0), localFinalScriptPubKey) :: Nil,
+      lockTime = 0)
+
+    // compute weight with a dummy 73 bytes signature (the largest you can get) and a dummy 33 bytes pubkey
+    val weight = Transactions.addSigs(ClaimP2WPKHOutputTx(input, tx), BinaryData("00" * 33), BinaryData("00" * 73)).tx.weight()
+    val fee = weight2fee(feeratePerKw, weight)
+
     val amount = input.txOut.amount - fee
     if (amount < localDustLimit) {
       throw AmountBelowDustLimit
     }
-    ClaimP2WPKHOutputTx(input, Transaction(
-      version = 2,
-      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0x00000000L) :: Nil,
-      txOut = TxOut(amount, localFinalScriptPubKey) :: Nil,
-      lockTime = 0))
+
+    val tx1 = tx.copy(txOut = tx.txOut(0).copy(amount = amount) :: Nil)
+    ClaimP2WPKHOutputTx(input, tx1)
   }
 
   def makeClaimDelayedOutputTx(delayedOutputTx: Transaction, localDustLimit: Satoshi, localRevocationPubkey: PublicKey, toLocalDelay: Int, localDelayedPaymentPubkey: PublicKey, localFinalScriptPubKey: BinaryData, feeratePerKw: Long): ClaimDelayedOutputTx = {
-    val fee = weight2fee(feeratePerKw, claimHtlcDelayedWeight)
     val redeemScript = toLocalDelayed(localRevocationPubkey, toLocalDelay, localDelayedPaymentPubkey)
     val pubkeyScript = write(pay2wsh(redeemScript))
     val outputIndex = findPubKeyScriptIndex(delayedOutputTx, pubkeyScript, outputsAlreadyUsed = Set.empty, amount_opt = None)
     val input = InputInfo(OutPoint(delayedOutputTx, outputIndex), delayedOutputTx.txOut(outputIndex), write(redeemScript))
+
+    // unsigned transaction
+    val tx = Transaction(
+      version = 2,
+      txIn = TxIn(input.outPoint, Array.emptyByteArray, toLocalDelay) :: Nil,
+      txOut = TxOut(Satoshi(0), localFinalScriptPubKey) :: Nil,
+      lockTime = 0)
+
+    // compute weight with a dummy 73 bytes signature (the largest you can get)
+    val weight = Transactions.addSigs(ClaimDelayedOutputTx(input, tx), BinaryData("00" * 73)).tx.weight()
+    val fee = weight2fee(feeratePerKw, weight)
+
     val amount = input.txOut.amount - fee
     if (amount < localDustLimit) {
       throw AmountBelowDustLimit
     }
-    ClaimDelayedOutputTx(input, Transaction(
-      version = 2,
-      txIn = TxIn(input.outPoint, Array.emptyByteArray, toLocalDelay) :: Nil,
-      txOut = TxOut(amount, localFinalScriptPubKey) :: Nil,
-      lockTime = 0))
+
+    val tx1 = tx.copy(txOut = tx.txOut(0).copy(amount = amount) :: Nil)
+    ClaimDelayedOutputTx(input, tx1)
   }
 
   def makeClaimDelayedOutputPenaltyTx(delayedOutputTx: Transaction, localDustLimit: Satoshi, localRevocationPubkey: PublicKey, toLocalDelay: Int, localDelayedPaymentPubkey: PublicKey, localFinalScriptPubKey: BinaryData, feeratePerKw: Long): ClaimDelayedOutputPenaltyTx = {
-    val fee = weight2fee(feeratePerKw, claimHtlcDelayedWeight)
     val redeemScript = toLocalDelayed(localRevocationPubkey, toLocalDelay, localDelayedPaymentPubkey)
     val pubkeyScript = write(pay2wsh(redeemScript))
     val outputIndex = findPubKeyScriptIndex(delayedOutputTx, pubkeyScript, outputsAlreadyUsed = Set.empty, amount_opt = None)
     val input = InputInfo(OutPoint(delayedOutputTx, outputIndex), delayedOutputTx.txOut(outputIndex), write(redeemScript))
+
+    // unsigned transaction
+    val tx = Transaction(
+      version = 2,
+      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0xffffffffL) :: Nil,
+      txOut = TxOut(Satoshi(0), localFinalScriptPubKey) :: Nil,
+      lockTime = 0)
+
+    // compute weight with a dummy 73 bytes signature (the largest you can get)
+    val weight = Transactions.addSigs(ClaimDelayedOutputPenaltyTx(input, tx), BinaryData("00" * 73)).tx.weight()
+    val fee = weight2fee(feeratePerKw, weight)
+
     val amount = input.txOut.amount - fee
     if (amount < localDustLimit) {
       throw AmountBelowDustLimit
     }
-    ClaimDelayedOutputPenaltyTx(input, Transaction(
-      version = 2,
-      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0xffffffffL) :: Nil,
-      txOut = TxOut(amount, localFinalScriptPubKey) :: Nil,
-      lockTime = 0))
+
+    val tx1 = tx.copy(txOut = tx.txOut(0).copy(amount = amount) :: Nil)
+    ClaimDelayedOutputPenaltyTx(input, tx1)
   }
 
   def makeMainPenaltyTx(commitTx: Transaction, localDustLimit: Satoshi, remoteRevocationPubkey: PublicKey, localFinalScriptPubKey: BinaryData, toRemoteDelay: Int, remoteDelayedPaymentPubkey: PublicKey, feeratePerKw: Long): MainPenaltyTx = {
-    val fee = weight2fee(feeratePerKw, mainPenaltyWeight)
     val redeemScript = toLocalDelayed(remoteRevocationPubkey, toRemoteDelay, remoteDelayedPaymentPubkey)
     val pubkeyScript = write(pay2wsh(redeemScript))
     val outputIndex = findPubKeyScriptIndex(commitTx, pubkeyScript, outputsAlreadyUsed = Set.empty, amount_opt = None)
     val input = InputInfo(OutPoint(commitTx, outputIndex), commitTx.txOut(outputIndex), write(redeemScript))
+
+    // unsigned transaction
+    val tx = Transaction(
+      version = 2,
+      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0xffffffffL) :: Nil,
+      txOut = TxOut(Satoshi(0), localFinalScriptPubKey) :: Nil,
+      lockTime = 0)
+
+    // compute weight with a dummy 73 bytes signature (the largest you can get)
+    val weight = Transactions.addSigs(MainPenaltyTx(input, tx), BinaryData("00" * 73)).tx.weight()
+    val fee = weight2fee(feeratePerKw, weight)
+
     val amount = input.txOut.amount - fee
     if (amount < localDustLimit) {
       throw AmountBelowDustLimit
     }
-    MainPenaltyTx(input, Transaction(
-      version = 2,
-      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0xffffffffL) :: Nil,
-      txOut = TxOut(amount, localFinalScriptPubKey) :: Nil,
-      lockTime = 0))
+
+    val tx1 = tx.copy(txOut = tx.txOut(0).copy(amount = amount) :: Nil)
+    MainPenaltyTx(input, tx1)
   }
 
   /**
     * We already have the redeemScript, no need to build it
     */
   def makeHtlcPenaltyTx(commitTx: Transaction, outputsAlreadyUsed: Set[Int], redeemScript: BinaryData, localDustLimit: Satoshi, localFinalScriptPubKey: BinaryData, feeratePerKw: Long): HtlcPenaltyTx = {
-    val fee = weight2fee(feeratePerKw, htlcPenaltyWeight)
     val pubkeyScript = write(pay2wsh(redeemScript))
     val outputIndex = findPubKeyScriptIndex(commitTx, pubkeyScript, outputsAlreadyUsed, amount_opt = None)
     val input = InputInfo(OutPoint(commitTx, outputIndex), commitTx.txOut(outputIndex), redeemScript)
+
+    // unsigned transaction
+    val tx = Transaction(
+      version = 2,
+      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0xffffffffL) :: Nil,
+      txOut = TxOut(Satoshi(0), localFinalScriptPubKey) :: Nil,
+      lockTime = 0)
+
+    // compute weight with a dummy 73 bytes signature (the largest you can get)
+    val weight = Transactions.addSigs(MainPenaltyTx(input, tx), BinaryData("00" * 73)).tx.weight()
+    val fee = weight2fee(feeratePerKw, weight)
+
     val amount = input.txOut.amount - fee
     if (amount < localDustLimit) {
       throw AmountBelowDustLimit
     }
-    HtlcPenaltyTx(input, Transaction(
-      version = 2,
-      txIn = TxIn(input.outPoint, Array.emptyByteArray, 0xffffffffL) :: Nil,
-      txOut = TxOut(amount, localFinalScriptPubKey) :: Nil,
-      lockTime = 0))
+
+    val tx1 = tx.copy(txOut = tx.txOut(0).copy(amount = amount) :: Nil)
+    HtlcPenaltyTx(input, tx1)
   }
 
   def makeClosingTx(commitTxInput: InputInfo, localScriptPubKey: BinaryData, remoteScriptPubKey: BinaryData, localIsFunder: Boolean, dustLimit: Satoshi, closingFee: Satoshi, spec: CommitmentSpec): ClosingTx = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/PackageSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/PackageSpec.scala
@@ -101,4 +101,9 @@ class PackageSpec extends FunSuite {
     }
     assert(e.getMessage.contains("is neither a valid Base58 address") && e.getMessage.contains("nor a valid Bech32 address"))
   }
+
+  test("convert fee rates and enforce a minimum feerate-per-kw") {
+    assert(feerateByte2Kw(1) == MinimumFeeratePerKw)
+    assert(feerateKB2Kw(1000) == MinimumFeeratePerKw)
+  }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
@@ -129,12 +129,12 @@ class WaitForOpenChannelStateSpec extends TestkitBaseClass with StateTestsHelper
     within(30 seconds) {
       val open = alice2bob.expectMsgType[OpenChannel]
       // set a very small fee
-      val tinyFee = 254
+      val tinyFee = 253
       bob ! open.copy(feeratePerKw = tinyFee)
       alice2bob.forward(bob)
       val error = bob2alice.expectMsgType[Error]
       // we check that the error uses the temporary channel id
-      assert(error === Error(open.temporaryChannelId, "local/remote feerates are too different: remoteFeeratePerKw=254 localFeeratePerKw=10000".getBytes("UTF-8")))
+      assert(error === Error(open.temporaryChannelId, "local/remote feerates are too different: remoteFeeratePerKw=253 localFeeratePerKw=10000".getBytes("UTF-8")))
       awaitCond(bob.stateName == CLOSED)
     }
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -1671,7 +1671,7 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
         claimHtlcTx.txOut(0).amount
       }).sum
       // at best we have a little less than 450 000 + 250 000 + 100 000 + 50 000 = 850 000 (because fees)
-      assert(amountClaimed == Satoshi(814920))
+      assert(amountClaimed == Satoshi(815160))
 
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0))) // claim-main
@@ -1734,7 +1734,7 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
         claimHtlcTx.txOut(0).amount
       }).sum
       // at best we have a little less than 500 000 + 250 000 + 100 000 = 850 000 (because fees)
-      assert(amountClaimed == Satoshi(822340))
+      assert(amountClaimed == Satoshi(822280))
 
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0))) // claim-main
@@ -1797,7 +1797,7 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       htlcPenaltyTxs.foreach(htlcPenaltyTx => Transaction.correctlySpends(htlcPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS))
 
       // two main outputs are 760 000 and 200 000
-      assert(mainTx.txOut(0).amount == Satoshi(741510))
+      assert(mainTx.txOut(0).amount == Satoshi(741490))
       assert(mainPenaltyTx.txOut(0).amount == Satoshi(195170))
       assert(htlcPenaltyTxs(0).txOut(0).amount == Satoshi(4230))
       assert(htlcPenaltyTxs(1).txOut(0).amount == Satoshi(4230))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -1687,7 +1687,7 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
         claimHtlcTx.txOut(0).amount
       }).sum
       // at best we have a little less than 450 000 + 250 000 + 100 000 + 50 000 = 850 000 (because fees)
-      assert(amountClaimed == Satoshi(815160))
+      assert(amountClaimed == Satoshi(814840))
 
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0))) // claim-main

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -1798,11 +1798,11 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
       // two main outputs are 760 000 and 200 000
       assert(mainTx.txOut(0).amount == Satoshi(741490))
-      assert(mainPenaltyTx.txOut(0).amount == Satoshi(195170))
-      assert(htlcPenaltyTxs(0).txOut(0).amount == Satoshi(4230))
-      assert(htlcPenaltyTxs(1).txOut(0).amount == Satoshi(4230))
-      assert(htlcPenaltyTxs(2).txOut(0).amount == Satoshi(4230))
-      assert(htlcPenaltyTxs(3).txOut(0).amount == Satoshi(4230))
+      assert(mainPenaltyTx.txOut(0).amount == Satoshi(195150))
+      assert(htlcPenaltyTxs(0).txOut(0).amount == Satoshi(4530))
+      assert(htlcPenaltyTxs(1).txOut(0).amount == Satoshi(4530))
+      assert(htlcPenaltyTxs(2).txOut(0).amount == Satoshi(4530))
+      assert(htlcPenaltyTxs(3).txOut(0).amount == Satoshi(4530))
 
       awaitCond(alice.stateName == CLOSING)
       assert(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 1)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -633,7 +633,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
         claimHtlcTx.txOut(0).amount
       }).sum
       // htlc will timeout and be eventually refunded so we have a little less than fundingSatoshis - pushMsat = 1000000 - 200000 = 800000 (because fees)
-      assert(amountClaimed == Satoshi(774070))
+      assert(amountClaimed == Satoshi(774010))
 
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0)))
@@ -681,7 +681,7 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
         claimHtlcTx.txOut(0).amount
       }).sum
       // htlc will timeout and be eventually refunded so we have a little less than fundingSatoshis - pushMsat - htlc1 = 1000000 - 200000 - 300 000 = 500000 (because fees)
-      assert(amountClaimed == Satoshi(481230))
+      assert(amountClaimed == Satoshi(481190))
 
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0)))
@@ -728,10 +728,10 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       Transaction.correctlySpends(htlc2PenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
       // two main outputs are 300 000 and 200 000, htlcs are 300 000 and 200 000
-      assert(mainTx.txOut(0).amount == Satoshi(284950))
-      assert(mainPenaltyTx.txOut(0).amount == Satoshi(195170))
-      assert(htlc1PenaltyTx.txOut(0).amount == Satoshi(194230))
-      assert(htlc2PenaltyTx.txOut(0).amount == Satoshi(294230))
+      assert(mainTx.txOut(0).amount == Satoshi(284930))
+      assert(mainPenaltyTx.txOut(0).amount == Satoshi(195150))
+      assert(htlc1PenaltyTx.txOut(0).amount == Satoshi(194530))
+      assert(htlc2PenaltyTx.txOut(0).amount == Satoshi(294530))
 
       awaitCond(alice.stateName == CLOSING)
       assert(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 1)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -92,7 +92,7 @@ class TransactionsSpec extends FunSuite {
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(20000), pubKeyScript) :: Nil, lockTime = 0)
       val claimP2WPKHOutputTx = makeClaimP2WPKHOutputTx(commitTx, localDustLimit, localPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       // we use dummy signatures to compute the weight
-      val weight = Transaction.weight(addSigs(claimP2WPKHOutputTx, localPaymentPriv.publicKey, "bb" * 71).tx)
+      val weight = Transaction.weight(addSigs(claimP2WPKHOutputTx, localPaymentPriv.publicKey, "bb" * 73).tx)
       assert(claimP2WPKHOutputWeight == weight)
     }
 
@@ -103,7 +103,7 @@ class TransactionsSpec extends FunSuite {
       val htlcSuccessOrTimeoutTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(20000), pubKeyScript) :: Nil, lockTime = 0)
       val claimHtlcDelayedTx = makeClaimDelayedOutputTx(htlcSuccessOrTimeoutTx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       // we use dummy signatures to compute the weight
-      val weight = Transaction.weight(addSigs(claimHtlcDelayedTx, "bb" * 71).tx)
+      val weight = Transaction.weight(addSigs(claimHtlcDelayedTx, "bb" * 73).tx)
       assert(claimHtlcDelayedWeight == weight)
     }
 
@@ -114,7 +114,7 @@ class TransactionsSpec extends FunSuite {
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(20000), pubKeyScript) :: Nil, lockTime = 0)
       val mainPenaltyTx = makeMainPenaltyTx(commitTx, localDustLimit, localRevocationPriv.publicKey, finalPubKeyScript, toLocalDelay, localPaymentPriv.publicKey, feeratePerKw)
       // we use dummy signatures to compute the weight
-      val weight = Transaction.weight(addSigs(mainPenaltyTx, "bb" * 71).tx)
+      val weight = Transaction.weight(addSigs(mainPenaltyTx, "bb" * 73).tx)
       assert(mainPenaltyWeight == weight)
     }
 
@@ -128,7 +128,7 @@ class TransactionsSpec extends FunSuite {
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(htlc.amountMsat / 1000), pubKeyScript) :: Nil, lockTime = 0)
       val htlcPenaltyTx = makeHtlcPenaltyTx(commitTx, outputsAlreadyUsed = Set.empty, Script.write(redeemScript), localDustLimit, finalPubKeyScript, feeratePerKw)
       // we use dummy signatures to compute the weight
-      val weight = Transaction.weight(addSigs(htlcPenaltyTx, "bb" * 71, localRevocationPriv.publicKey).tx)
+      val weight = Transaction.weight(addSigs(htlcPenaltyTx, "bb" * 73, localRevocationPriv.publicKey).tx)
       assert(htlcPenaltyWeight == weight)
     }
 
@@ -141,7 +141,7 @@ class TransactionsSpec extends FunSuite {
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(htlc.amountMsat / 1000), pubKeyScript) :: Nil, lockTime = 0)
       val claimHtlcSuccessTx = makeClaimHtlcSuccessTx(commitTx, outputsAlreadyUsed = Set.empty, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw)
       // we use dummy signatures to compute the weight
-      val weight = Transaction.weight(addSigs(claimHtlcSuccessTx, "bb" * 71, paymentPreimage).tx)
+      val weight = Transaction.weight(addSigs(claimHtlcSuccessTx, "bb" * 73, paymentPreimage).tx)
       assert(claimHtlcSuccessWeight == weight)
     }
 
@@ -154,7 +154,7 @@ class TransactionsSpec extends FunSuite {
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(htlc.amountMsat / 1000), pubKeyScript) :: Nil, lockTime = 0)
       val claimClaimHtlcTimeoutTx = makeClaimHtlcTimeoutTx(commitTx, outputsAlreadyUsed = Set.empty, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw)
       // we use dummy signatures to compute the weight
-      val weight = Transaction.weight(addSigs(claimClaimHtlcTimeoutTx, "bb" * 71).tx)
+      val weight = Transaction.weight(addSigs(claimClaimHtlcTimeoutTx, "bb" * 73).tx)
       assert(claimHtlcTimeoutWeight == weight)
     }
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -83,7 +83,7 @@ class TransactionsSpec extends FunSuite {
     val finalPubKeyScript = Script.write(Script.pay2wpkh(PrivateKey(BinaryData("fe" * 32), compressed = true).publicKey))
     val localDustLimit = Satoshi(546)
     val toLocalDelay = 144
-    val feeratePerKw = 1000
+    val feeratePerKw = fr.acinq.eclair.MinimumFeeratePerKw
 
     {
       // ClaimP2WPKHOutputTx
@@ -94,6 +94,7 @@ class TransactionsSpec extends FunSuite {
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(claimP2WPKHOutputTx, localPaymentPriv.publicKey, "bb" * 73).tx)
       assert(claimP2WPKHOutputWeight == weight)
+      assert(claimP2WPKHOutputTx.fee >= claimP2WPKHOutputTx.minRelayFee)
     }
 
     {
@@ -105,6 +106,7 @@ class TransactionsSpec extends FunSuite {
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(claimHtlcDelayedTx, "bb" * 73).tx)
       assert(claimHtlcDelayedWeight == weight)
+      assert(claimHtlcDelayedTx.fee >= claimHtlcDelayedTx.minRelayFee)
     }
 
     {
@@ -116,6 +118,7 @@ class TransactionsSpec extends FunSuite {
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(mainPenaltyTx, "bb" * 73).tx)
       assert(mainPenaltyWeight == weight)
+      assert(mainPenaltyTx.fee >= mainPenaltyTx.minRelayFee)
     }
 
     {
@@ -130,6 +133,7 @@ class TransactionsSpec extends FunSuite {
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(htlcPenaltyTx, "bb" * 73, localRevocationPriv.publicKey).tx)
       assert(htlcPenaltyWeight == weight)
+      assert(htlcPenaltyTx.fee >= htlcPenaltyTx.minRelayFee)
     }
 
     {
@@ -143,6 +147,7 @@ class TransactionsSpec extends FunSuite {
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(claimHtlcSuccessTx, "bb" * 73, paymentPreimage).tx)
       assert(claimHtlcSuccessWeight == weight)
+      assert(claimHtlcSuccessTx.fee >= claimHtlcSuccessTx.minRelayFee)
     }
 
     {
@@ -156,6 +161,7 @@ class TransactionsSpec extends FunSuite {
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(claimClaimHtlcTimeoutTx, "bb" * 73).tx)
       assert(claimHtlcTimeoutWeight == weight)
+      assert(claimClaimHtlcTimeoutTx.fee >= claimClaimHtlcTimeoutTx.minRelayFee)
     }
   }
 


### PR DESCRIPTION
We currently use feerate-per-kw = feerate-per-kb / 4, which gives 250 for 1000 sat/kb, which can result in transactions that are below the minimum relay fee of 1000 sat/kb.
This is because bitcoin core checks minimum relay fees using a transaction's virtual size (and not its actual size in bytes).
So we want :
    fee > 1000 * virtual size
    feerate-per-kw * weight > 1000 * (3 * weight / 4)
    feerate_per-kw > 250 + 3000 / (4 * weight)
    
With a conservative minimum weight of 400, we get a minimum feerate_per-kw of 253
