### PR TITLE
Clean up implicit execution contexts and allow ActorSystem to be pass…

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -52,10 +52,11 @@ import scala.concurrent.{Await, ExecutionContext, Future, Promise}
   *
   * @param datadir  directory where eclair-core will write/read its data
   * @param overrideDefaults
-  * @param actorSystem
   * @param seed_opt optional seed, if set eclair will use it instead of generating one and won't create a seed.dat file.
   */
-class Setup(datadir: File, overrideDefaults: Config = ConfigFactory.empty(), actorSystem: ActorSystem = ActorSystem(), seed_opt: Option[BinaryData] = None) extends Logging {
+class Setup(datadir: File,
+            overrideDefaults: Config = ConfigFactory.empty(),
+            seed_opt: Option[BinaryData] = None)(implicit system: ActorSystem) extends Logging {
 
   logger.info(s"hello!")
   logger.info(s"version=${getClass.getPackage.getImplementationVersion} commit=${getClass.getPackage.getSpecificationVersion}")
@@ -79,7 +80,6 @@ class Setup(datadir: File, overrideDefaults: Config = ConfigFactory.empty(), act
   // this will force the secure random instance to initialize itself right now, making sure it doesn't hang later (see comment in package.scala)
   secureRandom.nextInt()
 
-  implicit val system = actorSystem
   implicit val materializer = ActorMaterializer()
   implicit val timeout = Timeout(30 seconds)
   implicit val formats = org.json4s.DefaultFormats

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
@@ -22,7 +22,7 @@ import fr.acinq.eclair.blockchain.{NewBlock, NewTransaction}
 import org.zeromq.ZMQ.Event
 import org.zeromq.{ZContext, ZMQ, ZMsg}
 
-import scala.concurrent.Promise
+import scala.concurrent.{ExecutionContext, Promise}
 import scala.concurrent.duration._
 import scala.util.Try
 
@@ -44,7 +44,7 @@ class ZMQActor(address: String, connected: Option[Promise[Boolean]] = None) exte
   val monitor = ctx.createSocket(ZMQ.PAIR)
   monitor.connect("inproc://events")
 
-  import scala.concurrent.ExecutionContext.Implicits.global
+  implicit val ec: ExecutionContext = context.system.dispatcher
 
   // we check messages in a non-blocking manner with an interval, making sure to retrieve all messages before waiting again
   def checkEvent: Unit = Option(Event.recv(monitor, ZMQ.DONTWAIT)) match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/LocalPaymentHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/LocalPaymentHandler.scala
@@ -22,22 +22,23 @@ import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FULFILL_HTLC, Channel}
 import fr.acinq.eclair.db.Payment
 import fr.acinq.eclair.payment.PaymentLifecycle.{CheckPayment, ReceivePayment}
 import fr.acinq.eclair.wire._
-
-import scala.concurrent.duration._
 import fr.acinq.eclair.{Globals, NodeParams, randomBytes}
 
 import scala.compat.Platform
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.duration._
+import scala.util.Try
 
 /**
   * Created by PM on 17/06/2016.
   */
-class LocalPaymentHandler(nodeParams: NodeParams)(implicit ec: ExecutionContext = ExecutionContext.Implicits.global) extends Actor with ActorLogging {
+class LocalPaymentHandler(nodeParams: NodeParams) extends Actor with ActorLogging {
+
+  implicit val ec: ExecutionContext = context.system.dispatcher
 
   context.system.scheduler.schedule(10 minutes, 10 minutes)(self ! Platform.currentTime / 1000)
 
-  override def receive: Receive = run(Map())
+  override def receive: Receive = run(Map.empty)
 
   def run(hash2preimage: Map[BinaryData, (BinaryData, PaymentRequest)]): Receive = {
 
@@ -97,5 +98,7 @@ class LocalPaymentHandler(nodeParams: NodeParams)(implicit ec: ExecutionContext 
 }
 
 object LocalPaymentHandler {
-  def props(nodeParams: NodeParams) = Props(new LocalPaymentHandler(nodeParams))
+  def props(nodeParams: NodeParams): Props =  {
+    Props(new LocalPaymentHandler(nodeParams))
+  }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -124,7 +124,8 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
       write(config.root().render());
       close
     }
-    val setup = new Setup(datadir, actorSystem = ActorSystem(s"system-$name"))
+    implicit val system = ActorSystem(s"system-$name")
+    val setup = new Setup(datadir)
     val kit = Await.result(setup.bootstrap, 10 seconds)
     nodes = nodes + (name -> kit)
   }


### PR DESCRIPTION
…ed implicitly to setup

This allows for a user of the library to implicitly pass the `ActorSystem` to the eclair node. Although if you are running multiple eclair instances on the same machine you need to make sure the `ActorSystems` that are passed implicitly are unique. 