### PR TITLE
[WIP] JDK10/11 compatiblity: use Scala 2.11.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <scala.version>2.11.11</scala.version>
+        <scala.version>2.11.12</scala.version>
         <scala.version.short>2.11</scala.version.short>
         <akka.version>2.4.20</akka.version>
         <akka.http.version>10.0.11</akka.http.version>
@@ -127,6 +127,7 @@
                         <arg>-unchecked</arg>
                         <arg>-Xmax-classfile-name</arg>
                         <arg>140</arg>
+                        <arg>-nobootcp</arg>
                     </args>
                     <scalaCompatVersion>${scala.version.short}</scalaCompatVersion>
                 </configuration>


### PR DESCRIPTION
With this change, you can:
- compile eclair-core and eclair-node on JDK10/11
- run eclair-node on JDK10/11

You cannot compile or run eclair-node-gui, because it uses JavaFX which is now packaged differently from JDK8.

See https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html#jdk-9--up-compatibility-notes