### PR TITLE
Improve instructions in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ To change your node's configuration, create a file named `eclair.conf` in `~/.ec
 eclair.chain=testnet
 eclair.node-alias=eclair
 eclair.node-color=49daaa
+eclair.server.public-ips.0="YOUR_IP_HERE"
 ```
 
 Here are some of the most common options:


### PR DESCRIPTION
Add to the example eclair config a line to instruct eclair to advertise its public ip, the example uses the 'inline' syntax to specify the address as first element of the array.