### PR TITLE
API: fix fee rate conversion

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -78,7 +78,7 @@ class EclairImpl(appKit: Kit) extends Eclair {
       remoteNodeId = nodeId,
       fundingSatoshis = Satoshi(fundingSatoshis),
       pushMsat = pushMsat.map(MilliSatoshi).getOrElse(MilliSatoshi(0)),
-      fundingTxFeeratePerKw_opt = fundingFeerateSatByte,
+      fundingTxFeeratePerKw_opt = fundingFeerateSatByte.map(feerateByte2Kw),
       channelFlags = flags.map(_.toByte))).mapTo[String]
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -562,7 +562,7 @@ object Peer {
     require(pushMsat.amount <= 1000 * fundingSatoshis.amount, s"pushMsat must be less or equal to fundingSatoshis")
     require(fundingSatoshis.amount >= 0, s"fundingSatoshis must be positive")
     require(pushMsat.amount >= 0, s"pushMsat must be positive")
-    require(fundingTxFeeratePerKw_opt.getOrElse(0L) >= 0, s"funding tx feerate must be positive")
+    fundingTxFeeratePerKw_opt.foreach(feeratePerKw => require(feeratePerKw >= MinimumFeeratePerKw, s"fee rate $feeratePerKw is below minimum $MinimumFeeratePerKw rate/kw"))
   }
   case object GetPeerInfo
   case object SendPing

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -1,0 +1,47 @@
+package fr.acinq.eclair
+
+import akka.actor.ActorSystem
+import akka.testkit.{TestKit, TestProbe}
+import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.eclair.blockchain.TestWallet
+import fr.acinq.eclair.io.Peer.OpenChannel
+import org.scalatest.FunSuiteLike
+import scodec.bits._
+
+class EclairImplSpec extends TestKit(ActorSystem("mySystem")) with FunSuiteLike {
+  test("convert fee rate properly") {
+    val watcher = TestProbe()
+    val paymentHandler = TestProbe()
+    val register = TestProbe()
+    val relayer = TestProbe()
+    val router = TestProbe()
+    val switchboard = TestProbe()
+    val paymentInitiator = TestProbe()
+    val server = TestProbe()
+    val kit = Kit(
+      TestConstants.Alice.nodeParams,
+      system,
+      watcher.ref,
+      paymentHandler.ref,
+      register.ref,
+      relayer.ref,
+      router.ref,
+      switchboard.ref,
+      paymentInitiator.ref,
+      server.ref,
+      new TestWallet()
+    )
+    val eclair = new EclairImpl(kit)
+    val nodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
+
+    // standard conversion
+    eclair.open(nodeId, fundingSatoshis = 10000000L, pushMsat = None, fundingFeerateSatByte = Some(5), flags = None)
+    val open = switchboard.expectMsgType[OpenChannel]
+    assert(open.fundingTxFeeratePerKw_opt == Some(1250))
+
+    // check that minimum fee rate of 253 sat/bw is used
+    eclair.open(nodeId, fundingSatoshis = 10000000L, pushMsat = None, fundingFeerateSatByte = Some(1), flags = None)
+    val open1 = switchboard.expectMsgType[OpenChannel]
+    assert(open1.fundingTxFeeratePerKw_opt == Some(MinimumFeeratePerKw))
+  }
+}


### PR DESCRIPTION
Our `open` API calls expects an optional fee rate in satoshi/byte, which is the most widely
used unit, but failed to convert to satoshi/kiloweight which is the standard in LN.
We also check that the converted fee rate cannot go below 253 satoshi/kiloweight.