### PR TITLE
Compute routes backward

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ java -Dlogback.configurationFile=/path/to/logback-custom.xml -jar eclair-node-gu
   receive      | amountMsat, description                                                                | generate a payment request for a given amount
   receive      | amountMsat, description, expirySeconds                                                 | generate a payment request for a given amount that expires after given number of seconds
   checkinvoice | paymentRequest                                                                         | returns node, amount and payment hash in an invoice/paymentRequest
-  findroute    | paymentRequest|nodeId                                                                  | given a payment request or nodeID checks if there is a valid payment route returns JSON with attempts, nodes and channels of route
+  findroute    | paymentRequest|paymentRequest, amountMsat|nodeId, amountMsat                           | given a payment request or nodeID and an amount checks if there is a valid payment route returns JSON with attempts, nodes and channels of route
   send         | amountMsat, paymentHash, nodeId                                                        | send a payment to a lightning node
   send         | paymentRequest                                                                         | send a payment to a lightning node using a BOLT11 payment request
   send         | paymentRequest, amountMsat                                                             | send a payment to a lightning node using a BOLT11 payment request and a custom amount

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -41,7 +41,6 @@ import fr.acinq.eclair.io.{NodeURI, Peer}
 import fr.acinq.eclair.payment.PaymentLifecycle._
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.router.{ChannelDesc, RouteRequest, RouteResponse, Router}
-import fr.acinq.eclair.router.Router.DEFAULT_AMOUNT_MSAT
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement}
 import fr.acinq.eclair.{Kit, ShortChannelId, feerateByte2Kw}
 import grizzled.slf4j.Logging
@@ -244,15 +243,21 @@ trait Service extends Logging {
                       }
 
                       case "findroute" => req.params match {
-                        case JString(nodeId) :: Nil if nodeId.length() == 66 => Try(PublicKey(nodeId)) match {
-                          case Success(pk) => completeRpcFuture(req.id, (router ? RouteRequest(appKit.nodeParams.nodeId, pk, DEFAULT_AMOUNT_MSAT)).mapTo[RouteResponse])
+                        case JString(nodeId) :: JInt(amountMsat) :: Nil if nodeId.length() == 66 => Try(PublicKey(nodeId)) match {
+                          case Success(pk) => completeRpcFuture(req.id, (router ? RouteRequest(appKit.nodeParams.nodeId, pk, amountMsat.toLong)).mapTo[RouteResponse])
                           case Failure(_) => reject(RpcValidationRejection(req.id, s"invalid nodeId hash '$nodeId'"))
                         }
                         case JString(paymentRequest) :: Nil => Try(PaymentRequest.read(paymentRequest)) match {
-                          case Success(pr) => completeRpcFuture(req.id, (router ? RouteRequest(appKit.nodeParams.nodeId, pr.nodeId, pr.amount.map(_.toLong).getOrElse(DEFAULT_AMOUNT_MSAT))).mapTo[RouteResponse])
+                          case Success(PaymentRequest(_, Some(amountMsat), _, nodeId , _, _)) => completeRpcFuture(req.id, (router ? RouteRequest(appKit.nodeParams.nodeId, nodeId, amountMsat.toLong)).mapTo[RouteResponse])
+                          case Success(_) => reject(RpcValidationRejection(req.id, s"payment request is missing amount, please specify it"))
                           case Failure(t) => reject(RpcValidationRejection(req.id, s"invalid payment request ${t.getLocalizedMessage}"))
                         }
-                        case _ => reject(UnknownParamsRejection(req.id, "[payment_request] or [nodeId]"))
+                        case JString(paymentRequest) :: JInt(amountMsat) :: Nil => Try(PaymentRequest.read(paymentRequest)) match {
+                          case Success(PaymentRequest(_, None, _, nodeId , _, _)) => completeRpcFuture(req.id, (router ? RouteRequest(appKit.nodeParams.nodeId, nodeId, amountMsat.toLong)).mapTo[RouteResponse])
+                          case Success(_) => reject(RpcValidationRejection(req.id, s"amount was specified both in payment request and api call"))
+                          case Failure(t) => reject(RpcValidationRejection(req.id, s"invalid payment request ${t.getLocalizedMessage}"))
+                        }
+                        case _ => reject(UnknownParamsRejection(req.id, "[payment_request] or [payment_request, amountMsat] or [nodeId, amountMsat]"))
                       }
 
                       case "send" => req.params match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -136,13 +136,6 @@ object Graph {
     }
   }
 
-  // the total fee cost for this path
-  def pathCost(path: Seq[Hop], amountMsat: Long): Long = {
-    path.drop(1).reverse.foldLeft(amountMsat) { (fee, hop) =>
-        fee + nodeFee(hop.lastUpdate.feeBaseMsat, hop.lastUpdate.feeProportionalMillionths, fee)
-    }
-  }
-
   /**
     *
     * @param edge the edge for which we want to compute the weight

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -81,17 +81,17 @@ object Graph {
         // for each neighbor
         currentNeighbors.foreach { edge =>
 
-          //  test for ignored edges
-          if (!(edge.update.htlcMaximumMsat.exists(_ < amountMsat) ||
-            amountMsat < edge.update.htlcMinimumMsat ||
+          val neighbor = edge.desc.b
+
+          // note: 'cost' contains the smallest known cumulative cost (amount + fees) necessary to reach 'current' so far
+          // note: there is always an entry for the current in the 'cost' map
+          val newMinimumKnownCost = edgeWeight(edge, cost.get(current.key), neighbor == targetNode)
+
+          // test for ignored edges
+          if (!(edge.update.htlcMaximumMsat.exists(_ < newMinimumKnownCost) ||
+            newMinimumKnownCost < edge.update.htlcMinimumMsat ||
             ignoredEdges.contains(edge.desc))
           ) {
-
-            val neighbor = edge.desc.b
-
-            // note: 'cost' contains the smallest known cumulative cost (amount + fees) necessary to reach 'current' so far
-            // note: there is always an entry for the current in the 'cost' map
-            val newMinimumKnownCost = edgeWeight(edge, cost.get(current.key), neighbor == targetNode)
 
             // we call containsKey first because "getOrDefault" is not available in JDK7
             val neighborCost = cost.containsKey(neighbor) match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -95,7 +95,7 @@ object Graph {
           // test for ignored edges
           if (edge.update.htlcMaximumMsat.forall(newMinimumKnownCost <= _) &&
             newMinimumKnownCost >= edge.update.htlcMinimumMsat &&
-            neighborPathLength < ROUTE_MAX_LENGTH && // ignore this edge if it would make the path too long
+            neighborPathLength <= ROUTE_MAX_LENGTH && // ignore this edge if it would make the path too long
             !ignoredEdges.contains(edge.desc)
           ) {
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -178,7 +178,7 @@ object Graph {
         */
       def addEdge(edge: GraphEdge): DirectedGraph = {
 
-        val finalEdge = edge.copy(desc = reverseDesc(edge.desc))
+        val finalEdge = edge.copy(desc = edge.desc.reverse())
 
         val vertexIn = finalEdge.desc.a
         val vertexOut = finalEdge.desc.b
@@ -202,7 +202,7 @@ object Graph {
         * @return
         */
       def removeEdge(desc: ChannelDesc): DirectedGraph = {
-        val someDesc = reverseDesc(desc)
+        val someDesc = desc.reverse()
 
         containsEdge(desc) match {
           case true => DirectedGraph(vertices.updated(someDesc.a, vertices(someDesc.a).filterNot(_.desc == someDesc)))
@@ -223,7 +223,7 @@ object Graph {
       def getEdge(edge: GraphEdge): Option[GraphEdge] = getEdge(edge.desc)
 
       def getEdge(desc: ChannelDesc): Option[GraphEdge] = {
-        val someDesc = reverseDesc(desc)
+        val someDesc = desc.reverse()
         vertices.get(someDesc.a).flatMap { adj =>
           adj.find(e => e.desc.shortChannelId == someDesc.shortChannelId && e.desc.b == someDesc.b)
         }
@@ -297,7 +297,7 @@ object Graph {
         * @return true if this edge desc is in the graph. For edges to be considered equal they must have the same in/out vertices AND same shortChannelId
         */
       def containsEdge(desc: ChannelDesc): Boolean = {
-        val someDesc = reverseDesc(desc)
+        val someDesc = desc.reverse()
 
         vertices.get(someDesc.a) match {
           case None => false
@@ -335,7 +335,7 @@ object Graph {
 
         // add all the vertices and edges in one go
         descAndUpdates.foreach { case (desc, update) =>
-          val someDesc = reverseDesc(desc)
+          val someDesc = desc.reverse()
 
           // create or update vertex (desc.a) and update its neighbor
           mutableMap.put(someDesc.a, GraphEdge(someDesc, update) +: mutableMap.getOrElse(someDesc.a, List.empty[GraphEdge]))
@@ -347,8 +347,6 @@ object Graph {
 
         new DirectedGraph(mutableMap.toMap)
       }
-
-      def reverseDesc(desc: ChannelDesc): ChannelDesc = desc.copy(a = desc.b, b = desc.a)
 
       def graphEdgeToHop(graphEdge: GraphEdge): Hop = Hop(graphEdge.desc.b, graphEdge.desc.a, graphEdge.update)
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -93,10 +93,10 @@ object Graph {
           val newMinimumKnownCost = edgeWeight(edge, cost.get(current.key), neighbor == targetNode)
 
           // test for ignored edges
-          if (!(edge.update.htlcMaximumMsat.exists(_ < newMinimumKnownCost) ||
-            newMinimumKnownCost < edge.update.htlcMinimumMsat ||
-            ignoredEdges.contains(edge.desc) ||
-            neighborPathLength >= ROUTE_MAX_LENGTH) // ignore this edge if it would make the path too long
+          if (edge.update.htlcMaximumMsat.forall(newMinimumKnownCost <= _) &&
+            newMinimumKnownCost >= edge.update.htlcMinimumMsat &&
+            neighborPathLength < ROUTE_MAX_LENGTH && // ignore this edge if it would make the path too long
+            !ignoredEdges.contains(edge.desc)
           ) {
 
             // we call containsKey first because "getOrDefault" is not available in JDK7

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -129,9 +129,9 @@ object Graph {
 
     targetFound match {
       case false => Seq.empty[GraphEdge]
-      case true => {
+      case true =>
         // we traverse the list of "previous" backward building the final list of edges that make the shortest path
-        val edgePath = new mutable.ArrayBuffer[GraphEdge](21) // max path length is 20! https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#clarifications
+        val edgePath = new mutable.ArrayBuffer[GraphEdge](ROUTE_MAX_LENGTH) // max path length is 20! https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#clarifications
         var current = prev.get(targetNode)
 
         while (current != null) {
@@ -141,7 +141,6 @@ object Graph {
         }
 
         edgePath
-      }
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -36,11 +36,14 @@ object Graph {
     * @param extraEdges a list of extra edges we want to consider but are not currently in the graph
     * @return
     */
-  def shortestPath(g: DirectedGraph, sourceNode: PublicKey, targetNode: PublicKey, amountMsat: Long, ignoredEdges: Set[ChannelDesc], extraEdges: Set[GraphEdge]): Seq[Hop] = {
-    dijkstraShortestPath(g, sourceNode, targetNode, amountMsat, ignoredEdges, extraEdges).map(graphEdgeToHop)
+  def shortestPath(g: DirectedGraph, sourceNode: PublicKey, targetNode: PublicKey, amountMsat: Long, ignoredEdges: Set[ChannelDesc], extraEdges: Set[GraphEdge], reverse: Boolean = false): Seq[Hop] = {
+    dijkstraShortestPath(g, sourceNode, targetNode, amountMsat, ignoredEdges, extraEdges, reverse).map(edge => reverse match {
+      case false => Hop(edge.desc.a, edge.desc.b, edge.update)
+      case true  => Hop(edge.desc.b, edge.desc.a, edge.update)
+    })
   }
 
-  def dijkstraShortestPath(g: DirectedGraph, sourceNode: PublicKey, targetNode: PublicKey, amountMsat: Long, ignoredEdges: Set[ChannelDesc], extraEdges: Set[GraphEdge]): Seq[GraphEdge] = {
+  def dijkstraShortestPath(g: DirectedGraph, sourceNode: PublicKey, targetNode: PublicKey, amountMsat: Long, ignoredEdges: Set[ChannelDesc], extraEdges: Set[GraphEdge], reverse: Boolean = false): Seq[GraphEdge] = {
 
     // optionally add the extra edges to the graph
     val graphVerticesWithExtra = extraEdges.nonEmpty match {
@@ -130,7 +133,8 @@ object Graph {
           current = prev.get(current.desc.a)
         }
 
-        edgePath.reverse
+        // if we are searching "backward" the resulting edgePath is already reversed
+        if(!reverse) edgePath.reverse else edgePath
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -131,7 +131,7 @@ object Graph {
       case false => Seq.empty[GraphEdge]
       case true =>
         // we traverse the list of "previous" backward building the final list of edges that make the shortest path
-        val edgePath = new mutable.ArrayBuffer[GraphEdge](ROUTE_MAX_LENGTH) // max path length is 20! https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#clarifications
+        val edgePath = new mutable.ArrayBuffer[GraphEdge](ROUTE_MAX_LENGTH)
         var current = prev.get(targetNode)
 
         while (current != null) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -59,7 +59,7 @@ object Graph {
     val prev = new java.util.HashMap[PublicKey, GraphEdge](maxMapSize)
     val vertexQueue = new org.jheaps.tree.SimpleFibonacciHeap[WeightedNode, Short](QueueComparator)
 
-    //  initialize the queue and cost array
+    //  initialize the queue and cost array with the base cost (amount to be routed)
     cost.put(sourceNode, amountMsat)
     vertexQueue.insert(WeightedNode(sourceNode, amountMsat))
 
@@ -149,7 +149,7 @@ object Graph {
   }
 
   /**
-    * A graph data structure that uses the adjacency lists, stores the edges in reversed order
+    * A graph data structure that uses the adjacency lists, stores the incoming edges of the neighbors
     */
   object GraphStructure {
 
@@ -319,7 +319,7 @@ object Graph {
         makeGraph(edges.map(e => e.desc -> e.update).toMap)
       }
 
-      // optimized constructor, builds the graph with reversed edges
+      // optimized constructor
       def makeGraph(descAndUpdates: Map[ChannelDesc, ChannelUpdate]): DirectedGraph = {
 
         // initialize the map with the appropriate size to avoid resizing during the graph initialization
@@ -329,7 +329,7 @@ object Graph {
 
         // add all the vertices and edges in one go
         descAndUpdates.foreach { case (desc, update) =>
-          // create or update vertex (desc.a) and update its neighbor
+          // create or update vertex (desc.b) and update its neighbor
           mutableMap.put(desc.b, GraphEdge(desc, update) +: mutableMap.getOrElse(desc.b, List.empty[GraphEdge]))
           mutableMap.get(desc.a) match {
             case None => mutableMap += desc.a -> List.empty[GraphEdge]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -26,7 +26,9 @@ object Graph {
   }
 
   /**
-    * Finds the shortest path in the graph, Dijsktra's algorithm
+    * Finds the shortest path in the graph, uses a modified version of Dijsktra's algorithm that computes
+    * the shortest path from the target to the source (this is because we want to calculate the weight of the
+    * edges correctly). The graph @param g is optimized for querying the incoming edges given a vertex.
     *
     * @param g the graph on which will be performed the search
     * @param sourceNode the starting node of the path we're looking for
@@ -61,9 +63,9 @@ object Graph {
     val pathLength = new java.util.HashMap[PublicKey, Int](maxMapSize)
 
     // initialize the queue and cost array with the base cost (amount to be routed)
-    cost.put(sourceNode, amountMsat)
-    vertexQueue.insert(WeightedNode(sourceNode, amountMsat))
-    pathLength.put(sourceNode, 0) // the source node has distance 0
+    cost.put(targetNode, amountMsat)
+    vertexQueue.insert(WeightedNode(targetNode, amountMsat))
+    pathLength.put(targetNode, 0) // the source node has distance 0
 
     var targetFound = false
 
@@ -72,7 +74,7 @@ object Graph {
       // node with the smallest distance from the source
       val current = vertexQueue.deleteMin().getKey // O(log(n))
 
-      if (current.key != targetNode) {
+      if (current.key != sourceNode) {
 
         // build the neighbors with optional extra edges
         val currentNeighbors = extraEdges.isEmpty match {
@@ -90,7 +92,7 @@ object Graph {
 
           // note: 'cost' contains the smallest known cumulative cost (amount + fees) necessary to reach 'current' so far
           // note: there is always an entry for the current in the 'cost' map
-          val newMinimumKnownCost = edgeWeight(edge, cost.get(current.key), neighbor == targetNode)
+          val newMinimumKnownCost = edgeWeight(edge, cost.get(current.key), neighbor == sourceNode)
 
           // test for ignored edges
           if (edge.update.htlcMaximumMsat.forall(newMinimumKnownCost <= _) &&
@@ -132,7 +134,7 @@ object Graph {
       case true =>
         // we traverse the list of "previous" backward building the final list of edges that make the shortest path
         val edgePath = new mutable.ArrayBuffer[GraphEdge](ROUTE_MAX_LENGTH)
-        var current = prev.get(targetNode)
+        var current = prev.get(sourceNode)
 
         while (current != null) {
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -774,7 +774,7 @@ object Router {
   /**
     * https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#clarifications
     */
-  val ROUTE_MAX_LENGTH = 19
+  val ROUTE_MAX_LENGTH = 20
 
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -31,7 +31,6 @@ import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
-import DirectedGraph._
 import scala.collection.{SortedSet, mutable}
 import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.compat.Platform
@@ -41,9 +40,7 @@ import scala.util.Try
 
 // @formatter:off
 
-case class ChannelDesc(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey) {
-  def reverse():ChannelDesc = this.copy(a = b, b = a)
-}
+case class ChannelDesc(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey)
 case class Hop(nodeId: PublicKey, nextNodeId: PublicKey, lastUpdate: ChannelUpdate)
 case class RouteRequest(source: PublicKey, target: PublicKey, amountMsat: Long, assistedRoutes: Seq[Seq[ExtraHop]] = Nil, ignoreNodes: Set[PublicKey] = Set.empty, ignoreChannels: Set[ChannelDesc] = Set.empty)
 case class RouteResponse(hops: Seq[Hop], ignoreNodes: Set[PublicKey], ignoreChannels: Set[ChannelDesc]) {
@@ -793,7 +790,7 @@ object Router {
   def findRoute(g: DirectedGraph, localNodeId: PublicKey, targetNodeId: PublicKey, amountMsat: Long, extraEdges: Set[GraphEdge] = Set.empty, ignoredEdges: Set[ChannelDesc] = Set.empty): Try[Seq[Hop]] = Try {
     if (localNodeId == targetNodeId) throw CannotRouteToSelf
 
-    Graph.shortestPath(g, targetNodeId, localNodeId, amountMsat, ignoredEdges.map(_.reverse()), extraEdges.map(edge => edge.copy(desc = edge.desc.reverse()))) match {
+    Graph.shortestPath(g, targetNodeId, localNodeId, amountMsat, ignoredEdges, extraEdges) match {
       case Nil => throw RouteNotFound
       case path => path
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -777,6 +777,12 @@ object Router {
   val DEFAULT_AMOUNT_MSAT = 10000000
 
   /**
+    * https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#clarifications
+    */
+  val ROUTE_MAX_LENGTH = 19
+
+
+  /**
     * Find a route in the graph between localNodeId and targetNodeId, returns the route and its cost
     *
     * @param g

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -786,9 +786,10 @@ object Router {
     * @param amountMsat   the amount that will be sent along this route
     * @param extraEdges   a set of extra edges we want to CONSIDER during the search
     * @param ignoredEdges a set of extra edges we want to IGNORE during the search
+    * @param reverseSearch a flag indicating whether to perform the search backward from the target
     * @return the computed route to the destination @targetNodeId
     */
-  def findRoute(g: DirectedGraph, localNodeId: PublicKey, targetNodeId: PublicKey, amountMsat: Long, extraEdges: Set[GraphEdge] = Set.empty, ignoredEdges: Set[ChannelDesc] = Set.empty, reverseSearch: Boolean = false): Try[Seq[Hop]] = Try {
+  def findRoute(g: DirectedGraph, localNodeId: PublicKey, targetNodeId: PublicKey, amountMsat: Long, extraEdges: Set[GraphEdge] = Set.empty, ignoredEdges: Set[ChannelDesc] = Set.empty, reverseSearch: Boolean = true): Try[Seq[Hop]] = Try {
     if (localNodeId == targetNodeId) throw CannotRouteToSelf
 
     val source = if(reverseSearch) targetNodeId else localNodeId

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -31,7 +31,7 @@ import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
-
+import DirectedGraph._
 import scala.collection.{SortedSet, mutable}
 import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.compat.Platform
@@ -111,7 +111,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
       desc -> u
     }.toMap
     // this will be used to calculate routes
-    val graph = DirectedGraph.makeGraph(initChannelUpdates)
+    val graph = DirectedGraph.makeGraph(initChannelUpdates, reverse = true)
     val initNodes = nodes.map(n => (n.nodeId -> n)).toMap
     // send events for remaining channels/nodes
     initChannels.values.foreach(c => context.system.eventStream.publish(ChannelDiscovered(c, channels(c)._2)))
@@ -378,7 +378,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
       val ignoredUpdates = getIgnoredChannelDesc(d.updates ++ d.privateUpdates ++ assistedUpdates, ignoreNodes) ++ ignoreChannels ++ d.excludedChannels
       log.info(s"finding a route $start->$end with assistedChannels={} ignoreNodes={} ignoreChannels={} excludedChannels={}", assistedUpdates.keys.mkString(","), ignoreNodes.map(_.toBin).mkString(","), ignoreChannels.mkString(","), d.excludedChannels.mkString(","))
       val extraEdges = assistedUpdates.map { case (c, u) => GraphEdge(c, u) }.toSet
-      findRoute(d.graph, start, end, amount, extraEdges = extraEdges, ignoredEdges = ignoredUpdates.toSet)
+      findRoute(d.graph, start, end, amount, extraEdges = extraEdges, ignoredEdges = ignoredUpdates.toSet, reverseSearch = true)
         .map(r => sender ! RouteResponse(r, ignoreNodes, ignoreChannels))
         .recover { case t => sender ! Status.Failure(t) }
       stay
@@ -593,8 +593,8 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
         db.updateChannelUpdate(u)
         // update the graph
         val graph1 = Announcements.isEnabled(u.channelFlags) match {
-          case true => d.graph.removeEdge(desc).addEdge(desc, u)
-          case false => d.graph.removeEdge(desc) // if the channel is now disabled, we remove it from the graph
+          case true => d.graph.removeEdge(desc, reverse = true).addEdge(desc, u, reverse = true)
+          case false => d.graph.removeEdge(desc, reverse = true) // if the channel is now disabled, we remove it from the graph
         }
         d.copy(updates = d.updates + (desc -> u), rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> Set(origin))), graph = graph1)
       } else {
@@ -602,7 +602,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
         context.system.eventStream.publish(ChannelUpdateReceived(u))
         db.addChannelUpdate(u)
         // we also need to update the graph
-        val graph1 = d.graph.addEdge(desc, u)
+        val graph1 = d.graph.addEdge(desc, u, reverse = true)
         d.copy(updates = d.updates + (desc -> u), privateUpdates = d.privateUpdates - desc, rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> Set(origin))), graph = graph1)
       }
     } else if (d.awaiting.keys.exists(c => c.shortChannelId == u.shortChannelId)) {
@@ -634,13 +634,13 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
         log.debug("updated channel_update for shortChannelId={} public={} flags={} {}", u.shortChannelId, publicChannel, u.channelFlags, u)
         context.system.eventStream.publish(ChannelUpdateReceived(u))
         // we also need to update the graph
-        val graph1 = d.graph.removeEdge(desc).addEdge(desc, u)
+        val graph1 = d.graph.removeEdge(desc, reverse = true).addEdge(desc, u, reverse = true)
         d.copy(privateUpdates = d.privateUpdates + (desc -> u), graph = graph1)
       } else {
         log.debug("added channel_update for shortChannelId={} public={} flags={} {}", u.shortChannelId, publicChannel, u.channelFlags, u)
         context.system.eventStream.publish(ChannelUpdateReceived(u))
         // we also need to update the graph
-        val graph1 = d.graph.addEdge(desc, u)
+        val graph1 = d.graph.addEdge(desc, u, reverse = true)
         d.copy(privateUpdates = d.privateUpdates + (desc -> u), graph = graph1)
       }
     } else if (db.isPruned(u.shortChannelId) && !isStale(u)) {
@@ -788,10 +788,16 @@ object Router {
     * @param ignoredEdges a set of extra edges we want to IGNORE during the search
     * @return the computed route to the destination @targetNodeId
     */
-  def findRoute(g: DirectedGraph, localNodeId: PublicKey, targetNodeId: PublicKey, amountMsat: Long, extraEdges: Set[GraphEdge] = Set.empty, ignoredEdges: Set[ChannelDesc] = Set.empty): Try[Seq[Hop]] = Try {
+  def findRoute(g: DirectedGraph, localNodeId: PublicKey, targetNodeId: PublicKey, amountMsat: Long, extraEdges: Set[GraphEdge] = Set.empty, ignoredEdges: Set[ChannelDesc] = Set.empty, reverseSearch: Boolean = false): Try[Seq[Hop]] = Try {
     if (localNodeId == targetNodeId) throw CannotRouteToSelf
 
-    Graph.shortestPath(g, localNodeId, targetNodeId, amountMsat, ignoredEdges, extraEdges) match {
+    val source = if(reverseSearch) targetNodeId else localNodeId
+    val target = if(reverseSearch) localNodeId else targetNodeId
+
+    val ignored = if(reverseSearch) ignoredEdges.map(reverseDesc) else ignoredEdges
+    val extra = if(reverseSearch) extraEdges.map(edge => edge.copy(desc = reverseDesc(edge.desc))) else extraEdges
+
+    Graph.shortestPath(g, source, target, amountMsat, ignored, extra, reverse = reverseSearch) match {
       case Nil => throw RouteNotFound
       case path => path
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -772,11 +772,6 @@ object Router {
   }
 
   /**
-    * Routing fee have a variable part, this value will be used as a default if none is provided when search for a route
-    */
-  val DEFAULT_AMOUNT_MSAT = 10000000
-
-  /**
     * https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#clarifications
     */
   val ROUTE_MAX_LENGTH = 19

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -41,7 +41,9 @@ import scala.util.Try
 
 // @formatter:off
 
-case class ChannelDesc(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey)
+case class ChannelDesc(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey) {
+  def reverse():ChannelDesc = this.copy(a = b, b = a)
+}
 case class Hop(nodeId: PublicKey, nextNodeId: PublicKey, lastUpdate: ChannelUpdate)
 case class RouteRequest(source: PublicKey, target: PublicKey, amountMsat: Long, assistedRoutes: Seq[Seq[ExtraHop]] = Nil, ignoreNodes: Set[PublicKey] = Set.empty, ignoreChannels: Set[ChannelDesc] = Set.empty)
 case class RouteResponse(hops: Seq[Hop], ignoreNodes: Set[PublicKey], ignoreChannels: Set[ChannelDesc]) {
@@ -791,7 +793,7 @@ object Router {
   def findRoute(g: DirectedGraph, localNodeId: PublicKey, targetNodeId: PublicKey, amountMsat: Long, extraEdges: Set[GraphEdge] = Set.empty, ignoredEdges: Set[ChannelDesc] = Set.empty): Try[Seq[Hop]] = Try {
     if (localNodeId == targetNodeId) throw CannotRouteToSelf
 
-    Graph.shortestPath(g, targetNodeId, localNodeId, amountMsat, ignoredEdges.map(reverseDesc), extraEdges.map(edge => edge.copy(desc = reverseDesc(edge.desc)))) match {
+    Graph.shortestPath(g, targetNodeId, localNodeId, amountMsat, ignoredEdges.map(_.reverse()), extraEdges.map(edge => edge.copy(desc = edge.desc.reverse()))) match {
       case Nil => throw RouteNotFound
       case path => path
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -791,7 +791,7 @@ object Router {
   def findRoute(g: DirectedGraph, localNodeId: PublicKey, targetNodeId: PublicKey, amountMsat: Long, extraEdges: Set[GraphEdge] = Set.empty, ignoredEdges: Set[ChannelDesc] = Set.empty): Try[Seq[Hop]] = Try {
     if (localNodeId == targetNodeId) throw CannotRouteToSelf
 
-    Graph.shortestPath(g, targetNodeId, localNodeId, amountMsat, ignoredEdges, extraEdges) match {
+    Graph.shortestPath(g, localNodeId, targetNodeId, amountMsat, ignoredEdges, extraEdges) match {
       case Nil => throw RouteNotFound
       case path => path
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
@@ -37,7 +37,7 @@ class GraphSpec extends FunSuite {
       makeUpdate(6L, b, e, 0, 0)
     )
 
-    DirectedGraph.makeGraph(updates.toMap)
+    DirectedGraph.makeGraph(updates.toMap, reverse = false)
   }
 
   test("instantiate a graph, with vertices and then add edges") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -90,6 +90,14 @@ class RouteCalculationSpec extends FunSuite {
 
     assert(hops2Ids(route) === 4 :: 5 :: 6 :: Nil)
     assert(Graph.pathCost(route, amountMsat) === expectedCost)
+
+    // now channel 5 could route the amount (10000) but not the amount + fees (10007)
+    val (desc, update) = makeUpdate(5L, e, f, feeBaseMsat = 1, feeProportionalMillionth = 400, minHtlcMsat = 0, maxHtlcMsat = Some(10005))
+    val graph1 = graph.addEdge(desc, update)
+
+    val Success(route1) = Router.findRoute(graph1, a, d, amountMsat)
+
+    assert(hops2Ids(route1) === 1 :: 2 :: 3 :: Nil)
   }
 
   test("calculate route considering the direct channel pays no fees") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -526,18 +526,20 @@ class RouteCalculationSpec extends FunSuite {
 
   test("limit routes to 20 hops") {
 
-    val nodes = (for (_ <- 0 until 100) yield randomKey.publicKey).toList
+    val nodes = (for (_ <- 0 until 22) yield randomKey.publicKey).toList
 
     val updates = nodes
       .zip(nodes.drop(1)) // (0, 1) :: (1, 2) :: ...
       .zipWithIndex // ((0, 1), 0) :: ((1, 2), 1) :: ...
-      .map { case ((na, nb), index) => makeUpdate(index, na, nb, 5, 0) }
+      .map {case ((na, nb), index) => makeUpdate(index, na, nb, 5, 0)}
       .toMap
 
     val g = makeGraph(updates)
-    val route = Router.findRoute(g, nodes.head, nodes.last, DEFAULT_AMOUNT_MSAT)
 
-    assert(route === Failure(RouteNotFound))
+    assert(Router.findRoute(g, nodes(0), nodes(18), DEFAULT_AMOUNT_MSAT).map(hops2Ids) === Success(0 until 18))
+    assert(Router.findRoute(g, nodes(0), nodes(19), DEFAULT_AMOUNT_MSAT).map(hops2Ids) === Success(0 until 19))
+    assert(Router.findRoute(g, nodes(0), nodes(20), DEFAULT_AMOUNT_MSAT).map(hops2Ids) === Success(0 until 20))
+    assert(Router.findRoute(g, nodes(0), nodes(21), DEFAULT_AMOUNT_MSAT).map(hops2Ids) === Failure(RouteNotFound))
   }
 
   test("ignore cheaper route when it has more than 20 hops") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -462,7 +462,7 @@ object RouteCalculationSpec {
       htlcMaximumMsat = maxHtlcMsat
     )
 
-  def makeGraph(updates: Map[ChannelDesc, ChannelUpdate]) = DirectedGraph().addEdges(updates.toSeq)
+  def makeGraph(updates: Map[ChannelDesc, ChannelUpdate]) = DirectedGraph().addEdges(updates.toSeq, reverse = false)
 
   def hops2Ids(route: Seq[Hop]) = route.map(hop => hop.lastUpdate.shortChannelId.toLong)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -558,6 +558,22 @@ class RouteCalculationSpec extends FunSuite {
     assert(route.map(hops2Ids) === Success(0 :: 1 :: 99 :: 48 :: Nil))
   }
 
+  test("ignore loops") {
+
+    val updates = List(
+      makeUpdate(1L, a, b, 10, 10),
+      makeUpdate(2L, b, c, 10, 10),
+      makeUpdate(3L, c, a, 10, 10),
+      makeUpdate(4L, c, d, 10, 10),
+      makeUpdate(5L, d, e, 10, 10)
+    ).toMap
+
+    val g = makeGraph(updates)
+
+    val route1 = Router.findRoute(g, a, e, DEFAULT_AMOUNT_MSAT)
+    assert(route1.map(hops2Ids) === Success(1 :: 2  :: 4 :: 5 :: Nil))
+  }
+
 }
 
 object RouteCalculationSpec {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -53,10 +53,49 @@ class RouteCalculationSpec extends FunSuite {
     assert(route.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
   }
 
+  test("calculate the shortest path (correct fees)") {
+
+    val (a, b, c, d, e, f) = (
+      PublicKey("02999fa724ec3c244e4da52b4a91ad421dc96c9a810587849cd4b2469313519c73"), // a: source
+      PublicKey("03f1cb1af20fe9ccda3ea128e27d7c39ee27375c8480f11a87c17197e97541ca6a"),
+      PublicKey("0358e32d245ff5f5a3eb14c78c6f69c67cea7846bdf9aeeb7199e8f6fbb0306484"),
+      PublicKey("029e059b6780f155f38e83601969919aae631ddf6faed58fe860c72225eb327d7c"), // d: target
+      PublicKey("03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"),
+      PublicKey("020c65be6f9252e85ae2fe9a46eed892cb89565e2157730e78311b1621a0db4b22")
+    )
+
+    // note: we don't actually use floating point numbers
+    // cost(CD) = 10005 = amountMsat + 1 + (amountMsat * 400 / 1000000)
+    // cost(BC) = 10009,0015 = (cost(CD) + 1 + (cost(CD) * 300 / 1000000)
+    // cost(FD) = 10002 = amountMsat + 1 + (amountMsat * 100 / 1000000)
+    // cost(EF) = 10007,0008 = cost(FD) + 1 + (cost(FD) * 400 / 1000000)
+    // cost(AE) = 10007 -> A is source, shortest path found
+    // cost(AB) = 10009
+
+    val amountMsat = 10000
+    val expectedCost = 10007
+
+    val updates = List(
+      makeUpdate(1L, a, b, feeBaseMsat = 1, feeProportionalMillionth = 200, minHtlcMsat = 0),
+      makeUpdate(4L, a, e, feeBaseMsat = 1, feeProportionalMillionth =  200, minHtlcMsat = 0),
+      makeUpdate(2L, b, c, feeBaseMsat = 1, feeProportionalMillionth = 300, minHtlcMsat = 0),
+      makeUpdate(3L, c, d, feeBaseMsat = 1, feeProportionalMillionth = 400, minHtlcMsat = 0),
+      makeUpdate(5L, e, f, feeBaseMsat = 1, feeProportionalMillionth = 400, minHtlcMsat = 0),
+      makeUpdate(6L, f, d, feeBaseMsat = 1, feeProportionalMillionth = 100, minHtlcMsat = 0)
+    ).toMap
+
+    val graph = makeGraph(updates)
+
+    val Success(route) = Router.findRoute(graph, a, d, amountMsat)
+
+    assert(hops2Ids(route) === 4 :: 5 :: 6 :: Nil)
+    assert(Graph.pathCost(route, amountMsat) === expectedCost)
+  }
+
   test("calculate route considering the direct channel pays no fees") {
     val updates = List(
       makeUpdate(1L, a, b, 5, 0), // a -> b
-      makeUpdate(2L, a, d, 15, 0),// a -> d  this goes a bit closer to the targed and asks for higher fees but is a direct channel
+      makeUpdate(2L, a, d, 15, 0),// a -> d  this goes a bit closer to the target and asks for higher fees but is a direct channel
       makeUpdate(3L, b, c, 5, 0), // b -> c
       makeUpdate(4L, c, d, 5, 0), // c -> d
       makeUpdate(5L, d, e, 5, 0)  // d -> e
@@ -85,7 +124,6 @@ class RouteCalculationSpec extends FunSuite {
     val graphWithRemovedEdge = g.removeEdge(ChannelDesc(ShortChannelId(3L), c, d))
     val route2 = Router.findRoute(graphWithRemovedEdge, a, e, DEFAULT_AMOUNT_MSAT)
     assert(route2.map(hops2Ids) === Failure(RouteNotFound))
-
   }
 
   test("calculate the shortest path (hardcoded nodes)") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -21,7 +21,6 @@ import fr.acinq.bitcoin.{BinaryData, Block, Crypto}
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.router.Router.DEFAULT_AMOUNT_MSAT
 import fr.acinq.eclair.{ShortChannelId, nodeFee, randomKey}
 import org.scalatest.FunSuite
 
@@ -36,6 +35,7 @@ class RouteCalculationSpec extends FunSuite {
   import RouteCalculationSpec._
 
   val (a, b, c, d, e) = (randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey)
+
 
   // the total fee cost for this path
   def pathCost(path: Seq[Hop], amountMsat: Long): Long = {
@@ -577,6 +577,8 @@ class RouteCalculationSpec extends FunSuite {
 }
 
 object RouteCalculationSpec {
+
+  val DEFAULT_AMOUNT_MSAT = 10000000
 
   val DUMMY_SIG = BinaryData("3045022100e0a180fdd0fe38037cc878c03832861b40a29d32bd7b40b10c9e1efc8c1468a002205ae06d1624896d0d29f4b31e32772ea3cb1b4d7ed4e077e5da28dcc33c0e781201")
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -22,7 +22,7 @@ import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.router.Router.DEFAULT_AMOUNT_MSAT
-import fr.acinq.eclair.{ShortChannelId, randomKey}
+import fr.acinq.eclair.{ShortChannelId, nodeFee, randomKey}
 import org.scalatest.FunSuite
 
 import scala.util.{Failure, Success}
@@ -36,6 +36,13 @@ class RouteCalculationSpec extends FunSuite {
   import RouteCalculationSpec._
 
   val (a, b, c, d, e) = (randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey)
+
+  // the total fee cost for this path
+  def pathCost(path: Seq[Hop], amountMsat: Long): Long = {
+    path.drop(1).reverse.foldLeft(amountMsat) { (fee, hop) =>
+      fee + nodeFee(hop.lastUpdate.feeBaseMsat, hop.lastUpdate.feeProportionalMillionths, fee)
+    }
+  }
 
   test("calculate simple route") {
 
@@ -89,7 +96,7 @@ class RouteCalculationSpec extends FunSuite {
     val Success(route) = Router.findRoute(graph, a, d, amountMsat)
 
     assert(hops2Ids(route) === 4 :: 5 :: 6 :: Nil)
-    assert(Graph.pathCost(route, amountMsat) === expectedCost)
+    assert(pathCost(route, amountMsat) === expectedCost)
 
     // now channel 5 could route the amount (10000) but not the amount + fees (10007)
     val (desc, update) = makeUpdate(5L, e, f, feeBaseMsat = 1, feeProportionalMillionth = 400, minHtlcMsat = 0, maxHtlcMsat = Some(10005))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -433,6 +433,30 @@ class RouteCalculationSpec extends FunSuite {
       ChannelDesc(ShortChannelId(8L), i, j)
     ))
   }
+
+  test("backward search for a route in a reversed graph") {
+    val (f, g, h, i) = (
+      PublicKey("02999fa724ec3c244e4da52b4a91ad421dc96c9a810587849cd4b2469313519c73"), //source
+      PublicKey("03f1cb1af20fe9ccda3ea128e27d7c39ee27375c8480f11a87c17197e97541ca6a"),
+      PublicKey("0358e32d245ff5f5a3eb14c78c6f69c67cea7846bdf9aeeb7199e8f6fbb0306484"),
+      PublicKey("029e059b6780f155f38e83601969919aae631ddf6faed58fe860c72225eb327d7c") //target
+    )
+
+    val updates = List(
+      makeUpdate(1L, f, g, 0, 0),
+      makeUpdate(2L, g, h, 0, 0),
+      makeUpdate(3L, h, i, 0, 0),
+      makeUpdate(4L, f, i, 50, 0) //direct channel, more expensive
+    ).toMap
+
+    val graph = DirectedGraph.makeGraph(updates, reverse = false)
+    val reversedGraph = DirectedGraph.makeGraph(updates, reverse = true)
+
+    val Success(route) = Router.findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, reverseSearch = false)
+    val Success(route1) = Router.findRoute(reversedGraph, f, i, DEFAULT_AMOUNT_MSAT, reverseSearch = true)
+
+    assert(route === route1)
+  }
 }
 
 object RouteCalculationSpec {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -27,11 +27,10 @@ import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.io.Peer.{InvalidSignature, PeerRoutingMessage}
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.router.Announcements.makeChannelUpdate
-import fr.acinq.eclair.router.Router.DEFAULT_AMOUNT_MSAT
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire.QueryShortChannelIds
 import fr.acinq.eclair.{Globals, ShortChannelId, randomKey}
-
+import RouteCalculationSpec.DEFAULT_AMOUNT_MSAT
 import scala.collection.SortedSet
 import scala.compat.Platform
 import scala.concurrent.duration._


### PR DESCRIPTION
Compute the routes backward from the target and with the correct channels cost, nodes that are 'neighbor' to the local node (direct channel) will have a routing cost of 0.