### PR TITLE
Add random delay to rebroadcast 

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -463,6 +463,8 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
 
     case Event(_: Rebroadcast, _) => stay // ignored
 
+    case Event(_: DelayedRebroadcast, _) => stay // ignored
+
     case Event(_: RoutingState, _) => stay // ignored
 
     case Event(_: TransportHandler.ReadAck, _) => stay // ignored

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -474,6 +474,8 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
     case Event(_: Pong, _) => stay // we got disconnected before receiving the pong
 
     case Event(_: PingTimeout, _) => stay // we got disconnected after sending a ping
+
+    case Event(_: BadMessage, _) => stay // we got disconnected while syncing
   }
 
   onTransition {


### PR DESCRIPTION
This avoids herd effect that occured when all peers were synchronized.