### PR TITLE
Support for custom Electrum server

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -53,11 +53,12 @@ import scala.concurrent._
   * @param datadir  directory where eclair-core will write/read its data
   * @param overrideDefaults
   * @param seed_opt optional seed, if set eclair will use it instead of generating one and won't create a seed.dat file.
+  * @param overrideElectrumServers_opt optional electrum server which, if set, supersedes the default list of electrum server.
   */
 class Setup(datadir: File,
             overrideDefaults: Config = ConfigFactory.empty(),
             seed_opt: Option[BinaryData] = None,
-            electrumServerAddress: Option[InetSocketAddress] = None)(implicit system: ActorSystem) extends Logging {
+            overrideElectrumServers_opt: Option[InetSocketAddress] = None)(implicit system: ActorSystem) extends Logging {
 
   logger.info(s"hello!")
   logger.info(s"version=${getClass.getPackage.getImplementationVersion} commit=${getClass.getPackage.getSpecificationVersion}")
@@ -123,7 +124,7 @@ class Setup(datadir: File,
       Bitcoind(bitcoinClient)
     case ELECTRUM =>
       logger.warn("EXPERIMENTAL ELECTRUM MODE ENABLED!!!")
-      val addresses = electrumServerAddress match {
+      val addresses = overrideElectrumServers_opt match {
         case Some(address) => Set(address)
         case None =>
           val addressesFile = nodeParams.chainHash match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -122,10 +122,10 @@ class Setup(datadir: File,
       Bitcoind(bitcoinClient)
     case ELECTRUM =>
       logger.warn("EXPERIMENTAL ELECTRUM MODE ENABLED!!!")
-      val addresses = overrideDefaults.hasPath("eclair.electrum") match {
+      val addresses = config.hasPath("eclair.electrum") match {
         case true =>
-          val host = overrideDefaults.getString("eclair.electrum.host")
-          val port = overrideDefaults.getInt("eclair.electrum.port")
+          val host = config.getString("eclair.electrum.host")
+          val port = config.getInt("eclair.electrum.port")
           val address = InetSocketAddress.createUnresolved(host, port)
           logger.info(s"override electrum default with server=$address")
           Set(address)


### PR DESCRIPTION
Allows a user to bypass the default servers list and force eclair to always connect to a specific electrum server. This feature has been requested by users of the mobile node.

This PR adds an optional `overrideElectrumServers` parameters to the `Setup` class. This optional parameter, which is an `InetSocketAddress` object, will always supersede the default list of electrum servers. If this parameter is set, eclair will always attempt to connect to this particular server.