### PR TITLE
WIP: Adding hikari connection pool, release db connections back to pool af…

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -178,6 +178,12 @@
             <version>3.21.0.1</version>
         </dependency>
         <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>2.7.8</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
             <version>1.0.1</version>

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -79,41 +79,22 @@ eclair {
   max-payment-fee = 0.03 // max total fee for outgoing payments, in percentage: sending a payment will not be attempted if the cheapest route found is more expensive than that
   min-funding-satoshis = 100000
 
-  eclairDb {
+  db {
     driver="org.sqlite.JDBC"
     mainnet {
-      url = "jdbc:sqlite:"${HOME}"/.eclair/mainnet/eclair.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/mainnet/"
     }
 
     testnet {
-      url = "jdbc:sqlite:"${HOME}"/.eclair/testnet/eclair.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/testnet/"
     }
 
     regtest {
-      url = "jdbc:sqlite:"${HOME}"/.eclair/regtest/eclair.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/regtest/"
     }
 
     unittest {
-      url = "jdbc:sqlite:"${HOME}"/.eclair/unittest/eclair.sqlite"
-    }
-  }
-
-  networkDb {
-    driver="org.sqlite.JDBC"
-    mainnet {
-      url = "jdbc:sqlite:"${HOME}"/.eclair/mainnet/network.sqlite"
-    }
-
-    testnet {
-      url = "jdbc:sqlite:"${HOME}"/.eclair/testnet/network.sqlite"
-    }
-
-    regtest {
-      url = "jdbc:sqlite:"${HOME}"/.eclair/regtest/network.sqlite"
-    }
-
-    unittest {
-      url = "jdbc:sqlite:"${HOME}"/.eclair/unittest/network.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/unittest/"
     }
   }
 }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -78,4 +78,23 @@ eclair {
   max-pending-payment-requests = 10000000
   max-payment-fee = 0.03 // max total fee for outgoing payments, in percentage: sending a payment will not be attempted if the cheapest route found is more expensive than that
   min-funding-satoshis = 100000
+
+  db {
+    driver="org.sqlite.JDBC"
+    mainnet {
+      url = "jdbc:sqlite:/home/chris/.eclair/mainnet"
+    }
+
+    testnet {
+      url = "jdbc:sqlite:/home/chris/.eclair/testnet"
+    }
+
+    regtest {
+      url = "jdbc:sqlite:/home/chris/.eclair/regtest"
+    }
+
+    unittest {
+      url = "jdbc:sqlite::memory:"
+    }
+  }
 }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -79,22 +79,50 @@ eclair {
   max-payment-fee = 0.03 // max total fee for outgoing payments, in percentage: sending a payment will not be attempted if the cheapest route found is more expensive than that
   min-funding-satoshis = 100000
 
+<<<<<<< Updated upstream
   db {
     driver="org.sqlite.SQLiteDataSource"
+=======
+  eclairDb {
+    driver="org.sqlite.JDBC"
+>>>>>>> Stashed changes
     mainnet {
-      url = "jdbc:sqlite:/home/chris/.eclair/mainnet"
+      url = "jdbc:sqlite:/home/chris/.eclair/mainnet/eclair.sqlite"
     }
 
     testnet {
-      url = "jdbc:sqlite:/home/chris/.eclair/testnet"
+      url = "jdbc:sqlite:/home/chris/.eclair/testnet/eclair.sqlite"
     }
 
     regtest {
-      url = "jdbc:sqlite:/home/chris/.eclair/regtest"
+      url = "jdbc:sqlite:/home/chris/.eclair/regtest/eclair.sqlite"
     }
 
     unittest {
+<<<<<<< Updated upstream
       url = "jdbc:sqlite:/home/chris/.eclair/unittest"
+=======
+      url = "jdbc:sqlite:/home/chris/.eclair/unittest/eclair.sqlite"
+    }
+  }
+
+  networkDb {
+    driver="org.sqlite.JDBC"
+    mainnet {
+      url = "jdbc:sqlite:/home/chris/.eclair/mainnet/network.sqlite"
+    }
+
+    testnet {
+      url = "jdbc:sqlite:/home/chris/.eclair/testnet/network.sqlite"
+    }
+
+    regtest {
+      url = "jdbc:sqlite:/home/chris/.eclair/regtest/network.sqlite"
+    }
+
+    unittest {
+      url = "jdbc:sqlite:/home/chris/.eclair/unittest/network.sqlite"
+>>>>>>> Stashed changes
     }
   }
 }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -79,50 +79,41 @@ eclair {
   max-payment-fee = 0.03 // max total fee for outgoing payments, in percentage: sending a payment will not be attempted if the cheapest route found is more expensive than that
   min-funding-satoshis = 100000
 
-<<<<<<< Updated upstream
-  db {
-    driver="org.sqlite.SQLiteDataSource"
-=======
   eclairDb {
     driver="org.sqlite.JDBC"
->>>>>>> Stashed changes
     mainnet {
-      url = "jdbc:sqlite:/home/chris/.eclair/mainnet/eclair.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/mainnet/eclair.sqlite"
     }
 
     testnet {
-      url = "jdbc:sqlite:/home/chris/.eclair/testnet/eclair.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/testnet/eclair.sqlite"
     }
 
     regtest {
-      url = "jdbc:sqlite:/home/chris/.eclair/regtest/eclair.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/regtest/eclair.sqlite"
     }
 
     unittest {
-<<<<<<< Updated upstream
-      url = "jdbc:sqlite:/home/chris/.eclair/unittest"
-=======
-      url = "jdbc:sqlite:/home/chris/.eclair/unittest/eclair.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/unittest/eclair.sqlite"
     }
   }
 
   networkDb {
     driver="org.sqlite.JDBC"
     mainnet {
-      url = "jdbc:sqlite:/home/chris/.eclair/mainnet/network.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/mainnet/network.sqlite"
     }
 
     testnet {
-      url = "jdbc:sqlite:/home/chris/.eclair/testnet/network.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/testnet/network.sqlite"
     }
 
     regtest {
-      url = "jdbc:sqlite:/home/chris/.eclair/regtest/network.sqlite"
+      url = "jdbc:sqlite:"${HOME}"/.eclair/regtest/network.sqlite"
     }
 
     unittest {
-      url = "jdbc:sqlite:/home/chris/.eclair/unittest/network.sqlite"
->>>>>>> Stashed changes
+      url = "jdbc:sqlite:"${HOME}"/.eclair/unittest/network.sqlite"
     }
   }
 }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -80,7 +80,7 @@ eclair {
   min-funding-satoshis = 100000
 
   db {
-    driver="org.sqlite.JDBC"
+    driver="org.sqlite.SQLiteDataSource"
     mainnet {
       url = "jdbc:sqlite:/home/chris/.eclair/mainnet"
     }
@@ -94,7 +94,7 @@ eclair {
     }
 
     unittest {
-      url = "jdbc:sqlite::memory:"
+      url = "jdbc:sqlite:/home/chris/.eclair/unittest"
     }
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -73,11 +73,11 @@ case class NodeParams(keyManager: KeyManager,
   val privateKey = keyManager.nodeKey.privateKey
   val nodeId = keyManager.nodeId
 
-  lazy val channelsDb = new SqliteChannelsDb(dbConfig)
-  lazy val peersDb = new SqlitePeersDb(dbConfig)
-  lazy val networkDb = new SqliteNetworkDb(dbConfig)
-  lazy val pendingRelayDb = new SqlitePendingRelayDb(dbConfig)
-  lazy val paymentsDb = new SqlitePaymentsDb(dbConfig)
+  val channelsDb = new SqliteChannelsDb(dbConfig)
+  val peersDb = new SqlitePeersDb(dbConfig)
+  val networkDb = new SqliteNetworkDb(dbConfig)
+  val pendingRelayDb = new SqlitePendingRelayDb(dbConfig)
+  val paymentsDb = new SqlitePaymentsDb(dbConfig)
 
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -74,10 +74,15 @@ case class NodeParams(keyManager: KeyManager,
   val nodeId = keyManager.nodeId
 
   val channelsDb = new SqliteChannelsDb(dbConfig.eclairDb)
+  channelsDb.createTables //create tables if DNE
   val peersDb = new SqlitePeersDb(dbConfig.networkDb)
+  peersDb.createTables //create tables if DNE
   val networkDb = new SqliteNetworkDb(dbConfig.networkDb)
+  networkDb.createTables //create tables if DNE
   val pendingRelayDb = new SqlitePendingRelayDb(dbConfig.eclairDb)
+  pendingRelayDb.createTables //create tables if DNE
   val paymentsDb = new SqlitePaymentsDb(dbConfig.eclairDb)
+  paymentsDb.createTables //create tables if DNE
 
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -69,15 +69,15 @@ case class NodeParams(keyManager: KeyManager,
                       maxPendingPaymentRequests: Int,
                       maxPaymentFee: Double,
                       minFundingSatoshis: Long,
-                      dbConfig: DbConfig) {
+                      dbConfig: AppDbConfig) {
   val privateKey = keyManager.nodeKey.privateKey
   val nodeId = keyManager.nodeId
 
-  val channelsDb = new SqliteChannelsDb(dbConfig)
-  val peersDb = new SqlitePeersDb(dbConfig)
-  val networkDb = new SqliteNetworkDb(dbConfig)
-  val pendingRelayDb = new SqlitePendingRelayDb(dbConfig)
-  val paymentsDb = new SqlitePaymentsDb(dbConfig)
+  val channelsDb = new SqliteChannelsDb(dbConfig.eclairDb)
+  val peersDb = new SqlitePeersDb(dbConfig.networkDb)
+  val networkDb = new SqliteNetworkDb(dbConfig.networkDb)
+  val pendingRelayDb = new SqlitePendingRelayDb(dbConfig.networkDb)
+  val paymentsDb = new SqlitePaymentsDb(dbConfig.eclairDb)
 
 }
 
@@ -133,8 +133,9 @@ object NodeParams extends Logging {
     val chaindir = new File(datadir, chain)
     chaindir.mkdir()
 
-    val dbConfig = DbConfig.fromConfig(config)
-
+    val eclairDb = EclairDbConfig.fromConfig(config)
+    val networkDb = NetworkDbConfig.fromConfig(config)
+    val appDbConfig = AppDbConfig(eclairDb,networkDb)
     val color = BinaryData(config.getString("node-color"))
     require(color.size == 3, "color should be a 3-bytes hex buffer")
 
@@ -184,7 +185,7 @@ object NodeParams extends Logging {
       maxPendingPaymentRequests = config.getInt("max-pending-payment-requests"),
       maxPaymentFee = config.getDouble("max-payment-fee"),
       minFundingSatoshis = config.getLong("min-funding-satoshis"),
-      dbConfig = dbConfig
+      dbConfig = appDbConfig
     )
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -76,7 +76,7 @@ case class NodeParams(keyManager: KeyManager,
   val channelsDb = new SqliteChannelsDb(dbConfig.eclairDb)
   val peersDb = new SqlitePeersDb(dbConfig.networkDb)
   val networkDb = new SqliteNetworkDb(dbConfig.networkDb)
-  val pendingRelayDb = new SqlitePendingRelayDb(dbConfig.networkDb)
+  val pendingRelayDb = new SqlitePendingRelayDb(dbConfig.eclairDb)
   val paymentsDb = new SqlitePaymentsDb(dbConfig.eclairDb)
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -55,7 +55,10 @@ import scala.concurrent.{Await, ExecutionContext, Future, Promise}
   * @param actorSystem
   * @param seed_opt optional seed, if set eclair will use it instead of generating one and won't create a seed.dat file.
   */
-class Setup(datadir: File, overrideDefaults: Config = ConfigFactory.empty(), actorSystem: ActorSystem = ActorSystem(), seed_opt: Option[BinaryData] = None) extends Logging {
+class Setup(datadir: File,
+            overrideDefaults: Config = ConfigFactory.empty(),
+            actorSystem: ActorSystem = ActorSystem(),
+            seed_opt: Option[BinaryData] = None) extends Logging {
 
   logger.info(s"hello!")
   logger.info(s"version=${getClass.getPackage.getImplementationVersion} commit=${getClass.getPackage.getSpecificationVersion}")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
@@ -60,7 +60,10 @@ class ZMQActor(address: String, connected: Option[Promise[Boolean]] = None) exte
       self ! msg
       checkMsg
     case None =>
-      context.system.scheduler.scheduleOnce(1 second)(checkMsg)
+      context
+        .system
+        .scheduler
+        .scheduleOnce(1 second)(checkMsg)
   }
 
   checkEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -19,7 +19,7 @@ package fr.acinq.eclair.db
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.channel.HasCommitments
 
-trait ChannelsDb {
+trait ChannelsDb extends DbManagement {
 
   def addOrUpdateChannel(state: HasCommitments)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbConfig.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbConfig.scala
@@ -48,11 +48,9 @@ object EclairDbConfig extends Logging {
 
     //create file if it DNE
     val filePath = dbUrl.split(":").last
-    logger.info(s"filePath $filePath")
     val file = new File(filePath)
     file.mkdirs()
     val db = new File(file.getAbsolutePath + "/eclair.sqlite")
-    logger.info(s"db ${db.getAbsolutePath}")
     db.createNewFile()
 
     hikariConfig.setJdbcUrl(dbUrl + "/eclair.sqlite")
@@ -96,11 +94,9 @@ object NetworkDbConfig extends Logging  {
 
     //create file if it DNE
     val filePath = dbUrl.split(":").last
-    logger.info(s"filePath $filePath")
     val file = new File(filePath)
     file.mkdirs()
     val db = new File(file.getAbsolutePath + "/network.sqlite")
-    logger.info(s"db ${db.getAbsolutePath}")
     db.createNewFile()
 
     hikariConfig.setJdbcUrl(dbUrl + "/network.sqlite")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbConfig.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbConfig.scala
@@ -1,0 +1,55 @@
+package fr.acinq.eclair.db
+
+import java.sql.Connection
+
+import com.typesafe.config.Config
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
+
+class DbConfig(hikariConfig: HikariConfig) {
+
+  private val dataSource: HikariDataSource = new HikariDataSource(hikariConfig)
+
+  def getConnection(): Connection = dataSource.getConnection
+
+  /** Closes [[com.zaxxer.hikari.HikariDataSource]] */
+  def close(): Unit = dataSource.close()
+
+  def isClosed(): Boolean = dataSource.isClosed
+
+  def isRunning(): Boolean = dataSource.isRunning
+}
+
+
+object DbConfig {
+
+
+  /** Reads the network you want from the reference.conf file */
+  def fromConfig(config: Config): DbConfig = {
+    val chain = config.getString("eclair.chain")
+    fromConfig(config,chain)
+  }
+
+  private def fromConfig(config: Config, chain: String): DbConfig = {
+    val driver = config.getString("eclair.db.driver")
+    val dbUrl = config.getString(s"eclair.db.${chain}.url")
+    val hikariConfig = new HikariConfig()
+    hikariConfig.setJdbcUrl(dbUrl)
+    new DbConfig(hikariConfig)
+  }
+
+  def mainnetConfig(config: Config): DbConfig = {
+    fromConfig(config, "mainnet")
+  }
+
+  def testnetConfig(config: Config): DbConfig = {
+    fromConfig(config,"testnet")
+  }
+
+  def regtestConfig(config: Config): DbConfig = {
+    fromConfig(config,"regtest")
+  }
+
+  def unittestConfig(config: Config): DbConfig = {
+    fromConfig(config,"unittest")
+  }
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbConfig.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbConfig.scala
@@ -35,13 +35,13 @@ object EclairDbConfig extends Logging {
 
   /** Reads the network you want from the reference.conf file */
   def fromConfig(config: Config): EclairDbConfig = {
-    val chain = config.getString("eclair.chain")
+    val chain = config.getString("chain")
     fromConfig(config,chain)
   }
 
   private def fromConfig(config: Config, chain: String): EclairDbConfig = {
-    val driver = config.getString(s"eclair.db.driver")
-    val dbChainConfig = config.getConfig(s"eclair.db.${chain}")
+    val driver = config.getString(s"db.driver")
+    val dbChainConfig = config.getConfig(s"db.${chain}")
     val dbUrl = dbChainConfig.getString("url")
     val hikariConfig = new HikariConfig()
     hikariConfig.setDriverClassName(driver)
@@ -80,13 +80,13 @@ object NetworkDbConfig extends Logging  {
 
   /** Reads the network you want from the reference.conf file */
   def fromConfig(config: Config): NetworkDbConfig = {
-    val chain = config.getString("eclair.chain")
+    val chain = config.getString("chain")
     fromConfig(config,chain)
   }
 
   private def fromConfig(config: Config, chain: String): NetworkDbConfig = {
-    val driver = config.getString(s"eclair.db.driver")
-    val dbChainConfig = config.getConfig(s"eclair.db.${chain}")
+    val driver = config.getString(s"db.driver")
+    val dbChainConfig = config.getConfig(s"db.${chain}")
     val dbUrl = dbChainConfig.getString("url")
     val hikariConfig = new HikariConfig()
     hikariConfig.setDriverClassName(driver)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbConfig.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbConfig.scala
@@ -93,6 +93,7 @@ object NetworkDbConfig extends Logging  {
     val hikariConfig = new HikariConfig()
     hikariConfig.setDriverClassName(driver)
     hikariConfig.setJdbcUrl(dbUrl)
+
     //create file if it DNE
     val filePath = dbUrl.split(":").last
     logger.info(s"filePath $filePath")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbConfig.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbConfig.scala
@@ -50,7 +50,7 @@ object EclairDbConfig extends Logging {
     val filePath = dbUrl.split(":").last
     logger.info(s"filePath $filePath")
     val file = new File(filePath)
-    file.mkdir()
+    file.mkdirs()
     val db = new File(file.getAbsolutePath + "/eclair.sqlite")
     logger.info(s"db ${db.getAbsolutePath}")
     db.createNewFile()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbManagement.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbManagement.scala
@@ -1,0 +1,5 @@
+package fr.acinq.eclair.db
+
+trait DbManagement {
+  def dbConfig: DbConfig
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbManagement.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbManagement.scala
@@ -2,4 +2,8 @@ package fr.acinq.eclair.db
 
 trait DbManagement {
   def dbConfig: DbConfig
+
+  def createTables: Unit
+
+  def dropTables: Unit
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
@@ -21,7 +21,7 @@ import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement}
 
-trait NetworkDb {
+trait NetworkDb extends DbManagement {
 
   def addNode(n: NodeAnnouncement)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -33,7 +33,7 @@ import fr.acinq.bitcoin.BinaryData
   * </ul>
   * Payments should not be updated nor deleted.
   */
-trait PaymentsDb {
+trait PaymentsDb extends DbManagement {
 
   def addPayment(payment: Payment)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
@@ -20,7 +20,7 @@ import java.net.InetSocketAddress
 
 import fr.acinq.bitcoin.Crypto.PublicKey
 
-trait PeersDb {
+trait PeersDb extends DbManagement {
 
   def addOrUpdatePeer(nodeId: PublicKey, address: InetSocketAddress)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
@@ -31,7 +31,7 @@ import fr.acinq.eclair.channel.Command
   * to handle all corner cases.
   *
   */
-trait PendingRelayDb {
+trait PendingRelayDb extends DbManagement {
 
   def addPendingRelay(channelId: BinaryData, htlcId: Long, cmd: Command)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -49,9 +49,8 @@ class SqliteChannelsDb(override val dbConfig: EclairDbConfig) extends ChannelsDb
   override def dropTables: Unit = {
     using(conn.createStatement()) { statement =>
       require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
-      statement.execute("PRAGMA foreign_keys = ON")
-      statement.executeUpdate("DROP TABLE IF EXISTS local_channels")
       statement.executeUpdate("DROP TABLE IF EXISTS htlc_infos")
+      statement.executeUpdate("DROP TABLE IF EXISTS local_channels")
       statement.executeUpdate("DROP INDEX IF EXISTS htlc_infos_idx")
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -20,13 +20,13 @@ import java.sql.Connection
 
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.channel.HasCommitments
-import fr.acinq.eclair.db.{ChannelsDb, DbConfig}
+import fr.acinq.eclair.db.{ChannelsDb, DbConfig, EclairDbConfig}
 import fr.acinq.eclair.wire.ChannelCodecs.stateDataCodec
 import scodec.bits.BitVector
 
 import scala.collection.immutable.Queue
 
-class SqliteChannelsDb(override val dbConfig: DbConfig) extends ChannelsDb {
+class SqliteChannelsDb(override val dbConfig: EclairDbConfig) extends ChannelsDb {
 
   import SqliteUtils._
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -36,6 +36,7 @@ class SqliteChannelsDb(override val dbConfig: DbConfig) extends ChannelsDb {
   private def conn = dbConfig.getConnection()
 
   override def createTables: Unit = {
+
     using(conn.createStatement()) { statement =>
       require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
       statement.execute("PRAGMA foreign_keys = ON")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -20,20 +20,22 @@ import java.sql.Connection
 
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.channel.HasCommitments
-import fr.acinq.eclair.db.ChannelsDb
+import fr.acinq.eclair.db.{ChannelsDb, DbConfig}
 import fr.acinq.eclair.wire.ChannelCodecs.stateDataCodec
 import scodec.bits.BitVector
 
 import scala.collection.immutable.Queue
 
-class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb {
+class SqliteChannelsDb(override val dbConfig: DbConfig) extends ChannelsDb {
 
   import SqliteUtils._
 
   val DB_NAME = "channels"
   val CURRENT_VERSION = 1
 
-  using(sqlite.createStatement()) { statement =>
+  private def conn = dbConfig.getConnection()
+
+  using(conn.createStatement()) { statement =>
     require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
     statement.execute("PRAGMA foreign_keys = ON")
     statement.executeUpdate("CREATE TABLE IF NOT EXISTS local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL)")
@@ -43,11 +45,11 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb {
 
   override def addOrUpdateChannel(state: HasCommitments): Unit = {
     val data = stateDataCodec.encode(state).require.toByteArray
-    using (sqlite.prepareStatement("UPDATE local_channels SET data=? WHERE channel_id=?")) { update =>
+    using (conn.prepareStatement("UPDATE local_channels SET data=? WHERE channel_id=?")) { update =>
       update.setBytes(1, data)
       update.setBytes(2, state.channelId)
       if (update.executeUpdate() == 0) {
-        using(sqlite.prepareStatement("INSERT INTO local_channels VALUES (?, ?)")) { statement =>
+        using(conn.prepareStatement("INSERT INTO local_channels VALUES (?, ?)")) { statement =>
           statement.setBytes(1, state.channelId)
           statement.setBytes(2, data)
           statement.executeUpdate()
@@ -57,31 +59,31 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb {
   }
 
   override def removeChannel(channelId: BinaryData): Unit = {
-    using(sqlite.prepareStatement("DELETE FROM pending_relay WHERE channel_id=?")) { statement =>
+    using(conn.prepareStatement("DELETE FROM pending_relay WHERE channel_id=?")) { statement =>
       statement.setBytes(1, channelId)
       statement.executeUpdate()
     }
 
-    using(sqlite.prepareStatement("DELETE FROM htlc_infos WHERE channel_id=?")) { statement =>
+    using(conn.prepareStatement("DELETE FROM htlc_infos WHERE channel_id=?")) { statement =>
       statement.setBytes(1, channelId)
       statement.executeUpdate()
     }
 
-    using(sqlite.prepareStatement("DELETE FROM local_channels WHERE channel_id=?")) { statement =>
+    using(conn.prepareStatement("DELETE FROM local_channels WHERE channel_id=?")) { statement =>
       statement.setBytes(1, channelId)
       statement.executeUpdate()
     }
   }
 
   override def listChannels(): Seq[HasCommitments] = {
-    using(sqlite.createStatement) { statement =>
+    using(conn.createStatement) { statement =>
       val rs = statement.executeQuery("SELECT data FROM local_channels")
       codecSequence(rs, stateDataCodec)
     }
   }
 
   def addOrUpdateHtlcInfo(channelId: BinaryData, commitmentNumber: Long, paymentHash: BinaryData, cltvExpiry: Long): Unit = {
-    using(sqlite.prepareStatement("INSERT OR IGNORE INTO htlc_infos VALUES (?, ?, ?, ?)")) { statement =>
+    using(conn.prepareStatement("INSERT OR IGNORE INTO htlc_infos VALUES (?, ?, ?, ?)")) { statement =>
       statement.setBytes(1, channelId)
       statement.setLong(2, commitmentNumber)
       statement.setBytes(3, paymentHash)
@@ -91,7 +93,7 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb {
   }
 
   def listHtlcHtlcInfos(channelId: BinaryData, commitmentNumber: Long): Seq[(BinaryData, Long)] = {
-    using(sqlite.prepareStatement("SELECT payment_hash, cltv_expiry FROM htlc_infos WHERE channel_id=? AND commitment_number=?")) { statement =>
+    using(conn.prepareStatement("SELECT payment_hash, cltv_expiry FROM htlc_infos WHERE channel_id=? AND commitment_number=?")) { statement =>
       statement.setBytes(1, channelId)
       statement.setLong(2, commitmentNumber)
       val rs = statement.executeQuery

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -20,13 +20,13 @@ import java.sql.Connection
 
 import fr.acinq.bitcoin.{BinaryData, Crypto, Satoshi}
 import fr.acinq.eclair.ShortChannelId
-import fr.acinq.eclair.db.{DbConfig, NetworkDb}
+import fr.acinq.eclair.db.{DbConfig, NetworkDb, NetworkDbConfig}
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire.LightningMessageCodecs.{channelAnnouncementCodec, channelUpdateCodec, nodeAnnouncementCodec}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement}
 import scodec.bits.BitVector
 
-class SqliteNetworkDb(override val dbConfig: DbConfig) extends NetworkDb {
+class SqliteNetworkDb(override val dbConfig: NetworkDbConfig) extends NetworkDb {
 
   import SqliteUtils._
 
@@ -48,9 +48,9 @@ class SqliteNetworkDb(override val dbConfig: DbConfig) extends NetworkDb {
   override def dropTables: Unit = {
     using(conn.createStatement()) { statement =>
       require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
-      statement.executeUpdate("DROP TABLE IF EXISTS nodes")
-      statement.executeUpdate("DROP TABLE IF EXISTS channels")
       statement.executeUpdate("DROP TABLE IF EXISTS channel_updates")
+      statement.executeUpdate("DROP TABLE IF EXISTS channels")
+      statement.executeUpdate("DROP TABLE IF EXISTS nodes")
       statement.executeUpdate("DROP INDEX IF EXISTS channel_updates_idx")
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -20,7 +20,7 @@ import java.sql.Connection
 
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.db.sqlite.SqliteUtils.{getVersion, using}
-import fr.acinq.eclair.db.{DbConfig, Payment, PaymentsDb}
+import fr.acinq.eclair.db.{DbConfig, EclairDbConfig, Payment, PaymentsDb}
 import grizzled.slf4j.Logging
 
 import scala.collection.immutable.Queue
@@ -35,7 +35,7 @@ import scala.collection.immutable.Queue
   * <li>`amount_msat`: INTEGER
   * <li>`timestamp`: INTEGER (unix timestamp)
   */
-class SqlitePaymentsDb(override val dbConfig: DbConfig) extends PaymentsDb with Logging {
+class SqlitePaymentsDb(override val dbConfig: EclairDbConfig) extends PaymentsDb with Logging {
 
   val DB_NAME = "payments"
   val CURRENT_VERSION = 1

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -42,10 +42,20 @@ class SqlitePaymentsDb(override val dbConfig: DbConfig) extends PaymentsDb with 
 
   private def conn = dbConfig.getConnection()
 
-  using(conn.createStatement()) { statement =>
-    require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
-    statement.executeUpdate("CREATE TABLE IF NOT EXISTS payments (payment_hash BLOB NOT NULL PRIMARY KEY, amount_msat INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
+  override def createTables: Unit = {
+    using(conn.createStatement()) { statement =>
+      require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
+      statement.executeUpdate("CREATE TABLE IF NOT EXISTS payments (payment_hash BLOB NOT NULL PRIMARY KEY, amount_msat INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
+    }
   }
+
+  override def dropTables: Unit = {
+    using(conn.createStatement()) { statement =>
+      require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
+      statement.executeUpdate("DROP TABLE IF EXISTS payments")
+    }
+  }
+
 
   override def addPayment(payment: Payment): Unit = {
     using(conn.prepareStatement("INSERT INTO payments VALUES (?, ?, ?)")) { statement =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -20,7 +20,7 @@ import java.sql.Connection
 
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.db.sqlite.SqliteUtils.{getVersion, using}
-import fr.acinq.eclair.db.{Payment, PaymentsDb}
+import fr.acinq.eclair.db.{DbConfig, Payment, PaymentsDb}
 import grizzled.slf4j.Logging
 
 import scala.collection.immutable.Queue
@@ -35,18 +35,20 @@ import scala.collection.immutable.Queue
   * <li>`amount_msat`: INTEGER
   * <li>`timestamp`: INTEGER (unix timestamp)
   */
-class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
+class SqlitePaymentsDb(override val dbConfig: DbConfig) extends PaymentsDb with Logging {
 
   val DB_NAME = "payments"
   val CURRENT_VERSION = 1
 
-  using(sqlite.createStatement()) { statement =>
+  private def conn = dbConfig.getConnection()
+
+  using(conn.createStatement()) { statement =>
     require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
     statement.executeUpdate("CREATE TABLE IF NOT EXISTS payments (payment_hash BLOB NOT NULL PRIMARY KEY, amount_msat INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
   }
 
   override def addPayment(payment: Payment): Unit = {
-    using(sqlite.prepareStatement("INSERT INTO payments VALUES (?, ?, ?)")) { statement =>
+    using(conn.prepareStatement("INSERT INTO payments VALUES (?, ?, ?)")) { statement =>
       statement.setBytes(1, payment.payment_hash)
       statement.setLong(2, payment.amount_msat)
       statement.setLong(3, payment.timestamp)
@@ -56,7 +58,7 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
   }
 
   override def findByPaymentHash(paymentHash: BinaryData): Option[Payment] = {
-    using(sqlite.prepareStatement("SELECT payment_hash, amount_msat, timestamp FROM payments WHERE payment_hash = ?")) { statement =>
+    using(conn.prepareStatement("SELECT payment_hash, amount_msat, timestamp FROM payments WHERE payment_hash = ?")) { statement =>
       statement.setBytes(1, paymentHash)
       val rs = statement.executeQuery()
       if (rs.next()) {
@@ -68,7 +70,7 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
   }
 
   override def listPayments(): Seq[Payment] = {
-    using(sqlite.createStatement()) { statement =>
+    using(conn.createStatement()) { statement =>
       val rs = statement.executeQuery("SELECT payment_hash, amount_msat, timestamp FROM payments")
       var q: Queue[Payment] = Queue()
       while (rs.next()) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
@@ -33,12 +33,20 @@ class SqlitePeersDb(override val dbConfig: DbConfig) extends PeersDb {
 
   private def conn = dbConfig.getConnection()
 
-  {
+  override def createTables: Unit = {
     using(conn.createStatement()) { statement =>
       require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
       statement.executeUpdate("CREATE TABLE IF NOT EXISTS peers (node_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL)")
     }
   }
+
+  override def dropTables: Unit = {
+    using(conn.createStatement()) { statement =>
+      require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
+      statement.executeUpdate("DROP TABLE IF EXISTS peers")
+    }
+  }
+
 
 
   override def addOrUpdatePeer(nodeId: Crypto.PublicKey, address: InetSocketAddress): Unit = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
@@ -21,12 +21,12 @@ import java.sql.Connection
 
 import fr.acinq.bitcoin.Crypto
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.eclair.db.{DbConfig, PeersDb}
+import fr.acinq.eclair.db.{DbConfig, NetworkDbConfig, PeersDb}
 import fr.acinq.eclair.db.sqlite.SqliteUtils.{getVersion, using}
 import fr.acinq.eclair.wire.{IPv4, IPv6, LightningMessageCodecs, NodeAddress}
 import scodec.bits.BitVector
 
-class SqlitePeersDb(override val dbConfig: DbConfig) extends PeersDb {
+class SqlitePeersDb(override val dbConfig: NetworkDbConfig) extends PeersDb {
 
   val DB_NAME = "peers"
   val CURRENT_VERSION = 1

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
@@ -21,29 +21,34 @@ import java.sql.Connection
 
 import fr.acinq.bitcoin.Crypto
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.eclair.db.PeersDb
+import fr.acinq.eclair.db.{DbConfig, PeersDb}
 import fr.acinq.eclair.db.sqlite.SqliteUtils.{getVersion, using}
 import fr.acinq.eclair.wire.{IPv4, IPv6, LightningMessageCodecs, NodeAddress}
 import scodec.bits.BitVector
 
-class SqlitePeersDb(sqlite: Connection) extends PeersDb {
+class SqlitePeersDb(override val dbConfig: DbConfig) extends PeersDb {
 
   val DB_NAME = "peers"
   val CURRENT_VERSION = 1
 
-  using(sqlite.createStatement()) { statement =>
-    require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
-    statement.executeUpdate("CREATE TABLE IF NOT EXISTS peers (node_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL)")
+  private def conn = dbConfig.getConnection()
+
+  {
+    using(conn.createStatement()) { statement =>
+      require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
+      statement.executeUpdate("CREATE TABLE IF NOT EXISTS peers (node_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL)")
+    }
   }
+
 
   override def addOrUpdatePeer(nodeId: Crypto.PublicKey, address: InetSocketAddress): Unit = {
     val nodeaddress = NodeAddress(address)
     val data = LightningMessageCodecs.nodeaddress.encode(nodeaddress).require.toByteArray
-    using(sqlite.prepareStatement("UPDATE peers SET data=? WHERE node_id=?")) { update =>
+    using(conn.prepareStatement("UPDATE peers SET data=? WHERE node_id=?")) { update =>
       update.setBytes(1, data)
       update.setBytes(2, nodeId.toBin)
       if (update.executeUpdate() == 0) {
-        using(sqlite.prepareStatement("INSERT INTO peers VALUES (?, ?)")) { statement =>
+        using(conn.prepareStatement("INSERT INTO peers VALUES (?, ?)")) { statement =>
           statement.setBytes(1, nodeId.toBin)
           statement.setBytes(2, data)
           statement.executeUpdate()
@@ -53,14 +58,14 @@ class SqlitePeersDb(sqlite: Connection) extends PeersDb {
   }
 
   override def removePeer(nodeId: Crypto.PublicKey): Unit = {
-    using(sqlite.prepareStatement("DELETE FROM peers WHERE node_id=?")) { statement =>
+    using(conn.prepareStatement("DELETE FROM peers WHERE node_id=?")) { statement =>
       statement.setBytes(1, nodeId.toBin)
       statement.executeUpdate()
     }
   }
 
   override def listPeers(): Map[PublicKey, InetSocketAddress] = {
-    using(sqlite.createStatement()) { statement =>
+    using(conn.createStatement()) { statement =>
       val rs = statement.executeQuery("SELECT node_id, data FROM peers")
       var m: Map[PublicKey, InetSocketAddress] = Map()
       while (rs.next()) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
@@ -19,10 +19,10 @@ package fr.acinq.eclair.db.sqlite
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.channel.Command
 import fr.acinq.eclair.db.sqlite.SqliteUtils.{codecSequence, getVersion, using}
-import fr.acinq.eclair.db.{DbConfig, PendingRelayDb}
+import fr.acinq.eclair.db.{DbConfig, NetworkDbConfig, PendingRelayDb}
 import fr.acinq.eclair.wire.CommandCodecs.cmdCodec
 
-class SqlitePendingRelayDb(override val dbConfig: DbConfig) extends PendingRelayDb {
+class SqlitePendingRelayDb(override val dbConfig: NetworkDbConfig) extends PendingRelayDb {
 
   val DB_NAME = "pending_relay"
   val CURRENT_VERSION = 1

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
@@ -19,10 +19,10 @@ package fr.acinq.eclair.db.sqlite
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.channel.Command
 import fr.acinq.eclair.db.sqlite.SqliteUtils.{codecSequence, getVersion, using}
-import fr.acinq.eclair.db.{DbConfig, NetworkDbConfig, PendingRelayDb}
+import fr.acinq.eclair.db.{DbConfig, EclairDbConfig, NetworkDbConfig, PendingRelayDb}
 import fr.acinq.eclair.wire.CommandCodecs.cmdCodec
 
-class SqlitePendingRelayDb(override val dbConfig: NetworkDbConfig) extends PendingRelayDb {
+class SqlitePendingRelayDb(override val dbConfig: EclairDbConfig) extends PendingRelayDb {
 
   val DB_NAME = "pending_relay"
   val CURRENT_VERSION = 1

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
@@ -28,10 +28,20 @@ class SqlitePendingRelayDb(override val dbConfig: DbConfig) extends PendingRelay
   val CURRENT_VERSION = 1
   private def conn = dbConfig.getConnection()
 
-  using(conn.createStatement()) { statement =>
-    require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
-    // note: should we use a foreign key to local_channels table here?
-    statement.executeUpdate("CREATE TABLE IF NOT EXISTS pending_relay (channel_id BLOB NOT NULL, htlc_id INTEGER NOT NULL, data BLOB NOT NULL, PRIMARY KEY(channel_id, htlc_id))")
+  override def createTables: Unit = {
+    using(conn.createStatement()) { statement =>
+      require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
+      // note: should we use a foreign key to local_channels table here?
+      statement.executeUpdate("CREATE TABLE IF NOT EXISTS pending_relay (channel_id BLOB NOT NULL, htlc_id INTEGER NOT NULL, data BLOB NOT NULL, PRIMARY KEY(channel_id, htlc_id))")
+    }
+  }
+
+  override def dropTables: Unit = {
+    using(conn.createStatement()) { statement =>
+      require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
+      // note: should we use a foreign key to local_channels table here?
+      statement.executeUpdate("DROP TABLE IF EXISTS pending_relay")
+    }
   }
 
   override def addPendingRelay(channelId: BinaryData, htlcId: Long, cmd: Command): Unit = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
@@ -16,27 +16,26 @@
 
 package fr.acinq.eclair.db.sqlite
 
-import java.sql.Connection
-
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.channel.Command
-import fr.acinq.eclair.db.PendingRelayDb
 import fr.acinq.eclair.db.sqlite.SqliteUtils.{codecSequence, getVersion, using}
+import fr.acinq.eclair.db.{DbConfig, PendingRelayDb}
 import fr.acinq.eclair.wire.CommandCodecs.cmdCodec
 
-class SqlitePendingRelayDb(sqlite: Connection) extends PendingRelayDb {
+class SqlitePendingRelayDb(override val dbConfig: DbConfig) extends PendingRelayDb {
 
   val DB_NAME = "pending_relay"
   val CURRENT_VERSION = 1
+  private def conn = dbConfig.getConnection()
 
-  using(sqlite.createStatement()) { statement =>
+  using(conn.createStatement()) { statement =>
     require(getVersion(statement, DB_NAME, CURRENT_VERSION) == CURRENT_VERSION) // there is only one version currently deployed
     // note: should we use a foreign key to local_channels table here?
     statement.executeUpdate("CREATE TABLE IF NOT EXISTS pending_relay (channel_id BLOB NOT NULL, htlc_id INTEGER NOT NULL, data BLOB NOT NULL, PRIMARY KEY(channel_id, htlc_id))")
   }
 
   override def addPendingRelay(channelId: BinaryData, htlcId: Long, cmd: Command): Unit = {
-    using(sqlite.prepareStatement("INSERT OR IGNORE INTO pending_relay VALUES (?, ?, ?)")) { statement =>
+    using(conn.prepareStatement("INSERT OR IGNORE INTO pending_relay VALUES (?, ?, ?)")) { statement =>
       statement.setBytes(1, channelId)
       statement.setLong(2, htlcId)
       statement.setBytes(3, cmdCodec.encode(cmd).require.toByteArray)
@@ -45,7 +44,7 @@ class SqlitePendingRelayDb(sqlite: Connection) extends PendingRelayDb {
   }
 
   override def removePendingRelay(channelId: BinaryData, htlcId: Long): Unit = {
-    using(sqlite.prepareStatement("DELETE FROM pending_relay WHERE channel_id=? AND htlc_id=?")) { statement =>
+    using(conn.prepareStatement("DELETE FROM pending_relay WHERE channel_id=? AND htlc_id=?")) { statement =>
       statement.setBytes(1, channelId)
       statement.setLong(2, htlcId)
       statement.executeUpdate()
@@ -53,7 +52,7 @@ class SqlitePendingRelayDb(sqlite: Connection) extends PendingRelayDb {
   }
 
   override def listPendingRelay(channelId: BinaryData): Seq[Command] = {
-    using(sqlite.prepareStatement("SELECT htlc_id, data FROM pending_relay WHERE channel_id=?")) { statement =>
+    using(conn.prepareStatement("SELECT htlc_id, data FROM pending_relay WHERE channel_id=?")) { statement =>
       statement.setBytes(1, channelId)
       val rs = statement.executeQuery()
       codecSequence(rs, cmdCodec)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
@@ -35,7 +35,10 @@ object SqliteUtils {
     try {
       block(statement)
     } finally {
-      if (statement != null) statement.close()
+      if (statement != null) {
+        statement.close()
+        statement.getConnection.close()
+      }
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -375,7 +375,8 @@ object Peer {
 
   // @formatter:on
 
-  def makeChannelParams(nodeParams: NodeParams, defaultFinalScriptPubKey: BinaryData, isFunder: Boolean, fundingSatoshis: Long): LocalParams = {
+  def makeChannelParams(nodeParams: NodeParams, defaultFinalScriptPubKey: BinaryData,
+                        isFunder: Boolean, fundingSatoshis: Long): LocalParams = {
     val entropy = new Array[Byte](16)
     secureRandom.nextBytes(entropy)
     val bis = new ByteArrayInputStream(entropy)

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -45,7 +45,7 @@
     <!--logger name="fr.acinq.eclair.channel" level="DEBUG"/-->
     <logger name="fr.acinq.eclair.router" level="WARN"/>
 
-    <root level="TRACE">
+    <root level="DEBUG">
         <!--appender-ref ref="FILE"/>
         <appender-ref ref="CONSOLEWARN"/-->
         <appender-ref ref="CONSOLE"/>

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -45,6 +45,8 @@
     <!--logger name="fr.acinq.eclair.channel" level="DEBUG"/-->
     <logger name="fr.acinq.eclair.router" level="WARN"/>
 
+    <logger name="com.zaxxer" level="WARN"/>
+
     <root level="INFO">
         <!--appender-ref ref="FILE"/>
         <appender-ref ref="CONSOLEWARN"/-->

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -45,7 +45,7 @@
     <!--logger name="fr.acinq.eclair.channel" level="DEBUG"/-->
     <logger name="fr.acinq.eclair.router" level="WARN"/>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <!--appender-ref ref="FILE"/>
         <appender-ref ref="CONSOLEWARN"/-->
         <appender-ref ref="CONSOLE"/>

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -20,7 +20,7 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>
         <encoder>
-            <pattern>%date{HH:mm:ss.SSS} %highlight(%-5level) %X{akkaSource} - %msg%ex{12}%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} TKD [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
@@ -45,7 +45,7 @@
     <!--logger name="fr.acinq.eclair.channel" level="DEBUG"/-->
     <logger name="fr.acinq.eclair.router" level="WARN"/>
 
-    <root level="INFO">
+    <root level="TRACE">
         <!--appender-ref ref="FILE"/>
         <appender-ref ref="CONSOLEWARN"/-->
         <appender-ref ref="CONSOLE"/>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -43,7 +43,7 @@ object TestConstants extends Logging {
   val feeratePerKw = 10000L
 
 
-  private val config = ConfigFactory.load()
+  private val config = ConfigFactory.load().resolve()
 
   //currently both bob and alice will share these configs
   val eclairDb = EclairDbConfig.unittestConfig(config)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -46,14 +46,14 @@ object TestConstants extends Logging {
   private val config = ConfigFactory.load().resolve()
 
   //currently both bob and alice will share these configs
-  val eclairDb = EclairDbConfig.unittestConfig(config)
-  val networkDb = NetworkDbConfig.unittestConfig(config)
-  lazy val dbConfig = AppDbConfig(eclairDb,networkDb)
+  def eclairDb = EclairDbConfig.unittestConfig(config)
+  def networkDb = NetworkDbConfig.unittestConfig(config)
+  def dbConfig = AppDbConfig(eclairDb,networkDb)
 
   object Alice {
     val seed = BinaryData("01" * 32)
     val keyManager = new LocalKeyManager(seed, Block.RegtestGenesisBlock.hash)
-    lazy val aliceDbConfig = dbConfig
+    def aliceDbConfig = dbConfig
 
     // This is a function, and not a val! When called will return a new NodeParams
     def nodeParams: NodeParams = NodeParams(
@@ -105,7 +105,7 @@ object TestConstants extends Logging {
   object Bob {
     val seed = BinaryData("02" * 32)
     val keyManager = new LocalKeyManager(seed, Block.RegtestGenesisBlock.hash)
-    lazy val bobDbConfig = dbConfig
+    def bobDbConfig = dbConfig
     def nodeParams: NodeParams = NodeParams(
       keyManager = keyManager,
       alias = "bob",

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -26,7 +26,7 @@ import fr.acinq.bitcoin.{BinaryData, Block, Script}
 import fr.acinq.eclair.NodeParams.BITCOIND
 import fr.acinq.eclair.channel.LocalParams
 import fr.acinq.eclair.crypto.LocalKeyManager
-import fr.acinq.eclair.db.DbConfig
+import fr.acinq.eclair.db.{AppDbConfig, DbConfig, EclairDbConfig, NetworkDbConfig}
 import fr.acinq.eclair.db.sqlite._
 import fr.acinq.eclair.io.Peer
 import fr.acinq.eclair.wire.Color
@@ -42,13 +42,18 @@ object TestConstants extends Logging {
   val pushMsat = 200000000L
   val feeratePerKw = 10000L
 
-  val config = ConfigFactory.load()
-  //val dbConfig = DbConfig.unittestConfig(config)
+
+  private val config = ConfigFactory.load()
+
+  //currently both bob and alice will share these configs
+  val eclairDb = EclairDbConfig.unittestConfig(config)
+  val networkDb = NetworkDbConfig.unittestConfig(config)
+  lazy val dbConfig = AppDbConfig(eclairDb,networkDb)
 
   object Alice {
     val seed = BinaryData("01" * 32)
     val keyManager = new LocalKeyManager(seed, Block.RegtestGenesisBlock.hash)
-    lazy val aliceDbConfig = ???
+    lazy val aliceDbConfig = dbConfig
 
     // This is a function, and not a val! When called will return a new NodeParams
     def nodeParams: NodeParams = NodeParams(
@@ -100,7 +105,7 @@ object TestConstants extends Logging {
   object Bob {
     val seed = BinaryData("02" * 32)
     val keyManager = new LocalKeyManager(seed, Block.RegtestGenesisBlock.hash)
-    lazy val bobDbConfig = ???
+    lazy val bobDbConfig = dbConfig
     def nodeParams: NodeParams = NodeParams(
       keyManager = keyManager,
       alias = "bob",

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -43,12 +43,12 @@ object TestConstants extends Logging {
   val feeratePerKw = 10000L
 
 
-  private val config = ConfigFactory.load().resolve()
+  private val config = ConfigFactory.load().resolve().getConfig("eclair")
 
   //currently both bob and alice will share these configs
-  def eclairDb = EclairDbConfig.unittestConfig(config)
-  def networkDb = NetworkDbConfig.unittestConfig(config)
-  def dbConfig = AppDbConfig(eclairDb,networkDb)
+  lazy val  eclairDb = EclairDbConfig.unittestConfig(config)
+  lazy val networkDb = NetworkDbConfig.unittestConfig(config)
+  lazy val dbConfig = AppDbConfig(eclairDb,networkDb)
 
   object Alice {
     val seed = BinaryData("01" * 32)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
@@ -33,33 +33,31 @@ abstract class TestkitBaseClass extends TestKit(ActorSystem("test")) with fixtur
   with BeforeAndAfterEach with BeforeAndAfterAll with Logging {
 
   //val dbConfig = TestConstants.dbConfig
-  /*  lazy val aliceDbConfig = TestConstants.Alice.aliceDbConfig
+    lazy val aliceDbConfig = TestConstants.Alice.aliceDbConfig
     lazy val bobDbConfig = TestConstants.Bob.bobDbConfig
     private lazy val aliceDbs = List(
-      new SqliteChannelsDb(aliceDbConfig),
-      new SqlitePeersDb(aliceDbConfig),
-      new SqliteNetworkDb(aliceDbConfig),
-      new SqlitePendingRelayDb(aliceDbConfig),
-      new SqlitePaymentsDb(aliceDbConfig)
-    )*/
+      new SqliteChannelsDb(aliceDbConfig.eclairDb),
+      new SqlitePeersDb(aliceDbConfig.networkDb),
+      new SqliteNetworkDb(aliceDbConfig.networkDb),
+      new SqlitePendingRelayDb(aliceDbConfig.networkDb),
+      new SqlitePaymentsDb(aliceDbConfig.eclairDb)
+    )
 
-/*  private lazy val bobDbs = List(
-    new SqliteChannelsDb(bobDbConfig),
-    new SqlitePeersDb(bobDbConfig),
-    new SqliteNetworkDb(bobDbConfig),
-    new SqlitePendingRelayDb(bobDbConfig),
-    new SqlitePaymentsDb(bobDbConfig)
-  )*/
+  private lazy val bobDbs = List(
+    new SqliteChannelsDb(bobDbConfig.eclairDb),
+    new SqlitePeersDb(bobDbConfig.networkDb),
+    new SqliteNetworkDb(bobDbConfig.networkDb),
+    new SqlitePendingRelayDb(bobDbConfig.networkDb),
+    new SqlitePaymentsDb(bobDbConfig.eclairDb)
+  )
 
-  //private lazy val dbs = aliceDbs ++ bobDbs
+  private lazy val dbs = aliceDbs ++ bobDbs
 
   override def beforeAll(): Unit =  {
 
     Globals.blockCount.set(400000)
     Globals.feeratesPerKw.set(FeeratesPerKw.single(TestConstants.feeratePerKw))
-/*    dbs.foreach { db =>
-      db.createTables
-    }*/
+    dbs.foreach(_.createTables)
   }
 
   override def afterEach(): Unit = {
@@ -71,7 +69,7 @@ abstract class TestkitBaseClass extends TestKit(ActorSystem("test")) with fixtur
   }
 
   override def afterAll(): Unit = {
-    //dbs.foreach(_.dropTables)
+    dbs.foreach(_.dropTables)
     TestKit.shutdownActorSystem(system)
     Globals.feeratesPerKw.set(FeeratesPerKw.single(1))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
@@ -20,6 +20,7 @@ import akka.actor.{ActorNotFound, ActorSystem, PoisonPill}
 import akka.testkit.TestKit
 import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
 import fr.acinq.eclair.db.sqlite._
+import grizzled.slf4j.Logging
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, fixture}
 
 import scala.concurrent.Await
@@ -28,22 +29,40 @@ import scala.concurrent.Await
   * This base class kills all actor between each tests.
   * Created by PM on 06/09/2016.
   */
-abstract class TestkitBaseClass extends TestKit(ActorSystem("test")) with fixture.FunSuiteLike with BeforeAndAfterEach with BeforeAndAfterAll {
-  private val dbConfig = TestConstants.dbConfig
-  private val dbs = List(
-    new SqliteChannelsDb(dbConfig)
-    new SqlitePeersDb(dbConfig)
-    new SqliteNetworkDb(dbConfig)
-    new SqlitePendingRelayDb(dbConfig)
-    new SqlitePaymentsDb(dbConfig)
-  )
-  override def beforeAll {
+abstract class TestkitBaseClass extends TestKit(ActorSystem("test")) with fixture.FunSuiteLike
+  with BeforeAndAfterEach with BeforeAndAfterAll with Logging {
+
+  //val dbConfig = TestConstants.dbConfig
+  /*  lazy val aliceDbConfig = TestConstants.Alice.aliceDbConfig
+    lazy val bobDbConfig = TestConstants.Bob.bobDbConfig
+    private lazy val aliceDbs = List(
+      new SqliteChannelsDb(aliceDbConfig),
+      new SqlitePeersDb(aliceDbConfig),
+      new SqliteNetworkDb(aliceDbConfig),
+      new SqlitePendingRelayDb(aliceDbConfig),
+      new SqlitePaymentsDb(aliceDbConfig)
+    )*/
+
+/*  private lazy val bobDbs = List(
+    new SqliteChannelsDb(bobDbConfig),
+    new SqlitePeersDb(bobDbConfig),
+    new SqliteNetworkDb(bobDbConfig),
+    new SqlitePendingRelayDb(bobDbConfig),
+    new SqlitePaymentsDb(bobDbConfig)
+  )*/
+
+  //private lazy val dbs = aliceDbs ++ bobDbs
+
+  override def beforeAll(): Unit =  {
+
     Globals.blockCount.set(400000)
     Globals.feeratesPerKw.set(FeeratesPerKw.single(TestConstants.feeratePerKw))
-    dbs.foreach(_.createTables)
+/*    dbs.foreach { db =>
+      db.createTables
+    }*/
   }
 
-  override def afterEach() {
+  override def afterEach(): Unit = {
     system.actorSelection(system / "*") ! PoisonPill
     intercept[ActorNotFound] {
       import scala.concurrent.duration._
@@ -51,8 +70,8 @@ abstract class TestkitBaseClass extends TestKit(ActorSystem("test")) with fixtur
     }
   }
 
-  override def afterAll {
-    dbs.foreach(_.dropTables)
+  override def afterAll(): Unit = {
+    //dbs.foreach(_.dropTables)
     TestKit.shutdownActorSystem(system)
     Globals.feeratesPerKw.set(FeeratesPerKw.single(1))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
@@ -39,7 +39,7 @@ abstract class TestkitBaseClass extends TestKit(ActorSystem("test")) with fixtur
       new SqliteChannelsDb(aliceDbConfig.eclairDb),
       new SqlitePeersDb(aliceDbConfig.networkDb),
       new SqliteNetworkDb(aliceDbConfig.networkDb),
-      new SqlitePendingRelayDb(aliceDbConfig.networkDb),
+      new SqlitePendingRelayDb(aliceDbConfig.eclairDb),
       new SqlitePaymentsDb(aliceDbConfig.eclairDb)
     )
 
@@ -47,7 +47,7 @@ abstract class TestkitBaseClass extends TestKit(ActorSystem("test")) with fixtur
     new SqliteChannelsDb(bobDbConfig.eclairDb),
     new SqlitePeersDb(bobDbConfig.networkDb),
     new SqliteNetworkDb(bobDbConfig.networkDb),
-    new SqlitePendingRelayDb(bobDbConfig.networkDb),
+    new SqlitePendingRelayDb(bobDbConfig.eclairDb),
     new SqlitePaymentsDb(bobDbConfig.eclairDb)
   )
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
@@ -23,6 +23,7 @@ import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.Sphinx
+import fr.acinq.eclair.db.DbConfig
 import fr.acinq.eclair.payment.PaymentLifecycle
 import fr.acinq.eclair.router.Hop
 import fr.acinq.eclair.wire._
@@ -35,6 +36,8 @@ import scala.util.Random
   */
 trait StateTestsHelperMethods extends TestKitBase {
 
+  //val dbConfig: DbConfig
+
   def defaultOnion: BinaryData = "00" * Sphinx.PacketLength
 
   case class Setup(alice: TestFSMRef[State, Data, Channel],
@@ -46,7 +49,9 @@ trait StateTestsHelperMethods extends TestKitBase {
                    router: TestProbe,
                    relayer: TestProbe)
 
-  def init(nodeParamsA: NodeParams = TestConstants.Alice.nodeParams, nodeParamsB: NodeParams = TestConstants.Bob.nodeParams): Setup = {
+  def init(
+            nodeParamsA: NodeParams = TestConstants.Alice.nodeParams,
+           nodeParamsB: NodeParams = TestConstants.Bob.nodeParams): Setup = {
     Globals.feeratesPerKw.set(FeeratesPerKw.single(TestConstants.feeratePerKw))
     val alice2bob = TestProbe()
     val bob2alice = TestProbe()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
@@ -79,7 +79,9 @@ trait StateTestsHelperMethods extends TestKitBase {
     val aliceInit = Init(aliceParams.globalFeatures, aliceParams.localFeatures)
     val bobInit = Init(bobParams.globalFeatures, bobParams.localFeatures)
     // no announcements
-    alice ! INPUT_INIT_FUNDER("00" * 32, TestConstants.fundingSatoshis, TestConstants.pushMsat, TestConstants.feeratePerKw, TestConstants.feeratePerKw, aliceParams, alice2bob.ref, bobInit, channelFlags)
+    alice ! INPUT_INIT_FUNDER("00" * 32, TestConstants.fundingSatoshis, TestConstants.pushMsat,
+      TestConstants.feeratePerKw, TestConstants.feeratePerKw, aliceParams,
+      alice2bob.ref, bobInit, channelFlags)
     bob ! INPUT_INIT_FUNDEE("00" * 32, bobParams, bob2alice.ref, aliceInit)
     alice2bob.expectMsgType[OpenChannel]
     alice2bob.forward(bob)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
@@ -36,7 +36,6 @@ import scala.util.Random
   */
 trait StateTestsHelperMethods extends TestKitBase {
 
-  //val dbConfig: DbConfig
 
   def defaultOnion: BinaryData = "00" * Sphinx.PacketLength
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
@@ -78,7 +78,7 @@ class NegotiatingStateSpec extends TestkitBaseClass with StateTestsHelperMethods
     }
   }
 
-/*  test("recv ClosingSigned (theirCloseFee != ourCloseFee)") { case (alice, bob, alice2bob, bob2alice, _, _) =>
+  test("recv ClosingSigned (theirCloseFee != ourCloseFee)") { case (alice, bob, alice2bob, bob2alice, _, _) =>
     within(30 seconds) {
       // alice initiates the negotiation
       val aliceCloseSig1 = alice2bob.expectMsgType[ClosingSigned]
@@ -217,6 +217,6 @@ class NegotiatingStateSpec extends TestkitBaseClass with StateTestsHelperMethods
       alice2blockchain.expectMsgType[PublishAsap]
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
     }
-  }*/
+  }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
@@ -78,7 +78,7 @@ class NegotiatingStateSpec extends TestkitBaseClass with StateTestsHelperMethods
     }
   }
 
-  test("recv ClosingSigned (theirCloseFee != ourCloseFee)") { case (alice, bob, alice2bob, bob2alice, _, _) =>
+/*  test("recv ClosingSigned (theirCloseFee != ourCloseFee)") { case (alice, bob, alice2bob, bob2alice, _, _) =>
     within(30 seconds) {
       // alice initiates the negotiation
       val aliceCloseSig1 = alice2bob.expectMsgType[ClosingSigned]
@@ -217,6 +217,6 @@ class NegotiatingStateSpec extends TestkitBaseClass with StateTestsHelperMethods
       alice2blockchain.expectMsgType[PublishAsap]
       assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
     }
-  }
+  }*/
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/DbConfigTest.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/DbConfigTest.scala
@@ -1,0 +1,23 @@
+package fr.acinq.eclair.db
+
+import java.io.File
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class DbConfigTest extends FunSuite {
+
+  test("read regtest database configuration") {
+    val config = ConfigFactory.load()
+    val dbConfig = DbConfig.fromConfig(config)
+    val conn = dbConfig.getConnection()
+    assert(!conn.isClosed)
+    conn.close()
+    assert(conn.isClosed)
+    dbConfig.close()
+    assert(dbConfig.isClosed())
+  }
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/DbConfigTest.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/DbConfigTest.scala
@@ -10,14 +10,21 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class DbConfigTest extends FunSuite {
 
-  test("read regtest database configuration") {
+  test("read eclair db unittest database configuration") {
     val config = ConfigFactory.load()
-    val dbConfig = DbConfig.unittestConfig(config)
+    val dbConfig = EclairDbConfig.unittestConfig(config)
     val conn = dbConfig.getConnection()
     assert(!conn.isClosed)
     conn.close()
     assert(conn.isClosed)
-    dbConfig.close()
-    assert(dbConfig.isClosed())
+  }
+
+  test("read network db unittest database configuration") {
+    val config = ConfigFactory.load()
+    val dbConfig = NetworkDbConfig.unittestConfig(config)
+    val conn = dbConfig.getConnection()
+    assert(!conn.isClosed)
+    conn.close()
+    assert(conn.isClosed)
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/DbConfigTest.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/DbConfigTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.junit.JUnitRunner
 class DbConfigTest extends FunSuite {
 
   test("read eclair db unittest database configuration") {
-    val config = ConfigFactory.load()
+    val config = ConfigFactory.load().getConfig("eclair")
     val dbConfig = EclairDbConfig.unittestConfig(config)
     val conn = dbConfig.getConnection()
     assert(!conn.isClosed)
@@ -20,7 +20,7 @@ class DbConfigTest extends FunSuite {
   }
 
   test("read network db unittest database configuration") {
-    val config = ConfigFactory.load()
+    val config = ConfigFactory.load().getConfig("eclair")
     val dbConfig = NetworkDbConfig.unittestConfig(config)
     val conn = dbConfig.getConnection()
     assert(!conn.isClosed)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/DbConfigTest.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/DbConfigTest.scala
@@ -12,7 +12,7 @@ class DbConfigTest extends FunSuite {
 
   test("read regtest database configuration") {
     val config = ConfigFactory.load()
-    val dbConfig = DbConfig.fromConfig(config)
+    val dbConfig = DbConfig.unittestConfig(config)
     val conn = dbConfig.getConnection()
     assert(!conn.isClosed)
     conn.close()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -29,17 +29,22 @@ import org.sqlite.SQLiteException
 @RunWith(classOf[JUnitRunner])
 class SqliteChannelsDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")
   private val dbConfig = TestConstants.dbConfig
+  private val db = new SqliteChannelsDb(dbConfig)
+
+  override def beforeAll(): Unit = {
+    db.createTables
+  }
+
   test("init sqlite 2 times in a row") {
-    val sqlite = inmem
     val db1 = new SqliteChannelsDb(dbConfig)
     val db2 = new SqliteChannelsDb(dbConfig)
+    db1.createTables
+    db2.createTables
   }
 
   test("add/remove/list channels") {
-    val sqlite = inmem
-    val db = new SqliteChannelsDb(dbConfig)
+
     new SqlitePendingRelayDb(dbConfig) // needed by db.removeChannel
 
     val channel = ChannelStateSpec.normal
@@ -69,5 +74,8 @@ class SqliteChannelsDbSpec extends FunSuite with BeforeAndAfterAll {
     assert(db.listHtlcHtlcInfos(channel.channelId, commitNumber).toList == Nil)
   }
 
-  override def afterAll(): Unit = dbConfig.close()
+  override def afterAll(): Unit = {
+    db.dropTables
+    dbConfig.close()
+  }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -21,30 +21,34 @@ import java.sql.DriverManager
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.TestConstants
 import fr.acinq.eclair.db.sqlite.{SqliteChannelsDb, SqlitePendingRelayDb}
+import grizzled.slf4j.Logging
 import org.junit.runner.RunWith
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.scalatest.junit.JUnitRunner
 import org.sqlite.SQLiteException
 
 @RunWith(classOf[JUnitRunner])
-class SqliteChannelsDbSpec extends FunSuite with BeforeAndAfterAll {
+class SqliteChannelsDbSpec extends FunSuite with BeforeAndAfterAll with Logging {
 
-  private val dbConfig = TestConstants.dbConfig
-  private val db = new SqliteChannelsDb(dbConfig)
 
   override def beforeAll(): Unit = {
+    def dbConfig = DbConfig.regtestConfig(TestConstants.config)
+    val db = new SqliteChannelsDb(dbConfig)
+
     db.createTables
   }
 
-  test("init sqlite 2 times in a row") {
+/*  test("init sqlite 2 times in a row") {
     val db1 = new SqliteChannelsDb(dbConfig)
     val db2 = new SqliteChannelsDb(dbConfig)
     db1.createTables
     db2.createTables
-  }
+  }*/
 
   test("add/remove/list channels") {
-
+    val dbConfig = DbConfig.regtestConfig(TestConstants.config)
+    val db = new SqliteChannelsDb(dbConfig)
+    logger.info(s"db.isClose() ${dbConfig.isClosed()}")
     new SqlitePendingRelayDb(dbConfig) // needed by db.removeChannel
 
     val channel = ChannelStateSpec.normal
@@ -75,7 +79,7 @@ class SqliteChannelsDbSpec extends FunSuite with BeforeAndAfterAll {
   }
 
   override def afterAll(): Unit = {
-    db.dropTables
-    dbConfig.close()
+    //db.dropTables
+    //dbConfig.close()
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -32,9 +32,10 @@ class SqliteChannelsDbSpec extends FunSuite with BeforeAndAfterAll with Logging 
 
   val dbConfig = TestConstants.eclairDb
   val db = new SqliteChannelsDb(dbConfig)
-  val relayDb = new SqlitePendingRelayDb(TestConstants.networkDb) // needed by db.removeChannel
+  val relayDb = new SqlitePendingRelayDb(TestConstants.eclairDb) // needed by db.removeChannel
 
   override def beforeAll(): Unit = {
+    relayDb.createTables
     db.createTables
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -30,27 +30,22 @@ import org.sqlite.SQLiteException
 @RunWith(classOf[JUnitRunner])
 class SqliteChannelsDbSpec extends FunSuite with BeforeAndAfterAll with Logging {
 
+  val dbConfig = TestConstants.eclairDb
+  val db = new SqliteChannelsDb(dbConfig)
+  val relayDb = new SqlitePendingRelayDb(TestConstants.networkDb) // needed by db.removeChannel
 
   override def beforeAll(): Unit = {
-    def dbConfig = DbConfig.regtestConfig(TestConstants.config)
-    val db = new SqliteChannelsDb(dbConfig)
-
     db.createTables
   }
 
-/*  test("init sqlite 2 times in a row") {
+  test("init sqlite 2 times in a row") {
     val db1 = new SqliteChannelsDb(dbConfig)
     val db2 = new SqliteChannelsDb(dbConfig)
     db1.createTables
     db2.createTables
-  }*/
+  }
 
   test("add/remove/list channels") {
-    val dbConfig = DbConfig.regtestConfig(TestConstants.config)
-    val db = new SqliteChannelsDb(dbConfig)
-    logger.info(s"db.isClose() ${dbConfig.isClosed()}")
-    new SqlitePendingRelayDb(dbConfig) // needed by db.removeChannel
-
     val channel = ChannelStateSpec.normal
 
     val commitNumber = 42
@@ -79,7 +74,7 @@ class SqliteChannelsDbSpec extends FunSuite with BeforeAndAfterAll with Logging 
   }
 
   override def afterAll(): Unit = {
-    //db.dropTables
-    //dbConfig.close()
+    db.dropTables
+    relayDb.dropTables
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
@@ -32,16 +32,21 @@ import org.sqlite.SQLiteException
 @RunWith(classOf[JUnitRunner])
 class SqliteNetworkDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  val dbConfig = TestConstants.dbConfig
+  private val dbConfig = TestConstants.dbConfig
+  private val db = new SqliteNetworkDb(dbConfig = dbConfig)
+
+  override def beforeAll(): Unit = {
+    db.createTables
+  }
+
   test("init sqlite 2 times in a row") {
     val db1 = new SqliteNetworkDb(dbConfig)
     val db2 = new SqliteNetworkDb(dbConfig)
+    db1.createTables
+    db2.createTables
   }
 
   test("add/remove/list nodes") {
-    val sqlite = dbConfig
-    val db = new SqliteNetworkDb(sqlite)
-
     val node_1 = Announcements.makeNodeAnnouncement(randomKey, "node-alice", Color(100.toByte, 200.toByte, 300.toByte), new InetSocketAddress(InetAddress.getByAddress(Array[Byte](192.toByte, 168.toByte, 1.toByte, 42.toByte)), 42000) :: Nil)
     val node_2 = Announcements.makeNodeAnnouncement(randomKey, "node-bob", Color(100.toByte, 200.toByte, 300.toByte), new InetSocketAddress(InetAddress.getByAddress(Array[Byte](192.toByte, 168.toByte, 1.toByte, 42.toByte)), 42000) :: Nil)
     val node_3 = Announcements.makeNodeAnnouncement(randomKey, "node-charlie", Color(100.toByte, 200.toByte, 300.toByte), new InetSocketAddress(InetAddress.getByAddress(Array[Byte](192.toByte, 168.toByte, 1.toByte, 42.toByte)), 42000) :: Nil)
@@ -59,9 +64,6 @@ class SqliteNetworkDbSpec extends FunSuite with BeforeAndAfterAll {
   }
 
   test("add/remove/list channels and channel_updates") {
-    val sqlite = dbConfig
-    val db = new SqliteNetworkDb(sqlite)
-
     def sig = Crypto.encodeSignature(Crypto.sign(randomKey.toBin, randomKey)) :+ 1.toByte
 
     val channel_1 = Announcements.makeChannelAnnouncement(Block.RegtestGenesisBlock.hash, ShortChannelId(42), randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, sig, sig, sig, sig)
@@ -99,6 +101,9 @@ class SqliteNetworkDbSpec extends FunSuite with BeforeAndAfterAll {
     db.updateChannelUpdate(channel_update_1)
   }
 
-  override def afterAll: Unit = dbConfig.close()
+  override def afterAll: Unit = {
+    db.dropTables
+    dbConfig.close()
+  }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
@@ -32,7 +32,7 @@ import org.sqlite.SQLiteException
 @RunWith(classOf[JUnitRunner])
 class SqliteNetworkDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  private val dbConfig = ??? //TestConstants.dbConfig
+  private val dbConfig = TestConstants.networkDb
   private val db = new SqliteNetworkDb(dbConfig = dbConfig)
 
   override def beforeAll(): Unit = {
@@ -103,7 +103,6 @@ class SqliteNetworkDbSpec extends FunSuite with BeforeAndAfterAll {
 
   override def afterAll: Unit = {
     db.dropTables
-    //dbConfig.close()
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
@@ -32,7 +32,7 @@ import org.sqlite.SQLiteException
 @RunWith(classOf[JUnitRunner])
 class SqliteNetworkDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  private val dbConfig = TestConstants.dbConfig
+  private val dbConfig = ??? //TestConstants.dbConfig
   private val db = new SqliteNetworkDb(dbConfig = dbConfig)
 
   override def beforeAll(): Unit = {
@@ -103,7 +103,7 @@ class SqliteNetworkDbSpec extends FunSuite with BeforeAndAfterAll {
 
   override def afterAll: Unit = {
     db.dropTables
-    dbConfig.close()
+    //dbConfig.close()
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class SqlitePaymentsDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  private val dbConfig = ??? //TestConstants.dbConfig
+  private val dbConfig = TestConstants.eclairDb
   private val db = new SqlitePaymentsDb(dbConfig)
 
   override def beforeAll(): Unit = {
@@ -56,6 +56,5 @@ class SqlitePaymentsDbSpec extends FunSuite with BeforeAndAfterAll {
 
   override def afterAll: Unit = {
     db.dropTables
-    //dbConfig.close()
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
@@ -19,25 +19,24 @@ package fr.acinq.eclair.db
 import java.sql.DriverManager
 
 import fr.acinq.bitcoin.BinaryData
+import fr.acinq.eclair.TestConstants
 import fr.acinq.eclair.db.sqlite.SqlitePaymentsDb
 import org.junit.runner.RunWith
-import org.scalatest.FunSuite
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class SqlitePaymentsDbSpec extends FunSuite {
+class SqlitePaymentsDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")
+  val dbConfig = TestConstants.dbConfig
 
   test("init sqlite 2 times in a row") {
-    val sqlite = inmem
-    val db1 = new SqlitePaymentsDb(sqlite)
-    val db2 = new SqlitePaymentsDb(sqlite)
+    val db1 = new SqlitePaymentsDb(dbConfig)
+    val db2 = new SqlitePaymentsDb(dbConfig)
   }
 
   test("add/list payments/find 1 payment that exists/find 1 payment that does not exist") {
-    val sqlite = inmem
-    val db = new SqlitePaymentsDb(sqlite)
+    val db = new SqlitePaymentsDb(dbConfig)
 
     val p1 = Payment(BinaryData("08d47d5f7164d4b696e8f6b62a03094d4f1c65f16e9d7b11c4a98854707e55cf"), 12345678, 1513871928275L)
     val p2 = Payment(BinaryData("0f059ef9b55bb70cc09069ee4df854bf0fab650eee6f2b87ba26d1ad08ab114f"), 12345678, 1513871928275L)
@@ -48,4 +47,6 @@ class SqlitePaymentsDbSpec extends FunSuite {
     assert(db.findByPaymentHash(p1.payment_hash) === Some(p1))
     assert(db.findByPaymentHash("6e7e8018f05e169cf1d99e77dc22cb372d09f10b6a81f1eae410718c56cad187") === None)
   }
+
+  override def afterAll: Unit = dbConfig.close()
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class SqlitePaymentsDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  private val dbConfig = TestConstants.dbConfig
+  private val dbConfig = ??? //TestConstants.dbConfig
   private val db = new SqlitePaymentsDb(dbConfig)
 
   override def beforeAll(): Unit = {
@@ -56,6 +56,6 @@ class SqlitePaymentsDbSpec extends FunSuite with BeforeAndAfterAll {
 
   override def afterAll: Unit = {
     db.dropTables
-    dbConfig.close()
+    //dbConfig.close()
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
@@ -28,15 +28,21 @@ import org.scalatest.junit.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class SqlitePaymentsDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  val dbConfig = TestConstants.dbConfig
+  private val dbConfig = TestConstants.dbConfig
+  private val db = new SqlitePaymentsDb(dbConfig)
+
+  override def beforeAll(): Unit = {
+    db.createTables
+  }
 
   test("init sqlite 2 times in a row") {
     val db1 = new SqlitePaymentsDb(dbConfig)
     val db2 = new SqlitePaymentsDb(dbConfig)
+    db1.createTables
+    db2.createTables
   }
 
   test("add/list payments/find 1 payment that exists/find 1 payment that does not exist") {
-    val db = new SqlitePaymentsDb(dbConfig)
 
     val p1 = Payment(BinaryData("08d47d5f7164d4b696e8f6b62a03094d4f1c65f16e9d7b11c4a98854707e55cf"), 12345678, 1513871928275L)
     val p2 = Payment(BinaryData("0f059ef9b55bb70cc09069ee4df854bf0fab650eee6f2b87ba26d1ad08ab114f"), 12345678, 1513871928275L)
@@ -48,5 +54,8 @@ class SqlitePaymentsDbSpec extends FunSuite with BeforeAndAfterAll {
     assert(db.findByPaymentHash("6e7e8018f05e169cf1d99e77dc22cb372d09f10b6a81f1eae410718c56cad187") === None)
   }
 
-  override def afterAll: Unit = dbConfig.close()
+  override def afterAll: Unit = {
+    db.dropTables
+    dbConfig.close()
+  }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
@@ -27,11 +27,18 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 @RunWith(classOf[JUnitRunner])
 class SqlitePeersDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  val dbConfig = TestConstants.dbConfig
+  private val dbConfig = TestConstants.dbConfig
+  private val db = new SqlitePeersDb(dbConfig)
+
+  override def beforeAll(): Unit = {
+    db.createTables
+  }
 
   test("init sqlite 2 times in a row") {
     val db1 = new SqlitePeersDb(dbConfig)
     val db2 = new SqlitePeersDb(dbConfig)
+    db1.createTables
+    db2.createTables
   }
 
   test("add/remove/list peers") {
@@ -56,6 +63,7 @@ class SqlitePeersDbSpec extends FunSuite with BeforeAndAfterAll {
   }
 
   override def afterAll: Unit = {
+    db.dropTables
     dbConfig.close()
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 @RunWith(classOf[JUnitRunner])
 class SqlitePeersDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  private val dbConfig = ??? //TestConstants.dbConfig
+  private val dbConfig = TestConstants.networkDb
   private val db = new SqlitePeersDb(dbConfig)
 
   override def beforeAll(): Unit = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
@@ -17,28 +17,25 @@
 package fr.acinq.eclair.db
 
 import java.net.{InetAddress, InetSocketAddress}
-import java.sql.DriverManager
 
 import fr.acinq.eclair.db.sqlite.SqlitePeersDb
-import fr.acinq.eclair.randomKey
+import fr.acinq.eclair.{TestConstants, randomKey}
 import org.junit.runner.RunWith
-import org.scalatest.FunSuite
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 @RunWith(classOf[JUnitRunner])
-class SqlitePeersDbSpec extends FunSuite {
+class SqlitePeersDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")
+  val dbConfig = TestConstants.dbConfig
 
   test("init sqlite 2 times in a row") {
-    val sqlite = inmem
-    val db1 = new SqlitePeersDb(sqlite)
-    val db2 = new SqlitePeersDb(sqlite)
+    val db1 = new SqlitePeersDb(dbConfig)
+    val db2 = new SqlitePeersDb(dbConfig)
   }
 
   test("add/remove/list peers") {
-    val sqlite = inmem
-    val db = new SqlitePeersDb(sqlite)
+    val db = new SqlitePeersDb(dbConfig)
 
     val peer_1 = (randomKey.publicKey, new InetSocketAddress(InetAddress.getLoopbackAddress, 1111))
     val peer_1_bis = (peer_1._1, new InetSocketAddress(InetAddress.getLoopbackAddress, 1112))
@@ -56,6 +53,10 @@ class SqlitePeersDbSpec extends FunSuite {
     assert(db.listPeers().toSet === Set(peer_1, peer_3))
     db.addOrUpdatePeer(peer_1_bis._1, peer_1_bis._2)
     assert(db.listPeers().toSet === Set(peer_1_bis, peer_3))
+  }
+
+  override def afterAll: Unit = {
+    dbConfig.close()
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
@@ -27,7 +27,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 @RunWith(classOf[JUnitRunner])
 class SqlitePeersDbSpec extends FunSuite with BeforeAndAfterAll {
 
-  private val dbConfig = TestConstants.dbConfig
+  private val dbConfig = ??? //TestConstants.dbConfig
   private val db = new SqlitePeersDb(dbConfig)
 
   override def beforeAll(): Unit = {
@@ -64,7 +64,7 @@ class SqlitePeersDbSpec extends FunSuite with BeforeAndAfterAll {
 
   override def afterAll: Unit = {
     db.dropTables
-    dbConfig.close()
+    //dbConfig.close()
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePendingRelayDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePendingRelayDbSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class SqlitePendingRelayDbSpec extends FunSuite with BeforeAndAfterAll {
-  private val dbConfig = ??? //TestConstants.dbConfig
+  private val dbConfig = TestConstants.networkDb
   private val db = new SqlitePendingRelayDb(dbConfig)
   override def beforeAll(): Unit = {
     db.createTables

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePendingRelayDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePendingRelayDbSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class SqlitePendingRelayDbSpec extends FunSuite with BeforeAndAfterAll {
-  private val dbConfig = TestConstants.dbConfig
+  private val dbConfig = ??? //TestConstants.dbConfig
   private val db = new SqlitePendingRelayDb(dbConfig)
   override def beforeAll(): Unit = {
     db.createTables
@@ -69,7 +69,7 @@ class SqlitePendingRelayDbSpec extends FunSuite with BeforeAndAfterAll {
 
   override def afterAll(): Unit = {
     db.dropTables
-    dbConfig.close()
+    //dbConfig.close()
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePendingRelayDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePendingRelayDbSpec.scala
@@ -28,15 +28,21 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class SqlitePendingRelayDbSpec extends FunSuite with BeforeAndAfterAll {
-
   private val dbConfig = TestConstants.dbConfig
+  private val db = new SqlitePendingRelayDb(dbConfig)
+  override def beforeAll(): Unit = {
+    db.createTables
+  }
+
   test("init sqlite 2 times in a row") {
     val db1 = new SqlitePendingRelayDb(dbConfig)
     val db2 = new SqlitePendingRelayDb(dbConfig)
+    db1.createTables
+    db2.createTables
   }
 
   test("add/remove/list messages") {
-    val db = new SqlitePendingRelayDb(dbConfig)
+
 
     val channelId1 = randomBytes(32)
     val channelId2 = randomBytes(32)
@@ -62,6 +68,7 @@ class SqlitePendingRelayDbSpec extends FunSuite with BeforeAndAfterAll {
   }
 
   override def afterAll(): Unit = {
+    db.dropTables
     dbConfig.close()
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePendingRelayDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePendingRelayDbSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
 class SqlitePendingRelayDbSpec extends FunSuite with BeforeAndAfterAll {
-  private val dbConfig = TestConstants.networkDb
+  private val dbConfig = TestConstants.eclairDb
   private val db = new SqlitePendingRelayDb(dbConfig)
   override def beforeAll(): Unit = {
     db.createTables

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -117,7 +117,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
     sender.expectMsgType[JValue](30 seconds)
   }
 
-  def instantiateEclairNode(name: String, config: Config) = {
+  def instantiateEclairNode(name: String, config: Config): Unit= {
     val datadir = new File(INTEGRATION_TMP_DIR, s"datadir-eclair-$name")
     datadir.mkdirs()
     new PrintWriter(new File(datadir, "eclair.conf")) {
@@ -137,16 +137,39 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
 
   test("starting eclair nodes") {
     import collection.JavaConversions._
-    val commonConfig = ConfigFactory.parseMap(Map("eclair.chain" -> "regtest", "eclair.spv" -> false, "eclair.server.public-ips.1" -> "localhost", "eclair.bitcoind.port" -> 28333, "eclair.bitcoind.rpcport" -> 28332, "eclair.bitcoind.zmq" -> "tcp://127.0.0.1:28334", "eclair.mindepth-blocks" -> 2, "eclair.max-htlc-value-in-flight-msat" -> 100000000000L, "eclair.router-broadcast-interval" -> "2 second", "eclair.auto-reconnect" -> false))
+    val commonConfig = ConfigFactory.parseMap(
+      Map("eclair.chain" -> "regtest",
+        "eclair.spv" -> false,
+        "eclair.server.public-ips.1" -> "localhost",
+        "eclair.bitcoind.port" -> 28333,
+        "eclair.bitcoind.rpcport" -> 28332,
+        "eclair.bitcoind.zmq" -> "tcp://127.0.0.1:28334",
+        "eclair.mindepth-blocks" -> 2,
+        "eclair.max-htlc-value-in-flight-msat" -> 100000000000L,
+        "eclair.router-broadcast-interval" -> "2 second",
+        "eclair.auto-reconnect" -> false,
+        "eclair.db.driver" -> "org.sqlite.JDBC",
+        "eclair.db.regtest.url" -> "jdbc:sqlite:regtest/"
+      )
+    )
     instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.node-alias" -> "A", "eclair.delay-blocks" -> 130, "eclair.server.port" -> 29730, "eclair.api.port" -> 28080, "eclair.channel-flags" -> 0)).withFallback(commonConfig)) // A's channels are private
+
     instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.node-alias" -> "B", "eclair.delay-blocks" -> 131, "eclair.server.port" -> 29731, "eclair.api.port" -> 28081)).withFallback(commonConfig))
+
     instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.delay-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
+
     instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.node-alias" -> "D", "eclair.delay-blocks" -> 133, "eclair.server.port" -> 29733, "eclair.api.port" -> 28083)).withFallback(commonConfig))
+
     instantiateEclairNode("E", ConfigFactory.parseMap(Map("eclair.node-alias" -> "E", "eclair.delay-blocks" -> 134, "eclair.server.port" -> 29734, "eclair.api.port" -> 28084)).withFallback(commonConfig))
+
     instantiateEclairNode("F1", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F1", "eclair.delay-blocks" -> 135, "eclair.server.port" -> 29735, "eclair.api.port" -> 28085, "eclair.payment-handler" -> "noop")).withFallback(commonConfig)) // NB: eclair.payment-handler = noop allows us to manually fulfill htlcs
+
     instantiateEclairNode("F2", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F2", "eclair.delay-blocks" -> 136, "eclair.server.port" -> 29736, "eclair.api.port" -> 28086, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
+
     instantiateEclairNode("F3", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F3", "eclair.delay-blocks" -> 137, "eclair.server.port" -> 29737, "eclair.api.port" -> 28087, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
+
     instantiateEclairNode("F4", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F4", "eclair.delay-blocks" -> 138, "eclair.server.port" -> 29738, "eclair.api.port" -> 28088, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
+
     instantiateEclairNode("F5", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F5", "eclair.delay-blocks" -> 139, "eclair.server.port" -> 29739, "eclair.api.port" -> 28089, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
 
     // by default C has a normal payment handler, but this can be overriden in tests


### PR DESCRIPTION
…ter finished executing a statement, add hikari configuration stuff to reference.conf

This PR adds a connection pool to eclair so it is easier to manage database connections. I chose [HikariCP](https://github.com/brettwooldridge/HikariCP) as the connection pool which is used by scala slick. 

There is hikari connection pool configuration stuff in the `reference.conf` file now, and we can add things later if we want to adjust our pool settings. See the home page of hikari for information about configuration. Hopefully this will also make it easier for eclair developers to use different databases than sqlite (we probably will use Postgres at SuredBits). 

The last thing that is different about this PR is we are now closing the statement *and* the connection in the `using` util method. This will release the jdbc connection back to hikari. 

