### PR TITLE
Add exclusive locks to channels sqlite db

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -136,6 +136,7 @@ object NodeParams {
     chaindir.mkdir()
 
     val sqlite = DriverManager.getConnection(s"jdbc:sqlite:${new File(chaindir, "eclair.sqlite")}")
+    SqliteUtils.obtainExclusiveLock(sqlite) // there should only be one process writing to this file
     val channelsDb = new SqliteChannelsDb(sqlite)
     val peersDb = new SqlitePeersDb(sqlite)
     val pendingRelayDb = new SqlitePendingRelayDb(sqlite)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -41,6 +41,8 @@ trait AuditDb {
 
   def stats: Seq[Stats]
 
+  def close: Unit
+
 }
 
 case class NetworkFee(remoteNodeId: PublicKey, channelId: BinaryData, txId: BinaryData, feeSat: Long, txType: String, timestamp: Long)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -31,6 +31,6 @@ trait ChannelsDb {
 
   def listHtlcInfos(channelId: BinaryData, commitmentNumber: Long): Seq[(BinaryData, Long)]
 
-  def close: Unit
+  def close(): Unit
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -31,4 +31,6 @@ trait ChannelsDb {
 
   def listHtlcInfos(channelId: BinaryData, commitmentNumber: Long): Seq[(BinaryData, Long)]
 
+  def close: Unit
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
@@ -55,4 +55,6 @@ trait NetworkDb {
 
   def isPruned(shortChannelId: ShortChannelId): Boolean
 
+  def close: Unit
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
@@ -55,6 +55,6 @@ trait NetworkDb {
 
   def isPruned(shortChannelId: ShortChannelId): Boolean
 
-  def close: Unit
+  def close(): Unit
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -41,6 +41,8 @@ trait PaymentsDb {
 
   def listPayments(): Seq[Payment]
 
+  def close: Unit
+
 }
 
 /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
@@ -28,6 +28,6 @@ trait PeersDb {
 
   def listPeers(): Map[PublicKey, InetSocketAddress]
 
-  def close: Unit
+  def close(): Unit
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
@@ -28,4 +28,6 @@ trait PeersDb {
 
   def listPeers(): Map[PublicKey, InetSocketAddress]
 
+  def close: Unit
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
@@ -39,6 +39,6 @@ trait PendingRelayDb {
 
   def listPendingRelay(channelId: BinaryData): Seq[Command]
 
-  def close: Unit
+  def close(): Unit
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
@@ -39,4 +39,6 @@ trait PendingRelayDb {
 
   def listPendingRelay(channelId: BinaryData): Seq[Command]
 
+  def close: Unit
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -202,5 +202,5 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb {
       q
     }
 
-  override def close: Unit = sqlite.close()
+  override def close(): Unit = sqlite.close()
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -201,4 +201,6 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb {
       }
       q
     }
+
+  override def close: Unit = sqlite.close()
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -102,5 +102,5 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb {
     }
   }
 
-  override def close: Unit = sqlite.close
+  override def close(): Unit = sqlite.close
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -101,4 +101,6 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb {
       q
     }
   }
+
+  override def close: Unit = sqlite.close
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -149,4 +149,6 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
       rs.next()
     }
   }
+
+  override def close: Unit = sqlite.close
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -150,5 +150,5 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
     }
   }
 
-  override def close: Unit = sqlite.close
+  override def close(): Unit = sqlite.close
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -78,4 +78,5 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
     }
   }
 
+  override def close: Unit = sqlite.close()
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -78,5 +78,5 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
     }
   }
 
-  override def close: Unit = sqlite.close()
+  override def close(): Unit = sqlite.close()
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
@@ -76,5 +76,5 @@ class SqlitePeersDb(sqlite: Connection) extends PeersDb {
     }
   }
 
-  override def close: Unit = sqlite.close()
+  override def close(): Unit = sqlite.close()
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
@@ -75,4 +75,6 @@ class SqlitePeersDb(sqlite: Connection) extends PeersDb {
       m
     }
   }
+
+  override def close: Unit = sqlite.close()
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
@@ -60,4 +60,5 @@ class SqlitePendingRelayDb(sqlite: Connection) extends PendingRelayDb {
     }
   }
 
+  override def close: Unit = sqlite.close()
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
@@ -60,5 +60,5 @@ class SqlitePendingRelayDb(sqlite: Connection) extends PendingRelayDb {
     }
   }
 
-  override def close: Unit = sqlite.close()
+  override def close(): Unit = sqlite.close()
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
@@ -16,7 +16,7 @@
 
 package fr.acinq.eclair.db.sqlite
 
-import java.sql.{ResultSet, Statement}
+import java.sql.{Connection, ResultSet, Statement}
 
 import scodec.Codec
 import scodec.bits.BitVector
@@ -73,5 +73,21 @@ object SqliteUtils {
       q = q :+ codec.decode(BitVector(rs.getBytes("data"))).require.value
     }
     q
+  }
+
+  /**
+    * Obtain an exclusive lock on a sqlite database. This is useful when we want to make sure that only one process
+    * accesses the database file (see https://www.sqlite.org/pragma.html).
+    *
+    * The lock will be kept until the database is closed, or if the locking mode is explicitely reset.
+    *
+    * @param sqlite
+    */
+  def obtainExclusiveLock(sqlite: Connection){
+    val statement = sqlite.createStatement()
+    statement.execute("PRAGMA locking_mode = EXCLUSIVE")
+    // we have to make a write to actually obtain the lock
+    statement.executeUpdate("CREATE TABLE IF NOT EXISTS dummy_table_for_locking (a INTEGER NOT NULL)")
+    statement.executeUpdate("INSERT INTO dummy_table_for_locking VALUES (42)")
   }
 }


### PR DESCRIPTION
Note that there is no risk of corruption currently (concurrent writes would just fail with `SQLITE_BUSY`), but with this we make sure that there is only one instance of eclair using the same `eclair.sqlite` db file at any time.

From https://www.sqlite.org/pragma.html: 
> There are three reasons to set the locking-mode to EXCLUSIVE.
> 1. The application wants to prevent other processes from accessing the database file.
> 2. [...]
> 3. [...]
