### PR TITLE
Improve Electrum start-up time

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -92,7 +92,10 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
 
   def close() = {
     statusListeners.map(_ ! ElectrumDisconnected)
-    Option(context).foreach(_ stop self)
+    Option(context).foreach(ctx => {
+      statusListeners.map(_ ! ElectrumDisconnected)
+      ctx stop self
+    })
   }
 
   def errorHandler(t: Throwable) = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -92,7 +92,7 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
 
   def close() = {
     statusListeners.map(_ ! ElectrumDisconnected)
-    context stop self
+    Option(context).foreach(_ stop self)
   }
 
   def errorHandler(t: Throwable) = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -368,7 +368,7 @@ object ElectrumClient {
   case class GetAddressHistoryResponse(address: String, history: Seq[TransactionHistoryItem]) extends Response
 
   case class GetScriptHashHistory(scriptHash: BinaryData) extends Request
-  case class GetScriptHashHistoryResponse(scriptHash: BinaryData, history: Seq[TransactionHistoryItem]) extends Response
+  case class GetScriptHashHistoryResponse(scriptHash: BinaryData, history: List[TransactionHistoryItem]) extends Response
 
   case class AddressListUnspent(address: String) extends Request
   case class UnspentItem(tx_hash: BinaryData, tx_pos: Int, value: Long, height: Long) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
@@ -22,7 +22,7 @@ import fr.acinq.bitcoin.DeterministicWallet.{ExtendedPrivateKey, derivePrivateKe
 import fr.acinq.bitcoin.{Base58, Base58Check, BinaryData, Block, BlockHeader, Crypto, DeterministicWallet, OP_PUSHDATA, OutPoint, SIGHASH_ALL, Satoshi, Script, ScriptElt, ScriptWitness, SigVersion, Transaction, TxIn, TxOut}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.Error
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient._
-import fr.acinq.eclair.blockchain.electrum.db.WalletDb
+import fr.acinq.eclair.blockchain.electrum.db.{HeaderDb, WalletDb}
 import fr.acinq.eclair.transactions.Transactions
 import grizzled.slf4j.Logging
 
@@ -91,7 +91,7 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
   def advertiseTransactions(data: ElectrumWallet.Data): Unit = {
     data.transactions.values.foreach(tx => data.computeTransactionDelta(tx).foreach {
       case (received, sent, fee_opt) =>
-        context.system.eventStream.publish(TransactionReceived(tx, data.computeTransactionDepth(tx.txid), received, sent, fee_opt))
+        context.system.eventStream.publish(TransactionReceived(tx, data.computeTransactionDepth(tx.txid), received, sent, fee_opt, data.computeTimestamp(tx.txid, params.walletDb)))
     })
   }
 
@@ -218,7 +218,7 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
             data.heights.collect {
               case (txid, txheight) if txheight > 0 =>
                 val confirmations = computeDepth(height, txheight)
-                context.system.eventStream.publish(TransactionConfidenceChanged(txid, confirmations))
+                context.system.eventStream.publish(TransactionConfidenceChanged(txid, confirmations, data.computeTimestamp(txid, params.walletDb)))
             }
             val (blockchain2, saveme) = Blockchain.optimize(blockchain1)
             saveme.grouped(RETARGETING_PERIOD).foreach(chunk => params.walletDb.addHeaders(chunk.head.height, chunk.map(_.header)))
@@ -314,10 +314,10 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
             // height=0 => unconfirmed, height=-1 => unconfirmed and one input is unconfirmed
             case (None, height) if height > 0 =>
               // first time we get a height for this tx: either it was just confirmed, or we restarted the wallet
-              context.system.eventStream.publish(TransactionConfidenceChanged(txid, confirmations))
+              context.system.eventStream.publish(TransactionConfidenceChanged(txid, confirmations, data.computeTimestamp(txid, params.walletDb)))
             case (Some(previousHeight), height) if previousHeight != height =>
               // there was a reorg
-              context.system.eventStream.publish(TransactionConfidenceChanged(txid, confirmations))
+              context.system.eventStream.publish(TransactionConfidenceChanged(txid, confirmations, data.computeTimestamp(txid, params.walletDb)))
             case (Some(previousHeight), height) if previousHeight == height =>
             // no reorg, nothing to do
           }
@@ -346,7 +346,7 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
       data.computeTransactionDelta(tx) match {
         case Some((received, sent, fee_opt)) =>
           log.info(s"successfully connected txid=${tx.txid}")
-          context.system.eventStream.publish(TransactionReceived(tx, data.computeTransactionDepth(tx.txid), received, sent, fee_opt))
+          context.system.eventStream.publish(TransactionReceived(tx, data.computeTransactionDepth(tx.txid), received, sent, fee_opt, data.computeTimestamp(tx.txid, params.walletDb)))
           // when we have successfully processed a new tx, we retry all pending txes to see if they can be added now
           data.pendingTransactions.foreach(self ! GetTransactionResponse(_))
           val data1 = data.copy(transactions = data.transactions + (tx.txid -> tx), pendingTransactionRequests = data.pendingTransactionRequests - tx.txid, pendingTransactions = Nil)
@@ -404,7 +404,7 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
       // we know all the parents
       val (received, sent, Some(fee)) = data.computeTransactionDelta(tx).get
       // we notify here because the tx won't be downloaded again (it has been added to the state at commit)
-      context.system.eventStream.publish(TransactionReceived(tx, data1.computeTransactionDepth(tx.txid), received, sent, Some(fee)))
+      context.system.eventStream.publish(TransactionReceived(tx, data1.computeTransactionDepth(tx.txid), received, sent, Some(fee), None))
       stay using notifyReady(data1) replying CommitTransactionResponse(tx) // goto instead of stay because we want to fire transitions
 
     case Event(CancelTransaction(tx), data) =>
@@ -424,7 +424,8 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
       goto(DISCONNECTED) using data.copy(
         pendingHistoryRequests = Set(),
         pendingTransactionRequests = Set(),
-        pendingHeadersRequests = Set()
+        pendingHeadersRequests = Set(),
+        lastReadyMessage = None
       )
 
     case Event(GetCurrentReceiveAddress, data) => stay replying GetCurrentReceiveAddressResponse(data.currentReceiveAddress)
@@ -505,8 +506,8 @@ object ElectrumWallet {
     * @param sent
     * @param feeOpt is set only when we know it (i.e. for outgoing transactions)
     */
-  case class TransactionReceived(tx: Transaction, depth: Long, received: Satoshi, sent: Satoshi, feeOpt: Option[Satoshi]) extends WalletEvent
-  case class TransactionConfidenceChanged(txid: BinaryData, depth: Long) extends WalletEvent
+  case class TransactionReceived(tx: Transaction, depth: Long, received: Satoshi, sent: Satoshi, feeOpt: Option[Satoshi], timestamp: Option[Long]) extends WalletEvent
+  case class TransactionConfidenceChanged(txid: BinaryData, depth: Long, timestamp: Option[Long]) extends WalletEvent
   case class NewWalletReceiveAddress(address: String) extends WalletEvent
   case class WalletReady(confirmedBalance: Satoshi, unconfirmedBalance: Satoshi, height: Long, timestamp: Long) extends WalletEvent
   // @formatter:on
@@ -726,6 +727,20 @@ object ElectrumWallet {
     def isMine(txOut: TxOut): Boolean = publicScriptMap.contains(txOut.publicKeyScript)
 
     def computeTransactionDepth(txid: BinaryData): Long = heights.get(txid).map(height => if (height > 0) computeDepth(blockchain.tip.height, height) else 0).getOrElse(0)
+
+    /**
+      *
+      * @param data wallet data
+      * @param txid transaction id
+      * @param headerDb header db
+      * @return the timestamp of the block this tx was included in
+      */
+    def computeTimestamp(txid: BinaryData, headerDb: HeaderDb): Option[Long] = {
+      for {
+        height <- heights.get(txid).map(_.toInt)
+        header <- blockchain.getHeader(height).orElse(headerDb.getHeader(height))
+      } yield header.time
+    }
 
     /**
       *

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
@@ -160,11 +160,13 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
         data.accountKeys.foreach(key => client ! ElectrumClient.ScriptHashSubscription(computeScriptHashFromPublicKey(key.publicKey), self))
         data.changeKeys.foreach(key => client ! ElectrumClient.ScriptHashSubscription(computeScriptHashFromPublicKey(key.publicKey), self))
         advertiseTransactions(data)
+        // tell everyone we're ready
         goto(RUNNING) using notifyReady(data.copy(lastReadyMessage = None))
       } else {
         client ! ElectrumClient.GetHeaders(data.blockchain.tip.height + 1, RETARGETING_PERIOD)
         log.info(s"syncing headers from ${data.blockchain.height} to ${height}")
-        goto(SYNCING) using data.copy(lastReadyMessage = None)
+        // tell everyone we're ready while we catch up
+        goto(SYNCING) using notifyReady(data.copy(lastReadyMessage = None))
       }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
@@ -288,7 +288,6 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
         * download this header chunk.
         * We don't have this header because it's most likely older than our current checkpoint, downloading the whole header
         * chunk (2016 headers) is quick and they're easy to verify.
-        * @param height header height
         */
       def downloadHeadersIfMissing(height: Int): Unit = {
         if (data.blockchain.getHeader(height).orElse(params.walletDb.getHeader(height)).isEmpty) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
@@ -155,7 +155,6 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
         log.info("performing full sync")
         // now ask for the first header after our latest checkpoint
         client ! ElectrumClient.GetHeaders(data.blockchain.checkpoints.size * RETARGETING_PERIOD, RETARGETING_PERIOD)
-        // make sure there is not last ready message
         goto(SYNCING) using data
       } else if (header == data.blockchain.tip.header) {
         // nothing to sync

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/db/WalletDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/db/WalletDb.scala
@@ -2,6 +2,7 @@ package fr.acinq.eclair.blockchain.electrum.db
 
 import fr.acinq.bitcoin.{BinaryData, BlockHeader, Transaction}
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient.GetMerkleResponse
+import fr.acinq.eclair.blockchain.electrum.ElectrumWallet.PersistentData
 
 trait HeaderDb {
   def addHeader(height: Int, header: BlockHeader): Unit
@@ -26,4 +27,8 @@ trait TransactionDb {
   def getTransactions(): Seq[(Transaction, GetMerkleResponse)]
 }
 
-trait WalletDb extends HeaderDb with TransactionDb
+trait WalletDb extends HeaderDb with TransactionDb {
+  def persist(data: PersistentData): Unit
+
+  def readPersistentData(): Option[PersistentData]
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/db/WalletDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/db/WalletDb.scala
@@ -19,15 +19,7 @@ trait HeaderDb {
   def getTip: Option[(Int, BlockHeader)]
 }
 
-trait TransactionDb {
-  def addTransaction(tx: Transaction, proof: GetMerkleResponse): Unit
-
-  def getTransaction(txid: BinaryData): Option[(Transaction, GetMerkleResponse)]
-
-  def getTransactions(): Seq[(Transaction, GetMerkleResponse)]
-}
-
-trait WalletDb extends HeaderDb with TransactionDb {
+trait WalletDb extends HeaderDb {
   def persist(data: PersistentData): Unit
 
   def readPersistentData(): Option[PersistentData]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/db/sqlite/SqliteWalletDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/db/sqlite/SqliteWalletDb.scala
@@ -3,8 +3,9 @@ package fr.acinq.eclair.blockchain.electrum.db.sqlite
 import java.sql.Connection
 
 import fr.acinq.bitcoin.{BinaryData, BlockHeader, Transaction}
-import fr.acinq.eclair.blockchain.electrum.ElectrumClient
-import fr.acinq.eclair.blockchain.electrum.ElectrumClient.GetMerkleResponse
+import fr.acinq.eclair.blockchain.electrum.{ElectrumClient, ElectrumWallet}
+import fr.acinq.eclair.blockchain.electrum.ElectrumClient.{GetMerkleResponse, TransactionHistoryItem}
+import fr.acinq.eclair.blockchain.electrum.ElectrumWallet.PersistentData
 import fr.acinq.eclair.blockchain.electrum.db.WalletDb
 import fr.acinq.eclair.db.sqlite.SqliteUtils
 
@@ -17,6 +18,7 @@ class SqliteWalletDb(sqlite: Connection) extends WalletDb {
   using(sqlite.createStatement()) { statement =>
     statement.executeUpdate("CREATE TABLE IF NOT EXISTS headers (height INTEGER NOT NULL PRIMARY KEY, block_hash BLOB NOT NULL, header BLOB NOT NULL)")
     statement.executeUpdate("CREATE TABLE IF NOT EXISTS transactions (tx_hash BLOB PRIMARY KEY, tx BLOB NOT NULL, proof BLOB NOT NULL)")
+    statement.executeUpdate("CREATE TABLE IF NOT EXISTS wallet (data BLOB)")
   }
 
   override def addHeader(height: Int, header: BlockHeader): Unit = {
@@ -105,7 +107,7 @@ class SqliteWalletDb(sqlite: Connection) extends WalletDb {
       statement.setBytes(1, tx_hash)
       val rs = statement.executeQuery()
       if (rs.next()) {
-        Some((Transaction.read(rs.getBytes("tx")), SqliteWalletDb.deserialize((rs.getBytes("proof")))))
+        Some((Transaction.read(rs.getBytes("tx")), SqliteWalletDb.deserializeMerkleProof((rs.getBytes("proof")))))
       } else {
         None
       }
@@ -117,15 +119,41 @@ class SqliteWalletDb(sqlite: Connection) extends WalletDb {
       val rs = statement.executeQuery()
       var q: Queue[(Transaction, ElectrumClient.GetMerkleResponse)] = Queue()
       while (rs.next()) {
-        q = q :+ (Transaction.read(rs.getBytes("tx")), SqliteWalletDb.deserialize(rs.getBytes("proof")))
+        q = q :+ (Transaction.read(rs.getBytes("tx")), SqliteWalletDb.deserializeMerkleProof(rs.getBytes("proof")))
       }
       q
+    }
+  }
+
+  override def persist(data: ElectrumWallet.PersistentData): Unit = {
+    val bin = SqliteWalletDb.serialize(data)
+    using(sqlite.prepareStatement("UPDATE wallet SET data=(?)")) { update =>
+      update.setBytes(1, bin)
+      if (update.executeUpdate() == 0) {
+        using(sqlite.prepareStatement("INSERT INTO wallet VALUES (?)")) { statement =>
+          statement.setBytes(1, bin)
+          statement.executeUpdate()
+        }
+      }
+    }
+  }
+
+  override def readPersistentData(): Option[ElectrumWallet.PersistentData] = {
+    using(sqlite.prepareStatement("SELECT data FROM wallet")) { statement =>
+      val rs = statement.executeQuery()
+      if (rs.next()) {
+        Option(rs.getBytes(1)).map(bin => SqliteWalletDb.deserializePersistentData(BinaryData(bin)))
+      } else {
+        None
+      }
     }
   }
 }
 
 object SqliteWalletDb {
-  import fr.acinq.eclair.wire.LightningMessageCodecs.binarydata
+
+  import fr.acinq.eclair.wire.LightningMessageCodecs._
+  import fr.acinq.eclair.wire.ChannelCodecs._
   import scodec.Codec
   import scodec.bits.BitVector
   import scodec.codecs._
@@ -136,7 +164,56 @@ object SqliteWalletDb {
       ("block_height" | uint24) ::
       ("pos" | uint24)).as[GetMerkleResponse]
 
-  def serialize(proof: GetMerkleResponse) : BinaryData = proofCodec.encode(proof).require.toByteArray
+  def serialize(proof: GetMerkleResponse): BinaryData = proofCodec.encode(proof).require.toByteArray
 
-  def deserialize(bin: BinaryData) : GetMerkleResponse = proofCodec.decode(BitVector(bin.toArray)).require.value
+  def deserializeMerkleProof(bin: BinaryData): GetMerkleResponse = proofCodec.decode(BitVector(bin.toArray)).require.value
+
+  import fr.acinq.eclair.wire.LightningMessageCodecs._
+
+  val statusListCodec: Codec[List[(BinaryData, String)]] = listOfN(uint16, binarydata(32) ~ cstring)
+
+  val statusCodec: Codec[Map[BinaryData, String]] = Codec[Map[BinaryData, String]](
+    (map: Map[BinaryData, String]) => statusListCodec.encode(map.toList),
+    (wire: BitVector) => statusListCodec.decode(wire).map(_.map(_.toMap))
+  )
+
+  val heightsListCodec: Codec[List[(BinaryData, Long)]] = listOfN(uint16, binarydata(32) ~ uint32)
+
+  val heightsCodec: Codec[Map[BinaryData, Long]] = Codec[Map[BinaryData, Long]](
+    (map: Map[BinaryData, Long]) => heightsListCodec.encode(map.toList),
+    (wire: BitVector) => heightsListCodec.decode(wire).map(_.map(_.toMap))
+  )
+
+  val transactionListCodec: Codec[List[(BinaryData, Transaction)]] = listOfN(uint16, binarydata(32) ~ txCodec)
+
+  val transactionsCodec: Codec[Map[BinaryData, Transaction]] = Codec[Map[BinaryData, Transaction]](
+    (map: Map[BinaryData, Transaction]) => transactionListCodec.encode(map.toList),
+    (wire: BitVector) => transactionListCodec.decode(wire).map(_.map(_.toMap))
+  )
+
+  val transactionHistoryItemCodec: Codec[ElectrumClient.TransactionHistoryItem] = (
+    ("height" | int32) :: ("tx_hash" | binarydata(size = 32))).as[ElectrumClient.TransactionHistoryItem]
+
+  val seqOfTransactionHistoryItemCodec: Codec[List[TransactionHistoryItem]] = listOfN[TransactionHistoryItem](uint16, transactionHistoryItemCodec)
+
+  val historyListCodec: Codec[List[(BinaryData, List[ElectrumClient.TransactionHistoryItem])]] =
+    listOfN[(BinaryData, List[ElectrumClient.TransactionHistoryItem])](uint16, binarydata(32) ~ seqOfTransactionHistoryItemCodec)
+
+  val historyCodec: Codec[Map[BinaryData, List[ElectrumClient.TransactionHistoryItem]]] = Codec[Map[BinaryData, List[ElectrumClient.TransactionHistoryItem]]](
+    (map: Map[BinaryData, List[ElectrumClient.TransactionHistoryItem]]) => historyListCodec.encode(map.toList),
+    (wire: BitVector) => historyListCodec.decode(wire).map(_.map(_.toMap))
+  )
+
+  val persistentDataCodec: Codec[PersistentData] = (
+    ("accountKeysCount" | int32) ::
+      ("accountKeysCount" | int32) ::
+      ("status" | statusCodec) ::
+      ("transactions" | transactionsCodec) ::
+      ("heights" | heightsCodec) ::
+      ("history" | historyCodec) ::
+      ("locks" | setCodec(txCodec))).as[PersistentData]
+
+  def serialize(data: PersistentData): BinaryData = persistentDataCodec.encode(data).require.toByteArray
+
+  def deserializePersistentData(bin: BinaryData): PersistentData = persistentDataCodec.decode(BitVector(bin.toArray)).require.value
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/db/sqlite/SqliteWalletDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/db/sqlite/SqliteWalletDb.scala
@@ -211,6 +211,7 @@ object SqliteWalletDb {
       ("transactions" | transactionsCodec) ::
       ("heights" | heightsCodec) ::
       ("history" | historyCodec) ::
+      ("pendingTransactions" | listOfN(uint16, txCodec)) ::
       ("locks" | setCodec(txCodec))).as[PersistentData]
 
   def serialize(data: PersistentData): BinaryData = persistentDataCodec.encode(data).require.toByteArray

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
@@ -57,9 +57,9 @@ class ElectrumWalletBasicSpec extends FunSuite with Logging {
   def addFunds(data: Data, key: ExtendedPrivateKey, amount: Satoshi): Data = {
     val tx = Transaction(version = 1, txIn = Nil, txOut = TxOut(amount, ElectrumWallet.computePublicKeyScript(key.publicKey)) :: Nil, lockTime = 0)
     val scriptHash = ElectrumWallet.computeScriptHashFromPublicKey(key.publicKey)
-    val scriptHashHistory = data.history.getOrElse(scriptHash, Seq.empty[ElectrumClient.TransactionHistoryItem])
+    val scriptHashHistory = data.history.getOrElse(scriptHash, List.empty[ElectrumClient.TransactionHistoryItem])
     data.copy(
-      history = data.history.updated(scriptHash, scriptHashHistory :+ ElectrumClient.TransactionHistoryItem(100, tx.txid)),
+      history = data.history.updated(scriptHash, ElectrumClient.TransactionHistoryItem(100, tx.txid) :: scriptHashHistory),
       transactions = data.transactions + (tx.txid -> tx)
     )
   }
@@ -67,9 +67,9 @@ class ElectrumWalletBasicSpec extends FunSuite with Logging {
   def addFunds(data: Data, keyamount: (ExtendedPrivateKey, Satoshi)): Data = {
     val tx = Transaction(version = 1, txIn = Nil, txOut = TxOut(keyamount._2, ElectrumWallet.computePublicKeyScript(keyamount._1.publicKey)) :: Nil, lockTime = 0)
     val scriptHash = ElectrumWallet.computeScriptHashFromPublicKey(keyamount._1.publicKey)
-    val scriptHashHistory = data.history.getOrElse(scriptHash, Seq.empty[ElectrumClient.TransactionHistoryItem])
+    val scriptHashHistory = data.history.getOrElse(scriptHash, List.empty[ElectrumClient.TransactionHistoryItem])
     data.copy(
-      history = data.history.updated(scriptHash, scriptHashHistory :+ ElectrumClient.TransactionHistoryItem(100, tx.txid)),
+      history = data.history.updated(scriptHash, ElectrumClient.TransactionHistoryItem(100, tx.txid) :: scriptHashHistory),
       transactions = data.transactions + (tx.txid -> tx)
     )
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSimulatedClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSimulatedClientSpec.scala
@@ -69,7 +69,7 @@ class ElectrumWalletSimulatedClientSpec extends TestKit(ActorSystem("test")) wit
 
   // wallet sends a receive address notification as soon as it is created
   listener.expectMsgType[NewWalletReceiveAddress]
-  
+
   def makeHeader(previousHeader: BlockHeader, timestamp: Long): BlockHeader = {
     var template = previousHeader.copy(hashPreviousBlock = previousHeader.hash, time = timestamp, nonce = 0)
     while (!BlockHeader.checkProofOfWork(template)) {
@@ -185,7 +185,7 @@ class ElectrumWalletSimulatedClientSpec extends TestKit(ActorSystem("test")) wit
 
     client.expectMsg(GetTransaction(tx.txid))
     wallet ! GetTransactionResponse(tx)
-    val TransactionReceived(_, _, Satoshi(100000), _, _) = listener.expectMsgType[TransactionReceived]
+    val TransactionReceived(_, _, Satoshi(100000), _, _, _) = listener.expectMsgType[TransactionReceived]
     // we think we have some unconfirmed funds
     val WalletReady(Satoshi(100000), _, _, _) = listener.expectMsgType[WalletReady]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
@@ -38,7 +38,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 
-class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with BitcoindService with ElectrumxService  with BeforeAndAfterAll with Logging {
+class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with BitcoindService with ElectrumxService with BeforeAndAfterAll with Logging {
 
   import ElectrumWallet._
 
@@ -196,7 +196,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
       unconfirmed1 - unconfirmed == Satoshi(100000000L)
     }, max = 30 seconds, interval = 1 second)
 
-    val TransactionReceived(tx, 0, received, sent, _) = listener.receiveOne(5 seconds)
+    val TransactionReceived(tx, 0, received, sent, _, _) = listener.receiveOne(5 seconds)
     assert(tx.txid === BinaryData(txid))
     assert(received === Satoshi(100000000))
 
@@ -211,7 +211,10 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
 
     awaitCond({
       val msg = listener.receiveOne(5 seconds)
-      msg == TransactionConfidenceChanged(BinaryData(txid), 1)
+      msg match {
+        case TransactionConfidenceChanged(BinaryData(txid), 1, _) => true
+        case _ => false
+      }
     }, max = 30 seconds, interval = 1 second)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/db/sqlite/SqliteWalletDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/db/sqlite/SqliteWalletDbSpec.scala
@@ -84,6 +84,7 @@ class SqliteWalletDbSpec extends FunSuite {
         transactions = transactions.map(tx => tx.hash -> tx).toMap,
         heights = transactions.map(tx => tx.hash -> random.nextInt(500000).toLong).toMap,
         history = (for (i <- 0 until random.nextInt(100)) yield randomBytes(32) -> randomHistoryItems).toMap,
+        pendingTransactions = transactions.toList,
         locks = (for (i <- 0 until random.nextInt(10)) yield randomTransaction).toSet
       )
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/db/sqlite/SqliteWalletDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/db/sqlite/SqliteWalletDbSpec.scala
@@ -44,17 +44,6 @@ class SqliteWalletDbSpec extends FunSuite {
     })
   }
 
-  test("add/get/list transactions") {
-    val db = new SqliteWalletDb(inmem)
-    val tx = Transaction.read("0100000001b021a77dcaad3a2da6f1611d2403e1298a902af8567c25d6e65073f6b52ef12d000000006a473044022056156e9f0ad7506621bc1eb963f5133d06d7259e27b13fcb2803f39c7787a81c022056325330585e4be39bcf63af8090a2deff265bc29a3fb9b4bf7a31426d9798150121022dfb538041f111bb16402aa83bd6a3771fa8aa0e5e9b0b549674857fafaf4fe0ffffffff0210270000000000001976a91415c23e7f4f919e9ff554ec585cb2a67df952397488ac3c9d1000000000001976a9148982824e057ccc8d4591982df71aa9220236a63888ac00000000")
-    val proof = GetMerkleResponse(tx.hash, List(BinaryData("01" * 32), BinaryData("02" * 32)), 100000, 15)
-    db.addTransaction(tx, proof)
-
-    val Some((tx1, proof1)) = db.getTransaction(tx.hash)
-    assert(tx1 == tx)
-    assert(proof1 == proof)
-  }
-
   test("serialize persistent data") {
     val db = new SqliteWalletDb(inmem)
 
@@ -74,6 +63,8 @@ class SqliteWalletDbSpec extends FunSuite {
 
     def randomHistoryItems = (0 to random.nextInt(100)).map(_ => randomHistoryItem).toList
 
+    def randomProof = GetMerkleResponse(randomBytes(32), ((0 until 10).map(_ => randomBytes(32))).toList, random.nextInt(100000), 0)
+
     def randomPersistentData = {
       val transactions = for (i <- 0 until random.nextInt(100)) yield randomTransaction
 
@@ -84,6 +75,7 @@ class SqliteWalletDbSpec extends FunSuite {
         transactions = transactions.map(tx => tx.hash -> tx).toMap,
         heights = transactions.map(tx => tx.hash -> random.nextInt(500000).toLong).toMap,
         history = (for (i <- 0 until random.nextInt(100)) yield randomBytes(32) -> randomHistoryItems).toMap,
+        proofs = (for (i <- 0 until random.nextInt(100)) yield randomBytes(32) -> randomProof).toMap,
         pendingTransactions = transactions.toList,
         locks = (for (i <- 0 until random.nextInt(10)) yield randomTransaction).toSet
       )


### PR DESCRIPTION
Persist a partial view of our wallet to enable faster startup time.
Users will be able to create transactions as soon as we've checked that we're connected to a "good" electrum server. In the unlikely event where they were able to create and try to publish a transaction during the few seconds it took to finish syncing and their utxo was spent (because they were trying to use an unconfirmed utxo that got double spent, or if they spent their utxo themselves from another wallet initialized with the same seed  while his one was offline), publishing the tx will fail. 