### PR TITLE
Correctly handle multiple channel_range_replies

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/ChannelRangeQueries.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/ChannelRangeQueries.scala
@@ -23,16 +23,16 @@ object ChannelRangeQueries {
     * @param shortChannelIds must be sorted beforehand
     * @return a sequence of encoded short channel ids
     */
-  def encodeShortChannelIds(firstBlockIn: Long, numBlocksIn: Long, shortChannelIds: SortedSet[ShortChannelId], format: Byte, useGzip: Boolean = false): List[ShortChannelIdsBlock] = {
+  def encodeShortChannelIds(firstBlockIn: Long, numBlocksIn: Long, shortChannelIds: SortedSet[ShortChannelId], format: Byte, useGzip: Boolean = false, maxCount: Option[Int] = None): List[ShortChannelIdsBlock] = {
     if (shortChannelIds.isEmpty) {
       // special case: reply with an "empty" block
       List(ShortChannelIdsBlock(firstBlockIn, numBlocksIn, BinaryData("00")))
     } else {
       // LN messages must fit in 65 Kb so we split ids into groups to make sure that the output message will be valid
-      val count = format match {
+      val count = maxCount.getOrElse(format match {
         case UNCOMPRESSED_FORMAT => 7000
         case ZLIB_FORMAT => 12000 // TODO: do something less simplistic...
-      }
+      })
       shortChannelIds.grouped(count).map(ids => {
         val (firstBlock, numBlocks) = if (ids.isEmpty) (firstBlockIn, numBlocksIn) else {
           val firstBlock: Long = ShortChannelId.coordinates(ids.head).blockHeight

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -21,7 +21,7 @@ import java.io.StringWriter
 import akka.actor.{ActorRef, Props, Status}
 import akka.event.Logging.MDC
 import akka.pattern.pipe
-import fr.acinq.bitcoin.BinaryData
+import fr.acinq.bitcoin.{BinaryData, Block}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.Script.{pay2wsh, write}
 import fr.acinq.eclair._
@@ -402,8 +402,10 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSMDiagnosticAct
         .recover { case t => sender ! Status.Failure(t) }
       stay
 
-    case Event(SendChannelQuery(remoteNodeId, remote), _) =>
+    case Event(SendChannelQuery(_, remote), _) =>
       // ask for everything
+      // we currently send only one query_channel_range message per peer, when we just (re)connected to it, so we don't
+      // have to worry about sending a new query_channel_range when another query is still in progress
       val query = QueryChannelRange(nodeParams.chainHash, firstBlockNum = 0, numberOfBlocks = Int.MaxValue)
       log.info("sending query_channel_range={}", query)
       remote ! query
@@ -471,8 +473,10 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSMDiagnosticAct
       // TODO: we don't compress to be compatible with old mobile apps, switch to ZLIB ASAP
       // Careful: when we remove GZIP support, eclair-wallet 0.3.0 will stop working i.e. channels to ACINQ nodes will not
       // work anymore
-      val blocks = ChannelRangeQueries.encodeShortChannelIds(firstBlockNum, numberOfBlocks, shortChannelIds, ChannelRangeQueries.UNCOMPRESSED_FORMAT)
+      val maxCount = if (nodeParams.chainHash == Block.RegtestGenesisBlock.hash) Some(150) else None
+      val blocks = ChannelRangeQueries.encodeShortChannelIds(firstBlockNum, numberOfBlocks, shortChannelIds, ChannelRangeQueries.UNCOMPRESSED_FORMAT, maxCount = maxCount)
       log.info("sending back reply_channel_range with {} items for range=({}, {})", shortChannelIds.size, firstBlockNum, numberOfBlocks)
+      // there could be several reply_channel_range messages for a single query
       val replies = blocks.map(block => ReplyChannelRange(chainHash, block.firstBlock, block.numBlocks, 1, block.shortChannelIds))
       replies.foreach(reply => sender ! reply)
       stay
@@ -484,9 +488,19 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSMDiagnosticAct
       val missing: SortedSet[ShortChannelId] = theirShortChannelIds -- ourShortChannelIds
       log.info("received reply_channel_range, we're missing {} channel announcements/updates, format={} useGzip={}", missing.size, format, useGzip)
       val d1 = if (missing.nonEmpty) {
-        val (slice, rest) = missing.splitAt(SHORTID_WINDOW)
-        sender ! QueryShortChannelIds(chainHash, ChannelRangeQueries.encodeShortChannelIdsSingle(slice, format, useGzip))
-        d.copy(sync = d.sync + (remoteNodeId -> Sync(rest, missing.size)))
+        // they may send back several reply_channel_range messages for a single query_channel_range query, and we must not
+        // send another query_short_channel_ids query if they're still processing one
+        d.sync.get(remoteNodeId) match {
+          case None =>
+            // we don't have a pending query with this peer
+            val (slice, rest) = missing.splitAt(SHORTID_WINDOW)
+            sender ! QueryShortChannelIds(chainHash, ChannelRangeQueries.encodeShortChannelIdsSingle(slice, format, useGzip))
+            Sync(rest, missing.size)
+            d.copy(sync = d.sync + (remoteNodeId -> Sync(rest, missing.size)))
+          case Some(sync) =>
+            // we already have a pending query with this peer, add missing ids to our "sync" state
+            d.copy(sync = d.sync + (remoteNodeId -> Sync(sync.missing ++ missing, sync.count + missing.size)))
+        }
       } else d
       context.system.eventStream.publish(syncProgress(d1))
       stay using d1
@@ -512,11 +526,16 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSMDiagnosticAct
       log.info("received reply_short_channel_ids_end={}", routingMessage)
       // have we more channels to ask this peer?
       val d1 = d.sync.get(remoteNodeId) match {
-        case Some(sync) if sync.missing.nonEmpty =>
+        case Some(sync) =>
           log.info(s"asking {} for the next slice of short_channel_ids", remoteNodeId)
           val (slice, rest) = sync.missing.splitAt(SHORTID_WINDOW)
           sender ! QueryShortChannelIds(chainHash, ChannelRangeQueries.encodeShortChannelIdsSingle(slice, ChannelRangeQueries.UNCOMPRESSED_FORMAT, useGzip = false))
-          d.copy(sync = d.sync + (remoteNodeId -> sync.copy(missing = rest)))
+          val sync1 = if (rest.isEmpty) {
+            d.sync - remoteNodeId
+          } else {
+            d.sync + (remoteNodeId -> sync.copy(missing = rest))
+          }
+          d.copy(sync = sync1)
         case _ =>
           d
       }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -28,8 +28,8 @@ import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.router.Announcements.makeChannelUpdate
 import fr.acinq.eclair.transactions.Scripts
-import fr.acinq.eclair.wire.Error
-import fr.acinq.eclair.{ShortChannelId, randomKey}
+import fr.acinq.eclair.wire.{Error, QueryChannelRange}
+import fr.acinq.eclair.{ShortChannelId, TestConstants, randomKey}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -235,4 +235,11 @@ class RouterSpec extends BaseRouterSpec {
     assert(state.updates.size == 8)
   }
 
+  test("channel range queries") {  case (router, _) =>
+    val sender = TestProbe()
+    sender.send(router, SendChannelQuery(TestConstants.Alice.nodeParams.nodeId, sender.ref))
+    val routinTable = ChannelRangeQueriesSpec.shortChannelIds.take(500).map(RoutingSyncSpec.makeFakeRoutingInfo)
+    val queryChannelRange = sender.expectMsgType[QueryChannelRange]
+    println(queryChannelRange)
+  }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
@@ -1,18 +1,18 @@
 package fr.acinq.eclair.router
 
 import akka.actor.{Actor, ActorRef, Props}
-import akka.testkit.TestProbe
+import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{BinaryData, Block, Satoshi, Script, Transaction, TxOut}
-import fr.acinq.eclair
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.{ValidateRequest, ValidateResult, WatchSpentBasic}
+import fr.acinq.eclair.crypto.TransportHandler.ReadAck
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.router.Announcements.{makeChannelUpdate, makeNodeAnnouncement}
 import fr.acinq.eclair.router.BaseRouterSpec.channelAnnouncement
 import fr.acinq.eclair.transactions.Scripts
-import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement, RoutingMessage}
+import fr.acinq.eclair.wire._
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -24,16 +24,18 @@ class RoutingSyncSpec extends TestkitBaseClass {
   import RoutingSyncSpec._
 
   val txid = BinaryData("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+  val idA = PrivateKey(BinaryData("01"  *32), true).publicKey
+  val idB = PrivateKey(BinaryData("02"  *32), true).publicKey
 
   type FixtureParam = Tuple3[ActorRef, ActorRef, ActorRef]
 
   val shortChannelIds = ChannelRangeQueriesSpec.shortChannelIds.take(500)
 
   val fakeRoutingInfo = shortChannelIds.map(makeFakeRoutingInfo)
-  // A will be missing the last 1000 items
+  // A will be missing the last 100 items
   val routingInfoA = fakeRoutingInfo.dropRight(100)
-  // and B will be missing the first 1000 items
-  val routingInfoB = fakeRoutingInfo.drop(100)
+  // and B will be missing the first 100 items
+  val routingInfoB = fakeRoutingInfo.drop(200)
 
   class FakeWatcher extends Actor {
     def receive = {
@@ -57,15 +59,7 @@ class RoutingSyncSpec extends TestkitBaseClass {
         paramsA.networkDb.addNode(n1)
         paramsA.networkDb.addNode(n2)
     }
-    val probe = TestProbe()
-    val switchboard = system.actorOf(Props(new Actor {
-      override def receive: Receive = {
-        case msg => probe.ref forward msg
-      }
-    }), "switchboard")
-
     val routerA = system.actorOf(Props(new Router(paramsA, watcherA)), "routerA")
-    val idA = PrivateKey(BinaryData("01"  *32), true).publicKey
 
     val watcherB = system.actorOf(Props(new FakeWatcher()))
     val paramsB = Bob.nodeParams
@@ -78,9 +72,8 @@ class RoutingSyncSpec extends TestkitBaseClass {
         paramsB.networkDb.addNode(n2)
     }
     val routerB = system.actorOf(Props(new Router(paramsB, watcherB)), "routerB")
-    val idB = PrivateKey(BinaryData("02"  *32), true).publicKey
 
-    val pipe = system.actorOf(Props(new RoutingSyncSpec.Pipe(routerA, idA, routerB, idA)))
+    val pipe = system.actorOf(Props(new RoutingSyncSpec.Pipe(routerA, idA, routerB, idB)))
     val sender = TestProbe()
     awaitCond({
       sender.send(routerA, 'channels)
@@ -96,8 +89,8 @@ class RoutingSyncSpec extends TestkitBaseClass {
       Globals.blockCount.set(shortChannelIds.map(id => ShortChannelId.coordinates(id).blockHeight).max)
 
       val sender = TestProbe()
-      routerA ! SendChannelQuery(Alice.nodeParams.nodeId, pipe)
-      routerB ! SendChannelQuery(Bob.nodeParams.nodeId, pipe)
+      routerA ! SendChannelQuery(idB, pipe)
+      routerB ! SendChannelQuery(idA, pipe)
 
       awaitCond({
         sender.send(routerA, 'channels)
@@ -105,9 +98,40 @@ class RoutingSyncSpec extends TestkitBaseClass {
         sender.send(routerB, 'channels)
         val channelsB = sender.expectMsgType[Iterable[ChannelAnnouncement]]
         channelsA.toSet == channelsB.toSet
+        channelsA.size == fakeRoutingInfo.size
       }, max = 30 seconds)
     }
   }
+
+  test("handle split range replies") {
+    case (routerA, _, _) => {
+      Globals.blockCount.set(shortChannelIds.map(id => ShortChannelId.coordinates(id).blockHeight).max)
+
+      val sender = TestProbe()
+      sender.ignoreMsg {
+        case ReadAck(_) => true
+      }
+      val routerB =  TestFSMRef(new Router(Bob.nodeParams, TestProbe().ref), "routerBB")
+      routerB ! SendChannelQuery(Alice.nodeParams.nodeId, sender.ref)
+      val query = sender.expectMsgType[QueryChannelRange]
+      sender.expectMsgType[GossipTimestampFilter]
+
+      sender.send(routerA, PeerRoutingMessage(idB, query))
+      val reply1 = sender.expectMsgType[ReplyChannelRange]
+      val reply2 = sender.expectMsgType[ReplyChannelRange]
+
+
+      // tell routerB it's missing 150 channels
+      sender.send(routerB, PeerRoutingMessage(idA, reply1))
+      // now routerB thinks it's missing 150 channels
+      awaitCond(routerB.stateData.sync(idA).count == 150, 3 seconds)
+
+      // tell routerB it's missing another 150 channels
+      sender.send(routerB, PeerRoutingMessage(idA, reply2))
+      awaitCond(routerB.stateData.sync(idA).count == 300, 3 seconds)
+    }
+  }
+
 }
 
 object RoutingSyncSpec {


### PR DESCRIPTION
The scheme we use to keep tracks of channel queries with each peer would forget about
missing data when several channel_range_replies are sent back for a single channel_range_queries.