### PR TITLE
Allow access to audit of transactions from API

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ java -Dlogback.configurationFile=/path/to/logback-custom.xml -jar eclair-node-gu
   forceclose   | channelId                                                                              | force-close a channel by publishing the local commitment tx (careful: this is more expensive than a regular close and will incur a delay before funds are spendable)"
   audit        |                                                                                        | list all send/received/relayed payments
   audit        | from, to                                                                               | list send/received/relayed payments in that interval (from <= timestamp < to)
+  auditauditgetpayment|paymentHash                                                                      | returns null if nothing in audit else details of sent or received payment from audit database
+  auditauditgetpayment|paymentRequest                                                                   | returns null if nothing in audit else details of sent or received payment from audit database
   networkfees  |                                                                                        | list all network fees paid to the miners, by transaction
   networkfees  |from, to                                                                                | list network fees paid to the miners, by transaction, in that interval (from <= timestamp < to)
   help         |                                                                                        | display available methods

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -39,6 +39,8 @@ trait AuditDb {
 
   def listNetworkFees(from: Long, to: Long): Seq[NetworkFee]
 
+  def getPaymentInfo(paymentHash: BinaryData): Option[Either[PaymentSent,PaymentReceived]]
+
   def stats: Seq[Stats]
 
   def close: Unit

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
@@ -62,6 +62,12 @@ class SqliteAuditDbSpec extends FunSuite {
     assert(db.listRelayed(from = 0L, to = Long.MaxValue).toList === List(e3))
     assert(db.listNetworkFees(from = 0L, to = Long.MaxValue).size === 1)
     assert(db.listNetworkFees(from = 0L, to = Long.MaxValue).head.txType === "mutual")
+
+    assert(db.getPaymentInfo(e1.paymentHash)==Some(Left(e1)))
+    assert(db.getPaymentInfo(e2.paymentHash)==Some(Right(e2)))
+    assert(db.getPaymentInfo(e5.paymentHash)==Some(Left(e5)))
+    assert(db.getPaymentInfo(e6.paymentHash)==Some(Left(e6)))
+    assert(db.getPaymentInfo(randomBytes(32))==None)
   }
 
   test("stats") {


### PR DESCRIPTION
This would be an alternative to pr #802 as could get exact payment time using this.
Also can use to fix #615 as can check after a timeout if a payment went or not - just poll this till the invoice times out.