### PR TITLE
Minor fixes (dependencies, unit tests)

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -215,7 +215,7 @@ class TransactionsSpec extends FunSuite with Logging {
       assert(getCommitTxNumber(commitTx.tx, true, localPaymentPriv.publicKey, remotePaymentPriv.publicKey) == commitTxNumber)
       val hash = Crypto.sha256(localPaymentPriv.publicKey.toBin ++ remotePaymentPriv.publicKey.toBin)
       val num = Protocol.uint64(hash.takeRight(8).toArray, ByteOrder.BIG_ENDIAN) & 0xffffffffffffL
-      val check = ((commitTx.tx.txIn.head.sequence & 0xffffff) << 24) | commitTx.tx.lockTime
+      val check = ((commitTx.tx.txIn.head.sequence & 0xffffff) << 24) | (commitTx.tx.lockTime & 0xffffff)
       assert((check ^ num) == commitTxNumber)
     }
     val (htlcTimeoutTxs, htlcSuccessTxs) = makeHtlcTxs(commitTx.tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, spec)

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <akka.version>2.4.20</akka.version>
         <akka.http.version>10.0.11</akka.http.version>
         <sttp.version>1.3.9</sttp.version>
-        <bitcoinlib.version>0.10.1-SNAPSHOT</bitcoinlib.version>
+        <bitcoinlib.version>0.10</bitcoinlib.version>
         <guava.version>24.0-android</guava.version>
     </properties>
 


### PR DESCRIPTION
Use bitcoin-lib v0.10 which has finally been synced to maven central.
Fix transactions unit test (the check in the test was using the whole locktime and not the last 24 bits).