### PR TITLE
Set `MAX_BUFFERED` to 1,000,000

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/TransportHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/TransportHandler.scala
@@ -274,7 +274,7 @@ object TransportHandler {
 
   def props[T: ClassTag](keyPair: KeyPair, rs: Option[ByteVector], connection: ActorRef, codec: Codec[T]): Props = Props(new TransportHandler(keyPair, rs, connection, codec))
 
-  val MAX_BUFFERED = 100000L
+  val MAX_BUFFERED = 1000000L
 
   // see BOLT #8
   // this prefix is prepended to all Noise messages sent during the handshake phase


### PR DESCRIPTION
Note that this doesn't mean that we will buffer 1M objects in memory:
those are just pointers to (mostly) network announcements that already
exist in our routing table.

Routing table has recently gone over 100K elements (nodes,
announcements, updates) and this causes the connection to be closed when
peer requests a full initial sync.