### PR TITLE
Backup: explicitely specify move options

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -17,7 +17,7 @@ eclair {
   }
 
   // override this with a script/exe that will be called everytime a new database backup has been created
-  # backup-notify-script = ""
+  # backup-notify-script = "/path/to/script.sh"
 
   watcher-type = "bitcoind" // other *experimental* values include "electrum"
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -17,7 +17,7 @@ eclair {
   }
 
   // override this with a script/exe that will be called everytime a new database backup has been created
-  backup-notify-script = ""
+  # backup-notify-script = ""
 
   watcher-type = "bitcoind" // other *experimental* values include "electrum"
 


### PR DESCRIPTION
We now specify that we want to atomically overwrite the existing backup file with the new one (fixes
a potential issue on Windows).
We also publish a specific notification when the backup process has been completed.