### PR TITLE
Check `WatchSpent` in constant time

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
@@ -233,8 +233,8 @@ object ZmqWatcher {
   def computeWatchedUtxos(watches: Set[Watch]): Map[OutPoint, Set[Watch]] = {
     watches
       .collect {
-      case w: WatchSpent => OutPoint(w.txId, w.outputIndex) -> w
-      case w: WatchSpentBasic => OutPoint(w.txId, w.outputIndex) -> w
+      case w: WatchSpent => OutPoint(w.txId.reverse, w.outputIndex) -> w
+      case w: WatchSpentBasic => OutPoint(w.txId.reverse, w.outputIndex) -> w
     }
       .groupBy(_._1)
       .mapValues(_.map(_._2))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcherSpec.scala
@@ -1,0 +1,51 @@
+package fr.acinq.eclair.blockchain.bitcoind
+
+import fr.acinq.bitcoin.OutPoint
+import fr.acinq.eclair.blockchain.{Watch, WatchConfirmed, WatchSpent, WatchSpentBasic}
+import fr.acinq.eclair.channel.BITCOIN_FUNDING_SPENT
+import fr.acinq.eclair.randomBytes32
+import org.scalatest.FunSuite
+
+class ZmqWatcherSpec extends FunSuite {
+
+  test("add/remove watches from/to utxo map") {
+    import ZmqWatcher._
+
+    val m0 = Map.empty[OutPoint, Set[Watch]]
+
+    val txid = randomBytes32
+    val outputIndex = 42
+
+    val utxo = OutPoint(txid.reverse, outputIndex)
+
+    val w1 = WatchSpent(null, txid, outputIndex, randomBytes32, BITCOIN_FUNDING_SPENT)
+    val w2 = WatchSpent(null, txid, outputIndex, randomBytes32, BITCOIN_FUNDING_SPENT)
+    val w3 = WatchSpentBasic(null, txid, outputIndex, randomBytes32, BITCOIN_FUNDING_SPENT)
+    val w4 = WatchSpentBasic(null, randomBytes32, 5, randomBytes32, BITCOIN_FUNDING_SPENT)
+    val w5 = WatchConfirmed(null, txid, randomBytes32, 3, BITCOIN_FUNDING_SPENT)
+
+    // we test as if the collection was immutable
+    val m1 = addWatchedUtxos(m0, w1)
+    assert(m1.keySet == Set(utxo) && m1.size == 1)
+    val m2 = addWatchedUtxos(m1, w2)
+    assert(m2.keySet == Set(utxo) && m2(utxo).size == 2)
+    val m3 = addWatchedUtxos(m2, w3)
+    assert(m3.keySet == Set(utxo) && m3(utxo).size == 3)
+    val m4 = addWatchedUtxos(m3, w4)
+    assert(m4.keySet == Set(utxo, OutPoint(w4.txId.reverse, w4.outputIndex)) && m3(utxo).size == 3)
+    val m5 = addWatchedUtxos(m4, w5)
+    assert(m5.keySet == Set(utxo, OutPoint(w4.txId.reverse, w4.outputIndex)) && m5(utxo).size == 3)
+    val m6 = removeWatchedUtxos(m5, w3)
+    assert(m6.keySet == Set(utxo, OutPoint(w4.txId.reverse, w4.outputIndex)) && m6(utxo).size == 2)
+    val m7 = removeWatchedUtxos(m6, w3)
+    assert(m7.keySet == Set(utxo, OutPoint(w4.txId.reverse, w4.outputIndex)) && m7(utxo).size == 2)
+    val m8 = removeWatchedUtxos(m7, w2)
+    assert(m8.keySet == Set(utxo, OutPoint(w4.txId.reverse, w4.outputIndex)) && m8(utxo).size == 1)
+    val m9 = removeWatchedUtxos(m8, w1)
+    assert(m9.keySet == Set(OutPoint(w4.txId.reverse, w4.outputIndex)))
+    val m10 = removeWatchedUtxos(m9, w4)
+    assert(m10.isEmpty)
+  }
+
+
+}


### PR DESCRIPTION
Instead of iterating over watches, we use a map indexed by the `OutPoint` we are watching.