### PR TITLE
Make electrum tests pass on windows

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
@@ -88,7 +88,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
   }
 
   test("wait until wallet is ready") {
-    electrumClient = system.actorOf(Props(new ElectrumClientPool(Set(ElectrumServerAddress(new InetSocketAddress("localhost", 50001), SSL.OFF)))))
+    electrumClient = system.actorOf(Props(new ElectrumClientPool(Set(ElectrumServerAddress(new InetSocketAddress("localhost", electrumPort), SSL.OFF)))))
     wallet = system.actorOf(Props(new ElectrumWallet(seed, electrumClient, WalletParameters(Block.RegtestGenesisBlock.hash, new SqliteWalletDb(DriverManager.getConnection("jdbc:sqlite::memory:")), minimumFee = Satoshi(5000)))), "wallet")
     val probe = TestProbe()
     awaitCond({

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
@@ -50,7 +50,7 @@ class ElectrumWatcherSpec extends TestKit(ActorSystem("test")) with FunSuiteLike
     TestKit.shutdownActorSystem(system)
   }
 
-  val electrumAddress = ElectrumServerAddress(new InetSocketAddress("localhost", 50001), SSL.OFF)
+  val electrumAddress = ElectrumServerAddress(new InetSocketAddress("localhost", electrumPort), SSL.OFF)
 
   test("watch for confirmed transactions") {
     val probe = TestProbe()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumxService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumxService.scala
@@ -25,6 +25,8 @@ import org.scalatest.Suite
 trait ElectrumxService extends DockerTestKit {
   self: Suite =>
 
+  val electrumPort = 47000
+
   val electrumxContainer = if (System.getProperty("os.name").startsWith("Linux")) {
     // "host" mode will let the container access the host network on linux
     // we use our own docker image because other images on Docker lag behind and don't yet support 1.4
@@ -36,8 +38,8 @@ trait ElectrumxService extends DockerTestKit {
     // on windows or oxs, host mode is not available, but from docker 18.03 on host.docker.internal can be used instead
     // host.docker.internal is not (yet ?) available on linux though
     DockerContainer("acinq/electrumx")
-      .withPorts(50001 -> Some(50001))
-      .withEnv("DAEMON_URL=http://foo:bar@host.docker.internal:28332", "COIN=BitcoinSegwit", "NET=regtest", "TCP_PORT=50001")
+      .withPorts(electrumPort -> Some(electrumPort))
+      .withEnv("DAEMON_URL=http://foo:bar@host.docker.internal:28332", "COIN=BitcoinSegwit", "NET=regtest", s"TCP_PORT=$electrumPort")
       //.withLogLineReceiver(LogLineReceiver(true, println))
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumxService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumxService.scala
@@ -32,7 +32,7 @@ trait ElectrumxService extends DockerTestKit {
     // we use our own docker image because other images on Docker lag behind and don't yet support 1.4
     DockerContainer("acinq/electrumx")
       .withNetworkMode("host")
-      .withEnv("DAEMON_URL=http://foo:bar@localhost:28332", "COIN=BitcoinSegwit", "NET=regtest")
+      .withEnv("DAEMON_URL=http://foo:bar@localhost:28332", "COIN=BitcoinSegwit", "NET=regtest", s"TCP_PORT=$electrumPort")
       //.withLogLineReceiver(LogLineReceiver(true, println))
   } else {
     // on windows or oxs, host mode is not available, but from docker 18.03 on host.docker.internal can be used instead


### PR DESCRIPTION
There was an obscure Docker error when trying to start an Electrum
server in tests.

It appears that there is a [conflict between Docker and Hyper-V](https://github.com/docker/for-win/issues/3171) on some range of ports.

A workaround is to just change the port we were using.