### PR TITLE
Add a "smooth" fee provider

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -36,6 +36,7 @@ eclair {
     }
   }
   min-feerate = 2 // minimum feerate in satoshis per byte
+  smooth-feerate-window = 1 // 1 means no smoothing
 
   node-alias = "eclair"
   node-color = "49daaa"

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -36,7 +36,7 @@ eclair {
     }
   }
   min-feerate = 2 // minimum feerate in satoshis per byte
-  smooth-feerate-window = 1 // 1 means no smoothing
+  smooth-feerate-window = 3 // 1 = no smoothing
 
   node-alias = "eclair"
   node-color = "49daaa"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -146,10 +146,13 @@ class Setup(datadir: File,
         blocks_72 = config.getLong("default-feerates.delay-blocks.72")
       )
       minFeeratePerByte = config.getLong("min-feerate")
+      smoothFeerateWindow = config.getInt("smooth-feerate-window")
       feeProvider = (nodeParams.chainHash, bitcoin) match {
         case (Block.RegtestGenesisBlock.hash, _) => new FallbackFeeProvider(new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte)
-        case (_, Bitcoind(bitcoinClient)) => new FallbackFeeProvider(new BitgoFeeProvider(nodeParams.chainHash) :: new EarnDotComFeeProvider() :: new BitcoinCoreFeeProvider(bitcoinClient, defaultFeerates) :: new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte) // order matters!
-        case _ => new FallbackFeeProvider(new BitgoFeeProvider(nodeParams.chainHash) :: new EarnDotComFeeProvider() :: new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte) // order matters!
+        case (_, Bitcoind(bitcoinClient)) =>
+            new FallbackFeeProvider(new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(), smoothFeerateWindow) :: new SmoothFeeProvider(new BitcoinCoreFeeProvider(bitcoinClient, defaultFeerates), smoothFeerateWindow) :: new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte) // order matters!
+        case _ =>
+          new FallbackFeeProvider(new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(), smoothFeerateWindow) :: new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte) // order matters!
       }
       _ = system.scheduler.schedule(0 seconds, 10 minutes)(feeProvider.getFeerates.map {
         case feerates: FeeratesPerKB =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProvider.scala
@@ -1,0 +1,36 @@
+package fr.acinq.eclair.blockchain.fee
+import scala.concurrent.{ExecutionContext, Future}
+
+class SmoothFeeProvider(provider: FeeProvider, windowSize: Int)(implicit ec: ExecutionContext) extends FeeProvider {
+  require(windowSize > 0)
+
+  var queue = List.empty[FeeratesPerKB]
+
+  def add(rate: FeeratesPerKB) : Unit = synchronized {
+    queue = queue :+ rate
+    if (queue.length > windowSize) queue = queue.drop(1)
+  }
+
+  override def getFeerates: Future[FeeratesPerKB] = {
+    for {
+      rate <- provider.getFeerates
+      _ = add(rate)
+    } yield SmoothFeeProvider.avg(queue)
+  }
+}
+
+object SmoothFeeProvider {
+
+  def add(a: FeeratesPerKB, b: FeeratesPerKB) = a.copy(
+    block_1 = a.block_1 + b.block_1,
+    blocks_2 = a.blocks_2 + b.blocks_2,
+    blocks_6 = a.blocks_6 + b.blocks_6,
+    blocks_12 = a.blocks_12 + b.blocks_12,
+    blocks_36 = a.blocks_36 + b.blocks_36,
+    blocks_72 = a.blocks_72 + b.blocks_72)
+
+  def avg(rates: Seq[FeeratesPerKB]) : FeeratesPerKB = {
+    val s = rates.tail.foldLeft(rates.head)(add)
+    s.copy(s.block_1 / rates.size, s.blocks_2 / rates.size, s.blocks_6 / rates.size, s.blocks_12 / rates.size, s.blocks_36 / rates.size, s.blocks_72 / rates.size)
+  }
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProvider.scala
@@ -1,4 +1,5 @@
 package fr.acinq.eclair.blockchain.fee
+
 import scala.concurrent.{ExecutionContext, Future}
 
 class SmoothFeeProvider(provider: FeeProvider, windowSize: Int)(implicit ec: ExecutionContext) extends FeeProvider {
@@ -6,7 +7,7 @@ class SmoothFeeProvider(provider: FeeProvider, windowSize: Int)(implicit ec: Exe
 
   var queue = List.empty[FeeratesPerKB]
 
-  def add(rate: FeeratesPerKB) : Unit = synchronized {
+  def append(rate: FeeratesPerKB): Unit = synchronized {
     queue = queue :+ rate
     if (queue.length > windowSize) queue = queue.drop(1)
   }
@@ -14,23 +15,21 @@ class SmoothFeeProvider(provider: FeeProvider, windowSize: Int)(implicit ec: Exe
   override def getFeerates: Future[FeeratesPerKB] = {
     for {
       rate <- provider.getFeerates
-      _ = add(rate)
-    } yield SmoothFeeProvider.avg(queue)
+      _ = append(rate)
+    } yield SmoothFeeProvider.smooth(queue)
   }
 }
 
 object SmoothFeeProvider {
 
-  def add(a: FeeratesPerKB, b: FeeratesPerKB) = a.copy(
-    block_1 = a.block_1 + b.block_1,
-    blocks_2 = a.blocks_2 + b.blocks_2,
-    blocks_6 = a.blocks_6 + b.blocks_6,
-    blocks_12 = a.blocks_12 + b.blocks_12,
-    blocks_36 = a.blocks_36 + b.blocks_36,
-    blocks_72 = a.blocks_72 + b.blocks_72)
+  def avg(i: Seq[Long]): Long = i.sum / i.size
 
-  def avg(rates: Seq[FeeratesPerKB]) : FeeratesPerKB = {
-    val s = rates.tail.foldLeft(rates.head)(add)
-    s.copy(s.block_1 / rates.size, s.blocks_2 / rates.size, s.blocks_6 / rates.size, s.blocks_12 / rates.size, s.blocks_36 / rates.size, s.blocks_72 / rates.size)
-  }
+  def smooth(rates: Seq[FeeratesPerKB]): FeeratesPerKB =
+    FeeratesPerKB(
+      block_1 = avg(rates.map(_.block_1)),
+      blocks_2 = avg(rates.map(_.blocks_2)),
+      blocks_6 = avg(rates.map(_.blocks_6)),
+      blocks_12 = avg(rates.map(_.blocks_12)),
+      blocks_36 = avg(rates.map(_.blocks_36)),
+      blocks_72 = avg(rates.map(_.blocks_72)))
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProviderSpec.scala
@@ -103,8 +103,8 @@ class BitcoinCoreFeeProviderSpec extends TestKit(ActorSystem("test")) with Bitco
       }
     }
 
-    val mockPrivider = new BitcoinCoreFeeProvider(mockBitcoinClient, FeeratesPerKB(1, 2, 3, 4, 5, 6))
-    mockPrivider.getFeerates.pipeTo(sender.ref)
+    val mockProvider = new BitcoinCoreFeeProvider(mockBitcoinClient, FeeratesPerKB(1, 2, 3, 4, 5, 6))
+    mockProvider.getFeerates.pipeTo(sender.ref)
     assert(sender.expectMsgType[FeeratesPerKB] == ref)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProviderSpec.scala
@@ -67,7 +67,7 @@ class BitcoinCoreFeeProviderSpec extends TestKit(ActorSystem("test")) with Bitco
       port = config.getInt("bitcoind.rpcport"))
 
     // the regtest client doesn't have enough data to estimate fees yet, so it's suppose to fail
-    val regtestProvider = new BitcoinCoreFeeProvider(bitcoinClient, FeeratesPerKB(1,2,3,4,5,6))
+    val regtestProvider = new BitcoinCoreFeeProvider(bitcoinClient, FeeratesPerKB(1, 2, 3, 4, 5, 6))
     val sender = TestProbe()
     regtestProvider.getFeerates.pipeTo(sender.ref)
     assert(sender.expectMsgType[Failure].cause.asInstanceOf[RuntimeException].getMessage.contains("Insufficient data or no feerate found"))
@@ -103,7 +103,7 @@ class BitcoinCoreFeeProviderSpec extends TestKit(ActorSystem("test")) with Bitco
       }
     }
 
-    val mockPrivider = new BitcoinCoreFeeProvider(mockBitcoinClient, FeeratesPerKB(1,2,3,4,5,6))
+    val mockPrivider = new BitcoinCoreFeeProvider(mockBitcoinClient, FeeratesPerKB(1, 2, 3, 4, 5, 6))
     mockPrivider.getFeerates.pipeTo(sender.ref)
     assert(sender.expectMsgType[FeeratesPerKB] == ref)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
@@ -1,0 +1,45 @@
+package fr.acinq.eclair.blockchain.fee
+
+import org.junit.runner.RunWith
+import org.scalatest.FunSuite
+import org.scalatest.junit.JUnitRunner
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@RunWith(classOf[JUnitRunner])
+class SmoothFeeProviderSpec extends FunSuite {
+  test("smooth fee rates") {
+    val provider = new FeeProvider {
+      val rates = Array(
+        FeeratesPerKB(100, 200, 300, 400, 500, 600),
+        FeeratesPerKB(200, 300, 400, 500, 600, 700),
+        FeeratesPerKB(300, 400, 500, 600, 700, 800),
+        FeeratesPerKB(300, 400, 500, 600, 700, 800),
+        FeeratesPerKB(300, 400, 500, 600, 700, 800)
+      )
+      var index = 0
+
+      override def getFeerates: Future[FeeratesPerKB] = {
+        val rate = rates(index)
+        index = (index + 1) % rates.length
+        Future.successful(rate)
+      }
+    }
+
+    val smoothProvider = new SmoothFeeProvider(provider, windowSize = 3)
+    val f = for {
+      rate1 <- smoothProvider.getFeerates
+      rate2 <- smoothProvider.getFeerates
+      rate3 <- smoothProvider.getFeerates
+      rate4 <- smoothProvider.getFeerates
+      rate5 <- smoothProvider.getFeerates
+      rate6 <- smoothProvider.getFeerates
+    } yield (rate1, rate2, rate3, rate4, rate5, rate6)
+
+    val (rate1, rate2, rate3, rate4, rate5, rate6) = Await.result(f, 5 seconds)
+    assert(rate1 == FeeratesPerKB(100, 200, 300, 400, 500, 600))
+    assert(rate5 == FeeratesPerKB(300, 400, 500, 600, 700, 800))
+  }
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
@@ -11,15 +11,15 @@ import scala.concurrent.ExecutionContext.Implicits.global
 @RunWith(classOf[JUnitRunner])
 class SmoothFeeProviderSpec extends FunSuite {
   test("smooth fee rates") {
+    val rates = Array(
+      FeeratesPerKB(100, 200, 300, 400, 500, 600),
+      FeeratesPerKB(200, 300, 400, 500, 600, 700),
+      FeeratesPerKB(300, 400, 500, 600, 700, 800),
+      FeeratesPerKB(300, 400, 500, 600, 700, 800),
+      FeeratesPerKB(300, 400, 500, 600, 700, 800)
+    )
     val provider = new FeeProvider {
-      val rates = Array(
-        FeeratesPerKB(100, 200, 300, 400, 500, 600),
-        FeeratesPerKB(200, 300, 400, 500, 600, 700),
-        FeeratesPerKB(300, 400, 500, 600, 700, 800),
-        FeeratesPerKB(300, 400, 500, 600, 700, 800),
-        FeeratesPerKB(300, 400, 500, 600, 700, 800)
-      )
-      var index = 0
+       var index = 0
 
       override def getFeerates: Future[FeeratesPerKB] = {
         val rate = rates(index)
@@ -35,11 +35,14 @@ class SmoothFeeProviderSpec extends FunSuite {
       rate3 <- smoothProvider.getFeerates
       rate4 <- smoothProvider.getFeerates
       rate5 <- smoothProvider.getFeerates
-      rate6 <- smoothProvider.getFeerates
-    } yield (rate1, rate2, rate3, rate4, rate5, rate6)
+    } yield (rate1, rate2, rate3, rate4, rate5)
 
-    val (rate1, rate2, rate3, rate4, rate5, rate6) = Await.result(f, 5 seconds)
-    assert(rate1 == FeeratesPerKB(100, 200, 300, 400, 500, 600))
-    assert(rate5 == FeeratesPerKB(300, 400, 500, 600, 700, 800))
+    val (rate1, rate2, rate3, rate4, rate5) = Await.result(f, 5 seconds)
+    assert(rate1 == rates(0))
+    assert(rate2 == SmoothFeeProvider.smooth(Seq(rates(0), rates(1))))
+    assert(rate3 == SmoothFeeProvider.smooth(Seq(rates(0), rates(1), rates(2))))
+    assert(rate3 ==  FeeratesPerKB(200, 300, 400, 500, 600, 700))
+    assert(rate4 == SmoothFeeProvider.smooth(Seq(rates(1), rates(2), rates(3))))
+    assert(rate5 == rates(4)) // since the last 3 values are the same
   }
 }


### PR DESCRIPTION
It will return the moving average of fee estimates provided by its internal fee provider, within a user defined window that can be set with eclair.smooth-feerate-window. The default value is 1 which doe not change the current behaviour.
This should help prevent channels from getting closed when fees rise quickly and we send an `update fee` message that our peer disagrees with.