### PR TITLE
resolve hostname ip in docker level

### DIFF
--- a/contrib/docker-entrypoint.sh
+++ b/contrib/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+ECLAIR_RESOLVED_IP_OPT=""
+if ! [ -z "$PUBLIC_HOST" ]; then
+    RESOLVED_IP="$(dig +short $PUBLIC_HOST | grep -Eo '[0-9\.]{7,15}' | head -1)"
+	if ! [ -z "$RESOLVED_IP" ]; then
+		ECLAIR_RESOLVED_IP_OPT=" -Declair.server.public-ips.0=$RESOLVED_IP"
+	else
+	    ECLAIR_RESOLVED_IP_OPT=""
+	fi
+fi
+
+java $JAVA_OPTS $ECLAIR_RESOLVED_IP_OPT -Declair.datadir=$ECLAIR_DATADIR -jar eclair-node.jar


### PR DESCRIPTION
Good to note that this includes #956

This PR adds a new feature to the docker deployment.

By specifying a hostname through an environment variable name `PUBLIC_HOST`, it will resolve the ip and set the first public ip to it.