### PR TITLE
Wireshark dissector support

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/ChaCha20Poly1305.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/ChaCha20Poly1305.scala
@@ -96,6 +96,9 @@ object ChaCha20 {
   */
 object ChaCha20Poly1305 extends Logging {
 
+  // This logger is used to dump encryption keys to enable traffic analysis by the lightning-dissector.
+  // See https://github.com/nayutaco/lightning-dissector for more details.
+  // It is disabled by default (in the logback.xml configuration file).
   val keyLogger = Logger("keylog")
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/ChaCha20Poly1305.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/ChaCha20Poly1305.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.crypto
 import java.nio.ByteOrder
 
 import fr.acinq.bitcoin.{ByteVector32, Protocol}
+import grizzled.slf4j.Logger
 import grizzled.slf4j.Logging
 import org.spongycastle.crypto.engines.ChaCha7539Engine
 import org.spongycastle.crypto.params.{KeyParameter, ParametersWithIV}
@@ -31,8 +32,8 @@ import scodec.bits.ByteVector
 object Poly1305 {
   /**
     *
-    * @param key  input key
-    * @param data input data
+    * @param key   input key
+    * @param datas input data
     * @return a 16 byte authentication tag
     */
   def mac(key: ByteVector, datas: ByteVector*): ByteVector = {
@@ -50,6 +51,7 @@ object Poly1305 {
   * see https://tools.ietf.org/html/rfc7539#section-2.5
   */
 object ChaCha20 {
+  val NonceLength = 12
 
   def encrypt(plaintext: ByteVector, key: ByteVector, nonce: ByteVector, counter: Int = 0): ByteVector = {
     val engine = new ChaCha7539Engine()
@@ -94,6 +96,8 @@ object ChaCha20 {
   */
 object ChaCha20Poly1305 extends Logging {
 
+  val keyLogger = Logger("keylog")
+
   /**
     *
     * @param key       32 bytes encryption key
@@ -106,7 +110,12 @@ object ChaCha20Poly1305 extends Logging {
     val polykey = ChaCha20.encrypt(ByteVector32.Zeroes, key, nonce)
     val ciphertext = ChaCha20.encrypt(plaintext, key, nonce, 1)
     val tag = Poly1305.mac(polykey, aad, pad16(aad), ciphertext, pad16(ciphertext), Protocol.writeUInt64(aad.length, ByteOrder.LITTLE_ENDIAN), Protocol.writeUInt64(ciphertext.length, ByteOrder.LITTLE_ENDIAN))
+
     logger.debug(s"encrypt($key, $nonce, $aad, $plaintext) = ($ciphertext, $tag)")
+    if (nonce === ByteVector.fill(ChaCha20.NonceLength)(0.byteValue)) {
+      keyLogger.debug(s"${tag.toHex} ${key.toHex}")
+    }
+
     (ciphertext, tag)
   }
 
@@ -124,7 +133,12 @@ object ChaCha20Poly1305 extends Logging {
     val tag = Poly1305.mac(polykey, aad, pad16(aad), ciphertext, pad16(ciphertext), Protocol.writeUInt64(aad.length, ByteOrder.LITTLE_ENDIAN), Protocol.writeUInt64(ciphertext.length, ByteOrder.LITTLE_ENDIAN))
     require(tag == mac, "invalid mac")
     val plaintext = ChaCha20.decrypt(ciphertext, key, nonce, 1)
+
     logger.debug(s"decrypt($key, $nonce, $aad, $ciphertext, $mac) = $plaintext")
+    if (nonce === ByteVector.fill(ChaCha20.NonceLength)(0.byteValue)) {
+      keyLogger.debug(s"${mac.toHex} ${key.toHex}")
+    }
+
     plaintext
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/ChaCha20Poly1305.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/ChaCha20Poly1305.scala
@@ -51,7 +51,8 @@ object Poly1305 {
   * see https://tools.ietf.org/html/rfc7539#section-2.5
   */
 object ChaCha20 {
-  val NonceLength = 12
+  // Whenever key rotation happens, we start with a nonce value of 0 and increment it for each message.
+  val ZeroNonce = ByteVector.fill(12)(0.byteValue)
 
   def encrypt(plaintext: ByteVector, key: ByteVector, nonce: ByteVector, counter: Int = 0): ByteVector = {
     val engine = new ChaCha7539Engine()
@@ -115,7 +116,7 @@ object ChaCha20Poly1305 extends Logging {
     val tag = Poly1305.mac(polykey, aad, pad16(aad), ciphertext, pad16(ciphertext), Protocol.writeUInt64(aad.length, ByteOrder.LITTLE_ENDIAN), Protocol.writeUInt64(ciphertext.length, ByteOrder.LITTLE_ENDIAN))
 
     logger.debug(s"encrypt($key, $nonce, $aad, $plaintext) = ($ciphertext, $tag)")
-    if (nonce === ByteVector.fill(ChaCha20.NonceLength)(0.byteValue)) {
+    if (nonce === ChaCha20.ZeroNonce) {
       keyLogger.debug(s"${tag.toHex} ${key.toHex}")
     }
 
@@ -138,7 +139,7 @@ object ChaCha20Poly1305 extends Logging {
     val plaintext = ChaCha20.decrypt(ciphertext, key, nonce, 1)
 
     logger.debug(s"decrypt($key, $nonce, $aad, $ciphertext, $mac) = $plaintext")
-    if (nonce === ByteVector.fill(ChaCha20.NonceLength)(0.byteValue)) {
+    if (nonce === ChaCha20.ZeroNonce) {
       keyLogger.debug(s"${mac.toHex} ${key.toHex}")
     }
 

--- a/eclair-node/src/main/resources/logback.xml
+++ b/eclair-node/src/main/resources/logback.xml
@@ -39,6 +39,13 @@
         </encoder>
     </appender>
 
+    <appender name="KEYLOG" class="ch.qos.logback.core.FileAppender">
+        <file>${eclair.datadir:-${user.home}/.eclair}/keys.log</file>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+    </appender>
+
     <if condition='isDefined("eclair.printToConsole")'>
         <then>
             <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -51,6 +58,16 @@
             </root>
         </then>
     </if>
+
+    <!--
+    This logger can be used to dump encryption keys for traffic analysis.
+    It is used by the wireshark lightning dissector to troubleshoot issues between nodes.
+    To enable it, set the log level to "DEBUG" for this logger (no need to set it for the root logger).
+    See https://github.com/nayutaco/lightning-dissector for details.
+     -->
+    <logger level="OFF" name="keylog" additivity="false">
+        <appender-ref ref="KEYLOG"/>
+    </logger>
 
     <root level="INFO">
         <appender-ref ref="ROLLING"/>


### PR DESCRIPTION
The wireshark lightning-dissector used a hack to work with eclair: it read our log file in debug mode and parsed the encryptions keys via a very brittle regex. Unfortunately our log format had changed, thus breaking the regex.

The recommended way to integrate with the dissector is to write keys to a log file whenever key rotation happens (see https://github.com/nayutaco/lightning-dissector/blob/master/CONTRIBUTING.md).

This PR adds a new logger dedicated to that task, disabled by default. I also made the necessary changes to the `lightning-dissector` lua plugin and will send a PR upstream once we agree on the eclair changes.