### PR TITLE
Implement wumbo

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -26,6 +26,8 @@ import scodec.bits.ByteVector
   * Created by PM on 13/02/2017.
   */
 object Features {
+
+  /** LOCAL FEATURES **/
   val OPTION_DATA_LOSS_PROTECT_MANDATORY = 0
   val OPTION_DATA_LOSS_PROTECT_OPTIONAL = 1
 
@@ -36,6 +38,12 @@ object Features {
   val CHANNEL_RANGE_QUERIES_BIT_MANDATORY = 6
   val CHANNEL_RANGE_QUERIES_BIT_OPTIONAL = 7
 
+  val I_WUMBO_YOU_WUMBO_MANDATORY = 14
+  val I_WUMBO_YOU_WUMBO_OPTIONAL = 15
+
+  /** GLOBAL FEATURES **/
+  val WUMBORAMA_MANDATORY = 16
+  val WUMBORAMA_OPTIONAL = 17
 
   def hasFeature(features: BitSet, bit: Int): Boolean = features.get(bit)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -121,8 +121,15 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
       val remoteHasInitialRoutingSync = Features.hasFeature(remoteInit.localFeatures, Features.INITIAL_ROUTING_SYNC_BIT_OPTIONAL)
       val remoteHasChannelRangeQueriesOptional = Features.hasFeature(remoteInit.localFeatures, Features.CHANNEL_RANGE_QUERIES_BIT_OPTIONAL)
       val remoteHasChannelRangeQueriesMandatory = Features.hasFeature(remoteInit.localFeatures, Features.CHANNEL_RANGE_QUERIES_BIT_MANDATORY)
+      val remoteHasWumboOptional = Features.hasFeature(remoteInit.localFeatures, Features.I_WUMBO_YOU_WUMBO_OPTIONAL)
+      val remoteHasWumboMandatory = Features.hasFeature(remoteInit.localFeatures, Features.I_WUMBO_YOU_WUMBO_MANDATORY)
       log.info(s"peer is using globalFeatures=${remoteInit.globalFeatures.toBin} and localFeatures=${remoteInit.localFeatures.toBin}")
-      log.info(s"$remoteNodeId has features: initialRoutingSync=$remoteHasInitialRoutingSync channelRangeQueriesOptional=$remoteHasChannelRangeQueriesOptional channelRangeQueriesMandatory=$remoteHasChannelRangeQueriesMandatory")
+      log.info(s"$remoteNodeId has features: initialRoutingSync=$remoteHasInitialRoutingSync " +
+        s"channelRangeQueriesOptional=$remoteHasChannelRangeQueriesOptional " +
+        s"channelRangeQueriesMandatory=$remoteHasChannelRangeQueriesMandatory " +
+        s"wumboOptional=$remoteHasWumboOptional " +
+        s"wumboMandatory=$remoteHasWumboMandatory")
+
       if (Features.areSupported(remoteInit.localFeatures)) {
         d.origin_opt.foreach(origin => origin ! "connected")
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -123,6 +123,12 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
       val remoteHasChannelRangeQueriesMandatory = Features.hasFeature(remoteInit.localFeatures, Features.CHANNEL_RANGE_QUERIES_BIT_MANDATORY)
       val remoteHasWumboOptional = Features.hasFeature(remoteInit.localFeatures, Features.I_WUMBO_YOU_WUMBO_OPTIONAL)
       val remoteHasWumboMandatory = Features.hasFeature(remoteInit.localFeatures, Features.I_WUMBO_YOU_WUMBO_MANDATORY)
+      val remoteHasWumoramaOptional = Features.hasFeature(remoteInit.globalFeatures, Features.WUMBORAMA_OPTIONAL)
+      val remoteHasWumoramaMandatory = Features.hasFeature(remoteInit.globalFeatures, Features.WUMBORAMA_MANDATORY)
+
+      // If the remote peer advertised `option_wumborama` in its global features but doesn't `option_i_wumbo_you_wumbo` on local features
+      val hasWumboramaButNoLocalWumbo = (remoteHasWumoramaOptional || remoteHasWumoramaMandatory) && !(remoteHasWumboOptional || remoteHasWumboMandatory)
+
       log.info(s"peer is using globalFeatures=${remoteInit.globalFeatures.toBin} and localFeatures=${remoteInit.localFeatures.toBin}")
       log.info(s"$remoteNodeId has features: initialRoutingSync=$remoteHasInitialRoutingSync " +
         s"channelRangeQueriesOptional=$remoteHasChannelRangeQueriesOptional " +
@@ -130,7 +136,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
         s"wumboOptional=$remoteHasWumboOptional " +
         s"wumboMandatory=$remoteHasWumboMandatory")
 
-      if (Features.areSupported(remoteInit.localFeatures)) {
+      if (Features.areSupported(remoteInit.localFeatures) && !hasWumboramaButNoLocalWumbo) {
         d.origin_opt.foreach(origin => origin ! "connected")
 
         if (remoteHasInitialRoutingSync) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -553,7 +553,6 @@ object Peer {
   case object Disconnect
   case object ResumeAnnouncements
   case class OpenChannel(remoteNodeId: PublicKey, fundingSatoshis: Satoshi, pushMsat: MilliSatoshi, fundingTxFeeratePerKw_opt: Option[Long], channelFlags: Option[Byte]) {
-    require(fundingSatoshis.amount < Channel.MAX_FUNDING_SATOSHIS, s"fundingSatoshis must be less than ${Channel.MAX_FUNDING_SATOSHIS}")
     require(pushMsat.amount <= 1000 * fundingSatoshis.amount, s"pushMsat must be less or equal to fundingSatoshis")
     require(fundingSatoshis.amount >= 0, s"fundingSatoshis must be positive")
     require(pushMsat.amount >= 0, s"pushMsat must be positive")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Announcements.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Announcements.scala
@@ -73,7 +73,7 @@ object Announcements {
     )
   }
 
-  def makeNodeAnnouncement(nodeSecret: PrivateKey, alias: String, color: Color, nodeAddresses: List[NodeAddress], timestamp: Long = Platform.currentTime / 1000): NodeAnnouncement = {
+  def makeNodeAnnouncement(nodeSecret: PrivateKey, alias: String, color: Color, globalFeatures: ByteVector, nodeAddresses: List[NodeAddress], timestamp: Long = Platform.currentTime / 1000): NodeAnnouncement = {
     require(alias.size <= 32)
     val witness = nodeAnnouncementWitnessEncode(timestamp, nodeSecret.publicKey, color, alias, ByteVector.empty, nodeAddresses)
     val sig = Crypto.encodeSignature(Crypto.sign(witness, nodeSecret)) :+ 1.toByte
@@ -83,7 +83,7 @@ object Announcements {
       nodeId = nodeSecret.publicKey,
       rgbColor = color,
       alias = alias,
-      features = ByteVector.empty,
+      features = globalFeatures,
       addresses = nodeAddresses
     )
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -342,7 +342,7 @@ object Graph {
 
     // Low/High bound for channel capacity
     val CAPACITY_CHANNEL_LOW_MSAT = 1000 * 1000L // 1000 sat
-    val CAPACITY_CHANNEL_HIGH_MSAT = Channel.MAX_FUNDING_SATOSHIS * 1000L
+    val CAPACITY_CHANNEL_HIGH_MSAT = 50000000000L // 0.5 BTC
 
     // Low/High bound for CLTV channel value
     val CLTV_LOW = 9

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -168,7 +168,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
 
     // on restart we update our node announcement
     // note that if we don't currently have public channels, this will be ignored
-    val nodeAnn = Announcements.makeNodeAnnouncement(nodeParams.privateKey, nodeParams.alias, nodeParams.color, nodeParams.publicAddresses)
+    val nodeAnn = Announcements.makeNodeAnnouncement(nodeParams.privateKey, nodeParams.alias, nodeParams.color, nodeParams.globalFeatures, nodeParams.publicAddresses)
     self ! nodeAnn
 
     log.info(s"initialization completed, ready to process messages")
@@ -263,7 +263,7 @@ class Router(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Prom
             // in case we just validated our first local channel, we announce the local node
             if (!d0.nodes.contains(nodeParams.nodeId) && isRelatedTo(c, nodeParams.nodeId)) {
               log.info("first local channel validated, announcing local node")
-              val nodeAnn = Announcements.makeNodeAnnouncement(nodeParams.privateKey, nodeParams.alias, nodeParams.color, nodeParams.publicAddresses)
+              val nodeAnn = Announcements.makeNodeAnnouncement(nodeParams.privateKey, nodeParams.alias, nodeParams.color, nodeParams.globalFeatures, nodeParams.publicAddresses)
               self ! nodeAnn
             }
             true

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
@@ -51,4 +51,10 @@ class FeaturesSpec extends FunSuite {
     assert(areSupported(hex"0141") == false)
   }
 
+  test("'option_wumborama' feature") {
+    val globalFeatures = hex"20000"
+    assert(areSupported(globalFeatures))
+    assert(hasFeature(globalFeatures, WUMBORAMA_OPTIONAL))
+  }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
@@ -180,7 +180,7 @@ class WaitForOpenChannelStateSpec extends TestkitBaseClass with StateTestsHelper
     awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv OpenChannel with wumbo size", Tag("wumbo")) { f =>
+  test("recv OpenChannel (wumbo size)", Tag("wumbo")) { f =>
     import f._
     val open = alice2bob.expectMsgType[OpenChannel]
     val highFundingMsat = 100000000

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
@@ -25,6 +25,7 @@ import fr.acinq.eclair.wire.{Color, NodeAddress, Tor2}
 import fr.acinq.eclair.{ShortChannelId, randomBytes32, randomKey}
 import org.scalatest.FunSuite
 import org.sqlite.SQLiteException
+import scodec.bits.ByteVector
 
 
 class SqliteNetworkDbSpec extends FunSuite {
@@ -43,10 +44,10 @@ class SqliteNetworkDbSpec extends FunSuite {
     val sqlite = inmem
     val db = new SqliteNetworkDb(sqlite)
 
-    val node_1 = Announcements.makeNodeAnnouncement(randomKey, "node-alice", Color(100.toByte, 200.toByte, 300.toByte), NodeAddress.fromParts("192.168.1.42", 42000).get :: Nil)
-    val node_2 = Announcements.makeNodeAnnouncement(randomKey, "node-bob", Color(100.toByte, 200.toByte, 300.toByte), NodeAddress.fromParts("192.168.1.42", 42000).get :: Nil)
-    val node_3 = Announcements.makeNodeAnnouncement(randomKey, "node-charlie", Color(100.toByte, 200.toByte, 300.toByte), NodeAddress.fromParts("192.168.1.42", 42000).get :: Nil)
-    val node_4 = Announcements.makeNodeAnnouncement(randomKey, "node-charlie", Color(100.toByte, 200.toByte, 300.toByte), Tor2("aaaqeayeaudaocaj", 42000) :: Nil)
+    val node_1 = Announcements.makeNodeAnnouncement(randomKey, "node-alice", Color(100.toByte, 200.toByte, 300.toByte), ByteVector.empty, NodeAddress.fromParts("192.168.1.42", 42000).get :: Nil)
+    val node_2 = Announcements.makeNodeAnnouncement(randomKey, "node-bob", Color(100.toByte, 200.toByte, 300.toByte), ByteVector.empty, NodeAddress.fromParts("192.168.1.42", 42000).get :: Nil)
+    val node_3 = Announcements.makeNodeAnnouncement(randomKey, "node-charlie", Color(100.toByte, 200.toByte, 300.toByte), ByteVector.empty, NodeAddress.fromParts("192.168.1.42", 42000).get :: Nil)
+    val node_4 = Announcements.makeNodeAnnouncement(randomKey, "node-charlie", Color(100.toByte, 200.toByte, 300.toByte), ByteVector.empty, Tor2("aaaqeayeaudaocaj", 42000) :: Nil)
 
     assert(db.listNodes().toSet === Set.empty)
     db.addNode(node_1)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -140,8 +140,8 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
   test("starting eclair nodes") {
     import collection.JavaConversions._
     instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.node-alias" -> "A", "eclair.expiry-delta-blocks" -> 130, "eclair.server.port" -> 29730, "eclair.api.port" -> 28080, "eclair.channel-flags" -> 0)).withFallback(commonConfig)) // A's channels are private
-    instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.node-alias" -> "B", "eclair.expiry-delta-blocks" -> 131, "eclair.server.port" -> 29731, "eclair.api.port" -> 28081)).withFallback(commonConfig))
-    instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.expiry-delta-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
+    instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.node-alias" -> "B", "eclair.expiry-delta-blocks" -> 131, "eclair.server.port" -> 29731, "eclair.api.port" -> 28081, "eclair.local-features" -> "808a")).withFallback(commonConfig)) // 808a contains support for option_i_wumbo_you_wumbo
+    instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.expiry-delta-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082, "eclair.payment-handler" -> "noop", "eclair.local-features" -> "808a")).withFallback(commonConfig))
     instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.node-alias" -> "D", "eclair.expiry-delta-blocks" -> 133, "eclair.server.port" -> 29733, "eclair.api.port" -> 28083)).withFallback(commonConfig))
     instantiateEclairNode("E", ConfigFactory.parseMap(Map("eclair.node-alias" -> "E", "eclair.expiry-delta-blocks" -> 134, "eclair.server.port" -> 29734, "eclair.api.port" -> 28084)).withFallback(commonConfig))
     instantiateEclairNode("F1", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F1", "eclair.expiry-delta-blocks" -> 135, "eclair.server.port" -> 29735, "eclair.api.port" -> 28085, "eclair.payment-handler" -> "noop")).withFallback(commonConfig)) // NB: eclair.payment-handler = noop allows us to manually fulfill htlcs
@@ -149,7 +149,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     instantiateEclairNode("F3", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F3", "eclair.expiry-delta-blocks" -> 137, "eclair.server.port" -> 29737, "eclair.api.port" -> 28087, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
     instantiateEclairNode("F4", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F4", "eclair.expiry-delta-blocks" -> 138, "eclair.server.port" -> 29738, "eclair.api.port" -> 28088, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
     instantiateEclairNode("F5", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F5", "eclair.expiry-delta-blocks" -> 139, "eclair.server.port" -> 29739, "eclair.api.port" -> 28089, "eclair.payment-handler" -> "noop")).withFallback(commonConfig))
-    instantiateEclairNode("G", ConfigFactory.parseMap(Map("eclair.node-alias" -> "G", "eclair.expiry-delta-blocks" -> 140, "eclair.server.port" -> 29740, "eclair.api.port" -> 28090, "eclair.fee-base-msat" -> 1010, "eclair.fee-proportional-millionths" -> 102)).withFallback(commonConfig))
+    instantiateEclairNode("G", ConfigFactory.parseMap(Map("eclair.node-alias" -> "G", "eclair.expiry-delta-blocks" -> 140, "eclair.server.port" -> 29740, "eclair.api.port" -> 28090, "eclair.fee-base-msat" -> 1005, "eclair.fee-proportional-millionths" -> 102, "eclair.local-features" -> "808a")).withFallback(commonConfig))
 
     // by default C has a normal payment handler, but this can be overriden in tests
     val paymentHandlerC = nodes("C").system.actorOf(LocalPaymentHandler.props(nodes("C").nodeParams))
@@ -194,8 +194,8 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     connect(nodes("C"), nodes("F3"), 5000000, 0)
     connect(nodes("C"), nodes("F4"), 5000000, 0)
     connect(nodes("C"), nodes("F5"), 5000000, 0)
-    connect(nodes("B"), nodes("G"), 16000000, 0)
-    connect(nodes("G"), nodes("C"), 16000000, 0)
+    connect(nodes("B"), nodes("G"), 46700000, 0)
+    connect(nodes("G"), nodes("C"), 46700000, 0)
 
     val numberOfChannels = 13
     val channelEndpointsCount = 2 * numberOfChannels

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -84,8 +84,6 @@ class PeerSpec extends TestkitBaseClass {
     transport.expectMsgType[wire.Init]
     // Bob advertizes option_wumborama in the global features but nothing in the local features
     transport.send(peer, wire.Init(globalWumboramaOptional, Bob.nodeParams.localFeatures))
-    transport.expectMsgType[TransportHandler.ReadAck]
-    router.expectNoMsg(1 second)
     probe.send(peer, Peer.GetPeerInfo)
     assert(probe.expectMsgType[Peer.PeerInfo].state == "DISCONNECTED")
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -33,6 +33,7 @@ import fr.acinq.eclair.router._
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{Globals, ShortChannelId, randomBytes32}
+import scodec.bits.ByteVector
 
 /**
   * Created by PM on 29/08/2016.
@@ -334,7 +335,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
 
     val (priv_g, priv_funding_g) = (randomKey, randomKey)
     val (g, funding_g) = (priv_g.publicKey, priv_funding_g.publicKey)
-    val ann_g = makeNodeAnnouncement(priv_g, "node-G", Color(-30, 10, -50), Nil)
+    val ann_g = makeNodeAnnouncement(priv_g, "node-G", Color(-30, 10, -50), ByteVector.empty, Nil)
     val channelId_bg = ShortChannelId(420000, 5, 0)
     val chan_bg = channelAnnouncement(channelId_bg, priv_b, priv_g, priv_funding_b, priv_funding_g)
     val channelUpdate_bg = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, g, channelId_bg, cltvExpiryDelta = 9, htlcMinimumMsat = 0, feeBaseMsat = 0, feeProportionalMillionths = 0, htlcMaximumMsat = 500000000L)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsSpec.scala
@@ -48,7 +48,7 @@ class AnnouncementsSpec extends FunSuite {
   }
 
   test("create valid signed node announcement") {
-    val ann = makeNodeAnnouncement(Alice.nodeParams.privateKey, Alice.nodeParams.alias, Alice.nodeParams.color, Alice.nodeParams.publicAddresses)
+    val ann = makeNodeAnnouncement(Alice.nodeParams.privateKey, Alice.nodeParams.alias, Alice.nodeParams.color, ByteVector.empty, Alice.nodeParams.publicAddresses)
     assert(checkSig(ann))
     assert(checkSig(ann.copy(timestamp = 153)) === false)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -53,12 +53,12 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
 
   //val DUMMY_SIG = hex"3045022100e0a180fdd0fe38037cc878c03832861b40a29d32bd7b40b10c9e1efc8c1468a002205ae06d1624896d0d29f4b31e32772ea3cb1b4d7ed4e077e5da28dcc33c0e781201"
 
-  val ann_a = makeNodeAnnouncement(priv_a, "node-A", Color(15, 10, -70), Nil)
-  val ann_b = makeNodeAnnouncement(priv_b, "node-B", Color(50, 99, -80), Nil)
-  val ann_c = makeNodeAnnouncement(priv_c, "node-C", Color(123, 100, -40), Nil)
-  val ann_d = makeNodeAnnouncement(priv_d, "node-D", Color(-120, -20, 60), Nil)
-  val ann_e = makeNodeAnnouncement(priv_e, "node-E", Color(-50, 0, 10), Nil)
-  val ann_f = makeNodeAnnouncement(priv_f, "node-F", Color(30, 10, -50), Nil)
+  val ann_a = makeNodeAnnouncement(priv_a, "node-A", Color(15, 10, -70), ByteVector.empty, Nil)
+  val ann_b = makeNodeAnnouncement(priv_b, "node-B", Color(50, 99, -80), ByteVector.empty, Nil)
+  val ann_c = makeNodeAnnouncement(priv_c, "node-C", Color(123, 100, -40), ByteVector.empty, Nil)
+  val ann_d = makeNodeAnnouncement(priv_d, "node-D", Color(-120, -20, 60), ByteVector.empty, Nil)
+  val ann_e = makeNodeAnnouncement(priv_e, "node-E", Color(-50, 0, 10), ByteVector.empty, Nil)
+  val ann_f = makeNodeAnnouncement(priv_f, "node-F", Color(30, 10, -50), ByteVector.empty, Nil)
 
   val channelId_ab = ShortChannelId(420000, 1, 0)
   val channelId_bc = ShortChannelId(420000, 2, 0)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
@@ -19,7 +19,6 @@ package fr.acinq.eclair.router
 import akka.actor.ActorSystem
 import akka.testkit.{TestFSMRef, TestKit, TestProbe}
 import fr.acinq.bitcoin.Block
-import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair._
 import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
@@ -27,9 +26,8 @@ import fr.acinq.eclair.router.Announcements.{makeChannelUpdate, makeNodeAnnounce
 import fr.acinq.eclair.router.BaseRouterSpec.channelAnnouncement
 import fr.acinq.eclair.wire._
 import org.scalatest.FunSuiteLike
-
+import scodec.bits.ByteVector
 import scala.concurrent.duration._
-
 
 class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
 
@@ -134,8 +132,8 @@ object RoutingSyncSpec {
     val TxCoordinates(blockHeight, _, _) = ShortChannelId.coordinates(shortChannelId)
     val channelUpdate_ab = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, priv_b.publicKey, shortChannelId, cltvExpiryDelta = 7, 0, feeBaseMsat = 766000, feeProportionalMillionths = 10, 500000000L, timestamp = blockHeight)
     val channelUpdate_ba = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, priv_a.publicKey, shortChannelId, cltvExpiryDelta = 7, 0, feeBaseMsat = 766000, feeProportionalMillionths = 10, 500000000L, timestamp = blockHeight)
-    val nodeAnnouncement_a = makeNodeAnnouncement(priv_a, "a", Color(0, 0, 0), List())
-    val nodeAnnouncement_b = makeNodeAnnouncement(priv_b, "b", Color(0, 0, 0), List())
+    val nodeAnnouncement_a = makeNodeAnnouncement(priv_a, "a", Color(0, 0, 0), ByteVector.empty, List())
+    val nodeAnnouncement_b = makeNodeAnnouncement(priv_b, "b", Color(0, 0, 0), ByteVector.empty, List())
     (channelAnn_ab, channelUpdate_ab, channelUpdate_ba, nodeAnnouncement_a, nodeAnnouncement_b)
   }
 }


### PR DESCRIPTION
This PR aims at implementing both `option_wumborama` and `option_i_wumbo_you_wumbo`, see https://github.com/lightningnetwork/lightning-rfc/pull/590 . The features can be enabled via configuration file modifying local/global features according to one's need. The path-finding heuristics have been adjusted to consider channel capacity in a wumbo world.

TODO: adjust GUI 