### PR TITLE
ShortChannelId: use block height, tx index, output index explicitely

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
@@ -17,8 +17,8 @@
 package fr.acinq.eclair.blockchain.bitcoind.rpc
 
 import fr.acinq.bitcoin._
-import fr.acinq.eclair.ShortChannelId.coordinates
-import fr.acinq.eclair.TxCoordinates
+import fr.acinq.eclair
+import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.blockchain.ValidateResult
 import fr.acinq.eclair.wire.ChannelAnnouncement
 import org.json4s.JsonAST._
@@ -127,7 +127,7 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
     }
 
   def validate(c: ChannelAnnouncement)(implicit ec: ExecutionContext): Future[ValidateResult] = {
-    val TxCoordinates(blockHeight, txIndex, outputIndex) = coordinates(c.shortChannelId)
+    val ShortChannelId(blockHeight, txIndex, outputIndex) = c.shortChannelId
 
     for {
       blockHash: String <- rpcClient.invoke("getblockhash", blockHeight).map(_.extractOrElse[String]("00" * 32))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
@@ -25,7 +25,7 @@ import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient._
 import fr.acinq.eclair.channel.{BITCOIN_FUNDING_DEPTHOK, BITCOIN_FUNDING_SPENT, BITCOIN_PARENT_TX_CONFIRMED}
 import fr.acinq.eclair.transactions.Scripts
-import fr.acinq.eclair.{Globals, ShortChannelId, TxCoordinates}
+import fr.acinq.eclair.{Globals, ShortChannelId}
 
 import scala.collection.SortedMap
 
@@ -38,7 +38,7 @@ class ElectrumWatcher(client: ActorRef) extends Actor with Stash with ActorLoggi
     case ValidateRequest(c) =>
         log.info(s"blindly validating channel=$c")
         val pubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(PublicKey(c.bitcoinKey1), PublicKey(c.bitcoinKey2))))
-        val TxCoordinates(_, _, outputIndex) = ShortChannelId.coordinates(c.shortChannelId)
+        val outputIndex = c.shortChannelId.outputIndex
         val fakeFundingTx = Transaction(
           version = 2,
           txIn = Seq.empty[TxIn],

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/ChannelRangeQueries.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/ChannelRangeQueries.scala
@@ -35,8 +35,8 @@ object ChannelRangeQueries {
       }
       shortChannelIds.grouped(count).map(ids => {
         val (firstBlock, numBlocks) = if (ids.isEmpty) (firstBlockIn, numBlocksIn) else {
-          val firstBlock: Long = ShortChannelId.coordinates(ids.head).blockHeight
-          val numBlocks: Long = ShortChannelId.coordinates(ids.last).blockHeight - firstBlock + 1
+          val firstBlock: Long = ids.head.blockHeight
+          val numBlocks: Long = ids.last.blockHeight - firstBlock + 1
           (firstBlock, numBlocks)
         }
         val encoded = encodeShortChannelIdsSingle(ids, format, useGzip)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
@@ -27,17 +27,17 @@ class ShortChannelIdSpec extends FunSuite {
   test("handle values from 0 to 0xffffffffffff") {
 
     val expected = Map(
-      TxCoordinates(0, 0, 0) -> ShortChannelId(0),
-      TxCoordinates(42000, 27, 3) -> ShortChannelId(0x0000a41000001b0003L),
-      TxCoordinates(1258612, 63, 0) -> ShortChannelId(0x13347400003f0000L),
-      TxCoordinates(0xffffff, 0x000000, 0xffff) -> ShortChannelId(0xffffff000000ffffL),
-      TxCoordinates(0x000000, 0xffffff, 0xffff) -> ShortChannelId(0x000000ffffffffffL),
-      TxCoordinates(0xffffff, 0xffffff, 0x0000) -> ShortChannelId(0xffffffffffff0000L),
-      TxCoordinates(0xffffff, 0xffffff, 0xffff) -> ShortChannelId(0xffffffffffffffffL)
+      ShortChannelId(0, 0, 0) -> ShortChannelId(0),
+      ShortChannelId(42000, 27, 3) -> ShortChannelId(0x0000a41000001b0003L),
+      ShortChannelId(1258612, 63, 0) -> ShortChannelId(0x13347400003f0000L),
+      ShortChannelId(0xffffff, 0x000000, 0xffff) -> ShortChannelId(0xffffff000000ffffL),
+      ShortChannelId(0x000000, 0xffffff, 0xffff) -> ShortChannelId(0x000000ffffffffffL),
+      ShortChannelId(0xffffff, 0xffffff, 0x0000) -> ShortChannelId(0xffffffffffff0000L),
+      ShortChannelId(0xffffff, 0xffffff, 0xffff) -> ShortChannelId(0xffffffffffffffffL)
     )
     for ((coord, shortChannelId) <- expected) {
       assert(shortChannelId == ShortChannelId(coord.blockHeight, coord.txIndex, coord.outputIndex))
-      assert(coord == ShortChannelId.coordinates(shortChannelId))
+      assert(coord == shortChannelId)
     }
   }
 


### PR DESCRIPTION
Short channel ids will be logged as height:txIndex:outputIndex which is much easier to read