### PR TITLE
Tweak parameters to optimize ElectrumClient connections

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -24,6 +24,7 @@ import fr.acinq.bitcoin._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{Error, JsonRPCRequest, JsonRPCResponse}
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient.SSL
 import io.netty.bootstrap.Bootstrap
+import io.netty.buffer.PooledByteBufAllocator
 import io.netty.channel._
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.SocketChannel
@@ -52,7 +53,9 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
   b.group(workerGroup)
   b.channel(classOf[NioSocketChannel])
   b.option[java.lang.Boolean](ChannelOption.SO_KEEPALIVE, true)
+  b.option[java.lang.Boolean](ChannelOption.TCP_NODELAY, true)
   b.option[java.lang.Integer](ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+  b.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
   b.handler(new ChannelInitializer[SocketChannel]() {
     override def initChannel(ch: SocketChannel): Unit = {
       ssl match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -43,6 +43,10 @@ import scala.annotation.tailrec
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
+/**
+  * For later optimizations, see http://normanmaurer.me/presentations/2014-facebook-eng-netty/slides.html
+  * 
+  */
 class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec: ExecutionContext) extends Actor with Stash with ActorLogging {
 
   import ElectrumClient._


### PR DESCRIPTION
Turned on `TCP_NODELAY` to improve latency.