### PR TITLE
[WIP] Use a single link to represent multiple channels between two nodes

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -404,21 +404,6 @@ object Graph {
         }
       }
 
-      def shouldAdd(edge: GraphEdge): Option[GraphEdge] = {
-        getEdgeBetween(edge.desc.a, edge.desc.b) match {
-          case Some(existingLink) =>
-            // compare the maxHtlc
-            edge.update.htlcMaximumMsat match {
-              case Some(edgeMax) => existingLink.update.htlcMaximumMsat match {
-                case Some(existingHtlcMax) => if(existingHtlcMax < edgeMax) Some(existingLink) else None
-                case None => Some(existingLink)
-              }
-              case None => None
-            }
-          case None => None
-        }
-      }
-
       def prettyPrint(): String = {
         vertices.foldLeft("") { case (acc, (vertex, adj)) =>
           acc + s"[${vertex.toString().take(5)}]: ${adj.map("-> " + _.desc.b.toString().take(5))} \n"


### PR DESCRIPTION
The internal graph representation will keep at most one channel to represent the link between two nodes. This speeds up graph searching and doesn't affect the routing, after all when a routing node receives an incoming htlc it can forwards it to the next_node via any of the channels available between them.