### PR TITLE
Expose the websocket over HTTP GET

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -51,6 +51,7 @@ trait Service extends Directives with Logging {
   import JsonSupport.marshaller
   import JsonSupport.formats
   import JsonSupport.serialization
+
   // used to send typed messages over the websocket
   val formatsWithTypeHint = formats.withTypeHintFieldName("type") +
     CustomTypeHints(Map(
@@ -81,7 +82,7 @@ trait Service extends Directives with Logging {
 
   // map all the rejections to a JSON error object ErrorResponse
   val apiRejectionHandler = RejectionHandler.default.mapRejectionResponse {
-    case res @ HttpResponse(_, _, ent: HttpEntity.Strict, _) =>
+    case res@HttpResponse(_, _, ent: HttpEntity.Strict, _) =>
       res.copy(entity = HttpEntity(ContentTypes.`application/json`, serialization.writePretty(ErrorResponse(ent.data.utf8String))))
   }
 
@@ -127,7 +128,7 @@ trait Service extends Directives with Logging {
   val route: Route = {
     respondWithDefaultHeaders(customHeaders) {
       handleExceptions(apiExceptionHandler) {
-        handleRejections(apiRejectionHandler){
+        handleRejections(apiRejectionHandler) {
           withRequestTimeoutResponse(timeoutResponse) {
             authenticateBasicAsync(realm = "Access restricted", userPassAuthenticator) { _ =>
               post {
@@ -244,10 +245,11 @@ trait Service extends Directives with Logging {
                   } ~
                   path("channelstats") {
                     complete(eclairApi.channelStats())
-                  } ~
-                  path("ws") {
-                    handleWebSocketMessages(makeSocketHandler)
                   }
+              } ~ get {
+                path("ws") {
+                  handleWebSocketMessages(makeSocketHandler)
+                }
               }
             }
           }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -260,13 +260,11 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
 
     val mockService = new MockService(new EclairMock {})
 
-    val websocketRoute = Directives.path("ws") {
-      Directives.handleWebSocketMessages(mockService.makeSocketHandler)
-    }
-
     val wsClient = WSProbe()
 
-    WS("/ws", wsClient.flow) ~> websocketRoute ~>
+    WS("/ws", wsClient.flow) ~>
+      addCredentials(BasicHttpCredentials("", mockService.password)) ~>
+      mockService.route ~>
       check {
 
         val pf = PaymentFailed(ByteVector32.Zeroes, failures = Seq.empty)


### PR DESCRIPTION
This PR fixes the broken behavior of the websocket when used over HTTP POST together with basic auth. A test has been added to verify we can use the socket WITH authentication.