### PR TITLE
Inform clients about incoming payments via websocket connection

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -228,6 +228,8 @@ class Setup(datadir: File, overrideDefaults: Config = ConfigFactory.empty(), act
               blockHeight = Globals.blockCount.intValue()))
 
           override def appKit: Kit = kit
+
+          override val socketHandler = makeSocketHandler(system)(materializer)
         }
         val httpBound = Http().bindAndHandle(api.route, config.getString("api.binding-ip"), config.getInt("api.port")).recover {
           case _: BindFailedException => throw TCPBindException(config.getInt("api.port"))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -16,16 +16,20 @@
 
 package fr.acinq.eclair.api
 
-import akka.actor.{ActorRef, Scheduler}
+import akka.NotUsed
+import akka.actor.{Actor, ActorRef, ActorSystem, Props, Scheduler}
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.CacheDirectives.{`max-age`, `no-store`, public}
 import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.ws.{Message, TextMessage}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server._
 import akka.http.scaladsl.server.directives.Credentials
 import akka.http.scaladsl.server.directives.RouteDirectives.reject
 import akka.pattern.ask
+import akka.stream.{ActorMaterializer, OverflowStrategy}
+import akka.stream.scaladsl.{BroadcastHub, Flow, Keep, Source}
 import akka.util.Timeout
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport.ShouldWritePretty
@@ -35,7 +39,7 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.io.Peer.{GetPeerInfo, PeerInfo}
 import fr.acinq.eclair.io.{NodeURI, Peer}
 import fr.acinq.eclair.payment.PaymentLifecycle._
-import fr.acinq.eclair.payment.{PaymentLifecycle, PaymentRequest}
+import fr.acinq.eclair.payment.{PaymentLifecycle, PaymentReceived, PaymentRequest}
 import fr.acinq.eclair.router.{ChannelDesc, RouteRequest, RouteResponse}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement}
 import fr.acinq.eclair.{Kit, ShortChannelId, feerateByte2Kw}
@@ -79,6 +83,8 @@ trait Service extends Logging {
   def password: String
 
   def appKit: Kit
+
+  val socketHandler: Flow[Message, TextMessage.Strict, NotUsed]
 
   def userPassAuthenticator(credentials: Credentials): Future[Option[String]] = credentials match {
     case p@Credentials.Provided(id) if p.verify(password) => Future.successful(Some(id))
@@ -300,6 +306,8 @@ trait Service extends Logging {
                   }
                 }
               }
+            } ~ path("ws") {
+              handleWebSocketMessages(socketHandler)
             }
           }
         }
@@ -307,6 +315,23 @@ trait Service extends Logging {
     }
 
   def getInfoResponse: Future[GetInfoResponse]
+
+  def makeSocketHandler(system: ActorSystem)(implicit materializer: ActorMaterializer): Flow[Message, TextMessage.Strict, NotUsed] = {
+
+    // create a flow transforming a queue of string -> string
+    val (flowInput, flowOutput) = Source.queue[String](10, OverflowStrategy.dropTail).toMat(BroadcastHub.sink[String])(Keep.both).run()
+
+    // register an actor that feeds the queue when a payment is received
+    system.actorOf(Props(new Actor {
+      override def preStart: Unit = context.system.eventStream.subscribe(self, classOf[PaymentReceived])
+      def receive: Receive = { case received: PaymentReceived => flowInput.offer(received.paymentHash.toString) }
+    }))
+
+    Flow[Message]
+      .mapConcat(_ => Nil) // Ignore heartbeats and other data from the client
+      .merge(flowOutput) // Stream the data we want to the client
+      .map(TextMessage.apply)
+  }
 
   def help = List(
     "connect (uri): open a secure connection to a lightning node",


### PR DESCRIPTION
This is a second attempt based on suggestions from https://github.com/ACINQ/eclair/pull/594 since I've deleted my fork for that one.

`path("ws")` is moved inside `handleRejections` block, having it in `authenticateBasicAsync` yields `Missing` credentials even if I try to connect using `ws://eclair:pass@127.0.0.1:8080/ws`