### PR TITLE
add in api calls to allow async sends. Fixes #615

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ java -Declair.datadir=/tmp/node1 -jar eclair-node-gui-<version>-<commit_id>.jar
   send         | amountMsat, paymentHash, nodeId                                                        | send a payment to a lightning node
   send         | paymentRequest                                                                         | send a payment to a lightning node using a BOLT11 payment request
   send         | paymentRequest, amountMsat                                                             | send a payment to a lightning node using a BOLT11 payment request and a custom amount
+  sendasync    | as per send above                                                                      | send a payment to a lightning node. Same parameters as send but returns an ID instantly. 
+  checksentpayment| sendpaymentid                                                                       | returns if id is valid and a result if there is one. If no result payment is still pending.
   checkpayment | paymentHash                                                                            | returns true if the payment has been received, false otherwise
   checkpayment | paymentRequest                                                                         | returns true if the payment has been received, false otherwise
   close        | channelId                                                                              | close a channel

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentInitiator.scala
@@ -18,17 +18,27 @@ package fr.acinq.eclair.payment
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.eclair.payment.PaymentLifecycle.SendPayment
+import fr.acinq.eclair.payment.PaymentLifecycle.{SendPayment,PaymentResult}
 
 /**
   * Created by PM on 29/08/2016.
   */
 class PaymentInitiator(sourceNodeId: PublicKey, router: ActorRef, register: ActorRef) extends Actor with ActorLogging {
+  override def receive: Receive = run(Map(),Map(),0)
 
-  override def receive: Receive = {
+  def run(actors: Map[ActorRef, Long],results: Map[Long,Option[PaymentResult]] , paymentCounterId: Long): Receive = {
     case c: SendPayment =>
       val payFsm = context.actorOf(PaymentLifecycle.props(sourceNodeId, router, register))
+      if (c.async) sender ! SendPaymentId(paymentCounterId)
       payFsm forward c
+      context.become(run(actors + (payFsm -> paymentCounterId), results +(paymentCounterId -> None), paymentCounterId+1))
+    case (state: PaymentResult) =>
+      val id=actors(sender)
+      log.info("got:"+id+" state:"+state.toString())
+      context.become(run(actors,results + (id -> Some(state)),paymentCounterId))
+    case SendPaymentId(id) =>
+      log.info(s"got: $id state2:"+results.get(id))
+      sender ! CheckSendPaymentResult(results.contains(id),results.get(id))
   }
 
 }
@@ -36,3 +46,7 @@ class PaymentInitiator(sourceNodeId: PublicKey, router: ActorRef, register: Acto
 object PaymentInitiator {
   def props(sourceNodeId: PublicKey, router: ActorRef, register: ActorRef) = Props(classOf[PaymentInitiator], sourceNodeId, router, register)
 }
+
+case class SendPaymentId(id: Long) // A reference for this payment to allow api to callback to get status. As payments can hang.
+
+case class CheckSendPaymentResult(validId: Boolean, result: Option[Option[PaymentResult]])

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
@@ -171,6 +171,7 @@ class PaymentLifecycle(sourceNodeId: PublicKey, router: ActorRef, register: Acto
 
   def reply(to: ActorRef, e: PaymentResult) = {
     to ! e
+    context.parent ! e
     context.system.eventStream.publish(e)
   }
 
@@ -187,7 +188,8 @@ object PaymentLifecycle {
     * @param finalCltvExpiry by default we choose finalCltvExpiry = Channel.MIN_CLTV_EXPIRY + 1 to not have our htlc fail when a new block has just been found
     * @param maxFeePct set by default to 3% as a safety measure (even if a route is found, if fee is higher than that payment won't be attempted)
     */
-  case class SendPayment(amountMsat: Long, paymentHash: BinaryData, targetNodeId: PublicKey, assistedRoutes: Seq[Seq[ExtraHop]] = Nil, finalCltvExpiry: Long = Channel.MIN_CLTV_EXPIRY + 1, maxAttempts: Int = 5, maxFeePct: Double = 0.03) {
+  case class SendPayment(amountMsat: Long, paymentHash: BinaryData, targetNodeId: PublicKey, assistedRoutes: Seq[Seq[ExtraHop]] = Nil,
+      finalCltvExpiry: Long = Channel.MIN_CLTV_EXPIRY + 1, maxAttempts: Int = 5, maxFeePct: Double = 0.03, async: Boolean=false) {
     require(amountMsat > 0, s"amountMsat must be > 0")
   }
   case class CheckPayment(paymentHash: BinaryData)


### PR DESCRIPTION
Adds 2 API calls sendasync - this is identical to send but returns id instantly.
and checksentpayment - this takes the id as a parameter and return a result when there is one. If no results instantly returns nothing.