### PR TITLE
Update electrum testnet server list, and fix flaky client pool tests

### DIFF
--- a/eclair-core/src/main/resources/electrum/servers_testnet.json
+++ b/eclair-core/src/main/resources/electrum/servers_testnet.json
@@ -1,15 +1,31 @@
 {
-  "testnetnode.arihanc.com": {
-    "t": "51001",
-    "s": "51002"
-  },
-  "testnet.hsmiths.com": {
-    "t": "53011",
-    "s": "53012"
-  },
-  "testnet.qtornado.com": {
-    "t": "51001",
-    "s": "51002"
-  }
+    "electrumx.kekku.li": {
+        "pruning": "-",
+        "s": "51002",
+        "version": "1.2"
+    },
+    "hsmithsxurybd7uh.onion": {
+        "pruning": "-",
+        "s": "53012",
+        "t": "53011",
+        "version": "1.2"
+    },
+    "testnet.hsmiths.com": {
+        "pruning": "-",
+        "s": "53012",
+        "t": "53011",
+        "version": "1.2"
+    },
+    "testnet.qtornado.com": {
+        "pruning": "-",
+        "s": "51002",
+        "t": "51001",
+        "version": "1.2"
+    },
+    "testnet1.bauerj.eu": {
+        "pruning": "-",
+        "s": "50002",
+        "t": "50001",
+        "version": "1.2"
+    }
 }
-

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPoolSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPoolSpec.scala
@@ -49,8 +49,12 @@ class ElectrumClientPoolSpec extends TestKit(ActorSystem("test")) with FunSuiteL
 
   test("connect to an electrumx testnet server") {
     probe.send(router, AddStatusListener(probe.ref))
-    probe.expectMsgType[ElectrumReady](15 seconds)
-  }
+    // make sure our master is stable, if the first master that we select is behind the other servers we will switch
+    // during the first few seconds
+    awaitCond({
+      probe.expectMsgType[ElectrumReady]
+      probe.receiveOne(5 seconds) == null
+    }, max = 15 seconds, interval = 1000 millis)  }
 
   test("get transaction") {
     probe.send(router, GetTransaction("c5efb5cbd35a44ba956b18100be0a91c9c33af4c7f31be20e33741d95f04e202"))


### PR DESCRIPTION
Use the latest electrum testnet server list, and make sure we have selected a stable server before we start our client pool test.