### PR TITLE
Rollback funding tx if disconnected in WAIT_FOR_FUNDING_SIGNED

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/TestWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/TestWallet.scala
@@ -27,6 +27,8 @@ import scala.util.Try
   */
 class TestWallet extends EclairWallet {
 
+  var rolledback = Set.empty[Transaction]
+
   override def getBalance: Future[Satoshi] = ???
 
   override def getFinalAddress: Future[String] = Future.successful("2MsRZ1asG6k94m6GYUufDGaZJMoJ4EV5JKs")
@@ -36,7 +38,10 @@ class TestWallet extends EclairWallet {
 
   override def commit(tx: Transaction): Future[Boolean] = Future.successful(true)
 
-  override def rollback(tx: Transaction): Future[Boolean] = Future.successful(true)
+  override def rollback(tx: Transaction): Future[Boolean] = {
+    rolledback = rolledback + tx
+    Future.successful(true)
+  }
 
   override def doubleSpent(tx: Transaction): Future[Boolean] = Future.successful(false)
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -85,4 +85,13 @@ class WaitForFundingSignedStateSpec extends TestkitBaseClass with StateTestsHelp
     awaitCond(alice.stateName == CLOSED)
   }
 
+  test("recv INPUT_DISCONNECTED") { f =>
+    import f._
+    val fundingTx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_SIGNED].fundingTx
+    assert(alice.underlyingActor.wallet.asInstanceOf[TestWallet].rolledback.isEmpty)
+    alice ! INPUT_DISCONNECTED
+    awaitCond(alice.stateName == CLOSED)
+    assert(alice.underlyingActor.wallet.asInstanceOf[TestWallet].rolledback.contains(fundingTx))
+  }
+
 }


### PR DESCRIPTION
Otherwise the UTXOs will stay locked, and the channel will stay to `OFFLINE` forever because it doesn't have a commitment.