### PR TITLE
Fire together wire together

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -26,10 +26,7 @@ case class ShortChannelId(private val id: Long) extends Ordered[ShortChannelId] 
 
   def toLong: Long = id
 
-  override def toString: String = {
-    val TxCoordinates(blockHeight, txIndex, outputIndex) = ShortChannelId.coordinates(this)
-    s"${blockHeight}x${txIndex}x${outputIndex}"
-  }
+  override def toString: String = s"${txCoordinates.blockHeight}x${txCoordinates.outputIndex}x${txCoordinates.outputIndex}"
 
   // we use an unsigned long comparison here
   override def compare(that: ShortChannelId): Int = (this.id + Long.MinValue).compareTo(that.id + Long.MinValue)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -30,6 +30,8 @@ case class ShortChannelId(private val id: Long) extends Ordered[ShortChannelId] 
 
   // we use an unsigned long comparison here
   override def compare(that: ShortChannelId): Int = (this.id + Long.MinValue).compareTo(that.id + Long.MinValue)
+
+  lazy val txCoordinates = TxCoordinates(((id >> 40) & 0xFFFFFF).toInt, ((id >> 16) & 0xFFFFFF).toInt, (id & 0xFFFF).toInt)
 }
 
 object ShortChannelId {
@@ -39,8 +41,6 @@ object ShortChannelId {
   def apply(blockHeight: Int, txIndex: Int, outputIndex: Int): ShortChannelId = ShortChannelId(toShortId(blockHeight, txIndex, outputIndex))
 
   def toShortId(blockHeight: Int, txIndex: Int, outputIndex: Int): Long = ((blockHeight & 0xFFFFFFL) << 40) | ((txIndex & 0xFFFFFFL) << 16) | (outputIndex & 0xFFFFL)
-
-  def coordinates(shortChannelId: ShortChannelId): TxCoordinates = TxCoordinates(((shortChannelId.id >> 40) & 0xFFFFFF).toInt, ((shortChannelId.id >> 16) & 0xFFFFFF).toInt, (shortChannelId.id & 0xFFFF).toInt)
 }
 
 case class TxCoordinates(blockHeight: Int, txIndex: Int, outputIndex: Int)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -26,7 +26,10 @@ case class ShortChannelId(private val id: Long) extends Ordered[ShortChannelId] 
 
   def toLong: Long = id
 
-  override def toString: String = id.toHexString
+  override def toString: String = {
+    val TxCoordinates(blockHeight, txIndex, outputIndex) = ShortChannelId.coordinates(this)
+    s"${blockHeight}x${txIndex}x${outputIndex}"
+  }
 
   // we use an unsigned long comparison here
   override def compare(that: ShortChannelId): Int = (this.id + Long.MinValue).compareTo(that.id + Long.MinValue)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -26,7 +26,7 @@ case class ShortChannelId(private val id: Long) extends Ordered[ShortChannelId] 
 
   def toLong: Long = id
   
-  override def toString: String = s"${txCoordinates.blockHeight}x${txCoordinates.outputIndex}x${txCoordinates.outputIndex}"
+  override def toString: String = s"${txCoordinates.blockHeight}x${txCoordinates.txIndex}x${txCoordinates.outputIndex}"
 
   // we use an unsigned long comparison here
   override def compare(that: ShortChannelId): Int = (this.id + Long.MinValue).compareTo(that.id + Long.MinValue)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
@@ -38,11 +38,10 @@ class ElectrumWatcher(client: ActorRef) extends Actor with Stash with ActorLoggi
     case ValidateRequest(c) =>
         log.info(s"blindly validating channel=$c")
         val pubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(PublicKey(c.bitcoinKey1), PublicKey(c.bitcoinKey2))))
-        val TxCoordinates(_, _, outputIndex) = ShortChannelId.coordinates(c.shortChannelId)
         val fakeFundingTx = Transaction(
           version = 2,
           txIn = Seq.empty[TxIn],
-          txOut = List.fill(outputIndex + 1)(TxOut(Satoshi(0), pubkeyScript)), // quick and dirty way to be sure that the outputIndex'th output is of the expected format
+          txOut = List.fill(c.shortChannelId.txCoordinates.outputIndex + 1)(TxOut(Satoshi(0), pubkeyScript)), // quick and dirty way to be sure that the outputIndex'th output is of the expected format
           lockTime = 0)
       sender ! ValidateResult(c, Some(fakeFundingTx), true, None)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/ChannelRangeQueries.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/ChannelRangeQueries.scala
@@ -35,8 +35,8 @@ object ChannelRangeQueries {
       }
       shortChannelIds.grouped(count).map(ids => {
         val (firstBlock, numBlocks) = if (ids.isEmpty) (firstBlockIn, numBlocksIn) else {
-          val firstBlock: Long = ShortChannelId.coordinates(ids.head).blockHeight
-          val numBlocks: Long = ShortChannelId.coordinates(ids.last).blockHeight - firstBlock + 1
+          val firstBlock: Long = ids.head.txCoordinates.blockHeight
+          val numBlocks: Long = ids.last.txCoordinates.blockHeight - firstBlock + 1
           (firstBlock, numBlocks)
         }
         val encoded = encodeShortChannelIdsSingle(ids, format, useGzip)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
@@ -35,7 +35,7 @@ class ShortChannelIdSpec extends FunSuite {
     )
     for ((coord, shortChannelId) <- expected) {
       assert(shortChannelId == ShortChannelId(coord.blockHeight, coord.txIndex, coord.outputIndex))
-      assert(coord == ShortChannelId.coordinates(shortChannelId))
+      assert(coord == shortChannelId.txCoordinates)
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
@@ -39,4 +39,8 @@ class ShortChannelIdSpec extends FunSuite {
     }
   }
 
+  test("human readable format as per spec") {
+    assert(ShortChannelId(0x0000a41000001b0003L).toString == "42000x27x3")
+  }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -83,17 +83,65 @@ class RouteCalculationSpec extends FunSuite {
     )
 
     val updates = List(
-      makeUpdate(1L, f, g, 0, 0),
-      makeUpdate(2L, g, h, 0, 0),
-      makeUpdate(3L, h, i, 0, 0),
-      makeUpdate(4L, f, i, 50, 0) //direct channel, more expensive
+      makeUpdate(1L, f, g, 0, 0, DEFAULT_AMOUNT_MSAT, Some(16000000000L)),
+      makeUpdate(2L, g, h, 0, 0, DEFAULT_AMOUNT_MSAT, Some(16000000000L)),
+      makeUpdate(3L, h, i, 0, 0, DEFAULT_AMOUNT_MSAT, Some(16000000000L)),
+      makeUpdate(4L, f, i, 50, 0, DEFAULT_AMOUNT_MSAT, Some(16000000000L)) //direct channel, more expensive
     ).toMap
 
     val graph = makeGraph(updates)
 
     val route = Router.findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT)
     assert(route.map(hops2Ids) === Success(1 :: 2 :: 3 :: Nil))
+  }
 
+  test("same fee rate but older channel is prioritized") {
+
+    val (a, b, c, d) = (
+      PublicKey("02999fa724ec3c244e4da52b4a91ad421dc96c9a810587849cd4b2469313519c73"), //source
+      PublicKey("03f1cb1af20fe9ccda3ea128e27d7c39ee27375c8480f11a87c17197e97541ca6a"),
+      PublicKey("0358e32d245ff5f5a3eb14c78c6f69c67cea7846bdf9aeeb7199e8f6fbb0306484"),
+      PublicKey("029e059b6780f155f38e83601969919aae631ddf6faed58fe860c72225eb327d7c") //target
+    )
+
+    val ab = ShortChannelId(500000, 10, 1)
+    val ac = ShortChannelId(500001, 11, 2) // newer channel
+    val bd = ShortChannelId(500000, 12, 3)
+    val cd = ShortChannelId(500000, 13, 4)
+
+    val updates = List(
+      makeUpdate(ab.toLong, a, b, 50, 10, DEFAULT_AMOUNT_MSAT, Some(100000000L)),
+      makeUpdate(ac.toLong, a, c, 50, 10, DEFAULT_AMOUNT_MSAT, Some(100000000L)), // newer channel
+      makeUpdate(bd.toLong, b, d, 50, 10, DEFAULT_AMOUNT_MSAT, Some(100000000L)),
+      makeUpdate(cd.toLong, c, d, 50, 10, DEFAULT_AMOUNT_MSAT, Some(100000000L))
+    ).toMap
+
+    val graph = makeGraph(updates)
+
+    val route = Router.findRoute(graph, a, d, DEFAULT_AMOUNT_MSAT)
+    assert(route.map(hops2Ids) === Success(ab.toLong :: bd.toLong :: Nil))
+  }
+
+  test("smaller fee rate but larger channel is prioritized") {
+
+    val (a, b, c, d) = (
+      PublicKey("02999fa724ec3c244e4da52b4a91ad421dc96c9a810587849cd4b2469313519c73"), //source
+      PublicKey("03f1cb1af20fe9ccda3ea128e27d7c39ee27375c8480f11a87c17197e97541ca6a"),
+      PublicKey("0358e32d245ff5f5a3eb14c78c6f69c67cea7846bdf9aeeb7199e8f6fbb0306484"),
+      PublicKey("029e059b6780f155f38e83601969919aae631ddf6faed58fe860c72225eb327d7c") //target
+    )
+
+    val updates = List(
+      makeUpdate(1L, a, b, 1000, 100, DEFAULT_AMOUNT_MSAT, Some(5000000000L)), // larger channel
+      makeUpdate(2L, a, c, 960 , 100, DEFAULT_AMOUNT_MSAT, Some(100000000L)), // smaller base fee
+      makeUpdate(3L, b, d, 1000, 100, DEFAULT_AMOUNT_MSAT, Some(100000000L)),
+      makeUpdate(4L, c, d, 1000, 100, DEFAULT_AMOUNT_MSAT, Some(100000000L))
+    ).toMap
+
+    val graph = makeGraph(updates)
+
+    val route = Router.findRoute(graph, a, d, DEFAULT_AMOUNT_MSAT)
+    assert(route.map(hops2Ids) === Success(1 :: 3 :: Nil))
   }
 
   test("if there are multiple channels between the same node, select the cheapest") {
@@ -121,11 +169,11 @@ class RouteCalculationSpec extends FunSuite {
   test("calculate longer but cheaper route") {
 
     val updates = List(
-      makeUpdate(1L, a, b, 0, 0),
-      makeUpdate(2L, b, c, 0, 0),
-      makeUpdate(3L, c, d, 0, 0),
-      makeUpdate(4L, d, e, 0, 0),
-      makeUpdate(5L, a, e, 10, 10)
+      makeUpdate(1L, a, b, 0, 0, DEFAULT_AMOUNT_MSAT, Some(16000000000L)),
+      makeUpdate(2L, b, c, 0, 0, DEFAULT_AMOUNT_MSAT, Some(16000000000L)),
+      makeUpdate(3L, c, d, 0, 0, DEFAULT_AMOUNT_MSAT, Some(16000000000L)),
+      makeUpdate(4L, d, e, 0, 0, DEFAULT_AMOUNT_MSAT, Some(16000000000L)),
+      makeUpdate(5L, a, e, 10, 10, DEFAULT_AMOUNT_MSAT, Some(16000000000L))
     ).toMap
 
     val g = makeGraph(updates)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
@@ -115,9 +115,8 @@ object RoutingSyncSpec {
   def makeFakeRoutingInfo(shortChannelId: ShortChannelId): (ChannelAnnouncement, ChannelUpdate, ChannelUpdate, NodeAnnouncement, NodeAnnouncement) = {
     val (priv_a, priv_b, priv_funding_a, priv_funding_b) = (randomKey, randomKey, randomKey, randomKey)
     val channelAnn_ab = channelAnnouncement(shortChannelId, priv_a, priv_b, priv_funding_a, priv_funding_b)
-    val TxCoordinates(blockHeight, _, _) = ShortChannelId.coordinates(shortChannelId)
-    val channelUpdate_ab = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, priv_b.publicKey, shortChannelId, cltvExpiryDelta = 7, 0, feeBaseMsat = 766000, feeProportionalMillionths = 10, 500000000L, timestamp = blockHeight)
-    val channelUpdate_ba = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, priv_a.publicKey, shortChannelId, cltvExpiryDelta = 7, 0, feeBaseMsat = 766000, feeProportionalMillionths = 10, 500000000L, timestamp = blockHeight)
+    val channelUpdate_ab = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, priv_b.publicKey, shortChannelId, cltvExpiryDelta = 7, 0, feeBaseMsat = 766000, feeProportionalMillionths = 10, 500000000L, timestamp = shortChannelId.txCoordinates.blockHeight)
+    val channelUpdate_ba = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, priv_a.publicKey, shortChannelId, cltvExpiryDelta = 7, 0, feeBaseMsat = 766000, feeProportionalMillionths = 10, 500000000L, timestamp = shortChannelId.txCoordinates.blockHeight)
     val nodeAnnouncement_a = makeNodeAnnouncement(priv_a, "a", Alice.nodeParams.color, List())
     val nodeAnnouncement_b = makeNodeAnnouncement(priv_b, "b", Bob.nodeParams.color, List())
     (channelAnn_ab, channelUpdate_ab, channelUpdate_ba, nodeAnnouncement_a, nodeAnnouncement_b)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
@@ -37,8 +37,8 @@ class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
 
     // split our answer in 3 blocks
     val List(block1) = ChannelRangeQueries.encodeShortChannelIds(firstBlockNum, numberOfBlocks, shortChannelIds.take(100), ChannelRangeQueries.UNCOMPRESSED_FORMAT)
-    val List(block2) = ChannelRangeQueries.encodeShortChannelIds(firstBlockNum, numberOfBlocks, shortChannelIds.drop(100).take(100), ChannelRangeQueries.UNCOMPRESSED_FORMAT)
-    val List(block3) = ChannelRangeQueries.encodeShortChannelIds(firstBlockNum, numberOfBlocks, shortChannelIds.drop(200).take(150), ChannelRangeQueries.UNCOMPRESSED_FORMAT)
+    val List(block2) = ChannelRangeQueries.encodeShortChannelIds(firstBlockNum, numberOfBlocks, shortChannelIds.slice(100, 200), ChannelRangeQueries.UNCOMPRESSED_FORMAT)
+    val List(block3) = ChannelRangeQueries.encodeShortChannelIds(firstBlockNum, numberOfBlocks, shortChannelIds.slice(200, 350), ChannelRangeQueries.UNCOMPRESSED_FORMAT)
 
     // send first block
     sender.send(router, PeerRoutingMessage(transport.ref, remoteNodeId, ReplyChannelRange(chainHash, block1.firstBlock, block1.numBlocks, 1, block1.shortChannelIds)))
@@ -75,7 +75,7 @@ class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
     // router should ask for our second block of ids
     val QueryShortChannelIds(_, data2) = transport.expectMsgType[QueryShortChannelIds]
     val (_, shortChannelIds2, false) = ChannelRangeQueries.decodeShortChannelIds(data2)
-    assert(shortChannelIds2 == shortChannelIds.drop(100).take(100))
+    assert(shortChannelIds2 == shortChannelIds.slice(100, 200))
   }
 
   test("reset sync state on reconnection") {


### PR DESCRIPTION
This PR builds on https://github.com/ACINQ/eclair/pull/791 and adds yet another edge weight factor which is past channel's performance. 

Since routing failure can't be reliably punished we at least should endorse a success. The idea therefore is: if this channel has participated in recent successful payments then we can expect it to keep it that way and decrease it's weight in a graph. OTOH if this channel was not participating in recent successful payments (either by being excluded from graph because of failures or just by not being used) then we gradually forget about it's successful history and success factor stops playing a role in weight calculation.

Success factor is updated by exponentially decaying function which has desired properties: converges to either top `DEFAULT_SUCCESS_FACTOR` or bottom `0` depending on direction, substantially changes a factor at start (the very first successful payment already tells us a lot about channel reliability) and slows down with subsequent payments (20th successful payment does not tell us as much as 1st one).