### PR TITLE
Always add 1 block to the `finalCltvExpiry`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
@@ -51,7 +51,8 @@ class PaymentLifecycle(sourceNodeId: PublicKey, router: ActorRef, register: Acto
     case Event(RouteResponse(hops, ignoreNodes, ignoreChannels), WaitingForRoute(s, c, failures)) =>
       log.info(s"route found: attempt=${failures.size + 1}/${c.maxAttempts} route=${hops.map(_.nextNodeId).mkString("->")} channels=${hops.map(_.lastUpdate.shortChannelId).mkString("->")}")
       val firstHop = hops.head
-      val finalExpiry = Globals.blockCount.get().toInt + c.finalCltvExpiry.toInt
+      // we add one block in order to not have our htlc fail when a new block has just been found
+      val finalExpiry = Globals.blockCount.get().toInt + c.finalCltvExpiry.toInt + 1
 
       val (cmd, sharedSecrets) = buildCommand(c.amountMsat, finalExpiry, c.paymentHash, hops)
       val feePct = (cmd.amountMsat - c.amountMsat) / c.amountMsat.toDouble // c.amountMsat is required to be > 0, have to convert to double, otherwise will be rounded
@@ -190,10 +191,9 @@ object PaymentLifecycle {
   // @formatter:off
   case class ReceivePayment(amountMsat_opt: Option[MilliSatoshi], description: String, expirySeconds_opt: Option[Long] = None, extraHops: Seq[Seq[ExtraHop]] = Nil)
   /**
-    * @param finalCltvExpiry by default we choose finalCltvExpiry = Channel.MIN_CLTV_EXPIRY + 1 to not have our htlc fail when a new block has just been found
     * @param maxFeePct set by default to 3% as a safety measure (even if a route is found, if fee is higher than that payment won't be attempted)
     */
-  case class SendPayment(amountMsat: Long, paymentHash: BinaryData, targetNodeId: PublicKey, assistedRoutes: Seq[Seq[ExtraHop]] = Nil, finalCltvExpiry: Long = Channel.MIN_CLTV_EXPIRY + 1, maxAttempts: Int = 5, maxFeePct: Double = 0.03) {
+  case class SendPayment(amountMsat: Long, paymentHash: BinaryData, targetNodeId: PublicKey, assistedRoutes: Seq[Seq[ExtraHop]] = Nil, finalCltvExpiry: Long = Channel.MIN_CLTV_EXPIRY, maxAttempts: Int = 5, maxFeePct: Double = 0.03) {
     require(amountMsat > 0, s"amountMsat must be > 0")
   }
   case class CheckPayment(paymentHash: BinaryData)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
@@ -57,7 +57,7 @@ class SqliteAuditDbSpec extends FunSuite {
     db.add(e6)
 
     assert(db.listSent(from = 0L, to = Long.MaxValue).toSet === Set(e1, e5, e6))
-    assert(db.listSent(from = 100000L, to = Platform.currentTime).toList === List(e1))
+    assert(db.listSent(from = 100000L, to = Platform.currentTime + 1).toList === List(e1))
     assert(db.listReceived(from = 0L, to = Long.MaxValue).toList === List(e2))
     assert(db.listRelayed(from = 0L, to = Long.MaxValue).toList === List(e3))
     assert(db.listNetworkFees(from = 0L, to = Long.MaxValue).size === 1)


### PR DESCRIPTION
We add one block in order to not have our htlc fail when a new block has just been found.

This fixes #651.