### PR TITLE
Fix handling of born again channels

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -386,8 +386,8 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSMDiagnosticAct
       val ignoredUpdates = getIgnoredChannelDesc(d.updates ++ d.privateUpdates ++ assistedUpdates, ignoreNodes) ++ ignoreChannels ++ d.excludedChannels
       log.info(s"finding a route $start->$end with assistedChannels={} ignoreNodes={} ignoreChannels={} excludedChannels={}", assistedUpdates.keys.mkString(","), ignoreNodes.map(_.toBin).mkString(","), ignoreChannels.mkString(","), d.excludedChannels.mkString(","))
       findRoute(d.graph, start, end, withEdges = assistedUpdates, withoutEdges = ignoredUpdates)
-        .map(r => sender ! RouteResponse(r, ignoreNodes, ignoreChannels))
-        .recover { case t => sender ! Status.Failure(t) }
+            .map(r => sender ! RouteResponse(r, ignoreNodes, ignoreChannels))
+            .recover { case t => sender ! Status.Failure(t) }
       stay
 
     case Event(SendChannelQuery(remoteNodeId, remote), d) =>
@@ -417,10 +417,10 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSMDiagnosticAct
       log.debug("received channel update from {}", sender)
       stay using handle(u, sender, d)
 
-    case Event(PeerRoutingMessage(_, remoteNodeId, u: ChannelUpdate), d) =>
+    case Event(PeerRoutingMessage(transport, remoteNodeId, u: ChannelUpdate), d) =>
       sender ! TransportHandler.ReadAck(u)
       log.debug("received channel update for shortChannelId={}", u.shortChannelId)
-      stay using handle(u, sender, d, remoteNodeId_opt = Some(remoteNodeId))
+      stay using handle(u, sender, d, remoteNodeId_opt = Some(remoteNodeId), transport_opt = Some(transport))
 
     case Event(PeerRoutingMessage(_, _, c: ChannelAnnouncement), d) =>
       log.debug("received channel announcement for shortChannelId={} nodeId1={} nodeId2={}", c.shortChannelId, c.nodeId1, c.nodeId2)
@@ -574,7 +574,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSMDiagnosticAct
       d
     }
 
-  def handle(u: ChannelUpdate, origin: ActorRef, d: Data, remoteNodeId_opt: Option[PublicKey] = None): Data =
+  def handle(u: ChannelUpdate, origin: ActorRef, d: Data, remoteNodeId_opt: Option[PublicKey] = None, transport_opt: Option[ActorRef] = None): Data =
     if (d.channels.contains(u.shortChannelId)) {
       // related channel is already known (note: this means no related channel_update is in the stash)
       val publicChannel = true
@@ -657,21 +657,28 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSMDiagnosticAct
       // about that channel. We can ignore this update since we will receive it again
       log.info(s"channel shortChannelId=${u.shortChannelId} is back from the dead! requesting announcements about this channel")
       db.removeFromPruned(u.shortChannelId)
-      remoteNodeId_opt match {
-        case Some(remoteNodeId) =>
-          d.sync.get(remoteNodeId) match {
-            case Some(sync) =>
-              // we already have a pending request to that node, let's add this channel to the list and we'll get it later
-              d.copy(sync = d.sync + (remoteNodeId -> sync.copy(missing = sync.missing + u.shortChannelId, totalMissingCount = sync.totalMissingCount + 1)))
+
+      // transport_opt will contain a valid transport only when we're handling an update that we received from a peer, not
+      // when we're sending updates to ourselves
+      transport_opt match {
+        case Some(transport) =>
+          remoteNodeId_opt match {
+            case Some(remoteNodeId) =>
+              d.sync.get(remoteNodeId) match {
+                case Some(sync) =>
+                  // we already have a pending request to that node, let's add this channel to the list and we'll get it later
+                  d.copy(sync = d.sync + (remoteNodeId -> sync.copy(missing = sync.missing + u.shortChannelId, totalMissingCount = sync.totalMissingCount + 1)))
+                case None =>
+                  // we send the query right away
+                  transport ! QueryShortChannelIds(u.chainHash, ChannelRangeQueries.encodeShortChannelIdsSingle(Seq(u.shortChannelId), ChannelRangeQueries.UNCOMPRESSED_FORMAT, useGzip = false))
+                  d.copy(sync = d.sync + (remoteNodeId -> Sync(missing = SortedSet(u.shortChannelId), totalMissingCount = 1)))
+              }
             case None =>
-              // we send the query right away
-              origin ! QueryShortChannelIds(u.chainHash, ChannelRangeQueries.encodeShortChannelIdsSingle(Seq(u.shortChannelId), ChannelRangeQueries.UNCOMPRESSED_FORMAT, useGzip = false))
-              d.copy(sync = d.sync + (remoteNodeId -> Sync(missing = SortedSet(u.shortChannelId), totalMissingCount = 1)))
+              // we don't know which node this update came from (maybe it was stashed and the channel got pruned in the meantime or some other corner case)
+              // anyway, that's not really a big deal because we have removed the channel from the pruned db so next time it shows up we will revalidate it
+              d
           }
-        case None =>
-          // we don't know which node this update came from (maybe it was stashed and the channel got pruned in the meantime or some other corner case)
-          // anyway, that's not really a big deal because we have removed the channel from the pruned db so next time it shows up we will revalidate it
-          d
+        case None => d
       }
     } else {
       log.debug("ignoring announcement {} (unknown channel)", u)


### PR DESCRIPTION
When we receive a recent update for a channel that we had marked as stale we must send a query to the underlying transport, not the origin of the update (which would send the query back to the router).