### PR TITLE
Always select direct channel if there is one to the target

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -815,7 +815,10 @@ object Router {
     val foundRoutes = Graph.yenKshortestPaths(g, localNodeId, targetNodeId, amountMsat, ignoredEdges, extraEdges, numRoutes).toList match {
       case Nil => throw RouteNotFound
       case route :: Nil if route.path.isEmpty => throw RouteNotFound
-      case foundRoutes => foundRoutes
+      case routes => routes.find(_.path.size == 1) match {
+        case Some(directRoute) => directRoute :: Nil
+        case _ => routes
+      }
     }
 
     // minimum cost

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -167,15 +167,15 @@ class RouteCalculationSpec extends FunSuite {
 
     val updates = List(
       makeUpdate(1L, f, g, 0, 0),
-      makeUpdate(4L, f, h, 50, 0), // our starting node F has a direct channel with H, no routing fees are paid to traverse that
+      makeUpdate(4L, f, i, 50, 0), // our starting node F has a direct channel with I
       makeUpdate(2L, g, h, 0, 0),
       makeUpdate(3L, h, i, 0, 0)
     ).toMap
 
     val graph = makeGraph(updates)
 
-    val route = Router.findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 1)
-    assert(route.map(hops2Ids) === Success(4 :: 3 :: Nil))
+    val route = Router.findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 2)
+    assert(route.map(hops2Ids) === Success(4 :: Nil))
   }
 
   test("if there are multiple channels between the same node, select the cheapest") {


### PR DESCRIPTION
During route searching, bypass the route randomization to always select the direct channel if there is one to the target.