### PR TITLE
Ensure the cost function in path-finding is monotonic

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -221,8 +221,8 @@ object Graph {
         // note: there is always an entry for the current in the 'weight' map
         val currentWeight = weight.get(current.key)
 
-        // for each neighbor
-        currentNeighbors.foreach { edge =>
+        // for each neighbor with fees > 0
+        currentNeighbors.filterNot(edgeHasZeroFee).foreach { edge =>
 
           val neighbor = edge.desc.a
 
@@ -276,6 +276,10 @@ object Graph {
 
         edgePath
     }
+  }
+
+  private def edgeHasZeroFee(edge: GraphEdge): Boolean = {
+    edge.update.feeBaseMsat == 0 && edge.update.feeProportionalMillionths == 0
   }
 
   // Computes the compound weight for the given @param edge, the weight is cumulative and must account for the previous edge's weight.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -308,9 +308,9 @@ object Graph {
 
       // NB we're guaranteed to have weightRatios and factors > 0
       val factor = (cltvFactor * wr.cltvDeltaFactor) + (ageFactor * wr.ageFactor) + (capFactor * wr.capacityFactor)
-      val edgeWeight = if (isNeighborTarget) prev.weight else edgeCost * factor
+      val edgeWeight = if (isNeighborTarget) prev.weight else prev.weight + edgeCost * factor
 
-      RichWeight(cost = edgeCost, length = prev.length + 1, cltv = prev.cltv + channelCltvDelta, weight = prev.weight + edgeWeight)
+      RichWeight(cost = edgeCost, length = prev.length + 1, cltv = prev.cltv + channelCltvDelta, weight = edgeWeight)
   }
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -221,8 +221,8 @@ object Graph {
         // note: there is always an entry for the current in the 'weight' map
         val currentWeight = weight.get(current.key)
 
-        // for each neighbor with fees > 0
-        currentNeighbors.filterNot(edgeHasZeroFee).foreach { edge =>
+        // for each neighbor
+        currentNeighbors.foreach { edge =>
 
           val neighbor = edge.desc.a
 
@@ -276,10 +276,6 @@ object Graph {
 
         edgePath
     }
-  }
-
-  private def edgeHasZeroFee(edge: GraphEdge): Boolean = {
-    edge.update.feeBaseMsat == 0 && edge.update.feeProportionalMillionths == 0
   }
 
   // Computes the compound weight for the given @param edge, the weight is cumulative and must account for the previous edge's weight.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -306,7 +306,7 @@ object Graph {
       val factor = (cltvFactor * wr.cltvDeltaFactor) + (ageFactor * wr.ageFactor) + (capFactor * wr.capacityFactor)
       val edgeWeight = if (isNeighborTarget) prev.weight else edgeCost * factor
 
-      RichWeight(cost = edgeCost, length = prev.length + 1, cltv = prev.cltv + channelCltvDelta, weight = edgeWeight)
+      RichWeight(cost = edgeCost, length = prev.length + 1, cltv = prev.cltv + channelCltvDelta, weight = prev.weight + edgeWeight)
   }
 
   /**

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -122,10 +122,10 @@ class RouteCalculationSpec extends FunSuite {
   test("calculate simple route (add and remove edges") {
 
     val updates = List(
-      makeUpdate(1L, a, b, 1, 0),
-      makeUpdate(2L, b, c, 1, 0),
-      makeUpdate(3L, c, d, 1, 0),
-      makeUpdate(4L, d, e, 1, 0)
+      makeUpdate(1L, a, b, 0, 0),
+      makeUpdate(2L, b, c, 0, 0),
+      makeUpdate(3L, c, d, 0, 0),
+      makeUpdate(4L, d, e, 0, 0)
     ).toMap
 
     val g = makeGraph(updates)
@@ -148,9 +148,9 @@ class RouteCalculationSpec extends FunSuite {
     )
 
     val updates = List(
-      makeUpdate(1L, f, g, 1, 0),
-      makeUpdate(2L, g, h, 1, 0),
-      makeUpdate(3L, h, i, 1, 0),
+      makeUpdate(1L, f, g, 0, 0),
+      makeUpdate(2L, g, h, 0, 0),
+      makeUpdate(3L, h, i, 0, 0),
       makeUpdate(4L, f, h, 50, 0) // more expensive
     ).toMap
 
@@ -193,10 +193,10 @@ class RouteCalculationSpec extends FunSuite {
     )
 
     val updates = List(
-      makeUpdate(1L, f, g, 1, 0),
+      makeUpdate(1L, f, g, 0, 0),
       makeUpdate(2L, g, h, 5, 5), // expensive  g -> h channel
-      makeUpdate(6L, g, h, 1, 0), // cheap      g -> h channel
-      makeUpdate(3L, h, i, 1, 0)
+      makeUpdate(6L, g, h, 0, 0), // cheap      g -> h channel
+      makeUpdate(3L, h, i, 0, 0)
     ).toMap
 
     val graph = makeGraph(updates)
@@ -208,10 +208,10 @@ class RouteCalculationSpec extends FunSuite {
   test("calculate longer but cheaper route") {
 
     val updates = List(
-      makeUpdate(1L, a, b, 1, 0),
-      makeUpdate(2L, b, c, 1, 0),
-      makeUpdate(3L, c, d, 1, 0),
-      makeUpdate(4L, d, e, 1, 0),
+      makeUpdate(1L, a, b, 0, 0),
+      makeUpdate(2L, b, c, 0, 0),
+      makeUpdate(3L, c, d, 0, 0),
+      makeUpdate(4L, d, e, 0, 0),
       makeUpdate(5L, b, e, 10, 10)
     ).toMap
 
@@ -302,10 +302,10 @@ class RouteCalculationSpec extends FunSuite {
   test("route to immediate neighbor") {
 
     val updates = List(
-      makeUpdate(1L, a, b, 1, 0),
-      makeUpdate(2L, b, c, 1, 0),
-      makeUpdate(3L, c, d, 1, 0),
-      makeUpdate(4L, d, e, 1, 0)
+      makeUpdate(1L, a, b, 0, 0),
+      makeUpdate(2L, b, c, 0, 0),
+      makeUpdate(3L, c, d, 0, 0),
+      makeUpdate(4L, d, e, 0, 0)
     ).toMap
 
     val g = makeGraph(updates)
@@ -316,10 +316,10 @@ class RouteCalculationSpec extends FunSuite {
 
   test("directed graph") {
     val updates = List(
-      makeUpdate(1L, a, b, 1, 0),
-      makeUpdate(2L, b, c, 1, 0),
-      makeUpdate(3L, c, d, 1, 0),
-      makeUpdate(4L, d, e, 1, 0)
+      makeUpdate(1L, a, b, 0, 0),
+      makeUpdate(2L, b, c, 0, 0),
+      makeUpdate(3L, c, d, 0, 0),
+      makeUpdate(4L, d, e, 0, 0)
     ).toMap
 
     // a->e works, e->a fails
@@ -398,10 +398,10 @@ class RouteCalculationSpec extends FunSuite {
 
   test("blacklist routes") {
     val updates = List(
-      makeUpdate(1L, a, b, 1, 0),
-      makeUpdate(2L, b, c, 1, 0),
-      makeUpdate(3L, c, d, 1, 0),
-      makeUpdate(4L, d, e, 1, 0)
+      makeUpdate(1L, a, b, 0, 0),
+      makeUpdate(2L, b, c, 0, 0),
+      makeUpdate(3L, c, d, 0, 0),
+      makeUpdate(4L, d, e, 0, 0)
     ).toMap
 
     val g = makeGraph(updates)
@@ -438,6 +438,7 @@ class RouteCalculationSpec extends FunSuite {
     val route1 = Router.findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, extraEdges = extraGraphEdges, routeParams = DEFAULT_ROUTE_PARAMS)
     assert(route1.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
   }
+
 
   test("verify that extra hops takes precedence over known channels") {
     val updates = List(
@@ -589,21 +590,6 @@ class RouteCalculationSpec extends FunSuite {
     assert(route1.map(hops2Ids) === Success(1 :: 2 :: 4 :: 5 :: Nil))
   }
 
-  test("ignore channels with fees=0") {
-
-    val updates = List(
-      makeUpdate(1L, a, b, 10, 10),
-      makeUpdate(2L, b, c, 10, 10),
-      makeUpdate(3L, b, e, 0, 0), // goes straight to target with no fees!
-      makeUpdate(4L, c, d, 10, 10),
-      makeUpdate(5L, d, e, 10, 10)
-    ).toMap
-
-    val g = makeGraph(updates)
-
-    val route1 = Router.findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS)
-    assert(route1.map(hops2Ids) === Success(1 :: 2 :: 4 :: 5 :: Nil))
-  }
 
   /**
     *
@@ -753,8 +739,8 @@ class RouteCalculationSpec extends FunSuite {
     // A -> E -> F -> D is 'timeout optimized', lower CLTV route (totFees = 3, totCltv = 18)
     // A -> E -> C -> D is 'capacity optimized', more recent channel/larger capacity route
     val updates = List(
-      makeUpdate(1L, a, b, feeBaseMsat = 1, 0, minHtlcMsat = 0, maxHtlcMsat = None, cltvDelta = 13),
-      makeUpdate(4L, a, e, feeBaseMsat = 1, 0, minHtlcMsat = 0, maxHtlcMsat = None, cltvDelta = 12),
+      makeUpdate(1L, a, b, feeBaseMsat = 0, 0, minHtlcMsat = 0, maxHtlcMsat = None, cltvDelta = 13),
+      makeUpdate(4L, a, e, feeBaseMsat = 0, 0, minHtlcMsat = 0, maxHtlcMsat = None, cltvDelta = 12),
       makeUpdate(2L, b, c, feeBaseMsat = 1, 0, minHtlcMsat = 0, maxHtlcMsat = None, cltvDelta = 500),
       makeUpdate(3L, c, d, feeBaseMsat = 1, 0, minHtlcMsat = 0, maxHtlcMsat = None, cltvDelta = 500),
       makeUpdate(5L, e, f, feeBaseMsat = 2, 0, minHtlcMsat = 0, maxHtlcMsat = None, cltvDelta = 9),
@@ -828,6 +814,7 @@ class RouteCalculationSpec extends FunSuite {
 
     assert(hops2Nodes(routeScoreOptimized) === (a, b) :: (b, c) :: (c, d) :: Nil)
   }
+
 
   test("avoid a route that breaks off the max CLTV") {
 


### PR DESCRIPTION
With fe31f2d9d2754d6dd979bc1f454ae4bee7fc8b6d the heuristics introduced a cost function that is not monotonic and that led scenarios where the path-finding would produce an invalid result and even get stuck in an endless computation. This PR fixes that by making sure the cost function is monotonic.