### PR TITLE
Update scalatest and remove junit runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ scala:
  - 2.11.11
 env:
  - export LD_LIBRARY_PATH=/usr/local/lib
+before_install:
+ - wget http://mirror.ibcp.fr/pub/apache/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.zip
+ - unzip -qq apache-maven-3.5.4-bin.zip
+ - export M2_HOME=$PWD/apache-maven-3.5.4
+ - export PATH=$M2_HOME/bin:$PATH
 script:
  - mvn install
 cache:

--- a/BUILD.md
+++ b/BUILD.md
@@ -14,10 +14,6 @@ $ mvn install
 
 #### Other build options
 
-If you don't have Docker you can skip tests that depend on it:
-```shell
-$ mvn install -DexcludedGroups=fr.acinq.eclair.blockchain.electrum.DockerTest
-```
 To skip all tests, run:
 ```shell
 $ mvn install -DskipTests

--- a/BUILD.md
+++ b/BUILD.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 - [Java Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) 1.8u161 or newer
-- [Maven](https://maven.apache.org/download.cgi) 3.3.x or newer
+- [Maven](https://maven.apache.org/download.cgi) 3.5.4 or newer
 - [Inno Setup](http://www.jrsoftware.org/isdl.php) 5.5.9 (optional, if you want to generate the windows installer)
 - [Docker](https://www.docker.com/) 18.03 or newer (optional) if you want to run all tests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u151-jdk-alpine as BUILD
+FROM openjdk:8u171-jdk-alpine as BUILD
 
 # Setup maven, we don't use https://hub.docker.com/_/maven/ as it declare .m2 as volume, we loose all mvn cache
 # We can alternatively do as proposed by https://github.com/carlossg/docker-maven#packaging-a-local-repository-with-the-image
@@ -6,9 +6,9 @@ FROM openjdk:8u151-jdk-alpine as BUILD
 
 RUN apk add --no-cache curl tar bash
 
-ARG MAVEN_VERSION=3.3.9
+ARG MAVEN_VERSION=3.5.4
 ARG USER_HOME_DIR="/root"
-ARG SHA=6e3e9c949ab4695a204f74038717aa7b2689b1be94875899ac1b3fe42800ff82
+ARG SHA=ce50b1c91364cb77efe3776f756a6d92b76d9038b0a0782f7d53acf1e997a14d
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
@@ -31,7 +31,8 @@ COPY eclair-node/pom.xml eclair-node/pom.xml
 COPY eclair-node-gui/pom.xml eclair-node-gui/pom.xml
 RUN mkdir -p eclair-core/src/main/scala && touch eclair-core/src/main/scala/empty.scala
 # Blank build. We only care about eclair-node, and we use install because eclair-node depends on eclair-core
-RUN mvn install -pl eclair-node -am clean
+RUN mvn install -pl eclair-node -am
+RUN mvn clean
 
 # Only then do we copy the sources
 COPY . .
@@ -41,7 +42,7 @@ RUN mvn package -pl eclair-node -am -DskipTests -Dgit.commit.id=notag -Dgit.comm
 # It might be good idea to run the tests here, so that the docker build fail if the code is bugged
 
 # We currently use a debian image for runtime because of some jni-related issue with sqlite
-FROM openjdk:8u171-jre-slim
+FROM openjdk:8u181-jre-slim
 WORKDIR /app
 # Eclair only needs the eclair-node-*.jar to run
 COPY --from=BUILD /usr/src/eclair-node/target/eclair-node-*.jar .

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -49,8 +49,8 @@
 
     <root level="INFO">
         <!--appender-ref ref="FILE"/>
-        <appender-ref ref="CONSOLEWARN"/-->
-        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="CONSOLEWARN"/>
+        <appender-ref ref="CONSOLE"/-->
     </root>
 
 </configuration>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/CoinUtilsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/CoinUtilsSpec.scala
@@ -17,11 +17,9 @@
 package fr.acinq.eclair
 
 import fr.acinq.bitcoin.{Btc, MilliBtc, MilliSatoshi, Satoshi}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class CoinUtilsSpec  extends FunSuite {
 
   test("Convert string amount to the correct BtcAmount") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
@@ -20,14 +20,12 @@ import java.nio.ByteOrder
 
 import fr.acinq.bitcoin.Protocol
 import fr.acinq.eclair.Features._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 /**
   * Created by PM on 27/01/2017.
   */
-@RunWith(classOf[JUnitRunner])
+
 class FeaturesSpec extends FunSuite {
 
   test("'initial_routing_sync' feature") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/PackageSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/PackageSpec.scala
@@ -18,16 +18,14 @@ package fr.acinq.eclair
 
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{Base58, Base58Check, Bech32, BinaryData, Block, Crypto, Script}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import scala.util.Try
 
 /**
   * Created by PM on 27/01/2017.
   */
-@RunWith(classOf[JUnitRunner])
+
 class PackageSpec extends FunSuite {
 
   test("compute long channel id") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
@@ -16,12 +16,10 @@
 
 package fr.acinq.eclair
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 
-@RunWith(classOf[JUnitRunner])
+
 class ShortChannelIdSpec extends FunSuite {
 
   test("handle values from 0 to 0xffffffffffff") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -22,7 +22,6 @@ import java.sql.DriverManager
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{BinaryData, Block, Script}
 import fr.acinq.eclair.NodeParams.BITCOIND
-import fr.acinq.eclair.TestConstants.Alice.sqlite
 import fr.acinq.eclair.crypto.LocalKeyManager
 import fr.acinq.eclair.db.sqlite._
 import fr.acinq.eclair.io.Peer

--- a/eclair-core/src/test/scala/fr/acinq/eclair/UInt64Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/UInt64Spec.scala
@@ -17,12 +17,10 @@
 package fr.acinq.eclair
 
 import fr.acinq.bitcoin.BinaryData
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 
-@RunWith(classOf[JUnitRunner])
+
 class UInt64Spec extends FunSuite {
 
   test("handle values from 0 to 2^63-1") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
@@ -22,11 +22,9 @@ import fr.acinq.bitcoin.{BinaryData, OutPoint}
 import fr.acinq.eclair.transactions.{IN, OUT}
 import fr.acinq.eclair.wire.NodeAddress
 import org.json4s.jackson.Serialization
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{FunSuite, Matchers}
 
-@RunWith(classOf[JUnitRunner])
+
 class JsonSerializersSpec extends FunSuite with Matchers {
 
   test("deserialize Map[OutPoint, BinaryData]") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/WatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/WatcherSpec.scala
@@ -17,14 +17,12 @@
 package fr.acinq.eclair.blockchain
 
 import fr.acinq.bitcoin.Transaction
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 /**
   * Created by PM on 27/01/2017.
   */
-@RunWith(classOf[JUnitRunner])
+
 class WatcherSpec extends FunSuite {
 
   test("extract pay2wpkh pubkey script") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -30,8 +30,6 @@ import fr.acinq.eclair.{addressToPublicKeyScript, randomKey}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST._
 import org.json4s.{DefaultFormats, JString}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.collection.JavaConversions._
@@ -40,7 +38,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Random, Try}
 
-@RunWith(classOf[JUnitRunner])
+
 class BitcoinCoreWalletSpec extends TestKit(ActorSystem("test")) with BitcoindService with FunSuiteLike with BeforeAndAfterAll with Logging {
 
   val commonConfig = ConfigFactory.parseMap(Map("eclair.chain" -> "regtest", "eclair.spv" -> false, "eclair.server.public-ips.1" -> "localhost", "eclair.bitcoind.port" -> 28333, "eclair.bitcoind.rpcport" -> 28332, "eclair.bitcoind.zmq" -> "tcp://127.0.0.1:28334", "eclair.router-broadcast-interval" -> "2 second", "eclair.auto-reconnect" -> false))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
@@ -26,14 +26,12 @@ import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, Exten
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST._
 import org.json4s.{DefaultFormats, JString}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-@RunWith(classOf[JUnitRunner])
+
 class ExtendedBitcoinClientSpec extends TestKit(ActorSystem("test")) with BitcoindService with FunSuiteLike with BeforeAndAfterAll with Logging {
 
   val commonConfig = ConfigFactory.parseMap(Map("eclair.chain" -> "regtest", "eclair.spv" -> false, "eclair.server.public-ips.1" -> "localhost", "eclair.bitcoind.port" -> 28333, "eclair.bitcoind.rpcport" -> 28332, "eclair.bitcoind.zmq" -> "tcp://127.0.0.1:28334", "eclair.router-broadcast-interval" -> "2 second", "eclair.auto-reconnect" -> false))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPoolSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPoolSpec.scala
@@ -21,14 +21,12 @@ import akka.testkit.{TestKit, TestProbe}
 import fr.acinq.bitcoin.{BinaryData, Crypto, Transaction}
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient._
 import grizzled.slf4j.Logging
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.concurrent.duration._
 import scala.util.Random
 
-@RunWith(classOf[JUnitRunner])
+
 class ElectrumClientPoolSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with Logging with BeforeAndAfterAll {
   var router: ActorRef = _
   val probe = TestProbe()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientSpec.scala
@@ -22,14 +22,12 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
 import fr.acinq.bitcoin.{BinaryData, Crypto, Transaction}
 import grizzled.slf4j.Logging
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-@RunWith(classOf[JUnitRunner])
+
 class ElectrumClientSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with Logging with BeforeAndAfterAll {
 
   import ElectrumClient._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
@@ -21,13 +21,11 @@ import fr.acinq.bitcoin.DeterministicWallet.{ExtendedPrivateKey, derivePrivateKe
 import fr.acinq.bitcoin._
 import fr.acinq.eclair.transactions.Transactions
 import grizzled.slf4j.Logging
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import scala.util.{Failure, Random, Success, Try}
 
-@RunWith(classOf[JUnitRunner])
+
 class ElectrumWalletBasicSpec extends FunSuite with Logging {
 
   import ElectrumWallet._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSimulatedClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSimulatedClientSpec.scala
@@ -23,13 +23,11 @@ import akka.testkit.{TestFSMRef, TestKit, TestProbe}
 import fr.acinq.bitcoin.{BinaryData, Block, MnemonicCode, Satoshi}
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient.{ScriptHashSubscription, ScriptHashSubscriptionResponse}
 import fr.acinq.eclair.blockchain.electrum.ElectrumWallet._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuiteLike
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
-@RunWith(classOf[JUnitRunner])
+
 class ElectrumWalletSimulatedClientSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
   val sender = TestProbe()
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
@@ -27,20 +27,14 @@ import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.{FundTransactionRes
 import fr.acinq.eclair.blockchain.bitcoind.{BitcoinCoreWallet, BitcoindService}
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient.{BroadcastTransaction, BroadcastTransactionResponse}
 import grizzled.slf4j.Logging
-import org.json4s.JsonAST.{JDecimal, JDouble, JString, JValue}
-import org.junit.experimental.categories.Category
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
+import org.json4s.JsonAST.{JDecimal, JString, JValue}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-trait DockerTest {}
 
-@RunWith(classOf[JUnitRunner])
-@Category(Array(classOf[DockerTest]))
 class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with BitcoindService with ElectrumxService  with BeforeAndAfterAll with Logging {
 
   import ElectrumWallet._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
@@ -27,15 +27,11 @@ import fr.acinq.eclair.blockchain.{WatchConfirmed, WatchEventConfirmed, WatchEve
 import fr.acinq.eclair.channel.{BITCOIN_FUNDING_DEPTHOK, BITCOIN_FUNDING_SPENT}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST.{JArray, JString, JValue}
-import org.junit.experimental.categories.Category
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.concurrent.duration._
 
-@RunWith(classOf[JUnitRunner])
-@Category(Array(classOf[DockerTest]))
+
 class ElectrumWatcherSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with BitcoindService with ElectrumxService  with BeforeAndAfterAll with Logging {
 
   override def beforeAll(): Unit = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumxService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumxService.scala
@@ -19,7 +19,7 @@ package fr.acinq.eclair.blockchain.electrum
 import com.spotify.docker.client.{DefaultDockerClient, DockerClient}
 import com.whisk.docker.impl.spotify.SpotifyDockerFactory
 import com.whisk.docker.scalatest.DockerTestKit
-import com.whisk.docker.{DockerContainer, DockerFactory, LogLineReceiver}
+import com.whisk.docker.{DockerContainer, DockerFactory}
 import org.scalatest.Suite
 
 trait ElectrumxService extends DockerTestKit {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProviderSpec.scala
@@ -7,13 +7,11 @@ import akka.testkit.{TestKit, TestProbe}
 import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin._
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService
-import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, JsonRPCError}
+import fr.acinq.eclair.blockchain.bitcoind.rpc.BasicBitcoinJsonRPCClient
 import grizzled.slf4j.Logging
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST._
 import org.json4s.jackson.JsonMethods
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.collection.JavaConversions._
@@ -21,7 +19,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Random
 
-@RunWith(classOf[JUnitRunner])
+
 class BitcoinCoreFeeProviderSpec extends TestKit(ActorSystem("test")) with BitcoindService with FunSuiteLike with BeforeAndAfterAll with Logging {
 
   val commonConfig = ConfigFactory.parseMap(Map("eclair.chain" -> "regtest", "eclair.spv" -> false, "eclair.server.public-ips.1" -> "localhost", "eclair.bitcoind.port" -> 28333, "eclair.bitcoind.rpcport" -> 28332, "eclair.bitcoind.zmq" -> "tcp://127.0.0.1:28334", "eclair.router-broadcast-interval" -> "2 second", "eclair.auto-reconnect" -> false))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProviderSpec.scala
@@ -19,14 +19,12 @@ package fr.acinq.eclair.blockchain.fee
 import akka.actor.ActorSystem
 import akka.util.Timeout
 import org.json4s.DefaultFormats
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 /**
   * Created by PM on 27/01/2017.
   */
-@RunWith(classOf[JUnitRunner])
+
 class BitgoFeeProviderSpec extends FunSuite {
 
   import BitgoFeeProvider._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProviderSpec.scala
@@ -20,16 +20,14 @@ import akka.actor.ActorSystem
 import akka.util.Timeout
 import grizzled.slf4j.Logging
 import org.json4s.DefaultFormats
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.Await
 
 /**
   * Created by PM on 27/01/2017.
   */
-@RunWith(classOf[JUnitRunner])
+
 class EarnDotComFeeProviderSpec extends FunSuite with Logging {
 
   import EarnDotComFeeProvider._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProviderSpec.scala
@@ -16,15 +16,13 @@
 
 package fr.acinq.eclair.blockchain.fee
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.Random
 
-@RunWith(classOf[JUnitRunner])
+
 class FallbackFeeProviderSpec extends FunSuite {
 
   import scala.concurrent.ExecutionContext.Implicits.global

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
@@ -1,14 +1,12 @@
 package fr.acinq.eclair.blockchain.fee
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
 
-@RunWith(classOf[JUnitRunner])
+
 class SmoothFeeProviderSpec extends FunSuite {
   test("smooth fee rates") {
     val rates = Array(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -31,9 +31,7 @@ import fr.acinq.eclair.payment._
 import fr.acinq.eclair.router.Hop
 import fr.acinq.eclair.wire._
 import grizzled.slf4j.Logging
-import org.junit.runner.RunWith
 import org.scalatest.Tag
-import org.scalatest.junit.JUnitRunner
 
 import scala.collection.immutable.Nil
 import scala.concurrent.duration._
@@ -42,7 +40,7 @@ import scala.util.Random
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class FuzzySpec extends TestkitBaseClass with StateTestsHelperMethods with Logging {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], pipe: ActorRef, relayerA: ActorRef, relayerB: ActorRef, paymentHandlerA: ActorRef, paymentHandlerB: ActorRef)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/ThroughputSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/ThroughputSpec.scala
@@ -28,14 +28,12 @@ import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
 import fr.acinq.eclair.payment.Relayer
 import fr.acinq.eclair.wire.{Init, UpdateAddHtlc}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 import scala.util.Random
 
-@RunWith(classOf[JUnitRunner])
+
 class ThroughputSpec extends FunSuite {
   ignore("throughput") {
     implicit val system = ActorSystem()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptChannelStateSpec.scala
@@ -24,7 +24,7 @@ import fr.acinq.eclair.channel.{WAIT_FOR_FUNDING_INTERNAL, _}
 import fr.acinq.eclair.wire.{AcceptChannel, Error, Init, OpenChannel}
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
-import org.scalatest.Tag
+import org.scalatest.{Outcome, Tag}
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
@@ -35,9 +35,9 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class WaitForAcceptChannelStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple4[TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe]
+  case class FixtureParam(alice: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = if (test.tags.contains("mainnet")) {
       init(TestConstants.Alice.nodeParams.copy(chainHash = Block.LivenetGenesisBlock.hash), TestConstants.Bob.nodeParams.copy(chainHash = Block.LivenetGenesisBlock.hash))
     } else {
@@ -52,112 +52,102 @@ class WaitForAcceptChannelStateSpec extends TestkitBaseClass with StateTestsHelp
       alice2bob.expectMsgType[OpenChannel]
       alice2bob.forward(bob)
       awaitCond(alice.stateName == WAIT_FOR_ACCEPT_CHANNEL)
-    }
-    test((alice, alice2bob, bob2alice, alice2blockchain))
-  }
-
-  test("recv AcceptChannel") { case (alice, _, bob2alice, _) =>
-    within(30 seconds) {
-      bob2alice.expectMsgType[AcceptChannel]
-      bob2alice.forward(alice)
-      awaitCond(alice.stateName == WAIT_FOR_FUNDING_INTERNAL)
+      withFixture(test.toNoArgTest(FixtureParam(alice, alice2bob, bob2alice, alice2blockchain)))
     }
   }
 
-  test("recv AcceptChannel (invalid max accepted htlcs)") { case (alice, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val accept = bob2alice.expectMsgType[AcceptChannel]
-      // spec says max = 483
-      val invalidMaxAcceptedHtlcs = 484
-      alice ! accept.copy(maxAcceptedHtlcs = invalidMaxAcceptedHtlcs)
-      val error = alice2bob.expectMsgType[Error]
-      assert(error === Error(accept.temporaryChannelId, InvalidMaxAcceptedHtlcs(accept.temporaryChannelId, invalidMaxAcceptedHtlcs, Channel.MAX_ACCEPTED_HTLCS).getMessage.getBytes("UTF-8")))
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv AcceptChannel") { f =>
+    import f._
+    bob2alice.expectMsgType[AcceptChannel]
+    bob2alice.forward(alice)
+    awaitCond(alice.stateName == WAIT_FOR_FUNDING_INTERNAL)
   }
 
-  test("recv AcceptChannel (invalid dust limit)", Tag("mainnet")) { case (alice, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val accept = bob2alice.expectMsgType[AcceptChannel]
-      // we don't want their dust limit to be below 546
-      val lowDustLimitSatoshis = 545
-      alice ! accept.copy(dustLimitSatoshis = lowDustLimitSatoshis)
-      val error = alice2bob.expectMsgType[Error]
-      assert(error === Error(accept.temporaryChannelId, DustLimitTooSmall(accept.temporaryChannelId, lowDustLimitSatoshis, Channel.MIN_DUSTLIMIT).getMessage.getBytes("UTF-8")))
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv AcceptChannel (invalid max accepted htlcs)") { f =>
+    import f._
+    val accept = bob2alice.expectMsgType[AcceptChannel]
+    // spec says max = 483
+    val invalidMaxAcceptedHtlcs = 484
+    alice ! accept.copy(maxAcceptedHtlcs = invalidMaxAcceptedHtlcs)
+    val error = alice2bob.expectMsgType[Error]
+    assert(error === Error(accept.temporaryChannelId, InvalidMaxAcceptedHtlcs(accept.temporaryChannelId, invalidMaxAcceptedHtlcs, Channel.MAX_ACCEPTED_HTLCS).getMessage.getBytes("UTF-8")))
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv AcceptChannel (to_self_delay too high)") { case (alice, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val accept = bob2alice.expectMsgType[AcceptChannel]
-      val delayTooHigh = 10000
-      alice ! accept.copy(toSelfDelay = delayTooHigh)
-      val error = alice2bob.expectMsgType[Error]
-      assert(error === Error(accept.temporaryChannelId, ToSelfDelayTooHigh(accept.temporaryChannelId, delayTooHigh, Alice.nodeParams.maxToLocalDelayBlocks).getMessage.getBytes("UTF-8")))
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv AcceptChannel (invalid dust limit)", Tag("mainnet")) { f =>
+    import f._
+    val accept = bob2alice.expectMsgType[AcceptChannel]
+    // we don't want their dust limit to be below 546
+    val lowDustLimitSatoshis = 545
+    alice ! accept.copy(dustLimitSatoshis = lowDustLimitSatoshis)
+    val error = alice2bob.expectMsgType[Error]
+    assert(error === Error(accept.temporaryChannelId, DustLimitTooSmall(accept.temporaryChannelId, lowDustLimitSatoshis, Channel.MIN_DUSTLIMIT).getMessage.getBytes("UTF-8")))
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv AcceptChannel (reserve too high)") { case (alice, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val accept = bob2alice.expectMsgType[AcceptChannel]
-      // 30% is huge, recommended ratio is 1%
-      val reserveTooHigh = (0.3 * TestConstants.fundingSatoshis).toLong
-      alice ! accept.copy(channelReserveSatoshis = reserveTooHigh)
-      val error = alice2bob.expectMsgType[Error]
-      assert(error === Error(accept.temporaryChannelId, ChannelReserveTooHigh(accept.temporaryChannelId, reserveTooHigh, 0.3,  0.05).getMessage.getBytes("UTF-8")))
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv AcceptChannel (to_self_delay too high)") { f =>
+    import f._
+    val accept = bob2alice.expectMsgType[AcceptChannel]
+    val delayTooHigh = 10000
+    alice ! accept.copy(toSelfDelay = delayTooHigh)
+    val error = alice2bob.expectMsgType[Error]
+    assert(error === Error(accept.temporaryChannelId, ToSelfDelayTooHigh(accept.temporaryChannelId, delayTooHigh, Alice.nodeParams.maxToLocalDelayBlocks).getMessage.getBytes("UTF-8")))
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv AcceptChannel (reserve below dust limit)") { case (alice, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val accept = bob2alice.expectMsgType[AcceptChannel]
-      val reserveTooSmall = accept.dustLimitSatoshis - 1
-      alice ! accept.copy(channelReserveSatoshis = reserveTooSmall)
-      val error = alice2bob.expectMsgType[Error]
-      assert(error === Error(accept.temporaryChannelId, DustLimitTooLarge(accept.temporaryChannelId, accept.dustLimitSatoshis, reserveTooSmall).getMessage.getBytes("UTF-8")))
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv AcceptChannel (reserve too high)") { f =>
+    import f._
+    val accept = bob2alice.expectMsgType[AcceptChannel]
+    // 30% is huge, recommended ratio is 1%
+    val reserveTooHigh = (0.3 * TestConstants.fundingSatoshis).toLong
+    alice ! accept.copy(channelReserveSatoshis = reserveTooHigh)
+    val error = alice2bob.expectMsgType[Error]
+    assert(error === Error(accept.temporaryChannelId, ChannelReserveTooHigh(accept.temporaryChannelId, reserveTooHigh, 0.3, 0.05).getMessage.getBytes("UTF-8")))
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv AcceptChannel (reserve below our dust limit)") { case (alice, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val accept = bob2alice.expectMsgType[AcceptChannel]
-      val open = alice.stateData.asInstanceOf[DATA_WAIT_FOR_ACCEPT_CHANNEL].lastSent
-      val reserveTooSmall = open.dustLimitSatoshis - 1
-      alice ! accept.copy(channelReserveSatoshis = reserveTooSmall)
-      val error = alice2bob.expectMsgType[Error]
-      assert(error === Error(accept.temporaryChannelId, ChannelReserveBelowOurDustLimit(accept.temporaryChannelId, reserveTooSmall, open.dustLimitSatoshis).getMessage.getBytes("UTF-8")))
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv AcceptChannel (reserve below dust limit)") { f =>
+    import f._
+    val accept = bob2alice.expectMsgType[AcceptChannel]
+    val reserveTooSmall = accept.dustLimitSatoshis - 1
+    alice ! accept.copy(channelReserveSatoshis = reserveTooSmall)
+    val error = alice2bob.expectMsgType[Error]
+    assert(error === Error(accept.temporaryChannelId, DustLimitTooLarge(accept.temporaryChannelId, accept.dustLimitSatoshis, reserveTooSmall).getMessage.getBytes("UTF-8")))
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv AcceptChannel (dust limit above our reserve)") { case (alice, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val accept = bob2alice.expectMsgType[AcceptChannel]
-      val open = alice.stateData.asInstanceOf[DATA_WAIT_FOR_ACCEPT_CHANNEL].lastSent
-      val dustTooBig = open.channelReserveSatoshis + 1
-      alice ! accept.copy(dustLimitSatoshis = dustTooBig)
-      val error = alice2bob.expectMsgType[Error]
-      assert(error === Error(accept.temporaryChannelId, DustLimitAboveOurChannelReserve(accept.temporaryChannelId, dustTooBig, open.channelReserveSatoshis).getMessage.getBytes("UTF-8")))
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv AcceptChannel (reserve below our dust limit)") { f =>
+    import f._
+    val accept = bob2alice.expectMsgType[AcceptChannel]
+    val open = alice.stateData.asInstanceOf[DATA_WAIT_FOR_ACCEPT_CHANNEL].lastSent
+    val reserveTooSmall = open.dustLimitSatoshis - 1
+    alice ! accept.copy(channelReserveSatoshis = reserveTooSmall)
+    val error = alice2bob.expectMsgType[Error]
+    assert(error === Error(accept.temporaryChannelId, ChannelReserveBelowOurDustLimit(accept.temporaryChannelId, reserveTooSmall, open.dustLimitSatoshis).getMessage.getBytes("UTF-8")))
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv Error") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      bob ! Error("00" * 32, "oops".getBytes)
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv AcceptChannel (dust limit above our reserve)") { f =>
+    import f._
+    val accept = bob2alice.expectMsgType[AcceptChannel]
+    val open = alice.stateData.asInstanceOf[DATA_WAIT_FOR_ACCEPT_CHANNEL].lastSent
+    val dustTooBig = open.channelReserveSatoshis + 1
+    alice ! accept.copy(dustLimitSatoshis = dustTooBig)
+    val error = alice2bob.expectMsgType[Error]
+    assert(error === Error(accept.temporaryChannelId, DustLimitAboveOurChannelReserve(accept.temporaryChannelId, dustTooBig, open.channelReserveSatoshis).getMessage.getBytes("UTF-8")))
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv CMD_CLOSE") { case (alice, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      alice ! CMD_CLOSE(None)
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv Error") { f =>
+    import f._
+    alice ! Error("00" * 32, "oops".getBytes)
+    awaitCond(alice.stateName == CLOSED)
+  }
+
+  test("recv CMD_CLOSE") { f =>
+    import f._
+    alice ! CMD_CLOSE(None)
+    awaitCond(alice.stateName == CLOSED)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptChannelStateSpec.scala
@@ -23,16 +23,14 @@ import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.channel.{WAIT_FOR_FUNDING_INTERNAL, _}
 import fr.acinq.eclair.wire.{AcceptChannel, Error, Init, OpenChannel}
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
 import org.scalatest.{Outcome, Tag}
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class WaitForAcceptChannelStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
@@ -23,16 +23,14 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.wire.{Error, Init, OpenChannel}
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class WaitForOpenChannelStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, bob2blockchain: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
@@ -21,9 +21,10 @@ import fr.acinq.bitcoin.Block
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
-import fr.acinq.eclair.wire.{AcceptChannel, Error, Init, OpenChannel}
+import fr.acinq.eclair.wire.{Error, Init, OpenChannel}
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
+import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
@@ -34,9 +35,9 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class WaitForOpenChannelStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple4[TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe]
+  case class FixtureParam(bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, bob2blockchain: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()
     import setup._
     val aliceInit = Init(Alice.channelParams.globalFeatures, Alice.channelParams.localFeatures)
@@ -45,161 +46,147 @@ class WaitForOpenChannelStateSpec extends TestkitBaseClass with StateTestsHelper
       alice ! INPUT_INIT_FUNDER("00" * 32, TestConstants.fundingSatoshis, TestConstants.pushMsat, TestConstants.feeratePerKw, TestConstants.feeratePerKw, Alice.channelParams, alice2bob.ref, bobInit, ChannelFlags.Empty)
       bob ! INPUT_INIT_FUNDEE("00" * 32, Bob.channelParams, bob2alice.ref, aliceInit)
       awaitCond(bob.stateName == WAIT_FOR_OPEN_CHANNEL)
-    }
-    test((bob, alice2bob, bob2alice, bob2blockchain))
-  }
-
-  test("recv OpenChannel") { case (bob, alice2bob, _, _) =>
-    within(30 seconds) {
-      alice2bob.expectMsgType[OpenChannel]
-      alice2bob.forward(bob)
-      awaitCond(bob.stateName == WAIT_FOR_FUNDING_CREATED)
+      withFixture(test.toNoArgTest(FixtureParam(bob, alice2bob, bob2alice, bob2blockchain)))
     }
   }
 
-  test("recv OpenChannel (invalid chain)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      // using livenet genesis block
-      val livenetChainHash = Block.LivenetGenesisBlock.hash
-      bob ! open.copy(chainHash = livenetChainHash)
-      val error = bob2alice.expectMsgType[Error]
-      assert(error === Error(open.temporaryChannelId, new InvalidChainHash(open.temporaryChannelId, Block.RegtestGenesisBlock.hash, livenetChainHash).getMessage.getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel") { f =>
+    import f._
+    alice2bob.expectMsgType[OpenChannel]
+    alice2bob.forward(bob)
+    awaitCond(bob.stateName == WAIT_FOR_FUNDING_CREATED)
   }
 
-  test("recv OpenChannel (funding too low)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      val lowFundingMsat = 100
-      bob ! open.copy(fundingSatoshis = lowFundingMsat)
-      val error = bob2alice.expectMsgType[Error]
-      assert(error === Error(open.temporaryChannelId, new InvalidFundingAmount(open.temporaryChannelId, lowFundingMsat, Bob.nodeParams.minFundingSatoshis, Channel.MAX_FUNDING_SATOSHIS).getMessage.getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel (invalid chain)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    // using livenet genesis block
+    val livenetChainHash = Block.LivenetGenesisBlock.hash
+    bob ! open.copy(chainHash = livenetChainHash)
+    val error = bob2alice.expectMsgType[Error]
+    assert(error === Error(open.temporaryChannelId, InvalidChainHash(open.temporaryChannelId, Block.RegtestGenesisBlock.hash, livenetChainHash).getMessage.getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv OpenChannel (funding too high)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      val highFundingMsat = 100000000
-      bob ! open.copy(fundingSatoshis = highFundingMsat)
-      val error = bob2alice.expectMsgType[Error]
-      assert(error === Error(open.temporaryChannelId, new InvalidFundingAmount(open.temporaryChannelId, highFundingMsat, Bob.nodeParams.minFundingSatoshis, Channel.MAX_FUNDING_SATOSHIS).getMessage.getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel (funding too low)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    val lowFundingMsat = 100
+    bob ! open.copy(fundingSatoshis = lowFundingMsat)
+    val error = bob2alice.expectMsgType[Error]
+    assert(error === Error(open.temporaryChannelId, InvalidFundingAmount(open.temporaryChannelId, lowFundingMsat, Bob.nodeParams.minFundingSatoshis, Channel.MAX_FUNDING_SATOSHIS).getMessage.getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv OpenChannel (invalid max accepted htlcs)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      val invalidMaxAcceptedHtlcs = Channel.MAX_ACCEPTED_HTLCS + 1
-      bob ! open.copy(maxAcceptedHtlcs = invalidMaxAcceptedHtlcs)
-      val error = bob2alice.expectMsgType[Error]
-      assert(error === Error(open.temporaryChannelId, new InvalidMaxAcceptedHtlcs(open.temporaryChannelId, invalidMaxAcceptedHtlcs, Channel.MAX_ACCEPTED_HTLCS).getMessage.getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel (funding too high)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    val highFundingMsat = 100000000
+    bob ! open.copy(fundingSatoshis = highFundingMsat)
+    val error = bob2alice.expectMsgType[Error]
+    assert(error === Error(open.temporaryChannelId, InvalidFundingAmount(open.temporaryChannelId, highFundingMsat, Bob.nodeParams.minFundingSatoshis, Channel.MAX_FUNDING_SATOSHIS).getMessage.getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv OpenChannel (invalid push_msat)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      val invalidPushMsat = 100000000000L
-      bob ! open.copy(pushMsat = invalidPushMsat)
-      val error = bob2alice.expectMsgType[Error]
-      assert(error === Error(open.temporaryChannelId, new InvalidPushAmount(open.temporaryChannelId, invalidPushMsat, 1000 * open.fundingSatoshis).getMessage.getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel (invalid max accepted htlcs)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    val invalidMaxAcceptedHtlcs = Channel.MAX_ACCEPTED_HTLCS + 1
+    bob ! open.copy(maxAcceptedHtlcs = invalidMaxAcceptedHtlcs)
+    val error = bob2alice.expectMsgType[Error]
+    assert(error === Error(open.temporaryChannelId, InvalidMaxAcceptedHtlcs(open.temporaryChannelId, invalidMaxAcceptedHtlcs, Channel.MAX_ACCEPTED_HTLCS).getMessage.getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv OpenChannel (to_self_delay too high)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      val delayTooHigh = 10000
-      bob ! open.copy(toSelfDelay = delayTooHigh)
-      val error = bob2alice.expectMsgType[Error]
-      assert(error === Error(open.temporaryChannelId, ToSelfDelayTooHigh(open.temporaryChannelId, delayTooHigh, Alice.nodeParams.maxToLocalDelayBlocks).getMessage.getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel (invalid push_msat)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    val invalidPushMsat = 100000000000L
+    bob ! open.copy(pushMsat = invalidPushMsat)
+    val error = bob2alice.expectMsgType[Error]
+    assert(error === Error(open.temporaryChannelId, InvalidPushAmount(open.temporaryChannelId, invalidPushMsat, 1000 * open.fundingSatoshis).getMessage.getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv OpenChannel (reserve too high)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      // 30% is huge, recommended ratio is 1%
-      val reserveTooHigh = (0.3 * TestConstants.fundingSatoshis).toLong
-      bob ! open.copy(channelReserveSatoshis = reserveTooHigh)
-      val error = bob2alice.expectMsgType[Error]
-      assert(error === Error(open.temporaryChannelId, new ChannelReserveTooHigh(open.temporaryChannelId, reserveTooHigh, 0.3,  0.05).getMessage.getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel (to_self_delay too high)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    val delayTooHigh = 10000
+    bob ! open.copy(toSelfDelay = delayTooHigh)
+    val error = bob2alice.expectMsgType[Error]
+    assert(error === Error(open.temporaryChannelId, ToSelfDelayTooHigh(open.temporaryChannelId, delayTooHigh, Alice.nodeParams.maxToLocalDelayBlocks).getMessage.getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv OpenChannel (fee too low, but still valid)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      // set a very small fee
-      val tinyFee = 253
-      bob ! open.copy(feeratePerKw = tinyFee)
-      val error = bob2alice.expectMsgType[Error]
-      // we check that the error uses the temporary channel id
-      assert(error === Error(open.temporaryChannelId, "local/remote feerates are too different: remoteFeeratePerKw=253 localFeeratePerKw=10000".getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel (reserve too high)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    // 30% is huge, recommended ratio is 1%
+    val reserveTooHigh = (0.3 * TestConstants.fundingSatoshis).toLong
+    bob ! open.copy(channelReserveSatoshis = reserveTooHigh)
+    val error = bob2alice.expectMsgType[Error]
+    assert(error === Error(open.temporaryChannelId, ChannelReserveTooHigh(open.temporaryChannelId, reserveTooHigh, 0.3, 0.05).getMessage.getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv OpenChannel (fee below absolute valid minimum)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      // set a very small fee
-      val tinyFee = 252
-      bob ! open.copy(feeratePerKw = tinyFee)
-      val error = bob2alice.expectMsgType[Error]
-      // we check that the error uses the temporary channel id
-      assert(error === Error(open.temporaryChannelId, "remote fee rate is too small: remoteFeeratePerKw=252".getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel (fee too low, but still valid)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    // set a very small fee
+    val tinyFee = 253
+    bob ! open.copy(feeratePerKw = tinyFee)
+    val error = bob2alice.expectMsgType[Error]
+    // we check that the error uses the temporary channel id
+    assert(error === Error(open.temporaryChannelId, "local/remote feerates are too different: remoteFeeratePerKw=253 localFeeratePerKw=10000".getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
+  }
+
+  test("recv OpenChannel (fee below absolute valid minimum)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    // set a very small fee
+    val tinyFee = 252
+    bob ! open.copy(feeratePerKw = tinyFee)
+    val error = bob2alice.expectMsgType[Error]
+    // we check that the error uses the temporary channel id
+    assert(error === Error(open.temporaryChannelId, "remote fee rate is too small: remoteFeeratePerKw=252".getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
 
-  test("recv OpenChannel (reserve below dust)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      val reserveTooSmall = open.dustLimitSatoshis - 1
-      bob ! open.copy(channelReserveSatoshis = reserveTooSmall)
-      val error = bob2alice.expectMsgType[Error]
-      // we check that the error uses the temporary channel id
-      assert(error === Error(open.temporaryChannelId, DustLimitTooLarge(open.temporaryChannelId, open.dustLimitSatoshis, reserveTooSmall).getMessage.getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel (reserve below dust)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    val reserveTooSmall = open.dustLimitSatoshis - 1
+    bob ! open.copy(channelReserveSatoshis = reserveTooSmall)
+    val error = bob2alice.expectMsgType[Error]
+    // we check that the error uses the temporary channel id
+    assert(error === Error(open.temporaryChannelId, DustLimitTooLarge(open.temporaryChannelId, open.dustLimitSatoshis, reserveTooSmall).getMessage.getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv OpenChannel (toLocal + toRemote below reserve)") { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val open = alice2bob.expectMsgType[OpenChannel]
-      val fundingSatoshis = open.channelReserveSatoshis + 499
-      val pushMsat = 500 * 1000
-      bob ! open.copy(fundingSatoshis = fundingSatoshis, pushMsat = pushMsat)
-      val error = bob2alice.expectMsgType[Error]
-      // we check that the error uses the temporary channel id
-      assert(error === Error(open.temporaryChannelId, ChannelReserveNotMet(open.temporaryChannelId, 500 * 1000, (open.channelReserveSatoshis - 1) * 1000, open.channelReserveSatoshis).getMessage.getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv OpenChannel (toLocal + toRemote below reserve)") { f =>
+    import f._
+    val open = alice2bob.expectMsgType[OpenChannel]
+    val fundingSatoshis = open.channelReserveSatoshis + 499
+    val pushMsat = 500 * 1000
+    bob ! open.copy(fundingSatoshis = fundingSatoshis, pushMsat = pushMsat)
+    val error = bob2alice.expectMsgType[Error]
+    // we check that the error uses the temporary channel id
+    assert(error === Error(open.temporaryChannelId, ChannelReserveNotMet(open.temporaryChannelId, 500 * 1000, (open.channelReserveSatoshis - 1) * 1000, open.channelReserveSatoshis).getMessage.getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv Error") { case (bob, _, _, _) =>
-    within(30 seconds) {
-      bob ! Error("00" * 32, "oops".getBytes())
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv Error") { f =>
+    import f._
+    bob ! Error("00" * 32, "oops".getBytes())
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv CMD_CLOSE") { case (bob, _, _, _) =>
-    within(30 seconds) {
-      bob ! CMD_CLOSE(None)
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv CMD_CLOSE") { f =>
+    import f._
+    bob ! CMD_CLOSE(None)
+    awaitCond(bob.stateName == CLOSED)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedInternalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedInternalStateSpec.scala
@@ -22,16 +22,14 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class WaitForFundingCreatedInternalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedStateSpec.scala
@@ -25,7 +25,7 @@ import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
-import org.scalatest.Tag
+import org.scalatest.{Outcome, Tag}
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
@@ -36,9 +36,9 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class WaitForFundingCreatedStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple4[TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe]
+  case class FixtureParam(bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, bob2blockchain: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()
     import setup._
     val (fundingSatoshis, pushMsat) = if (test.tags.contains("funder_below_reserve")) {
@@ -56,46 +56,42 @@ class WaitForFundingCreatedStateSpec extends TestkitBaseClass with StateTestsHel
       bob2alice.expectMsgType[AcceptChannel]
       bob2alice.forward(alice)
       awaitCond(bob.stateName == WAIT_FOR_FUNDING_CREATED)
-    }
-    test((bob, alice2bob, bob2alice, bob2blockchain))
-  }
-
-  test("recv FundingCreated") { case (bob, alice2bob, bob2alice, bob2blockchain) =>
-    within(30 seconds) {
-      alice2bob.expectMsgType[FundingCreated]
-      alice2bob.forward(bob)
-      awaitCond(bob.stateName == WAIT_FOR_FUNDING_CONFIRMED)
-      bob2alice.expectMsgType[FundingSigned]
-      bob2blockchain.expectMsgType[WatchSpent]
-      bob2blockchain.expectMsgType[WatchConfirmed]
+      withFixture(test.toNoArgTest(FixtureParam(bob, alice2bob, bob2alice, bob2blockchain)))
     }
   }
 
-  test("recv FundingCreated (funder can't pay fees)", Tag("funder_below_reserve")) { case (bob, alice2bob, bob2alice, _) =>
-    within(30 seconds) {
-      val fees = Transactions.commitWeight * TestConstants.feeratePerKw / 1000
-      val reserve = Bob.channelParams.channelReserveSatoshis
-      val missing = 100 - fees - reserve
-      val fundingCreated = alice2bob.expectMsgType[FundingCreated]
-      alice2bob.forward(bob)
-      val error = bob2alice.expectMsgType[Error]
-      assert(error === Error(fundingCreated.temporaryChannelId, s"can't pay the fee: missingSatoshis=${-1 * missing} reserveSatoshis=$reserve feesSatoshis=$fees".getBytes("UTF-8")))
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv FundingCreated") { f =>
+    import f._
+    alice2bob.expectMsgType[FundingCreated]
+    alice2bob.forward(bob)
+    awaitCond(bob.stateName == WAIT_FOR_FUNDING_CONFIRMED)
+    bob2alice.expectMsgType[FundingSigned]
+    bob2blockchain.expectMsgType[WatchSpent]
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv Error") { case (bob, _, _, _) =>
-    within(30 seconds) {
-      bob ! Error("00" * 32, "oops".getBytes)
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv FundingCreated (funder can't pay fees)", Tag("funder_below_reserve")) { f =>
+    import f._
+    val fees = Transactions.commitWeight * TestConstants.feeratePerKw / 1000
+    val reserve = Bob.channelParams.channelReserveSatoshis
+    val missing = 100 - fees - reserve
+    val fundingCreated = alice2bob.expectMsgType[FundingCreated]
+    alice2bob.forward(bob)
+    val error = bob2alice.expectMsgType[Error]
+    assert(error === Error(fundingCreated.temporaryChannelId, s"can't pay the fee: missingSatoshis=${-1 * missing} reserveSatoshis=$reserve feesSatoshis=$fees".getBytes("UTF-8")))
+    awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv CMD_CLOSE") { case (bob, _, _, _) =>
-    within(30 seconds) {
-      bob ! CMD_CLOSE(None)
-      awaitCond(bob.stateName == CLOSED)
-    }
+  test("recv Error") { f =>
+    import f._
+    bob ! Error("00" * 32, "oops".getBytes)
+    awaitCond(bob.stateName == CLOSED)
+  }
+
+  test("recv CMD_CLOSE") { f =>
+    import f._
+    bob ! CMD_CLOSE(None)
+    awaitCond(bob.stateName == CLOSED)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedStateSpec.scala
@@ -24,16 +24,14 @@ import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
 import org.scalatest.{Outcome, Tag}
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class WaitForFundingCreatedStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, bob2blockchain: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -24,16 +24,14 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.wire.{AcceptChannel, Error, FundingCreated, FundingSigned, Init, OpenChannel}
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class WaitForFundingSignedStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -25,6 +25,7 @@ import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.wire.{AcceptChannel, Error, FundingCreated, FundingSigned, Init, OpenChannel}
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
+import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
@@ -35,9 +36,9 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class WaitForFundingSignedStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple4[TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe]
+  case class FixtureParam(alice: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()
     import setup._
     val aliceInit = Init(Alice.channelParams.globalFeatures, Alice.channelParams.localFeatures)
@@ -52,41 +53,37 @@ class WaitForFundingSignedStateSpec extends TestkitBaseClass with StateTestsHelp
       alice2bob.expectMsgType[FundingCreated]
       alice2bob.forward(bob)
       awaitCond(alice.stateName == WAIT_FOR_FUNDING_SIGNED)
-    }
-    test((alice, alice2bob, bob2alice, alice2blockchain))
-  }
-
-  test("recv FundingSigned with valid signature") { case (alice, _, bob2alice, alice2blockchain) =>
-    within(30 seconds) {
-      bob2alice.expectMsgType[FundingSigned]
-      bob2alice.forward(alice)
-      awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
-      alice2blockchain.expectMsgType[WatchSpent]
-      alice2blockchain.expectMsgType[WatchConfirmed]
+      withFixture(test.toNoArgTest(FixtureParam(alice, alice2bob, bob2alice, alice2blockchain)))
     }
   }
 
-  test("recv FundingSigned with invalid signature") { case (alice, alice2bob, _, _) =>
-    within(30 seconds) {
-      // sending an invalid sig
-      alice ! FundingSigned("00" * 32, BinaryData("00" * 64))
-      awaitCond(alice.stateName == CLOSED)
-      alice2bob.expectMsgType[Error]
-    }
+  test("recv FundingSigned with valid signature") { f =>
+    import f._
+    bob2alice.expectMsgType[FundingSigned]
+    bob2alice.forward(alice)
+    awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
+    alice2blockchain.expectMsgType[WatchSpent]
+    alice2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv CMD_CLOSE") { case (alice, _, _, _) =>
-    within(30 seconds) {
-      alice ! CMD_CLOSE(None)
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv FundingSigned with invalid signature") { f =>
+    import f._
+    // sending an invalid sig
+    alice ! FundingSigned("00" * 32, BinaryData("00" * 64))
+    awaitCond(alice.stateName == CLOSED)
+    alice2bob.expectMsgType[Error]
   }
 
-  test("recv CMD_FORCECLOSE") { case (alice, _, _, _) =>
-    within(30 seconds) {
-      alice ! CMD_FORCECLOSE
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv CMD_CLOSE") { f =>
+    import f._
+    alice ! CMD_CLOSE(None)
+    awaitCond(alice.stateName == CLOSED)
+  }
+
+  test("recv CMD_FORCECLOSE") { f =>
+    import f._
+    alice ! CMD_FORCECLOSE
+    awaitCond(alice.stateName == CLOSED)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -25,16 +25,14 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.wire.{AcceptChannel, Error, FundingCreated, FundingLocked, FundingSigned, Init, OpenChannel}
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class WaitForFundingConfirmedStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -26,6 +26,7 @@ import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.wire.{AcceptChannel, Error, FundingCreated, FundingLocked, FundingSigned, Init, OpenChannel}
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
+import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
@@ -36,9 +37,9 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class WaitForFundingConfirmedStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple5[TestFSMRef[State, Data, Channel], TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe]
+  case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()
     import setup._
     val aliceInit = Init(Alice.channelParams.globalFeatures, Alice.channelParams.localFeatures)
@@ -57,95 +58,86 @@ class WaitForFundingConfirmedStateSpec extends TestkitBaseClass with StateTestsH
       alice2blockchain.expectMsgType[WatchSpent]
       alice2blockchain.expectMsgType[WatchConfirmed]
       awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
-    }
-    test((alice, bob, alice2bob, bob2alice, alice2blockchain))
-  }
-
-  test("recv FundingLocked") { case (alice, bob, _, bob2alice, _) =>
-    within(30 seconds) {
-      // make bob send a FundingLocked msg
-      bob ! WatchEventConfirmed(BITCOIN_FUNDING_DEPTHOK, 42000, 42)
-      val msg = bob2alice.expectMsgType[FundingLocked]
-      bob2alice.forward(alice)
-      awaitCond(alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].deferred == Some(msg))
-      awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
+      withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain)))
     }
   }
 
-  test("recv BITCOIN_FUNDING_DEPTHOK") { case (alice, _, alice2bob, _, alice2blockchain) =>
-    within(30 seconds) {
-      alice ! WatchEventConfirmed(BITCOIN_FUNDING_DEPTHOK, 42000, 42)
-      awaitCond(alice.stateName == WAIT_FOR_FUNDING_LOCKED)
-      alice2blockchain.expectMsgType[WatchLost]
-      alice2bob.expectMsgType[FundingLocked]
-    }
+  test("recv FundingLocked") { f =>
+    import f._
+    // make bob send a FundingLocked msg
+    bob ! WatchEventConfirmed(BITCOIN_FUNDING_DEPTHOK, 42000, 42)
+    val msg = bob2alice.expectMsgType[FundingLocked]
+    bob2alice.forward(alice)
+    awaitCond(alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].deferred.contains(msg))
+    awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
   }
 
-  test("recv BITCOIN_FUNDING_PUBLISH_FAILED") { case (alice, _, alice2bob, _, _) =>
-    within(30 seconds) {
-      alice ! BITCOIN_FUNDING_PUBLISH_FAILED
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSED)
-    }
+  test("recv BITCOIN_FUNDING_DEPTHOK") { f =>
+    import f._
+    alice ! WatchEventConfirmed(BITCOIN_FUNDING_DEPTHOK, 42000, 42)
+    awaitCond(alice.stateName == WAIT_FOR_FUNDING_LOCKED)
+    alice2blockchain.expectMsgType[WatchLost]
+    alice2bob.expectMsgType[FundingLocked]
   }
 
-  test("recv BITCOIN_FUNDING_TIMEOUT") { case (alice, _, alice2bob, _, _) =>
-    within(30 seconds) {
-      alice ! BITCOIN_FUNDING_TIMEOUT
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == ERR_FUNDING_TIMEOUT)
-    }
+  test("recv BITCOIN_FUNDING_PUBLISH_FAILED") { f =>
+    import f._
+    alice ! BITCOIN_FUNDING_PUBLISH_FAILED
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (remote commit)") { case (alice, bob, _, _, alice2blockchain) =>
-    within(30 seconds) {
-      // bob publishes his commitment tx
-      val tx = bob.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, tx)
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-      awaitCond(alice.stateName == CLOSING)
-    }
+  test("recv BITCOIN_FUNDING_TIMEOUT") { f =>
+    import f._
+    alice ! BITCOIN_FUNDING_TIMEOUT
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == ERR_FUNDING_TIMEOUT)
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (other commit)") { case (alice, _, alice2bob, _, alice2blockchain) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, Transaction(0, Nil, Nil, 0))
-      alice2bob.expectMsgType[Error]
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
-    }
+  test("recv BITCOIN_FUNDING_SPENT (remote commit)") { f =>
+    import f._
+    // bob publishes his commitment tx
+    val tx = bob.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, tx)
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+    awaitCond(alice.stateName == CLOSING)
   }
 
-  test("recv Error") { case (alice, _, _, _, alice2blockchain) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! Error("00" * 32, "oops".getBytes)
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap] // claim-main-delayed
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
-    }
+  test("recv BITCOIN_FUNDING_SPENT (other commit)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, Transaction(0, Nil, Nil, 0))
+    alice2bob.expectMsgType[Error]
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
   }
 
-  test("recv CMD_CLOSE") { case (alice, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg(Failure(CommandUnavailableInThisState(channelId(alice), "close", WAIT_FOR_FUNDING_CONFIRMED)))
-    }
+  test("recv Error") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! Error("00" * 32, "oops".getBytes)
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap] // claim-main-delayed
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
   }
 
-  test("recv CMD_FORCECLOSE") { case (alice, _, _, _, alice2blockchain) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! CMD_FORCECLOSE
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap] // claim-main-delayed
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
-    }
+  test("recv CMD_CLOSE") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg(Failure(CommandUnavailableInThisState(channelId(alice), "close", WAIT_FOR_FUNDING_CONFIRMED)))
+  }
+
+  test("recv CMD_FORCECLOSE") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! CMD_FORCECLOSE
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap] // claim-main-delayed
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingLockedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingLockedStateSpec.scala
@@ -25,16 +25,14 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class WaitForFundingLockedStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, router: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingLockedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingLockedStateSpec.scala
@@ -16,7 +16,6 @@
 
 package fr.acinq.eclair.channel.states.c
 
-import akka.actor.Status
 import akka.actor.Status.Failure
 import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.Transaction
@@ -27,6 +26,7 @@ import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
+import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
@@ -37,9 +37,9 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class WaitForFundingLockedStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple6[TestFSMRef[State, Data, Channel], TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe, TestProbe]
+  case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, router: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()
     import setup._
     val aliceInit = Init(Alice.channelParams.globalFeatures, Alice.channelParams.localFeatures)
@@ -66,68 +66,62 @@ class WaitForFundingLockedStateSpec extends TestkitBaseClass with StateTestsHelp
       alice2bob.expectMsgType[FundingLocked]
       awaitCond(alice.stateName == WAIT_FOR_FUNDING_LOCKED)
       awaitCond(bob.stateName == WAIT_FOR_FUNDING_LOCKED)
-    }
-    test((alice, bob, alice2bob, bob2alice, alice2blockchain, router))
-  }
-
-  test("recv FundingLocked") { case (alice, _, alice2bob, bob2alice, alice2blockchain, router) =>
-    within(30 seconds) {
-      bob2alice.expectMsgType[FundingLocked]
-      bob2alice.forward(alice)
-      awaitCond(alice.stateName == NORMAL)
-      bob2alice.expectNoMsg(200 millis)
+      withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain, router)))
     }
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (remote commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, router) =>
-    within(30 seconds) {
-      // bob publishes his commitment tx
-      val tx = bob.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_LOCKED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, tx)
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-      awaitCond(alice.stateName == CLOSING)
-    }
+  test("recv FundingLocked") { f =>
+    import f._
+    bob2alice.expectMsgType[FundingLocked]
+    bob2alice.forward(alice)
+    awaitCond(alice.stateName == NORMAL)
+    bob2alice.expectNoMsg(200 millis)
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (other commit)") { case (alice, _, alice2bob, _, alice2blockchain, _) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_LOCKED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, Transaction(0, Nil, Nil, 0))
-      alice2bob.expectMsgType[Error]
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
-    }
+  test("recv BITCOIN_FUNDING_SPENT (remote commit)") { f =>
+    import f._
+    // bob publishes his commitment tx
+    val tx = bob.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_LOCKED].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, tx)
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+    awaitCond(alice.stateName == CLOSING)
   }
 
-  test("recv Error") { case (alice, _, _, _, alice2blockchain, _) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_LOCKED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! Error("00" * 32, "oops".getBytes)
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
-    }
+  test("recv BITCOIN_FUNDING_SPENT (other commit)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_LOCKED].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, Transaction(0, Nil, Nil, 0))
+    alice2bob.expectMsgType[Error]
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
   }
 
-  test("recv CMD_CLOSE") { case (alice, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg(Failure(CommandUnavailableInThisState(channelId(alice), "close", WAIT_FOR_FUNDING_LOCKED)))
-    }
+  test("recv Error") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_LOCKED].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! Error("00" * 32, "oops".getBytes)
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
   }
 
-  test("recv CMD_FORCECLOSE") { case (alice, _, _, _, alice2blockchain, _) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_LOCKED].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! CMD_FORCECLOSE
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
-    }
+  test("recv CMD_CLOSE") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg(Failure(CommandUnavailableInThisState(channelId(alice), "close", WAIT_FOR_FUNDING_LOCKED)))
+  }
+
+  test("recv CMD_FORCECLOSE") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_LOCKED].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! CMD_FORCECLOSE
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -33,8 +33,8 @@ import fr.acinq.eclair.transactions.{IN, OUT}
 import fr.acinq.eclair.wire.{AnnouncementSignatures, ChannelUpdate, ClosingSigned, CommitSig, Error, FailureMessageCodecs, PermanentChannelFailure, RevokeAndAck, Shutdown, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFee, UpdateFulfillHtlc}
 import fr.acinq.eclair.{Globals, TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
-import org.scalatest.Tag
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.{Outcome, Tag}
 
 import scala.concurrent.duration._
 
@@ -44,2021 +44,1916 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple7[TestFSMRef[State, Data, Channel], TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe, TestProbe, TestProbe]
+  case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, relayer: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()
     import setup._
     within(30 seconds) {
       reachNormal(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer, test.tags)
       awaitCond(alice.stateName == NORMAL)
       awaitCond(bob.stateName == NORMAL)
+      withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer)))
     }
-    test((alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer))
   }
 
-  test("recv CMD_ADD_HTLC (empty origin)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val sender = TestProbe()
-      val h = BinaryData("42" * 32)
+  test("recv CMD_ADD_HTLC (empty origin)") { f =>
+    import f._
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val sender = TestProbe()
+    val h = BinaryData("42" * 32)
+    sender.send(alice, CMD_ADD_HTLC(50000000, h, 400144))
+    sender.expectMsg("ok")
+    val htlc = alice2bob.expectMsgType[UpdateAddHtlc]
+    assert(htlc.id == 0 && htlc.paymentHash == h)
+    awaitCond(alice.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localNextHtlcId = 1,
+        localChanges = initialState.commitments.localChanges.copy(proposed = htlc :: Nil),
+        originChannels = Map(0L -> Local(Some(sender.ref)))
+      )))
+  }
+
+  test("recv CMD_ADD_HTLC (incrementing ids)") { f =>
+    import f._
+    val sender = TestProbe()
+    val h = BinaryData("42" * 32)
+    for (i <- 0 until 10) {
       sender.send(alice, CMD_ADD_HTLC(50000000, h, 400144))
       sender.expectMsg("ok")
       val htlc = alice2bob.expectMsgType[UpdateAddHtlc]
-      assert(htlc.id == 0 && htlc.paymentHash == h)
-      awaitCond(alice.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localNextHtlcId = 1,
-          localChanges = initialState.commitments.localChanges.copy(proposed = htlc :: Nil),
-          originChannels = Map(0L -> Local(Some(sender.ref)))
-        )))
+      assert(htlc.id == i && htlc.paymentHash == h)
     }
   }
 
-  test("recv CMD_ADD_HTLC (incrementing ids)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val h = BinaryData("42" * 32)
-      for (i <- 0 until 10) {
-        sender.send(alice, CMD_ADD_HTLC(50000000, h, 400144))
-        sender.expectMsg("ok")
-        val htlc = alice2bob.expectMsgType[UpdateAddHtlc]
-        assert(htlc.id == i && htlc.paymentHash == h)
-      }
-    }
+  test("recv CMD_ADD_HTLC (relayed htlc)") { f =>
+    import f._
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val sender = TestProbe()
+    val h = BinaryData("42" * 32)
+    val originHtlc = UpdateAddHtlc(channelId = "42" * 32, id = 5656, amountMsat = 50000000, expiry = 400144, paymentHash = h, onionRoutingPacket = "00" * 1254)
+    val cmd = CMD_ADD_HTLC(originHtlc.amountMsat - 10000, h, originHtlc.expiry - 7, upstream_opt = Some(originHtlc))
+    sender.send(alice, cmd)
+    sender.expectMsg("ok")
+    val htlc = alice2bob.expectMsgType[UpdateAddHtlc]
+    assert(htlc.id == 0 && htlc.paymentHash == h)
+    awaitCond(alice.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localNextHtlcId = 1,
+        localChanges = initialState.commitments.localChanges.copy(proposed = htlc :: Nil),
+        originChannels = Map(0L -> Relayed(originHtlc.channelId, originHtlc.id, originHtlc.amountMsat, htlc.amountMsat))
+      )))
   }
 
-  test("recv CMD_ADD_HTLC (relayed htlc)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val sender = TestProbe()
-      val h = BinaryData("42" * 32)
-      val originHtlc = UpdateAddHtlc(channelId = "42" * 32, id = 5656, amountMsat = 50000000, expiry = 400144, paymentHash = h, onionRoutingPacket = "00" * 1254)
-      val cmd = CMD_ADD_HTLC(originHtlc.amountMsat - 10000, h, originHtlc.expiry - 7, upstream_opt = Some(originHtlc))
-      sender.send(alice, cmd)
-      sender.expectMsg("ok")
-      val htlc = alice2bob.expectMsgType[UpdateAddHtlc]
-      assert(htlc.id == 0 && htlc.paymentHash == h)
-      awaitCond(alice.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localNextHtlcId = 1,
-          localChanges = initialState.commitments.localChanges.copy(proposed = htlc :: Nil),
-          originChannels = Map(0L -> Relayed(originHtlc.channelId, originHtlc.id, originHtlc.amountMsat, htlc.amountMsat))
-        )))
-    }
+  test("recv CMD_ADD_HTLC (invalid payment hash)") { f =>
+    import f._
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val sender = TestProbe()
+    val add = CMD_ADD_HTLC(500000000, "11" * 42, expiry = 400144)
+    sender.send(alice, add)
+    val error = InvalidPaymentHash(channelId(alice))
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_ADD_HTLC (invalid payment hash)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val sender = TestProbe()
-      val add = CMD_ADD_HTLC(500000000, "11" * 42, expiry = 400144)
-      sender.send(alice, add)
-      val error = InvalidPaymentHash(channelId(alice))
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+  test("recv CMD_ADD_HTLC (expiry too small)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val currentBlockCount = Globals.blockCount.get
+    val expiryTooSmall = currentBlockCount + 3
+    val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = expiryTooSmall)
+    sender.send(alice, add)
+    val error = ExpiryTooSmall(channelId(alice), currentBlockCount + Channel.MIN_CLTV_EXPIRY, expiryTooSmall, currentBlockCount)
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_ADD_HTLC (expiry too small)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val currentBlockCount = Globals.blockCount.get
-      val expiryTooSmall = currentBlockCount + 3
-      val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = expiryTooSmall)
-      sender.send(alice, add)
-      val error = ExpiryTooSmall(channelId(alice), currentBlockCount + Channel.MIN_CLTV_EXPIRY, expiryTooSmall, currentBlockCount)
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+  test("recv CMD_ADD_HTLC (expiry too big)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val currentBlockCount = Globals.blockCount.get
+    val expiryTooBig = currentBlockCount + Channel.MAX_CLTV_EXPIRY + 1
+    val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = expiryTooBig)
+    sender.send(alice, add)
+    val error = ExpiryTooBig(channelId(alice), maximum = currentBlockCount + Channel.MAX_CLTV_EXPIRY, actual = expiryTooBig, blockCount = currentBlockCount)
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_ADD_HTLC (expiry too big)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val currentBlockCount = Globals.blockCount.get
-      val expiryTooBig = currentBlockCount + Channel.MAX_CLTV_EXPIRY + 1
-      val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = expiryTooBig)
-      sender.send(alice, add)
-      val error = ExpiryTooBig(channelId(alice), maximum = currentBlockCount + Channel.MAX_CLTV_EXPIRY, actual = expiryTooBig, blockCount = currentBlockCount)
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+  test("recv CMD_ADD_HTLC (value too small)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val add = CMD_ADD_HTLC(50, "11" * 32, 400144)
+    sender.send(alice, add)
+    val error = HtlcValueTooSmall(channelId(alice), 1000, 50)
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_ADD_HTLC (value too small)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val add = CMD_ADD_HTLC(50, "11" * 32, 400144)
-      sender.send(alice, add)
-      val error = HtlcValueTooSmall(channelId(alice), 1000, 50)
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+  test("recv CMD_ADD_HTLC (insufficient funds)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val add = CMD_ADD_HTLC(Int.MaxValue, "11" * 32, 400144)
+    sender.send(alice, add)
+    val error = InsufficientFunds(channelId(alice), amountMsat = Int.MaxValue, missingSatoshis = 1376443, reserveSatoshis = 20000, feesSatoshis = 8960)
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_ADD_HTLC (insufficient funds)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val add = CMD_ADD_HTLC(Int.MaxValue, "11" * 32, 400144)
-      sender.send(alice, add)
-      val error = InsufficientFunds(channelId(alice), amountMsat = Int.MaxValue, missingSatoshis = 1376443, reserveSatoshis = 20000, feesSatoshis = 8960)
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+  test("recv CMD_ADD_HTLC (insufficient funds w/ pending htlcs and 0 balance)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(alice, CMD_ADD_HTLC(500000000, "11" * 32, 400144))
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    sender.send(alice, CMD_ADD_HTLC(200000000, "22" * 32, 400144))
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    sender.send(alice, CMD_ADD_HTLC(67600000, "33" * 32, 400144))
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    val add = CMD_ADD_HTLC(1000000, "44" * 32, 400144)
+    sender.send(alice, add)
+    val error = InsufficientFunds(channelId(alice), amountMsat = 1000000, missingSatoshis = 1000, reserveSatoshis = 20000, feesSatoshis = 12400)
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_ADD_HTLC (insufficient funds w/ pending htlcs and 0 balance)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(alice, CMD_ADD_HTLC(500000000, "11" * 32, 400144))
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[UpdateAddHtlc]
-      sender.send(alice, CMD_ADD_HTLC(200000000, "22" * 32, 400144))
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[UpdateAddHtlc]
-      sender.send(alice, CMD_ADD_HTLC(67600000, "33" * 32, 400144))
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[UpdateAddHtlc]
-      val add = CMD_ADD_HTLC(1000000, "44" * 32, 400144)
-      sender.send(alice, add)
-      val error = InsufficientFunds(channelId(alice), amountMsat = 1000000, missingSatoshis = 1000, reserveSatoshis = 20000, feesSatoshis = 12400)
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+  test("recv CMD_ADD_HTLC (insufficient funds w/ pending htlcs 2/2)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(alice, CMD_ADD_HTLC(300000000, "11" * 32, 400144))
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    sender.send(alice, CMD_ADD_HTLC(300000000, "22" * 32, 400144))
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    val add = CMD_ADD_HTLC(500000000, "33" * 32, 400144)
+    sender.send(alice, add)
+    val error = InsufficientFunds(channelId(alice), amountMsat = 500000000, missingSatoshis = 332400, reserveSatoshis = 20000, feesSatoshis = 12400)
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_ADD_HTLC (insufficient funds w/ pending htlcs 2/2)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(alice, CMD_ADD_HTLC(300000000, "11" * 32, 400144))
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[UpdateAddHtlc]
-      sender.send(alice, CMD_ADD_HTLC(300000000, "22" * 32, 400144))
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[UpdateAddHtlc]
-      val add = CMD_ADD_HTLC(500000000, "33" * 32, 400144)
-      sender.send(alice, add)
-      val error = InsufficientFunds(channelId(alice), amountMsat = 500000000, missingSatoshis = 332400, reserveSatoshis = 20000, feesSatoshis = 12400)
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+  test("recv CMD_ADD_HTLC (over max inflight htlc value)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+    val add = CMD_ADD_HTLC(151000000, "11" * 32, 400144)
+    sender.send(bob, add)
+    val error = HtlcValueTooHighInFlight(channelId(bob), maximum = 150000000, actual = 151000000)
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(bob), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
+    bob2alice.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_ADD_HTLC (over max inflight htlc value)") { case (_, bob, _, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-      val add = CMD_ADD_HTLC(151000000, "11" * 32, 400144)
-      sender.send(bob, add)
-      val error = HtlcValueTooHighInFlight(channelId(bob), maximum = 150000000, actual = 151000000)
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(bob), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
-      bob2alice.expectNoMsg(200 millis)
-    }
-  }
-
-  test("recv CMD_ADD_HTLC (over max accepted htlcs)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      // Bob accepts a maximum of 30 htlcs
-      for (i <- 0 until 30) {
-        sender.send(alice, CMD_ADD_HTLC(10000000, "11" * 32, 400144))
-        sender.expectMsg("ok")
-        alice2bob.expectMsgType[UpdateAddHtlc]
-      }
-      val add = CMD_ADD_HTLC(10000000, "33" * 32, 400144)
-      sender.send(alice, add)
-      val error = TooManyAcceptedHtlcs(channelId(alice), maximum = 30)
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
-  }
-
-  test("recv CMD_ADD_HTLC (over capacity)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val add1 = CMD_ADD_HTLC(TestConstants.fundingSatoshis * 2 / 3 * 1000, "11" * 32, 400144)
-      sender.send(alice, add1)
+  test("recv CMD_ADD_HTLC (over max accepted htlcs)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    // Bob accepts a maximum of 30 htlcs
+    for (i <- 0 until 30) {
+      sender.send(alice, CMD_ADD_HTLC(10000000, "11" * 32, 400144))
       sender.expectMsg("ok")
       alice2bob.expectMsgType[UpdateAddHtlc]
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      // this is over channel-capacity
-      val add2 = CMD_ADD_HTLC(TestConstants.fundingSatoshis * 2 / 3 * 1000, "22" * 32, 400144)
-      sender.send(alice, add2)
-      val error = InsufficientFunds(channelId(alice), add2.amountMsat, 564012, 20000, 10680)
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add2.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add2))))
-      alice2bob.expectNoMsg(200 millis)
     }
+    val add = CMD_ADD_HTLC(10000000, "33" * 32, 400144)
+    sender.send(alice, add)
+    val error = TooManyAcceptedHtlcs(channelId(alice), maximum = 30)
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_ADD_HTLC (after having sent Shutdown)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[Shutdown]
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isDefined && !alice.stateData.asInstanceOf[DATA_NORMAL].remoteShutdown.isDefined)
-
-      // actual test starts here
-      val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 400144)
-      sender.send(alice, add)
-      val error = NoMoreHtlcsClosingInProgress(channelId(alice))
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+  test("recv CMD_ADD_HTLC (over capacity)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val add1 = CMD_ADD_HTLC(TestConstants.fundingSatoshis * 2 / 3 * 1000, "11" * 32, 400144)
+    sender.send(alice, add1)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    // this is over channel-capacity
+    val add2 = CMD_ADD_HTLC(TestConstants.fundingSatoshis * 2 / 3 * 1000, "22" * 32, 400144)
+    sender.send(alice, add2)
+    val error = InsufficientFunds(channelId(alice), add2.amountMsat, 564012, 20000, 10680)
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add2.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add2))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_ADD_HTLC (after having received Shutdown)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      // let's make alice send an htlc
-      val add1 = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 400144)
-      sender.send(alice, add1)
-      sender.expectMsg("ok")
-      // at the same time bob initiates a closing
-      sender.send(bob, CMD_CLOSE(None))
-      sender.expectMsg("ok")
-      // this command will be received by alice right after having received the shutdown
-      val add2 = CMD_ADD_HTLC(100000000, "22" * 32, expiry = 300000)
-      // messages cross
-      alice2bob.expectMsgType[UpdateAddHtlc]
-      alice2bob.forward(bob)
-      bob2alice.expectMsgType[Shutdown]
-      bob2alice.forward(alice)
-      sender.send(alice, add2)
-      val error = NoMoreHtlcsClosingInProgress(channelId(alice))
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add2.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add2))))
-    }
+  test("recv CMD_ADD_HTLC (after having sent Shutdown)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[Shutdown]
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isDefined && !alice.stateData.asInstanceOf[DATA_NORMAL].remoteShutdown.isDefined)
+
+    // actual test starts here
+    val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 400144)
+    sender.send(alice, add)
+    val error = NoMoreHtlcsClosingInProgress(channelId(alice))
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv UpdateAddHtlc") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val initialData = bob.stateData.asInstanceOf[DATA_NORMAL]
-      val htlc = UpdateAddHtlc("00" * 32, 0, 150000, BinaryData("42" * 32), 400144, defaultOnion)
-      bob ! htlc
-      awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ htlc), remoteNextHtlcId = 1)))
-    }
+  test("recv CMD_ADD_HTLC (after having received Shutdown)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    // let's make alice send an htlc
+    val add1 = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 400144)
+    sender.send(alice, add1)
+    sender.expectMsg("ok")
+    // at the same time bob initiates a closing
+    sender.send(bob, CMD_CLOSE(None))
+    sender.expectMsg("ok")
+    // this command will be received by alice right after having received the shutdown
+    val add2 = CMD_ADD_HTLC(100000000, "22" * 32, expiry = 300000)
+    // messages cross
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[Shutdown]
+    bob2alice.forward(alice)
+    sender.send(alice, add2)
+    val error = NoMoreHtlcsClosingInProgress(channelId(alice))
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add2.paymentHash, error, Local(Some(sender.ref)), Some(initialState.channelUpdate), Some(add2))))
   }
 
-  test("recv UpdateAddHtlc (unexpected id)") { case (_, bob, _, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val htlc = UpdateAddHtlc("00" * 32, 42, 150000, BinaryData("42" * 32), 400144, defaultOnion)
-      bob ! htlc.copy(id = 0)
-      bob ! htlc.copy(id = 1)
-      bob ! htlc.copy(id = 2)
-      bob ! htlc.copy(id = 3)
-      bob ! htlc.copy(id = 42)
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === UnexpectedHtlcId(channelId(bob), expected = 4, actual = 42).getMessage)
-      awaitCond(bob.stateName == CLOSING)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateAddHtlc") { f =>
+    import f._
+    val initialData = bob.stateData.asInstanceOf[DATA_NORMAL]
+    val htlc = UpdateAddHtlc("00" * 32, 0, 150000, BinaryData("42" * 32), 400144, defaultOnion)
+    bob ! htlc
+    awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ htlc), remoteNextHtlcId = 1)))
   }
 
-  test("recv UpdateAddHtlc (invalid payment hash)") { case (_, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val htlc = UpdateAddHtlc("00" * 32, 0, 150000, "11" * 42, 400144, defaultOnion)
-      alice2bob.forward(bob, htlc)
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === InvalidPaymentHash(channelId(bob)).getMessage)
-      awaitCond(bob.stateName == CLOSING)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateAddHtlc (unexpected id)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val htlc = UpdateAddHtlc("00" * 32, 42, 150000, BinaryData("42" * 32), 400144, defaultOnion)
+    bob ! htlc.copy(id = 0)
+    bob ! htlc.copy(id = 1)
+    bob ! htlc.copy(id = 2)
+    bob ! htlc.copy(id = 3)
+    bob ! htlc.copy(id = 42)
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === UnexpectedHtlcId(channelId(bob), expected = 4, actual = 42).getMessage)
+    awaitCond(bob.stateName == CLOSING)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateAddHtlc (value too small)") { case (_, bob, alice2bob, bob2alice, _, bob2blockchain, relayer) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val htlc = UpdateAddHtlc("00" * 32, 0, 150, BinaryData("42" * 32), expiry = 400144, defaultOnion)
-      alice2bob.forward(bob, htlc)
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === HtlcValueTooSmall(channelId(bob), minimum = 1000, actual = 150).getMessage)
-      awaitCond(bob.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateAddHtlc (invalid payment hash)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val htlc = UpdateAddHtlc("00" * 32, 0, 150000, "11" * 42, 400144, defaultOnion)
+    alice2bob.forward(bob, htlc)
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === InvalidPaymentHash(channelId(bob)).getMessage)
+    awaitCond(bob.stateName == CLOSING)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateAddHtlc (insufficient funds)") { case (_, bob, alice2bob, bob2alice, _, bob2blockchain, relayer) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val htlc = UpdateAddHtlc("00" * 32, 0, Long.MaxValue, BinaryData("42" * 32), 400144, defaultOnion)
-      alice2bob.forward(bob, htlc)
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === InsufficientFunds(channelId(bob), amountMsat = Long.MaxValue, missingSatoshis = 9223372036083735L, reserveSatoshis = 20000, feesSatoshis = 8960).getMessage)
-      awaitCond(bob.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateAddHtlc (value too small)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val htlc = UpdateAddHtlc("00" * 32, 0, 150, BinaryData("42" * 32), expiry = 400144, defaultOnion)
+    alice2bob.forward(bob, htlc)
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === HtlcValueTooSmall(channelId(bob), minimum = 1000, actual = 150).getMessage)
+    awaitCond(bob.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateAddHtlc (insufficient funds w/ pending htlcs 1/2)") { case (_, bob, alice2bob, bob2alice, _, bob2blockchain, relayer) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 0, 400000000, "11" * 32, 400144, defaultOnion))
-      alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 1, 200000000, "22" * 32, 400144, defaultOnion))
-      alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 2, 167600000, "33" * 32, 400144, defaultOnion))
-      alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 3, 10000000, "44" * 32, 400144, defaultOnion))
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === InsufficientFunds(channelId(bob), amountMsat = 10000000, missingSatoshis = 11720, reserveSatoshis = 20000, feesSatoshis = 14120).getMessage)
-      awaitCond(bob.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateAddHtlc (insufficient funds)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val htlc = UpdateAddHtlc("00" * 32, 0, Long.MaxValue, BinaryData("42" * 32), 400144, defaultOnion)
+    alice2bob.forward(bob, htlc)
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === InsufficientFunds(channelId(bob), amountMsat = Long.MaxValue, missingSatoshis = 9223372036083735L, reserveSatoshis = 20000, feesSatoshis = 8960).getMessage)
+    awaitCond(bob.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateAddHtlc (insufficient funds w/ pending htlcs 2/2)") { case (_, bob, alice2bob, bob2alice, _, bob2blockchain, relayer) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 0, 300000000, "11" * 32, 400144, defaultOnion))
-      alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 1, 300000000, "22" * 32, 400144, defaultOnion))
-      alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 2, 500000000, "33" * 32, 400144, defaultOnion))
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === InsufficientFunds(channelId(bob), amountMsat = 500000000, missingSatoshis = 332400, reserveSatoshis = 20000, feesSatoshis = 12400).getMessage)
-      awaitCond(bob.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateAddHtlc (insufficient funds w/ pending htlcs 1/2)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 0, 400000000, "11" * 32, 400144, defaultOnion))
+    alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 1, 200000000, "22" * 32, 400144, defaultOnion))
+    alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 2, 167600000, "33" * 32, 400144, defaultOnion))
+    alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 3, 10000000, "44" * 32, 400144, defaultOnion))
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === InsufficientFunds(channelId(bob), amountMsat = 10000000, missingSatoshis = 11720, reserveSatoshis = 20000, feesSatoshis = 14120).getMessage)
+    awaitCond(bob.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateAddHtlc (over max inflight htlc value)") { case (alice, _, alice2bob, _, alice2blockchain, _, relayer) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      alice2bob.forward(alice, UpdateAddHtlc("00" * 32, 0, 151000000, "11" * 32, 400144, defaultOnion))
-      val error = alice2bob.expectMsgType[Error]
-      assert(new String(error.data) === HtlcValueTooHighInFlight(channelId(alice), maximum = 150000000, actual = 151000000).getMessage)
-      awaitCond(alice.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateAddHtlc (insufficient funds w/ pending htlcs 2/2)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 0, 300000000, "11" * 32, 400144, defaultOnion))
+    alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 1, 300000000, "22" * 32, 400144, defaultOnion))
+    alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 2, 500000000, "33" * 32, 400144, defaultOnion))
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === InsufficientFunds(channelId(bob), amountMsat = 500000000, missingSatoshis = 332400, reserveSatoshis = 20000, feesSatoshis = 12400).getMessage)
+    awaitCond(bob.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateAddHtlc (over max accepted htlcs)") { case (_, bob, alice2bob, bob2alice, _, bob2blockchain, relayer) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      // Bob accepts a maximum of 30 htlcs
-      for (i <- 0 until 30) {
-        alice2bob.forward(bob, UpdateAddHtlc("00" * 32, i, 1000000, "11" * 32, 400144, defaultOnion))
-      }
-      alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 30, 1000000, "11" * 32, 400144, defaultOnion))
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === TooManyAcceptedHtlcs(channelId(bob), maximum = 30).getMessage)
-      awaitCond(bob.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateAddHtlc (over max inflight htlc value)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    alice2bob.forward(alice, UpdateAddHtlc("00" * 32, 0, 151000000, "11" * 32, 400144, defaultOnion))
+    val error = alice2bob.expectMsgType[Error]
+    assert(new String(error.data) === HtlcValueTooHighInFlight(channelId(alice), maximum = 150000000, actual = 151000000).getMessage)
+    awaitCond(alice.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv CMD_SIGN") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      val commitSig = alice2bob.expectMsgType[CommitSig]
-      assert(commitSig.htlcSignatures.size == 1)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isLeft)
+  test("recv UpdateAddHtlc (over max accepted htlcs)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    // Bob accepts a maximum of 30 htlcs
+    for (i <- 0 until 30) {
+      alice2bob.forward(bob, UpdateAddHtlc("00" * 32, i, 1000000, "11" * 32, 400144, defaultOnion))
     }
+    alice2bob.forward(bob, UpdateAddHtlc("00" * 32, 30, 1000000, "11" * 32, 400144, defaultOnion))
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === TooManyAcceptedHtlcs(channelId(bob), maximum = 30).getMessage)
+    awaitCond(bob.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv CMD_SIGN (two identical htlcs in each direction)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val add = CMD_ADD_HTLC(10000000, "11" * 32, 400144)
-      sender.send(alice, add)
+  test("recv CMD_SIGN") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    val commitSig = alice2bob.expectMsgType[CommitSig]
+    assert(commitSig.htlcSignatures.size == 1)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isLeft)
+  }
+
+  test("recv CMD_SIGN (two identical htlcs in each direction)") { f =>
+    import f._
+    val sender = TestProbe()
+    val add = CMD_ADD_HTLC(10000000, "11" * 32, 400144)
+    sender.send(alice, add)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    alice2bob.forward(bob)
+    sender.send(alice, add)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    alice2bob.forward(bob)
+
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    sender.send(bob, add)
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[UpdateAddHtlc]
+    bob2alice.forward(alice)
+    sender.send(bob, add)
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[UpdateAddHtlc]
+    bob2alice.forward(alice)
+
+    // actual test starts here
+    sender.send(bob, CMD_SIGN)
+    sender.expectMsg("ok")
+    val commitSig = bob2alice.expectMsgType[CommitSig]
+    assert(commitSig.htlcSignatures.toSet.size == 4)
+  }
+
+  test("recv CMD_SIGN (htlcs with same pubkeyScript but different amounts)") { f =>
+    import f._
+    val sender = TestProbe()
+    val add = CMD_ADD_HTLC(10000000, "11" * 32, 400144)
+    val epsilons = List(3, 1, 5, 7, 6) // unordered on purpose
+  val htlcCount = epsilons.size
+    for (i <- epsilons) {
+      sender.send(alice, add.copy(amountMsat = add.amountMsat + i * 1000))
       sender.expectMsg("ok")
       alice2bob.expectMsgType[UpdateAddHtlc]
       alice2bob.forward(bob)
-      sender.send(alice, add)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[UpdateAddHtlc]
-      alice2bob.forward(bob)
+    }
+    // actual test starts here
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    val commitSig = alice2bob.expectMsgType[CommitSig]
+    assert(commitSig.htlcSignatures.toSet.size == htlcCount)
+    alice2bob.forward(bob)
+    awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs.size == htlcCount)
+    val htlcTxs = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs
+    val amounts = htlcTxs.map(_.txinfo.tx.txOut.head.amount.toLong)
+    assert(amounts === amounts.sorted)
+  }
 
+  test("recv CMD_SIGN (no changes)") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, CMD_SIGN)
+    sender.expectNoMsg(1 second) // just ignored
+    //sender.expectMsg("cannot sign when there are no changes")
+  }
+
+  test("recv CMD_SIGN (while waiting for RevokeAndAck (no pending changes)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isLeft)
+    val waitForRevocation = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.left.toOption.get
+    assert(waitForRevocation.reSignAsap === false)
+
+    // actual test starts here
+    sender.send(alice, CMD_SIGN)
+    sender.expectNoMsg(300 millis)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo === Left(waitForRevocation))
+  }
+
+  test("recv CMD_SIGN (while waiting for RevokeAndAck (with pending changes)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r1, htlc1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isLeft)
+    val waitForRevocation = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.left.toOption.get
+    assert(waitForRevocation.reSignAsap === false)
+
+    // actual test starts here
+    val (r2, htlc2) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    sender.send(alice, CMD_SIGN)
+    sender.expectNoMsg(300 millis)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo === Left(waitForRevocation.copy(reSignAsap = true)))
+  }
+
+  test("recv CommitSig (one htlc received)") { f =>
+    import f._
+    val sender = TestProbe()
+
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+
+    // actual test begins
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+
+    bob2alice.expectMsgType[RevokeAndAck]
+    // bob replies immediately with a signature
+    bob2alice.expectMsgType[CommitSig]
+
+    awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.htlcs.exists(h => h.add.id == htlc.id && h.direction == IN))
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs.size == 1)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.toLocalMsat == initialState.commitments.localCommit.spec.toLocalMsat)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteChanges.acked.size == 0)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteChanges.signed.size == 1)
+  }
+
+  test("recv CommitSig (one htlc sent)") { f =>
+    import f._
+    val sender = TestProbe()
+
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+
+    // actual test begins (note that channel sends a CMD_SIGN to itself when it receives RevokeAndAck and there are changes)
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.htlcs.exists(h => h.add.id == htlc.id && h.direction == OUT))
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs.size == 1)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.toLocalMsat == initialState.commitments.localCommit.spec.toLocalMsat)
+  }
+
+  test("recv CommitSig (multiple htlcs in both directions)") { f =>
+    import f._
+    val sender = TestProbe()
+
+    val (r1, htlc1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice) // a->b (regular)
+
+    val (r2, htlc2) = addHtlc(8000000, alice, bob, alice2bob, bob2alice) //  a->b (regular)
+
+    val (r3, htlc3) = addHtlc(300000, bob, alice, bob2alice, alice2bob) //   b->a (dust)
+
+    val (r4, htlc4) = addHtlc(1000000, alice, bob, alice2bob, bob2alice) //  a->b (regular)
+
+    val (r5, htlc5) = addHtlc(50000000, bob, alice, bob2alice, alice2bob) // b->a (regular)
+
+    val (r6, htlc6) = addHtlc(500000, alice, bob, alice2bob, bob2alice) //   a->b (dust)
+
+    val (r7, htlc7) = addHtlc(4000000, bob, alice, bob2alice, alice2bob) //  b->a (regular)
+
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+
+    // actual test begins
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.index == 1)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs.size == 3)
+  }
+
+  test("recv CommitSig (only fee update)") { f =>
+    import f._
+    val sender = TestProbe()
+
+    sender.send(alice, CMD_UPDATE_FEE(TestConstants.feeratePerKw + 1000, commit = false))
+    sender.expectMsg("ok")
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+
+    // actual test begins (note that channel sends a CMD_SIGN to itself when it receives RevokeAndAck and there are changes)
+    alice2bob.expectMsgType[UpdateFee]
+    alice2bob.forward(bob)
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+  }
+
+  test("recv CommitSig (two htlcs received with same r)") { f =>
+    import f._
+    val sender = TestProbe()
+    val r = BinaryData("42" * 32)
+    val h: BinaryData = Crypto.sha256(r)
+
+    sender.send(alice, CMD_ADD_HTLC(50000000, h, 400144))
+    sender.expectMsg("ok")
+    val htlc1 = alice2bob.expectMsgType[UpdateAddHtlc]
+    alice2bob.forward(bob)
+
+    sender.send(alice, CMD_ADD_HTLC(50000000, h, 400144))
+    sender.expectMsg("ok")
+    val htlc2 = alice2bob.expectMsgType[UpdateAddHtlc]
+    alice2bob.forward(bob)
+
+    awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteChanges.proposed == htlc1 :: htlc2 :: Nil)
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+
+    crossSign(alice, bob, alice2bob, bob2alice)
+    awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.htlcs.exists(h => h.add.id == htlc1.id && h.direction == IN))
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs.size == 2)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.toLocalMsat == initialState.commitments.localCommit.spec.toLocalMsat)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx.txOut.count(_.amount == Satoshi(50000)) == 2)
+  }
+
+  test("recv CommitSig (no changes)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    // signature is invalid but it doesn't matter
+    sender.send(bob, CommitSig("00" * 32, "00" * 64, Nil))
+    bob2alice.expectMsgType[Error]
+    awaitCond(bob.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv CommitSig (invalid signature)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+
+    // actual test begins
+    sender.send(bob, CommitSig("00" * 32, "00" * 64, Nil))
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data).startsWith("invalid commitment signature"))
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv CommitSig (bad htlc sig count)") { f =>
+    import f._
+    val sender = TestProbe()
+
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    val commitSig = alice2bob.expectMsgType[CommitSig]
+
+    // actual test begins
+    val badCommitSig = commitSig.copy(htlcSignatures = commitSig.htlcSignatures ::: commitSig.htlcSignatures)
+    sender.send(bob, badCommitSig)
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === HtlcSigCountMismatch(channelId(bob), expected = 1, actual = 2).getMessage)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv CommitSig (invalid htlc sig)") { f =>
+    import f._
+    val sender = TestProbe()
+
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    val commitSig = alice2bob.expectMsgType[CommitSig]
+
+    // actual test begins
+    val badCommitSig = commitSig.copy(htlcSignatures = commitSig.signature :: Nil)
+    sender.send(bob, badCommitSig)
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data).startsWith("invalid htlc signature"))
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+
+  test("recv RevokeAndAck (one htlc sent)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+
+    // actual test begins
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isLeft)
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localChanges.acked.size == 1)
+  }
+
+  test("recv RevokeAndAck (one htlc received)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
+
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+
+    // actual test begins
+    alice2bob.expectMsgType[RevokeAndAck]
+    alice2bob.forward(bob)
+    awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
+  }
+
+  test("recv RevokeAndAck (multiple htlcs in both directions)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r1, htlc1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice) // a->b (regular)
+
+    val (r2, htlc2) = addHtlc(8000000, alice, bob, alice2bob, bob2alice) //  a->b (regular)
+
+    val (r3, htlc3) = addHtlc(300000, bob, alice, bob2alice, alice2bob) //   b->a (dust)
+
+    val (r4, htlc4) = addHtlc(1000000, alice, bob, alice2bob, bob2alice) //  a->b (regular)
+
+    val (r5, htlc5) = addHtlc(50000000, bob, alice, bob2alice, alice2bob) // b->a (regular)
+
+    val (r6, htlc6) = addHtlc(500000, alice, bob, alice2bob, bob2alice) //   a->b (dust)
+
+    val (r7, htlc7) = addHtlc(4000000, bob, alice, bob2alice, alice2bob) //  b->a (regular)
+
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
+
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+
+    // actual test begins
+    alice2bob.expectMsgType[RevokeAndAck]
+    alice2bob.forward(bob)
+
+    awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteCommit.index == 1)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteCommit.spec.htlcs.size == 7)
+  }
+
+  test("recv RevokeAndAck (with reSignAsap=true)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r1, htlc1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    val (r2, htlc2) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    sender.send(alice, CMD_SIGN)
+    sender.expectNoMsg(300 millis)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.left.toOption.get.reSignAsap === true)
+
+    // actual test starts here
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[CommitSig]
+  }
+
+  test("recv RevokeAndAck (invalid preimage)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+
+    // actual test begins
+    bob2alice.expectMsgType[RevokeAndAck]
+    sender.send(alice, RevokeAndAck("00" * 32, Scalar("11" * 32), Scalar("22" * 32).toPoint))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv RevokeAndAck (unexpectedly)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
+    sender.send(alice, RevokeAndAck("00" * 32, Scalar("11" * 32), Scalar("22" * 32).toPoint))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv CMD_FULFILL_HTLC") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // actual test begins
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(bob, CMD_FULFILL_HTLC(htlc.id, r))
+    sender.expectMsg("ok")
+    val fulfill = bob2alice.expectMsgType[UpdateFulfillHtlc]
+    awaitCond(bob.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fulfill))))
+  }
+
+  test("recv CMD_FULFILL_HTLC (unknown htlc id)") { f =>
+    import f._
+    val sender = TestProbe()
+    val r: BinaryData = "11" * 32
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+
+    sender.send(bob, CMD_FULFILL_HTLC(42, r))
+    sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
+    assert(initialState == bob.stateData)
+  }
+
+  test("recv CMD_FULFILL_HTLC (invalid preimage)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // actual test begins
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(bob, CMD_FULFILL_HTLC(htlc.id, "00" * 32))
+    sender.expectMsg(Failure(InvalidHtlcPreimage(channelId(bob), 0)))
+    assert(initialState == bob.stateData)
+  }
+
+  test("recv UpdateFulfillHtlc") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    sender.send(bob, CMD_FULFILL_HTLC(htlc.id, r))
+    sender.expectMsg("ok")
+    val fulfill = bob2alice.expectMsgType[UpdateFulfillHtlc]
+
+    // actual test begins
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    bob2alice.forward(alice)
+    awaitCond(alice.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fulfill))))
+  }
+
+  test("recv UpdateFulfillHtlc (sender has not signed htlc)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+
+    // actual test begins
+    val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    sender.send(alice, UpdateFulfillHtlc("00" * 32, htlc.id, r))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv UpdateFulfillHtlc (unknown htlc id)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(alice, UpdateFulfillHtlc("00" * 32, 42, "00" * 32))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv UpdateFulfillHtlc (invalid preimage)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+
+    // actual test begins
+    sender.send(alice, UpdateFulfillHtlc("00" * 32, htlc.id, "00" * 32))
+    relayer.expectMsgType[ForwardAdd]
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap] // main delayed
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed
+    alice2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv CMD_FAIL_HTLC") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // actual test begins
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(bob, CMD_FAIL_HTLC(htlc.id, Right(PermanentChannelFailure)))
+    sender.expectMsg("ok")
+    val fail = bob2alice.expectMsgType[UpdateFailHtlc]
+    awaitCond(bob.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fail))))
+  }
+
+  test("recv CMD_FAIL_HTLC (unknown htlc id)") { f =>
+    import f._
+    val sender = TestProbe()
+    val r: BinaryData = "11" * 32
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+
+    sender.send(bob, CMD_FAIL_HTLC(42, Right(PermanentChannelFailure)))
+    sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
+    assert(initialState == bob.stateData)
+  }
+
+  test("recv CMD_FAIL_MALFORMED_HTLC") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // actual test begins
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(bob, CMD_FAIL_MALFORMED_HTLC(htlc.id, Crypto.sha256(htlc.onionRoutingPacket), FailureMessageCodecs.BADONION))
+    sender.expectMsg("ok")
+    val fail = bob2alice.expectMsgType[UpdateFailMalformedHtlc]
+    awaitCond(bob.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fail))))
+  }
+
+  test("recv CMD_FAIL_MALFORMED_HTLC (unknown htlc id)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(bob, CMD_FAIL_MALFORMED_HTLC(42, "00" * 32, FailureMessageCodecs.BADONION))
+    sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
+    assert(initialState == bob.stateData)
+  }
+
+  test("recv CMD_FAIL_HTLC (invalid failure_code)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(bob, CMD_FAIL_MALFORMED_HTLC(42, "00" * 32, 42))
+    sender.expectMsg(Failure(InvalidFailureCode(channelId(bob))))
+    assert(initialState == bob.stateData)
+  }
+
+  test("recv UpdateFailHtlc") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    sender.send(bob, CMD_FAIL_HTLC(htlc.id, Right(PermanentChannelFailure)))
+    sender.expectMsg("ok")
+    val fail = bob2alice.expectMsgType[UpdateFailHtlc]
+
+    // actual test begins
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    bob2alice.forward(alice)
+    awaitCond(alice.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fail))))
+  }
+
+  test("recv UpdateFailMalformedHtlc") { f =>
+    import f._
+    val sender = TestProbe()
+
+    // Alice sends an HTLC to Bob, which they both sign
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // Bob fails the HTLC because he cannot parse it
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(bob, CMD_FAIL_MALFORMED_HTLC(htlc.id, Crypto.sha256(htlc.onionRoutingPacket), FailureMessageCodecs.BADONION))
+    sender.expectMsg("ok")
+    val fail = bob2alice.expectMsgType[UpdateFailMalformedHtlc]
+    bob2alice.forward(alice)
+
+    awaitCond(alice.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fail))))
+
+    sender.send(bob, CMD_SIGN)
+    val sig = bob2alice.expectMsgType[CommitSig]
+    // Bob should not have the htlc in its remote commit anymore
+    assert(sig.htlcSignatures.isEmpty)
+
+    // and Alice should accept this signature
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[RevokeAndAck]
+  }
+
+  test("recv UpdateFailMalformedHtlc (invalid failure_code)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // actual test begins
+    val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val fail = UpdateFailMalformedHtlc("00" * 32, htlc.id, Crypto.sha256(htlc.onionRoutingPacket), 42)
+    sender.send(alice, fail)
+    val error = alice2bob.expectMsgType[Error]
+    assert(new String(error.data) === InvalidFailureCode("00" * 32).getMessage)
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    alice2blockchain.expectMsgType[PublishAsap] // main delayed
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed
+    alice2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv UpdateFailHtlc (sender has not signed htlc)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+
+    // actual test begins
+    val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    sender.send(alice, UpdateFailHtlc("00" * 32, htlc.id, "00" * 152))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv UpdateFailHtlc (unknown htlc id)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(alice, UpdateFailHtlc("00" * 32, 42, "00" * 152))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv CMD_UPDATE_FEE") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(alice, CMD_UPDATE_FEE(20000))
+    sender.expectMsg("ok")
+    val fee = alice2bob.expectMsgType[UpdateFee]
+    awaitCond(alice.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fee))))
+  }
+
+  test("recv CMD_UPDATE_FEE (two in a row)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(alice, CMD_UPDATE_FEE(20000))
+    sender.expectMsg("ok")
+    val fee1 = alice2bob.expectMsgType[UpdateFee]
+    sender.send(alice, CMD_UPDATE_FEE(30000))
+    sender.expectMsg("ok")
+    val fee2 = alice2bob.expectMsgType[UpdateFee]
+    awaitCond(alice.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fee2))))
+  }
+
+  test("recv CMD_UPDATE_FEE (when fundee)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(bob, CMD_UPDATE_FEE(20000))
+    sender.expectMsg(Failure(FundeeCannotSendUpdateFee(channelId(bob))))
+    assert(initialState == bob.stateData)
+  }
+
+  test("recv UpdateFee") { f =>
+    import f._
+    val initialData = bob.stateData.asInstanceOf[DATA_NORMAL]
+    val fee1 = UpdateFee("00" * 32, 12000)
+    bob ! fee1
+    val fee2 = UpdateFee("00" * 32, 14000)
+    bob ! fee2
+    awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ fee2), remoteNextHtlcId = 0)))
+  }
+
+  test("recv UpdateFee (two in a row)") { f =>
+    import f._
+    val initialData = bob.stateData.asInstanceOf[DATA_NORMAL]
+    val fee = UpdateFee("00" * 32, 12000)
+    bob ! fee
+    awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ fee), remoteNextHtlcId = 0)))
+  }
+
+  test("recv UpdateFee (when sender is not funder)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(alice, UpdateFee("00" * 32, 12000))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv UpdateFee (sender can't afford it)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    val fee = UpdateFee("00" * 32, 100000000)
+    // we first update the global variable so that we don't trigger a 'fee too different' error
+    Globals.feeratesPerKw.set(FeeratesPerKw.single(fee.feeratePerKw))
+    sender.send(bob, fee)
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === CannotAffordFees(channelId(bob), missingSatoshis = 71620000L, reserveSatoshis = 20000L, feesSatoshis = 72400000L).getMessage)
+    awaitCond(bob.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    //bob2blockchain.expectMsgType[PublishAsap] // main delayed (removed because of the high fees)
+    bob2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv UpdateFee (local/remote feerates are too different)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(bob, UpdateFee("00" * 32, 85000))
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === "local/remote feerates are too different: remoteFeeratePerKw=85000 localFeeratePerKw=10000")
+    awaitCond(bob.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv UpdateFee (remote feerate is too small)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(bob, UpdateFee("00" * 32, 252))
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === "remote fee rate is too small: remoteFeeratePerKw=252")
+    awaitCond(bob.stateName == CLOSING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv CMD_UPDATE_RELAY_FEE ") { f =>
+    import f._
+    val sender = TestProbe()
+    val newFeeBaseMsat = TestConstants.Alice.nodeParams.feeBaseMsat * 2
+    val newFeeProportionalMillionth = TestConstants.Alice.nodeParams.feeProportionalMillionth * 2
+    sender.send(alice, CMD_UPDATE_RELAY_FEE(newFeeBaseMsat, newFeeProportionalMillionth))
+    sender.expectMsg("ok")
+
+    val localUpdate = relayer.expectMsgType[LocalChannelUpdate]
+    assert(localUpdate.channelUpdate.feeBaseMsat == newFeeBaseMsat)
+    assert(localUpdate.channelUpdate.feeProportionalMillionths == newFeeProportionalMillionth)
+    relayer.expectNoMsg(1 seconds)
+  }
+
+  test("recv CMD_CLOSE (no pending htlcs)") { f =>
+    import f._
+    val sender = TestProbe()
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isEmpty)
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[Shutdown]
+    awaitCond(alice.stateName == NORMAL)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isDefined)
+  }
+
+  test("recv CMD_CLOSE (with unacked sent htlcs)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg(Failure(CannotCloseWithUnsignedOutgoingHtlcs(channelId(bob))))
+  }
+
+  test("recv CMD_CLOSE (with invalid final script)") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, CMD_CLOSE(Some(BinaryData("00112233445566778899"))))
+    sender.expectMsg(Failure(InvalidFinalScript(channelId(alice))))
+  }
+
+  test("recv CMD_CLOSE (with signed sent htlcs)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[Shutdown]
+    awaitCond(alice.stateName == NORMAL)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isDefined)
+  }
+
+  test("recv CMD_CLOSE (two in a row)") { f =>
+    import f._
+    val sender = TestProbe()
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isEmpty)
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[Shutdown]
+    awaitCond(alice.stateName == NORMAL)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isDefined)
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg(Failure(ClosingAlreadyInProgress(channelId(alice))))
+  }
+
+  test("recv CMD_CLOSE (while waiting for a RevokeAndAck)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    // actual test begins
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[Shutdown]
+    awaitCond(alice.stateName == NORMAL)
+  }
+
+  test("recv Shutdown (no pending htlcs)") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, Shutdown("00" * 32, Bob.channelParams.defaultFinalScriptPubKey))
+    alice2bob.expectMsgType[Shutdown]
+    alice2bob.expectMsgType[ClosingSigned]
+    awaitCond(alice.stateName == NEGOTIATING)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_NEGOTIATING].channelId)
+  }
+
+  test("recv Shutdown (with unacked sent htlcs)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    sender.send(bob, CMD_CLOSE(None))
+    bob2alice.expectMsgType[Shutdown]
+    // actual test begins
+    bob2alice.forward(alice)
+    // alice sends a new sig
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    // bob replies with a revocation
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+    // as soon as alice as received the revocation, she will send her shutdown message
+    alice2bob.expectMsgType[Shutdown]
+    awaitCond(alice.stateName == SHUTDOWN)
+    // channel should be advertised as down
+    assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_SHUTDOWN].channelId)
+  }
+
+  test("recv Shutdown (with unacked received htlcs)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    // actual test begins
+    sender.send(bob, Shutdown("00" * 32, TestConstants.Alice.channelParams.defaultFinalScriptPubKey))
+    bob2alice.expectMsgType[Error]
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+    awaitCond(bob.stateName == CLOSING)
+  }
+
+  test("recv Shutdown (with invalid final script)") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(bob, Shutdown("00" * 32, BinaryData("00112233445566778899")))
+    bob2alice.expectMsgType[Error]
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+    awaitCond(bob.stateName == CLOSING)
+  }
+
+  test("recv Shutdown (with invalid final script and signed htlcs, in response to a Shutdown)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    sender.send(bob, CMD_CLOSE(None))
+    bob2alice.expectMsgType[Shutdown]
+    // actual test begins
+    sender.send(bob, Shutdown("00" * 32, BinaryData("00112233445566778899")))
+    bob2alice.expectMsgType[Error]
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+    awaitCond(bob.stateName == CLOSING)
+  }
+
+  test("recv Shutdown (with signed htlcs)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // actual test begins
+    sender.send(bob, Shutdown("00" * 32, TestConstants.Alice.channelParams.defaultFinalScriptPubKey))
+    bob2alice.expectMsgType[Shutdown]
+    awaitCond(bob.stateName == SHUTDOWN)
+  }
+
+  test("recv Shutdown (while waiting for a RevokeAndAck)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    sender.send(bob, CMD_CLOSE(None))
+    bob2alice.expectMsgType[Shutdown]
+    // actual test begins
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[Shutdown]
+    awaitCond(alice.stateName == SHUTDOWN)
+  }
+
+  test("recv Shutdown (while waiting for a RevokeAndAck with pending outgoing htlc)") { f =>
+    import f._
+    val sender = TestProbe()
+    // let's make bob send a Shutdown message
+    sender.send(bob, CMD_CLOSE(None))
+    bob2alice.expectMsgType[Shutdown]
+    // this is just so we have something to sign
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    // now we can sign
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    // adding an outgoing pending htlc
+    val (r1, htlc1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    // actual test begins
+    // alice eventually gets bob's shutdown
+    bob2alice.forward(alice)
+    // alice can't do anything for now other than waiting for bob to send the revocation
+    alice2bob.expectNoMsg()
+    // bob sends the revocation
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+    // bob will also sign back
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    // then alice can sign the 2nd htlc
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    // and reply to bob's first signature
+    alice2bob.expectMsgType[RevokeAndAck]
+    alice2bob.forward(bob)
+    // bob replies with the 2nd revocation
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+    // then alice can send her shutdown
+    alice2bob.expectMsgType[Shutdown]
+    awaitCond(alice.stateName == SHUTDOWN)
+    // note: bob will sign back a second time, but that is out of our scope
+  }
+
+  test("recv CurrentBlockCount (no htlc timed out)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // actual test begins
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    sender.send(alice, CurrentBlockCount(400143))
+    awaitCond(alice.stateData == initialState)
+  }
+
+  test("recv CurrentBlockCount (an htlc timed out)") { f =>
+    import f._
+    val sender = TestProbe()
+    val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // actual test begins
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val aliceCommitTx = initialState.commitments.localCommit.publishableTxs.commitTx.tx
+    sender.send(alice, CurrentBlockCount(400145))
+    alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
+
+    alice2blockchain.expectMsgType[PublishAsap] // main delayed
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed
+  val watch = alice2blockchain.expectMsgType[WatchConfirmed]
+    assert(watch.event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
+  }
+
+  test("recv CurrentFeerate (when funder, triggers an UpdateFee)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val event = CurrentFeerates(FeeratesPerKw.single(20000))
+    sender.send(alice, event)
+    alice2bob.expectMsg(UpdateFee(initialState.commitments.channelId, event.feeratesPerKw.blocks_2))
+  }
+
+  test("recv CurrentFeerate (when funder, doesn't trigger an UpdateFee)") { f =>
+    import f._
+    val sender = TestProbe()
+    val event = CurrentFeerates(FeeratesPerKw.single(10010))
+    sender.send(alice, event)
+    alice2bob.expectNoMsg(500 millis)
+  }
+
+  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are close)") { f =>
+    import f._
+    val sender = TestProbe()
+    val event = CurrentFeerates(FeeratesPerKw.single(11000))
+    sender.send(bob, event)
+    bob2alice.expectNoMsg(500 millis)
+  }
+
+  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are very different)") { f =>
+    import f._
+    val sender = TestProbe()
+    val event = CurrentFeerates(FeeratesPerKw.single(100))
+    sender.send(bob, event)
+    bob2alice.expectMsgType[Error]
+    bob2blockchain.expectMsgType[PublishAsap] // commit tx
+    bob2blockchain.expectMsgType[PublishAsap] // main delayed
+    bob2blockchain.expectMsgType[WatchConfirmed]
+    awaitCond(bob.stateName == CLOSING)
+  }
+
+  test("recv BITCOIN_FUNDING_SPENT (their commit w/ htlc)") { f =>
+    import f._
+    val sender = TestProbe()
+
+    val (ra1, htlca1) = addHtlc(250000000, alice, bob, alice2bob, bob2alice)
+    val (ra2, htlca2) = addHtlc(100000000, alice, bob, alice2bob, bob2alice)
+    val (ra3, htlca3) = addHtlc(10000, alice, bob, alice2bob, bob2alice)
+    val (rb1, htlcb1) = addHtlc(50000000, bob, alice, bob2alice, alice2bob)
+    val (rb2, htlcb2) = addHtlc(55000000, bob, alice, bob2alice, alice2bob)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    fulfillHtlc(1, ra2, bob, alice, bob2alice, alice2bob)
+    fulfillHtlc(0, rb1, alice, bob, alice2bob, bob2alice)
+
+    // at this point here is the situation from alice pov and what she should do when bob publishes his commit tx:
+    // balances :
+    //    alice's balance : 449 999 990                             => nothing to do
+    //    bob's balance   :  95 000 000                             => nothing to do
+    // htlcs :
+    //    alice -> bob    : 250 000 000 (bob does not have the preimage)   => wait for the timeout and spend
+    //    alice -> bob    : 100 000 000 (bob has the preimage)             => if bob does not use the preimage, wait for the timeout and spend
+    //    alice -> bob    :          10 (dust)                             => won't appear in the commitment tx
+    //    bob -> alice    :  50 000 000 (alice has the preimage)           => spend immediately using the preimage
+    //    bob -> alice    :  55 000 000 (alice does not have the preimage) => nothing to do, bob will get his money back after the timeout
+
+    // bob publishes his current commit tx
+    val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    assert(bobCommitTx.txOut.size == 6) // two main outputs and 4 pending htlcs
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
+
+    // in response to that, alice publishes its claim txes
+    val claimTxes = for (i <- 0 until 4) yield alice2blockchain.expectMsgType[PublishAsap].tx
+    // in addition to its main output, alice can only claim 3 out of 4 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the preimage
+    val amountClaimed = (for (claimHtlcTx <- claimTxes) yield {
+      assert(claimHtlcTx.txIn.size == 1)
+      assert(claimHtlcTx.txOut.size == 1)
+      Transaction.correctlySpends(claimHtlcTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+      claimHtlcTx.txOut(0).amount
+    }).sum
+    // at best we have a little less than 450 000 + 250 000 + 100 000 + 50 000 = 850 000 (because fees)
+    assert(amountClaimed == Satoshi(814840))
+
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0))) // claim-main
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    alice2blockchain.expectNoMsg(1 second)
+
+    awaitCond(alice.stateName == CLOSING)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.isDefined)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.get.claimHtlcSuccessTxs.size == 1)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.get.claimHtlcTimeoutTxs.size == 2)
+  }
+
+  test("recv BITCOIN_FUNDING_SPENT (their *next* commit w/ htlc)") { f =>
+    import f._
+    val sender = TestProbe()
+
+    val (ra1, htlca1) = addHtlc(250000000, alice, bob, alice2bob, bob2alice)
+    val (ra2, htlca2) = addHtlc(100000000, alice, bob, alice2bob, bob2alice)
+    val (ra3, htlca3) = addHtlc(10000, alice, bob, alice2bob, bob2alice)
+    val (rb1, htlcb1) = addHtlc(50000000, bob, alice, bob2alice, alice2bob)
+    val (rb2, htlcb2) = addHtlc(55000000, bob, alice, bob2alice, alice2bob)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    fulfillHtlc(1, ra2, bob, alice, bob2alice, alice2bob)
+    fulfillHtlc(0, rb1, alice, bob, alice2bob, bob2alice)
+    // alice sign but we intercept bob's revocation
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[RevokeAndAck]
+
+    // as far as alice knows, bob currently has two valid unrevoked commitment transactions
+
+    // at this point here is the situation from bob's pov with the latest sig received from alice,
+    // and what alice should do when bob publishes his commit tx:
+    // balances :
+    //    alice's balance : 499 999 990                             => nothing to do
+    //    bob's balance   :  95 000 000                             => nothing to do
+    // htlcs :
+    //    alice -> bob    : 250 000 000 (bob does not have the preimage)   => wait for the timeout and spend
+    //    alice -> bob    : 100 000 000 (bob has the preimage)             => if bob does not use the preimage, wait for the timeout and spend
+    //    alice -> bob    :          10 (dust)                             => won't appear in the commitment tx
+    //    bob -> alice    :  55 000 000 (alice does not have the preimage) => nothing to do, bob will get his money back after the timeout
+
+    // bob publishes his current commit tx
+    val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    assert(bobCommitTx.txOut.size == 5) // two main outputs and 3 pending htlcs
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
+
+    // in response to that, alice publishes its claim txes
+    val claimTxes = for (i <- 0 until 3) yield alice2blockchain.expectMsgType[PublishAsap].tx
+    // in addition to its main output, alice can only claim 2 out of 3 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the preimage
+    val amountClaimed = (for (claimHtlcTx <- claimTxes) yield {
+      assert(claimHtlcTx.txIn.size == 1)
+      assert(claimHtlcTx.txOut.size == 1)
+      Transaction.correctlySpends(claimHtlcTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+      claimHtlcTx.txOut(0).amount
+    }).sum
+    // at best we have a little less than 500 000 + 250 000 + 100 000 = 850 000 (because fees)
+    assert(amountClaimed == Satoshi(822280))
+
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0))) // claim-main
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    alice2blockchain.expectNoMsg(1 second)
+
+    awaitCond(alice.stateName == CLOSING)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.isDefined)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.get.claimHtlcSuccessTxs.size == 0)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.get.claimHtlcTimeoutTxs.size == 2)
+  }
+
+  test("recv BITCOIN_FUNDING_SPENT (revoked commit)") { f =>
+    import f._
+    val sender = TestProbe()
+
+    // initially we have :
+    // alice = 800 000
+    //   bob = 200 000
+    def send(): Transaction = {
+      // alice sends 8 000 sat
+      val (r, htlc) = addHtlc(10000000, alice, bob, alice2bob, bob2alice)
       crossSign(alice, bob, alice2bob, bob2alice)
 
-      sender.send(bob, add)
-      sender.expectMsg("ok")
-      bob2alice.expectMsgType[UpdateAddHtlc]
-      bob2alice.forward(alice)
-      sender.send(bob, add)
-      sender.expectMsg("ok")
-      bob2alice.expectMsgType[UpdateAddHtlc]
-      bob2alice.forward(alice)
-
-      // actual test starts here
-      sender.send(bob, CMD_SIGN)
-      sender.expectMsg("ok")
-      val commitSig = bob2alice.expectMsgType[CommitSig]
-      assert(commitSig.htlcSignatures.toSet.size == 4)
-    }
-  }
-
-  test("recv CMD_SIGN (htlcs with same pubkeyScript but different amounts)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val add = CMD_ADD_HTLC(10000000, "11" * 32, 400144)
-      val epsilons = List(3, 1, 5, 7, 6) // unordered on purpose
-      val htlcCount = epsilons.size
-      for (i <- epsilons) {
-        sender.send(alice, add.copy(amountMsat = add.amountMsat + i * 1000))
-        sender.expectMsg("ok")
-        alice2bob.expectMsgType[UpdateAddHtlc]
-        alice2bob.forward(bob)
-      }
-      // actual test starts here
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      val commitSig = alice2bob.expectMsgType[CommitSig]
-      assert(commitSig.htlcSignatures.toSet.size == htlcCount)
-      alice2bob.forward(bob)
-      awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs.size == htlcCount)
-      val htlcTxs = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs
-      val amounts = htlcTxs.map(_.txinfo.tx.txOut.head.amount.toLong)
-      assert(amounts === amounts.sorted)
-    }
-  }
-
-  test("recv CMD_SIGN (no changes)") { case (alice, _, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, CMD_SIGN)
-      sender.expectNoMsg(1 second) // just ignored
-      //sender.expectMsg("cannot sign when there are no changes")
-    }
-  }
-
-  test("recv CMD_SIGN (while waiting for RevokeAndAck (no pending changes)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isLeft)
-      val waitForRevocation = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.left.toOption.get
-      assert(waitForRevocation.reSignAsap === false)
-
-      // actual test starts here
-      sender.send(alice, CMD_SIGN)
-      sender.expectNoMsg(300 millis)
-      assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo === Left(waitForRevocation))
-    }
-  }
-
-  test("recv CMD_SIGN (while waiting for RevokeAndAck (with pending changes)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r1, htlc1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isLeft)
-      val waitForRevocation = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.left.toOption.get
-      assert(waitForRevocation.reSignAsap === false)
-
-      // actual test starts here
-      val (r2, htlc2) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      sender.send(alice, CMD_SIGN)
-      sender.expectNoMsg(300 millis)
-      assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo === Left(waitForRevocation.copy(reSignAsap = true)))
-    }
-  }
-
-  test("recv CommitSig (one htlc received)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-
-      // actual test begins
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-
-      bob2alice.expectMsgType[RevokeAndAck]
-      // bob replies immediately with a signature
-      bob2alice.expectMsgType[CommitSig]
-
-      awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.htlcs.exists(h => h.add.id == htlc.id && h.direction == IN))
-      assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs.size == 1)
-      assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.toLocalMsat == initialState.commitments.localCommit.spec.toLocalMsat)
-      assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteChanges.acked.size == 0)
-      assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteChanges.signed.size == 1)
-    }
-  }
-
-  test("recv CommitSig (one htlc sent)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      bob2alice.expectMsgType[RevokeAndAck]
-      bob2alice.forward(alice)
-
-      // actual test begins (note that channel sends a CMD_SIGN to itself when it receives RevokeAndAck and there are changes)
-      bob2alice.expectMsgType[CommitSig]
-      bob2alice.forward(alice)
-
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.htlcs.exists(h => h.add.id == htlc.id && h.direction == OUT))
-      assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs.size == 1)
-      assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.toLocalMsat == initialState.commitments.localCommit.spec.toLocalMsat)
-    }
-  }
-
-  test("recv CommitSig (multiple htlcs in both directions)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      val (r1, htlc1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice) // a->b (regular)
-
-      val (r2, htlc2) = addHtlc(8000000, alice, bob, alice2bob, bob2alice) //  a->b (regular)
-
-      val (r3, htlc3) = addHtlc(300000, bob, alice, bob2alice, alice2bob) //   b->a (dust)
-
-      val (r4, htlc4) = addHtlc(1000000, alice, bob, alice2bob, bob2alice) //  a->b (regular)
-
-      val (r5, htlc5) = addHtlc(50000000, bob, alice, bob2alice, alice2bob) // b->a (regular)
-
-      val (r6, htlc6) = addHtlc(500000, alice, bob, alice2bob, bob2alice) //   a->b (dust)
-
-      val (r7, htlc7) = addHtlc(4000000, bob, alice, bob2alice, alice2bob) //  b->a (regular)
-
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      bob2alice.expectMsgType[RevokeAndAck]
-      bob2alice.forward(alice)
-
-      // actual test begins
-      bob2alice.expectMsgType[CommitSig]
-      bob2alice.forward(alice)
-
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.index == 1)
-      assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs.size == 3)
-    }
-  }
-
-  test("recv CommitSig (only fee update)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      sender.send(alice, CMD_UPDATE_FEE(TestConstants.feeratePerKw + 1000, commit = false))
-      sender.expectMsg("ok")
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-
-      // actual test begins (note that channel sends a CMD_SIGN to itself when it receives RevokeAndAck and there are changes)
-      alice2bob.expectMsgType[UpdateFee]
-      alice2bob.forward(bob)
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      bob2alice.expectMsgType[RevokeAndAck]
-      bob2alice.forward(alice)
-    }
-  }
-
-  test("recv CommitSig (two htlcs received with same r)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val r = BinaryData("42" * 32)
-      val h: BinaryData = Crypto.sha256(r)
-
-      sender.send(alice, CMD_ADD_HTLC(50000000, h, 400144))
-      sender.expectMsg("ok")
-      val htlc1 = alice2bob.expectMsgType[UpdateAddHtlc]
-      alice2bob.forward(bob)
-
-      sender.send(alice, CMD_ADD_HTLC(50000000, h, 400144))
-      sender.expectMsg("ok")
-      val htlc2 = alice2bob.expectMsgType[UpdateAddHtlc]
-      alice2bob.forward(bob)
-
-      awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteChanges.proposed == htlc1 :: htlc2 :: Nil)
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-
-      crossSign(alice, bob, alice2bob, bob2alice)
-      awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.htlcs.exists(h => h.add.id == htlc1.id && h.direction == IN))
-      assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.htlcTxsAndSigs.size == 2)
-      assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.toLocalMsat == initialState.commitments.localCommit.spec.toLocalMsat)
-      assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx.txOut.count(_.amount == Satoshi(50000)) == 2)
-    }
-  }
-
-  test("recv CommitSig (no changes)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, relayer) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      // signature is invalid but it doesn't matter
-      sender.send(bob, CommitSig("00" * 32, "00" * 64, Nil))
-      bob2alice.expectMsgType[Error]
-      awaitCond(bob.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv CommitSig (invalid signature)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-
-      // actual test begins
-      sender.send(bob, CommitSig("00" * 32, "00" * 64, Nil))
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data).startsWith("invalid commitment signature"))
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv CommitSig (bad htlc sig count)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      val commitSig = alice2bob.expectMsgType[CommitSig]
-
-      // actual test begins
-      val badCommitSig = commitSig.copy(htlcSignatures = commitSig.htlcSignatures ::: commitSig.htlcSignatures)
-      sender.send(bob, badCommitSig)
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === HtlcSigCountMismatch(channelId(bob), expected = 1, actual = 2).getMessage)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv CommitSig (invalid htlc sig)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      val commitSig = alice2bob.expectMsgType[CommitSig]
-
-      // actual test begins
-      val badCommitSig = commitSig.copy(htlcSignatures = commitSig.signature :: Nil)
-      sender.send(bob, badCommitSig)
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data).startsWith("invalid htlc signature"))
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-
-  test("recv RevokeAndAck (one htlc sent)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-
-      // actual test begins
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isLeft)
-      bob2alice.expectMsgType[RevokeAndAck]
-      bob2alice.forward(alice)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localChanges.acked.size == 1)
-    }
-  }
-
-  test("recv RevokeAndAck (one htlc received)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      bob2alice.expectMsgType[RevokeAndAck]
-      bob2alice.forward(alice)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
-
-      bob2alice.expectMsgType[CommitSig]
-      bob2alice.forward(alice)
-
-      // actual test begins
-      alice2bob.expectMsgType[RevokeAndAck]
-      alice2bob.forward(bob)
-      awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
-    }
-  }
-
-  test("recv RevokeAndAck (multiple htlcs in both directions)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r1, htlc1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice) // a->b (regular)
-
-      val (r2, htlc2) = addHtlc(8000000, alice, bob, alice2bob, bob2alice) //  a->b (regular)
-
-      val (r3, htlc3) = addHtlc(300000, bob, alice, bob2alice, alice2bob) //   b->a (dust)
-
-      val (r4, htlc4) = addHtlc(1000000, alice, bob, alice2bob, bob2alice) //  a->b (regular)
-
-      val (r5, htlc5) = addHtlc(50000000, bob, alice, bob2alice, alice2bob) // b->a (regular)
-
-      val (r6, htlc6) = addHtlc(500000, alice, bob, alice2bob, bob2alice) //   a->b (dust)
-
-      val (r7, htlc7) = addHtlc(4000000, bob, alice, bob2alice, alice2bob) //  b->a (regular)
-
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      bob2alice.expectMsgType[RevokeAndAck]
-      bob2alice.forward(alice)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
-
-      bob2alice.expectMsgType[CommitSig]
-      bob2alice.forward(alice)
-
-      // actual test begins
-      alice2bob.expectMsgType[RevokeAndAck]
-      alice2bob.forward(bob)
-
-      awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
-      assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteCommit.index == 1)
-      assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteCommit.spec.htlcs.size == 7)
-    }
-  }
-
-  test("recv RevokeAndAck (with reSignAsap=true)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r1, htlc1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      val (r2, htlc2) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      sender.send(alice, CMD_SIGN)
-      sender.expectNoMsg(300 millis)
-      assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.left.toOption.get.reSignAsap === true)
-
-      // actual test starts here
-      bob2alice.expectMsgType[RevokeAndAck]
-      bob2alice.forward(alice)
-      alice2bob.expectMsgType[CommitSig]
-    }
-  }
-
-  test("recv RevokeAndAck (invalid preimage)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, relayer) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-
-      // actual test begins
-      bob2alice.expectMsgType[RevokeAndAck]
-      sender.send(alice, RevokeAndAck("00" * 32, Scalar("11" * 32), Scalar("22" * 32).toPoint))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv RevokeAndAck (unexpectedly)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, relayer) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.remoteNextCommitInfo.isRight)
-      sender.send(alice, RevokeAndAck("00" * 32, Scalar("11" * 32), Scalar("22" * 32).toPoint))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv CMD_FULFILL_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      // actual test begins
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(bob, CMD_FULFILL_HTLC(htlc.id, r))
-      sender.expectMsg("ok")
-      val fulfill = bob2alice.expectMsgType[UpdateFulfillHtlc]
-      awaitCond(bob.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fulfill))))
-    }
-  }
-
-  test("recv CMD_FULFILL_HTLC (unknown htlc id)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val r: BinaryData = "11" * 32
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-
-      sender.send(bob, CMD_FULFILL_HTLC(42, r))
-      sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
-      assert(initialState == bob.stateData)
-    }
-  }
-
-  test("recv CMD_FULFILL_HTLC (invalid preimage)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      // actual test begins
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(bob, CMD_FULFILL_HTLC(htlc.id, "00" * 32))
-      sender.expectMsg(Failure(InvalidHtlcPreimage(channelId(bob), 0)))
-      assert(initialState == bob.stateData)
-    }
-  }
-
-  test("recv UpdateFulfillHtlc") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-      sender.send(bob, CMD_FULFILL_HTLC(htlc.id, r))
-      sender.expectMsg("ok")
-      val fulfill = bob2alice.expectMsgType[UpdateFulfillHtlc]
-
-      // actual test begins
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      bob2alice.forward(alice)
-      awaitCond(alice.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fulfill))))
-    }
-  }
-
-  test("recv UpdateFulfillHtlc (sender has not signed htlc)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-
-      // actual test begins
-      val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      sender.send(alice, UpdateFulfillHtlc("00" * 32, htlc.id, r))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv UpdateFulfillHtlc (unknown htlc id)") { case (alice, _, alice2bob, _, alice2blockchain, _, relayer) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(alice, UpdateFulfillHtlc("00" * 32, 42, "00" * 32))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv UpdateFulfillHtlc (invalid preimage)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-      val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-
-      // actual test begins
-      sender.send(alice, UpdateFulfillHtlc("00" * 32, htlc.id, "00" * 32))
-      relayer.expectMsgType[ForwardAdd]
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap] // main delayed
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv CMD_FAIL_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      // actual test begins
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(bob, CMD_FAIL_HTLC(htlc.id, Right(PermanentChannelFailure)))
-      sender.expectMsg("ok")
-      val fail = bob2alice.expectMsgType[UpdateFailHtlc]
-      awaitCond(bob.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fail))))
-    }
-  }
-
-  test("recv CMD_FAIL_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val r: BinaryData = "11" * 32
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-
-      sender.send(bob, CMD_FAIL_HTLC(42, Right(PermanentChannelFailure)))
-      sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
-      assert(initialState == bob.stateData)
-    }
-  }
-
-  test("recv CMD_FAIL_MALFORMED_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      // actual test begins
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(bob, CMD_FAIL_MALFORMED_HTLC(htlc.id, Crypto.sha256(htlc.onionRoutingPacket), FailureMessageCodecs.BADONION))
-      sender.expectMsg("ok")
-      val fail = bob2alice.expectMsgType[UpdateFailMalformedHtlc]
-      awaitCond(bob.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fail))))
-    }
-  }
-
-  test("recv CMD_FAIL_MALFORMED_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(bob, CMD_FAIL_MALFORMED_HTLC(42, "00" * 32, FailureMessageCodecs.BADONION))
-      sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
-      assert(initialState == bob.stateData)
-    }
-  }
-
-  test("recv CMD_FAIL_HTLC (invalid failure_code)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(bob, CMD_FAIL_MALFORMED_HTLC(42, "00" * 32, 42))
-      sender.expectMsg(Failure(InvalidFailureCode(channelId(bob))))
-      assert(initialState == bob.stateData)
-    }
-  }
-
-  test("recv UpdateFailHtlc") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      sender.send(bob, CMD_FAIL_HTLC(htlc.id, Right(PermanentChannelFailure)))
-      sender.expectMsg("ok")
-      val fail = bob2alice.expectMsgType[UpdateFailHtlc]
-
-      // actual test begins
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      bob2alice.forward(alice)
-      awaitCond(alice.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fail))))
-    }
-  }
-
-  test("recv UpdateFailMalformedHtlc") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      // Alice sends an HTLC to Bob, which they both sign
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      // Bob fails the HTLC because he cannot parse it
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(bob, CMD_FAIL_MALFORMED_HTLC(htlc.id, Crypto.sha256(htlc.onionRoutingPacket), FailureMessageCodecs.BADONION))
-      sender.expectMsg("ok")
-      val fail = bob2alice.expectMsgType[UpdateFailMalformedHtlc]
-      bob2alice.forward(alice)
-
-      awaitCond(alice.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fail))))
-
-      sender.send(bob, CMD_SIGN)
-      val sig = bob2alice.expectMsgType[CommitSig]
-      // Bob should not have the htlc in its remote commit anymore
-      assert(sig.htlcSignatures.isEmpty)
-
-      // and Alice should accept this signature
-      bob2alice.forward(alice)
-      alice2bob.expectMsgType[RevokeAndAck]
-    }
-  }
-
-  test("recv UpdateFailMalformedHtlc (invalid failure_code)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      // actual test begins
-      val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val fail = UpdateFailMalformedHtlc("00" * 32, htlc.id, Crypto.sha256(htlc.onionRoutingPacket), 42)
-      sender.send(alice, fail)
-      val error = alice2bob.expectMsgType[Error]
-      assert(new String(error.data) === InvalidFailureCode("00" * 32).getMessage)
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      alice2blockchain.expectMsgType[PublishAsap] // main delayed
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv UpdateFailHtlc (sender has not signed htlc)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-
-      // actual test begins
-      val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      sender.send(alice, UpdateFailHtlc("00" * 32, htlc.id, "00" * 152))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
+      bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    }
+
+    val txs = for (i <- 0 until 10) yield send()
+    // bob now has 10 spendable tx, 9 of them being revoked
+
+    // let's say that bob published this tx
+    val revokedTx = txs(3)
+    // channel state for this revoked tx is as follows:
+    // alice = 760 000
+    //   bob = 200 000
+    //  a->b =  10 000
+    //  a->b =  10 000
+    //  a->b =  10 000
+    //  a->b =  10 000
+    // two main outputs + 4 htlc
+    assert(revokedTx.txOut.size == 6)
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, revokedTx)
+    alice2bob.expectMsgType[Error]
+
+    val mainTx = alice2blockchain.expectMsgType[PublishAsap].tx
+    val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
+    val htlcPenaltyTxs = for (i <- 0 until 4) yield alice2blockchain.expectMsgType[PublishAsap].tx
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(revokedTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(mainTx))
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // main-penalty
+    // let's make sure that htlc-penalty txs each spend a different output
+    assert(htlcPenaltyTxs.map(_.txIn.head.outPoint.index).toSet.size === htlcPenaltyTxs.size)
+    htlcPenaltyTxs.foreach(htlcPenaltyTx => assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT))
+    alice2blockchain.expectNoMsg(1 second)
+
+    Transaction.correctlySpends(mainTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(mainPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    htlcPenaltyTxs.foreach(htlcPenaltyTx => Transaction.correctlySpends(htlcPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS))
+
+    // two main outputs are 760 000 and 200 000
+    assert(mainTx.txOut(0).amount == Satoshi(741490))
+    assert(mainPenaltyTx.txOut(0).amount == Satoshi(195150))
+    assert(htlcPenaltyTxs(0).txOut(0).amount == Satoshi(4530))
+    assert(htlcPenaltyTxs(1).txOut(0).amount == Satoshi(4530))
+    assert(htlcPenaltyTxs(2).txOut(0).amount == Satoshi(4530))
+    assert(htlcPenaltyTxs(3).txOut(0).amount == Satoshi(4530))
+
+    awaitCond(alice.stateName == CLOSING)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 1)
+
+  }
+
+  test("recv BITCOIN_FUNDING_SPENT (revoked commit with identical htlcs)") { f =>
+    import f._
+    val sender = TestProbe()
+
+    // initially we have :
+    // alice = 800 000
+    //   bob = 200 000
+
+    val add = CMD_ADD_HTLC(10000000, "11" * 32, 400144)
+    sender.send(alice, add)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    alice2bob.forward(bob)
+    sender.send(alice, add)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    alice2bob.forward(bob)
+
+    crossSign(alice, bob, alice2bob, bob2alice)
+    // bob will publish this tx after it is revoked
+    val revokedTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+
+    sender.send(alice, add)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    alice2bob.forward(bob)
+
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // channel state for this revoked tx is as follows:
+    // alice = 780 000
+    //   bob = 200 000
+    //  a->b =  10 000
+    //  a->b =  10 000
+    assert(revokedTx.txOut.size == 4)
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, revokedTx)
+    alice2bob.expectMsgType[Error]
+
+    val mainTx = alice2blockchain.expectMsgType[PublishAsap].tx
+    val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
+    val htlcPenaltyTxs = for (i <- 0 until 2) yield alice2blockchain.expectMsgType[PublishAsap].tx
+    // let's make sure that htlc-penalty txs each spend a different output
+    assert(htlcPenaltyTxs.map(_.txIn.head.outPoint.index).toSet.size === htlcPenaltyTxs.size)
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(revokedTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(mainTx))
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // main-penalty
+    htlcPenaltyTxs.foreach(htlcPenaltyTx => assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT))
+    alice2blockchain.expectNoMsg(1 second)
+
+    Transaction.correctlySpends(mainTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(mainPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    htlcPenaltyTxs.foreach(htlcPenaltyTx => Transaction.correctlySpends(htlcPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS))
+  }
 
-  test("recv UpdateFailHtlc (unknown htlc id)") { case (alice, _, alice2bob, _, alice2blockchain, _, relayer) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(alice, UpdateFailHtlc("00" * 32, 42, "00" * 152))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv CMD_UPDATE_FEE") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(alice, CMD_UPDATE_FEE(20000))
-      sender.expectMsg("ok")
-      val fee = alice2bob.expectMsgType[UpdateFee]
-      awaitCond(alice.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fee))))
-    }
-  }
-
-  test("recv CMD_UPDATE_FEE (two in a row)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(alice, CMD_UPDATE_FEE(20000))
-      sender.expectMsg("ok")
-      val fee1 = alice2bob.expectMsgType[UpdateFee]
-      sender.send(alice, CMD_UPDATE_FEE(30000))
-      sender.expectMsg("ok")
-      val fee2 = alice2bob.expectMsgType[UpdateFee]
-      awaitCond(alice.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fee2))))
-    }
-  }
-
-  test("recv CMD_UPDATE_FEE (when fundee)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(bob, CMD_UPDATE_FEE(20000))
-      sender.expectMsg(Failure(FundeeCannotSendUpdateFee(channelId(bob))))
-      assert(initialState == bob.stateData)
-    }
-  }
-
-  test("recv UpdateFee") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val initialData = bob.stateData.asInstanceOf[DATA_NORMAL]
-      val fee1 = UpdateFee("00" * 32, 12000)
-      bob ! fee1
-      val fee2 = UpdateFee("00" * 32, 14000)
-      bob ! fee2
-      awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ fee2), remoteNextHtlcId = 0)))
-    }
-  }
-
-  test("recv UpdateFee (two in a row)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val initialData = bob.stateData.asInstanceOf[DATA_NORMAL]
-      val fee = UpdateFee("00" * 32, 12000)
-      bob ! fee
-      awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ fee), remoteNextHtlcId = 0)))
-    }
-  }
-
-  test("recv UpdateFee (when sender is not funder)") { case (alice, _, alice2bob, _, alice2blockchain, _, relayer) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(alice, UpdateFee("00" * 32, 12000))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv UpdateFee (sender can't afford it)") { case (_, bob, _, bob2alice, _, bob2blockchain, relayer) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      val fee = UpdateFee("00" * 32, 100000000)
-      // we first update the global variable so that we don't trigger a 'fee too different' error
-      Globals.feeratesPerKw.set(FeeratesPerKw.single(fee.feeratePerKw))
-      sender.send(bob, fee)
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === CannotAffordFees(channelId(bob), missingSatoshis = 71620000L, reserveSatoshis = 20000L, feesSatoshis = 72400000L).getMessage)
-      awaitCond(bob.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      //bob2blockchain.expectMsgType[PublishAsap] // main delayed (removed because of the high fees)
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv UpdateFee (local/remote feerates are too different)") { case (_, bob, _, bob2alice, _, bob2blockchain, relayer) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(bob, UpdateFee("00" * 32, 85000))
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === "local/remote feerates are too different: remoteFeeratePerKw=85000 localFeeratePerKw=10000")
-      awaitCond(bob.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv UpdateFee (remote feerate is too small)") { case (_, bob, _, bob2alice, _, bob2blockchain, relayer) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(bob, UpdateFee("00" * 32, 252))
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === "remote fee rate is too small: remoteFeeratePerKw=252")
-      awaitCond(bob.stateName == CLOSING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === bob.stateData.asInstanceOf[DATA_CLOSING].channelId)
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv CMD_UPDATE_RELAY_FEE ") { case (alice, bob, alice2bob, bob2alice, _, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val newFeeBaseMsat = TestConstants.Alice.nodeParams.feeBaseMsat * 2
-      val newFeeProportionalMillionth = TestConstants.Alice.nodeParams.feeProportionalMillionth * 2
-      sender.send(alice, CMD_UPDATE_RELAY_FEE(newFeeBaseMsat, newFeeProportionalMillionth))
-      sender.expectMsg("ok")
-
-      val localUpdate = relayer.expectMsgType[LocalChannelUpdate]
-      assert(localUpdate.channelUpdate.feeBaseMsat == newFeeBaseMsat)
-      assert(localUpdate.channelUpdate.feeProportionalMillionths == newFeeProportionalMillionth)
-      relayer.expectNoMsg(1 seconds)
-    }
-  }
-
-  test("recv CMD_CLOSE (no pending htlcs)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isEmpty)
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[Shutdown]
-      awaitCond(alice.stateName == NORMAL)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isDefined)
-    }
-  }
-
-  test("recv CMD_CLOSE (with unacked sent htlcs)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg(Failure(CannotCloseWithUnsignedOutgoingHtlcs(channelId(bob))))
-    }
-  }
-
-  test("recv CMD_CLOSE (with invalid final script)") { case (alice, _, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, CMD_CLOSE(Some(BinaryData("00112233445566778899"))))
-      sender.expectMsg(Failure(InvalidFinalScript(channelId(alice))))
-    }
-  }
-
-  test("recv CMD_CLOSE (with signed sent htlcs)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[Shutdown]
-      awaitCond(alice.stateName == NORMAL)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isDefined)
-    }
-  }
-
-  test("recv CMD_CLOSE (two in a row)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isEmpty)
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[Shutdown]
-      awaitCond(alice.stateName == NORMAL)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].localShutdown.isDefined)
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg(Failure(ClosingAlreadyInProgress(channelId(alice))))
-    }
-  }
-
-  test("recv CMD_CLOSE (while waiting for a RevokeAndAck)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      // actual test begins
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[Shutdown]
-      awaitCond(alice.stateName == NORMAL)
-    }
-  }
-
-  test("recv Shutdown (no pending htlcs)") { case (alice, _, alice2bob, _, _, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, Shutdown("00" * 32, Bob.channelParams.defaultFinalScriptPubKey))
-      alice2bob.expectMsgType[Shutdown]
-      alice2bob.expectMsgType[ClosingSigned]
-      awaitCond(alice.stateName == NEGOTIATING)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_NEGOTIATING].channelId)
-    }
-  }
-
-  test("recv Shutdown (with unacked sent htlcs)") { case (alice, bob, alice2bob, bob2alice, _, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      sender.send(bob, CMD_CLOSE(None))
-      bob2alice.expectMsgType[Shutdown]
-      // actual test begins
-      bob2alice.forward(alice)
-      // alice sends a new sig
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      // bob replies with a revocation
-      bob2alice.expectMsgType[RevokeAndAck]
-      bob2alice.forward(alice)
-      // as soon as alice as received the revocation, she will send her shutdown message
-      alice2bob.expectMsgType[Shutdown]
-      awaitCond(alice.stateName == SHUTDOWN)
-      // channel should be advertised as down
-      assert(relayer.expectMsgType[LocalChannelDown].channelId === alice.stateData.asInstanceOf[DATA_SHUTDOWN].channelId)
-    }
-  }
-
-  test("recv Shutdown (with unacked received htlcs)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      // actual test begins
-      sender.send(bob, Shutdown("00" * 32, TestConstants.Alice.channelParams.defaultFinalScriptPubKey))
-      bob2alice.expectMsgType[Error]
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-      awaitCond(bob.stateName == CLOSING)
-    }
-  }
-
-  test("recv Shutdown (with invalid final script)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(bob, Shutdown("00" * 32, BinaryData("00112233445566778899")))
-      bob2alice.expectMsgType[Error]
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-      awaitCond(bob.stateName == CLOSING)
-    }
-  }
-
-  test("recv Shutdown (with invalid final script and signed htlcs, in response to a Shutdown)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-      sender.send(bob, CMD_CLOSE(None))
-      bob2alice.expectMsgType[Shutdown]
-      // actual test begins
-      sender.send(bob, Shutdown("00" * 32, BinaryData("00112233445566778899")))
-      bob2alice.expectMsgType[Error]
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-      awaitCond(bob.stateName == CLOSING)
-    }
-  }
-
-  test("recv Shutdown (with signed htlcs)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      // actual test begins
-      sender.send(bob, Shutdown("00" * 32, TestConstants.Alice.channelParams.defaultFinalScriptPubKey))
-      bob2alice.expectMsgType[Shutdown]
-      awaitCond(bob.stateName == SHUTDOWN)
-    }
-  }
-
-  test("recv Shutdown (while waiting for a RevokeAndAck)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      sender.send(bob, CMD_CLOSE(None))
-      bob2alice.expectMsgType[Shutdown]
-      // actual test begins
-      bob2alice.forward(alice)
-      alice2bob.expectMsgType[Shutdown]
-      awaitCond(alice.stateName == SHUTDOWN)
-    }
-  }
-
-  test("recv Shutdown (while waiting for a RevokeAndAck with pending outgoing htlc)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      // let's make bob send a Shutdown message
-      sender.send(bob, CMD_CLOSE(None))
-      bob2alice.expectMsgType[Shutdown]
-      // this is just so we have something to sign
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      // now we can sign
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      // adding an outgoing pending htlc
-      val (r1, htlc1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      // actual test begins
-      // alice eventually gets bob's shutdown
-      bob2alice.forward(alice)
-      // alice can't do anything for now other than waiting for bob to send the revocation
-      alice2bob.expectNoMsg()
-      // bob sends the revocation
-      bob2alice.expectMsgType[RevokeAndAck]
-      bob2alice.forward(alice)
-      // bob will also sign back
-      bob2alice.expectMsgType[CommitSig]
-      bob2alice.forward(alice)
-      // then alice can sign the 2nd htlc
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      // and reply to bob's first signature
-      alice2bob.expectMsgType[RevokeAndAck]
-      alice2bob.forward(bob)
-      // bob replies with the 2nd revocation
-      bob2alice.expectMsgType[RevokeAndAck]
-      bob2alice.forward(alice)
-      // then alice can send her shutdown
-      alice2bob.expectMsgType[Shutdown]
-      awaitCond(alice.stateName == SHUTDOWN)
-      // note: bob will sign back a second time, but that is out of our scope
-    }
-  }
-
-  test("recv CurrentBlockCount (no htlc timed out)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      // actual test begins
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      sender.send(alice, CurrentBlockCount(400143))
-      awaitCond(alice.stateData == initialState)
-    }
-  }
-
-  test("recv CurrentBlockCount (an htlc timed out)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val (r, htlc) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      // actual test begins
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val aliceCommitTx = initialState.commitments.localCommit.publishableTxs.commitTx.tx
-      sender.send(alice, CurrentBlockCount(400145))
-      alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
-
-      alice2blockchain.expectMsgType[PublishAsap] // main delayed
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed
-      val watch = alice2blockchain.expectMsgType[WatchConfirmed]
-      assert(watch.event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
-    }
-  }
-
-  test("recv CurrentFeerate (when funder, triggers an UpdateFee)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val event = CurrentFeerates(FeeratesPerKw.single(20000))
-      sender.send(alice, event)
-      alice2bob.expectMsg(UpdateFee(initialState.commitments.channelId, event.feeratesPerKw.blocks_2))
-    }
-  }
-
-  test("recv CurrentFeerate (when funder, doesn't trigger an UpdateFee)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val event = CurrentFeerates(FeeratesPerKw.single(10010))
-      sender.send(alice, event)
-      alice2bob.expectNoMsg(500 millis)
-    }
-  }
-
-  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are close)") { case (_, bob, _, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val event = CurrentFeerates(FeeratesPerKw.single(11000))
-      sender.send(bob, event)
-      bob2alice.expectNoMsg(500 millis)
-    }
-  }
-
-  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are very different)") { case (_, bob, _, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val event = CurrentFeerates(FeeratesPerKw.single(100))
-      sender.send(bob, event)
-      bob2alice.expectMsgType[Error]
-      bob2blockchain.expectMsgType[PublishAsap] // commit tx
-      bob2blockchain.expectMsgType[PublishAsap] // main delayed
-      bob2blockchain.expectMsgType[WatchConfirmed]
-      awaitCond(bob.stateName == CLOSING)
-    }
-  }
-
-  test("recv BITCOIN_FUNDING_SPENT (their commit w/ htlc)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      val (ra1, htlca1) = addHtlc(250000000, alice, bob, alice2bob, bob2alice)
-      val (ra2, htlca2) = addHtlc(100000000, alice, bob, alice2bob, bob2alice)
-      val (ra3, htlca3) = addHtlc(10000, alice, bob, alice2bob, bob2alice)
-      val (rb1, htlcb1) = addHtlc(50000000, bob, alice, bob2alice, alice2bob)
-      val (rb2, htlcb2) = addHtlc(55000000, bob, alice, bob2alice, alice2bob)
-      crossSign(alice, bob, alice2bob, bob2alice)
-      fulfillHtlc(1, ra2, bob, alice, bob2alice, alice2bob)
-      fulfillHtlc(0, rb1, alice, bob, alice2bob, bob2alice)
-
-      // at this point here is the situation from alice pov and what she should do when bob publishes his commit tx:
-      // balances :
-      //    alice's balance : 449 999 990                             => nothing to do
-      //    bob's balance   :  95 000 000                             => nothing to do
-      // htlcs :
-      //    alice -> bob    : 250 000 000 (bob does not have the preimage)   => wait for the timeout and spend
-      //    alice -> bob    : 100 000 000 (bob has the preimage)             => if bob does not use the preimage, wait for the timeout and spend
-      //    alice -> bob    :          10 (dust)                             => won't appear in the commitment tx
-      //    bob -> alice    :  50 000 000 (alice has the preimage)           => spend immediately using the preimage
-      //    bob -> alice    :  55 000 000 (alice does not have the preimage) => nothing to do, bob will get his money back after the timeout
-
-      // bob publishes his current commit tx
-      val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      assert(bobCommitTx.txOut.size == 6) // two main outputs and 4 pending htlcs
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
-
-      // in response to that, alice publishes its claim txes
-      val claimTxes = for (i <- 0 until 4) yield alice2blockchain.expectMsgType[PublishAsap].tx
-      // in addition to its main output, alice can only claim 3 out of 4 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the preimage
-      val amountClaimed = (for (claimHtlcTx <- claimTxes) yield {
-        assert(claimHtlcTx.txIn.size == 1)
-        assert(claimHtlcTx.txOut.size == 1)
-        Transaction.correctlySpends(claimHtlcTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-        claimHtlcTx.txOut(0).amount
-      }).sum
-      // at best we have a little less than 450 000 + 250 000 + 100 000 + 50 000 = 850 000 (because fees)
-      assert(amountClaimed == Satoshi(814840))
-
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0))) // claim-main
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      alice2blockchain.expectNoMsg(1 second)
-
-      awaitCond(alice.stateName == CLOSING)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.isDefined)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.get.claimHtlcSuccessTxs.size == 1)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.get.claimHtlcTimeoutTxs.size == 2)
-    }
-  }
-
-  test("recv BITCOIN_FUNDING_SPENT (their *next* commit w/ htlc)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      val (ra1, htlca1) = addHtlc(250000000, alice, bob, alice2bob, bob2alice)
-      val (ra2, htlca2) = addHtlc(100000000, alice, bob, alice2bob, bob2alice)
-      val (ra3, htlca3) = addHtlc(10000, alice, bob, alice2bob, bob2alice)
-      val (rb1, htlcb1) = addHtlc(50000000, bob, alice, bob2alice, alice2bob)
-      val (rb2, htlcb2) = addHtlc(55000000, bob, alice, bob2alice, alice2bob)
-      crossSign(alice, bob, alice2bob, bob2alice)
-      fulfillHtlc(1, ra2, bob, alice, bob2alice, alice2bob)
-      fulfillHtlc(0, rb1, alice, bob, alice2bob, bob2alice)
-      // alice sign but we intercept bob's revocation
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      bob2alice.expectMsgType[RevokeAndAck]
-
-      // as far as alice knows, bob currently has two valid unrevoked commitment transactions
-
-      // at this point here is the situation from bob's pov with the latest sig received from alice,
-      // and what alice should do when bob publishes his commit tx:
-      // balances :
-      //    alice's balance : 499 999 990                             => nothing to do
-      //    bob's balance   :  95 000 000                             => nothing to do
-      // htlcs :
-      //    alice -> bob    : 250 000 000 (bob does not have the preimage)   => wait for the timeout and spend
-      //    alice -> bob    : 100 000 000 (bob has the preimage)             => if bob does not use the preimage, wait for the timeout and spend
-      //    alice -> bob    :          10 (dust)                             => won't appear in the commitment tx
-      //    bob -> alice    :  55 000 000 (alice does not have the preimage) => nothing to do, bob will get his money back after the timeout
-
-      // bob publishes his current commit tx
-      val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      assert(bobCommitTx.txOut.size == 5) // two main outputs and 3 pending htlcs
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
-
-      // in response to that, alice publishes its claim txes
-      val claimTxes = for (i <- 0 until 3) yield alice2blockchain.expectMsgType[PublishAsap].tx
-      // in addition to its main output, alice can only claim 2 out of 3 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the preimage
-      val amountClaimed = (for (claimHtlcTx <- claimTxes) yield {
-        assert(claimHtlcTx.txIn.size == 1)
-        assert(claimHtlcTx.txOut.size == 1)
-        Transaction.correctlySpends(claimHtlcTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-        claimHtlcTx.txOut(0).amount
-      }).sum
-      // at best we have a little less than 500 000 + 250 000 + 100 000 = 850 000 (because fees)
-      assert(amountClaimed == Satoshi(822280))
-
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0))) // claim-main
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      alice2blockchain.expectNoMsg(1 second)
-
-      awaitCond(alice.stateName == CLOSING)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.isDefined)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.get.claimHtlcSuccessTxs.size == 0)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.get.claimHtlcTimeoutTxs.size == 2)
-    }
-  }
-
-  test("recv BITCOIN_FUNDING_SPENT (revoked commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      // initially we have :
-      // alice = 800 000
-      //   bob = 200 000
-      def send(): Transaction = {
-        // alice sends 8 000 sat
-        val (r, htlc) = addHtlc(10000000, alice, bob, alice2bob, bob2alice)
-        crossSign(alice, bob, alice2bob, bob2alice)
-
-        bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      }
-
-      val txs = for (i <- 0 until 10) yield send()
-      // bob now has 10 spendable tx, 9 of them being revoked
-
-      // let's say that bob published this tx
-      val revokedTx = txs(3)
-      // channel state for this revoked tx is as follows:
-      // alice = 760 000
-      //   bob = 200 000
-      //  a->b =  10 000
-      //  a->b =  10 000
-      //  a->b =  10 000
-      //  a->b =  10 000
-      // two main outputs + 4 htlc
-      assert(revokedTx.txOut.size == 6)
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, revokedTx)
-      alice2bob.expectMsgType[Error]
-
-      val mainTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      val htlcPenaltyTxs = for (i <- 0 until 4) yield alice2blockchain.expectMsgType[PublishAsap].tx
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(revokedTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(mainTx))
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // main-penalty
-      // let's make sure that htlc-penalty txs each spend a different output
-      assert(htlcPenaltyTxs.map(_.txIn.head.outPoint.index).toSet.size === htlcPenaltyTxs.size)
-      htlcPenaltyTxs.foreach(htlcPenaltyTx => assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT))
-      alice2blockchain.expectNoMsg(1 second)
-
-      Transaction.correctlySpends(mainTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(mainPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      htlcPenaltyTxs.foreach(htlcPenaltyTx => Transaction.correctlySpends(htlcPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS))
-
-      // two main outputs are 760 000 and 200 000
-      assert(mainTx.txOut(0).amount == Satoshi(741490))
-      assert(mainPenaltyTx.txOut(0).amount == Satoshi(195150))
-      assert(htlcPenaltyTxs(0).txOut(0).amount == Satoshi(4530))
-      assert(htlcPenaltyTxs(1).txOut(0).amount == Satoshi(4530))
-      assert(htlcPenaltyTxs(2).txOut(0).amount == Satoshi(4530))
-      assert(htlcPenaltyTxs(3).txOut(0).amount == Satoshi(4530))
-
-      awaitCond(alice.stateName == CLOSING)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 1)
-
-    }
-  }
-
-  test("recv BITCOIN_FUNDING_SPENT (revoked commit with identical htlcs)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-
-      // initially we have :
-      // alice = 800 000
-      //   bob = 200 000
-
-      val add = CMD_ADD_HTLC(10000000, "11" * 32, 400144)
-      sender.send(alice, add)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[UpdateAddHtlc]
-      alice2bob.forward(bob)
-      sender.send(alice, add)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[UpdateAddHtlc]
-      alice2bob.forward(bob)
-
-      crossSign(alice, bob, alice2bob, bob2alice)
-      // bob will publish this tx after it is revoked
-      val revokedTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-
-      sender.send(alice, add)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[UpdateAddHtlc]
-      alice2bob.forward(bob)
-
-      crossSign(alice, bob, alice2bob, bob2alice)
-
-      // channel state for this revoked tx is as follows:
-      // alice = 780 000
-      //   bob = 200 000
-      //  a->b =  10 000
-      //  a->b =  10 000
-      assert(revokedTx.txOut.size == 4)
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, revokedTx)
-      alice2bob.expectMsgType[Error]
-
-      val mainTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      val htlcPenaltyTxs = for (i <- 0 until 2) yield alice2blockchain.expectMsgType[PublishAsap].tx
-      // let's make sure that htlc-penalty txs each spend a different output
-      assert(htlcPenaltyTxs.map(_.txIn.head.outPoint.index).toSet.size === htlcPenaltyTxs.size)
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(revokedTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(mainTx))
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // main-penalty
-      htlcPenaltyTxs.foreach(htlcPenaltyTx => assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT))
-      alice2blockchain.expectNoMsg(1 second)
-
-      Transaction.correctlySpends(mainTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(mainPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      htlcPenaltyTxs.foreach(htlcPenaltyTx => Transaction.correctlySpends(htlcPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS))
-    }
-  }
-
-  test("recv Error") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val (ra1, htlca1) = addHtlc(250000000, alice, bob, alice2bob, bob2alice)
-      val (ra2, htlca2) = addHtlc(100000000, alice, bob, alice2bob, bob2alice)
-      val (ra3, htlca3) = addHtlc(10000, alice, bob, alice2bob, bob2alice)
-      val (rb1, htlcb1) = addHtlc(50000000, bob, alice, bob2alice, alice2bob)
-      val (rb2, htlcb2) = addHtlc(55000000, bob, alice, bob2alice, alice2bob)
-      crossSign(alice, bob, alice2bob, bob2alice)
-      fulfillHtlc(1, ra2, bob, alice, bob2alice, alice2bob)
-      fulfillHtlc(0, rb1, alice, bob, alice2bob, bob2alice)
-
-      // at this point here is the situation from alice pov and what she should do when she publishes his commit tx:
-      // balances :
-      //    alice's balance : 449 999 990                             => nothing to do
-      //    bob's balance   :  95 000 000                             => nothing to do
-      // htlcs :
-      //    alice -> bob    : 250 000 000 (bob does not have the preimage)   => wait for the timeout and spend using 2nd stage htlc-timeout
-      //    alice -> bob    : 100 000 000 (bob has the preimage)             => if bob does not use the preimage, wait for the timeout and spend using 2nd stage htlc-timeout
-      //    alice -> bob    :          10 (dust)                             => won't appear in the commitment tx
-      //    bob -> alice    :  50 000 000 (alice has the preimage)           => spend immediately using the preimage using htlc-success
-      //    bob -> alice    :  55 000 000 (alice does not have the preimage) => nothing to do, bob will get his money back after the timeout
-
-      // an error occurs and alice publishes her commit tx
-      val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! Error("00" * 32, "oops".getBytes())
-      alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
-      assert(aliceCommitTx.txOut.size == 6) // two main outputs and 4 pending htlcs
-
-      // alice can only claim 3 out of 4 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the htlc
-      // so we expect 7 transactions:
-      // - 1 tx to claim the main delayed output
-      // - 3 txes for each htlc
-      // - 3 txes for each delayed output of the claimed htlc
-      val claimTxs = for (i <- 0 until 7) yield alice2blockchain.expectMsgType[PublishAsap].tx
-
-      // the main delayed output spends the commitment transaction
-      Transaction.correctlySpends(claimTxs(0), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-
-      // 2nd stage transactions spend the commitment transaction
-      Transaction.correctlySpends(claimTxs(1), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(claimTxs(2), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(claimTxs(3), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-
-      // 3rd stage transactions spend their respective HTLC-Success/HTLC-Timeout transactions
-      Transaction.correctlySpends(claimTxs(4), claimTxs(1) :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(claimTxs(5), claimTxs(2) :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(claimTxs(6), claimTxs(3) :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(0))) // main-delayed
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(4))) // htlc-delayed
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(5))) // htlc-delayed
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(6))) // htlc-delayed
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      alice2blockchain.expectNoMsg(1 second)
-
-      awaitCond(alice.stateName == CLOSING)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.isDefined)
-      val localCommitPublished = alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.get
-      assert(localCommitPublished.commitTx == aliceCommitTx)
-      assert(localCommitPublished.htlcSuccessTxs.size == 1)
-      assert(localCommitPublished.htlcTimeoutTxs.size == 2)
-      assert(localCommitPublished.claimHtlcDelayedTxs.size == 3)
-    }
-  }
-
-  test("recv BITCOIN_FUNDING_DEEPLYBURIED", Tag("channels_public")) { case (alice, _, alice2bob, _, _, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
-      val annSigs = alice2bob.expectMsgType[AnnouncementSignatures]
-      // public channel: we don't send the channel_update directly to the peer
-      alice2bob.expectNoMsg(1 second)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId == annSigs.shortChannelId && alice.stateData.asInstanceOf[DATA_NORMAL].buried == true)
-      // we don't re-publish the same channel_update if there was no change
-      relayer.expectNoMsg(1 second)
-    }
-  }
-
-  test("recv BITCOIN_FUNDING_DEEPLYBURIED (short channel id changed)", Tag("channels_public")) { case (alice, _, alice2bob, _, _, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400001, 22))
-      val annSigs = alice2bob.expectMsgType[AnnouncementSignatures]
-      // public channel: we don't send the channel_update directly to the peer
-      alice2bob.expectNoMsg(1 second)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId == annSigs.shortChannelId && alice.stateData.asInstanceOf[DATA_NORMAL].buried == true)
-      assert(relayer.expectMsgType[LocalChannelUpdate].shortChannelId == alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId)
-      relayer.expectNoMsg(1 second)
-    }
-  }
-
-  test("recv BITCOIN_FUNDING_DEEPLYBURIED (private channel)") { case (alice, _, alice2bob, _, _, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
-      // private channel: we send the channel_update directly to the peer
-      val channelUpdate = alice2bob.expectMsgType[ChannelUpdate]
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId == channelUpdate.shortChannelId && alice.stateData.asInstanceOf[DATA_NORMAL].buried == true)
-      // we don't re-publish the same channel_update if there was no change
-      relayer.expectNoMsg(1 second)
-    }
-  }
-
-  test("recv BITCOIN_FUNDING_DEEPLYBURIED (private channel, short channel id changed)") { case (alice, _, alice2bob, _, _, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400001, 22))
-      // private channel: we send the channel_update directly to the peer
-      val channelUpdate = alice2bob.expectMsgType[ChannelUpdate]
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId == channelUpdate.shortChannelId && alice.stateData.asInstanceOf[DATA_NORMAL].buried == true)
-      // LocalChannelUpdate should not be published
-      assert(relayer.expectMsgType[LocalChannelUpdate].shortChannelId == alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId)
-      relayer.expectNoMsg(1 second)
-    }
-  }
-
-  test("recv AnnouncementSignatures", Tag("channels_public")) { case (alice, bob, alice2bob, bob2alice, _, _, relayer) =>
-    within(30 seconds) {
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val sender = TestProbe()
-      sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
-      val annSigsA = alice2bob.expectMsgType[AnnouncementSignatures]
-      sender.send(bob, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
-      val annSigsB = bob2alice.expectMsgType[AnnouncementSignatures]
-      import initialState.commitments.{localParams, remoteParams}
-      val channelAnn = Announcements.makeChannelAnnouncement(Alice.nodeParams.chainHash, annSigsA.shortChannelId, Alice.nodeParams.nodeId, remoteParams.nodeId, Alice.keyManager.fundingPublicKey(localParams.channelKeyPath).publicKey, remoteParams.fundingPubKey, annSigsA.nodeSignature, annSigsB.nodeSignature, annSigsA.bitcoinSignature, annSigsB.bitcoinSignature)
-      // actual test starts here
-      bob2alice.forward(alice)
-      awaitCond({
-        val normal = alice.stateData.asInstanceOf[DATA_NORMAL]
-        normal.shortChannelId == annSigsA.shortChannelId && normal.buried && normal.channelAnnouncement == Some(channelAnn) && normal.channelUpdate.shortChannelId == annSigsA.shortChannelId
-      })
-      assert(relayer.expectMsgType[LocalChannelUpdate].channelAnnouncement_opt === Some(channelAnn))
-    }
-  }
-
-  test("recv AnnouncementSignatures (re-send)", Tag("channels_public")) { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-      val sender = TestProbe()
-      sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 42, 10))
-      val annSigsA = alice2bob.expectMsgType[AnnouncementSignatures]
-      sender.send(bob, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 42, 10))
-      val annSigsB = bob2alice.expectMsgType[AnnouncementSignatures]
-      import initialState.commitments.{localParams, remoteParams}
-      val channelAnn = Announcements.makeChannelAnnouncement(Alice.nodeParams.chainHash, annSigsA.shortChannelId, Alice.nodeParams.nodeId, remoteParams.nodeId, Alice.keyManager.fundingPublicKey(localParams.channelKeyPath).publicKey, remoteParams.fundingPubKey, annSigsA.nodeSignature, annSigsB.nodeSignature, annSigsA.bitcoinSignature, annSigsB.bitcoinSignature)
-      bob2alice.forward(alice)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].channelAnnouncement === Some(channelAnn))
-
-      // actual test starts here
-      // simulate bob re-sending its sigs
-      bob2alice.send(alice, annSigsA)
-      // alice re-sends her sigs
-      alice2bob.expectMsg(annSigsA)
-    }
-  }
-
-  test("recv TickRefreshChannelUpdate", Tag("channels_public")) { case (alice, bob, _, bob2alice, _, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
-      sender.send(bob, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
-      bob2alice.expectMsgType[AnnouncementSignatures]
-      bob2alice.forward(alice)
-      val update1 = relayer.expectMsgType[LocalChannelUpdate]
-
-      // actual test starts here
-      Thread.sleep(1100)
-      sender.send(alice, TickRefreshChannelUpdate)
-      val update2 = relayer.expectMsgType[LocalChannelUpdate]
-      assert(update1.channelUpdate.timestamp < update2.channelUpdate.timestamp)
-    }
-  }
-
-  test("recv INPUT_DISCONNECTED", Tag("channels_public")) { case (alice, bob, _, bob2alice, _, _, relayer) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
-      sender.send(bob, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
-      bob2alice.expectMsgType[AnnouncementSignatures]
-      bob2alice.forward(alice)
-      val update1 = relayer.expectMsgType[LocalChannelUpdate]
-      assert(Announcements.isEnabled(update1.channelUpdate.flags) == true)
-
-      // actual test starts here
-      Thread.sleep(1100)
-      sender.send(alice, INPUT_DISCONNECTED)
-      val update2 = relayer.expectMsgType[LocalChannelUpdate]
-      assert(update1.channelUpdate.timestamp < update2.channelUpdate.timestamp)
-      assert(Announcements.isEnabled(update2.channelUpdate.flags) == false)
-      awaitCond(alice.stateName == OFFLINE)
-    }
+  test("recv Error") { f =>
+    import f._
+    val (ra1, htlca1) = addHtlc(250000000, alice, bob, alice2bob, bob2alice)
+    val (ra2, htlca2) = addHtlc(100000000, alice, bob, alice2bob, bob2alice)
+    val (ra3, htlca3) = addHtlc(10000, alice, bob, alice2bob, bob2alice)
+    val (rb1, htlcb1) = addHtlc(50000000, bob, alice, bob2alice, alice2bob)
+    val (rb2, htlcb2) = addHtlc(55000000, bob, alice, bob2alice, alice2bob)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    fulfillHtlc(1, ra2, bob, alice, bob2alice, alice2bob)
+    fulfillHtlc(0, rb1, alice, bob, alice2bob, bob2alice)
+
+    // at this point here is the situation from alice pov and what she should do when she publishes his commit tx:
+    // balances :
+    //    alice's balance : 449 999 990                             => nothing to do
+    //    bob's balance   :  95 000 000                             => nothing to do
+    // htlcs :
+    //    alice -> bob    : 250 000 000 (bob does not have the preimage)   => wait for the timeout and spend using 2nd stage htlc-timeout
+    //    alice -> bob    : 100 000 000 (bob has the preimage)             => if bob does not use the preimage, wait for the timeout and spend using 2nd stage htlc-timeout
+    //    alice -> bob    :          10 (dust)                             => won't appear in the commitment tx
+    //    bob -> alice    :  50 000 000 (alice has the preimage)           => spend immediately using the preimage using htlc-success
+    //    bob -> alice    :  55 000 000 (alice does not have the preimage) => nothing to do, bob will get his money back after the timeout
+
+    // an error occurs and alice publishes her commit tx
+    val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! Error("00" * 32, "oops".getBytes())
+    alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
+    assert(aliceCommitTx.txOut.size == 6) // two main outputs and 4 pending htlcs
+
+    // alice can only claim 3 out of 4 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the htlc
+    // so we expect 7 transactions:
+    // - 1 tx to claim the main delayed output
+    // - 3 txes for each htlc
+    // - 3 txes for each delayed output of the claimed htlc
+    val claimTxs = for (i <- 0 until 7) yield alice2blockchain.expectMsgType[PublishAsap].tx
+
+    // the main delayed output spends the commitment transaction
+    Transaction.correctlySpends(claimTxs(0), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+
+    // 2nd stage transactions spend the commitment transaction
+    Transaction.correctlySpends(claimTxs(1), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(claimTxs(2), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(claimTxs(3), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+
+    // 3rd stage transactions spend their respective HTLC-Success/HTLC-Timeout transactions
+    Transaction.correctlySpends(claimTxs(4), claimTxs(1) :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(claimTxs(5), claimTxs(2) :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(claimTxs(6), claimTxs(3) :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(0))) // main-delayed
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(4))) // htlc-delayed
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(5))) // htlc-delayed
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(6))) // htlc-delayed
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    alice2blockchain.expectNoMsg(1 second)
+
+    awaitCond(alice.stateName == CLOSING)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.isDefined)
+    val localCommitPublished = alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.get
+    assert(localCommitPublished.commitTx == aliceCommitTx)
+    assert(localCommitPublished.htlcSuccessTxs.size == 1)
+    assert(localCommitPublished.htlcTimeoutTxs.size == 2)
+    assert(localCommitPublished.claimHtlcDelayedTxs.size == 3)
+  }
+
+  test("recv BITCOIN_FUNDING_DEEPLYBURIED", Tag("channels_public")) { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
+    val annSigs = alice2bob.expectMsgType[AnnouncementSignatures]
+    // public channel: we don't send the channel_update directly to the peer
+    alice2bob.expectNoMsg(1 second)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId == annSigs.shortChannelId && alice.stateData.asInstanceOf[DATA_NORMAL].buried == true)
+    // we don't re-publish the same channel_update if there was no change
+    relayer.expectNoMsg(1 second)
+  }
+
+  test("recv BITCOIN_FUNDING_DEEPLYBURIED (short channel id changed)", Tag("channels_public")) { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400001, 22))
+    val annSigs = alice2bob.expectMsgType[AnnouncementSignatures]
+    // public channel: we don't send the channel_update directly to the peer
+    alice2bob.expectNoMsg(1 second)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId == annSigs.shortChannelId && alice.stateData.asInstanceOf[DATA_NORMAL].buried == true)
+    assert(relayer.expectMsgType[LocalChannelUpdate].shortChannelId == alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId)
+    relayer.expectNoMsg(1 second)
+  }
+
+  test("recv BITCOIN_FUNDING_DEEPLYBURIED (private channel)") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
+    // private channel: we send the channel_update directly to the peer
+    val channelUpdate = alice2bob.expectMsgType[ChannelUpdate]
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId == channelUpdate.shortChannelId && alice.stateData.asInstanceOf[DATA_NORMAL].buried == true)
+    // we don't re-publish the same channel_update if there was no change
+    relayer.expectNoMsg(1 second)
+  }
+
+  test("recv BITCOIN_FUNDING_DEEPLYBURIED (private channel, short channel id changed)") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400001, 22))
+    // private channel: we send the channel_update directly to the peer
+    val channelUpdate = alice2bob.expectMsgType[ChannelUpdate]
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId == channelUpdate.shortChannelId && alice.stateData.asInstanceOf[DATA_NORMAL].buried == true)
+    // LocalChannelUpdate should not be published
+    assert(relayer.expectMsgType[LocalChannelUpdate].shortChannelId == alice.stateData.asInstanceOf[DATA_NORMAL].shortChannelId)
+    relayer.expectNoMsg(1 second)
+  }
+
+  test("recv AnnouncementSignatures", Tag("channels_public")) { f =>
+    import f._
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val sender = TestProbe()
+    sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
+    val annSigsA = alice2bob.expectMsgType[AnnouncementSignatures]
+    sender.send(bob, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
+    val annSigsB = bob2alice.expectMsgType[AnnouncementSignatures]
+    import initialState.commitments.{localParams, remoteParams}
+    val channelAnn = Announcements.makeChannelAnnouncement(Alice.nodeParams.chainHash, annSigsA.shortChannelId, Alice.nodeParams.nodeId, remoteParams.nodeId, Alice.keyManager.fundingPublicKey(localParams.channelKeyPath).publicKey, remoteParams.fundingPubKey, annSigsA.nodeSignature, annSigsB.nodeSignature, annSigsA.bitcoinSignature, annSigsB.bitcoinSignature)
+    // actual test starts here
+    bob2alice.forward(alice)
+    awaitCond({
+      val normal = alice.stateData.asInstanceOf[DATA_NORMAL]
+      normal.shortChannelId == annSigsA.shortChannelId && normal.buried && normal.channelAnnouncement == Some(channelAnn) && normal.channelUpdate.shortChannelId == annSigsA.shortChannelId
+    })
+    assert(relayer.expectMsgType[LocalChannelUpdate].channelAnnouncement_opt === Some(channelAnn))
+  }
+
+  test("recv AnnouncementSignatures (re-send)", Tag("channels_public")) { f =>
+    import f._
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    val sender = TestProbe()
+    sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 42, 10))
+    val annSigsA = alice2bob.expectMsgType[AnnouncementSignatures]
+    sender.send(bob, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 42, 10))
+    val annSigsB = bob2alice.expectMsgType[AnnouncementSignatures]
+    import initialState.commitments.{localParams, remoteParams}
+    val channelAnn = Announcements.makeChannelAnnouncement(Alice.nodeParams.chainHash, annSigsA.shortChannelId, Alice.nodeParams.nodeId, remoteParams.nodeId, Alice.keyManager.fundingPublicKey(localParams.channelKeyPath).publicKey, remoteParams.fundingPubKey, annSigsA.nodeSignature, annSigsB.nodeSignature, annSigsA.bitcoinSignature, annSigsB.bitcoinSignature)
+    bob2alice.forward(alice)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].channelAnnouncement === Some(channelAnn))
+
+    // actual test starts here
+    // simulate bob re-sending its sigs
+    bob2alice.send(alice, annSigsA)
+    // alice re-sends her sigs
+    alice2bob.expectMsg(annSigsA)
+  }
+
+  test("recv TickRefreshChannelUpdate", Tag("channels_public")) { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
+    sender.send(bob, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
+    bob2alice.expectMsgType[AnnouncementSignatures]
+    bob2alice.forward(alice)
+    val update1 = relayer.expectMsgType[LocalChannelUpdate]
+
+    // actual test starts here
+    Thread.sleep(1100)
+    sender.send(alice, TickRefreshChannelUpdate)
+    val update2 = relayer.expectMsgType[LocalChannelUpdate]
+    assert(update1.channelUpdate.timestamp < update2.channelUpdate.timestamp)
+  }
+
+  test("recv INPUT_DISCONNECTED", Tag("channels_public")) { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
+    sender.send(bob, WatchEventConfirmed(BITCOIN_FUNDING_DEEPLYBURIED, 400000, 42))
+    bob2alice.expectMsgType[AnnouncementSignatures]
+    bob2alice.forward(alice)
+    val update1 = relayer.expectMsgType[LocalChannelUpdate]
+    assert(Announcements.isEnabled(update1.channelUpdate.flags) == true)
+
+    // actual test starts here
+    Thread.sleep(1100)
+    sender.send(alice, INPUT_DISCONNECTED)
+    val update2 = relayer.expectMsgType[LocalChannelUpdate]
+    assert(update1.channelUpdate.timestamp < update2.channelUpdate.timestamp)
+    assert(Announcements.isEnabled(update2.channelUpdate.flags) == false)
+    awaitCond(alice.stateName == OFFLINE)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -32,8 +32,6 @@ import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.transactions.{IN, OUT}
 import fr.acinq.eclair.wire.{AnnouncementSignatures, ChannelUpdate, ClosingSigned, CommitSig, Error, FailureMessageCodecs, PermanentChannelFailure, RevokeAndAck, Shutdown, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFee, UpdateFulfillHtlc}
 import fr.acinq.eclair.{Globals, TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Outcome, Tag}
 
 import scala.concurrent.duration._
@@ -41,7 +39,7 @@ import scala.concurrent.duration._
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, relayer: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -26,16 +26,14 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, relayer: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -27,6 +27,7 @@ import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
+import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
@@ -37,23 +38,24 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple7[TestFSMRef[State, Data, Channel], TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe, TestProbe, TestProbe]
+  case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, relayer: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()
     import setup._
     within(30 seconds) {
       reachNormal(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer)
       awaitCond(alice.stateName == NORMAL)
       awaitCond(bob.stateName == NORMAL)
-      test((alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer))
+      withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer)))
     }
   }
 
   /**
     * This test checks the case where a disconnection occurs *right before* the counterparty receives a new sig
     */
-  test("re-send update+sig after first commitment") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
+  test("re-send update+sig after first commitment") { f =>
+    import f._
     val sender = TestProbe()
 
     sender.send(alice, CMD_ADD_HTLC(1000000, BinaryData("42" * 32), 400144))
@@ -75,7 +77,7 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     val bobCommitments = bob.stateData.asInstanceOf[HasCommitments].commitments
     val aliceCommitments = alice.stateData.asInstanceOf[HasCommitments].commitments
 
-    val bobCurrentPerCommitmentPoint =  TestConstants.Bob.keyManager.commitmentPoint(bobCommitments.localParams.channelKeyPath, bobCommitments.localCommit.index)
+    val bobCurrentPerCommitmentPoint = TestConstants.Bob.keyManager.commitmentPoint(bobCommitments.localParams.channelKeyPath, bobCommitments.localCommit.index)
     val aliceCurrentPerCommitmentPoint = TestConstants.Alice.keyManager.commitmentPoint(aliceCommitments.localParams.channelKeyPath, aliceCommitments.localCommit.index)
 
 
@@ -129,7 +131,8 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
   /**
     * This test checks the case where a disconnection occurs *right after* the counterparty receives a new sig
     */
-  test("re-send lost revocation") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
+  test("re-send lost revocation") { f =>
+    import f._
     val sender = TestProbe()
 
     sender.send(alice, CMD_ADD_HTLC(1000000, BinaryData("42" * 32), 400144))
@@ -158,7 +161,7 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     val bobCommitments = bob.stateData.asInstanceOf[HasCommitments].commitments
     val aliceCommitments = alice.stateData.asInstanceOf[HasCommitments].commitments
 
-    val bobCurrentPerCommitmentPoint =  TestConstants.Bob.keyManager.commitmentPoint(bobCommitments.localParams.channelKeyPath, bobCommitments.localCommit.index)
+    val bobCurrentPerCommitmentPoint = TestConstants.Bob.keyManager.commitmentPoint(bobCommitments.localParams.channelKeyPath, bobCommitments.localCommit.index)
     val aliceCurrentPerCommitmentPoint = TestConstants.Alice.keyManager.commitmentPoint(aliceCommitments.localParams.channelKeyPath, aliceCommitments.localCommit.index)
 
     // a didn't receive the sig
@@ -189,7 +192,8 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   }
 
-  test("discover that we have a revoked commitment") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
+  test("discover that we have a revoked commitment") { f =>
+    import f._
     val sender = TestProbe()
 
     val (ra1, htlca1) = addHtlc(250000000, alice, bob, alice2bob, bob2alice)
@@ -242,7 +246,8 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   }
 
-  test("discover that they have a more recent commit than the one we know") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
+  test("discover that they have a more recent commit than the one we know") { f =>
+    import f._
     val sender = TestProbe()
 
     // we start by storing the current state
@@ -293,7 +298,8 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   }
 
-  test("counterparty lies about having a more recent commitment") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
+  test("counterparty lies about having a more recent commitment") { f =>
+    import f._
     val sender = TestProbe()
 
     // we simulate a disconnection
@@ -319,8 +325,8 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     assert(new String(error.data) === InvalidRevokedCommitProof(channelId(alice), 0, 42, ba_reestablish_forged.yourLastPerCommitmentSecret.get).getMessage)
   }
 
-  test("change relay fee while offline") { case (alice, bob, alice2bob, bob2alice, _, _, relayer) =>
-
+  test("change relay fee while offline") { f =>
+    import f._
     val sender = TestProbe()
 
     // we simulate a disconnection

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -24,11 +24,12 @@ import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.channel.{Data, State, _}
-import fr.acinq.eclair.payment.{ForwardAdd, Local, PaymentLifecycle, _}
+import fr.acinq.eclair.payment.{ForwardAdd, Local, PaymentLifecycle}
 import fr.acinq.eclair.router.Hop
-import fr.acinq.eclair.wire.{ChannelUpdate, CommitSig, Error, FailureMessageCodecs, PermanentChannelFailure, RevokeAndAck, Shutdown, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFee, UpdateFulfillHtlc}
+import fr.acinq.eclair.wire.{CommitSig, Error, FailureMessageCodecs, PermanentChannelFailure, RevokeAndAck, Shutdown, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFee, UpdateFulfillHtlc}
 import fr.acinq.eclair.{Globals, TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
+import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
@@ -39,9 +40,9 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple7[TestFSMRef[State, Data, Channel], TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe, TestProbe, TestProbe]
+  case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, relayer: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()
     import setup._
     within(30 seconds) {
@@ -91,711 +92,666 @@ class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       bob2alice.forward(alice)
       awaitCond(alice.stateName == SHUTDOWN)
       awaitCond(bob.stateName == SHUTDOWN)
-      test((alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer))
+      withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer)))
     }
   }
 
-  test("recv CMD_ADD_HTLC") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 300000)
-      sender.send(alice, add)
-      val error = ChannelUnavailable(channelId(alice))
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), None, Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+  test("recv CMD_ADD_HTLC") { f =>
+    import f._
+    val sender = TestProbe()
+    val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 300000)
+    sender.send(alice, add)
+    val error = ChannelUnavailable(channelId(alice))
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), None, Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_FULFILL_HTLC") { case (_, bob, _, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
-      sender.expectMsg("ok")
-      val fulfill = bob2alice.expectMsgType[UpdateFulfillHtlc]
-      awaitCond(bob.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fulfill))))
-    }
+  test("recv CMD_FULFILL_HTLC") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
+    sender.expectMsg("ok")
+    val fulfill = bob2alice.expectMsgType[UpdateFulfillHtlc]
+    awaitCond(bob.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fulfill))))
   }
 
-  test("recv CMD_FULFILL_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(bob, CMD_FULFILL_HTLC(42, "12" * 32))
-      sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
-      assert(initialState == bob.stateData)
-    }
+  test("recv CMD_FULFILL_HTLC (unknown htlc id)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(bob, CMD_FULFILL_HTLC(42, "12" * 32))
+    sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
+    assert(initialState == bob.stateData)
   }
 
-  test("recv CMD_FULFILL_HTLC (invalid preimage)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(bob, CMD_FULFILL_HTLC(1, "00" * 32))
-      sender.expectMsg(Failure(InvalidHtlcPreimage(channelId(bob), 1)))
-      assert(initialState == bob.stateData)
-    }
+  test("recv CMD_FULFILL_HTLC (invalid preimage)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(bob, CMD_FULFILL_HTLC(1, "00" * 32))
+    sender.expectMsg(Failure(InvalidHtlcPreimage(channelId(bob), 1)))
+    assert(initialState == bob.stateData)
   }
 
-  test("recv UpdateFulfillHtlc") { case (alice, _, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-      val fulfill = UpdateFulfillHtlc("00" * 32, 0, "11" * 32)
-      sender.send(alice, fulfill)
-      awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments == initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fulfill)))
-    }
+  test("recv UpdateFulfillHtlc") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
+    val fulfill = UpdateFulfillHtlc("00" * 32, 0, "11" * 32)
+    sender.send(alice, fulfill)
+    awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments == initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fulfill)))
   }
 
-  test("recv UpdateFulfillHtlc (unknown htlc id)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      val fulfill = UpdateFulfillHtlc("00" * 32, 42, "00" * 32)
-      sender.send(alice, fulfill)
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      alice2blockchain.expectMsgType[PublishAsap] // main delayed
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateFulfillHtlc (unknown htlc id)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    val fulfill = UpdateFulfillHtlc("00" * 32, 42, "00" * 32)
+    sender.send(alice, fulfill)
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    alice2blockchain.expectMsgType[PublishAsap] // main delayed
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
+    alice2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateFulfillHtlc (invalid preimage)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(alice, UpdateFulfillHtlc("00" * 32, 42, "00" * 32))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      alice2blockchain.expectMsgType[PublishAsap] // main delayed
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateFulfillHtlc (invalid preimage)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(alice, UpdateFulfillHtlc("00" * 32, 42, "00" * 32))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    alice2blockchain.expectMsgType[PublishAsap] // main delayed
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
+    alice2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv CMD_FAIL_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(bob, CMD_FAIL_HTLC(1, Right(PermanentChannelFailure)))
-      sender.expectMsg("ok")
-      val fail = bob2alice.expectMsgType[UpdateFailHtlc]
-      awaitCond(bob.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fail))))
-    }
+  test("recv CMD_FAIL_HTLC") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(bob, CMD_FAIL_HTLC(1, Right(PermanentChannelFailure)))
+    sender.expectMsg("ok")
+    val fail = bob2alice.expectMsgType[UpdateFailHtlc]
+    awaitCond(bob.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fail))))
   }
 
-  test("recv CMD_FAIL_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(bob, CMD_FAIL_HTLC(42, Right(PermanentChannelFailure)))
-      sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
-      assert(initialState == bob.stateData)
-    }
+  test("recv CMD_FAIL_HTLC (unknown htlc id)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(bob, CMD_FAIL_HTLC(42, Right(PermanentChannelFailure)))
+    sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
+    assert(initialState == bob.stateData)
   }
 
-  test("recv CMD_FAIL_MALFORMED_HTLC") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(bob, CMD_FAIL_MALFORMED_HTLC(1, Crypto.sha256(BinaryData.empty), FailureMessageCodecs.BADONION))
-      sender.expectMsg("ok")
-      val fail = bob2alice.expectMsgType[UpdateFailMalformedHtlc]
-      awaitCond(bob.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fail))))
-    }
+  test("recv CMD_FAIL_MALFORMED_HTLC") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(bob, CMD_FAIL_MALFORMED_HTLC(1, Crypto.sha256(BinaryData.empty), FailureMessageCodecs.BADONION))
+    sender.expectMsg("ok")
+    val fail = bob2alice.expectMsgType[UpdateFailMalformedHtlc]
+    awaitCond(bob.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fail))))
   }
 
-  test("recv CMD_FAIL_MALFORMED_HTLC (unknown htlc id)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(bob, CMD_FAIL_MALFORMED_HTLC(42, "00" * 32, FailureMessageCodecs.BADONION))
-      sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
-      assert(initialState == bob.stateData)
-    }
+  test("recv CMD_FAIL_MALFORMED_HTLC (unknown htlc id)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(bob, CMD_FAIL_MALFORMED_HTLC(42, "00" * 32, FailureMessageCodecs.BADONION))
+    sender.expectMsg(Failure(UnknownHtlcId(channelId(bob), 42)))
+    assert(initialState == bob.stateData)
   }
 
-  test("recv CMD_FAIL_HTLC (invalid failure_code)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(bob, CMD_FAIL_MALFORMED_HTLC(42, "00" * 32, 42))
-      sender.expectMsg(Failure(InvalidFailureCode(channelId(bob))))
-      assert(initialState == bob.stateData)
-    }
+  test("recv CMD_FAIL_HTLC (invalid failure_code)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(bob, CMD_FAIL_MALFORMED_HTLC(42, "00" * 32, 42))
+    sender.expectMsg(Failure(InvalidFailureCode(channelId(bob))))
+    assert(initialState == bob.stateData)
   }
 
-  test("recv UpdateFailHtlc") { case (alice, _, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-      val fail = UpdateFailHtlc("00" * 32, 1, "00" * 152)
-      sender.send(alice, fail)
-      awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments == initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fail)))
-    }
+  test("recv UpdateFailHtlc") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
+    val fail = UpdateFailHtlc("00" * 32, 1, "00" * 152)
+    sender.send(alice, fail)
+    awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments == initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fail)))
   }
 
-  test("recv UpdateFailHtlc (unknown htlc id)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(alice, UpdateFailHtlc("00" * 32, 42, "00" * 152))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      alice2blockchain.expectMsgType[PublishAsap] // main delayed
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateFailHtlc (unknown htlc id)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(alice, UpdateFailHtlc("00" * 32, 42, "00" * 152))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    alice2blockchain.expectMsgType[PublishAsap] // main delayed
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
+    alice2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateFailMalformedHtlc") { case (alice, _, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-      val fail = UpdateFailMalformedHtlc("00" * 32, 1, Crypto.sha256(BinaryData.empty), FailureMessageCodecs.BADONION)
-      sender.send(alice, fail)
-      awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments == initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fail)))
-    }
+  test("recv UpdateFailMalformedHtlc") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
+    val fail = UpdateFailMalformedHtlc("00" * 32, 1, Crypto.sha256(BinaryData.empty), FailureMessageCodecs.BADONION)
+    sender.send(alice, fail)
+    awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments == initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fail)))
   }
 
-  test("recv UpdateFailMalformedHtlc (invalid failure_code)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val fail = UpdateFailMalformedHtlc("00" * 32, 1, Crypto.sha256(BinaryData.empty), 42)
-      sender.send(alice, fail)
-      val error = alice2bob.expectMsgType[Error]
-      assert(new String(error.data) === InvalidFailureCode("00" * 32).getMessage)
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      alice2blockchain.expectMsgType[PublishAsap] // main delayed
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateFailMalformedHtlc (invalid failure_code)") { f =>
+    import f._
+    val sender = TestProbe()
+    val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val fail = UpdateFailMalformedHtlc("00" * 32, 1, Crypto.sha256(BinaryData.empty), 42)
+    sender.send(alice, fail)
+    val error = alice2bob.expectMsgType[Error]
+    assert(new String(error.data) === InvalidFailureCode("00" * 32).getMessage)
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    alice2blockchain.expectMsgType[PublishAsap] // main delayed
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
+    alice2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv CMD_SIGN") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      // we need to have something to sign so we first send a fulfill and acknowledge (=sign) it
-      sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
-      bob2alice.expectMsgType[UpdateFulfillHtlc]
-      bob2alice.forward(alice)
-      sender.send(bob, CMD_SIGN)
-      bob2alice.expectMsgType[CommitSig]
-      bob2alice.forward(alice)
-      alice2bob.expectMsgType[RevokeAndAck]
-      alice2bob.forward(bob)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo.isLeft)
-    }
+  test("recv CMD_SIGN") { f =>
+    import f._
+    val sender = TestProbe()
+    // we need to have something to sign so we first send a fulfill and acknowledge (=sign) it
+    sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
+    bob2alice.expectMsgType[UpdateFulfillHtlc]
+    bob2alice.forward(alice)
+    sender.send(bob, CMD_SIGN)
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[RevokeAndAck]
+    alice2bob.forward(bob)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo.isLeft)
   }
 
-  test("recv CMD_SIGN (no changes)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, CMD_SIGN)
-      sender.expectNoMsg(1 second) // just ignored
-      //sender.expectMsg("cannot sign when there are no changes")
-    }
+  test("recv CMD_SIGN (no changes)") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, CMD_SIGN)
+    sender.expectNoMsg(1 second) // just ignored
+    //sender.expectMsg("cannot sign when there are no changes")
   }
 
-  test("recv CMD_SIGN (while waiting for RevokeAndAck)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
-      sender.expectMsg("ok")
-      bob2alice.expectMsgType[UpdateFulfillHtlc]
-      sender.send(bob, CMD_SIGN)
-      sender.expectMsg("ok")
-      bob2alice.expectMsgType[CommitSig]
-      awaitCond(bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo.isLeft)
-      val waitForRevocation = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo.left.toOption.get
-      assert(waitForRevocation.reSignAsap === false)
+  test("recv CMD_SIGN (while waiting for RevokeAndAck)") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[UpdateFulfillHtlc]
+    sender.send(bob, CMD_SIGN)
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[CommitSig]
+    awaitCond(bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo.isLeft)
+    val waitForRevocation = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo.left.toOption.get
+    assert(waitForRevocation.reSignAsap === false)
 
-      // actual test starts here
-      sender.send(bob, CMD_SIGN)
-      sender.expectNoMsg(300 millis)
-      assert(bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo === Left(waitForRevocation))
-    }
+    // actual test starts here
+    sender.send(bob, CMD_SIGN)
+    sender.expectNoMsg(300 millis)
+    assert(bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo === Left(waitForRevocation))
   }
 
-  test("recv CommitSig") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
-      sender.expectMsg("ok")
-      bob2alice.expectMsgType[UpdateFulfillHtlc]
-      bob2alice.forward(alice)
-      sender.send(bob, CMD_SIGN)
-      sender.expectMsg("ok")
-      bob2alice.expectMsgType[CommitSig]
-      bob2alice.forward(alice)
-      alice2bob.expectMsgType[RevokeAndAck]
-    }
+  test("recv CommitSig") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[UpdateFulfillHtlc]
+    bob2alice.forward(alice)
+    sender.send(bob, CMD_SIGN)
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[RevokeAndAck]
   }
 
-  test("recv CommitSig (no changes)") { case (_, bob, _, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      // signature is invalid but it doesn't matter
-      sender.send(bob, CommitSig("00" * 32, "00" * 64, Nil))
-      bob2alice.expectMsgType[Error]
-      awaitCond(bob.stateName == CLOSING)
-      bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      bob2blockchain.expectMsgType[PublishAsap] // main delayed
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv CommitSig (no changes)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    // signature is invalid but it doesn't matter
+    sender.send(bob, CommitSig("00" * 32, "00" * 64, Nil))
+    bob2alice.expectMsgType[Error]
+    awaitCond(bob.stateName == CLOSING)
+    bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    bob2blockchain.expectMsgType[PublishAsap] // main delayed
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv CommitSig (invalid signature)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(bob, CommitSig("00" * 32, "00" * 64, Nil))
-      bob2alice.expectMsgType[Error]
-      awaitCond(bob.stateName == CLOSING)
-      bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      bob2blockchain.expectMsgType[PublishAsap] // main delayed
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv CommitSig (invalid signature)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(bob, CommitSig("00" * 32, "00" * 64, Nil))
+    bob2alice.expectMsgType[Error]
+    awaitCond(bob.stateName == CLOSING)
+    bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    bob2blockchain.expectMsgType[PublishAsap] // main delayed
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv RevokeAndAck (with remaining htlcs on both sides)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      fulfillHtlc(1, "22" * 32, bob, alice, bob2alice, alice2bob)
-      // this will cause alice and bob to receive RevokeAndAcks
-      crossSign(bob, alice, bob2alice, alice2bob)
-      // actual test starts here
-      assert(alice.stateName == SHUTDOWN)
-      awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.spec.htlcs.size == 1)
-      awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteCommit.spec.htlcs.size == 1)
-    }
+  test("recv RevokeAndAck (with remaining htlcs on both sides)") { f =>
+    import f._
+    fulfillHtlc(1, "22" * 32, bob, alice, bob2alice, alice2bob)
+    // this will cause alice and bob to receive RevokeAndAcks
+    crossSign(bob, alice, bob2alice, alice2bob)
+    // actual test starts here
+    assert(alice.stateName == SHUTDOWN)
+    awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.spec.htlcs.size == 1)
+    awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteCommit.spec.htlcs.size == 1)
   }
 
-  test("recv RevokeAndAck (with remaining htlcs on one side)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
-      fulfillHtlc(1, "22" * 32, bob, alice, bob2alice, alice2bob)
-      val sender = TestProbe()
-      sender.send(bob, CMD_SIGN)
-      sender.expectMsg("ok")
-      bob2alice.expectMsgType[CommitSig]
-      bob2alice.forward(alice)
-      alice2bob.expectMsgType[RevokeAndAck]
-      // actual test starts here
-      bob2alice.forward(bob)
-      assert(alice.stateName == SHUTDOWN)
-      awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.spec.htlcs.isEmpty)
-      awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteCommit.spec.htlcs.size == 2)
-    }
+  test("recv RevokeAndAck (with remaining htlcs on one side)") { f =>
+    import f._
+    fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
+    fulfillHtlc(1, "22" * 32, bob, alice, bob2alice, alice2bob)
+    val sender = TestProbe()
+    sender.send(bob, CMD_SIGN)
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[RevokeAndAck]
+    // actual test starts here
+    bob2alice.forward(bob)
+    assert(alice.stateName == SHUTDOWN)
+    awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.spec.htlcs.isEmpty)
+    awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteCommit.spec.htlcs.size == 2)
   }
 
-  test("recv RevokeAndAck (no more htlcs on either side)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
-      fulfillHtlc(1, "22" * 32, bob, alice, bob2alice, alice2bob)
-      crossSign(bob, alice, bob2alice, alice2bob)
-      // actual test starts here
-      awaitCond(alice.stateName == NEGOTIATING)
-    }
+  test("recv RevokeAndAck (no more htlcs on either side)") { f =>
+    import f._
+    fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
+    fulfillHtlc(1, "22" * 32, bob, alice, bob2alice, alice2bob)
+    crossSign(bob, alice, bob2alice, alice2bob)
+    // actual test starts here
+    awaitCond(alice.stateName == NEGOTIATING)
   }
 
-  test("recv RevokeAndAck (invalid preimage)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
-      sender.expectMsg("ok")
-      bob2alice.expectMsgType[UpdateFulfillHtlc]
-      bob2alice.forward(alice)
-      sender.send(bob, CMD_SIGN)
-      sender.expectMsg("ok")
-      bob2alice.expectMsgType[CommitSig]
-      bob2alice.forward(alice)
-      alice2bob.expectMsgType[RevokeAndAck]
-      awaitCond(bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo.isLeft)
-      sender.send(bob, RevokeAndAck("00" * 32, Scalar("11" * 32), Scalar("22" * 32).toPoint))
-      bob2alice.expectMsgType[Error]
-      awaitCond(bob.stateName == CLOSING)
-      bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      bob2blockchain.expectMsgType[PublishAsap] // main delayed
-      bob2blockchain.expectMsgType[PublishAsap] // htlc success
-      bob2blockchain.expectMsgType[PublishAsap] // htlc delayed
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv RevokeAndAck (invalid preimage)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(bob, CMD_FULFILL_HTLC(0, "11" * 32))
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[UpdateFulfillHtlc]
+    bob2alice.forward(alice)
+    sender.send(bob, CMD_SIGN)
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[RevokeAndAck]
+    awaitCond(bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo.isLeft)
+    sender.send(bob, RevokeAndAck("00" * 32, Scalar("11" * 32), Scalar("22" * 32).toPoint))
+    bob2alice.expectMsgType[Error]
+    awaitCond(bob.stateName == CLOSING)
+    bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    bob2blockchain.expectMsgType[PublishAsap] // main delayed
+    bob2blockchain.expectMsgType[PublishAsap] // htlc success
+    bob2blockchain.expectMsgType[PublishAsap] // htlc delayed
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv RevokeAndAck (unexpectedly)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo.isRight)
-      sender.send(alice, RevokeAndAck("00" * 32, Scalar("11" * 32), Scalar("22" * 32).toPoint))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      alice2blockchain.expectMsgType[PublishAsap] // main delayed
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv RevokeAndAck (unexpectedly)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    awaitCond(alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.remoteNextCommitInfo.isRight)
+    sender.send(alice, RevokeAndAck("00" * 32, Scalar("11" * 32), Scalar("22" * 32).toPoint))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    alice2blockchain.expectMsgType[PublishAsap] // main delayed
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
+    alice2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv CMD_UPDATE_FEE") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(alice, CMD_UPDATE_FEE(20000))
-      sender.expectMsg("ok")
-      val fee = alice2bob.expectMsgType[UpdateFee]
-      awaitCond(alice.stateData == initialState.copy(
-        commitments = initialState.commitments.copy(
-          localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fee))))
-    }
+  test("recv CMD_UPDATE_FEE") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(alice, CMD_UPDATE_FEE(20000))
+    sender.expectMsg("ok")
+    val fee = alice2bob.expectMsgType[UpdateFee]
+    awaitCond(alice.stateData == initialState.copy(
+      commitments = initialState.commitments.copy(
+        localChanges = initialState.commitments.localChanges.copy(initialState.commitments.localChanges.proposed :+ fee))))
   }
 
-  test("recv CMD_UPDATE_FEE (when fundee)") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(bob, CMD_UPDATE_FEE(20000))
-      sender.expectMsg(Failure(FundeeCannotSendUpdateFee(channelId(bob))))
-      assert(initialState == bob.stateData)
-    }
+  test("recv CMD_UPDATE_FEE (when fundee)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(bob, CMD_UPDATE_FEE(20000))
+    sender.expectMsg(Failure(FundeeCannotSendUpdateFee(channelId(bob))))
+    assert(initialState == bob.stateData)
   }
 
-  test("recv UpdateFee") { case (_, bob, _, _, _, _, _) =>
-    within(30 seconds) {
-      val initialData = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-      val fee = UpdateFee("00" * 32, 12000)
-      bob ! fee
-      awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ fee))))
-    }
+  test("recv UpdateFee") { f =>
+    import f._
+    val initialData = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
+    val fee = UpdateFee("00" * 32, 12000)
+    bob ! fee
+    awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ fee))))
   }
 
-  test("recv UpdateFee (when sender is not funder)") { case (alice, _, alice2bob, _, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(alice, UpdateFee("00" * 32, 12000))
-      alice2bob.expectMsgType[Error]
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      alice2blockchain.expectMsgType[PublishAsap] // main delayed
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
-      alice2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateFee (when sender is not funder)") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(alice, UpdateFee("00" * 32, 12000))
+    alice2bob.expectMsgType[Error]
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    alice2blockchain.expectMsgType[PublishAsap] // main delayed
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
+    alice2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateFee (sender can't afford it)") { case (_, bob, _, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      val fee = UpdateFee("00" * 32, 100000000)
-      // we first update the global variable so that we don't trigger a 'fee too different' error
-      Globals.feeratesPerKw.set(FeeratesPerKw.single(fee.feeratePerKw))
-      sender.send(bob, fee)
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === CannotAffordFees(channelId(bob), missingSatoshis = 72120000L, reserveSatoshis = 20000L, feesSatoshis = 72400000L).getMessage)
-      awaitCond(bob.stateName == CLOSING)
-      bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      //bob2blockchain.expectMsgType[PublishAsap] // main delayed (removed because of the high fees)
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateFee (sender can't afford it)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    val fee = UpdateFee("00" * 32, 100000000)
+    // we first update the global variable so that we don't trigger a 'fee too different' error
+    Globals.feeratesPerKw.set(FeeratesPerKw.single(fee.feeratePerKw))
+    sender.send(bob, fee)
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === CannotAffordFees(channelId(bob), missingSatoshis = 72120000L, reserveSatoshis = 20000L, feesSatoshis = 72400000L).getMessage)
+    awaitCond(bob.stateName == CLOSING)
+    bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    //bob2blockchain.expectMsgType[PublishAsap] // main delayed (removed because of the high fees)
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateFee (local/remote feerates are too different)") { case (_, bob, _, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(bob, UpdateFee("00" * 32, 65000))
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === "local/remote feerates are too different: remoteFeeratePerKw=65000 localFeeratePerKw=10000")
-      awaitCond(bob.stateName == CLOSING)
-      bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      bob2blockchain.expectMsgType[PublishAsap] // main delayed
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateFee (local/remote feerates are too different)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(bob, UpdateFee("00" * 32, 65000))
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === "local/remote feerates are too different: remoteFeeratePerKw=65000 localFeeratePerKw=10000")
+    awaitCond(bob.stateName == CLOSING)
+    bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    bob2blockchain.expectMsgType[PublishAsap] // main delayed
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv UpdateFee (remote feerate is too small)") { case (_, bob, _, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      val sender = TestProbe()
-      sender.send(bob, UpdateFee("00" * 32, 252))
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data) === "remote fee rate is too small: remoteFeeratePerKw=252")
-      awaitCond(bob.stateName == CLOSING)
-      bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
-      bob2blockchain.expectMsgType[PublishAsap] // main delayed
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
+  test("recv UpdateFee (remote feerate is too small)") { f =>
+    import f._
+    val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    val sender = TestProbe()
+    sender.send(bob, UpdateFee("00" * 32, 252))
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data) === "remote fee rate is too small: remoteFeeratePerKw=252")
+    awaitCond(bob.stateName == CLOSING)
+    bob2blockchain.expectMsg(PublishAsap(tx)) // commit tx
+    bob2blockchain.expectMsgType[PublishAsap] // main delayed
+    bob2blockchain.expectMsgType[WatchConfirmed]
   }
 
-  test("recv CurrentBlockCount (no htlc timed out)") { case (alice, bob, alice2bob, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-      sender.send(alice, CurrentBlockCount(400143))
-      awaitCond(alice.stateData == initialState)
-    }
+  test("recv CurrentBlockCount (no htlc timed out)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
+    sender.send(alice, CurrentBlockCount(400143))
+    awaitCond(alice.stateData == initialState)
   }
 
-  test("recv CurrentBlockCount (an htlc timed out)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-      val aliceCommitTx = initialState.commitments.localCommit.publishableTxs.commitTx.tx
-      sender.send(alice, CurrentBlockCount(400145))
-      alice2blockchain.expectMsg(PublishAsap(aliceCommitTx)) // commit tx
-      alice2blockchain.expectMsgType[PublishAsap] // main delayed
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
-      alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
-      val watch = alice2blockchain.expectMsgType[WatchConfirmed]
-      assert(watch.event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
-    }
+  test("recv CurrentBlockCount (an htlc timed out)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
+    val aliceCommitTx = initialState.commitments.localCommit.publishableTxs.commitTx.tx
+    sender.send(alice, CurrentBlockCount(400145))
+    alice2blockchain.expectMsg(PublishAsap(aliceCommitTx)) // commit tx
+    alice2blockchain.expectMsgType[PublishAsap] // main delayed
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc timeout 2
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 1
+    alice2blockchain.expectMsgType[PublishAsap] // htlc delayed 2
+  val watch = alice2blockchain.expectMsgType[WatchConfirmed]
+    assert(watch.event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
   }
 
-  test("recv CurrentFeerate (when funder, triggers an UpdateFee)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-      val event = CurrentFeerates(FeeratesPerKw.single(20000))
-      sender.send(alice, event)
-      alice2bob.expectMsg(UpdateFee(initialState.commitments.channelId, event.feeratesPerKw.blocks_2))
-    }
+  test("recv CurrentFeerate (when funder, triggers an UpdateFee)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
+    val event = CurrentFeerates(FeeratesPerKw.single(20000))
+    sender.send(alice, event)
+    alice2bob.expectMsg(UpdateFee(initialState.commitments.channelId, event.feeratesPerKw.blocks_2))
   }
 
-  test("recv CurrentFeerate (when funder, doesn't trigger an UpdateFee)") { case (alice, _, alice2bob, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val event = CurrentFeerates(FeeratesPerKw.single(10010))
-      sender.send(alice, event)
-      alice2bob.expectNoMsg(500 millis)
-    }
+  test("recv CurrentFeerate (when funder, doesn't trigger an UpdateFee)") { f =>
+    import f._
+    val sender = TestProbe()
+    val event = CurrentFeerates(FeeratesPerKw.single(10010))
+    sender.send(alice, event)
+    alice2bob.expectNoMsg(500 millis)
   }
 
-  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are close)") { case (_, bob, _, bob2alice, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val event = CurrentFeerates(FeeratesPerKw.single(11000))
-      sender.send(bob, event)
-      bob2alice.expectNoMsg(500 millis)
-    }
+  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are close)") { f =>
+    import f._
+    val sender = TestProbe()
+    val event = CurrentFeerates(FeeratesPerKw.single(11000))
+    sender.send(bob, event)
+    bob2alice.expectNoMsg(500 millis)
   }
 
-  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are very different)") { case (_, bob, _, bob2alice, _, bob2blockchain, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val event = CurrentFeerates(FeeratesPerKw.single(1000))
-      sender.send(bob, event)
-      bob2alice.expectMsgType[Error]
-      bob2blockchain.expectMsgType[PublishAsap] // commit tx
-      bob2blockchain.expectMsgType[PublishAsap] // main delayed
-      bob2blockchain.expectMsgType[WatchConfirmed]
-      awaitCond(bob.stateName == CLOSING)
-    }
+  test("recv CurrentFeerate (when fundee, commit-fee/network-fee are very different)") { f =>
+    import f._
+    val sender = TestProbe()
+    val event = CurrentFeerates(FeeratesPerKw.single(1000))
+    sender.send(bob, event)
+    bob2alice.expectMsgType[Error]
+    bob2blockchain.expectMsgType[PublishAsap] // commit tx
+    bob2blockchain.expectMsgType[PublishAsap] // main delayed
+    bob2blockchain.expectMsgType[WatchConfirmed]
+    awaitCond(bob.stateName == CLOSING)
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (their commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      // bob publishes his current commit tx, which contains two pending htlcs alice->bob
-      val bobCommitTx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      assert(bobCommitTx.txOut.size == 4) // two main outputs and 2 pending htlcs
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
+  test("recv BITCOIN_FUNDING_SPENT (their commit)") { f =>
+    import f._
+    // bob publishes his current commit tx, which contains two pending htlcs alice->bob
+    val bobCommitTx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    assert(bobCommitTx.txOut.size == 4) // two main outputs and 2 pending htlcs
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
 
-      // in response to that, alice publishes its claim txes
-      val claimTxes = for (i <- 0 until 3) yield alice2blockchain.expectMsgType[PublishAsap].tx
-      // in addition to its main output, alice can only claim 2 out of 3 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the preimage
-      val amountClaimed = (for (claimHtlcTx <- claimTxes) yield {
-        assert(claimHtlcTx.txIn.size == 1)
-        assert(claimHtlcTx.txOut.size == 1)
-        Transaction.correctlySpends(claimHtlcTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-        claimHtlcTx.txOut(0).amount
-      }).sum
-      // htlc will timeout and be eventually refunded so we have a little less than fundingSatoshis - pushMsat = 1000000 - 200000 = 800000 (because fees)
-      assert(amountClaimed == Satoshi(774010))
+    // in response to that, alice publishes its claim txes
+    val claimTxes = for (i <- 0 until 3) yield alice2blockchain.expectMsgType[PublishAsap].tx
+    // in addition to its main output, alice can only claim 2 out of 3 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the preimage
+    val amountClaimed = (for (claimHtlcTx <- claimTxes) yield {
+      assert(claimHtlcTx.txIn.size == 1)
+      assert(claimHtlcTx.txOut.size == 1)
+      Transaction.correctlySpends(claimHtlcTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+      claimHtlcTx.txOut(0).amount
+    }).sum
+    // htlc will timeout and be eventually refunded so we have a little less than fundingSatoshis - pushMsat = 1000000 - 200000 = 800000 (because fees)
+    assert(amountClaimed == Satoshi(774010))
 
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0)))
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      alice2blockchain.expectNoMsg(1 second)
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0)))
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    alice2blockchain.expectNoMsg(1 second)
 
-      awaitCond(alice.stateName == CLOSING)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.isDefined)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.get.claimHtlcSuccessTxs.size == 0)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.get.claimHtlcTimeoutTxs.size == 2)
-    }
+    awaitCond(alice.stateName == CLOSING)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.isDefined)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.get.claimHtlcSuccessTxs.size == 0)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.get.claimHtlcTimeoutTxs.size == 2)
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (their next commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      // bob fulfills the first htlc
-      fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
-      // then signs
-      val sender = TestProbe()
-      sender.send(bob, CMD_SIGN)
-      sender.expectMsg("ok")
-      bob2alice.expectMsgType[CommitSig]
-      bob2alice.forward(alice)
-      alice2bob.expectMsgType[RevokeAndAck]
-      alice2bob.forward(bob)
-      alice2bob.expectMsgType[CommitSig]
-      alice2bob.forward(bob)
-      bob2alice.expectMsgType[RevokeAndAck]
-      // we intercept bob's revocation
-      // as far as alice knows, bob currently has two valid unrevoked commitment transactions
+  test("recv BITCOIN_FUNDING_SPENT (their next commit)") { f =>
+    import f._
+    // bob fulfills the first htlc
+    fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
+    // then signs
+    val sender = TestProbe()
+    sender.send(bob, CMD_SIGN)
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[RevokeAndAck]
+    alice2bob.forward(bob)
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[RevokeAndAck]
+    // we intercept bob's revocation
+    // as far as alice knows, bob currently has two valid unrevoked commitment transactions
 
-      // bob publishes his current commit tx, which contains one pending htlc alice->bob
-      val bobCommitTx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      assert(bobCommitTx.txOut.size == 3) // two main outputs and 1 pending htlc
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
+    // bob publishes his current commit tx, which contains one pending htlc alice->bob
+    val bobCommitTx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    assert(bobCommitTx.txOut.size == 3) // two main outputs and 1 pending htlc
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
 
-      // in response to that, alice publishes its claim txes
-      val claimTxes = for (i <- 0 until 2) yield alice2blockchain.expectMsgType[PublishAsap].tx
-      // in addition to its main output, alice can only claim 2 out of 3 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the preimage
-      val amountClaimed = (for (claimHtlcTx <- claimTxes) yield {
-        assert(claimHtlcTx.txIn.size == 1)
-        assert(claimHtlcTx.txOut.size == 1)
-        Transaction.correctlySpends(claimHtlcTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-        claimHtlcTx.txOut(0).amount
-      }).sum
-      // htlc will timeout and be eventually refunded so we have a little less than fundingSatoshis - pushMsat - htlc1 = 1000000 - 200000 - 300 000 = 500000 (because fees)
-      assert(amountClaimed == Satoshi(481190))
+    // in response to that, alice publishes its claim txes
+    val claimTxes = for (i <- 0 until 2) yield alice2blockchain.expectMsgType[PublishAsap].tx
+    // in addition to its main output, alice can only claim 2 out of 3 htlcs, she can't do anything regarding the htlc sent by bob for which she does not have the preimage
+    val amountClaimed = (for (claimHtlcTx <- claimTxes) yield {
+      assert(claimHtlcTx.txIn.size == 1)
+      assert(claimHtlcTx.txOut.size == 1)
+      Transaction.correctlySpends(claimHtlcTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+      claimHtlcTx.txOut(0).amount
+    }).sum
+    // htlc will timeout and be eventually refunded so we have a little less than fundingSatoshis - pushMsat - htlc1 = 1000000 - 200000 - 300 000 = 500000 (because fees)
+    assert(amountClaimed == Satoshi(481190))
 
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0)))
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      alice2blockchain.expectNoMsg(1 second)
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(bobCommitTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxes(0)))
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    alice2blockchain.expectNoMsg(1 second)
 
-      awaitCond(alice.stateName == CLOSING)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.isDefined)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.get.claimHtlcSuccessTxs.size == 0)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.get.claimHtlcTimeoutTxs.size == 1)
-    }
+    awaitCond(alice.stateName == CLOSING)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.isDefined)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.get.claimHtlcSuccessTxs.size == 0)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.get.claimHtlcTimeoutTxs.size == 1)
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (revoked tx)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val revokedTx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      // two main outputs + 2 htlc
-      assert(revokedTx.txOut.size == 4)
+  test("recv BITCOIN_FUNDING_SPENT (revoked tx)") { f =>
+    import f._
+    val revokedTx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    // two main outputs + 2 htlc
+    assert(revokedTx.txOut.size == 4)
 
-      // bob fulfills one of the pending htlc (just so that he can have a new sig)
-      fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
-      // bob and alice sign
-      crossSign(bob, alice, bob2alice, alice2bob)
-      // bob now has a new commitment tx
+    // bob fulfills one of the pending htlc (just so that he can have a new sig)
+    fulfillHtlc(0, "11" * 32, bob, alice, bob2alice, alice2bob)
+    // bob and alice sign
+    crossSign(bob, alice, bob2alice, alice2bob)
+    // bob now has a new commitment tx
 
-      // bob published the revoked tx
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, revokedTx)
-      alice2bob.expectMsgType[Error]
+    // bob published the revoked tx
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, revokedTx)
+    alice2bob.expectMsgType[Error]
 
-      val mainTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      val htlc1PenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      val htlc2PenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(revokedTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(mainTx))
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // main-penalty
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // htlc1-penalty
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // htlc2-penalty
-      alice2blockchain.expectNoMsg(1 second)
+    val mainTx = alice2blockchain.expectMsgType[PublishAsap].tx
+    val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
+    val htlc1PenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
+    val htlc2PenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(revokedTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event == BITCOIN_TX_CONFIRMED(mainTx))
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // main-penalty
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // htlc1-penalty
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT) // htlc2-penalty
+    alice2blockchain.expectNoMsg(1 second)
 
-      Transaction.correctlySpends(mainTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(mainPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(htlc1PenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(htlc2PenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(mainTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(mainPenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(htlc1PenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(htlc2PenaltyTx, Seq(revokedTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
-      // two main outputs are 300 000 and 200 000, htlcs are 300 000 and 200 000
-      assert(mainTx.txOut(0).amount == Satoshi(284930))
-      assert(mainPenaltyTx.txOut(0).amount == Satoshi(195150))
-      assert(htlc1PenaltyTx.txOut(0).amount == Satoshi(194530))
-      assert(htlc2PenaltyTx.txOut(0).amount == Satoshi(294530))
+    // two main outputs are 300 000 and 200 000, htlcs are 300 000 and 200 000
+    assert(mainTx.txOut(0).amount == Satoshi(284930))
+    assert(mainPenaltyTx.txOut(0).amount == Satoshi(195150))
+    assert(htlc1PenaltyTx.txOut(0).amount == Satoshi(194530))
+    assert(htlc2PenaltyTx.txOut(0).amount == Satoshi(294530))
 
-      awaitCond(alice.stateName == CLOSING)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 1)
-    }
+    awaitCond(alice.stateName == CLOSING)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 1)
   }
 
-  test("recv CMD_CLOSE") { case (alice, _, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg(Failure(ClosingAlreadyInProgress(channelId(alice))))
-    }
+  test("recv CMD_CLOSE") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg(Failure(ClosingAlreadyInProgress(channelId(alice))))
   }
 
-  test("recv Error") { case (alice, _, _, _, alice2blockchain, _, _) =>
-    within(30 seconds) {
-      val aliceCommitTx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! Error("00" * 32, "oops".getBytes)
-      alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
-      assert(aliceCommitTx.txOut.size == 4) // two main outputs and two htlcs
+  test("recv Error") { f =>
+    import f._
+    val aliceCommitTx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! Error("00" * 32, "oops".getBytes)
+    alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
+    assert(aliceCommitTx.txOut.size == 4) // two main outputs and two htlcs
 
-      // alice can claim both htlc after a timeout
-      // so we expect 5 transactions:
-      // - 1 tx to claim the main delayed output
-      // - 2 txes for each htlc
-      // - 2 txes for each delayed output of the claimed htlc
-      val claimTxs = for (i <- 0 until 5) yield alice2blockchain.expectMsgType[PublishAsap].tx
+    // alice can claim both htlc after a timeout
+    // so we expect 5 transactions:
+    // - 1 tx to claim the main delayed output
+    // - 2 txes for each htlc
+    // - 2 txes for each delayed output of the claimed htlc
+    val claimTxs = for (i <- 0 until 5) yield alice2blockchain.expectMsgType[PublishAsap].tx
 
-      // the main delayed output spends the commitment transaction
-      Transaction.correctlySpends(claimTxs(0), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    // the main delayed output spends the commitment transaction
+    Transaction.correctlySpends(claimTxs(0), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
-      // 2nd stage transactions spend the commitment transaction
-      Transaction.correctlySpends(claimTxs(1), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(claimTxs(2), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    // 2nd stage transactions spend the commitment transaction
+    Transaction.correctlySpends(claimTxs(1), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(claimTxs(2), aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
-      // 3rd stage transactions spend their respective HTLC-Timeout transactions
-      Transaction.correctlySpends(claimTxs(3), claimTxs(1) :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      Transaction.correctlySpends(claimTxs(4), claimTxs(2) :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    // 3rd stage transactions spend their respective HTLC-Timeout transactions
+    Transaction.correctlySpends(claimTxs(3), claimTxs(1) :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    Transaction.correctlySpends(claimTxs(4), claimTxs(2) :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(0))) // main-delayed
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(3))) // htlc-delayed
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(4))) // htlc-delayed
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      alice2blockchain.expectNoMsg(1 second)
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(0))) // main-delayed
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(3))) // htlc-delayed
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(claimTxs(4))) // htlc-delayed
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    alice2blockchain.expectNoMsg(1 second)
 
-      awaitCond(alice.stateName == CLOSING)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.isDefined)
-    }
+    awaitCond(alice.stateName == CLOSING)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.isDefined)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -28,16 +28,14 @@ import fr.acinq.eclair.payment.{ForwardAdd, Local, PaymentLifecycle}
 import fr.acinq.eclair.router.Hop
 import fr.acinq.eclair.wire.{CommitSig, Error, FailureMessageCodecs, PermanentChannelFailure, RevokeAndAck, Shutdown, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFee, UpdateFulfillHtlc}
 import fr.acinq.eclair.{Globals, TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class ShutdownStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, relayer: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
@@ -17,6 +17,7 @@
 package fr.acinq.eclair.channel.states.g
 
 import akka.actor.Status.Failure
+import akka.event.LoggingAdapter
 import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.Satoshi
 import fr.acinq.eclair.TestConstants.Bob
@@ -26,11 +27,11 @@ import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.channel.{Data, State, _}
 import fr.acinq.eclair.payment.Local
-import fr.acinq.eclair.wire.{ClosingSigned, CommitSig, Error, Shutdown}
+import fr.acinq.eclair.wire.{ClosingSigned, Error, Shutdown}
 import fr.acinq.eclair.{Globals, TestkitBaseClass}
 import org.junit.runner.RunWith
-import org.scalatest.Tag
 import org.scalatest.junit.JUnitRunner
+import org.scalatest.{Outcome, Tag}
 
 import scala.concurrent.duration._
 import scala.util.Success
@@ -41,9 +42,9 @@ import scala.util.Success
 @RunWith(classOf[JUnitRunner])
 class NegotiatingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple6[TestFSMRef[State, Data, Channel], TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe, TestProbe]
+  case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()
     import setup._
     within(30 seconds) {
@@ -62,161 +63,147 @@ class NegotiatingStateSpec extends TestkitBaseClass with StateTestsHelperMethods
       if (test.tags.contains("fee2")) Globals.feeratesPerKw.set(FeeratesPerKw.single(4316)) else Globals.feeratesPerKw.set(FeeratesPerKw.single(5000))
       alice2bob.forward(bob)
       awaitCond(bob.stateName == NEGOTIATING)
-      test((alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain))
+      withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)))
     }
   }
 
-  test("recv CMD_ADD_HTLC") { case (alice, _, alice2bob, _, _, _) =>
-    within(30 seconds) {
-      alice2bob.expectMsgType[ClosingSigned]
-      val sender = TestProbe()
-      val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 300000)
-      sender.send(alice, add)
-      val error = ChannelUnavailable(channelId(alice))
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), None, Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+  test("recv CMD_ADD_HTLC") { f =>
+    import f._
+    alice2bob.expectMsgType[ClosingSigned]
+    val sender = TestProbe()
+    val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 300000)
+    sender.send(alice, add)
+    val error = ChannelUnavailable(channelId(alice))
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), None, Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv ClosingSigned (theirCloseFee != ourCloseFee)") { case (alice, bob, alice2bob, bob2alice, _, _) =>
-    within(30 seconds) {
-      // alice initiates the negotiation
-      val aliceCloseSig1 = alice2bob.expectMsgType[ClosingSigned]
+  test("recv ClosingSigned (theirCloseFee != ourCloseFee)") { f =>
+    import f._
+    // alice initiates the negotiation
+    val aliceCloseSig1 = alice2bob.expectMsgType[ClosingSigned]
+    alice2bob.forward(bob)
+    // bob answers with a counter proposition
+    val bobCloseSig1 = bob2alice.expectMsgType[ClosingSigned]
+    assert(aliceCloseSig1.feeSatoshis > bobCloseSig1.feeSatoshis)
+    // actual test starts here
+    val initialState = alice.stateData.asInstanceOf[DATA_NEGOTIATING]
+    bob2alice.forward(alice)
+    val aliceCloseSig2 = alice2bob.expectMsgType[ClosingSigned]
+    // BOLT 2: If the receiver [doesn't agree with the fee] it SHOULD propose a value strictly between the received fee-satoshis and its previously-sent fee-satoshis
+    assert(aliceCloseSig2.feeSatoshis < aliceCloseSig1.feeSatoshis && aliceCloseSig2.feeSatoshis > bobCloseSig1.feeSatoshis)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NEGOTIATING].closingTxProposed.last.map(_.localClosingSigned) == initialState.closingTxProposed.last.map(_.localClosingSigned) :+ aliceCloseSig2)
+  }
+
+  private def testFeeConverge(f: FixtureParam) = {
+    import f._
+    var aliceCloseFee, bobCloseFee = 0L
+    do {
+      aliceCloseFee = alice2bob.expectMsgType[ClosingSigned].feeSatoshis
       alice2bob.forward(bob)
-      // bob answers with a counter proposition
-      val bobCloseSig1 = bob2alice.expectMsgType[ClosingSigned]
-      assert(aliceCloseSig1.feeSatoshis > bobCloseSig1.feeSatoshis)
-      // actual test starts here
-      val initialState = alice.stateData.asInstanceOf[DATA_NEGOTIATING]
-      bob2alice.forward(alice)
-      val aliceCloseSig2 = alice2bob.expectMsgType[ClosingSigned]
-      // BOLT 2: If the receiver [doesn't agree with the fee] it SHOULD propose a value strictly between the received fee-satoshis and its previously-sent fee-satoshis
-      assert(aliceCloseSig2.feeSatoshis < aliceCloseSig1.feeSatoshis && aliceCloseSig2.feeSatoshis > bobCloseSig1.feeSatoshis)
-      awaitCond(alice.stateData.asInstanceOf[DATA_NEGOTIATING].closingTxProposed.last.map(_.localClosingSigned) == initialState.closingTxProposed.last.map(_.localClosingSigned) :+ aliceCloseSig2)
-    }
+      if (!bob2blockchain.msgAvailable) {
+        bobCloseFee = bob2alice.expectMsgType[ClosingSigned].feeSatoshis
+        bob2alice.forward(alice)
+      }
+    } while (!alice2blockchain.msgAvailable && !bob2blockchain.msgAvailable)
   }
 
-  def testFeeConverge(alice: TestFSMRef[State, Data, Channel],
-                      bob: TestFSMRef[State, Data, Channel],
-                      alice2bob: TestProbe,
-                      bob2alice: TestProbe,
-                      alice2blockchain: TestProbe,
-                      bob2blockchain: TestProbe) = {
-    within(30 seconds) {
-      var aliceCloseFee, bobCloseFee = 0L
-      do {
-        aliceCloseFee = alice2bob.expectMsgType[ClosingSigned].feeSatoshis
-        alice2bob.forward(bob)
-        if (!bob2blockchain.msgAvailable) {
-          bobCloseFee = bob2alice.expectMsgType[ClosingSigned].feeSatoshis
+  test("recv ClosingSigned (theirCloseFee == ourCloseFee) (fee 1)") { f =>
+    testFeeConverge(f)
+  }
+
+  test("recv ClosingSigned (theirCloseFee == ourCloseFee) (fee 2)", Tag("fee2")) { f =>
+    testFeeConverge(f)
+  }
+
+  test("recv ClosingSigned (fee too high)") { f =>
+    import f._
+    val aliceCloseSig = alice2bob.expectMsgType[ClosingSigned]
+    val sender = TestProbe()
+    val tx = bob.stateData.asInstanceOf[DATA_NEGOTIATING].commitments.localCommit.publishableTxs.commitTx.tx
+    sender.send(bob, aliceCloseSig.copy(feeSatoshis = 99000)) // sig doesn't matter, it is checked later
+  val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data).startsWith("invalid close fee: fee_satoshis=99000"))
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv ClosingSigned (invalid sig)") { f =>
+    import f._
+    val aliceCloseSig = alice2bob.expectMsgType[ClosingSigned]
+    val sender = TestProbe()
+    val tx = bob.stateData.asInstanceOf[DATA_NEGOTIATING].commitments.localCommit.publishableTxs.commitTx.tx
+    sender.send(bob, aliceCloseSig.copy(signature = "00" * 64))
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data).startsWith("invalid close signature"))
+    bob2blockchain.expectMsg(PublishAsap(tx))
+    bob2blockchain.expectMsgType[PublishAsap]
+    bob2blockchain.expectMsgType[WatchConfirmed]
+  }
+
+  test("recv BITCOIN_FUNDING_SPENT (counterparty's mutual close)") { f =>
+    import f._
+    var aliceCloseFee, bobCloseFee = 0L
+    do {
+      aliceCloseFee = alice2bob.expectMsgType[ClosingSigned].feeSatoshis
+      alice2bob.forward(bob)
+      if (!bob2blockchain.msgAvailable) {
+        bobCloseFee = bob2alice.expectMsgType[ClosingSigned].feeSatoshis
+        if (aliceCloseFee != bobCloseFee) {
           bob2alice.forward(alice)
         }
-      } while (!alice2blockchain.msgAvailable && !bob2blockchain.msgAvailable)
-    }
+      }
+    } while (!alice2blockchain.msgAvailable && !bob2blockchain.msgAvailable)
+    // at this point alice and bob have converged on closing fees, but alice has not yet received the final signature whereas bob has
+    // bob publishes the mutual close and alice is notified that the funding tx has been spent
+    // actual test starts here
+    assert(alice.stateName == NEGOTIATING)
+    val mutualCloseTx = bob2blockchain.expectMsgType[PublishAsap].tx
+    assert(bob2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(mutualCloseTx))
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, mutualCloseTx)
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+    alice2blockchain.expectNoMsg(100 millis)
+    assert(alice.stateName == CLOSING)
   }
 
-  test("recv ClosingSigned (theirCloseFee == ourCloseFee) (fee 1)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain) =>
-    testFeeConverge(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-  }
+  test("recv BITCOIN_FUNDING_SPENT (an older mutual close)") { f =>
+    import f._
+    val aliceClose1 = alice2bob.expectMsgType[ClosingSigned]
+    alice2bob.forward(bob)
+    val bobClose1 = bob2alice.expectMsgType[ClosingSigned]
+    bob2alice.forward(alice)
+    val aliceClose2 = alice2bob.expectMsgType[ClosingSigned]
+    assert(aliceClose2.feeSatoshis != bobClose1.feeSatoshis)
+    // at this point alice and bob have not yet converged on closing fees, but bob decides to publish a mutual close with one of the previous sigs
+    val d = bob.stateData.asInstanceOf[DATA_NEGOTIATING]
+    implicit val log: LoggingAdapter = bob.underlyingActor.implicitLog
+    val Success(bobClosingTx) = Closing.checkClosingSignature(Bob.keyManager, d.commitments, d.localShutdown.scriptPubKey, d.remoteShutdown.scriptPubKey, Satoshi(aliceClose1.feeSatoshis), aliceClose1.signature)
 
-  test("recv ClosingSigned (theirCloseFee == ourCloseFee) (fee 2)", Tag("fee2")) { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain) =>
-    testFeeConverge(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-  }
-
-  test("recv ClosingSigned (fee too high)") { case (_, bob, alice2bob, bob2alice, _, bob2blockchain) =>
-    within(30 seconds) {
-      val aliceCloseSig = alice2bob.expectMsgType[ClosingSigned]
-      val sender = TestProbe()
-      val tx = bob.stateData.asInstanceOf[DATA_NEGOTIATING].commitments.localCommit.publishableTxs.commitTx.tx
-      sender.send(bob, aliceCloseSig.copy(feeSatoshis = 99000)) // sig doesn't matter, it is checked later
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data).startsWith("invalid close fee: fee_satoshis=99000"))
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv ClosingSigned (invalid sig)") { case (_, bob, alice2bob, bob2alice, _, bob2blockchain) =>
-    within(30 seconds) {
-      val aliceCloseSig = alice2bob.expectMsgType[ClosingSigned]
-      val sender = TestProbe()
-      val tx = bob.stateData.asInstanceOf[DATA_NEGOTIATING].commitments.localCommit.publishableTxs.commitTx.tx
-      sender.send(bob, aliceCloseSig.copy(signature = "00" * 64))
-      val error = bob2alice.expectMsgType[Error]
-      assert(new String(error.data).startsWith("invalid close signature"))
-      bob2blockchain.expectMsg(PublishAsap(tx))
-      bob2blockchain.expectMsgType[PublishAsap]
-      bob2blockchain.expectMsgType[WatchConfirmed]
-    }
-  }
-
-  test("recv BITCOIN_FUNDING_SPENT (counterparty's mutual close)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain) =>
-    within(30 seconds) {
-      var aliceCloseFee, bobCloseFee = 0L
-      do {
-        aliceCloseFee = alice2bob.expectMsgType[ClosingSigned].feeSatoshis
-        alice2bob.forward(bob)
-        if (!bob2blockchain.msgAvailable) {
-          bobCloseFee = bob2alice.expectMsgType[ClosingSigned].feeSatoshis
-          if (aliceCloseFee != bobCloseFee) {
-            bob2alice.forward(alice)
-          }
-        }
-      } while (!alice2blockchain.msgAvailable && !bob2blockchain.msgAvailable)
-      // at this point alice and bob have converged on closing fees, but alice has not yet received the final signature whereas bob has
-      // bob publishes the mutual close and alice is notified that the funding tx has been spent
-      // actual test starts here
-      assert(alice.stateName == NEGOTIATING)
-      val mutualCloseTx = bob2blockchain.expectMsgType[PublishAsap].tx
-      assert(bob2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(mutualCloseTx))
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, mutualCloseTx)
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-      alice2blockchain.expectNoMsg(100 millis)
-      assert(alice.stateName == CLOSING)
-    }
-  }
-
-  test("recv BITCOIN_FUNDING_SPENT (an older mutual close)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain) =>
-    within(30 seconds) {
-      val aliceClose1 = alice2bob.expectMsgType[ClosingSigned]
-      alice2bob.forward(bob)
-      val bobClose1 = bob2alice.expectMsgType[ClosingSigned]
-      bob2alice.forward(alice)
-      val aliceClose2 = alice2bob.expectMsgType[ClosingSigned]
-      assert(aliceClose2.feeSatoshis != bobClose1.feeSatoshis)
-      // at this point alice and bob have not yet converged on closing fees, but bob decides to publish a mutual close with one of the previous sigs
-      val d = bob.stateData.asInstanceOf[DATA_NEGOTIATING]
-      implicit val log = bob.underlyingActor.implicitLog
-      val Success(bobClosingTx) = Closing.checkClosingSignature(Bob.keyManager, d.commitments, d.localShutdown.scriptPubKey, d.remoteShutdown.scriptPubKey, Satoshi(aliceClose1.feeSatoshis), aliceClose1.signature)
-
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobClosingTx)
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed]
-      alice2blockchain.expectNoMsg(100 millis)
-      assert(alice.stateName == CLOSING)
-    }
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobClosingTx)
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed]
+    alice2blockchain.expectNoMsg(100 millis)
+    assert(alice.stateName == CLOSING)
   }
 
 
-  test("recv CMD_CLOSE") { case (alice, _, _, _, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg(Failure(ClosingAlreadyInProgress(channelId(alice))))
-    }
+  test("recv CMD_CLOSE") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg(Failure(ClosingAlreadyInProgress(channelId(alice))))
   }
 
-  test("recv Error") { case (alice, _, _, _, alice2blockchain, _) =>
-    within(30 seconds) {
-      val tx = alice.stateData.asInstanceOf[DATA_NEGOTIATING].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! Error("00" * 32, "oops".getBytes())
-      awaitCond(alice.stateName == CLOSING)
-      alice2blockchain.expectMsg(PublishAsap(tx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
-    }
+  test("recv Error") { f =>
+    import f._
+    val tx = alice.stateData.asInstanceOf[DATA_NEGOTIATING].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! Error("00" * 32, "oops".getBytes())
+    awaitCond(alice.stateName == CLOSING)
+    alice2blockchain.expectMsg(PublishAsap(tx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(tx))
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
@@ -29,8 +29,6 @@ import fr.acinq.eclair.channel.{Data, State, _}
 import fr.acinq.eclair.payment.Local
 import fr.acinq.eclair.wire.{ClosingSigned, Error, Shutdown}
 import fr.acinq.eclair.{Globals, TestkitBaseClass}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{Outcome, Tag}
 
 import scala.concurrent.duration._
@@ -39,7 +37,7 @@ import scala.util.Success
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class NegotiatingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -20,7 +20,6 @@ import akka.actor.Status
 import akka.actor.Status.Failure
 import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.{OutPoint, ScriptFlags, Transaction, TxIn}
-import fr.acinq.eclair.{Globals, TestConstants, TestkitBaseClass}
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
@@ -28,7 +27,9 @@ import fr.acinq.eclair.channel.{Data, State, _}
 import fr.acinq.eclair.payment.{CommandBuffer, ForwardAdd, ForwardFulfill, Local}
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
+import fr.acinq.eclair.{Globals, TestConstants, TestkitBaseClass}
 import org.junit.runner.RunWith
+import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
@@ -39,13 +40,13 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  type FixtureParam = Tuple8[TestFSMRef[State, Data, Channel], TestFSMRef[State, Data, Channel], TestProbe, TestProbe, TestProbe, TestProbe, TestProbe, List[PublishableTxs]]
+  case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, relayer: TestProbe, bobCommitTxes: List[PublishableTxs])
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()
     import setup._
 
-    val bobCommitTxes = within(30 seconds) {
+    within(30 seconds) {
       reachNormal(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer)
       val bobCommitTxes: List[PublishableTxs] = (for (amt <- List(100000000, 200000000, 300000000)) yield {
         val (r, htlc) = addHtlc(amt, alice, bob, alice2bob, bob2alice)
@@ -71,9 +72,8 @@ class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
       // - revoked commit
       // and we want to be able to test the different scenarii.
       // Hence the NORMAL->CLOSING transition will occur in the individual tests.
-      bobCommitTxes
+      withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer, bobCommitTxes)))
     }
-    test((alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, relayer, bobCommitTxes))
   }
 
   def mutualClose(alice: TestFSMRef[State, Data, Channel],
@@ -106,438 +106,420 @@ class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     // both nodes are now in CLOSING state with a mutual close tx pending for confirmation
   }
 
-  test("recv CMD_ADD_HTLC") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, _) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+  test("recv CMD_ADD_HTLC") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
 
-      // actual test starts here
-      val sender = TestProbe()
-      val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 300000)
-      sender.send(alice, add)
-      val error = ChannelUnavailable(channelId(alice))
-      sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), None, Some(add))))
-      alice2bob.expectNoMsg(200 millis)
-    }
+    // actual test starts here
+    val sender = TestProbe()
+    val add = CMD_ADD_HTLC(500000000, "11" * 32, expiry = 300000)
+    sender.send(alice, add)
+    val error = ChannelUnavailable(channelId(alice))
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(alice), add.paymentHash, error, Local(Some(sender.ref)), None, Some(add))))
+    alice2bob.expectNoMsg(200 millis)
   }
 
-  test("recv CMD_FULFILL_HTLC (unexisting htlc)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, _) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+  test("recv CMD_FULFILL_HTLC (unexisting htlc)") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
 
-      // actual test starts here
-      val sender = TestProbe()
-      sender.send(alice, CMD_FULFILL_HTLC(42, "42" * 32))
-      sender.expectMsg(Failure(UnknownHtlcId(channelId(alice), 42)))
+    // actual test starts here
+    val sender = TestProbe()
+    sender.send(alice, CMD_FULFILL_HTLC(42, "42" * 32))
+    sender.expectMsg(Failure(UnknownHtlcId(channelId(alice), 42)))
 
-      // NB: nominal case is tested in IntegrationSpec
-    }
+    // NB: nominal case is tested in IntegrationSpec
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (mutual close before converging)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      // alice initiates a closing
-      sender.send(alice, CMD_CLOSE(None))
-      alice2bob.expectMsgType[Shutdown]
-      alice2bob.forward(bob)
-      bob2alice.expectMsgType[Shutdown]
-      bob2alice.forward(alice)
-      // agreeing on a closing fee
-      val aliceCloseFee = alice2bob.expectMsgType[ClosingSigned].feeSatoshis
-      Globals.feeratesPerKw.set(FeeratesPerKw.single(100))
-      alice2bob.forward(bob)
-      val bobCloseFee = bob2alice.expectMsgType[ClosingSigned].feeSatoshis
-      bob2alice.forward(alice)
-      // they don't converge yet, but alice has a publishable commit tx now
-      assert(aliceCloseFee != bobCloseFee)
-      val Some(mutualCloseTx) = alice.stateData.asInstanceOf[DATA_NEGOTIATING].bestUnpublishedClosingTx_opt
-      // let's make alice publish this closing tx
-      alice ! Error("00" * 32, "")
-      awaitCond(alice.stateName == CLOSING)
-      assert(mutualCloseTx === alice.stateData.asInstanceOf[DATA_CLOSING].mutualClosePublished.last)
+  test("recv BITCOIN_FUNDING_SPENT (mutual close before converging)") { f =>
+    import f._
+    val sender = TestProbe()
+    // alice initiates a closing
+    sender.send(alice, CMD_CLOSE(None))
+    alice2bob.expectMsgType[Shutdown]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[Shutdown]
+    bob2alice.forward(alice)
+    // agreeing on a closing fee
+    val aliceCloseFee = alice2bob.expectMsgType[ClosingSigned].feeSatoshis
+    Globals.feeratesPerKw.set(FeeratesPerKw.single(100))
+    alice2bob.forward(bob)
+    val bobCloseFee = bob2alice.expectMsgType[ClosingSigned].feeSatoshis
+    bob2alice.forward(alice)
+    // they don't converge yet, but alice has a publishable commit tx now
+    assert(aliceCloseFee != bobCloseFee)
+    val Some(mutualCloseTx) = alice.stateData.asInstanceOf[DATA_NEGOTIATING].bestUnpublishedClosingTx_opt
+    // let's make alice publish this closing tx
+    alice ! Error("00" * 32, "")
+    awaitCond(alice.stateName == CLOSING)
+    assert(mutualCloseTx === alice.stateData.asInstanceOf[DATA_CLOSING].mutualClosePublished.last)
 
-      // actual test starts here
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, mutualCloseTx)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(mutualCloseTx), 0, 0)
-      awaitCond(alice.stateName == CLOSED)
-    }
+    // actual test starts here
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, mutualCloseTx)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(mutualCloseTx), 0, 0)
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv BITCOIN_TX_CONFIRMED (mutual close)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, _) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-      val mutualCloseTx = alice.stateData.asInstanceOf[DATA_CLOSING].mutualClosePublished.last
+  test("recv BITCOIN_TX_CONFIRMED (mutual close)") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+    val mutualCloseTx = alice.stateData.asInstanceOf[DATA_CLOSING].mutualClosePublished.last
 
-      // actual test starts here
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(mutualCloseTx), 0, 0)
-      awaitCond(alice.stateName == CLOSED)
-    }
+    // actual test starts here
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(mutualCloseTx), 0, 0)
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (local commit)") { case (alice, _, _, _, alice2blockchain, _, _, _) =>
-    within(30 seconds) {
-      // an error occurs and alice publishes her commit tx
-      val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! Error("00" * 32, "oops".getBytes)
-      alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed].txId == aliceCommitTx.txid
-      awaitCond(alice.stateName == CLOSING)
-      val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
-      assert(initialState.localCommitPublished.isDefined)
+  test("recv BITCOIN_FUNDING_SPENT (local commit)") { f =>
+    import f._
+    // an error occurs and alice publishes her commit tx
+    val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! Error("00" * 32, "oops".getBytes)
+    alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed].txId == aliceCommitTx.txid
+    awaitCond(alice.stateName == CLOSING)
+    val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
+    assert(initialState.localCommitPublished.isDefined)
 
-      // actual test starts here
-      // we are notified afterwards from our watcher about the tx that we just published
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, aliceCommitTx)
-      assert(alice.stateData == initialState) // this was a no-op
-    }
+    // actual test starts here
+    // we are notified afterwards from our watcher about the tx that we just published
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, aliceCommitTx)
+    assert(alice.stateData == initialState) // this was a no-op
   }
 
-  test("recv BITCOIN_OUTPUT_SPENT") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, relayer, _) =>
-    within(30 seconds) {
-      // alice sends an htlc to bob
-      val (ra1, htlca1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-      relayer.expectMsgType[ForwardAdd]
-      // an error occurs and alice publishes her commit tx
-      val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! Error("00" * 32, "oops".getBytes)
-      alice2blockchain.expectMsg(PublishAsap(aliceCommitTx)) // commit tx
-      alice2blockchain.expectMsgType[PublishAsap] // main-delayed-output
-      alice2blockchain.expectMsgType[PublishAsap] // htlc-timeout
-      alice2blockchain.expectMsgType[PublishAsap] // claim-delayed-output
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event.isInstanceOf[BITCOIN_TX_CONFIRMED]) // main-delayed-output
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event.isInstanceOf[BITCOIN_TX_CONFIRMED]) // claim-delayed-output
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      awaitCond(alice.stateName == CLOSING)
-      val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
-      assert(initialState.localCommitPublished.isDefined)
+  test("recv BITCOIN_OUTPUT_SPENT") { f =>
+    import f._
+    // alice sends an htlc to bob
+    val (ra1, htlca1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    relayer.expectMsgType[ForwardAdd]
+    // an error occurs and alice publishes her commit tx
+    val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! Error("00" * 32, "oops".getBytes)
+    alice2blockchain.expectMsg(PublishAsap(aliceCommitTx)) // commit tx
+    alice2blockchain.expectMsgType[PublishAsap] // main-delayed-output
+    alice2blockchain.expectMsgType[PublishAsap] // htlc-timeout
+    alice2blockchain.expectMsgType[PublishAsap] // claim-delayed-output
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event.isInstanceOf[BITCOIN_TX_CONFIRMED]) // main-delayed-output
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event.isInstanceOf[BITCOIN_TX_CONFIRMED]) // claim-delayed-output
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    awaitCond(alice.stateName == CLOSING)
+    val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
+    assert(initialState.localCommitPublished.isDefined)
 
-      // actual test starts here
-      relayer.expectMsgType[LocalChannelDown]
+    // actual test starts here
+    relayer.expectMsgType[LocalChannelDown]
 
-      // scenario 1: bob claims the htlc output from the commit tx using its preimage
-      val claimHtlcSuccessFromCommitTx = Transaction(version = 0, txIn = TxIn(outPoint = OutPoint("22" * 32, 0), signatureScript = "", sequence = 0, witness = Scripts.witnessClaimHtlcSuccessFromCommitTx("11" * 70, ra1, "33" * 130)) :: Nil, txOut = Nil, lockTime = 0)
-      alice ! WatchEventSpent(BITCOIN_OUTPUT_SPENT, claimHtlcSuccessFromCommitTx)
-      assert(relayer.expectMsgType[ForwardFulfill].fulfill === UpdateFulfillHtlc(htlca1.channelId, htlca1.id, ra1))
+    // scenario 1: bob claims the htlc output from the commit tx using its preimage
+    val claimHtlcSuccessFromCommitTx = Transaction(version = 0, txIn = TxIn(outPoint = OutPoint("22" * 32, 0), signatureScript = "", sequence = 0, witness = Scripts.witnessClaimHtlcSuccessFromCommitTx("11" * 70, ra1, "33" * 130)) :: Nil, txOut = Nil, lockTime = 0)
+    alice ! WatchEventSpent(BITCOIN_OUTPUT_SPENT, claimHtlcSuccessFromCommitTx)
+    assert(relayer.expectMsgType[ForwardFulfill].fulfill === UpdateFulfillHtlc(htlca1.channelId, htlca1.id, ra1))
 
-      // scenario 2: bob claims the htlc output from his own commit tx using its preimage (let's assume both parties had published their commitment tx)
-      val claimHtlcSuccessTx = Transaction(version = 0, txIn = TxIn(outPoint = OutPoint("22" * 32, 0), signatureScript = "", sequence = 0, witness = Scripts.witnessHtlcSuccess("11" * 70, "22" * 70, ra1, "33" * 130)) :: Nil, txOut = Nil, lockTime = 0)
-      alice ! WatchEventSpent(BITCOIN_OUTPUT_SPENT, claimHtlcSuccessTx)
-      assert(relayer.expectMsgType[ForwardFulfill].fulfill === UpdateFulfillHtlc(htlca1.channelId, htlca1.id, ra1))
+    // scenario 2: bob claims the htlc output from his own commit tx using its preimage (let's assume both parties had published their commitment tx)
+    val claimHtlcSuccessTx = Transaction(version = 0, txIn = TxIn(outPoint = OutPoint("22" * 32, 0), signatureScript = "", sequence = 0, witness = Scripts.witnessHtlcSuccess("11" * 70, "22" * 70, ra1, "33" * 130)) :: Nil, txOut = Nil, lockTime = 0)
+    alice ! WatchEventSpent(BITCOIN_OUTPUT_SPENT, claimHtlcSuccessTx)
+    assert(relayer.expectMsgType[ForwardFulfill].fulfill === UpdateFulfillHtlc(htlca1.channelId, htlca1.id, ra1))
 
-      assert(alice.stateData == initialState) // this was a no-op
-    }
+    assert(alice.stateData == initialState) // this was a no-op
   }
 
-  test("recv BITCOIN_TX_CONFIRMED (local commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, _, _) =>
-    within(30 seconds) {
-      val listener = TestProbe()
-      system.eventStream.subscribe(listener.ref, classOf[LocalCommitConfirmed])
-      // alice sends an htlc to bob
-      val (ra1, htlca1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-      // an error occurs and alice publishes her commit tx
-      val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! Error("00" * 32, "oops".getBytes)
-      alice2blockchain.expectMsg(PublishAsap(aliceCommitTx)) // commit tx
-      val claimMainDelayedTx = alice2blockchain.expectMsgType[PublishAsap].tx // main-delayed-output
-      val htlcTimeoutTx = alice2blockchain.expectMsgType[PublishAsap].tx // htlc-timeout
-      val claimDelayedTx = alice2blockchain.expectMsgType[PublishAsap].tx // claim-delayed-output
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event.isInstanceOf[BITCOIN_TX_CONFIRMED]) // main-delayed-output
-      assert(alice2blockchain.expectMsgType[WatchConfirmed].event.isInstanceOf[BITCOIN_TX_CONFIRMED]) // claim-delayed-output
-      assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
-      awaitCond(alice.stateName == CLOSING)
-      val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
-      assert(initialState.localCommitPublished.isDefined)
+  test("recv BITCOIN_TX_CONFIRMED (local commit)") { f =>
+    import f._
+    val listener = TestProbe()
+    system.eventStream.subscribe(listener.ref, classOf[LocalCommitConfirmed])
+    // alice sends an htlc to bob
+    val (ra1, htlca1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    // an error occurs and alice publishes her commit tx
+    val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! Error("00" * 32, "oops".getBytes)
+    alice2blockchain.expectMsg(PublishAsap(aliceCommitTx)) // commit tx
+  val claimMainDelayedTx = alice2blockchain.expectMsgType[PublishAsap].tx // main-delayed-output
+  val htlcTimeoutTx = alice2blockchain.expectMsgType[PublishAsap].tx // htlc-timeout
+  val claimDelayedTx = alice2blockchain.expectMsgType[PublishAsap].tx // claim-delayed-output
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event.isInstanceOf[BITCOIN_TX_CONFIRMED]) // main-delayed-output
+    assert(alice2blockchain.expectMsgType[WatchConfirmed].event.isInstanceOf[BITCOIN_TX_CONFIRMED]) // claim-delayed-output
+    assert(alice2blockchain.expectMsgType[WatchSpent].event === BITCOIN_OUTPUT_SPENT)
+    awaitCond(alice.stateName == CLOSING)
+    val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
+    assert(initialState.localCommitPublished.isDefined)
 
-      // actual test starts here
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(aliceCommitTx), 42, 0)
-      assert(listener.expectMsgType[LocalCommitConfirmed].refundAtBlock == 42 + TestConstants.Bob.channelParams.toSelfDelay)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimMainDelayedTx), 200, 0)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(htlcTimeoutTx), 201, 0)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimDelayedTx), 202, 0)
-      awaitCond(alice.stateName == CLOSED)
-    }
+    // actual test starts here
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(aliceCommitTx), 42, 0)
+    assert(listener.expectMsgType[LocalCommitConfirmed].refundAtBlock == 42 + TestConstants.Bob.channelParams.toSelfDelay)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimMainDelayedTx), 200, 0)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(htlcTimeoutTx), 201, 0)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimDelayedTx), 202, 0)
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv BITCOIN_TX_CONFIRMED (local commit with htlcs only signed by local)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, _, relayer, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      // alice sends an htlc
-      val (r, htlc) = addHtlc(4200000, alice, bob, alice2bob, bob2alice)
-      // and signs it (but bob doesn't sign it)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      // note that bob doesn't receive the new sig!
-      // then we make alice unilaterally close the channel
-      alice ! Error("00" * 32, "oops".getBytes)
-      alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
-      awaitCond(alice.stateName == CLOSING)
-      val aliceData = alice.stateData.asInstanceOf[DATA_CLOSING]
-      assert(aliceData.localCommitPublished.isDefined)
-      relayer.expectMsgType[LocalChannelDown]
+  test("recv BITCOIN_TX_CONFIRMED (local commit with htlcs only signed by local)") { f =>
+    import f._
+    val sender = TestProbe()
+    val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    // alice sends an htlc
+    val (r, htlc) = addHtlc(4200000, alice, bob, alice2bob, bob2alice)
+    // and signs it (but bob doesn't sign it)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    // note that bob doesn't receive the new sig!
+    // then we make alice unilaterally close the channel
+    alice ! Error("00" * 32, "oops".getBytes)
+    alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
+    awaitCond(alice.stateName == CLOSING)
+    val aliceData = alice.stateData.asInstanceOf[DATA_CLOSING]
+    assert(aliceData.localCommitPublished.isDefined)
+    relayer.expectMsgType[LocalChannelDown]
 
-      // actual test starts here
-      // when the commit tx is signed, alice knows that the htlc she sent right before the unilateral close will never reach the chain
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(aliceCommitTx), 0, 0)
-      // so she fails it
-      val origin = alice.stateData.asInstanceOf[DATA_CLOSING].commitments.originChannels(htlc.id)
-      relayer.expectMsg(Status.Failure(AddHtlcFailed(aliceData.channelId, htlc.paymentHash, HtlcOverridenByLocalCommit(aliceData.channelId), origin, None, None)))
-    }
+    // actual test starts here
+    // when the commit tx is signed, alice knows that the htlc she sent right before the unilateral close will never reach the chain
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(aliceCommitTx), 0, 0)
+    // so she fails it
+    val origin = alice.stateData.asInstanceOf[DATA_CLOSING].commitments.originChannels(htlc.id)
+    relayer.expectMsg(Status.Failure(AddHtlcFailed(aliceData.channelId, htlc.paymentHash, HtlcOverridenByLocalCommit(aliceData.channelId), origin, None, None)))
   }
 
-  test("recv BITCOIN_TX_CONFIRMED (remote commit with htlcs only signed by local in next remote commit)") { case (alice, bob, alice2bob, bob2alice, _, bob2blockchain, relayer, _) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      // alice sends an htlc
-      val (r, htlc) = addHtlc(4200000, alice, bob, alice2bob, bob2alice)
-      // and signs it (but bob doesn't sign it)
-      sender.send(alice, CMD_SIGN)
-      sender.expectMsg("ok")
-      alice2bob.expectMsgType[CommitSig]
-      // then we make alice believe bob unilaterally close the channel
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
-      awaitCond(alice.stateName == CLOSING)
-      val aliceData = alice.stateData.asInstanceOf[DATA_CLOSING]
-      assert(aliceData.remoteCommitPublished.isDefined)
-      relayer.expectMsgType[LocalChannelDown]
+  test("recv BITCOIN_TX_CONFIRMED (remote commit with htlcs only signed by local in next remote commit)") { f =>
+    import f._
+    val sender = TestProbe()
+    val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    // alice sends an htlc
+    val (r, htlc) = addHtlc(4200000, alice, bob, alice2bob, bob2alice)
+    // and signs it (but bob doesn't sign it)
+    sender.send(alice, CMD_SIGN)
+    sender.expectMsg("ok")
+    alice2bob.expectMsgType[CommitSig]
+    // then we make alice believe bob unilaterally close the channel
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
+    awaitCond(alice.stateName == CLOSING)
+    val aliceData = alice.stateData.asInstanceOf[DATA_CLOSING]
+    assert(aliceData.remoteCommitPublished.isDefined)
+    relayer.expectMsgType[LocalChannelDown]
 
-      // actual test starts here
-      // when the commit tx is signed, alice knows that the htlc she sent right before the unilateral close will never reach the chain
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobCommitTx), 0, 0)
-      // so she fails it
-      val origin = alice.stateData.asInstanceOf[DATA_CLOSING].commitments.originChannels(htlc.id)
-      relayer.expectMsg(Status.Failure(AddHtlcFailed(aliceData.channelId, htlc.paymentHash, HtlcOverridenByLocalCommit(aliceData.channelId), origin, None, None)))
-    }
+    // actual test starts here
+    // when the commit tx is signed, alice knows that the htlc she sent right before the unilateral close will never reach the chain
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobCommitTx), 0, 0)
+    // so she fails it
+    val origin = alice.stateData.asInstanceOf[DATA_CLOSING].commitments.originChannels(htlc.id)
+    relayer.expectMsg(Status.Failure(AddHtlcFailed(aliceData.channelId, htlc.paymentHash, HtlcOverridenByLocalCommit(aliceData.channelId), origin, None, None)))
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (remote commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, bobCommitTxes) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-      val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
-      // bob publishes his last current commit tx, the one it had when entering NEGOTIATING state
-      val bobCommitTx = bobCommitTxes.last.commitTx.tx
-      assert(bobCommitTx.txOut.size == 2) // two main outputs
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
+  test("recv BITCOIN_FUNDING_SPENT (remote commit)") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+    val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
+    // bob publishes his last current commit tx, the one it had when entering NEGOTIATING state
+    val bobCommitTx = bobCommitTxes.last.commitTx.tx
+    assert(bobCommitTx.txOut.size == 2) // two main outputs
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
 
-      alice2blockchain.expectMsgType[PublishAsap]
-      alice2blockchain.expectMsgType[WatchConfirmed].txId == bobCommitTx.txid
+    alice2blockchain.expectMsgType[PublishAsap]
+    alice2blockchain.expectMsgType[WatchConfirmed].txId == bobCommitTx.txid
 
-      awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.isDefined)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].copy(remoteCommitPublished = None) == initialState)
-    }
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.isDefined)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].copy(remoteCommitPublished = None) == initialState)
   }
 
-  test("recv BITCOIN_TX_CONFIRMED (remote commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, bobCommitTxes) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-      val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
-      // bob publishes his last current commit tx, the one it had when entering NEGOTIATING state
-      val bobCommitTx = bobCommitTxes.last.commitTx.tx
-      assert(bobCommitTx.txOut.size == 2) // two main outputs
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
-      val claimMainTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      alice2blockchain.expectMsgType[WatchConfirmed].txId == bobCommitTx.txid
-      awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.isDefined)
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].copy(remoteCommitPublished = None) == initialState)
+  test("recv BITCOIN_TX_CONFIRMED (remote commit)") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+    val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
+    // bob publishes his last current commit tx, the one it had when entering NEGOTIATING state
+    val bobCommitTx = bobCommitTxes.last.commitTx.tx
+    assert(bobCommitTx.txOut.size == 2) // two main outputs
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
+    val claimMainTx = alice2blockchain.expectMsgType[PublishAsap].tx
+    alice2blockchain.expectMsgType[WatchConfirmed].txId == bobCommitTx.txid
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.isDefined)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].copy(remoteCommitPublished = None) == initialState)
 
-      // actual test starts here
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobCommitTx), 0, 0)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimMainTx), 0, 0)
-      awaitCond(alice.stateName == CLOSED)
-    }
+    // actual test starts here
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobCommitTx), 0, 0)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimMainTx), 0, 0)
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv BITCOIN_TX_CONFIRMED (future remote commit)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, bobCommitTxes) =>
-    within(30 seconds) {
-      val sender = TestProbe()
-      val oldStateData = alice.stateData
-      val (ra1, htlca1) = addHtlc(25000000, alice, bob, alice2bob, bob2alice)
-      crossSign(alice, bob, alice2bob, bob2alice)
-      fulfillHtlc(htlca1.id, ra1, bob, alice, bob2alice, alice2bob)
-      crossSign(bob, alice, bob2alice, alice2bob)
-      // we simulate a disconnection
-      sender.send(alice, INPUT_DISCONNECTED)
-      sender.send(bob, INPUT_DISCONNECTED)
-      awaitCond(alice.stateName == OFFLINE)
-      awaitCond(bob.stateName == OFFLINE)
-      // then we manually replace alice's state with an older one
-      alice.setState(OFFLINE, oldStateData)
-      // then we reconnect them
-      sender.send(alice, INPUT_RECONNECTED(alice2bob.ref))
-      sender.send(bob, INPUT_RECONNECTED(bob2alice.ref))
-      // peers exchange channel_reestablish messages
-      alice2bob.expectMsgType[ChannelReestablish]
-      bob2alice.expectMsgType[ChannelReestablish]
-      // alice then realizes it has an old state...
-      bob2alice.forward(alice)
-      // ... and ask bob to publish its current commitment
-      val error = alice2bob.expectMsgType[Error]
-      assert(new String(error.data) === PleasePublishYourCommitment(channelId(alice)).getMessage)
-      // alice now waits for bob to publish its commitment
-      awaitCond(alice.stateName == WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT)
-      // bob is nice and publishes its commitment
-      val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
-      // alice is able to claim its main output
-      val claimMainTx = alice2blockchain.expectMsgType[PublishAsap].tx
-      Transaction.correctlySpends(claimMainTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      alice2blockchain.expectMsgType[WatchConfirmed].txId == bobCommitTx.txid
-      awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].futureRemoteCommitPublished.isDefined)
+  test("recv BITCOIN_TX_CONFIRMED (future remote commit)") { f =>
+    import f._
+    val sender = TestProbe()
+    val oldStateData = alice.stateData
+    val (ra1, htlca1) = addHtlc(25000000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    fulfillHtlc(htlca1.id, ra1, bob, alice, bob2alice, alice2bob)
+    crossSign(bob, alice, bob2alice, alice2bob)
+    // we simulate a disconnection
+    sender.send(alice, INPUT_DISCONNECTED)
+    sender.send(bob, INPUT_DISCONNECTED)
+    awaitCond(alice.stateName == OFFLINE)
+    awaitCond(bob.stateName == OFFLINE)
+    // then we manually replace alice's state with an older one
+    alice.setState(OFFLINE, oldStateData)
+    // then we reconnect them
+    sender.send(alice, INPUT_RECONNECTED(alice2bob.ref))
+    sender.send(bob, INPUT_RECONNECTED(bob2alice.ref))
+    // peers exchange channel_reestablish messages
+    alice2bob.expectMsgType[ChannelReestablish]
+    bob2alice.expectMsgType[ChannelReestablish]
+    // alice then realizes it has an old state...
+    bob2alice.forward(alice)
+    // ... and ask bob to publish its current commitment
+    val error = alice2bob.expectMsgType[Error]
+    assert(new String(error.data) === PleasePublishYourCommitment(channelId(alice)).getMessage)
+    // alice now waits for bob to publish its commitment
+    awaitCond(alice.stateName == WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT)
+    // bob is nice and publishes its commitment
+    val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTx)
+    // alice is able to claim its main output
+    val claimMainTx = alice2blockchain.expectMsgType[PublishAsap].tx
+    Transaction.correctlySpends(claimMainTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    alice2blockchain.expectMsgType[WatchConfirmed].txId == bobCommitTx.txid
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].futureRemoteCommitPublished.isDefined)
 
-      // actual test starts here
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobCommitTx), 0, 0)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimMainTx), 0, 0)
-      awaitCond(alice.stateName == CLOSED)
-    }
+    // actual test starts here
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobCommitTx), 0, 0)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimMainTx), 0, 0)
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (one revoked tx)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, bobCommitTxes) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-      val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
-      // bob publishes one of his revoked txes
-      val bobRevokedTx = bobCommitTxes.head.commitTx.tx
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobRevokedTx)
+  test("recv BITCOIN_FUNDING_SPENT (one revoked tx)") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+    val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
+    // bob publishes one of his revoked txes
+    val bobRevokedTx = bobCommitTxes.head.commitTx.tx
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobRevokedTx)
 
-      // alice publishes and watches the penalty tx
-      alice2blockchain.expectMsgType[PublishAsap] // claim-main
-      alice2blockchain.expectMsgType[PublishAsap] // main-penalty
-      alice2blockchain.expectMsgType[PublishAsap] // htlc-penalty
-      alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
-      alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
-      alice2blockchain.expectMsgType[WatchSpent] // main-penalty
-      alice2blockchain.expectMsgType[WatchSpent] // htlc-penalty
-      alice2blockchain.expectNoMsg(1 second)
+    // alice publishes and watches the penalty tx
+    alice2blockchain.expectMsgType[PublishAsap] // claim-main
+    alice2blockchain.expectMsgType[PublishAsap] // main-penalty
+    alice2blockchain.expectMsgType[PublishAsap] // htlc-penalty
+    alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
+    alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
+    alice2blockchain.expectMsgType[WatchSpent] // main-penalty
+    alice2blockchain.expectMsgType[WatchSpent] // htlc-penalty
+    alice2blockchain.expectNoMsg(1 second)
 
-      awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 1)
-      awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].copy(revokedCommitPublished = Nil) == initialState)
-    }
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 1)
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].copy(revokedCommitPublished = Nil) == initialState)
   }
 
-  test("recv BITCOIN_FUNDING_SPENT (multiple revoked tx)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, bobCommitTxes) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-      // bob publishes multiple revoked txes (last one isn't revoked)
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTxes(0).commitTx.tx)
-      // alice publishes and watches the penalty tx
-      alice2blockchain.expectMsgType[PublishAsap] // claim-main
-      alice2blockchain.expectMsgType[PublishAsap] // main-penalty
-      alice2blockchain.expectMsgType[PublishAsap] // htlc-penalty
-      alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
-      alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
-      alice2blockchain.expectMsgType[WatchSpent] // main-penalty
-      alice2blockchain.expectMsgType[WatchSpent] // htlc-penalty
-      alice2blockchain.expectNoMsg(1 second)
+  test("recv BITCOIN_FUNDING_SPENT (multiple revoked tx)") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+    // bob publishes multiple revoked txes (last one isn't revoked)
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTxes(0).commitTx.tx)
+    // alice publishes and watches the penalty tx
+    alice2blockchain.expectMsgType[PublishAsap] // claim-main
+    alice2blockchain.expectMsgType[PublishAsap] // main-penalty
+    alice2blockchain.expectMsgType[PublishAsap] // htlc-penalty
+    alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
+    alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
+    alice2blockchain.expectMsgType[WatchSpent] // main-penalty
+    alice2blockchain.expectMsgType[WatchSpent] // htlc-penalty
+    alice2blockchain.expectNoMsg(1 second)
 
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTxes(1).commitTx.tx)
-      // alice publishes and watches the penalty tx
-      alice2blockchain.expectMsgType[PublishAsap] // claim-main
-      alice2blockchain.expectMsgType[PublishAsap] // main-penalty
-      alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
-      alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
-      alice2blockchain.expectMsgType[WatchSpent] // main-penalty
-      alice2blockchain.expectNoMsg(1 second)
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTxes(1).commitTx.tx)
+    // alice publishes and watches the penalty tx
+    alice2blockchain.expectMsgType[PublishAsap] // claim-main
+    alice2blockchain.expectMsgType[PublishAsap] // main-penalty
+    alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
+    alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
+    alice2blockchain.expectMsgType[WatchSpent] // main-penalty
+    alice2blockchain.expectNoMsg(1 second)
 
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTxes(2).commitTx.tx)
-      // alice publishes and watches the penalty tx
-      alice2blockchain.expectMsgType[PublishAsap] // claim-main
-      alice2blockchain.expectMsgType[PublishAsap] // main-penalty
-      alice2blockchain.expectMsgType[PublishAsap] // htlc-penalty
-      alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
-      alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
-      alice2blockchain.expectMsgType[WatchSpent] // main-penalty
-      alice2blockchain.expectMsgType[WatchSpent] // htlc-penalty
-      alice2blockchain.expectNoMsg(1 second)
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobCommitTxes(2).commitTx.tx)
+    // alice publishes and watches the penalty tx
+    alice2blockchain.expectMsgType[PublishAsap] // claim-main
+    alice2blockchain.expectMsgType[PublishAsap] // main-penalty
+    alice2blockchain.expectMsgType[PublishAsap] // htlc-penalty
+    alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
+    alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
+    alice2blockchain.expectMsgType[WatchSpent] // main-penalty
+    alice2blockchain.expectMsgType[WatchSpent] // htlc-penalty
+    alice2blockchain.expectNoMsg(1 second)
 
-      assert(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 3)
-    }
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.size == 3)
   }
 
-  test("recv BITCOIN_OUTPUT_SPENT (one revoked tx, counterparty published HtlcSuccess tx)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, bobCommitTxes) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-      // bob publishes one of his revoked txes
-      val bobRevokedTx = bobCommitTxes.head
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobRevokedTx.commitTx.tx)
-      // alice publishes and watches the penalty tx
-      val claimMainTx = alice2blockchain.expectMsgType[PublishAsap].tx // claim-main
-      val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx // main-penalty
-      val htlcPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx // htlc-penalty
-      alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
-      alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
-      alice2blockchain.expectMsgType[WatchSpent] // main-penalty
-      alice2blockchain.expectMsgType[WatchSpent] // htlc-penalty
-      alice2blockchain.expectNoMsg(1 second)
-      awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.head.commitTx == bobRevokedTx.commitTx.tx)
+  test("recv BITCOIN_OUTPUT_SPENT (one revoked tx, counterparty published HtlcSuccess tx)") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+    // bob publishes one of his revoked txes
+    val bobRevokedTx = bobCommitTxes.head
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobRevokedTx.commitTx.tx)
+    // alice publishes and watches the penalty tx
+    val claimMainTx = alice2blockchain.expectMsgType[PublishAsap].tx // claim-main
+  val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx // main-penalty
+  val htlcPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx // htlc-penalty
+    alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
+    alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
+    alice2blockchain.expectMsgType[WatchSpent] // main-penalty
+    alice2blockchain.expectMsgType[WatchSpent] // htlc-penalty
+    alice2blockchain.expectNoMsg(1 second)
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.head.commitTx == bobRevokedTx.commitTx.tx)
 
-      // actual test starts here
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobRevokedTx.commitTx.tx), 0, 0)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimMainTx), 0, 0)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(mainPenaltyTx), 0, 0)
-      alice ! WatchEventSpent(BITCOIN_OUTPUT_SPENT, htlcPenaltyTx) // we published this
-      alice2blockchain.expectMsgType[WatchConfirmed] // htlc-penalty
-      val bobHtlcSuccessTx = bobRevokedTx.htlcTxsAndSigs.head.txinfo.tx
-      alice ! WatchEventSpent(BITCOIN_OUTPUT_SPENT, bobHtlcSuccessTx) // bob published his HtlcSuccess tx
-      alice2blockchain.expectMsgType[WatchConfirmed] // htlc-success
-      val claimHtlcDelayedPenaltyTxs = alice2blockchain.expectMsgType[PublishAsap].tx // we publish a tx spending the output of bob's HtlcSuccess tx
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobHtlcSuccessTx), 0, 0) // bob won
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimHtlcDelayedPenaltyTxs), 0, 0) // bob won
-      awaitCond(alice.stateName == CLOSED)
-    }
+    // actual test starts here
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobRevokedTx.commitTx.tx), 0, 0)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimMainTx), 0, 0)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(mainPenaltyTx), 0, 0)
+    alice ! WatchEventSpent(BITCOIN_OUTPUT_SPENT, htlcPenaltyTx) // we published this
+    alice2blockchain.expectMsgType[WatchConfirmed] // htlc-penalty
+  val bobHtlcSuccessTx = bobRevokedTx.htlcTxsAndSigs.head.txinfo.tx
+    alice ! WatchEventSpent(BITCOIN_OUTPUT_SPENT, bobHtlcSuccessTx) // bob published his HtlcSuccess tx
+    alice2blockchain.expectMsgType[WatchConfirmed] // htlc-success
+  val claimHtlcDelayedPenaltyTxs = alice2blockchain.expectMsgType[PublishAsap].tx // we publish a tx spending the output of bob's HtlcSuccess tx
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobHtlcSuccessTx), 0, 0) // bob won
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimHtlcDelayedPenaltyTxs), 0, 0) // bob won
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv BITCOIN_TX_CONFIRMED (one revoked tx)") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, bobCommitTxes) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-      // bob publishes one of his revoked txes
-      val bobRevokedTx = bobCommitTxes.head
-      alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobRevokedTx.commitTx.tx)
-      // alice publishes and watches the penalty tx
-      val claimMainTx = alice2blockchain.expectMsgType[PublishAsap].tx // claim-main
-      val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx // main-penalty
-      val htlcPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx // htlc-penalty
-      alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
-      alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
-      alice2blockchain.expectMsgType[WatchSpent] // main-penalty
-      alice2blockchain.expectMsgType[WatchSpent] // htlc-penalty
-      alice2blockchain.expectNoMsg(1 second)
-      awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.head.commitTx == bobRevokedTx.commitTx.tx)
+  test("recv BITCOIN_TX_CONFIRMED (one revoked tx)") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+    // bob publishes one of his revoked txes
+    val bobRevokedTx = bobCommitTxes.head
+    alice ! WatchEventSpent(BITCOIN_FUNDING_SPENT, bobRevokedTx.commitTx.tx)
+    // alice publishes and watches the penalty tx
+    val claimMainTx = alice2blockchain.expectMsgType[PublishAsap].tx // claim-main
+  val mainPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx // main-penalty
+  val htlcPenaltyTx = alice2blockchain.expectMsgType[PublishAsap].tx // htlc-penalty
+    alice2blockchain.expectMsgType[WatchConfirmed] // revoked commit
+    alice2blockchain.expectMsgType[WatchConfirmed] // claim-main
+    alice2blockchain.expectMsgType[WatchSpent] // main-penalty
+    alice2blockchain.expectMsgType[WatchSpent] // htlc-penalty
+    alice2blockchain.expectNoMsg(1 second)
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].revokedCommitPublished.head.commitTx == bobRevokedTx.commitTx.tx)
 
-      // actual test starts here
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobRevokedTx.commitTx.tx), 0, 0)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimMainTx), 0, 0)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(mainPenaltyTx), 0, 0)
-      alice ! WatchEventSpent(BITCOIN_OUTPUT_SPENT, htlcPenaltyTx)
-      alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(htlcPenaltyTx), 0, 0)
-      awaitCond(alice.stateName == CLOSED)
-    }
+    // actual test starts here
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(bobRevokedTx.commitTx.tx), 0, 0)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimMainTx), 0, 0)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(mainPenaltyTx), 0, 0)
+    alice ! WatchEventSpent(BITCOIN_OUTPUT_SPENT, htlcPenaltyTx)
+    alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(htlcPenaltyTx), 0, 0)
+    awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv ChannelReestablish") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, _) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-      val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
-      val sender = TestProbe()
-      sender.send(alice, ChannelReestablish(channelId(bob), 42, 42))
-      val error = alice2bob.expectMsgType[Error]
-      assert(new String(error.data) === FundingTxSpent(channelId(alice), initialState.spendingTxes.head).getMessage)
-    }
+  test("recv ChannelReestablish") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+    val initialState = alice.stateData.asInstanceOf[DATA_CLOSING]
+    val sender = TestProbe()
+    sender.send(alice, ChannelReestablish(channelId(bob), 42, 42))
+    val error = alice2bob.expectMsgType[Error]
+    assert(new String(error.data) === FundingTxSpent(channelId(alice), initialState.spendingTxes.head).getMessage)
   }
 
-  test("recv CMD_CLOSE") { case (alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, _, _) =>
-    within(30 seconds) {
-      mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
-      val sender = TestProbe()
-      sender.send(alice, CMD_CLOSE(None))
-      sender.expectMsg(Failure(ClosingAlreadyInProgress(channelId(alice))))
-    }
+  test("recv CMD_CLOSE") { f =>
+    import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+    val sender = TestProbe()
+    sender.send(alice, CMD_CLOSE(None))
+    sender.expectMsg(Failure(ClosingAlreadyInProgress(channelId(alice))))
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -28,16 +28,14 @@ import fr.acinq.eclair.payment.{CommandBuffer, ForwardAdd, ForwardFulfill, Local
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{Globals, TestConstants, TestkitBaseClass}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 05/07/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
   case class FixtureParam(alice: TestFSMRef[State, Data, Channel], bob: TestFSMRef[State, Data, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, relayer: TestProbe, bobCommitTxes: List[PublishableTxs])

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/BitStreamSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/BitStreamSpec.scala
@@ -16,15 +16,13 @@
 
 package fr.acinq.eclair.crypto
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.spongycastle.util.encoders.Hex
 
 /**
   * Created by fabrice on 22/06/17.
   */
-@RunWith(classOf[JUnitRunner])
+
 class BitStreamSpec extends FunSuite {
 
   import BitStream._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/ChaCha20Poly1305Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/ChaCha20Poly1305Spec.scala
@@ -17,12 +17,10 @@
 package fr.acinq.eclair.crypto
 
 import fr.acinq.bitcoin.BinaryData
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 
-@RunWith(classOf[JUnitRunner])
+
 class ChaCha20Poly1305Spec extends FunSuite {
   test("Poly1305") {
     // from https://tools.ietf.org/html/rfc7539 ch 2.5.2

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/GeneratorsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/GeneratorsSpec.scala
@@ -18,11 +18,9 @@ package fr.acinq.eclair.crypto
 
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.bitcoin.Crypto.{Point, Scalar}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class GeneratorsSpec extends FunSuite {
   val base_secret: Scalar = BinaryData("0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
   val per_commitment_secret: Scalar = BinaryData("0x1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/LocalKeyManagerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/LocalKeyManagerSpec.scala
@@ -19,11 +19,9 @@ package fr.acinq.eclair.crypto
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.DeterministicWallet.KeyPath
 import fr.acinq.bitcoin.{BinaryData, Block}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class LocalKeyManagerSpec extends FunSuite {
   test("generate the same node id from the same seed") {
     // if this test breaks it means that we will generate a different node id  from

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/NoiseSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/NoiseSpec.scala
@@ -18,12 +18,10 @@ package fr.acinq.eclair.crypto
 
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.crypto.Noise._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.spongycastle.crypto.ec.CustomNamedCurves
 
-@RunWith(classOf[JUnitRunner])
+
 class NoiseSpec extends FunSuite {
 
   import Noise._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/ShaChainSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/ShaChainSpec.scala
@@ -17,11 +17,9 @@
 package fr.acinq.eclair.crypto
 
 import fr.acinq.bitcoin.{BinaryData, Hash}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class ShaChainSpec extends FunSuite {
   val expected: List[BinaryData] = List(
     "f85a0f7f237ed2139855703db4264de380ec731f64a3d832c22a5f2ef615f1d5",

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/SphinxSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/SphinxSpec.scala
@@ -19,17 +19,14 @@ package fr.acinq.eclair.crypto
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.eclair.wire._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
-import scodec.bits.BitVector
 
 import scala.util.Success
 
 /**
   * Created by fabrice on 10/01/17.
   */
-@RunWith(classOf[JUnitRunner])
+
 class SphinxSpec extends FunSuite {
 
   import Sphinx._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/TransportHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/TransportHandlerSpec.scala
@@ -25,8 +25,6 @@ import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.crypto.Noise.{Chacha20Poly1305CipherFunctions, CipherState}
 import fr.acinq.eclair.crypto.TransportHandler.{Encryptor, ExtendedCipherState, Listener}
 import fr.acinq.eclair.wire.LightningMessageCodecs
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 import scodec.Codec
 import scodec.codecs._
@@ -34,7 +32,7 @@ import scodec.codecs._
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 
-@RunWith(classOf[JUnitRunner])
+
 class TransportHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with BeforeAndAfterAll {
 
   import TransportHandlerSpec._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelStateSpec.scala
@@ -27,14 +27,12 @@ import fr.acinq.eclair.transactions.Transactions.CommitTx
 import fr.acinq.eclair.transactions._
 import fr.acinq.eclair.wire.{ChannelCodecs, UpdateAddHtlc}
 import fr.acinq.eclair.{ShortChannelId, UInt64, randomKey}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 /**
   * Created by fabrice on 07/02/17.
   */
-@RunWith(classOf[JUnitRunner])
+
 class ChannelStateSpec extends FunSuite {
 
   import ChannelStateSpec._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
@@ -23,13 +23,11 @@ import fr.acinq.eclair.channel.NetworkFeePaid
 import fr.acinq.eclair.db.sqlite.SqliteAuditDb
 import fr.acinq.eclair.payment.{PaymentReceived, PaymentRelayed, PaymentSent}
 import fr.acinq.eclair.{randomBytes, randomKey}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import scala.compat.Platform
 
-@RunWith(classOf[JUnitRunner])
+
 class SqliteAuditDbSpec extends FunSuite {
 
   def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -20,12 +20,10 @@ import java.sql.DriverManager
 
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.db.sqlite.{SqliteChannelsDb, SqlitePendingRelayDb}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.sqlite.SQLiteException
 
-@RunWith(classOf[JUnitRunner])
+
 class SqliteChannelsDbSpec extends FunSuite {
 
   def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
@@ -21,15 +21,13 @@ import java.sql.DriverManager
 
 import fr.acinq.bitcoin.{Block, Crypto, Satoshi}
 import fr.acinq.eclair.db.sqlite.SqliteNetworkDb
-import fr.acinq.eclair.{ShortChannelId, randomKey}
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire.Color
-import org.junit.runner.RunWith
+import fr.acinq.eclair.{ShortChannelId, randomKey}
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import org.sqlite.SQLiteException
 
-@RunWith(classOf[JUnitRunner])
+
 class SqliteNetworkDbSpec extends FunSuite {
 
   def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
@@ -20,11 +20,9 @@ import java.sql.DriverManager
 
 import fr.acinq.bitcoin.BinaryData
 import fr.acinq.eclair.db.sqlite.SqlitePaymentsDb
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class SqlitePaymentsDbSpec extends FunSuite {
 
   def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePeersDbSpec.scala
@@ -21,11 +21,9 @@ import java.sql.DriverManager
 
 import fr.acinq.eclair.db.sqlite.SqlitePeersDb
 import fr.acinq.eclair.randomKey
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class SqlitePeersDbSpec extends FunSuite {
 
   def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePendingRelayDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePendingRelayDbSpec.scala
@@ -22,11 +22,9 @@ import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FAIL_MALFORMED_HTLC, CMD_FULF
 import fr.acinq.eclair.db.sqlite.SqlitePendingRelayDb
 import fr.acinq.eclair.randomBytes
 import fr.acinq.eclair.wire.FailureMessageCodecs
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class SqlitePendingRelayDbSpec extends FunSuite {
 
   def inmem = DriverManager.getConnection("jdbc:sqlite::memory:")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -44,8 +44,6 @@ import fr.acinq.eclair.{Globals, Kit, Setup}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST.JValue
 import org.json4s.{DefaultFormats, JString}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.concurrent.Await
@@ -55,7 +53,7 @@ import scala.concurrent.duration._
 /**
   * Created by PM on 15/03/2017.
   */
-@RunWith(classOf[JUnitRunner])
+
 class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService with FunSuiteLike with BeforeAndAfterAll with Logging {
 
   var nodes: Map[String, Kit] = Map()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
@@ -28,8 +28,6 @@ import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.payment.NoopPaymentHandler
 import fr.acinq.eclair.wire.Init
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 import org.scalatest.{BeforeAndAfterAll, Matchers, Outcome, fixture}
 
 import scala.concurrent.duration._
@@ -38,7 +36,7 @@ import scala.io.Source
 /**
   * Created by PM on 30/05/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class RustyTestsSpec extends TestKit(ActorSystem("test")) with Matchers with fixture.FunSuiteLike with BeforeAndAfterAll {
 
   case class FixtureParam(ref: List[String], res: List[String])

--- a/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
@@ -30,7 +30,7 @@ import fr.acinq.eclair.payment.NoopPaymentHandler
 import fr.acinq.eclair.wire.Init
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
-import org.scalatest.{BeforeAndAfterAll, Matchers, fixture}
+import org.scalatest.{BeforeAndAfterAll, Matchers, Outcome, fixture}
 
 import scala.concurrent.duration._
 import scala.io.Source
@@ -41,9 +41,9 @@ import scala.io.Source
 @RunWith(classOf[JUnitRunner])
 class RustyTestsSpec extends TestKit(ActorSystem("test")) with Matchers with fixture.FunSuiteLike with BeforeAndAfterAll {
 
-  type FixtureParam = Tuple2[List[String], List[String]]
+  case class FixtureParam(ref: List[String], res: List[String])
 
-  override def withFixture(test: OneArgTest) = {
+  override def withFixture(test: OneArgTest): Outcome = {
     Globals.blockCount.set(0)
     val latch = new CountDownLatch(1)
     val pipe: ActorRef = system.actorOf(Props(new SynchronizationPipe(latch)))
@@ -74,12 +74,12 @@ class RustyTestsSpec extends TestKit(ActorSystem("test")) with Matchers with fix
       bob2blockchain.expectMsgType[WatchLost]
       awaitCond(alice.stateName == NORMAL)
       awaitCond(bob.stateName == NORMAL)
+      pipe ! new File(getClass.getResource(s"/scenarii/${test.name}.script").getFile)
+      latch.await(30, TimeUnit.SECONDS)
+      val ref = Source.fromFile(getClass.getResource(s"/scenarii/${test.name}.script.expected").getFile).getLines().filterNot(_.startsWith("#")).toList
+      val res = Source.fromFile(new File(s"${System.getProperty("buildDirectory")}/result.tmp")).getLines().filterNot(_.startsWith("#")).toList
+      withFixture(test.toNoArgTest(FixtureParam(ref, res)))
     }
-    pipe ! new File(getClass.getResource(s"/scenarii/${test.name}.script").getFile)
-    latch.await(30, TimeUnit.SECONDS)
-    val ref = Source.fromFile(getClass.getResource(s"/scenarii/${test.name}.script.expected").getFile).getLines().filterNot(_.startsWith("#")).toList
-    val res = Source.fromFile(new File(s"${System.getProperty("buildDirectory")}/result.tmp")).getLines().filterNot(_.startsWith("#")).toList
-    test((ref, res))
   }
 
   override def afterAll {
@@ -87,15 +87,15 @@ class RustyTestsSpec extends TestKit(ActorSystem("test")) with Matchers with fix
     TestKit.shutdownActorSystem(system)
   }
 
-  test("01-offer1") { case (ref, res) => assert(ref === res) }
-  test("02-offer2") { case (ref, res) => assert(ref === res) }
-  //test("03-fulfill1") { case (ref, res) => assert(ref === res) }
-  // test("04-two-commits-onedir") { case (ref, res) => assert(ref === res) } DOES NOT PASS : we now automatically sign back when we receive a revocation and have acked changes
-  // test("05-two-commits-in-flight") { case (ref, res) => assert(ref === res)} DOES NOT PASS : cannot send two commit in a row (without having first revocation)
-  test("10-offers-crossover") { case (ref, res) => assert(ref === res) }
-  test("11-commits-crossover") { case (ref, res) => assert(ref === res) }
-  /*test("13-fee") { case (ref, res) => assert(ref === res)}
-  test("14-fee-twice") { case (ref, res) => assert(ref === res)}
-  test("15-fee-twice-back-to-back") { case (ref, res) => assert(ref === res)}*/
+  test("01-offer1") { f => assert(f.ref === f.res) }
+  test("02-offer2") { f => assert(f.ref === f.res) }
+  //test("03-fulfill1") { f => assert(f.ref === f.res) }
+  // test("04-two-commits-onedir") { f => assert(f.ref === f.res) } DOES NOT PASS : we now automatically sign back when we receive a revocation and have acked changes
+  // test("05-two-commits-in-flight") { f => assert(f.ref === f.res)} DOES NOT PASS : cannot send two commit in a row (without having first revocation)
+  test("10-offers-crossover") { f => assert(f.ref === f.res) }
+  test("11-commits-crossover") { f => assert(f.ref === f.res) }
+  /*test("13-fee") { f => assert(f.ref === f.res)}
+  test("14-fee-twice") { f => assert(f.ref === f.res)}
+  test("15-fee-twice-back-to-back") { f => assert(f.ref === f.res)}*/
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/NodeURISpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/NodeURISpec.scala
@@ -16,11 +16,9 @@
 
 package fr.acinq.eclair.io
 
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class NodeURISpec extends FunSuite {
 
   val PUBKEY = "03933884aaf1d6b108397e5efe5c86bcf2d8ca8d2f700eda99db9214fc2712b134"

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -12,13 +12,11 @@ import fr.acinq.eclair.io.Peer.ResumeAnnouncements
 import fr.acinq.eclair.router.RoutingSyncSpec.makeFakeRoutingInfo
 import fr.acinq.eclair.router.{ChannelRangeQueries, ChannelRangeQueriesSpec, Rebroadcast}
 import fr.acinq.eclair.{ShortChannelId, TestkitBaseClass, wire}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
-@RunWith(classOf[JUnitRunner])
+
 class PeerSpec extends TestkitBaseClass {
   val shortChannelIds = ChannelRangeQueriesSpec.shortChannelIds.take(100)
   val fakeRoutingInfo = shortChannelIds.map(makeFakeRoutingInfo)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/HtlcGenerationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/HtlcGenerationSpec.scala
@@ -25,9 +25,7 @@ import fr.acinq.eclair.payment.PaymentLifecycle._
 import fr.acinq.eclair.router.Hop
 import fr.acinq.eclair.wire.{ChannelUpdate, LightningMessageCodecs, PerHopPayload}
 import fr.acinq.eclair.{ShortChannelId, TestConstants, nodeFee, randomBytes}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import scodec.bits.BitVector
 
 import scala.util.Success
@@ -35,7 +33,7 @@ import scala.util.Success
 /**
   * Created by PM on 31/05/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class HtlcGenerationSpec extends FunSuite {
 
   test("compute fees") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
@@ -26,16 +26,14 @@ import fr.acinq.eclair.payment.PaymentLifecycle.{CheckPayment, ReceivePayment}
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.wire.{FinalExpiryTooSoon, UpdateAddHtlc}
 import fr.acinq.eclair.{Globals, ShortChannelId, randomKey}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuiteLike
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 24/03/2017.
   */
-@RunWith(classOf[JUnitRunner])
+
 class PaymentHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
 
   test("LocalPaymentHandler should reply with a fulfill/fail, emit a PaymentReceived and adds payment in DB") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -21,8 +21,8 @@ import akka.actor.Status
 import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.{BinaryData, Block, MilliSatoshi}
 import fr.acinq.eclair.Globals
-import fr.acinq.eclair.channel.{AddHtlcFailed, ChannelUnavailable}
 import fr.acinq.eclair.channel.Register.ForwardShortId
+import fr.acinq.eclair.channel.{AddHtlcFailed, ChannelUnavailable}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.crypto.Sphinx.ErrorPacket
 import fr.acinq.eclair.payment.PaymentLifecycle._
@@ -44,7 +44,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
   val defaultAmountMsat = 142000000L
   val defaultPaymentHash = BinaryData("42" * 32)
 
-  test("payment failed (route not found)") { case (router, _) =>
+  test("payment failed (route not found)") { fixture =>
+    import fixture._
     val paymentFSM = system.actorOf(PaymentLifecycle.props(a, router, TestProbe().ref))
     val monitor = TestProbe()
     val sender = TestProbe()
@@ -59,7 +60,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.expectMsg(PaymentFailed(request.paymentHash, LocalFailure(RouteNotFound) :: Nil))
   }
 
-  test("payment failed (route too expensive)") { case (router, _) =>
+  test("payment failed (route too expensive)") { fixture =>
+    import fixture._
     val paymentFSM = system.actorOf(PaymentLifecycle.props(a, router, TestProbe().ref))
     val monitor = TestProbe()
     val sender = TestProbe()
@@ -74,7 +76,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val Seq(LocalFailure(RouteTooExpensive(_, _))) = sender.expectMsgType[PaymentFailed].failures
   }
 
-  test("payment failed (unparsable failure)") { case (router, _) =>
+  test("payment failed (unparsable failure)") { fixture =>
+    import fixture._
     val relayer = TestProbe()
     val routerForwarder = TestProbe()
     val paymentFSM = TestFSMRef(new PaymentLifecycle(a, routerForwarder.ref, relayer.ref))
@@ -111,7 +114,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.expectMsg(PaymentFailed(request.paymentHash, UnreadableRemoteFailure(hops) :: UnreadableRemoteFailure(hops) :: Nil))
   }
 
-  test("payment failed (local error)") { case (router, _) =>
+  test("payment failed (local error)") { fixture =>
+    import fixture._
     val relayer = TestProbe()
     val routerForwarder = TestProbe()
     val paymentFSM = TestFSMRef(new PaymentLifecycle(a, routerForwarder.ref, relayer.ref))
@@ -138,7 +142,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     awaitCond(paymentFSM.stateName == WAITING_FOR_ROUTE)
   }
 
-  test("payment failed (first hop returns an UpdateFailMalformedHtlc)") { case (router, _) =>
+  test("payment failed (first hop returns an UpdateFailMalformedHtlc)") { fixture =>
+    import fixture._
     val relayer = TestProbe()
     val routerForwarder = TestProbe()
     val paymentFSM = TestFSMRef(new PaymentLifecycle(a, routerForwarder.ref, relayer.ref))
@@ -165,7 +170,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     awaitCond(paymentFSM.stateName == WAITING_FOR_ROUTE)
   }
 
-  test("payment failed (TemporaryChannelFailure)") { case (router, _) =>
+  test("payment failed (TemporaryChannelFailure)") { fixture =>
+    import fixture._
     val relayer = TestProbe()
     val routerForwarder = TestProbe()
     val paymentFSM = TestFSMRef(new PaymentLifecycle(a, routerForwarder.ref, relayer.ref))
@@ -201,7 +207,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.expectMsg(PaymentFailed(request.paymentHash, RemoteFailure(hops, ErrorPacket(b, failure)) :: LocalFailure(RouteNotFound) :: Nil))
   }
 
-  test("payment failed (Update)") { case (router, _) =>
+  test("payment failed (Update)") { fixture =>
+    import fixture._
     val relayer = TestProbe()
     val routerForwarder = TestProbe()
     val paymentFSM = TestFSMRef(new PaymentLifecycle(a, routerForwarder.ref, relayer.ref))
@@ -257,7 +264,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.expectMsg(PaymentFailed(request.paymentHash, RemoteFailure(hops, ErrorPacket(b, failure)) :: RemoteFailure(hops2, ErrorPacket(b, failure2)) :: LocalFailure(RouteNotFound) :: Nil))
   }
 
-  test("payment failed (PermanentChannelFailure)") { case (router, _) =>
+  test("payment failed (PermanentChannelFailure)") { fixture =>
+    import fixture._
     val relayer = TestProbe()
     val routerForwarder = TestProbe()
     val paymentFSM = TestFSMRef(new PaymentLifecycle(a, routerForwarder.ref, relayer.ref))
@@ -290,7 +298,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.expectMsg(PaymentFailed(request.paymentHash, RemoteFailure(hops, ErrorPacket(b, failure)) :: LocalFailure(RouteNotFound) :: Nil))
   }
 
-  test("payment succeeded") { case (router, _) =>
+  test("payment succeeded") { fixture =>
+    import fixture._
     val paymentFSM = system.actorOf(PaymentLifecycle.props(a, router, TestProbe().ref))
     val monitor = TestProbe()
     val sender = TestProbe()
@@ -313,7 +322,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     assert(fee === MilliSatoshi(paymentOK.amountMsat - request.amountMsat))
   }
 
-  test("filter errors properly") { case _ =>
+  test("filter errors properly") { fixture =>
     val failures = LocalFailure(RouteNotFound) :: RemoteFailure(Hop(a, b, channelUpdate_ab) :: Nil, ErrorPacket(a, TemporaryNodeFailure)) :: LocalFailure(AddHtlcFailed("00" * 32, "00" * 32, ChannelUnavailable("00" * 32), Local(None), None, None)) :: LocalFailure(RouteNotFound) :: Nil
     val filtered = PaymentLifecycle.transformForUser(failures)
     assert(filtered == LocalFailure(RouteNotFound) :: RemoteFailure(Hop(a, b, channelUpdate_ab) :: Nil, ErrorPacket(a, TemporaryNodeFailure)) :: LocalFailure(ChannelUnavailable("00" * 32)) :: Nil)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -29,13 +29,11 @@ import fr.acinq.eclair.payment.PaymentLifecycle._
 import fr.acinq.eclair.router.Announcements.makeChannelUpdate
 import fr.acinq.eclair.router._
 import fr.acinq.eclair.wire._
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
 /**
   * Created by PM on 29/08/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class PaymentLifecycleSpec extends BaseRouterSpec {
 
   val initialBlockCount = 420000

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
@@ -22,14 +22,12 @@ import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{Bech32, BinaryData, Block, Btc, Crypto, MilliBtc, MilliSatoshi, Protocol, Satoshi}
 import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.payment.PaymentRequest._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 /**
   * Created by fabrice on 15/05/17.
   */
-@RunWith(classOf[JUnitRunner])
+
 class PaymentRequestSpec extends FunSuite {
 
   val priv = PrivateKey(BinaryData("e126f68f7eafcc8b74f54d269fe206be715000f94dac067d1c04a8ca3b2db734"), compressed = true)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -27,6 +27,7 @@ import fr.acinq.eclair.transactions.CommitmentSpec
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass, randomBytes, randomKey}
 import org.junit.runner.RunWith
+import org.scalatest.Outcome
 import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
@@ -40,17 +41,16 @@ class RelayerSpec extends TestkitBaseClass {
   // let's reuse the existing test data
   import HtlcGenerationSpec._
 
-  type FixtureParam = Tuple3[ActorRef, TestProbe, TestProbe]
+  case class FixtureParam(relayer: ActorRef, register: TestProbe, paymentHandler: TestProbe)
 
-  override def withFixture(test: OneArgTest) = {
-
+  override def withFixture(test: OneArgTest): Outcome = {
     within(30 seconds) {
       val register = TestProbe()
       val paymentHandler = TestProbe()
       // we are node B in the route A -> B -> C -> ....
       //val relayer = system.actorOf(Relayer.props(TestConstants.Bob.nodeParams.copy(nodeKey = priv_b), register.ref, paymentHandler.ref))
       val relayer = system.actorOf(Relayer.props(TestConstants.Bob.nodeParams, register.ref, paymentHandler.ref))
-      test((relayer, register, paymentHandler))
+      withFixture(test.toNoArgTest(FixtureParam(relayer, register, paymentHandler)))
     }
   }
 
@@ -61,7 +61,8 @@ class RelayerSpec extends TestkitBaseClass {
     RemoteCommit(42, CommitmentSpec(Set.empty, 20000, 5000000, 100000000), "00" * 32, randomKey.toPoint),
     null, null, 0, 0, Map.empty, null, null, null, channelId)
 
-  test("relay an htlc-add") { case (relayer, register, paymentHandler) =>
+  test("relay an htlc-add") { f =>
+    import f._
     val sender = TestProbe()
 
     // we use this to build a valid onion
@@ -80,7 +81,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("fail to relay an htlc-add when we have no channel_update for the next channel") { case (relayer, register, paymentHandler) =>
+  test("fail to relay an htlc-add when we have no channel_update for the next channel") { f =>
+    import f._
     val sender = TestProbe()
 
     // we use this to build a valid onion
@@ -99,7 +101,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("fail to relay an htlc-add when register returns an error") { case (relayer, register, paymentHandler) =>
+  test("fail to relay an htlc-add when register returns an error") { f =>
+    import f._
     val sender = TestProbe()
 
     // we use this to build a valid onion
@@ -125,7 +128,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("fail to relay an htlc-add when the channel is advertised as unusable (down)") { case (relayer, register, paymentHandler) =>
+  test("fail to relay an htlc-add when the channel is advertised as unusable (down)") { f =>
+    import f._
     val sender = TestProbe()
 
     // check that payments are sent properly
@@ -143,7 +147,7 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
 
     // now tell the relayer that the channel is down and try again
-    relayer ! LocalChannelDown(sender.ref, channelId = channelId_bc, shortChannelId =  channelUpdate_bc.shortChannelId, remoteNodeId = TestConstants.Bob.nodeParams.nodeId)
+    relayer ! LocalChannelDown(sender.ref, channelId = channelId_bc, shortChannelId = channelUpdate_bc.shortChannelId, remoteNodeId = TestConstants.Bob.nodeParams.nodeId)
 
     val (cmd1, _) = buildCommand(finalAmountMsat, finalExpiry, "02" * 32, hops)
     val add_ab1 = UpdateAddHtlc(channelId = channelId_ab, id = 123456, cmd1.amountMsat, cmd1.paymentHash, cmd1.expiry, cmd1.onion)
@@ -157,7 +161,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("fail to relay an htlc-add when the requested channel is disabled") { case (relayer, register, paymentHandler) =>
+  test("fail to relay an htlc-add when the requested channel is disabled") { f =>
+    import f._
     val sender = TestProbe()
 
     // we use this to build a valid onion
@@ -177,7 +182,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("fail to relay an htlc-add when the onion is malformed") { case (relayer, register, paymentHandler) =>
+  test("fail to relay an htlc-add when the onion is malformed") { f =>
+    import f._
     val sender = TestProbe()
 
     // we use this to build a valid onion
@@ -196,7 +202,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("fail to relay an htlc-add when amount is below the next hop's requirements") { case (relayer, register, paymentHandler) =>
+  test("fail to relay an htlc-add when amount is below the next hop's requirements") { f =>
+    import f._
     val sender = TestProbe()
 
     // we use this to build a valid onion
@@ -215,7 +222,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("fail to relay an htlc-add when expiry does not match next hop's requirements") { case (relayer, register, paymentHandler) =>
+  test("fail to relay an htlc-add when expiry does not match next hop's requirements") { f =>
+    import f._
     val sender = TestProbe()
 
     val hops1 = hops.updated(1, hops(1).copy(lastUpdate = hops(1).lastUpdate.copy(cltvExpiryDelta = 0)))
@@ -234,7 +242,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("fail to relay an htlc-add when relay fee isn't sufficient") { case (relayer, register, paymentHandler) =>
+  test("fail to relay an htlc-add when relay fee isn't sufficient") { f =>
+    import f._
     val sender = TestProbe()
 
     val hops1 = hops.updated(1, hops(1).copy(lastUpdate = hops(1).lastUpdate.copy(feeBaseMsat = hops(1).lastUpdate.feeBaseMsat / 2)))
@@ -253,7 +262,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("fail an htlc-add at the final node when amount has been modified by second-to-last node") { case (relayer, register, paymentHandler) =>
+  test("fail an htlc-add at the final node when amount has been modified by second-to-last node") { f =>
+    import f._
     val sender = TestProbe()
 
     // to simulate this we use a zero-hop route A->B where A is the 'attacker'
@@ -273,7 +283,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("fail an htlc-add at the final node when expiry has been modified by second-to-last node") { case (relayer, register, paymentHandler) =>
+  test("fail an htlc-add at the final node when expiry has been modified by second-to-last node") { f =>
+    import f._
     val sender = TestProbe()
 
     // to simulate this we use a zero-hop route A->B where A is the 'attacker'
@@ -293,7 +304,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("correctly translates errors returned by channel when attempting to add an htlc") { case (relayer, register, paymentHandler) =>
+  test("correctly translates errors returned by channel when attempting to add an htlc") { f =>
+    import f._
     val sender = TestProbe()
 
     val paymentHash = randomBytes(32)
@@ -322,7 +334,8 @@ class RelayerSpec extends TestkitBaseClass {
     paymentHandler.expectNoMsg(100 millis)
   }
 
-  test("relay an htlc-fulfill") { case (relayer, register, _) =>
+  test("relay an htlc-fulfill") { f =>
+    import f._
     val sender = TestProbe()
     val eventListener = TestProbe()
 
@@ -342,7 +355,8 @@ class RelayerSpec extends TestkitBaseClass {
     assert(paymentRelayed.copy(timestamp = 0) === PaymentRelayed(MilliSatoshi(origin.amountMsatIn), MilliSatoshi(origin.amountMsatOut), add_bc.paymentHash, channelId_ab, channelId_bc, timestamp = 0))
   }
 
-  test("relay an htlc-fail") { case (relayer, register, _) =>
+  test("relay an htlc-fail") { f =>
+    import f._
     val sender = TestProbe()
 
     // we build a fake htlc for the downstream channel

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -26,16 +26,14 @@ import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.transactions.CommitmentSpec
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestConstants, TestkitBaseClass, randomBytes, randomKey}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
 /**
   * Created by PM on 29/08/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class RelayerSpec extends TestkitBaseClass {
 
   // let's reuse the existing test data

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsBatchValidationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsBatchValidationSpec.scala
@@ -17,8 +17,8 @@
 package fr.acinq.eclair.router
 
 import akka.actor.ActorSystem
-import akka.testkit.TestProbe
 import akka.pattern.pipe
+import akka.testkit.TestProbe
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{BinaryData, Block, Satoshi, Script, Transaction}
 import fr.acinq.eclair.blockchain.ValidateResult
@@ -27,9 +27,7 @@ import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, Exten
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate}
 import fr.acinq.eclair.{ShortChannelId, randomKey}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
@@ -37,7 +35,7 @@ import scala.concurrent.{Await, ExecutionContext}
 /**
   * Created by PM on 31/05/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class AnnouncementsBatchValidationSpec extends FunSuite {
 
   import AnnouncementsBatchValidationSpec._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsSpec.scala
@@ -21,14 +21,12 @@ import fr.acinq.bitcoin.{BinaryData, Block}
 import fr.acinq.eclair.TestConstants.Alice
 import fr.acinq.eclair._
 import fr.acinq.eclair.router.Announcements._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 /**
   * Created by PM on 31/05/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class AnnouncementsSpec extends FunSuite {
 
   test("check nodeId1/nodeId2 lexical ordering") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -28,9 +28,7 @@ import fr.acinq.eclair.router.Announcements._
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestkitBaseClass, randomKey, _}
-import org.junit.runner.RunWith
 import org.scalatest.Outcome
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
@@ -39,7 +37,7 @@ import scala.concurrent.duration._
   * It is re-used in payment FSM tests
   * Created by PM on 29/08/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 abstract class BaseRouterSpec extends TestkitBaseClass {
 
   case class FixtureParam(router: ActorRef, watcher: TestProbe)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -3,13 +3,11 @@ package fr.acinq.eclair.router
 import fr.acinq.bitcoin.Block
 import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.wire.ReplyChannelRange
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import scala.collection.{SortedSet, immutable}
 
-@RunWith(classOf[JUnitRunner])
+
 class ChannelRangeQueriesSpec extends FunSuite {
   import ChannelRangeQueriesSpec._
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -20,19 +20,16 @@ import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{BinaryData, Block, Crypto}
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.{Globals, ShortChannelId, randomKey}
+import fr.acinq.eclair.{ShortChannelId, randomKey}
 import org.jgrapht.graph.DirectedWeightedPseudograph
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-import scala.compat.Platform
 import scala.util.{Failure, Success}
 
 /**
   * Created by PM on 31/05/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class RouteCalculationSpec extends FunSuite {
 
   import RouteCalculationSpec._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -29,8 +29,6 @@ import fr.acinq.eclair.router.Announcements.makeChannelUpdate
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire.QueryShortChannelIds
 import fr.acinq.eclair.{Globals, ShortChannelId, randomKey}
-import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
 
 import scala.collection.SortedSet
 import scala.compat.Platform
@@ -39,7 +37,7 @@ import scala.concurrent.duration._
 /**
   * Created by PM on 29/08/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class RouterSpec extends BaseRouterSpec {
 
   test("properly announce valid new channels and ignore invalid ones") { fixture =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.io.Peer.{InvalidSignature, PeerRoutingMessage}
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.router.Announcements.makeChannelUpdate
 import fr.acinq.eclair.transactions.Scripts
-import fr.acinq.eclair.wire.{Error, QueryShortChannelIds}
+import fr.acinq.eclair.wire.QueryShortChannelIds
 import fr.acinq.eclair.{Globals, ShortChannelId, randomKey}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -42,7 +42,8 @@ import scala.concurrent.duration._
 @RunWith(classOf[JUnitRunner])
 class RouterSpec extends BaseRouterSpec {
 
-  test("properly announce valid new channels and ignore invalid ones") { case (router, watcher) =>
+  test("properly announce valid new channels and ignore invalid ones") { fixture =>
+    import fixture._
     val eventListener = TestProbe()
     system.eventStream.subscribe(eventListener.ref, classOf[NetworkEvent])
 
@@ -87,7 +88,8 @@ class RouterSpec extends BaseRouterSpec {
     eventListener.expectMsg(ChannelDiscovered(chan_ac, Satoshi(1000000)))
   }
 
-  test("properly announce lost channels and nodes") { case (router, _) =>
+  test("properly announce lost channels and nodes") { fixture =>
+    import fixture._
     val eventListener = TestProbe()
     system.eventStream.subscribe(eventListener.ref, classOf[NetworkEvent])
 
@@ -111,7 +113,8 @@ class RouterSpec extends BaseRouterSpec {
 
   }
 
-  test("handle bad signature for ChannelAnnouncement") { case (router, _) =>
+  test("handle bad signature for ChannelAnnouncement") { fixture =>
+    import fixture._
     val sender = TestProbe()
     val channelId_ac = ShortChannelId(420000, 5, 0)
     val chan_ac = channelAnnouncement(channelId_ac, priv_a, priv_c, priv_funding_a, priv_funding_c)
@@ -121,7 +124,8 @@ class RouterSpec extends BaseRouterSpec {
     sender.expectMsg(InvalidSignature(buggy_chan_ac))
   }
 
-  test("handle bad signature for NodeAnnouncement") { case (router, _) =>
+  test("handle bad signature for NodeAnnouncement") { fixture =>
+    import fixture._
     val sender = TestProbe()
     val buggy_ann_a = ann_a.copy(signature = ann_b.signature, timestamp = ann_a.timestamp + 1)
     sender.send(router, PeerRoutingMessage(null, remoteNodeId, buggy_ann_a))
@@ -129,7 +133,8 @@ class RouterSpec extends BaseRouterSpec {
     sender.expectMsg(InvalidSignature(buggy_ann_a))
   }
 
-  test("handle bad signature for ChannelUpdate") { case (router, _) =>
+  test("handle bad signature for ChannelUpdate") { fixture =>
+    import fixture._
     val sender = TestProbe()
     val buggy_channelUpdate_ab = channelUpdate_ab.copy(signature = ann_b.signature, timestamp = channelUpdate_ab.timestamp + 1)
     sender.send(router, PeerRoutingMessage(null, remoteNodeId, buggy_channelUpdate_ab))
@@ -137,28 +142,32 @@ class RouterSpec extends BaseRouterSpec {
     sender.expectMsg(InvalidSignature(buggy_channelUpdate_ab))
   }
 
-  test("route not found (unreachable target)") { case (router, _) =>
+  test("route not found (unreachable target)") { fixture =>
+    import fixture._
     val sender = TestProbe()
     // no route a->f
     sender.send(router, RouteRequest(a, f))
     sender.expectMsg(Failure(RouteNotFound))
   }
 
-  test("route not found (non-existing source)") { case (router, _) =>
+  test("route not found (non-existing source)") { fixture =>
+    import fixture._
     val sender = TestProbe()
     // no route a->f
     sender.send(router, RouteRequest(randomKey.publicKey, f))
     sender.expectMsg(Failure(RouteNotFound))
   }
 
-  test("route not found (non-existing target)") { case (router, _) =>
+  test("route not found (non-existing target)") { fixture =>
+    import fixture._
     val sender = TestProbe()
     // no route a->f
     sender.send(router, RouteRequest(a, randomKey.publicKey))
     sender.expectMsg(Failure(RouteNotFound))
   }
 
-  test("route found") { case (router, _) =>
+  test("route found") { fixture =>
+    import fixture._
     val sender = TestProbe()
     sender.send(router, RouteRequest(a, d))
     val res = sender.expectMsgType[RouteResponse]
@@ -166,7 +175,8 @@ class RouterSpec extends BaseRouterSpec {
     assert(res.hops.last.nextNodeId === d)
   }
 
-  test("route found (with extra routing info)") { case (router, _) =>
+  test("route found (with extra routing info)") { fixture =>
+    import fixture._
     val sender = TestProbe()
     val x = randomKey.publicKey
     val y = randomKey.publicKey
@@ -180,7 +190,8 @@ class RouterSpec extends BaseRouterSpec {
     assert(res.hops.last.nextNodeId === z)
   }
 
-  test("route not found (channel disabled)") { case (router, _) =>
+  test("route not found (channel disabled)") { fixture =>
+    import fixture._
     val sender = TestProbe()
     sender.send(router, RouteRequest(a, d))
     val res = sender.expectMsgType[RouteResponse]
@@ -194,7 +205,8 @@ class RouterSpec extends BaseRouterSpec {
     sender.expectMsg(Failure(RouteNotFound))
   }
 
-  test("temporary channel exclusion") { case (router, _) =>
+  test("temporary channel exclusion") { fixture =>
+    import fixture._
     val sender = TestProbe()
     sender.send(router, RouteRequest(a, d))
     sender.expectMsgType[RouteResponse]
@@ -212,7 +224,8 @@ class RouterSpec extends BaseRouterSpec {
     sender.expectMsgType[RouteResponse]
   }
 
-  test("export graph in dot format") { case (router, _) =>
+  test("export graph in dot format") { fixture =>
+    import fixture._
     val sender = TestProbe()
     sender.send(router, 'dot)
     val dot = sender.expectMsgType[String]
@@ -226,7 +239,8 @@ class RouterSpec extends BaseRouterSpec {
     Files.write(img, new File("graph.png"))*/
   }
 
-  test("send routing state") { case (router, _) =>
+  test("send routing state") { fixture =>
+    import fixture._
     val sender = TestProbe()
     sender.send(router, GetRoutingState)
     val state = sender.expectMsgType[RoutingState]
@@ -235,7 +249,8 @@ class RouterSpec extends BaseRouterSpec {
     assert(state.updates.size == 8)
   }
 
-  test("ask for channels that we marked as stale for which we receive a new update") { case (router, watcher) =>
+  test("ask for channels that we marked as stale for which we receive a new update") { fixture =>
+    import fixture._
     val blockHeight = Globals.blockCount.get().toInt - 2020
     val channelId = ShortChannelId(blockHeight, 5, 0)
     val announcement = channelAnnouncement(channelId, priv_a, priv_c, priv_funding_a, priv_funding_c)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
@@ -10,13 +10,11 @@ import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.router.Announcements.{makeChannelUpdate, makeNodeAnnouncement}
 import fr.acinq.eclair.router.BaseRouterSpec.channelAnnouncement
 import fr.acinq.eclair.wire._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuiteLike
-import org.scalatest.junit.JUnitRunner
 
 import scala.concurrent.duration._
 
-@RunWith(classOf[JUnitRunner])
+
 class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
 
   import RoutingSyncSpec.makeFakeRoutingInfo

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
@@ -37,7 +37,7 @@ class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
     val QueryChannelRange(chainHash, firstBlockNum, numberOfBlocks) = sender.expectMsgType[QueryChannelRange]
     sender.expectMsgType[GossipTimestampFilter]
 
-    // split our anwser in 3 blocks
+    // split our answer in 3 blocks
     val List(block1) = ChannelRangeQueries.encodeShortChannelIds(firstBlockNum, numberOfBlocks, shortChannelIds.take(100), ChannelRangeQueries.UNCOMPRESSED_FORMAT)
     val List(block2) = ChannelRangeQueries.encodeShortChannelIds(firstBlockNum, numberOfBlocks, shortChannelIds.drop(100).take(100), ChannelRangeQueries.UNCOMPRESSED_FORMAT)
     val List(block3) = ChannelRangeQueries.encodeShortChannelIds(firstBlockNum, numberOfBlocks, shortChannelIds.drop(200).take(150), ChannelRangeQueries.UNCOMPRESSED_FORMAT)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/ClaimReceivedHtlcSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/ClaimReceivedHtlcSpec.scala
@@ -19,11 +19,9 @@ package fr.acinq.eclair.transactions
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin._
 import fr.acinq.eclair.transactions.Scripts._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class ClaimReceivedHtlcSpec extends FunSuite {
 
   object Alice {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/ClaimSentHtlcSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/ClaimSentHtlcSpec.scala
@@ -19,11 +19,9 @@ package fr.acinq.eclair.transactions
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin._
 import fr.acinq.eclair.transactions.Scripts._
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class ClaimSentHtlcSpec extends FunSuite {
 
   object Alice {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/CommitmentSpecSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/CommitmentSpecSpec.scala
@@ -18,11 +18,9 @@ package fr.acinq.eclair.transactions
 
 import fr.acinq.bitcoin.{BinaryData, Crypto}
 import fr.acinq.eclair.wire.{UpdateAddHtlc, UpdateFailHtlc, UpdateFulfillHtlc}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
-@RunWith(classOf[JUnitRunner])
+
 class CommitmentSpecSpec extends FunSuite {
   test("add, fulfill and fail htlcs from the sender side") {
     val spec = CommitmentSpec(htlcs = Set(), feeratePerKw = 1000, toLocalMsat = 5000 * 1000, toRemoteMsat = 0)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -26,9 +26,7 @@ import fr.acinq.eclair.transactions.Scripts.{htlcOffered, htlcReceived, toLocalD
 import fr.acinq.eclair.transactions.Transactions.{addSigs, _}
 import fr.acinq.eclair.wire.UpdateAddHtlc
 import grizzled.slf4j.Logging
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import scala.io.Source
 import scala.util.{Failure, Random, Success, Try}
@@ -36,7 +34,7 @@ import scala.util.{Failure, Random, Success, Try}
 /**
   * Created by PM on 16/12/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class TransactionsSpec extends FunSuite with Logging {
 
   test("encode/decode sequence and locktime (one example)") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
@@ -24,16 +24,14 @@ import fr.acinq.eclair.payment.{Local, Relayed}
 import fr.acinq.eclair.transactions._
 import fr.acinq.eclair.wire.ChannelCodecs._
 import fr.acinq.eclair.{UInt64, randomKey}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 import scala.util.Random
 
 /**
   * Created by PM on 31/05/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class ChannelCodecsSpec extends FunSuite {
 
   def randomBytes(size: Int): BinaryData = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/CommandCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/CommandCodecsSpec.scala
@@ -18,14 +18,12 @@ package fr.acinq.eclair.wire
 
 import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FAIL_MALFORMED_HTLC, CMD_FULFILL_HTLC, Command}
 import fr.acinq.eclair.randomBytes
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 
 /**
   * Created by PM on 31/05/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class CommandCodecsSpec extends FunSuite {
 
   test("encode/decode all channel messages") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/FailureMessageCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/FailureMessageCodecsSpec.scala
@@ -18,9 +18,7 @@ package fr.acinq.eclair.wire
 
 import fr.acinq.bitcoin.{BinaryData, Block}
 import fr.acinq.eclair.ShortChannelId
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import scodec.bits.BitVector
 
 import scala.util.Random
@@ -28,7 +26,7 @@ import scala.util.Random
 /**
   * Created by PM on 31/05/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class FailureMessageCodecsSpec extends FunSuite {
   val channelUpdate = ChannelUpdate(
     signature = BinaryData("3045022100c451cd65c88f55b1767941a247e849e12f5f4d4a93a07316659e22f5267d2088022009042a595c6bc8942cd9d729317b82b306edc259fb6b3a3cecb3dd1bd446e90601"),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/LightningMessageCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/LightningMessageCodecsSpec.scala
@@ -24,15 +24,13 @@ import fr.acinq.bitcoin.{BinaryData, Block, Crypto}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.wire.LightningMessageCodecs._
 import fr.acinq.eclair.{ShortChannelId, UInt64, randomBytes, randomKey}
-import org.junit.runner.RunWith
 import org.scalatest.FunSuite
-import org.scalatest.junit.JUnitRunner
 import scodec.bits.{BitVector, ByteVector, HexStringSyntax}
 
 /**
   * Created by PM on 31/05/2016.
   */
-@RunWith(classOf[JUnitRunner])
+
 class LightningMessageCodecsSpec extends FunSuite {
 
   import LightningMessageCodecsSpec._

--- a/pom.xml
+++ b/pom.xml
@@ -230,15 +230,15 @@
             <version>${scala.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>5.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.version.short}</artifactId>
-            <version>2.2.6</version>
+            <version>3.0.5</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.2</version>
                 <configuration>
                     <args combine.children="append">
                         <arg>-deprecation</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -193,25 +193,34 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- disable surefire -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.20</version>
                 <configuration>
-                    <argLine>-Xmx1024m</argLine>
-                    <useFile>false</useFile>
-                    <disableXmlReport>false</disableXmlReport>
-                    <!-- If you have classpath issue like NoDefClassError,... -->
-                    <!-- useManifestOnlyJar>false</useManifestOnlyJar -->
-                    <includes>
-                        <include>**/*Spec.*</include>
-                        <include>**/*Test.*</include>
-                        <include>**/*Suite.*</include>
-                    </includes>
-                    <systemPropertyVariables>
-                        <buildDirectory>${project.build.directory}</buildDirectory>
-                    </systemPropertyVariables>
+                    <skipTests>true</skipTests>
                 </configuration>
+            </plugin>
+            <!-- enable scalatest -->
+            <plugin>
+                <groupId>org.scalatest</groupId>
+                <artifactId>scalatest-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <configuration>
+                    <parallel>false</parallel>
+                    <systemProperties>
+                        <buildDirectory>${project.build.directory}</buildDirectory>
+                    </systemProperties>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -228,12 +237,6 @@
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
             <version>${scala.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>5.3.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>


### PR DESCRIPTION
This is better reviewed commit by commit.

Updating scalatest was long overdue, it makes tests a tiny bit more readable.

I also switched to using scalatest as test runner instead of junit, after having noticed that test results were far more readable on Intellij (which doesn't use junit) compared to travis (which does). As an added benefit, since test results are better, we can turn off test logging.