### PR TITLE
Wait for Router to be initialized

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -72,6 +72,8 @@ eclair {
   channel-exclude-duration = 60 seconds // when a temporary channel failure is returned, we exclude the channel from our payment routes for this duration
   router-broadcast-interval = 60 seconds // see BOLT #7
 
+  router-init-timeout = 5 minutes
+
   ping-interval = 30 seconds
   auto-reconnect = true
 


### PR DESCRIPTION
The number of channels in LN keeps increasing, and so does the initialization time of the router. Uninitialized `Router` prevents `TransportHandler` from processing the wire messages. I added a `Promise` to track `Router`'s initialization progress to make sure that all connections are established  after that.