### PR TITLE
Add channel errors in audit db

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -47,7 +47,7 @@ case class ChannelSignatureSent(channel: ActorRef, commitments: Commitments) ext
 
 case class ChannelSignatureReceived(channel: ActorRef, commitments: Commitments) extends ChannelEvent
 
-case class ChannelFailed(channel: ActorRef, channelId: ByteVector32, remoteNodeId: PublicKey, data: Data, error: ChannelError) extends ChannelEvent
+case class ChannelErrorOccured(channel: ActorRef, channelId: ByteVector32, remoteNodeId: PublicKey, data: Data, error: ChannelError, isFatal: Boolean) extends ChannelEvent
 
 case class NetworkFeePaid(channel: ActorRef, remoteNodeId: PublicKey, channelId: ByteVector32, tx: Transaction, fee: Satoshi, txType: String) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -35,6 +35,8 @@ trait AuditDb {
 
   def add(networkFeePaid: NetworkFeePaid)
 
+  def add(channelErrorOccured: ChannelErrorOccured)
+
   def listSent(from: Long, to: Long): Seq[PaymentSent]
 
   def listReceived(from: Long, to: Long): Seq[PaymentReceived]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Auditor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Auditor.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.payment
 import akka.actor.{Actor, ActorLogging, Props}
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.NodeParams
+import fr.acinq.eclair.channel.Channel.{LocalError, RemoteError}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.{AuditDb, ChannelLifecycleEvent}
 
@@ -32,6 +33,7 @@ class Auditor(nodeParams: NodeParams) extends Actor with ActorLogging {
   context.system.eventStream.subscribe(self, classOf[PaymentEvent])
   context.system.eventStream.subscribe(self, classOf[NetworkFeePaid])
   context.system.eventStream.subscribe(self, classOf[AvailableBalanceChanged])
+  context.system.eventStream.subscribe(self, classOf[ChannelErrorOccured])
   context.system.eventStream.subscribe(self, classOf[ChannelStateChanged])
   context.system.eventStream.subscribe(self, classOf[ChannelClosed])
 
@@ -48,6 +50,8 @@ class Auditor(nodeParams: NodeParams) extends Actor with ActorLogging {
     case e: NetworkFeePaid => db.add(e)
 
     case e: AvailableBalanceChanged => balanceEventThrottler ! e
+
+    case e: ChannelErrorOccured => db.add(e)
 
     case e: ChannelStateChanged =>
       e match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
@@ -17,6 +17,7 @@
 package fr.acinq.eclair.wire
 
 import java.net.{Inet4Address, Inet6Address, InetAddress, InetSocketAddress}
+import java.nio.charset.StandardCharsets
 
 import com.google.common.base.Charsets
 import fr.acinq.bitcoin.ByteVector32
@@ -47,7 +48,9 @@ case class Init(globalFeatures: ByteVector,
                 localFeatures: ByteVector) extends SetupMessage
 
 case class Error(channelId: ByteVector32,
-                 data: ByteVector) extends SetupMessage with HasChannelId
+                 data: ByteVector) extends SetupMessage with HasChannelId {
+  def toAscii: String = if (fr.acinq.eclair.isAsciiPrintable(data)) new String(data.toArray, StandardCharsets.US_ASCII) else "n/a"
+}
 
 object Error {
   def apply(channelId: ByteVector32, msg: String): Error = Error(channelId, ByteVector.view(msg.getBytes(Charsets.US_ASCII)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
@@ -125,7 +125,7 @@ class SqliteAuditDbSpec extends FunSuite {
     }
 
     using(connection.createStatement()) { statement =>
-      assert(getVersion(statement, "audit", 3) == 1) // version 1 is deployed now
+      assert(getVersion(statement, "audit", 3) == 1) // we expect version 1
     }
 
     val ps = PaymentSent(UUID.randomUUID(), MilliSatoshi(42000), MilliSatoshi(1000), randomBytes32, randomBytes32, randomBytes32)
@@ -209,7 +209,7 @@ class SqliteAuditDbSpec extends FunSuite {
     val postMigrationDb = new SqliteAuditDb(connection)
 
     using(connection.createStatement()) { statement =>
-      assert(getVersion(statement, "audit", 3) == 3) // version 2
+      assert(getVersion(statement, "audit", 3) == 3) // version 3
     }
 
     postMigrationDb.add(e2)


### PR DESCRIPTION
We now keep track of all local/remote channel errors in the audit db.