### PR TITLE
Removed max body size in http client

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
@@ -96,15 +96,6 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
   def getTransaction(txId: String)(implicit ec: ExecutionContext): Future[Transaction] =
     getRawTransaction(txId).map(raw => Transaction.read(raw))
 
-  def getTransaction(height: Int, index: Int)(implicit ec: ExecutionContext): Future[Transaction] =
-    for {
-      hash <- rpcClient.invoke("getblockhash", height).map(json => json.extract[String])
-      json <- rpcClient.invoke("getblock", hash)
-      JArray(txs) = json \ "tx"
-      txid = txs(index).extract[String]
-      tx <- getTransaction(txid)
-    } yield tx
-
   def isTransactionOutputSpendable(txId: String, outputIndex: Int, includeMempool: Boolean)(implicit ec: ExecutionContext): Future[Boolean] =
     for {
       json <- rpcClient.invoke("gettxout", txId, outputIndex, includeMempool)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
@@ -69,21 +69,6 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
     } yield txs
 
   /**
-    * *used in interop test*
-    * tell bitcoind to sent bitcoins from a specific local account
-    *
-    * @param account     name of the local account to send bitcoins from
-    * @param destination destination address
-    * @param amount      amount in BTC (not milliBTC, not Satoshis !!)
-    * @param ec          execution context
-    * @return a Future[txid] where txid (a String) is the is of the tx that sends the bitcoins
-    */
-  def sendFromAccount(account: String, destination: String, amount: Double)(implicit ec: ExecutionContext): Future[String] =
-    rpcClient.invoke("sendfrom", account, destination, amount) collect {
-      case JString(txid) => txid
-    }
-
-  /**
     * @param txId
     * @param ec
     * @return

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1637,7 +1637,10 @@ class Channel(val nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: Pu
     */
   def publishIfNeeded(txes: Iterable[Transaction], irrevocablySpent: Map[OutPoint, BinaryData]) = {
     val (skip, process) = txes.partition(Closing.inputsAlreadySpent(_, irrevocablySpent))
-    process.foreach(tx => blockchain ! PublishAsap(tx))
+    process.foreach { tx =>
+      log.info(s"publishing txid=${tx.txid}")
+      blockchain ! PublishAsap(tx)
+    }
     skip.foreach(tx => log.info(s"no need to republish txid=${tx.txid}, it has already been confirmed"))
   }
 

--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -21,4 +21,17 @@ akka {
 
     }
   }
+
+  # Default maximum content length which should not be exceeded by incoming request entities.
+  # Can be changed at runtime (to a higher or lower value) via the `HttpEntity::withSizeLimit` method.
+  # Note that it is not necessarily a problem to set this to a high value as all stream operations
+  # are always properly backpressured.
+  # Nevertheless you might want to apply some limit in order to prevent a single client from consuming
+  # an excessive amount of server resources.
+  #
+  # Set to `infinite` to completely disable entity length checks. (Even then you can still apply one
+  # programmatically via `withSizeLimit`.)
+  #
+  # We disable the size check, because the batching bitcoin json-rpc client may return very large results
+  http.client.parsing.max-content-length=infinite
 }


### PR DESCRIPTION
This is required because since f3676c6 we retrieve multiple full blocks in parallel.

Also added minor improvements.