### PR TITLE
Disable route randomization by default

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -92,7 +92,7 @@ eclair {
   autoprobe-count = 0 // number of parallel tasks that send test payments to detect invalid channels
 
   router {
-    randomize-route-selection = true // when computing a route for a payment we randomize the final selection
+    randomize-route-selection = false // when computing a route for a payment we randomize the final selection
     channel-exclude-duration = 60 seconds // when a temporary channel failure is returned, we exclude the channel from our payment routes for this duration
     broadcast-interval = 60 seconds // see BOLT #7
     init-timeout = 5 minutes


### PR DESCRIPTION
With the current size of the network the randomization of path-finding has shown some memory related drawbacks, this PR aims at disabling it by default to provide a better user experience.