### PR TITLE
Do not print the stacktrace on stderr when there is an error at boot

### DIFF
--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/JavafxBoot.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/JavafxBoot.scala
@@ -40,8 +40,9 @@ object JavafxBoot extends App with Logging {
     }
   } catch {
     case t: Throwable =>
-      System.err.println(s"fatal error: ${t.getMessage}")
-      logger.error(s"fatal error: ${t.getMessage}")
+      val errorMsg = if (t.getMessage != null) t.getMessage else t.getClass.getSimpleName
+      System.err.println(s"fatal error: $errorMsg")
+      logger.error(s"fatal error: $errorMsg", t)
       System.exit(1)
   }
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -47,8 +47,9 @@ object Boot extends App with Logging {
   }
 
   def onError(t: Throwable): Unit = {
-    logger.error(s"fatal error:", t)
-    t.printStackTrace()
+    val errorMsg = if (t.getMessage != null) t.getMessage else t.getClass.getSimpleName
+    System.err.println(s"fatal error: $errorMsg")
+    logger.error(s"fatal error: $errorMsg", t)
     System.exit(1)
   }
 }


### PR DESCRIPTION
This PR partially reverts the behavior introduced with #949, now in case of error at boot we print only a friendly message to stderr, logs however still contain the full stack trace.