### PR TITLE
Electrum: update client name

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -335,7 +335,7 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
 }
 
 object ElectrumClient {
-  val CLIENT_NAME = "3.3.2" // client name that we will include in our "version" message
+  val CLIENT_NAME = "3.3.4" // client name that we will include in our "version" message
   val PROTOCOL_VERSION = "1.4" // version of the protocol that we require
 
   // this is expensive and shared with all clients

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPool.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPool.scala
@@ -88,15 +88,18 @@ class ElectrumClientPool(serverAddresses: Set[ElectrumServerAddress])(implicit v
       stay
 
     case Event(Terminated(actor), d: ConnectedData) =>
-      log.info("lost connection to {}", addresses(actor))
+      val address = addresses(actor)
       addresses -= actor
       context.system.scheduler.scheduleOnce(5 seconds, self, Connect)
       val tips1 = d.tips - actor
       if (tips1.isEmpty) {
+        log.info("lost connection to {}, no active connections left", address)
         goto(Disconnected) using DisconnectedData // no more connections
       } else if (d.master != actor) {
+        log.info("lost connection to {}, we still have our master server", address)
         stay using d.copy(tips = tips1) // we don't care, this wasn't our master
       } else {
+        log.info("lost connection to our master server {}", address)
         // we choose next best candidate as master
         val tips1 = d.tips - actor
         val (bestClient, bestTip) = tips1.toSeq.maxBy(_._2._1)


### PR DESCRIPTION
(At least on testnet), when using 3.3.2 or below, some servers will send back errors with a message that says "no errors but please upgrade". 
Also specify in our logs when we get disconnected from our master Electrum server or from a backup server.