### PR TITLE
Add `balances` API endpoint

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -27,15 +27,17 @@ import fr.acinq.eclair.channel.Register.{Forward, ForwardShortId}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.{IncomingPayment, NetworkFee, OutgoingPayment, Stats}
 import fr.acinq.eclair.io.Peer.{GetPeerInfo, PeerInfo}
-import fr.acinq.eclair.io.{NodeURI, Peer, Switchboard}
+import fr.acinq.eclair.io.{NodeURI, Peer}
 import fr.acinq.eclair.payment.PaymentLifecycle._
 import fr.acinq.eclair.router.{ChannelDesc, RouteRequest, RouteResponse, Router}
 import scodec.bits.ByteVector
+
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import fr.acinq.eclair.payment.{PaymentReceived, PaymentRelayed, PaymentRequest, PaymentSent}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAddress, NodeAnnouncement}
 import TimestampQueryFilters._
+import fr.acinq.eclair.payment.Relayer.OutgoingChannel
 
 case class GetInfoResponse(nodeId: PublicKey, alias: String, chainHash: ByteVector32, blockHeight: Int, publicAddresses: Seq[NodeAddress])
 
@@ -105,6 +107,7 @@ trait Eclair {
 
   def getInfoResponse()(implicit timeout: Timeout): Future[GetInfoResponse]
 
+  def usableBalances()(implicit timeout: Timeout): Future[Iterable[OutgoingChannel]]
 }
 
 class EclairImpl(appKit: Kit) extends Eclair {
@@ -269,4 +272,5 @@ class EclairImpl(appKit: Kit) extends Eclair {
       publicAddresses = appKit.nodeParams.publicAddresses)
   )
 
+  override def usableBalances()(implicit timeout: Timeout): Future[Iterable[OutgoingChannel]] = (appKit.relayer ? 'usableBalances).mapTo[Iterable[OutgoingChannel]]
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -34,10 +34,9 @@ import scodec.bits.ByteVector
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import fr.acinq.eclair.payment.{PaymentReceived, PaymentRelayed, PaymentRequest, PaymentSent}
+import fr.acinq.eclair.payment.{GetUsableBalances, PaymentReceived, PaymentRelayed, PaymentRequest, PaymentSent, UsableBalances}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAddress, NodeAnnouncement}
 import TimestampQueryFilters._
-import fr.acinq.eclair.payment.Relayer.OutgoingChannel
 
 case class GetInfoResponse(nodeId: PublicKey, alias: String, chainHash: ByteVector32, blockHeight: Int, publicAddresses: Seq[NodeAddress])
 
@@ -107,7 +106,7 @@ trait Eclair {
 
   def getInfoResponse()(implicit timeout: Timeout): Future[GetInfoResponse]
 
-  def usableBalances()(implicit timeout: Timeout): Future[Iterable[OutgoingChannel]]
+  def usableBalances()(implicit timeout: Timeout): Future[Iterable[UsableBalances]]
 }
 
 class EclairImpl(appKit: Kit) extends Eclair {
@@ -272,5 +271,5 @@ class EclairImpl(appKit: Kit) extends Eclair {
       publicAddresses = appKit.nodeParams.publicAddresses)
   )
 
-  override def usableBalances()(implicit timeout: Timeout): Future[Iterable[OutgoingChannel]] = (appKit.relayer ? 'usableBalances).mapTo[Iterable[OutgoingChannel]]
+  override def usableBalances()(implicit timeout: Timeout): Future[Iterable[UsableBalances]] = (appKit.relayer ? GetUsableBalances).mapTo[Iterable[UsableBalances]]
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -281,6 +281,9 @@ trait Service extends ExtraDirectives with Logging {
                       } ~
                       path("channelstats") {
                         complete(eclairApi.channelStats())
+                      } ~
+                      path("usablebalances") {
+                        complete(eclairApi.usableBalances())
                       }
                   } ~ get {
                     path("ws") {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -73,13 +73,13 @@ case class Commitments(localParams: LocalParams, remoteParams: RemoteParams,
 
   val announceChannel: Boolean = (channelFlags & 0x01) != 0
 
-  def availableBalanceForSendMsat: Long = {
+  lazy val availableBalanceForSendMsat: Long = {
     val reduced = CommitmentSpec.reduce(remoteCommit.spec, remoteChanges.acked, localChanges.proposed)
     val feesMsat = if (localParams.isFunder) Transactions.commitTxFee(Satoshi(remoteParams.dustLimitSatoshis), reduced).amount * 1000 else 0
     reduced.toRemoteMsat - remoteParams.channelReserveSatoshis * 1000 - feesMsat
   }
 
-  def availableBalanceForReceiveMsat: Long = {
+  lazy val availableBalanceForReceiveMsat: Long = {
     val reduced = CommitmentSpec.reduce(localCommit.spec, localChanges.acked, remoteChanges.proposed)
     val feesMsat = if (localParams.isFunder) 0 else Transactions.commitTxFee(Satoshi(localParams.dustLimitSatoshis), reduced).amount * 1000
     reduced.toRemoteMsat - localParams.channelReserveSatoshis * 1000 - feesMsat

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -81,7 +81,7 @@ case class Commitments(localParams: LocalParams, remoteParams: RemoteParams,
 
   def availableBalanceForReceiveMsat: Long = {
     val reduced = CommitmentSpec.reduce(localCommit.spec, localChanges.acked, remoteChanges.proposed)
-    val feesMsat = if (localParams.isFunder) 0 else Transactions.commitTxFee(Satoshi(remoteParams.dustLimitSatoshis), reduced).amount * 1000
+    val feesMsat = if (localParams.isFunder) 0 else Transactions.commitTxFee(Satoshi(localParams.dustLimitSatoshis), reduced).amount * 1000
     reduced.toRemoteMsat - localParams.channelReserveSatoshis * 1000 - feesMsat
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Relayer.scala
@@ -69,35 +69,28 @@ class Relayer(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorR
 
   private val commandBuffer = context.actorOf(Props(new CommandBuffer(nodeParams, register)))
 
-  override def receive: Receive = main(Map.empty, new mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId], Map.empty)
+  override def receive: Receive = main(Map.empty, new mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId])
 
-  def main(channelUpdates: Map[ShortChannelId, OutgoingChannel],
-           node2channels: mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId],
-           usableBalances: Map[ShortChannelId, UsableBalances]): Receive = {
+  def main(channelUpdates: Map[ShortChannelId, OutgoingChannel], node2channels: mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId]): Receive = {
 
     case GetUsableBalances =>
-      sender ! usableBalances.values
+      sender ! channelUpdates.values.map(o => UsableBalances(o.commitments.availableBalanceForSendMsat, o.commitments.availableBalanceForReceiveMsat, o.commitments.announceChannel))
 
     case LocalChannelUpdate(_, channelId, shortChannelId, remoteNodeId, _, channelUpdate, commitments) =>
       log.debug(s"updating local channel info for channelId=$channelId shortChannelId=$shortChannelId remoteNodeId=$remoteNodeId channelUpdate={} commitments={}", channelUpdate, commitments)
-      val channelUpdates1 = channelUpdates + (channelUpdate.shortChannelId -> OutgoingChannel(remoteNodeId, channelUpdate, commitments.availableBalanceForSendMsat))
-      val usableBalances1 = usableBalances + (channelUpdate.shortChannelId -> UsableBalances(commitments.availableBalanceForSendMsat, commitments.availableBalanceForReceiveMsat, commitments.announceChannel))
-      context become main(channelUpdates1, node2channels.addBinding(remoteNodeId, channelUpdate.shortChannelId), usableBalances1)
+      val channelUpdates1 = channelUpdates + (channelUpdate.shortChannelId -> OutgoingChannel(remoteNodeId, channelUpdate, commitments))
+      context become main(channelUpdates1, node2channels.addBinding(remoteNodeId, channelUpdate.shortChannelId))
 
     case LocalChannelDown(_, channelId, shortChannelId, remoteNodeId) =>
       log.debug(s"removed local channel info for channelId=$channelId shortChannelId=$shortChannelId")
-      context become main(channelUpdates - shortChannelId, node2channels.removeBinding(remoteNodeId, shortChannelId), usableBalances - shortChannelId)
+      context become main(channelUpdates - shortChannelId, node2channels.removeBinding(remoteNodeId, shortChannelId))
 
     case AvailableBalanceChanged(_, _, shortChannelId, _, commitments) =>
       val channelUpdates1 = channelUpdates.get(shortChannelId) match {
-        case Some(c: OutgoingChannel) => channelUpdates + (shortChannelId -> c.copy(availableBalanceMsat = commitments.availableBalanceForSendMsat))
+        case Some(c: OutgoingChannel) => channelUpdates + (shortChannelId -> c.copy(commitments = commitments))
         case None => channelUpdates // we only consider the balance if we have the channel_update
       }
-      val usableBalances1 = usableBalances.get(shortChannelId) match {
-        case Some(u: UsableBalances) => usableBalances + (shortChannelId -> u.copy(canSendMsat = commitments.availableBalanceForSendMsat, canReceiveMsat = commitments.availableBalanceForReceiveMsat))
-        case None => usableBalances // we only consider the balance if we have the channel_update
-      }
-      context become main(channelUpdates1, node2channels, usableBalances1)
+      context become main(channelUpdates1, node2channels)
 
     case ForwardAdd(add, previousFailures) =>
       log.debug(s"received forwarding request for htlc #${add.id} paymentHash=${add.paymentHash} from channelId=${add.channelId}")
@@ -211,7 +204,7 @@ class Relayer(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorR
 object Relayer {
   def props(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorRef) = Props(classOf[Relayer], nodeParams, register, paymentHandler)
 
-  case class OutgoingChannel(nextNodeId: PublicKey, channelUpdate: ChannelUpdate, availableBalanceMsat: Long)
+  case class OutgoingChannel(nextNodeId: PublicKey, channelUpdate: ChannelUpdate, commitments: Commitments)
 
   // @formatter:off
   sealed trait NextPayload
@@ -316,10 +309,10 @@ object Relayer {
             val channelInfo_opt = channelUpdates.get(shortChannelId)
             val channelUpdate_opt = channelInfo_opt.map(_.channelUpdate)
             val relayResult = relayOrFail(relayPayload, channelUpdate_opt)
-            log.debug(s"candidate channel for htlc #${add.id} paymentHash=${add.paymentHash}: shortChannelId={} balanceMsat={} channelUpdate={} relayResult={}", shortChannelId, channelInfo_opt.map(_.availableBalanceMsat).getOrElse(""), channelUpdate_opt.getOrElse(""), relayResult)
+            log.debug(s"candidate channel for htlc #${add.id} paymentHash=${add.paymentHash}: shortChannelId={} balanceMsat={} channelUpdate={} relayResult={}", shortChannelId, channelInfo_opt.map(_.commitments.availableBalanceForSendMsat).getOrElse(""), channelUpdate_opt.getOrElse(""), relayResult)
             (shortChannelId, channelInfo_opt, relayResult)
           }
-          .collect { case (shortChannelId, Some(channelInfo), Right(_)) => (shortChannelId, channelInfo.availableBalanceMsat) }
+          .collect { case (shortChannelId, Some(channelInfo), Right(_)) => (shortChannelId, channelInfo.commitments.availableBalanceForSendMsat) }
           .filter(_._2 > relayPayload.payload.amtToForward) // we only keep channels that have enough balance to handle this payment
           .toList // needed for ordering
           .sortBy(_._2) // we want to use the channel with the lowest available balance that can process the payment

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestUtils.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestUtils.scala
@@ -18,9 +18,6 @@ package fr.acinq.eclair
 
 import java.io.File
 
-import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.eclair.channel.Commitments
-
 object TestUtils {
 
   /**
@@ -30,10 +27,4 @@ object TestUtils {
     .props
     .get("buildDirectory") // this is defined if we run from maven
     .getOrElse(new File(sys.props("user.dir"), "target").getAbsolutePath) // otherwise we probably are in intellij, so we build it manually assuming that user.dir == path to the module
-
-  def makeCommitments(channelId: ByteVector32, availableBalanceMsat: Long = 50000000L) =
-    new Commitments(null, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, null, null, channelId) {
-      override def availableBalanceForSendMsat: Long = availableBalanceMsat
-      override def availableBalanceForReceiveMsat: Long = availableBalanceMsat
-    }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestUtils.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestUtils.scala
@@ -18,6 +18,9 @@ package fr.acinq.eclair
 
 import java.io.File
 
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.eclair.channel.Commitments
+
 object TestUtils {
 
   /**
@@ -28,4 +31,9 @@ object TestUtils {
     .get("buildDirectory") // this is defined if we run from maven
     .getOrElse(new File(sys.props("user.dir"), "target").getAbsolutePath) // otherwise we probably are in intellij, so we build it manually assuming that user.dir == path to the module
 
+  def makeCommitments(channelId: ByteVector32, availableBalanceMsat: Long = 50000000L) =
+    new Commitments(null, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, null, null, channelId) {
+      override def availableBalanceForSendMsat: Long = availableBalanceMsat
+      override def availableBalanceForReceiveMsat: Long = availableBalanceMsat
+    }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
@@ -103,7 +103,7 @@ trait StateTestsHelperMethods extends TestKitBase {
     bob2blockchain.expectMsgType[WatchConfirmed] // deeply buried
     awaitCond(alice.stateName == NORMAL)
     awaitCond(bob.stateName == NORMAL)
-    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.availableBalanceForSendMsat == pushMsat - TestConstants.Alice.channelParams.channelReserveSatoshis * 1000)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.usableBalances.localMsat == pushMsat - TestConstants.Alice.channelParams.channelReserveSatoshis * 1000)
     // x2 because alice and bob share the same relayer
     channelUpdateListener.expectMsgType[LocalChannelUpdate]
     channelUpdateListener.expectMsgType[LocalChannelUpdate]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
@@ -103,7 +103,7 @@ trait StateTestsHelperMethods extends TestKitBase {
     bob2blockchain.expectMsgType[WatchConfirmed] // deeply buried
     awaitCond(alice.stateName == NORMAL)
     awaitCond(bob.stateName == NORMAL)
-    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.usableBalances.localMsat == pushMsat - TestConstants.Alice.channelParams.channelReserveSatoshis * 1000)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.availableBalanceForSendMsat == pushMsat - TestConstants.Alice.channelParams.channelReserveSatoshis * 1000)
     // x2 because alice and bob share the same relayer
     channelUpdateListener.expectMsgType[LocalChannelUpdate]
     channelUpdateListener.expectMsgType[LocalChannelUpdate]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
@@ -16,11 +16,12 @@
 
 package fr.acinq.eclair.payment
 
-import fr.acinq.bitcoin.Block
+import fr.acinq.bitcoin.{Block, ByteVector32}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.channel.{CMD_ADD_HTLC, CMD_FAIL_HTLC}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.Relayer.{OutgoingChannel, RelayPayload}
+import fr.acinq.eclair.TestUtils.makeCommitments
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{ShortChannelId, randomBytes32, randomKey}
@@ -81,11 +82,11 @@ class ChannelSelectionSpec extends FunSuite {
     val channelUpdate = dummyUpdate(ShortChannelId(12345), 10, 100, 1000, 100, 10000000, true)
 
     val channelUpdates = Map(
-      ShortChannelId(11111) -> OutgoingChannel(a, channelUpdate, 100000000),
-      ShortChannelId(12345) -> OutgoingChannel(a, channelUpdate, 20000000),
-      ShortChannelId(22222) -> OutgoingChannel(a, channelUpdate, 10000000),
-      ShortChannelId(33333) -> OutgoingChannel(a, channelUpdate, 100000),
-      ShortChannelId(44444) -> OutgoingChannel(b, channelUpdate, 1000000)
+      ShortChannelId(11111) -> OutgoingChannel(a, channelUpdate, makeCommitments(ByteVector32.Zeroes, 100000000)),
+      ShortChannelId(12345) -> OutgoingChannel(a, channelUpdate, makeCommitments(ByteVector32.Zeroes, 20000000)),
+      ShortChannelId(22222) -> OutgoingChannel(a, channelUpdate, makeCommitments(ByteVector32.Zeroes, 10000000)),
+      ShortChannelId(33333) -> OutgoingChannel(a, channelUpdate, makeCommitments(ByteVector32.Zeroes, 100000)),
+      ShortChannelId(44444) -> OutgoingChannel(b, channelUpdate, makeCommitments(ByteVector32.Zeroes, 1000000))
     )
 
     val node2channels = new mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
@@ -21,10 +21,10 @@ import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.channel.{CMD_ADD_HTLC, CMD_FAIL_HTLC}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.Relayer.{OutgoingChannel, RelayPayload}
-import fr.acinq.eclair.TestUtils.makeCommitments
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{ShortChannelId, randomBytes32, randomKey}
+import fr.acinq.eclair.payment.HtlcGenerationSpec.makeCommitments
 import org.scalatest.FunSuite
 import scodec.bits.ByteVector
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.payment
 
 import fr.acinq.bitcoin.Block
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.eclair.channel.{AddHtlcFailed, UsableBalances, CMD_ADD_HTLC, CMD_FAIL_HTLC}
+import fr.acinq.eclair.channel.{CMD_ADD_HTLC, CMD_FAIL_HTLC}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.Relayer.{OutgoingChannel, RelayPayload}
 import fr.acinq.eclair.router.Announcements
@@ -81,11 +81,11 @@ class ChannelSelectionSpec extends FunSuite {
     val channelUpdate = dummyUpdate(ShortChannelId(12345), 10, 100, 1000, 100, 10000000, true)
 
     val channelUpdates = Map(
-      ShortChannelId(11111) -> OutgoingChannel(a, channelUpdate, UsableBalances(100000000, 0, isPublic = true)),
-      ShortChannelId(12345) -> OutgoingChannel(a, channelUpdate, UsableBalances(20000000, 0, isPublic = true)),
-      ShortChannelId(22222) -> OutgoingChannel(a, channelUpdate, UsableBalances(10000000, 0, isPublic = false)),
-      ShortChannelId(33333) -> OutgoingChannel(a, channelUpdate, UsableBalances(100000, 0, isPublic = false)),
-      ShortChannelId(44444) -> OutgoingChannel(b, channelUpdate, UsableBalances(1000000, 0, isPublic = true))
+      ShortChannelId(11111) -> OutgoingChannel(a, channelUpdate, 100000000),
+      ShortChannelId(12345) -> OutgoingChannel(a, channelUpdate, 20000000),
+      ShortChannelId(22222) -> OutgoingChannel(a, channelUpdate, 10000000),
+      ShortChannelId(33333) -> OutgoingChannel(a, channelUpdate, 100000),
+      ShortChannelId(44444) -> OutgoingChannel(b, channelUpdate, 1000000)
     )
 
     val node2channels = new mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.payment
 
 import fr.acinq.bitcoin.Block
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.eclair.channel.{AddHtlcFailed, CMD_ADD_HTLC, CMD_FAIL_HTLC}
+import fr.acinq.eclair.channel.{AddHtlcFailed, UsableBalances, CMD_ADD_HTLC, CMD_FAIL_HTLC}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.Relayer.{OutgoingChannel, RelayPayload}
 import fr.acinq.eclair.router.Announcements
@@ -81,11 +81,11 @@ class ChannelSelectionSpec extends FunSuite {
     val channelUpdate = dummyUpdate(ShortChannelId(12345), 10, 100, 1000, 100, 10000000, true)
 
     val channelUpdates = Map(
-      ShortChannelId(11111) -> OutgoingChannel(a, channelUpdate, 100000000),
-      ShortChannelId(12345) -> OutgoingChannel(a, channelUpdate, 20000000),
-      ShortChannelId(22222) -> OutgoingChannel(a, channelUpdate, 10000000),
-      ShortChannelId(33333) -> OutgoingChannel(a, channelUpdate, 100000),
-      ShortChannelId(44444) -> OutgoingChannel(b, channelUpdate, 1000000)
+      ShortChannelId(11111) -> OutgoingChannel(a, channelUpdate, UsableBalances(100000000, 0, isPublic = true)),
+      ShortChannelId(12345) -> OutgoingChannel(a, channelUpdate, UsableBalances(20000000, 0, isPublic = true)),
+      ShortChannelId(22222) -> OutgoingChannel(a, channelUpdate, UsableBalances(10000000, 0, isPublic = false)),
+      ShortChannelId(33333) -> OutgoingChannel(a, channelUpdate, UsableBalances(100000, 0, isPublic = false)),
+      ShortChannelId(44444) -> OutgoingChannel(b, channelUpdate, UsableBalances(1000000, 0, isPublic = true))
     )
 
     val node2channels = new mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/HtlcGenerationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/HtlcGenerationSpec.scala
@@ -19,8 +19,8 @@ package fr.acinq.eclair.payment
 import java.util.UUID
 
 import fr.acinq.bitcoin.DeterministicWallet.ExtendedPrivateKey
-import fr.acinq.bitcoin.{Block, Crypto, DeterministicWallet}
-import fr.acinq.eclair.channel.Channel
+import fr.acinq.bitcoin.{Block, ByteVector32, Crypto, DeterministicWallet}
+import fr.acinq.eclair.channel.{Channel, Commitments}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.crypto.Sphinx.{PacketAndSecrets, ParsedPacket}
 import fr.acinq.eclair.payment.PaymentLifecycle._
@@ -150,6 +150,12 @@ class HtlcGenerationSpec extends FunSuite {
 }
 
 object HtlcGenerationSpec {
+
+  def makeCommitments(channelId: ByteVector32, availableBalanceForSend: Long = 50000000L, availableBalanceForReceive: Long = 50000000L) =
+    new Commitments(null, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, null, null, channelId) {
+      override def availableBalanceForSendMsat: Long = availableBalanceForSend
+      override def availableBalanceForReceiveMsat: Long = availableBalanceForReceive
+    }
 
   def randomExtendedPrivateKey: ExtendedPrivateKey = DeterministicWallet.generate(randomBytes32)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/HtlcGenerationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/HtlcGenerationSpec.scala
@@ -153,8 +153,8 @@ object HtlcGenerationSpec {
 
   def makeCommitments(channelId: ByteVector32, availableBalanceForSend: Long = 50000000L, availableBalanceForReceive: Long = 50000000L) =
     new Commitments(null, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, null, null, channelId) {
-      override def availableBalanceForSendMsat: Long = availableBalanceForSend
-      override def availableBalanceForReceiveMsat: Long = availableBalanceForReceive
+      override lazy val availableBalanceForSendMsat: Long = availableBalanceForSend
+      override lazy val availableBalanceForReceiveMsat: Long = availableBalanceForReceive
     }
 
   def randomExtendedPrivateKey: ExtendedPrivateKey = DeterministicWallet.generate(randomBytes32)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -25,9 +25,8 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.PaymentLifecycle.buildCommand
 import fr.acinq.eclair.router.Announcements
-import fr.acinq.eclair.transactions.CommitmentSpec
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.{ShortChannelId, TestConstants, TestkitBaseClass, UInt64, randomBytes32, randomKey}
+import fr.acinq.eclair.{ShortChannelId, TestConstants, TestkitBaseClass, UInt64, randomBytes32}
 import org.scalatest.Outcome
 import scodec.bits.ByteVector
 
@@ -59,7 +58,8 @@ class RelayerSpec extends TestkitBaseClass {
   val channelId_bc = randomBytes32
 
   def makeCommitments(channelId: ByteVector32, availableBalanceMsat: Long = 50000000L) = new Commitments(null, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, null, null, channelId) {
-    override def usableBalances: UsableBalances = UsableBalances(availableBalanceMsat, 0, isPublic = true)
+    override def availableBalanceForSendMsat: Long = availableBalanceMsat
+    override def availableBalanceForReceiveMsat: Long = availableBalanceMsat
   }
 
   test("relay an htlc-add") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -411,4 +411,11 @@ class RelayerSpec extends TestkitBaseClass {
     assert(fwd.channelId === origin.originChannelId)
     assert(fwd.message.id === origin.originHtlcId)
   }
+
+  test("a") { f =>
+    import f._
+    val sender = TestProbe()
+    sender.send(relayer, GetUsableBalances)
+    sender.expectMsgType[Iterable[UsableBalances]]
+  }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -58,9 +58,8 @@ class RelayerSpec extends TestkitBaseClass {
   val channelId_ab = randomBytes32
   val channelId_bc = randomBytes32
 
-  def makeCommitments(channelId: ByteVector32, availableBalanceMsat: Long = 50000000L) = new Commitments(null, null, 0.toByte, null, null,
-    null, null, 0, 0, Map.empty, null, null, null, channelId) {
-    override def availableBalanceForSendMsat: Long = availableBalanceMsat
+  def makeCommitments(channelId: ByteVector32, availableBalanceMsat: Long = 50000000L) = new Commitments(null, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, null, null, channelId) {
+    override def usableBalances: UsableBalances = UsableBalances(availableBalanceMsat, 0, isPublic = true)
   }
 
   test("relay an htlc-add") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -27,6 +27,7 @@ import fr.acinq.eclair.payment.PaymentLifecycle.buildCommand
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{ShortChannelId, TestConstants, TestkitBaseClass, UInt64, randomBytes32}
+import fr.acinq.eclair.TestUtils.makeCommitments
 import org.scalatest.Outcome
 import scodec.bits.ByteVector
 
@@ -56,11 +57,6 @@ class RelayerSpec extends TestkitBaseClass {
 
   val channelId_ab = randomBytes32
   val channelId_bc = randomBytes32
-
-  def makeCommitments(channelId: ByteVector32, availableBalanceMsat: Long = 50000000L) = new Commitments(null, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, null, null, channelId) {
-    override def availableBalanceForSendMsat: Long = availableBalanceMsat
-    override def availableBalanceForReceiveMsat: Long = availableBalanceMsat
-  }
 
   test("relay an htlc-add") { f =>
     import f._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -412,7 +412,7 @@ class RelayerSpec extends TestkitBaseClass {
     assert(fwd.message.id === origin.originHtlcId)
   }
 
-  test("a") { f =>
+  test("get usable balances") { f =>
     import f._
     val sender = TestProbe()
     sender.send(relayer, GetUsableBalances)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -421,7 +421,7 @@ class RelayerSpec extends TestkitBaseClass {
 
     relayer ! AvailableBalanceChanged(null, channelId_bc, channelUpdate_bc.shortChannelId, 0, makeCommitments(channelId_bc, 200000, 500000))
     sender.send(relayer, GetUsableBalances)
-    assert(sender.expectMsgType[Iterable[UsableBalances]].last.canReceiveMsat == 500000)
+    assert(sender.expectMsgType[Iterable[UsableBalances]].last.canReceiveMsat === 500000)
 
     relayer ! LocalChannelDown(null, channelId_bc, channelUpdate_bc.shortChannelId, c)
     sender.send(relayer, GetUsableBalances)


### PR DESCRIPTION
Currently balances can be obtained from `channels` call but this requires a lot of work on caller side and also some specific knowledge (reserves, commit tx fee, in-flight payments), so this new `balances` endpoint only returns a correct balance info for each channel. 

Data is taken from `Relayer` actor which already has exactly what we need: a map of `OutgoingChannel` objects which now contain correctly calculated `can send / can receive` balances for each `NORMAL` channel. Additionally, obtaining balances this way has a minimal performance hit when compared to querying each channel used in `channels`.