### PR TITLE
Set default `to-remote-delay-blocks` to 720

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -61,7 +61,7 @@ eclair {
   reserve-to-funding-ratio = 0.01 // recommended by BOLT #2
   max-reserve-to-funding-ratio = 0.05 // channel reserve can't be more than 5% of the funding amount (recommended: 1%)
 
-  to-remote-delay-blocks = 144 // number of blocks that the other node's to-self outputs must be delayed (144 ~ 1 day)
+  to-remote-delay-blocks = 720 // number of blocks that the other node's to-self outputs must be delayed (720 ~ 5 days)
   max-to-local-delay-blocks = 2016 // maximum number of blocks that we are ready to accept for our own delayed outputs (2016 ~ 2 weeks)
   mindepth-blocks = 3
   expiry-delta-blocks = 144

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -73,7 +73,18 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     ))
   ))
 
-  val commonConfig = ConfigFactory.parseMap(Map("eclair.chain" -> "regtest", "eclair.server.public-ips.1" -> "127.0.0.1", "eclair.bitcoind.port" -> 28333, "eclair.bitcoind.rpcport" -> 28332, "eclair.bitcoind.zmqblock" -> "tcp://127.0.0.1:28334", "eclair.bitcoind.zmqtx" -> "tcp://127.0.0.1:28335", "eclair.mindepth-blocks" -> 2, "eclair.max-htlc-value-in-flight-msat" -> 100000000000L, "eclair.router.broadcast-interval" -> "2 second", "eclair.auto-reconnect" -> false))
+  val commonConfig = ConfigFactory.parseMap(Map(
+    "eclair.chain" -> "regtest",
+    "eclair.server.public-ips.1" -> "127.0.0.1",
+    "eclair.bitcoind.port" -> 28333,
+    "eclair.bitcoind.rpcport" -> 28332,
+    "eclair.bitcoind.zmqblock" -> "tcp://127.0.0.1:28334",
+    "eclair.bitcoind.zmqtx" -> "tcp://127.0.0.1:28335",
+    "eclair.mindepth-blocks" -> 2,
+    "eclair.max-htlc-value-in-flight-msat" -> 100000000000L,
+    "eclair.router.broadcast-interval" -> "2 second",
+    "eclair.auto-reconnect" -> false,
+    "eclair.to-remote-delay-blocks" -> 144))
 
   implicit val formats = DefaultFormats
 
@@ -125,19 +136,6 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
 
   test("starting eclair nodes") {
     import collection.JavaConversions._
-    val commonConfig = ConfigFactory.parseMap(Map(
-      "eclair.chain" -> "regtest",
-      "eclair.spv" -> false,
-      "eclair.server.public-ips.1" -> "127.0.0.1",
-      "eclair.bitcoind.port" -> 28333,
-      "eclair.bitcoind.rpcport" -> 28332,
-      "eclair.bitcoind.zmqblock" -> "tcp://127.0.0.1:28334",
-      "eclair.bitcoind.zmqtx" -> "tcp://127.0.0.1:28335",
-      "eclair.mindepth-blocks" -> 2,
-      "eclair.max-htlc-value-in-flight-msat" -> 100000000000L,
-      "eclair.router.broadcast-interval" -> "2 second",
-      "eclair.auto-reconnect" -> false,
-      "eclair.to-remote-delay-blocks" -> 144))
     instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.node-alias" -> "A", "eclair.expiry-delta-blocks" -> 130, "eclair.server.port" -> 29730, "eclair.api.port" -> 28080, "eclair.channel-flags" -> 0)).withFallback(commonConfig)) // A's channels are private
     instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.node-alias" -> "B", "eclair.expiry-delta-blocks" -> 131, "eclair.server.port" -> 29731, "eclair.api.port" -> 28081)).withFallback(commonConfig))
     instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.expiry-delta-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -112,7 +112,19 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
 
   test("starting eclair nodes") {
     import collection.JavaConversions._
-    val commonConfig = ConfigFactory.parseMap(Map("eclair.chain" -> "regtest", "eclair.spv" -> false, "eclair.server.public-ips.1" -> "127.0.0.1", "eclair.bitcoind.port" -> 28333, "eclair.bitcoind.rpcport" -> 28332, "eclair.bitcoind.zmqblock" -> "tcp://127.0.0.1:28334", "eclair.bitcoind.zmqtx" -> "tcp://127.0.0.1:28335", "eclair.mindepth-blocks" -> 2, "eclair.max-htlc-value-in-flight-msat" -> 100000000000L, "eclair.router.broadcast-interval" -> "2 second", "eclair.auto-reconnect" -> false))
+    val commonConfig = ConfigFactory.parseMap(Map(
+      "eclair.chain" -> "regtest",
+      "eclair.spv" -> false,
+      "eclair.server.public-ips.1" -> "127.0.0.1",
+      "eclair.bitcoind.port" -> 28333,
+      "eclair.bitcoind.rpcport" -> 28332,
+      "eclair.bitcoind.zmqblock" -> "tcp://127.0.0.1:28334",
+      "eclair.bitcoind.zmqtx" -> "tcp://127.0.0.1:28335",
+      "eclair.mindepth-blocks" -> 2,
+      "eclair.max-htlc-value-in-flight-msat" -> 100000000000L,
+      "eclair.router.broadcast-interval" -> "2 second",
+      "eclair.auto-reconnect" -> false,
+      "eclair.to-remote-delay-blocks" -> 144))
     instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.node-alias" -> "A", "eclair.delay-blocks" -> 130, "eclair.server.port" -> 29730, "eclair.api.port" -> 28080, "eclair.channel-flags" -> 0)).withFallback(commonConfig)) // A's channels are private
     instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.node-alias" -> "B", "eclair.delay-blocks" -> 131, "eclair.server.port" -> 29731, "eclair.api.port" -> 28081)).withFallback(commonConfig))
     instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.delay-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))


### PR DESCRIPTION
It sounds like a more reasonable default value, 144 was too short.