### PR TITLE
Cleanup internal Eclair API

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -27,7 +27,7 @@ import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
 import fr.acinq.bitcoin.{BinaryData, Block}
 import fr.acinq.eclair.NodeParams.{BITCOIND, ELECTRUM}
-import fr.acinq.eclair.api.{GetInfoResponse, Service}
+import fr.acinq.eclair.api.{EclairClient, GetInfoResponse, Service}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, BatchingBitcoinJsonRPCClient, ExtendedBitcoinClient}
 import fr.acinq.eclair.blockchain.bitcoind.zmq.ZMQActor
 import fr.acinq.eclair.blockchain.bitcoind.{BitcoinCoreWallet, ZmqWatcher}
@@ -66,6 +66,7 @@ class Setup(datadir: File, overrideDefaults: Config = ConfigFactory.empty(), act
   val chain = config.getString("chain")
   val keyManager = new LocalKeyManager(seed, NodeParams.makeChainHash(chain))
   val nodeParams = NodeParams.makeNodeParams(datadir, config, keyManager)
+
 
   // early checks
   DBCompatChecker.checkDBCompatibility(nodeParams)
@@ -212,7 +213,7 @@ class Setup(datadir: File, overrideDefaults: Config = ConfigFactory.empty(), act
       _ <- if (config.getBoolean("api.enabled")) {
         logger.info(s"json-rpc api enabled on port=${config.getInt("api.port")}")
         val api = new Service {
-
+          override val client: EclairClient = new EclairClient(datadir)
           override def scheduler = system.scheduler
 
           override val password = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/EclairApi.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/EclairApi.scala
@@ -1,13 +1,20 @@
 package fr.acinq.eclair.api
 
-import fr.acinq.bitcoin.{MilliSatoshi, Satoshi}
-import fr.acinq.eclair.io.NodeURI
-import fr.acinq.eclair.payment.PaymentLifecycle.PaymentResult
+import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.bitcoin.{BinaryData, MilliSatoshi, Satoshi}
+import fr.acinq.eclair.NodeParams
+import fr.acinq.eclair.channel.RES_GETINFO
+import fr.acinq.eclair.io.{NodeURI, Peer}
+import fr.acinq.eclair.payment.PaymentLifecycle.{PaymentResult, ReceivePayment, SendPayment}
 import fr.acinq.eclair.payment.PaymentRequest
+import fr.acinq.eclair.router.{ChannelDesc, RouteResponse}
+import fr.acinq.eclair.wire.{ChannelUpdate, NodeAnnouncement}
 
 import scala.concurrent.Future
 
 trait EclairApi {
+
+  def nodeParams: NodeParams
 
   def getBalance: Future[Satoshi]
 
@@ -19,11 +26,38 @@ trait EclairApi {
   /** Send money to the given invoice */
   def payInvoice(invoice: PaymentRequest): Future[PaymentResult]
 
+  def getPeers: Future[Vector[Peer.PeerInfo]]
 
   def checkPayment(invoice: PaymentRequest): Future[Boolean]
 
   def connectToNode(nodeURI: NodeURI): Future[String]
 
-  def openChannel(nodeURI: NodeURI, amt: MilliSatoshi, pushMSat: MilliSatoshi): Future[String]
+  def openChannel(openChannelMsg: Peer.OpenChannel): Future[String]
+
+  def close(id: String, spk: Option[BinaryData]): Future[String]
+
+  def forceClose(id: String): Future[String]
+
+  def channels(nodeIdOpt: Option[PublicKey]): Future[Vector[LocalChannelInfo]]
+
+  def channel(id: String): Future[RES_GETINFO]
+
+  def allChannels(): Future[Vector[ChannelDesc]]
+
+  def allNodes(): Future[Vector[NodeAnnouncement]]
+
+  def allUpdates(nodeIdOpt: Option[PublicKey]): Future[Vector[ChannelUpdate]]
+
+  def receive(receivePayment: ReceivePayment): Future[PaymentRequest]
+
+  def checkInvoice(invoice: PaymentRequest): Future[Boolean]
+
+  def findRoute(nodeId: PublicKey): Future[RouteResponse]
+
+  def findRoute(paymentRequest: PaymentRequest): Future[RouteResponse]
+
+  def send(invoice: SendPayment): Future[PaymentResult]
+
+  def checkPayment(paymentHash: BinaryData): Future[Boolean]
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/EclairApi.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/EclairApi.scala
@@ -1,0 +1,29 @@
+package fr.acinq.eclair.api
+
+import fr.acinq.bitcoin.{MilliSatoshi, Satoshi}
+import fr.acinq.eclair.io.NodeURI
+import fr.acinq.eclair.payment.PaymentLifecycle.PaymentResult
+import fr.acinq.eclair.payment.PaymentRequest
+
+import scala.concurrent.Future
+
+trait EclairApi {
+
+  def getBalance: Future[Satoshi]
+
+  /** Creates an invoice for the give amount of mSatoshi */
+  def createInvoice(amt: MilliSatoshi, description: String = ""): Future[PaymentRequest]
+
+  def getNodeURI: NodeURI
+
+  /** Send money to the given invoice */
+  def payInvoice(invoice: PaymentRequest): Future[PaymentResult]
+
+
+  def checkPayment(invoice: PaymentRequest): Future[Boolean]
+
+  def connectToNode(nodeURI: NodeURI): Future[String]
+
+  def openChannel(nodeURI: NodeURI, amt: MilliSatoshi, pushMSat: MilliSatoshi): Future[String]
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/EclairClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/EclairClient.scala
@@ -2,16 +2,22 @@ package fr.acinq.eclair.api
 
 import java.io.File
 
-import akka.actor.ActorSystem
+import akka.actor.{ActorRef, ActorSystem}
+import akka.http.scaladsl.model.HttpMethods.register
 import akka.pattern.ask
 import akka.util.Timeout
 import com.google.common.net.HostAndPort
-import fr.acinq.bitcoin.{MilliSatoshi, Satoshi}
-import fr.acinq.eclair.{Kit, Setup}
+import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.bitcoin.{BinaryData, MilliSatoshi, Satoshi}
+import fr.acinq.eclair.{Kit, NodeParams, Setup, ShortChannelId}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BasicBitcoinJsonRPCClient
+import fr.acinq.eclair.channel._
+import fr.acinq.eclair.io.Peer.{GetPeerInfo, PeerInfo}
 import fr.acinq.eclair.io.{NodeURI, Peer}
-import fr.acinq.eclair.payment.PaymentLifecycle.{CheckPayment, PaymentResult, ReceivePayment, SendPayment}
-import fr.acinq.eclair.payment.PaymentRequest
+import fr.acinq.eclair.payment.PaymentLifecycle._
+import fr.acinq.eclair.payment.{PaymentLifecycle, PaymentRequest}
+import fr.acinq.eclair.router.{ChannelDesc, RouteRequest, RouteResponse}
+import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.Future
@@ -26,15 +32,13 @@ class EclairClient(datadir: File = new File(s"${System.getenv("HOME")}/.eclair")
   private val kitF: Future[Kit] = setup.bootstrap
   private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
 
+  def nodeParams: NodeParams = setup.nodeParams
+
   override def getBalance: Future[Satoshi] = kitF.flatMap(_.wallet.getBalance)
 
   override def createInvoice(amt: MilliSatoshi, description: String = ""): Future[PaymentRequest] = {
-    kitF.flatMap { kit =>
-      (kit.paymentHandler.ask(
-        ReceivePayment(Some(MilliSatoshi(amt.toLong)),
-          description)
-      )).mapTo[PaymentRequest]
-    }
+    val recv = ReceivePayment(Some(MilliSatoshi(amt.toLong)), description)
+    receive(recv)
   }
 
 
@@ -46,10 +50,7 @@ class EclairClient(datadir: File = new File(s"${System.getenv("HOME")}/.eclair")
   }
 
   override def checkPayment(invoice: PaymentRequest): Future[Boolean] = {
-    kitF.flatMap { kit =>
-      val checkPayment = CheckPayment(invoice.paymentHash)
-      kit.paymentHandler.ask(checkPayment).mapTo[Boolean]
-    }
+    checkPayment(invoice.paymentHash)
   }
 
   override def connectToNode(nodeURI: NodeURI): Future[String] = {
@@ -67,14 +68,141 @@ class EclairClient(datadir: File = new File(s"${System.getenv("HOME")}/.eclair")
     new NodeURI(setup.nodeParams.nodeId,hostAndPort)
   }
 
-  override def openChannel(nodeURI: NodeURI, amount: MilliSatoshi, pushMSat: MilliSatoshi): Future[String] = {
-    logger.debug(s"${setup.nodeParams.nodeId} is opening a channel with ${nodeURI.nodeId}")
+  override def openChannel(openChannelMsg: Peer.OpenChannel): Future[String] = {
+    logger.debug(s"${setup.nodeParams.nodeId} is opening a channel with ${openChannelMsg.remoteNodeId}")
     kitF.flatMap { kit =>
-      val openChannelMsg = Peer.OpenChannel(nodeURI.nodeId,
-        Satoshi(amount.toLong), pushMSat,
-        fundingTxFeeratePerKw_opt = None, channelFlags = None)
       val channel = kit.switchboard.ask(openChannelMsg).mapTo[String]
       channel
     }
   }
+
+  override def getPeers: Future[Vector[Peer.PeerInfo]] = {
+    kitF.flatMap { kit =>
+      val result: Future[Iterable[PeerInfo]] = for {
+        peers <- (kit.switchboard ? 'peers).mapTo[Map[PublicKey, ActorRef]]
+        peerinfos <- Future.sequence(peers.values.map(peer => (peer ? GetPeerInfo).mapTo[PeerInfo]))
+      } yield peerinfos
+      result.map(_.toVector)
+    }
+  }
+
+  override def close(id: String, spk: Option[BinaryData]): Future[String] = {
+    sendToChannel(id, CMD_CLOSE(scriptPubKey = spk)).mapTo[String]
+  }
+
+  override def forceClose(id: String): Future[String] = {
+    sendToChannel(id, CMD_FORCECLOSE).mapTo[String]
+  }
+
+  override def channels(pubKeyOpt: Option[PublicKey]): Future[Vector[LocalChannelInfo]] = {
+    kitF.flatMap { kit =>
+
+      val channelsIdF: Future[Iterable[BinaryData]] = (kit.register ? 'channels)
+        .mapTo[Map[BinaryData, ActorRef]]
+        .map { m :Map[BinaryData, ActorRef] =>
+          if (pubKeyOpt.isDefined) {
+            m.filter(_._2 == pubKeyOpt.get).keys
+          } else {
+            m.keys
+          }
+        }
+
+      val sentF: Future[Iterable[RES_GETINFO]] = channelsIdF.flatMap { channels_id: Iterable[BinaryData] =>
+        val x: Iterable[Future[RES_GETINFO]] = channels_id.map { channel_id =>
+          sendToChannel(channel_id.toString(), CMD_GETINFO).mapTo[RES_GETINFO]
+        }
+        Future.sequence(x)
+      }
+
+      val f: Future[Iterable[LocalChannelInfo]] = sentF.map { sent =>
+        sent.map(s => LocalChannelInfo(s.nodeId, s.channelId, s.state.toString))
+      }
+
+      f.map(_.toVector)
+    }
+  }
+
+  override def channel(id: String): Future[RES_GETINFO] = {
+    sendToChannel(id, CMD_GETINFO).mapTo[RES_GETINFO]
+  }
+
+  override def allChannels(): Future[Vector[ChannelDesc]] = {
+    kitF.flatMap { kit =>
+      val descs: Future[Iterable[ChannelDesc]] = {
+        (kit.router ? 'channels).mapTo[Iterable[ChannelAnnouncement]]
+        .map(_.map(c => ChannelDesc(c.shortChannelId, c.nodeId1, c.nodeId2)))
+      }
+      descs.map(_.toVector)
+    }
+  }
+
+  override def allNodes(): Future[Vector[NodeAnnouncement]] = {
+    kitF.flatMap { kit =>
+      val ann = (kit.router ? 'nodes).mapTo[Iterable[NodeAnnouncement]]
+      ann.map(_.toVector)
+    }
+  }
+
+  override def allUpdates(nodeIdOpt: Option[PublicKey]): Future[Vector[ChannelUpdate]] = {
+    kitF.flatMap { kit =>
+      val updates: Future[Iterable[ChannelUpdate]] = if (nodeIdOpt.isDefined) {
+        val updateMap: Future[Map[ChannelDesc, ChannelUpdate]] = {
+          (kit.router ? 'updatesMap).mapTo[Map[ChannelDesc, ChannelUpdate]]
+        }
+        updateMap.map(_.filter(e => e._1.a == nodeIdOpt.get || e._1.b == nodeIdOpt.get).values)
+      } else {
+        (kit.router ? 'updates).mapTo[Iterable[ChannelUpdate]]
+      }
+      updates.map(_.toVector)
+    }
+  }
+
+  override def receive(receivePayment: ReceivePayment): Future[PaymentRequest] = {
+    kitF.flatMap { kit =>
+      (kit.paymentHandler.ask(receivePayment)).mapTo[PaymentRequest]
+    }
+  }
+
+  override def checkInvoice(invoice: PaymentRequest): Future[Boolean] = {
+    kitF.flatMap { kit =>
+      val checkPayment = CheckPayment(invoice.paymentHash)
+      kit.paymentHandler.ask(checkPayment).mapTo[Boolean]
+    }
+  }
+
+  override def findRoute(nodeId: PublicKey): Future[RouteResponse] = {
+    kitF.flatMap { kit =>
+      (kit.router ? RouteRequest(kit.nodeParams.nodeId, nodeId)).mapTo[RouteResponse]
+    }
+  }
+
+  override def findRoute(paymentRequest: PaymentRequest): Future[RouteResponse] = {
+    findRoute(paymentRequest.nodeId)
+  }
+
+  override def send(invoice: SendPayment): Future[PaymentResult]  = {
+    kitF.flatMap { kit =>
+      kit.paymentInitiator.ask(invoice).mapTo[PaymentResult].map {
+        case s: PaymentSucceeded => s
+        case f: PaymentFailed => f.copy(failures = PaymentLifecycle.transformForUser(f.failures))
+      }
+    }
+  }
+
+  override def checkPayment(paymentHash: BinaryData): Future[Boolean] = {
+    kitF.flatMap { kit =>
+      (kit.paymentHandler ? CheckPayment(paymentHash)).mapTo[Boolean]
+    }
+  }
+
+  /** Pasting this over here for now as a bridge between old implementation in Service
+    * and the new implementation in EclairClient
+    */
+  private def sendToChannel(channelIdentifier: String, request: Any): Future[Any] =
+    for {
+      fwdReq <- Future(Register.ForwardShortId(ShortChannelId(channelIdentifier), request))
+        .recoverWith { case _ => Future(Register.Forward(BinaryData(channelIdentifier), request)) }
+        .recoverWith { case _ => Future.failed(new RuntimeException(s"invalid channel identifier '$channelIdentifier'")) }
+      res <- kitF.map(kit => kit.register ? fwdReq)
+    } yield res
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/EclairClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/EclairClient.scala
@@ -1,0 +1,80 @@
+package fr.acinq.eclair.api
+
+import java.io.File
+
+import akka.actor.ActorSystem
+import akka.pattern.ask
+import akka.util.Timeout
+import com.google.common.net.HostAndPort
+import fr.acinq.bitcoin.{MilliSatoshi, Satoshi}
+import fr.acinq.eclair.{Kit, Setup}
+import fr.acinq.eclair.blockchain.bitcoind.rpc.BasicBitcoinJsonRPCClient
+import fr.acinq.eclair.io.{NodeURI, Peer}
+import fr.acinq.eclair.payment.PaymentLifecycle.{CheckPayment, PaymentResult, ReceivePayment, SendPayment}
+import fr.acinq.eclair.payment.PaymentRequest
+import org.slf4j.LoggerFactory
+
+import scala.concurrent.Future
+
+class EclairClient(datadir: File = new File(s"${System.getenv("HOME")}/.eclair"))
+                  (implicit system: ActorSystem, timeout: Timeout) extends EclairApi {
+
+
+  implicit val dispatcher = system.dispatcher
+  private val _ = datadir.mkdirs()
+  private val setup = new Setup(datadir, actorSystem = system)
+  private val kitF: Future[Kit] = setup.bootstrap
+  private val logger = LoggerFactory.getLogger(this.getClass.getSimpleName)
+
+  override def getBalance: Future[Satoshi] = kitF.flatMap(_.wallet.getBalance)
+
+  override def createInvoice(amt: MilliSatoshi, description: String = ""): Future[PaymentRequest] = {
+    kitF.flatMap { kit =>
+      (kit.paymentHandler.ask(
+        ReceivePayment(Some(MilliSatoshi(amt.toLong)),
+          description)
+      )).mapTo[PaymentRequest]
+    }
+  }
+
+
+  override def payInvoice(invoice: PaymentRequest): Future[PaymentResult] = {
+    kitF.flatMap { kit =>
+      val sendPayment = SendPayment(invoice.amount.get.toLong,invoice.paymentHash,invoice.nodeId)
+      kit.paymentInitiator.ask(sendPayment).mapTo[PaymentResult]
+    }
+  }
+
+  override def checkPayment(invoice: PaymentRequest): Future[Boolean] = {
+    kitF.flatMap { kit =>
+      val checkPayment = CheckPayment(invoice.paymentHash)
+      kit.paymentHandler.ask(checkPayment).mapTo[Boolean]
+    }
+  }
+
+  override def connectToNode(nodeURI: NodeURI): Future[String] = {
+    logger.debug(s"${setup.nodeParams.nodeId} is connecting to ${nodeURI.nodeId}")
+    kitF.flatMap { kit =>
+      val conn = (kit.switchboard.ask(Peer.Connect(nodeURI))).mapTo[String]
+      conn
+    }
+  }
+
+
+  override def getNodeURI: NodeURI = {
+    val address = setup.nodeParams.publicAddresses.head
+    val hostAndPort =  HostAndPort.fromParts(address.getHostString,address.getPort)
+    new NodeURI(setup.nodeParams.nodeId,hostAndPort)
+  }
+
+  override def openChannel(nodeURI: NodeURI, amount: MilliSatoshi, pushMSat: MilliSatoshi): Future[String] = {
+    logger.debug(s"${setup.nodeParams.nodeId} is opening a channel with ${nodeURI.nodeId}")
+    kitF.flatMap { kit =>
+      val openChannelMsg = Peer.OpenChannel(nodeURI.nodeId,
+        Satoshi(amount.toLong), pushMSat,
+        fundingTxFeeratePerKw_opt = None, channelFlags = None)
+      val channel = kit.switchboard.ask(openChannelMsg).mapTo[String]
+      channel
+    }
+  }
+}


### PR DESCRIPTION
I ended up writing this to use for a suredbits project, but figured it would be better to just open source and allow for a little bit of a cleaner abstraction in eclair that hides all of the actor stuff. This currently implements a subset of the Actor messages `Service`. 

The goal with this is to replace all of the actor asks in `Service` with this eventually. For now I just wanted to get this out here and see what people think. 

I think the return types for some of the Actors (`openChannel`, `connectToNode`) probably should return something different than just a `String`. 