### PR TITLE
Stop disconnected peer when it has no channels

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -184,8 +184,8 @@ trait Service extends Logging {
                         }
                         // local network methods
                         case "peers" => completeRpcFuture(req.id, for {
-                          peers <- (switchboard ? 'peers).mapTo[Map[PublicKey, ActorRef]]
-                          peerinfos <- Future.sequence(peers.values.map(peer => (peer ? GetPeerInfo).mapTo[PeerInfo]))
+                          peers <- (switchboard ? 'peers).mapTo[Iterable[ActorRef]]
+                          peerinfos <- Future.sequence(peers.map(peer => (peer ? GetPeerInfo).mapTo[PeerInfo]))
                         } yield peerinfos)
                         case "channels" => req.params match {
                           case Nil =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -164,7 +164,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
         // we have no existing channels, we can forget about this peer
         stop(FSM.Normal)
       } else {
-        stay using d.copy(channels = d.channels -- h)
+        stay using d.copy(channels = channels1)
       }
   }
 
@@ -456,8 +456,6 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
     case Event(_: Pong, _) => stay // we got disconnected before receiving the pong
 
     case Event(_: PingTimeout, _) => stay // we got disconnected after sending a ping
-
-    case Event(_: Terminated, _) => stay // this channel got closed before having a commitment and we got disconnected (e.g. a funding error occured)
   }
 
   onTransition {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -99,9 +99,10 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
   /**
     * Retrieves a peer based on its public key.
     *
-    * NB: Internally akka uses a TreeMap to store the binding, so this lookup is O(log(N)). We could make it O(1) by
-    * using our own HashMap, but it creates other problems when we need to clean up peers. This seems like a reasonable
-    * trade-off because we make only make this call once per connection.
+    * NB: Internally akka uses a TreeMap to store the binding, so this lookup is O(log(N)) where N is the number of
+    * peers. We could make it O(1) by using our own HashMap, but it creates other problems when we need to remove an
+    * existing peer. This seems like a reasonable trade-off because we only make this call once per connection, and N
+    * should never be very big anyway.
     *
     * @param remoteNodeId
     * @return

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.io
 
 import java.net.InetSocketAddress
 
-import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, Status, SupervisorStrategy, Terminated}
+import akka.actor.{Actor, ActorLogging, ActorRef, DeadLetter, OneForOneStrategy, Props, Status, SupervisorStrategy, Terminated}
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.blockchain.EclairWallet

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -95,7 +95,17 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
   }
 
   def peerActorName(remoteNodeId: PublicKey): String = s"peer-$remoteNodeId"
-  
+
+  /**
+    * Retrieves a peer based on its public key.
+    *
+    * NB: Internally akka uses a TreeMap to store the binding, so this lookup is O(log(N)). We could make it O(1) by
+    * using our own HashMap, but it creates other problems when we need to clean up peers. This seems like a reasonable
+    * trade-off because we make only make this call once per connection.
+    *
+    * @param remoteNodeId
+    * @return
+    */
   def getPeer(remoteNodeId: PublicKey): Option[ActorRef] = context.child(peerActorName(remoteNodeId))
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.io
 
 import java.net.InetSocketAddress
 
-import akka.actor.{Actor, ActorLogging, ActorRef, DeadLetter, OneForOneStrategy, Props, Status, SupervisorStrategy, Terminated}
+import akka.actor.{Actor, ActorLogging, ActorRef, OneForOneStrategy, Props, Status, SupervisorStrategy, Terminated}
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.blockchain.EclairWallet

--- a/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonRpcServiceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonRpcServiceSpec.scala
@@ -162,7 +162,7 @@ class JsonRpcServiceSpec extends FunSuite with ScalatestRouteTest {
     val mockService = new MockService(defaultMockKit.copy(
       switchboard = system.actorOf(Props(new {} with MockActor {
         override def receive = {
-          case 'peers => sender() ! Map(Alice.nodeParams.nodeId -> mockAlicePeer, Bob.nodeParams.nodeId -> mockBobPeer)
+          case 'peers => sender() ! List(mockAlicePeer, mockBobPeer)
         }
       }))
     ))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -416,8 +416,9 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     val previouslyReceivedByC = res.filter(_ \ "address" == JString(finalAddressC)).flatMap(_ \ "txids" \\ classOf[JString])
     // we then kill the connection between C and F
     sender.send(nodes("F1").switchboard, 'peers)
-    val peers = sender.expectMsgType[Map[PublicKey, ActorRef]]
-    peers(nodes("C").nodeParams.nodeId) ! Disconnect
+    val peers = sender.expectMsgType[Iterable[ActorRef]]
+    // F's only node is C
+    peers.head ! Disconnect
     // we then wait for F to be in disconnected state
     awaitCond({
       sender.send(nodes("F1").register, Forward(htlc.channelId, CMD_GETSTATE))
@@ -494,8 +495,9 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     val previouslyReceivedByC = res.filter(_ \ "address" == JString(finalAddressC)).flatMap(_ \ "txids" \\ classOf[JString])
     // we then kill the connection between C and F
     sender.send(nodes("F2").switchboard, 'peers)
-    val peers = sender.expectMsgType[Map[PublicKey, ActorRef]]
-    peers(nodes("C").nodeParams.nodeId) ! Disconnect
+    val peers = sender.expectMsgType[Iterable[ActorRef]]
+    // F's only node is C
+    peers.head ! Disconnect
     // we then wait for F to be in disconnected state
     awaitCond({
       sender.send(nodes("F2").register, Forward(htlc.channelId, CMD_GETSTATE))


### PR DESCRIPTION
When we are disconnected and we don't have any channel with that peer,
we can stop it and remove its address from db.

We also need to handle the case where we are in `DISCONNECTED` or
`INITIALIZING` state and we are notified that the last channel we had
with that peer just got closed.

~Note that this opens a race condition in the switchboard, if we receive
an incoming connection from that same peer right after we stopped it,
and before the switchboard received the `Terminated` event. If that
happens, then `Peer.Connect` or `Peer.OpenChannel` will timeout. We
could also have the switchboard listens to deadletter events, but that
seems a bit over the top.~ Not anymore since eea7253.