### PR TITLE
Electrum: make debug logs shorter

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -391,7 +391,9 @@ object ElectrumClient {
   }
 
   case class GetHeaders(start_height: Int, count: Int, cp_height: Int = 0) extends Request
-  case class GetHeadersResponse(start_height: Int, headers: Seq[BlockHeader], max: Int) extends Response
+  case class GetHeadersResponse(start_height: Int, headers: Seq[BlockHeader], max: Int) extends Response {
+    override def toString = s"GetHeadersResponse($start_height, ${headers.length}, ${headers.headOption}, ${headers.lastOption}, $max)"
+  }
 
   case class GetMerkle(txid: ByteVector32, height: Int) extends Request
   case class GetMerkleResponse(txid: ByteVector32, merkle: List[ByteVector32], block_height: Int, pos: Int) extends Response {


### PR DESCRIPTION
Instead of logging all headers when we download header chunks, we just logs the first and last ones.