### PR TITLE
Logging: use a rolling file appender

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -309,7 +309,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef) extends FSMDiagnosticAct
       if (d.rebroadcast.channels.isEmpty && d.rebroadcast.updates.isEmpty && d.rebroadcast.nodes.isEmpty) {
         stay
       } else {
-        log.info("broadcasting routing messages")
+        log.debug("broadcasting routing messages")
         log.debug("staggered broadcast details: channels={} updates={} nodes={}", d.rebroadcast.channels.size, d.rebroadcast.updates.size, d.rebroadcast.nodes.size)
         context.actorSelection(context.system / "*" / "switchboard") ! d.rebroadcast
         stay using d.copy(rebroadcast = Rebroadcast(channels = Map.empty, updates = Map.empty, nodes = Map.empty))

--- a/eclair-node/src/main/resources/logback.xml
+++ b/eclair-node/src/main/resources/logback.xml
@@ -25,9 +25,15 @@
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${eclair.datadir:-${user.home}/.eclair}/eclair.log</file>
-        <append>true</append>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>${eclair.datadir:-${user.home}/.eclair}/eclair.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- keep 90 days' worth of history capped at 5 GB total size -->
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>5GB</totalSizeCap>
+        </rollingPolicy>
         <encoder>
             <pattern>%d %-5level %logger{24} %X{nodeId}%X{channelId} - %msg%ex{24}%n</pattern>
         </encoder>
@@ -47,7 +53,7 @@
     </if>
 
     <root level="INFO">
-        <appender-ref ref="FILE"/>
+        <appender-ref ref="ROLLING"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
Use one file per day, keep 90 days of logs with a total maximum size capped at 5 Gb.