### PR TITLE
Multipart payments

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentLifecycle.scala
@@ -180,10 +180,8 @@ object PaymentLifecycle {
   def props(sourceNodeId: PublicKey, router: ActorRef, register: ActorRef) = Props(classOf[PaymentLifecycle], sourceNodeId, router, register)
 
   // @formatter:off
-  case class ReceivePayment(amountMsat_opt: Option[MilliSatoshi], description: String, expirySeconds_opt: Option[Long] = None, extraHops: List[List[ExtraHop]] = Nil, fallbackAddress: Option[String] = None)
-  /**
-    * @param maxFeePct set by default to 3% as a safety measure (even if a route is found, if fee is higher than that payment won't be attempted)
-    */
+  case class ReceivePayment(amountMsat_opt: Option[MilliSatoshi], description: String, expirySeconds_opt: Option[Long] = None, extraHops: List[List[ExtraHop]] = Nil, fallbackAddress: Option[String] = None, lnUrl: Option[String] = None, quantity: Int = 1)
+
   case class SendPayment(amountMsat: Long,
                          paymentHash: ByteVector32,
                          targetNodeId: PublicKey,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -26,6 +26,7 @@ import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
+import fr.acinq.eclair.payment.LocalPaymentHandler.GeneratedPaymentRequests
 import fr.acinq.eclair.payment.PaymentLifecycle.ReceivePayment
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.router.Hop
@@ -108,8 +109,8 @@ class FuzzySpec extends TestkitBaseClass with StateTestsHelperMethods with Loggi
     override def receive: Receive = ???
 
     def waitingForPaymentRequest: Receive = {
-      case req: PaymentRequest =>
-        channel ! buildCmdAdd(req.paymentHash, req.nodeId)
+      case gpr: GeneratedPaymentRequests =>
+        channel ! buildCmdAdd(gpr.requests.head.paymentHash, gpr.requests.head.nodeId)
         context become waitingForFulfill(false)
     }
 

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
@@ -22,6 +22,7 @@ import fr.acinq.bitcoin.MilliSatoshi
 import fr.acinq.eclair._
 import fr.acinq.eclair.gui.controllers._
 import fr.acinq.eclair.io.{NodeURI, Peer}
+import fr.acinq.eclair.payment.LocalPaymentHandler.GeneratedPaymentRequests
 import fr.acinq.eclair.payment.PaymentLifecycle.{PaymentResult, ReceivePayment, SendPayment}
 import fr.acinq.eclair.payment._
 import grizzled.slf4j.Logging
@@ -102,7 +103,7 @@ class Handlers(fKit: Future[Kit])(implicit ec: ExecutionContext = ExecutionConte
 
   def receive(amountMsat_opt: Option[MilliSatoshi], description: String): Future[String] = for {
     kit <- fKit
-    res <- (kit.paymentHandler ? ReceivePayment(amountMsat_opt, description)).mapTo[PaymentRequest].map(PaymentRequest.write)
+    res <- (kit.paymentHandler ? ReceivePayment(amountMsat_opt, description)).mapTo[GeneratedPaymentRequests].map(PaymentRequest write _.requests.head)
   } yield res
 
   /**


### PR DESCRIPTION
This adds basic server-side support for multipart payments by adding a special LNURL tag and enabling generation of multiple payment requests at once.

Overview and demo: https://medium.com/@akumaigorodski/multipart-payments-647cdf5cc15a

Technical description: https://github.com/btcontract/lnurl-rfc/blob/master/spec.md#5-multipart-payments