### PR TITLE
Use BOLT specific formatting for short channel id

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -26,7 +26,10 @@ case class ShortChannelId(private val id: Long) extends Ordered[ShortChannelId] 
 
   def toLong: Long = id
 
-  override def toString: String = id.toHexString
+  override def toString: String = {
+    val TxCoordinates(blockHeight, txIndex, outputIndex) = ShortChannelId.coordinates(this)
+    s"${blockHeight}x${txIndex}x${outputIndex}"
+  }
 
   // we use an unsigned long comparison here
   override def compare(that: ShortChannelId): Int = (this.id + Long.MinValue).compareTo(that.id + Long.MinValue)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
@@ -39,4 +39,8 @@ class ShortChannelIdSpec extends FunSuite {
     }
   }
 
+  test("human readable format as per spec") {
+    assert(ShortChannelId(0x0000a41000001b0003L).toString == "42000x27x3")
+  }
+
 }


### PR DESCRIPTION
This PR implements the new human readable format proposed in the BOLT1.1 for the short_channel_id.  