### PR TITLE
Electrum: use current change address as channel closing address

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumEclairWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumEclairWallet.scala
@@ -31,7 +31,7 @@ class ElectrumEclairWallet(val wallet: ActorRef, chainHash: BinaryData)(implicit
 
   override def getBalance = (wallet ? GetBalance).mapTo[GetBalanceResponse].map(balance => balance.confirmed + balance.unconfirmed)
 
-  override def getFinalAddress = (wallet ? GetCurrentReceiveAddress).mapTo[GetCurrentReceiveAddressResponse].map(_.address)
+  override def getFinalAddress = (wallet ? GetCurrentChangeAddress).mapTo[GetCurrentChangeAddressResponse].map(_.address)
 
   def getXpub: Future[GetXpubResponse] = (wallet ? GetXpub).mapTo[GetXpubResponse]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
@@ -459,6 +459,8 @@ class ElectrumWallet(seed: BinaryData, client: ActorRef, params: ElectrumWallet.
 
     case Event(GetCurrentReceiveAddress, data) => stay replying GetCurrentReceiveAddressResponse(data.currentReceiveAddress)
 
+    case Event(GetCurrentChangeAddress, data) => stay replying GetCurrentChangeAddressResponse(data.currentChangeAddress)
+
     case Event(GetBalance, data) =>
       val (confirmed, unconfirmed) = data.balance
       stay replying GetBalanceResponse(confirmed, unconfirmed)
@@ -500,6 +502,9 @@ object ElectrumWallet {
 
   case object GetCurrentReceiveAddress extends Request
   case class GetCurrentReceiveAddressResponse(address: String) extends Response
+
+  case object GetCurrentChangeAddress extends Request
+  case class GetCurrentChangeAddressResponse(address: String) extends Response
 
   case object GetData extends Request
   case class GetDataResponse(state: Data) extends Response


### PR DESCRIPTION
We currently use the current receive address as closing address for new channels.
But if we create several new channels without any onchain activity, they will all use the same
closing address for their closing transaction.

Using the current change address instead is much better since it will be changed as soon as the
transactions is published.

Fixes  #882 