### PR TITLE
Add payment hash to `HtlcTimeoutTx` in backwards compatible way

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -27,8 +27,12 @@ sealed trait PaymentEvent {
   val paymentHash: BinaryData
 }
 
-case class PaymentSent(amount: MilliSatoshi, feesPaid: MilliSatoshi, paymentHash: BinaryData, paymentPreimage: BinaryData, toChannelId: BinaryData, timestamp: Long = Platform.currentTime) extends PaymentEvent
+case class PaymentSent(amount: MilliSatoshi, feesPaid: MilliSatoshi, paymentHash: BinaryData, paymentPreimage: BinaryData, toChannelId: BinaryData, timestamp: Long = Platform.currentTime, tag: String = "PaymentSent") extends PaymentEvent
 
-case class PaymentRelayed(amountIn: MilliSatoshi, amountOut: MilliSatoshi, paymentHash: BinaryData, fromChannelId: BinaryData, toChannelId: BinaryData, timestamp: Long = Platform.currentTime) extends PaymentEvent
+case class PaymentRelayed(amountIn: MilliSatoshi, amountOut: MilliSatoshi, paymentHash: BinaryData, fromChannelId: BinaryData, toChannelId: BinaryData, timestamp: Long = Platform.currentTime, tag: String = "PaymentRelayed") extends PaymentEvent
 
-case class PaymentReceived(amount: MilliSatoshi, paymentHash: BinaryData, fromChannelId: BinaryData, timestamp: Long = Platform.currentTime) extends PaymentEvent
+case class PaymentReceived(amount: MilliSatoshi, paymentHash: BinaryData, fromChannelId: BinaryData, timestamp: Long = Platform.currentTime, tag: String = "PaymentReceived") extends PaymentEvent
+
+case class PaymentSettlingOnChain(offChainAmount: MilliSatoshi, onChainAmount: MilliSatoshi, paymentHash: BinaryData, txid: BinaryData, refundType: String, isDone: Boolean, timestamp: Long = Platform.currentTime, tag: String = "PaymentSettlingOnChain") extends PaymentEvent
+
+case class PaymentLostOnChain(amount: MilliSatoshi, paymentHash: BinaryData, timestamp: Long = Platform.currentTime, tag: String = "PaymentLostOnChain") extends PaymentEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
@@ -104,10 +104,15 @@ object ChannelCodecs extends Logging {
       ("txOut" | txOutCodec) ::
       ("redeemScript" | varsizebinarydata)).as[InputInfo]
 
+  private val inputInfoWithHash =
+    ("inputInfo" | inputInfoCodec) ::
+      ("tx" | txCodec) ::
+      ("paymentHash" | binarydata(32))
+
   val txWithInputInfoCodec: Codec[TransactionWithInputInfo] = discriminated[TransactionWithInputInfo].by(uint16)
     .typecase(0x01, (("inputInfo" | inputInfoCodec) :: ("tx" | txCodec)).as[CommitTx])
-    .typecase(0x02, (("inputInfo" | inputInfoCodec) :: ("tx" | txCodec) :: ("paymentHash" | binarydata(32))).as[HtlcSuccessTx])
-    .typecase(0x03, (("inputInfo" | inputInfoCodec) :: ("tx" | txCodec)).as[HtlcTimeoutTx])
+    .typecase(0x02, inputInfoWithHash.as[HtlcSuccessTx])
+    .typecase(0x03, (("inputInfo" | inputInfoCodec) :: ("tx" | txCodec)).as[HtlcTimeoutTxLegacy])
     .typecase(0x04, (("inputInfo" | inputInfoCodec) :: ("tx" | txCodec)).as[ClaimHtlcSuccessTx])
     .typecase(0x05, (("inputInfo" | inputInfoCodec) :: ("tx" | txCodec)).as[ClaimHtlcTimeoutTx])
     .typecase(0x06, (("inputInfo" | inputInfoCodec) :: ("tx" | txCodec)).as[ClaimP2WPKHOutputTx])
@@ -115,6 +120,7 @@ object ChannelCodecs extends Logging {
     .typecase(0x08, (("inputInfo" | inputInfoCodec) :: ("tx" | txCodec)).as[MainPenaltyTx])
     .typecase(0x09, (("inputInfo" | inputInfoCodec) :: ("tx" | txCodec)).as[HtlcPenaltyTx])
     .typecase(0x10, (("inputInfo" | inputInfoCodec) :: ("tx" | txCodec)).as[ClosingTx])
+    .typecase(0x11, inputInfoWithHash.as[HtlcTimeoutTx])
 
   val htlcTxAndSigsCodec: Codec[HtlcTxAndSigs] = (
     ("txinfo" | txWithInputInfoCodec) ::

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -24,7 +24,7 @@ import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.channel.{Data, State, _}
-import fr.acinq.eclair.payment.{CommandBuffer, ForwardAdd, ForwardFulfill, Local}
+import fr.acinq.eclair.payment._
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{Globals, TestConstants, TestkitBaseClass}
@@ -189,12 +189,15 @@ class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
   test("recv BITCOIN_OUTPUT_SPENT") { f =>
     import f._
     // alice sends an htlc to bob
+    val listener1 = TestProbe()
     val (ra1, htlca1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
+    system.eventStream.subscribe(listener1.ref, classOf[PaymentSettlingOnChain])
     crossSign(alice, bob, alice2bob, bob2alice)
     relayer.expectMsgType[ForwardAdd]
     // an error occurs and alice publishes her commit tx
     val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
     alice ! Error("00" * 32, "oops".getBytes)
+    listener1.expectMsgType[PaymentSettlingOnChain]
     alice2blockchain.expectMsg(PublishAsap(aliceCommitTx)) // commit tx
     alice2blockchain.expectMsgType[PublishAsap] // main-delayed-output
     alice2blockchain.expectMsgType[PublishAsap] // htlc-timeout
@@ -226,7 +229,9 @@ class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
   test("recv BITCOIN_TX_CONFIRMED (local commit)") { f =>
     import f._
     val listener = TestProbe()
+    val listener1 = TestProbe()
     system.eventStream.subscribe(listener.ref, classOf[LocalCommitConfirmed])
+    system.eventStream.subscribe(listener1.ref, classOf[PaymentSettlingOnChain])
     // alice sends an htlc to bob
     val (ra1, htlca1) = addHtlc(50000000, alice, bob, alice2bob, bob2alice)
     crossSign(alice, bob, alice2bob, bob2alice)
@@ -234,9 +239,10 @@ class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
     alice ! Error("00" * 32, "oops".getBytes)
     alice2blockchain.expectMsg(PublishAsap(aliceCommitTx)) // commit tx
-  val claimMainDelayedTx = alice2blockchain.expectMsgType[PublishAsap].tx // main-delayed-output
-  val htlcTimeoutTx = alice2blockchain.expectMsgType[PublishAsap].tx // htlc-timeout
-  val claimDelayedTx = alice2blockchain.expectMsgType[PublishAsap].tx // claim-delayed-output
+    listener1.expectMsgType[PaymentSettlingOnChain]
+    val claimMainDelayedTx = alice2blockchain.expectMsgType[PublishAsap].tx // main-delayed-output
+    val htlcTimeoutTx = alice2blockchain.expectMsgType[PublishAsap].tx // htlc-timeout
+    val claimDelayedTx = alice2blockchain.expectMsgType[PublishAsap].tx // claim-delayed-output
     assert(alice2blockchain.expectMsgType[WatchConfirmed].event === BITCOIN_TX_CONFIRMED(aliceCommitTx))
     assert(alice2blockchain.expectMsgType[WatchConfirmed].event.isInstanceOf[BITCOIN_TX_CONFIRMED]) // main-delayed-output
     assert(alice2blockchain.expectMsgType[WatchConfirmed].event.isInstanceOf[BITCOIN_TX_CONFIRMED]) // claim-delayed-output
@@ -252,6 +258,22 @@ class ClosingStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(htlcTimeoutTx), 201, 0)
     alice ! WatchEventConfirmed(BITCOIN_TX_CONFIRMED(claimDelayedTx), 202, 0)
     awaitCond(alice.stateName == CLOSED)
+  }
+
+  test("recv BITCOIN_TX_CONFIRMED (local commit htlc is too small for on-chain)") { f =>
+    import f._
+    val listener1 = TestProbe()
+    val listener = TestProbe()
+    system.eventStream.subscribe(listener.ref, classOf[LocalCommitConfirmed])
+    system.eventStream.subscribe(listener1.ref, classOf[PaymentLostOnChain])
+    // alice sends an htlc to bob
+    val (ra1, htlca1) = addHtlc(5000, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    // an error occurs and alice publishes her commit tx
+    val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
+    alice ! Error("00" * 32, "oops".getBytes)
+    alice2blockchain.expectMsg(PublishAsap(aliceCommitTx)) // commit tx
+    listener1.expectMsgType[PaymentLostOnChain]
   }
 
   test("recv BITCOIN_TX_CONFIRMED (local commit with htlcs only signed by local)") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -315,7 +315,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.send(paymentFSM, UpdateFulfillHtlc("00" * 32, 0, defaultPaymentHash))
 
     val paymentOK = sender.expectMsgType[PaymentSucceeded]
-    val PaymentSent(MilliSatoshi(request.amountMsat), fee, request.paymentHash, paymentOK.paymentPreimage, _, _) = eventListener.expectMsgType[PaymentSent]
+    val PaymentSent(MilliSatoshi(request.amountMsat), fee, request.paymentHash, paymentOK.paymentPreimage, _, _, _) = eventListener.expectMsgType[PaymentSent]
     assert(fee > MilliSatoshi(0))
     assert(fee === MilliSatoshi(paymentOK.amountMsat - request.amountMsat))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
@@ -17,14 +17,16 @@
 package fr.acinq.eclair.wire
 
 import fr.acinq.bitcoin.DeterministicWallet.KeyPath
-import fr.acinq.bitcoin.{BinaryData, DeterministicWallet, OutPoint}
-import fr.acinq.eclair.channel.{LocalParams, RemoteParams}
+import fr.acinq.bitcoin.{BinaryData, DeterministicWallet, OutPoint, Transaction}
+import fr.acinq.eclair.channel.{HtlcTxAndSigs, LocalParams, PublishableTxs, RemoteParams}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.{Local, Relayed}
+import fr.acinq.eclair.transactions.Transactions.{CommitTx, HtlcTimeoutTx, HtlcTimeoutTxLegacy, InputInfo}
 import fr.acinq.eclair.transactions._
 import fr.acinq.eclair.wire.ChannelCodecs._
 import fr.acinq.eclair.{UInt64, randomKey}
 import org.scalatest.FunSuite
+import scodec.bits.BitVector
 
 import scala.util.Random
 
@@ -168,6 +170,30 @@ class ChannelCodecsSpec extends FunSuite {
       OutPoint(randomBytes(32), 454513) -> randomBytes(32)
       )
     assert(spentMapCodec.decodeValue(spentMapCodec.encode(map).require).require === map)
+  }
+
+  test("HtlcTimeoutTx compatibility") {
+    val tx1 = Transaction.read("0200000001adbb20ea41a8423ea937e76e8151636bf6093b70eaff942930d20576600521fd000000006b48304502210090587b6201e166ad6af0227d3036a9454223d49a1f11839c1a362184340ef0240220577f7cd5cca78719405cbf1de7414ac027f0239ef6e214c90fcaab0454d84b3b012103535b32d5eb0a6ed0982a0479bbadc9868d9836f6ba94dd5a63be16d875069184ffffffff028096980000000000220020c015c4a6be010e21657068fc2e6a9d02b27ebe4d490a25846f7237f104d1a3cd20256d29010000001600143ca33c2e4446f4a305f23c80df8ad1afdcf652f900000000")
+    val tx2 = Transaction.read("020000000001012537488e9d066a8f3550cc9adc141a11668425e046e69e07f53bb831f3296cbf00000000000000000001bf8401000000000017a9143f398d81d3c42367b779ea869c7dd3b6826fbb7487024730440220477b961f6360ef6cb62a76898dcecbb130627c7e6a452646e3be601f04627c1f02202572313d0c0afecbfb0c7d0e47ba689427a54f3debaded6d406daa1f5da4918c01210291ed78158810ad867465377f5920036ea865a29b3a39a1b1808d0c3c351a4b4100000000")
+    val input1 = InputInfo(OutPoint(tx1, 0), tx1.txOut.head, randomBytes(32))
+    val input2 = InputInfo(OutPoint(tx2, 0), tx2.txOut.head, randomBytes(32))
+
+    val htlcTimeoutTx1 = HtlcTimeoutTx(input1, tx1, randomBytes(32))
+    val htlcTimeoutTx2 =
+    // This is an old `HtlcTimeoutTx` which should now be `HtlcTimeoutTxLegacy`
+      txWithInputInfoCodec.decodeValue(BitVector.fromHex("00030024d52085191bef26a0cc7fbf286c2bef9b85e9776155b94060120bc5d61c31b2b1000000000020bf840100000" +
+        "0000017a9143f398d81d3c42367b779ea869c7dd3b6826fbb74870020111111111111111111111111111111111111111111111111111111111111111100c00200000" +
+        "00001012537488e9d066a8f3550cc9adc141a11668425e046e69e07f53bb831f3296cbf00000000000000000001bf8401000000000017a9143f398d81d3c42367b77" +
+        "9ea869c7dd3b6826fbb7487024730440220477b961f6360ef6cb62a76898dcecbb130627c7e6a452646e3be601f04627c1f02202572313d0c0afecbfb0c7d0e47ba6" +
+        "89427a54f3debaded6d406daa1f5da4918c01210291ed78158810ad867465377f5920036ea865a29b3a39a1b1808d0c3c351a4b4100000000").get).require
+
+    val htlcTxAndSigs1 = HtlcTxAndSigs(htlcTimeoutTx1, randomBytes(64), randomBytes(64))
+    val htlcTxAndSigs2 = HtlcTxAndSigs(htlcTimeoutTx2, randomBytes(64), randomBytes(64))
+    val publishableTxs = PublishableTxs(CommitTx(input2, tx1), List(htlcTxAndSigs1, htlcTxAndSigs2))
+
+    val decoded = publishableTxsCodec.decodeValue(publishableTxsCodec.encode(publishableTxs).require).require
+    assert(decoded === publishableTxs)
+    assert(decoded.htlcTxsAndSigs(1).txinfo.isInstanceOf[HtlcTimeoutTxLegacy])
   }
 
 }


### PR DESCRIPTION
This enables two new types of `PaymentEvent`s: `PaymentSettlingOnChain` and `PaymentLostOnChain`. 

The most valuable fields in those events are off-chain `paymentHash` and related on-chain refunding `txid` (or knowledge that payment is lost instead of `txid` in case of `PaymentLostOnChain`). With these events present an external API caller (payee) can always find out what happened to a payment in edge cases such as uncooperative closings and resolve an issue with a payer.

The problem with old `HtlcTimeoutTxLegacy` format is I see no obvious way to obtain a related `paymentHash` when a refunding `txid` gets generated so new `HtlcTimeoutTx` has this field added.