### PR TITLE
Handle unknown remote commit in recovery logic

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -16,6 +16,7 @@
 
 package fr.acinq.eclair.channel
 
+import fr.acinq.bitcoin.Crypto.Scalar
 import fr.acinq.bitcoin.{BinaryData, Transaction}
 import fr.acinq.eclair.UInt64
 import fr.acinq.eclair.payment.{Origin, Relayed}
@@ -76,6 +77,7 @@ case class CannotSignWithoutChanges            (override val channelId: BinaryDa
 case class CannotSignBeforeRevocation          (override val channelId: BinaryData) extends ChannelException(channelId, "cannot sign until next revocation hash is received")
 case class UnexpectedRevocation                (override val channelId: BinaryData) extends ChannelException(channelId, "received unexpected RevokeAndAck message")
 case class InvalidRevocation                   (override val channelId: BinaryData) extends ChannelException(channelId, "invalid revocation")
+case class InvalidRevokedCommitProof           (override val channelId: BinaryData, ourCommitmentNumber: Long, theirCommitmentNumber: Long, perCommitmentSecret: Scalar) extends ChannelException(channelId, s"counterparty claimed that we have a revoked commit but their proof doesn't check out: ourCommitmentNumber=$ourCommitmentNumber theirCommitmentNumber=$theirCommitmentNumber perCommitmentSecret=$perCommitmentSecret")
 case class CommitmentSyncError                 (override val channelId: BinaryData) extends ChannelException(channelId, "commitment sync error")
 case class RevocationSyncError                 (override val channelId: BinaryData) extends ChannelException(channelId, "revocation sync error")
 case class InvalidFailureCode                  (override val channelId: BinaryData) extends ChannelException(channelId, "UpdateFailMalformedHtlc message doesn't have BADONION bit set")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -226,8 +226,8 @@ object Helpers {
     * @param nextRemoteRevocationNumber
     * @return
     */
-  def ourNextLocalCommitmentNumberCheck(d: HasCommitments, nextRemoteRevocationNumber: Long): Boolean = {
-    d.commitments.localCommit.index < nextRemoteRevocationNumber
+  def checkLocalCommit(d: HasCommitments, nextRemoteRevocationNumber: Long): Boolean = {
+    d.commitments.localCommit.index >= nextRemoteRevocationNumber
   }
 
   /**
@@ -237,7 +237,7 @@ object Helpers {
     * @param nextLocalCommitmentNumber
     * @return
     */
-  def theirNextLocalCommitmentNumberCheck(d: HasCommitments, nextLocalCommitmentNumber: Long): Boolean = {
+  def checkRemoteCommit(d: HasCommitments, nextLocalCommitmentNumber: Long): Boolean = {
     d.commitments.remoteNextCommitInfo match {
       case Left(waitingForRevocation) if nextLocalCommitmentNumber == waitingForRevocation.nextRemoteCommit.index =>
         // // we just sent a new commitment but they didn't receive the new commitment


### PR DESCRIPTION
Our recovery logic didn't handle the case were our local commit is
up-to-date, but we don't know their local commit (probably because we
just lost the last state were we sent them a new `commit_sig`).

Also, process all cases in the same `channel_reestablish` handler, like we do
everywhere else.

Moved the sync tests in `Helpers` so that they are more understandable.