### PR TITLE
Fix Dockerfile Maven Sha checksum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache curl tar bash
 
 ARG MAVEN_VERSION=3.6.0
 ARG USER_HOME_DIR="/root"
-ARG SHA=ce50b1c91364cb77efe3776f756a6d92b76d9038b0a0782f7d53acf1e997a14d
+ARG SHA=6a1b346af36a1f1a491c1c1a141667c5de69b42e6611d3687df26868bc0f4637
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \


### PR DESCRIPTION
The Maven 3.6.0 SHA256 checksum was invalid and cause the docker build to fail( the current checksum is for Maven 3.5.4)
References: 
Old checksum: https://checker.apache.org/sums/89eea39183139e5f8a0c1601d495b3b6
New checksum: https://checker.apache.org/paths/maven/maven-3/3.6.0/binaries/apache-maven-3.6.0-bin.tar.gz.html