### PR TITLE
ElectrumWallet should not send ready if syncing

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
@@ -172,8 +172,7 @@ class ElectrumWallet(seed: ByteVector, client: ActorRef, params: ElectrumWallet.
       } else {
         client ! ElectrumClient.GetHeaders(data.blockchain.tip.height + 1, RETARGETING_PERIOD)
         log.info(s"syncing headers from ${data.blockchain.height} to ${height}, ready=${data.isReady(params.swipeRange)}")
-        // tell everyone we're ready while we catch up
-        goto(SYNCING) using persistAndNotify(data)
+        goto(SYNCING) using data
       }
   }
 


### PR DESCRIPTION
In order to improve startup time, electrum wallet would dispatch its "ready" event even though if it was still syncing, which could sometimes make the wallet have an incorrect state. This PR fixes that.

Note that this fix is already embedded in version `0.2-android-beta22` used by Eclair Mobile `0.4.5`