### PR TITLE
Generate payment request with extra routing information

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
@@ -182,7 +182,7 @@ object PaymentLifecycle {
   def props(sourceNodeId: PublicKey, router: ActorRef, register: ActorRef) = Props(classOf[PaymentLifecycle], sourceNodeId, router, register)
 
   // @formatter:off
-  case class ReceivePayment(amountMsat_opt: Option[MilliSatoshi], description: String, expirySeconds_opt: Option[Long] = None, extraHops_opt: Seq[Seq[ExtraHop]] = Nil)
+  case class ReceivePayment(amountMsat_opt: Option[MilliSatoshi], description: String, expirySeconds_opt: Option[Long] = None, extraHops: Seq[Seq[ExtraHop]] = Nil)
   /**
     * @param finalCltvExpiry by default we choose finalCltvExpiry = Channel.MIN_CLTV_EXPIRY + 1 to not have our htlc fail when a new block has just been found
     * @param maxFeePct set by default to 3% as a safety measure (even if a route is found, if fee is higher than that payment won't be attempted)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
@@ -33,7 +33,6 @@ import fr.acinq.eclair.wire._
 import scodec.Attempt
 
 import scala.util.{Failure, Success}
-import scala.concurrent.duration.FiniteDuration
 
 /**
   * Created by PM on 26/08/2016.
@@ -183,7 +182,7 @@ object PaymentLifecycle {
   def props(sourceNodeId: PublicKey, router: ActorRef, register: ActorRef) = Props(classOf[PaymentLifecycle], sourceNodeId, router, register)
 
   // @formatter:off
-  case class ReceivePayment(amountMsat_opt: Option[MilliSatoshi], description: String, expirySeconds_opt: Option[Long] = None)
+  case class ReceivePayment(amountMsat_opt: Option[MilliSatoshi], description: String, expirySeconds_opt: Option[Long] = None, extraHops_opt: Seq[Seq[ExtraHop]] = Nil)
   /**
     * @param finalCltvExpiry by default we choose finalCltvExpiry = Channel.MIN_CLTV_EXPIRY + 1 to not have our htlc fail when a new block has just been found
     * @param maxFeePct set by default to 3% as a safety measure (even if a route is found, if fee is higher than that payment won't be attempted)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
@@ -16,15 +16,16 @@
 
 package fr.acinq.eclair.payment
 
-import akka.actor.{ActorSystem, Status}
 import akka.actor.Status.Failure
+import akka.actor.{ActorSystem, Status}
 import akka.testkit.{TestKit, TestProbe}
 import fr.acinq.bitcoin.{MilliSatoshi, Satoshi}
-import fr.acinq.eclair.Globals
 import fr.acinq.eclair.TestConstants.Alice
 import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FULFILL_HTLC}
 import fr.acinq.eclair.payment.PaymentLifecycle.{CheckPayment, ReceivePayment}
+import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.wire.{FinalExpiryTooSoon, UpdateAddHtlc}
+import fr.acinq.eclair.{Globals, ShortChannelId, randomKey}
 import org.junit.runner.RunWith
 import org.scalatest.FunSuiteLike
 import org.scalatest.junit.JUnitRunner
@@ -148,5 +149,24 @@ class PaymentHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
 
     sender.send(handler, ReceivePayment(Some(MilliSatoshi(42000)), "1 coffee with custom expiry", expirySeconds_opt = Some(60)))
     assert(sender.expectMsgType[PaymentRequest].expiry === Some(60))
+  }
+
+  test("Generated payment request contains the provided extra hops") {
+    val handler = system.actorOf(LocalPaymentHandler.props(Alice.nodeParams))
+    val sender = TestProbe()
+
+    val x = randomKey.publicKey
+    val y = randomKey.publicKey
+    val extraHop_x_y = ExtraHop(x, ShortChannelId(1), 10, 11, 12)
+    val extraHop_y_z = ExtraHop(y, ShortChannelId(2), 20, 21, 22)
+    val extraHop_x_t = ExtraHop(x, ShortChannelId(3), 30, 31, 32)
+    val route_x_z = extraHop_x_y :: extraHop_y_z :: Nil
+    val route_x_t = extraHop_x_t :: Nil
+
+    sender.send(handler, ReceivePayment(Some(MilliSatoshi(42000)), "1 coffee with additional routing info", extraHops_opt = Seq(route_x_z, route_x_t)))
+    assert(sender.expectMsgType[PaymentRequest].routingInfo === Seq(route_x_z, route_x_t))
+
+    sender.send(handler, ReceivePayment(Some(MilliSatoshi(42000)), "1 coffee without routing info"))
+    assert(sender.expectMsgType[PaymentRequest].routingInfo === Nil)
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
@@ -163,7 +163,7 @@ class PaymentHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     val route_x_z = extraHop_x_y :: extraHop_y_z :: Nil
     val route_x_t = extraHop_x_t :: Nil
 
-    sender.send(handler, ReceivePayment(Some(MilliSatoshi(42000)), "1 coffee with additional routing info", extraHops_opt = Seq(route_x_z, route_x_t)))
+    sender.send(handler, ReceivePayment(Some(MilliSatoshi(42000)), "1 coffee with additional routing info", extraHops = Seq(route_x_z, route_x_t)))
     assert(sender.expectMsgType[PaymentRequest].routingInfo === Seq(route_x_z, route_x_t))
 
     sender.send(handler, ReceivePayment(Some(MilliSatoshi(42000)), "1 coffee without routing info"))


### PR DESCRIPTION
Added an optional routing parameter to the `ReceivePayment` object to be able to create a `PaymentRequest` with extra routing information, which is useful for nodes that are not announced on the network but still want to receive funds.