### PR TITLE
Faster gui startup

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/NetworkEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/NetworkEvents.scala
@@ -26,16 +26,18 @@ import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncemen
   */
 trait NetworkEvent
 
-case class NodeDiscovered(ann: NodeAnnouncement) extends NetworkEvent
+case class NodesDiscovered(ann: Iterable[NodeAnnouncement]) extends NetworkEvent
 
 case class NodeUpdated(ann: NodeAnnouncement) extends NetworkEvent
 
 case class NodeLost(nodeId: PublicKey) extends NetworkEvent
 
-case class ChannelDiscovered(ann: ChannelAnnouncement, capacity: Satoshi) extends NetworkEvent
+case class SingleChannelDiscovered(ann: ChannelAnnouncement, capacity: Satoshi)
+
+case class ChannelsDiscovered(c: Iterable[SingleChannelDiscovered]) extends NetworkEvent
 
 case class ChannelLost(shortChannelId: ShortChannelId) extends NetworkEvent
 
-case class ChannelUpdateReceived(ann: ChannelUpdate) extends NetworkEvent
+case class ChannelUpdatesReceived(ann: Iterable[ChannelUpdate]) extends NetworkEvent
 
 case class SyncProgress(progress: Double) extends NetworkEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -133,9 +133,9 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
     val graph = DirectedGraph.makeGraph(initChannelUpdates)
     val initNodes = nodes.map(n => (n.nodeId -> n)).toMap
     // send events for remaining channels/nodes
-    initChannels.values.foreach(c => context.system.eventStream.publish(ChannelDiscovered(c, channels(c)._2)))
-    initChannelUpdates.values.foreach(u => context.system.eventStream.publish(ChannelUpdateReceived(u)))
-    initNodes.values.foreach(n => context.system.eventStream.publish(NodeDiscovered(n)))
+    context.system.eventStream.publish(ChannelsDiscovered(initChannels.values.map(c => SingleChannelDiscovered(c, channels(c)._2))))
+    context.system.eventStream.publish(ChannelUpdatesReceived(initChannelUpdates.values))
+    context.system.eventStream.publish(NodesDiscovered(initNodes.values))
 
     // watch the funding tx of all these channels
     // note: some of them may already have been spent, in that case we will receive the watch event immediately
@@ -237,7 +237,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
             // TODO: check feature bit set
             log.debug("added channel channelId={}", c.shortChannelId)
             val capacity = tx.txOut(outputIndex).amount
-            context.system.eventStream.publish(ChannelDiscovered(c, capacity))
+            context.system.eventStream.publish(ChannelsDiscovered(SingleChannelDiscovered(c, capacity) :: Nil))
             db.addChannel(c, tx.txid, capacity)
 
             // in case we just validated our first local channel, we announce the local node
@@ -580,7 +580,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
       d.copy(nodes = d.nodes + (n.nodeId -> n), rebroadcast = d.rebroadcast.copy(nodes = d.rebroadcast.nodes + (n -> Set(origin))))
     } else if (d.channels.values.exists(c => isRelatedTo(c, n.nodeId))) {
       log.debug("added node nodeId={}", n.nodeId)
-      context.system.eventStream.publish(NodeDiscovered(n))
+      context.system.eventStream.publish(NodesDiscovered(n :: Nil))
       db.addNode(n)
       d.copy(nodes = d.nodes + (n.nodeId -> n), rebroadcast = d.rebroadcast.copy(nodes = d.rebroadcast.nodes + (n -> Set(origin))))
     } else if (d.awaiting.keys.exists(c => isRelatedTo(c, n.nodeId))) {
@@ -615,7 +615,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
         d
       } else if (d.updates.contains(desc)) {
         log.debug("updated channel_update for shortChannelId={} public={} flags={} {}", u.shortChannelId, publicChannel, u.channelFlags, u)
-        context.system.eventStream.publish(ChannelUpdateReceived(u))
+        context.system.eventStream.publish(ChannelUpdatesReceived(u :: Nil))
         db.updateChannelUpdate(u)
         // update the graph
         val graph1 = Announcements.isEnabled(u.channelFlags) match {
@@ -625,7 +625,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
         d.copy(updates = d.updates + (desc -> u), rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> Set(origin))), graph = graph1)
       } else {
         log.debug("added channel_update for shortChannelId={} public={} flags={} {}", u.shortChannelId, publicChannel, u.channelFlags, u)
-        context.system.eventStream.publish(ChannelUpdateReceived(u))
+        context.system.eventStream.publish(ChannelUpdatesReceived(u :: Nil))
         db.addChannelUpdate(u)
         // we also need to update the graph
         val graph1 = d.graph.addEdge(desc, u)
@@ -658,13 +658,13 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
         d
       } else if (d.privateUpdates.contains(desc)) {
         log.debug("updated channel_update for shortChannelId={} public={} flags={} {}", u.shortChannelId, publicChannel, u.channelFlags, u)
-        context.system.eventStream.publish(ChannelUpdateReceived(u))
+        context.system.eventStream.publish(ChannelUpdatesReceived(u :: Nil))
         // we also need to update the graph
         val graph1 = d.graph.removeEdge(desc).addEdge(desc, u)
         d.copy(privateUpdates = d.privateUpdates + (desc -> u), graph = graph1)
       } else {
         log.debug("added channel_update for shortChannelId={} public={} flags={} {}", u.shortChannelId, publicChannel, u.channelFlags, u)
-        context.system.eventStream.publish(ChannelUpdateReceived(u))
+        context.system.eventStream.publish(ChannelUpdatesReceived(u :: Nil))
         // we also need to update the graph
         val graph1 = d.graph.addEdge(desc, u)
         d.copy(privateUpdates = d.privateUpdates + (desc -> u), graph = graph1)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -86,7 +86,7 @@ class RouterSpec extends BaseRouterSpec {
     watcher.expectMsgType[WatchSpentBasic]
     watcher.expectNoMsg(1 second)
 
-    eventListener.expectMsg(ChannelDiscovered(chan_ac, Satoshi(1000000)))
+    eventListener.expectMsg(ChannelsDiscovered(SingleChannelDiscovered(chan_ac, Satoshi(1000000)) :: Nil))
   }
 
   test("properly announce lost channels and nodes") { fixture =>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/MainController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/MainController.scala
@@ -22,14 +22,15 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 import com.google.common.net.HostAndPort
+import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{MilliSatoshi, Satoshi}
 import fr.acinq.eclair.NodeParams.{BITCOIND, ELECTRUM}
 import fr.acinq.eclair.gui.stages._
-import fr.acinq.eclair.gui.utils.{ContextMenuUtils, CopyAction}
+import fr.acinq.eclair.gui.utils.{ContextMenuUtils, CopyAction, IndexedObservableList}
 import fr.acinq.eclair.gui.{FxApp, Handlers}
 import fr.acinq.eclair.payment.{PaymentEvent, PaymentReceived, PaymentRelayed, PaymentSent}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, NodeAnnouncement}
-import fr.acinq.eclair.{CoinUtils, Setup}
+import fr.acinq.eclair.{CoinUtils, Setup, ShortChannelId}
 import grizzled.slf4j.Logging
 import javafx.animation.{FadeTransition, ParallelTransition, SequentialTransition, TranslateTransition}
 import javafx.application.{HostServices, Platform}
@@ -95,7 +96,8 @@ class MainController(val handlers: Handlers, val hostServices: HostServices) ext
   @FXML var channelsTab: Tab = _
 
   // all nodes tab
-  val networkNodesList = FXCollections.observableArrayList[NodeAnnouncement]()
+  val networkNodesMap = new IndexedObservableList[PublicKey, NodeAnnouncement]
+  private val networkNodesList = networkNodesMap.list
   @FXML var networkNodesTab: Tab = _
   @FXML var networkNodesTable: TableView[NodeAnnouncement] = _
   @FXML var networkNodesIdColumn: TableColumn[NodeAnnouncement, String] = _
@@ -104,7 +106,8 @@ class MainController(val handlers: Handlers, val hostServices: HostServices) ext
   @FXML var networkNodesIPColumn: TableColumn[NodeAnnouncement, String] = _
 
   // all channels
-  val networkChannelsList = FXCollections.observableArrayList[ChannelInfo]()
+  val networkChannelsMap = new IndexedObservableList[ShortChannelId, ChannelInfo]
+  private val networkChannelsList = networkChannelsMap.list
   @FXML var networkChannelsTab: Tab = _
   @FXML var networkChannelsTable: TableView[ChannelInfo] = _
   @FXML var networkChannelsIdColumn: TableColumn[ChannelInfo, String] = _

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/IndexedObservableList.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/IndexedObservableList.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.gui.utils
+
+import java.util
+
+import javafx.collections.FXCollections
+
+class IndexedObservableList[K, V] {
+
+  val map2index = new util.HashMap[K, Int]()
+  val list = FXCollections.observableArrayList[V]()
+
+  def containsKey(key: K) = {
+    map2index.containsKey(key)
+  }
+
+  def get(key: K): V = {
+    if (map2index.containsKey(key)) {
+      val index = map2index.get(key)
+      list.get(index)
+    } else throw new RuntimeException("key not found")
+  }
+
+  def put(key: K, value: V) = {
+    if (map2index.containsKey(key)) {
+      val index = map2index.get(key)
+      list.set(index, value)
+    } else {
+      val index = list.size()
+      map2index.put(key, index)
+      list.add(index, value)
+    }
+  }
+
+  def remove(key: K) = {
+    if (map2index.containsKey(key)) {
+      val index = map2index.get(key)
+      map2index.remove(key)
+      list.remove(index)
+    }
+  }
+
+}


### PR DESCRIPTION
The GUI took a very long time to startup because nodes and channels were
stored in javafx `ObervableList` which doesn't allow random access. We
can't easily use `ObservableMap` because `TableView` do not support
them.

As a workaround, created an `IndexedObservableList` which keeps track of
indices in `ObservableList` so that we can still have fast random
access.

Also, now grouping announcements in `Networkevent` instead of sending
them one by one.