### PR TITLE
Add instructions for Bitcoin Core 0.17.0 [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Please see the latest [release note](https://github.com/ACINQ/eclair/releases) f
 
 ### Configuring Bitcoin Core
 
-:warning: Eclair requires Bitcoin Core 0.16.0 or higher. If you are upgrading an existing wallet, you need to create a new address and send all your funds to that address.
+:warning: Eclair requires Bitcoin Core 0.16.3 or higher. If you are upgrading an existing wallet, you need to create a new address and send all your funds to that address.
 
 Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node. 
 Eclair will use any BTC it finds in the Bitcoin Core wallet to fund any channels you choose to open. Eclair will return BTC from closed channels to this wallet.
@@ -45,6 +45,11 @@ txindex=1
 zmqpubrawblock=tcp://127.0.0.1:29000
 zmqpubrawtx=tcp://127.0.0.1:29000
 addresstype=p2sh-segwit
+```
+
+:warning: If you are using Bitcoin Core 0.17.0 you need to add following line to your `bitcoin.conf`:
+```
+deprecatedrpc=signrawtransaction
 ```
 
 ### Installing Eclair
@@ -198,6 +203,10 @@ zmqpubrawtx=tcp://127.0.0.1:29000
 addresstype=p2sh-segwit
 ```
 
+:warning: If you are using Bitcoin Core 0.17.0 you need to add following line to your `bitcoin.conf`:
+```
+deprecatedrpc=signrawtransaction
+```
 ### Eclair configuration
 
 ```

--- a/README.md
+++ b/README.md
@@ -51,19 +51,6 @@ addresstype=p2sh-segwit
 ```
 deprecatedrpc=signrawtransaction
 ```
-You may also want to take advantage of the new configuration sections in `bitcoin.conf` to manage parameters that are network speficic, for example you could use:
-```
-testnet=1
-server=1
-txindex=1
-addresstype=p2sh-segwit
-[test]
-rpcuser=foo
-rpcpassword=bar
-zmqpubrawblock=tcp://127.0.0.1:29000
-zmqpubrawtx=tcp://127.0.0.1:29000
-```
-And yes, it's not a typo, the name of the `testnet` section really is `test` ...
 
 ### Installing Eclair
 
@@ -220,15 +207,34 @@ addresstype=p2sh-segwit
 ```
 deprecatedrpc=signrawtransaction
 ```
+
+You may also want to take advantage of the new configuration sections in `bitcoin.conf` to manage parameters that are network speficic, so you can reasliy run your bitcoin node on both mainnet and testnet. For example you could use:
+
+```
+server=1
+txindex=1
+addresstype=p2sh-segwit
+deprecatedrpc=signrawtransaction
+[main]
+rpcuser=<your-mainnet-rpc-user-here>
+rpcpassword=<your-mainnet-rpc-password-here>
+zmqpubrawblock=tcp://127.0.0.1:29000
+zmqpubrawtx=tcp://127.0.0.1:29000
+[test]
+rpcuser=<your-testnet-rpc-user-here>
+rpcpassword=<your-testnet-rpc-password-here>
+zmqpubrawblock=tcp://127.0.0.1:29001
+zmqpubrawtx=tcp://127.0.0.1:29001
+```
+
 ### Eclair configuration
 
 ```
 eclair.chain=mainnet
 eclair.bitcoind.rpcport=8332
-eclair.bitcoind.rpcuser=<your-bitcoin-core-rpc-user-here>
-eclair.bitcoind.rpcpassword=<your-bitcoin-core-rpc-passsword-here>
+eclair.bitcoind.rpcuser=<your-mainnet-rpc-user-here>
+eclair.bitcoind.rpcpassword=<your-mainnet-rpc-password-here>
 ```
-
 
 ## Resources
 - [1] [The Bitcoin Lightning Network: Scalable Off-Chain Instant Payments](https://lightning.network/lightning-network-paper.pdf) by Joseph Poon and Thaddeus Dryja

--- a/README.md
+++ b/README.md
@@ -51,6 +51,24 @@ addresstype=p2sh-segwit
 ```
 deprecatedrpc=signrawtransaction
 ```
+You may also want to take advantage of the new configuration sections in `bitcoin.conf` to manage parameters that are network speficic, for example you could use:
+```
+testnet=1
+server=1
+txindex=1
+addresstype=p2sh-segwit
+[test]
+rpcuser=foo1
+rpcpassword=bar1
+zmqpubrawblock=tcp://127.0.0.1:29001
+zmqpubrawtx=tcp://127.0.0.1:29001
+[regtest]
+rpcuser=foo2
+rpcpassword=bar2
+zmqpubrawblock=tcp://127.0.0.1:29002
+zmqpubrawtx=tcp://127.0.0.1:29002
+```
+And yes, it's not a typo, the name of the `testnet` section really is `test` ...
 
 ### Installing Eclair
 

--- a/README.md
+++ b/README.md
@@ -58,15 +58,10 @@ server=1
 txindex=1
 addresstype=p2sh-segwit
 [test]
-rpcuser=foo1
-rpcpassword=bar1
-zmqpubrawblock=tcp://127.0.0.1:29001
-zmqpubrawtx=tcp://127.0.0.1:29001
-[regtest]
-rpcuser=foo2
-rpcpassword=bar2
-zmqpubrawblock=tcp://127.0.0.1:29002
-zmqpubrawtx=tcp://127.0.0.1:29002
+rpcuser=foo
+rpcpassword=bar
+zmqpubrawblock=tcp://127.0.0.1:29000
+zmqpubrawtx=tcp://127.0.0.1:29000
 ```
 And yes, it's not a typo, the name of the `testnet` section really is `test` ...
 


### PR DESCRIPTION
Bitcoin Core 0.17.0 deprecates the `signrawtransaction` RPC call, which will be removed in version 0.18.0, you need to enable it call if you want your eclair node to use a 0.1.70 node. 
See #730 