### PR TITLE
Restrict scope of the code coverage report

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,3 +5,7 @@ coverage:
 
 comment:
   layout: "diff, files"
+
+ignore:
+  - "eclair-node/**/*"
+  - "eclair-node-gui/**/*"


### PR DESCRIPTION
Ignore subprojects *eclair-node* and *eclair-node-gui* when generating a coverage report (codecov).