### PR TITLE
Rename `eclair.bak` to `eclair.sqlite.bak`

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,19 +135,19 @@ java -Dlogback.configurationFile=/path/to/logback-custom.xml -jar eclair-node-gu
 
 The files that you need to backup are located in your data directory. You must backup:
 - your seed (`seed.dat`)
-- your channel database (`eclair.bak` under directory `mainnet`, `testnet` or `regtest` depending on which chain you're running on)
+- your channel database (`eclair.sqlite.bak` under directory `mainnet`, `testnet` or `regtest` depending on which chain you're running on)
 
 Your seed never changes once it has been created, but your channels will change whenever you receive or send payments. Eclair will
-create and maintain a snapshot of its database, named `eclair.bak`, in your data directory, and update it when needed. This file is 
+create and maintain a snapshot of its database, named `eclair.sqlite.bak`, in your data directory, and update it when needed. This file is 
 always consistent and safe to use even when Eclair is running, and this is what you should backup regularly.
 
 For example you could configure a `cron` task for your backup job. Or you could configure an optional notification script to be called by eclair once a new database snapshot has been created, using the following option:
 ```
-eclair.backup-notify-script = "absolute-path-to-your-script"
+eclair.backup-notify-script = "/path/to/script.sh"
 ```
-Make sure that your script is executable and uses an absolute path name for `eclair.bak`.
+Make sure that your script is executable and uses an absolute path name for `eclair.sqlite.bak`.
 
-Note that depending on your filesystem, in your backup process we recommend first moving `eclair.bak` to some temporary file 
+Note that depending on your filesystem, in your backup process we recommend first moving `eclair.sqlite.bak` to some temporary file 
 before copying that file to your final backup location.
 
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ always consistent and safe to use even when Eclair is running, and this is what 
 
 For example you could configure a `cron` task for your backup job. Or you could configure an optional notification script to be called by eclair once a new database snapshot has been created, using the following option:
 ```
-eclair.backup-notify-script = "/path/to/script.sh"
+eclair.backup-notify-script = "/absolute/path/to/script.sh"
 ```
 Make sure that your script is executable and uses an absolute path name for `eclair.sqlite.bak`.
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -17,7 +17,7 @@ eclair {
   }
 
   // override this with a script/exe that will be called everytime a new database backup has been created
-  # backup-notify-script = "/path/to/script.sh"
+  # backup-notify-script = "/absolute/path/to/script.sh"
 
   watcher-type = "bitcoind" // other *experimental* values include "electrum"
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -238,7 +238,7 @@ class Setup(datadir: File,
       backupHandler = system.actorOf(SimpleSupervisor.props(
         BackupHandler.props(
           nodeParams.db,
-          new File(chaindir, "eclair.bak"),
+          new File(chaindir, "eclair.sqlite.bak"),
           if (config.hasPath("backup-notify-script")) Some(config.getString("backup-notify-script")) else None
         ),"backuphandler", SupervisorStrategy.Resume))
       audit = system.actorOf(SimpleSupervisor.props(Auditor.props(nodeParams), "auditor", SupervisorStrategy.Resume))


### PR DESCRIPTION
This removes any ambiguity about the content of the file.