### PR TITLE
Live channel database backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ The files that you need to backup are located in your data directory. You must b
 Your seed never changes once it is created, but your channels do change whenever you receive our send payments.
 `eclair.bak` is safe to backup even when your system is running. We recommend that you implement your backup 
 process in 2 steps:
-- first, rename `eclair.bak` to a new local file
+- first, move `eclair.bak` to a new local file
 - then, backup the renamed file using whatever tool you like.
 
 ## Docker

--- a/README.md
+++ b/README.md
@@ -142,10 +142,19 @@ The files that you need to backup are located in your data directory. You must b
 - your seed (`seed.dat`)
 - your channel database (`eclair.bak` under directory `mainnet`, `testnet` or `regtest` depending on which chain you're running on)
 
-Your seed never changes once it has been created, but your channels will change whenever you receive our send payments. Eclair will
+Your seed never changes once it has been created, but your channels will change whenever you receive or send payments. Eclair will
 create and maintain a snapshot of its database, named `eclair.bak`, in your data directory, and update it when needed. This file is 
-always consistent and safe to use even when Eclair is running, and this is what you should backup (for example, you could 
-move/rename it and upload the renamed file to a dedicated backup system, ...)
+always consistent and safe to use even when Eclair is running, and this is what you should backup regularly, e.g. with a `cron` task.
+
+Note that depending on your filesystem, we recommend first moving `eclair.bak` to some temporary file before copying that file to your final backup location.
+
+You can configure an optional script/exe to be called by eclair once a new database snapshot has been created, using the following option:
+
+```
+eclair.backup-notify-script = "absolute-path-to-your-script"
+```
+
+Make sure that your script is executable and uses an absolute path name for `eclair.bak`
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ eclair.bitcoind.rpcpassword=<your-mainnet-rpc-password-here>
 
 The files that you need to backup are located in your data directory. You must backup:
 - your seed (`seed.dat`)
-- your channel database (`eclair.bak` in`mainnet`, `testnet` or `regtest` depending on which chain you're running on)
+- your channel database (`eclair.bak` under directory `mainnet`, `testnet` or `regtest` depending on which chain you're running on)
 
 Your seed never changes once it is created, but your channels do change whenever you receive our send payments.
 `eclair.bak` is safe to backup even when your system is running. We recommend that you implement your backup 

--- a/README.md
+++ b/README.md
@@ -144,15 +144,13 @@ The files that you need to backup are located in your data directory. You must b
 
 Your seed never changes once it has been created, but your channels will change whenever you receive or send payments. Eclair will
 create and maintain a snapshot of its database, named `eclair.bak`, in your data directory, and update it when needed. This file is 
-always consistent and safe to use even when Eclair is running, and this is what you should backup regularly, e.g. with a `cron` task.
+always consistent and safe to use even when Eclair is running, and this is what you should backup regularly.
 
-You can configure an optional notification script/exe to be called by eclair once a new database snapshot has been created, using the following option:
-
+For example you could configure a `cron` task for your backup job. Or you could configure an optional notification script to be called by eclair once a new database snapshot has been created, using the following option:
 ```
 eclair.backup-notify-script = "absolute-path-to-your-script"
 ```
-
-Make sure that your script is executable and uses an absolute path name for `eclair.bak`
+Make sure that your script is executable and uses an absolute path name for `eclair.bak`.
 
 Note that depending on your filesystem, in your backup process we recommend first moving `eclair.bak` to some temporary file 
 before copying that file to your final backup location.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,21 @@ eclair.bitcoind.rpcuser=<your-mainnet-rpc-user-here>
 eclair.bitcoind.rpcpassword=<your-mainnet-rpc-password-here>
 ```
 
+### Backups
+
+The files that you need to backup are located in your data directory. You must backup:
+- your seed (`seed.dat`)
+- your channel database (`eclair.bak` in`mainnet`, `testnet` or `regtest` depending on which chain you're running on)
+
+Your seed never changes once it is created, but your channels do change whenever you receive our send payments.
+`eclair.bak` is safe to backup even when your system is running. We recommend that you implement your backup 
+process in 2 steps:
+- first, rename `eclair.bak` to a new local file
+- then, backup the renamed file using whatever tool you like.
+
+
+
+
 ## Resources
 - [1] [The Bitcoin Lightning Network: Scalable Off-Chain Instant Payments](https://lightning.network/lightning-network-paper.pdf) by Joseph Poon and Thaddeus Dryja
 - [2] [Reaching The Ground With Lightning](https://github.com/ElementsProject/lightning/raw/master/doc/deployable-lightning.pdf) by Rusty Russell

--- a/README.md
+++ b/README.md
@@ -146,15 +146,17 @@ Your seed never changes once it has been created, but your channels will change 
 create and maintain a snapshot of its database, named `eclair.bak`, in your data directory, and update it when needed. This file is 
 always consistent and safe to use even when Eclair is running, and this is what you should backup regularly, e.g. with a `cron` task.
 
-Note that depending on your filesystem, we recommend first moving `eclair.bak` to some temporary file before copying that file to your final backup location.
-
-You can configure an optional script/exe to be called by eclair once a new database snapshot has been created, using the following option:
+You can configure an optional notification script/exe to be called by eclair once a new database snapshot has been created, using the following option:
 
 ```
 eclair.backup-notify-script = "absolute-path-to-your-script"
 ```
 
 Make sure that your script is executable and uses an absolute path name for `eclair.bak`
+
+Note that depending on your filesystem, in your backup process we recommend first moving `eclair.bak` to some temporary file 
+before copying that file to your final backup location.
+
 
 ## Docker
 
@@ -221,9 +223,6 @@ eclair.bitcoind.rpcport=8332
 eclair.bitcoind.rpcuser=<your-mainnet-rpc-user-here>
 eclair.bitcoind.rpcpassword=<your-mainnet-rpc-password-here>
 ```
-
-
-
 
 ## Resources
 - [1] [The Bitcoin Lightning Network: Scalable Off-Chain Instant Payments](https://lightning.network/lightning-network-paper.pdf) by Joseph Poon and Thaddeus Dryja

--- a/README.md
+++ b/README.md
@@ -136,6 +136,18 @@ Eclair uses [`logback`](https://logback.qos.ch) for logging. To use a different 
 java -Dlogback.configurationFile=/path/to/logback-custom.xml -jar eclair-node-gui-<version>-<commit_id>.jar
 ```
 
+#### Backup
+
+The files that you need to backup are located in your data directory. You must backup:
+- your seed (`seed.dat`)
+- your channel database (`eclair.bak` under directory `mainnet`, `testnet` or `regtest` depending on which chain you're running on)
+
+Your seed never changes once it is created, but your channels do change whenever you receive our send payments.
+`eclair.bak` is safe to backup even when your system is running. We recommend that you implement your backup 
+process in 2 steps:
+- first, rename `eclair.bak` to a new local file
+- then, backup the renamed file using whatever tool you like.
+
 ## Docker
 
 A [Dockerfile](Dockerfile) image is built on each commit on [docker hub](https://hub.docker.com/r/acinq/eclair) for running a dockerized eclair-node.
@@ -201,18 +213,6 @@ eclair.bitcoind.rpcport=8332
 eclair.bitcoind.rpcuser=<your-mainnet-rpc-user-here>
 eclair.bitcoind.rpcpassword=<your-mainnet-rpc-password-here>
 ```
-
-### Backups
-
-The files that you need to backup are located in your data directory. You must backup:
-- your seed (`seed.dat`)
-- your channel database (`eclair.bak` under directory `mainnet`, `testnet` or `regtest` depending on which chain you're running on)
-
-Your seed never changes once it is created, but your channels do change whenever you receive our send payments.
-`eclair.bak` is safe to backup even when your system is running. We recommend that you implement your backup 
-process in 2 steps:
-- first, rename `eclair.bak` to a new local file
-- then, backup the renamed file using whatever tool you like.
 
 
 

--- a/README.md
+++ b/README.md
@@ -142,11 +142,10 @@ The files that you need to backup are located in your data directory. You must b
 - your seed (`seed.dat`)
 - your channel database (`eclair.bak` under directory `mainnet`, `testnet` or `regtest` depending on which chain you're running on)
 
-Your seed never changes once it is created, but your channels do change whenever you receive our send payments.
-`eclair.bak` is safe to backup even when your system is running. We recommend that you implement your backup 
-process in 2 steps:
-- first, move `eclair.bak` to a new local file
-- then, backup the renamed file using whatever tool you like.
+Your seed never changes once it has been created, but your channels will change whenever you receive our send payments. Eclair will
+create and maintain a snapshot of its database, named `eclair.bak`, in your data directory, and update it when needed. This file is 
+always consistent and safe to use even when Eclair is running, and this is what you should backup (for example, you could 
+move/rename it and upload the renamed file to a dedicated backup system, ...)
 
 ## Docker
 

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -203,7 +203,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.21.0.1</version>
+            <version>3.27.2.1</version>
         </dependency>
         <dependency>
             <!-- This is to get rid of '[WARNING] warning: Class javax.annotation.Nonnull not found - continuing with a stub.' compile errors -->

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -18,7 +18,13 @@ eclair {
 
   watcher-type = "bitcoind" // other *experimental* values include "electrum"
 
-  backup-file = "eclair.sqlite.backup"
+  // specific mail box for our backup handler, bounded to 1 message
+  // DO NOT overwrite these settings
+  backup-mailbox {
+    mailbox-type = "akka.dispatch.BoundedMailbox"
+    mailbox-capacity = 1
+    mailbox-push-timeout-time = 0
+  }
 
   bitcoind {
     host = "localhost"

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -16,6 +16,9 @@ eclair {
     use-old-api = false
   }
 
+  // override this with a script/exe that will be called everytime a new database backup has been created
+  backup-notify-script = ""
+
   watcher-type = "bitcoind" // other *experimental* values include "electrum"
 
   bitcoind {

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -18,6 +18,8 @@ eclair {
 
   watcher-type = "bitcoind" // other *experimental* values include "electrum"
 
+  backup-file = "eclair.sqlite.backup"
+
   bitcoind {
     host = "localhost"
     rpcport = 18332

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -18,14 +18,6 @@ eclair {
 
   watcher-type = "bitcoind" // other *experimental* values include "electrum"
 
-  // specific mail box for our backup handler, bounded to 1 message
-  // DO NOT overwrite these settings
-  backup-mailbox {
-    mailbox-type = "akka.dispatch.BoundedMailbox"
-    mailbox-capacity = 1
-    mailbox-push-timeout-time = 0
-  }
-
   bitcoind {
     host = "localhost"
     rpcport = 18332
@@ -141,5 +133,17 @@ eclair {
     host = "127.0.0.1"
     port = 9051
     private-key-file = "tor.dat"
+  }
+}
+
+eclair.backup-mailbox {
+  mailbox-type = "akka.dispatch.BoundedMailbox"
+  mailbox-capacity = 1
+  mailbox-push-timeout-time = 0
+}
+
+akka.actor.deployment {
+  "/*/backuphandler" {
+    mailbox = eclair.backup-mailbox
   }
 }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -137,8 +137,14 @@ eclair {
 }
 
 // do not edit or move this section
-eclair.backup-mailbox {
-  mailbox-type = "akka.dispatch.BoundedMailbox"
-  mailbox-capacity = 1
-  mailbox-push-timeout-time = 0
+eclair {
+  backup-mailbox {
+    mailbox-type = "akka.dispatch.BoundedMailbox"
+    mailbox-capacity = 1
+    mailbox-push-timeout-time = 0
+  }
+  backup-dispatcher {
+    executor = "thread-pool-executor"
+    type = PinnedDispatcher
+  }
 }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -136,14 +136,9 @@ eclair {
   }
 }
 
+// do not edit or move this section
 eclair.backup-mailbox {
   mailbox-type = "akka.dispatch.BoundedMailbox"
   mailbox-capacity = 1
   mailbox-push-timeout-time = 0
-}
-
-akka.actor.deployment {
-  "/*/backuphandler" {
-    mailbox = eclair.backup-mailbox
-  }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -234,7 +234,13 @@ class Setup(datadir: File,
         case address => logger.info(s"initial wallet address=$address")
       }
       // do not change the name of this actor. it is used in the configuration to specify a custom bounded mailbox
-      backupHandler = system.actorOf(SimpleSupervisor.props(BackupHandler.props(nodeParams.db, new File(chaindir, "eclair.bak"), config.getString("backup-notify-script")), "backuphandler", SupervisorStrategy.Resume))
+
+      backupHandler = system.actorOf(SimpleSupervisor.props(
+        BackupHandler.props(
+          nodeParams.db,
+          new File(chaindir, "eclair.bak"),
+          if (config.hasPath("backup-notify-script")) Some(config.getString("backup-notify-script")) else None
+        ),"backuphandler", SupervisorStrategy.Resume))
       audit = system.actorOf(SimpleSupervisor.props(Auditor.props(nodeParams), "auditor", SupervisorStrategy.Resume))
       paymentHandler = system.actorOf(SimpleSupervisor.props(config.getString("payment-handler") match {
         case "local" => LocalPaymentHandler.props(nodeParams)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -234,7 +234,7 @@ class Setup(datadir: File,
         case address => logger.info(s"initial wallet address=$address")
       }
       // do not change the name of this actor. it is used in the configuration to specify a custom bounded mailbox
-      backupHandler = system.actorOf(SimpleSupervisor.props(BackupHandler.props(nodeParams.db, new File(chaindir, "eclair.bak")), "backuphandler", SupervisorStrategy.Resume))
+      backupHandler = system.actorOf(SimpleSupervisor.props(BackupHandler.props(nodeParams.db, new File(chaindir, "eclair.bak"), config.getString("backup-notify-script")), "backuphandler", SupervisorStrategy.Resume))
       audit = system.actorOf(SimpleSupervisor.props(Auditor.props(nodeParams), "auditor", SupervisorStrategy.Resume))
       paymentHandler = system.actorOf(SimpleSupervisor.props(config.getString("payment-handler") match {
         case "local" => LocalPaymentHandler.props(nodeParams)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -235,13 +235,12 @@ class Setup(datadir: File,
         case address => logger.info(s"initial wallet address=$address")
       }
       backupHandler = system.actorOf(
-        SimpleSupervisor.props(Props(
-          new BackupHandler(
+        SimpleSupervisor.props(
+          BackupHandler.props(
             nodeParams.db,
-            new File(chaindir, config.getString("backup-file").concat(".wip")),
-            new File(chaindir, config.getString("backup-file"))
-          )
-        ), "backup", SupervisorStrategy.Resume)
+            new File(chaindir, "eclair.bak.wip"),
+            new File(chaindir, "eclair.bak")
+          ), "backup", SupervisorStrategy.Resume)
       )
       audit = system.actorOf(SimpleSupervisor.props(Auditor.props(nodeParams), "auditor", SupervisorStrategy.Resume))
       paymentHandler = system.actorOf(SimpleSupervisor.props(config.getString("payment-handler") match {
@@ -353,8 +352,11 @@ class Setup(datadir: File,
 
 // @formatter:off
 sealed trait Bitcoin
+
 case class Bitcoind(bitcoinClient: BasicBitcoinJsonRPCClient) extends Bitcoin
+
 case class Electrum(electrumClient: ActorRef) extends Bitcoin
+
 // @formatter:on
 
 case class Kit(nodeParams: NodeParams,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/BackupHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/BackupHandler.scala
@@ -1,0 +1,87 @@
+package fr.acinq.eclair.db
+
+import java.io.File
+
+import akka.actor.{Actor, ActorLogging, Status}
+import akka.pattern.pipe
+import fr.acinq.eclair.channel.ChannelPersisted
+import grizzled.slf4j.{Logger, Logging}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class BackupHandler(databases: Databases, wip: File, destination: File)(implicit ec: ExecutionContext) extends Actor with ActorLogging {
+  import BackupHandler._
+
+  // we listen to ChannelPersisted events, which will trigger a backup
+  override def preStart(): Unit = {
+    super.preStart()
+    context.system.eventStream.subscribe(self, classOf[ChannelPersisted])
+  }
+
+  override def unhandled(message: Any): Unit = {
+    super.unhandled(message)
+    log.warning(s"unhandled message $message")
+  }
+
+  def receive = idle
+
+  // idle mode: start backup as soon as we receive an event
+  def idle: Receive = {
+    case persisted: ChannelPersisted =>
+      doBackup(databases, wip, destination, persisted) pipeTo self
+      context become busy(None)
+  }
+
+  // busy mode: there is already a backup in progress
+  // `again` tells us if we have to do another one when we're done with the current one
+  def busy(again: Option[ChannelPersisted]): Receive = {
+    case persisted: ChannelPersisted =>
+      log.info(s"replacing pending backup with a newer one")
+      context become busy(Some(persisted))
+
+    case Done if again.isDefined =>
+      doBackup(databases, wip, destination, again.get) pipeTo self
+      context become busy(None)
+
+    case Done =>
+      context become idle
+
+      // we use the pipe pattern so errors are wrapped in akka.Status.Failure
+    case Status.Failure(cause) if again.isDefined =>
+      log.error("database backup failed: {}", cause)
+      doBackup(databases, wip, destination, again.get) pipeTo self
+      context become busy(None)
+
+    case Status.Failure(cause) =>
+      log.error("database backup failed: {}", cause)
+      context become idle
+  }
+}
+
+object BackupHandler extends Logging {
+
+  case object Done
+  /**
+    * Database backup of our database to a destination file.
+    * Backup is done is 2 steps: first it it written to a wip file, then this file is renamed to the destination file.
+    * Renaming/moving a file * should * be atomic so the destination file is always consistent and usable but this is
+    * implementation dependent and it may not be the case with some file systems and/or operating systems
+    *
+    * @param databases database to backup
+    * @param wip work-in-progress file
+    * @param destination destination file
+    * @param persisted channel persistence event that triggered the backup
+    * @param ec execution context
+    * @return `Done` if backup was successful
+    */
+  def doBackup(databases: Databases, wip: File, destination: File, persisted: ChannelPersisted)(implicit ec: ExecutionContext) : Future[BackupHandler.Done.type] = Future {
+    logger.info(s" database backup triggered by ${persisted.channelId} to $destination starts")
+    val start = System.currentTimeMillis()
+    databases.backup(wip)
+    val result = wip.renameTo(destination)
+    require(result, s"cannot rename $wip to $destination")
+    val end = System.currentTimeMillis()
+    logger.info(s" database backup triggered by ${persisted.channelId} to $destination done in ${end - start} ms")
+    Done
+  }
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/BackupHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/BackupHandler.scala
@@ -44,5 +44,7 @@ class BackupHandler private(databases: Databases, backupFile: File) extends Acto
 }
 
 object BackupHandler {
-  def props(databases: Databases, backupFile: File) = Props(new BackupHandler(databases, backupFile)).withMailbox("eclair.backup-mailbox")
+  // using this method is the only way to create a BackupHandler actor
+  // we make sure that it uses a custom bounded mailbox, and a custom pinned dispatcher (i.e our actor will have its own thread pool with 1 single thread)
+  def props(databases: Databases, backupFile: File) = Props(new BackupHandler(databases, backupFile)).withMailbox("eclair.backup-mailbox").withDispatcher("eclair.backup-dispatcher")
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/BackupHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/BackupHandler.scala
@@ -6,6 +6,8 @@ import akka.actor.{Actor, ActorLogging, Props}
 import akka.dispatch.{BoundedMessageQueueSemantics, RequiresMessageQueue}
 import fr.acinq.eclair.channel.ChannelPersisted
 
+import scala.util.{Failure, Success, Try}
+
 
 /**
   * This actor will synchronously make a backup of the database it was initialized with whenever it receives
@@ -26,7 +28,7 @@ import fr.acinq.eclair.channel.ChannelPersisted
   *
   * Constructor is private so users will have to use BackupHandler.props() which always specific a custom mailbox
   */
-class BackupHandler private(databases: Databases, backupFile: File) extends Actor with RequiresMessageQueue[BoundedMessageQueueSemantics] with ActorLogging {
+class BackupHandler private(databases: Databases, backupFile: File, backupScript: String) extends Actor with RequiresMessageQueue[BoundedMessageQueueSemantics] with ActorLogging {
 
   // we listen to ChannelPersisted events, which will trigger a backup
   context.system.eventStream.subscribe(self, classOf[ChannelPersisted])
@@ -40,11 +42,21 @@ class BackupHandler private(databases: Databases, backupFile: File) extends Acto
       require(result, s"cannot rename $tmpFile to $backupFile")
       val end = System.currentTimeMillis()
       log.info(s"database backup triggered by channelId=${persisted.channelId} took ${end - start}ms")
+      if (!backupScript.isEmpty) {
+        Try {
+          val processBuilder = new ProcessBuilder(backupScript)
+          // this process will run in the background
+          processBuilder.start()
+        } match {
+          case Success(_) => log.info(s"backup notify script $backupScript started successfully")
+          case Failure(cause) => log.warning(s"cannot start backup notify script $backupScript:  $cause")
+        }
+      }
   }
 }
 
 object BackupHandler {
   // using this method is the only way to create a BackupHandler actor
   // we make sure that it uses a custom bounded mailbox, and a custom pinned dispatcher (i.e our actor will have its own thread pool with 1 single thread)
-  def props(databases: Databases, backupFile: File) = Props(new BackupHandler(databases, backupFile)).withMailbox("eclair.backup-mailbox").withDispatcher("eclair.backup-dispatcher")
+  def props(databases: Databases, backupFile: File, backupScript: String) = Props(new BackupHandler(databases, backupFile, backupScript)).withMailbox("eclair.backup-mailbox").withDispatcher("eclair.backup-dispatcher")
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/BackupHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/BackupHandler.scala
@@ -2,86 +2,45 @@ package fr.acinq.eclair.db
 
 import java.io.File
 
-import akka.actor.{Actor, ActorLogging, Status}
-import akka.pattern.pipe
+import akka.actor.{Actor, ActorLogging, Props}
 import fr.acinq.eclair.channel.ChannelPersisted
-import grizzled.slf4j.{Logger, Logging}
 
-import scala.concurrent.{ExecutionContext, Future}
 
-class BackupHandler(databases: Databases, wip: File, destination: File)(implicit ec: ExecutionContext) extends Actor with ActorLogging {
-  import BackupHandler._
+/**
+  * README !
+  * This actor will synchronously make a backup of the database it was initialized with whenever it receives
+  * a ChannelPersisted event.
+  * To avoid piling up messages and entering an endless backup loop, it is supposed to be used with a bounded mailbox
+  * with a single item:
+  *
+  * backup-mailbox {
+  *   mailbox-type = "akka.dispatch.BoundedMailbox"
+  *   mailbox-capacity = 1
+  *   mailbox-push-timeout-time = 0
+  * }
+  *
+  * Messages that cannot be processed will be sent to dead letters
+  *
+  * @param databases database to backup
+  * @param wip work-in-progress file
+  * @param destination destination file
+  */
+class BackupHandler(databases: Databases, wip: File, destination: File) extends Actor with ActorLogging {
 
   // we listen to ChannelPersisted events, which will trigger a backup
-  override def preStart(): Unit = {
-    super.preStart()
-    context.system.eventStream.subscribe(self, classOf[ChannelPersisted])
-  }
+  context.system.eventStream.subscribe(self, classOf[ChannelPersisted])
 
-  override def unhandled(message: Any): Unit = {
-    super.unhandled(message)
-    log.warning(s"unhandled message $message")
-  }
-
-  def receive = idle
-
-  // idle mode: start backup as soon as we receive an event
-  def idle: Receive = {
+  def receive = {
     case persisted: ChannelPersisted =>
-      doBackup(databases, wip, destination, persisted) pipeTo self
-      context become busy(None)
-  }
-
-  // busy mode: there is already a backup in progress
-  // `again` tells us if we have to do another one when we're done with the current one
-  def busy(again: Option[ChannelPersisted]): Receive = {
-    case persisted: ChannelPersisted =>
-      log.info(s"replacing pending backup with a newer one")
-      context become busy(Some(persisted))
-
-    case Done if again.isDefined =>
-      doBackup(databases, wip, destination, again.get) pipeTo self
-      context become busy(None)
-
-    case Done =>
-      context become idle
-
-      // we use the pipe pattern so errors are wrapped in akka.Status.Failure
-    case Status.Failure(cause) if again.isDefined =>
-      log.error("database backup failed: {}", cause)
-      doBackup(databases, wip, destination, again.get) pipeTo self
-      context become busy(None)
-
-    case Status.Failure(cause) =>
-      log.error("database backup failed: {}", cause)
-      context become idle
+      val start = System.currentTimeMillis()
+      databases.backup(wip)
+      val result = wip.renameTo(destination)
+      require(result, s"cannot rename $wip to $destination")
+      val end = System.currentTimeMillis()
+      log.info(s" database backup triggered by ${persisted.channelId} to $destination done in ${end - start} ms")
   }
 }
 
-object BackupHandler extends Logging {
-
-  case object Done
-  /**
-    * Database backup of our database to a destination file.
-    * Backup is done is 2 steps: first it it written to a wip file, then this file is renamed to the destination file.
-    * Renaming/moving a file * should * be atomic so the destination file is always consistent and usable but this is
-    * implementation dependent and it may not be the case with some file systems and/or operating systems
-    *
-    * @param databases database to backup
-    * @param wip work-in-progress file
-    * @param destination destination file
-    * @param persisted channel persistence event that triggered the backup
-    * @param ec execution context
-    * @return `Done` if backup was successful
-    */
-  def doBackup(databases: Databases, wip: File, destination: File, persisted: ChannelPersisted)(implicit ec: ExecutionContext) : Future[BackupHandler.Done.type] = Future {
-    logger.info(s" database backup triggered by ${persisted.channelId} to $destination starts")
-    val start = System.currentTimeMillis()
-    databases.backup(wip)
-    val result = wip.renameTo(destination)
-    require(result, s"cannot rename $wip to $destination")
-    val end = System.currentTimeMillis()
-    logger.info(s" database backup triggered by ${persisted.channelId} to $destination done in ${end - start} ms")
-    Done
-  }
+object BackupHandler {
+  def props(databases: Databases, wip: File, destination: File) = Props(new BackupHandler(databases: Databases, wip: File, destination: File)).withMailbox("eclair.backup-mailbox")
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
@@ -19,6 +19,7 @@ trait Databases {
 
   val pendingRelay: PendingRelayDb
 
+  def backup(file: File) : Unit
 }
 
 object Databases {
@@ -45,6 +46,12 @@ object Databases {
     override val peers = new SqlitePeersDb(eclairJdbc)
     override val payments = new SqlitePaymentsDb(eclairJdbc)
     override val pendingRelay = new SqlitePendingRelayDb(eclairJdbc)
+    override def backup(file: File): Unit = {
+      SqliteUtils.using(eclairJdbc.createStatement()) {
+        statement =>  {
+          statement.executeUpdate(s"backup to ${file.getAbsolutePath}")
+        }
+      }
+    }
   }
-
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
@@ -82,7 +82,7 @@ object SqliteUtils {
     * Obtain an exclusive lock on a sqlite database. This is useful when we want to make sure that only one process
     * accesses the database file (see https://www.sqlite.org/pragma.html).
     *
-    * The lock will be kept until the database is closed, or if the locking mode is explicitely reset.
+    * The lock will be kept until the database is closed, or if the locking mode is explicitly reset.
     *
     * @param sqlite
     */

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/BackupHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/BackupHandlerSpec.scala
@@ -25,7 +25,7 @@ class BackupHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
     db.channels.addOrUpdateChannel(channel)
     assert(db.channels.listLocalChannels() == Seq(channel))
 
-    val handler = system.actorOf(BackupHandler.props(db, dest))
+    val handler = system.actorOf(BackupHandler.props(db, dest, ""))
     handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)
     handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)
     handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/BackupHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/BackupHandlerSpec.scala
@@ -25,7 +25,7 @@ class BackupHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
     db.channels.addOrUpdateChannel(channel)
     assert(db.channels.listLocalChannels() == Seq(channel))
 
-    val handler = system.actorOf(BackupHandler.props(db, dest, ""))
+    val handler = system.actorOf(BackupHandler.props(db, dest, None))
     handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)
     handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)
     handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/BackupHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/BackupHandlerSpec.scala
@@ -1,0 +1,38 @@
+package fr.acinq.eclair.db
+
+import java.io.File
+import java.sql.DriverManager
+import java.util.UUID
+
+import akka.actor.{ActorSystem, Props}
+import akka.testkit.TestKit
+import fr.acinq.eclair.channel.ChannelPersisted
+import fr.acinq.eclair.db.sqlite.SqliteChannelsDb
+import fr.acinq.eclair.{TestConstants, TestUtils, randomBytes32}
+import org.scalatest.FunSuiteLike
+
+import scala.concurrent.duration._
+
+class BackupHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
+
+  test("process backups") {
+    val db = TestConstants.inMemoryDb()
+    val wip = new File(TestUtils.BUILD_DIRECTORY, s"wip-${UUID.randomUUID()}")
+    val dest = new File(TestUtils.BUILD_DIRECTORY, s"backup-${UUID.randomUUID()}")
+    wip.deleteOnExit()
+    dest.deleteOnExit()
+    val channel = ChannelStateSpec.normal
+    db.channels.addOrUpdateChannel(channel)
+    assert(db.channels.listLocalChannels() == Seq(channel))
+
+    val handler = system.actorOf(BackupHandler.props(db, wip, dest))
+    handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)
+    handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)
+    handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)
+    awaitCond(dest.exists(), 5 seconds)
+
+    val db1 = new SqliteChannelsDb(DriverManager.getConnection(s"jdbc:sqlite:$dest"))
+    val check = db1.listLocalChannels()
+    assert(check == Seq(channel))
+  }
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/BackupHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/BackupHandlerSpec.scala
@@ -25,7 +25,7 @@ class BackupHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
     db.channels.addOrUpdateChannel(channel)
     assert(db.channels.listLocalChannels() == Seq(channel))
 
-    val handler = system.actorOf(BackupHandler.props(db, wip, dest))
+    val handler = system.actorOf(BackupHandler.props(db, dest))
     handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)
     handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)
     handler ! ChannelPersisted(null, TestConstants.Alice.nodeParams.nodeId, randomBytes32, null)


### PR DESCRIPTION
Backups are handled by a custom actor that listens to persistence events sent by channels. They are done in 2 steps:

- create a sqlite backup in a temporary file
- rename the temporary file, which should be atomic (though it actually depends on the OS and file system).

Users would typically rename/move the backup file then make a safe copy of it.

Backups are sequential. If backup requests pile up while a backup is still in progress, only the last one will be kept.
