### PR TITLE
Cleaned up mainnet electrum servers list

### DIFF
--- a/eclair-core/src/main/resources/electrum/servers_mainnet.json
+++ b/eclair-core/src/main/resources/electrum/servers_mainnet.json
@@ -10,18 +10,6 @@
         "t": "50001",
         "version": "1.2"
     },
-    "74.222.1.20": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
-    "88.198.43.231": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
     "E-X.not.fyi": {
         "pruning": "-",
         "s": "50002",
@@ -40,11 +28,6 @@
         "t": "50001",
         "version": "1.2"
     },
-    "aspinall.io": {
-        "pruning": "-",
-        "s": "50002",
-        "version": "1.2"
-    },
     "bauerjda5hnedjam.onion": {
         "pruning": "-",
         "s": "50002",
@@ -52,12 +35,6 @@
         "version": "1.2"
     },
     "bauerjhejlv6di7s.onion": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
-    "btc.asis.io": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
@@ -74,18 +51,7 @@
         "s": "995",
         "version": "1.2"
     },
-    "cryptohead.de": {
-        "pruning": "-",
-        "s": "50002",
-        "version": "1.2"
-    },
     "daedalus.bauerj.eu": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
-    "de.hamster.science": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
@@ -103,18 +69,6 @@
         "version": "1.2"
     },
     "electrum-server.ninja": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
-    "electrum.achow101.com": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
-    "electrum.cutie.ga": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
@@ -143,49 +97,13 @@
         "s": "50002",
         "version": "1.2"
     },
-    "electrum.poorcoding.com": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
     "electrum.qtornado.com": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
         "version": "1.2"
     },
-    "electrum.vom-stausee.de": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
-    "electrum0.snel.it": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
-    "electrumx-core.1209k.com": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
     "electrumx.bot.nu": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
-    "electrumx.nmdps.net": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
-    "electrumx.westeurope.cloudapp.azure.com": {
         "pruning": "-",
         "s": "50002",
         "t": "50001",
@@ -254,12 +172,6 @@
         "t": "50001",
         "version": "1.2"
     },
-    "node.erratic.space": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001",
-        "version": "1.2"
-    },
     "ozahtqwp25chjdjd.onion": {
         "pruning": "-",
         "s": "50002",
@@ -285,12 +197,6 @@
     },
     "s7clinmo4cazmhul.onion": {
         "pruning": "-",
-        "t": "50001",
-        "version": "1.2"
-    },
-    "songbird.bauerj.eu": {
-        "pruning": "-",
-        "s": "50002",
         "t": "50001",
         "version": "1.2"
     },


### PR DESCRIPTION
Some servers in this list are unresponsive, or connection always fails. Removing these servers improves startup performances when using electrum.