### PR TITLE
Update bash autocompletition for eclair-cli

### DIFF
--- a/contrib/eclair-cli.bash-completion
+++ b/contrib/eclair-cli.bash-completion
@@ -21,7 +21,7 @@ _eclair-cli()
         *)
             # works fine, but is too slow at the moment.
             # allopts=$($eclaircli help 2>&1 | awk '$1 ~ /^"/ { sub(/,/, ""); print $1}' | sed 's/[":]//g')
-            allopts="getinfo connect open close forceclose updaterelayfee peers channels channel allnodes allchannels allupdates receive parseinvoice findroute findroutetonode send sendtonode checkpayment audit networkfees channelstats"
+            allopts="getinfo connect open close forceclose updaterelayfee peers channels channel allnodes allchannels allupdates findroute findroutetonode parseinvoice payinvoice sendtonode getsentinfo createinvoice getinvoice listinvoices listpendinginvoices getreceivedinfo audit networkfees channelstats"
 
             if ! [[ " $allopts " =~ " $prev " ]]; then          # prevent double arguments
                 if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then

--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -28,10 +28,10 @@ where OPTIONS can be:
 
 and COMMAND is one of:
   getinfo, connect, open, close, forceclose, updaterelayfee,
-  peers, channels, channel, allnodes, allchannels, allupdates,
-  receive, parseinvoice, findroute, findroutetonode,
-  payinvoice, sendtonode, getreceivedinfo, audit, networkfees,
-  channelstats, getsentinfo, getinvoice, allinvoice, listpendinginvoices
+  peers, channels, channel, allnodes, allchannels, allupdates
+  findroute, findroutetonode, parseinvoice, payinvoice, sendtonode,
+  getsentinfo, createinvoice, getinvoice, listinvoices,
+  listpendinginvoices, getreceivedinfo, audit, networkfees, channelstats
 
 Examples
 --------


### PR DESCRIPTION
This PR updates the bash autocompletition for eclair-cli to suggest all the correct endpoints (updated for the new APIs).