### PR TITLE
Support all-uppercase payment requests

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
@@ -427,10 +427,11 @@ object PaymentRequest {
   def read(input: String): PaymentRequest = {
     // used only for data validation
     Bech32.decode(input)
-    val separatorIndex = input.lastIndexOf('1')
-    val hrp = input.take(separatorIndex)
+    val lowercaseInput = input.toLowerCase
+    val separatorIndex = lowercaseInput.lastIndexOf('1')
+    val hrp = lowercaseInput.take(separatorIndex)
     val prefix: String = prefixes.values.find(prefix => hrp.startsWith(prefix)).getOrElse(throw new RuntimeException("unknown prefix"))
-    val data = string2Bits(input.slice(separatorIndex + 1, input.size - 6)) // 6 == checksum size
+    val data = string2Bits(lowercaseInput.slice(separatorIndex + 1, lowercaseInput.size - 6)) // 6 == checksum size
     val bolt11Data = Codecs.bolt11DataCodec.decode(data).require.value
     val signature = bolt11Data.signature
     val r = new BigInteger(1, signature.take(32).toArray)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
@@ -245,6 +245,12 @@ class PaymentRequestSpec extends FunSuite {
     val Some(unknownTag) = pr1.tags.collectFirst { case u: UnknownTag21 => u }
   }
 
+  test("accept uppercase payment request") {
+    val input = "lntb1500n1pwxx94fpp5q3xzmwuvxpkyhz6pvg3fcfxz0259kgh367qazj62af9rs0pw07dsdpa2fjkzep6yp58garswvaz7tmvd9nksarwd9hxw6n0w4kx2tnrdakj7grfwvs8wcqzysxqr23sjzv0d8794te26xhexuc26eswf9sjpv4t8sma2d9y8dmpgf0qseg8259my8tcs6zte7ex0tz4exm5pjezuxrq9u0vjewa02qhedk9x4gppweupu"
+
+    assert(PaymentRequest.write(PaymentRequest.read(input.toUpperCase())) == input)
+  }
+
   test("nonreg") {
     val requests = List(
       "lnbc40n1pw9qjvwpp5qq3w2ln6krepcslqszkrsfzwy49y0407hvks30ec6pu9s07jur3sdpstfshq5n9v9jzucm0d5s8vmm5v5s8qmmnwssyj3p6yqenwdencqzysxqrrss7ju0s4dwx6w8a95a9p2xc5vudl09gjl0w2n02sjrvffde632nxwh2l4w35nqepj4j5njhh4z65wyfc724yj6dn9wajvajfn5j7em6wsq2elakl",


### PR DESCRIPTION
This is a regression caused by 884812ade0060aa09c5fe97bbd70cac0fdf66ca8, added a test.