### PR TITLE
Use "unsigned long" comparison for short channel ids

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -28,7 +28,8 @@ case class ShortChannelId(private val id: Long) extends Ordered[ShortChannelId] 
 
   override def toString: String = id.toHexString
 
-  override def compare(that: ShortChannelId): Int = this.id.compareTo(that.id)
+  // we use an unsigned long comparison here
+  override def compare(that: ShortChannelId): Int = (this.id + Long.MinValue).compareTo(that.id + Long.MinValue)
 }
 
 object ShortChannelId {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/PackageSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/PackageSpec.scala
@@ -106,4 +106,11 @@ class PackageSpec extends FunSuite {
     assert(feerateByte2Kw(1) == MinimumFeeratePerKw)
     assert(feerateKB2Kw(1000) == MinimumFeeratePerKw)
   }
+
+  test("compare short channel ids as unsigned longs") {
+    assert(ShortChannelId(Long.MinValue - 1) < ShortChannelId(Long.MinValue))
+    assert(ShortChannelId(Long.MinValue) < ShortChannelId(Long.MinValue + 1))
+    assert(ShortChannelId(Long.MaxValue - 1) < ShortChannelId(Long.MaxValue))
+    assert(ShortChannelId(Long.MaxValue) < ShortChannelId(Long.MaxValue + 1))
+  }
 }


### PR DESCRIPTION
Java Longs are signed, and we cannot use Long.compareUnsigned() which is not available in JDK7