### PR TITLE
Increase Service and EclairImpl test coverage

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -260,5 +260,11 @@
             <version>${akka.http.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-scala-scalatest_2.11</artifactId>
+            <version>1.4.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -38,8 +38,11 @@ import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAddress, No
 import TimestampQueryFilters._
 
 case class GetInfoResponse(nodeId: PublicKey, alias: String, chainHash: ByteVector32, blockHeight: Int, publicAddresses: Seq[NodeAddress])
+
 case class AuditResponse(sent: Seq[PaymentSent], received: Seq[PaymentReceived], relayed: Seq[PaymentRelayed])
+
 case class TimestampQueryFilters(from: Long, to: Long)
+
 object TimestampQueryFilters {
   def getDefaultTimestampFilters(from_opt: Option[Long], to_opt: Option[Long]) = {
     val from = from_opt.getOrElse(0L)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -34,10 +34,20 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import fr.acinq.eclair.payment.{PaymentReceived, PaymentRelayed, PaymentRequest, PaymentSent}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAddress, NodeAnnouncement}
+import TimestampQueryFilters._
 
 case class GetInfoResponse(nodeId: PublicKey, alias: String, chainHash: ByteVector32, blockHeight: Int, publicAddresses: Seq[NodeAddress])
-
 case class AuditResponse(sent: Seq[PaymentSent], received: Seq[PaymentReceived], relayed: Seq[PaymentRelayed])
+case class TimestampQueryFilters(from: Long, to: Long)
+object TimestampQueryFilters {
+  def getDefaultTimestampFilters(from_opt: Option[Long], to_opt: Option[Long]) = {
+    val from = from_opt.getOrElse(0L)
+    val to = to_opt.getOrElse(MaxEpochSeconds)
+
+    TimestampQueryFilters(from, to)
+  }
+}
+
 
 trait Eclair {
 
@@ -215,13 +225,6 @@ class EclairImpl(appKit: Kit) extends Eclair {
     appKit.nodeParams.db.payments.getPaymentRequest(paymentHash)
   }
 
-  def getDefaultTimestampFilters(from_opt: Option[Long], to_opt: Option[Long]) = {
-    val from = from_opt.getOrElse(0L)
-    val to = to_opt.getOrElse(MaxEpochSeconds)
-
-    TimestampQueryFilters(from, to)
-  }
-
   /**
     * Sends a request to a channel and expects a response
     *
@@ -241,7 +244,5 @@ class EclairImpl(appKit: Kit) extends Eclair {
       blockHeight = Globals.blockCount.intValue(),
       publicAddresses = appKit.nodeParams.publicAddresses)
   )
-
-  case class TimestampQueryFilters(from: Long, to: Long)
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -200,7 +200,7 @@ class EclairImplSpec extends TestKit(ActorSystem("mySystem")) with fixture.FunSu
     val fResponse = eclair.networkFees(None, None)
 
     awaitCond({ fResponse.isCompleted }, 10 seconds)
-    auditDb.listNetworkFees(eqTo(0), eqTo(MaxEpochSeconds)).wasCalled(once) // assert the call was made only once and with the specified params
+    auditDb.listNetworkFees(0, MaxEpochSeconds).wasCalled(once) // assert the call was made only once and with the specified params
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -33,14 +33,11 @@ import TestConstants._
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.router.RouteCalculationSpec.makeUpdate
-import org.mockito.Mockito
-import org.mockito.scalatest.MockitoSugar
 import org.mockito.scalatest.IdiomaticMockito
-
 import scala.util.{Failure, Success}
 import scala.concurrent.duration._
 
-class EclairImplSpec extends TestKit(ActorSystem("mySystem")) with fixture.FunSuiteLike with IdiomaticMockito with Matchers {
+class EclairImplSpec extends TestKit(ActorSystem("mySystem")) with fixture.FunSuiteLike with IdiomaticMockito {
 
   implicit val timeout = Timeout(30 seconds)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -18,18 +18,20 @@ package fr.acinq.eclair
 
 import akka.actor.ActorSystem
 import akka.testkit.{TestKit, TestProbe}
-import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.{ByteVector32, MilliSatoshi}
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.blockchain.TestWallet
 import fr.acinq.eclair.io.Peer.OpenChannel
-import fr.acinq.eclair.payment.PaymentLifecycle.{SendPayment}
+import fr.acinq.eclair.payment.PaymentLifecycle.{ReceivePayment, SendPayment}
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import org.scalatest.{Outcome, fixture}
 import scodec.bits._
 import TestConstants._
 import fr.acinq.eclair.channel.{CMD_FORCECLOSE, Register}
+import fr.acinq.eclair.payment.PaymentRequest
 import fr.acinq.eclair.router.RouteCalculationSpec.makeUpdate
+
 import scala.util.{Failure, Success}
 import scala.concurrent.duration._
 
@@ -37,7 +39,7 @@ class EclairImplSpec extends TestKit(ActorSystem("mySystem")) with fixture.FunSu
 
   implicit val timeout = Timeout(30 seconds)
 
-  case class FixtureParam(register: TestProbe, router: TestProbe, paymentInitiator: TestProbe, switchboard: TestProbe, kit: Kit)
+  case class FixtureParam(register: TestProbe, router: TestProbe, paymentInitiator: TestProbe, switchboard: TestProbe, paymentHandler: TestProbe, kit: Kit)
 
   override def withFixture(test: OneArgTest): Outcome = {
     val watcher = TestProbe()
@@ -62,7 +64,7 @@ class EclairImplSpec extends TestKit(ActorSystem("mySystem")) with fixture.FunSu
       new TestWallet()
     )
 
-    withFixture(test.toNoArgTest(FixtureParam(register, router, paymentInitiator, switchboard, kit)))
+    withFixture(test.toNoArgTest(FixtureParam(register, router, paymentInitiator, switchboard, paymentHandler, kit)))
   }
 
   test("convert fee rate properly") { f =>
@@ -152,5 +154,23 @@ class EclairImplSpec extends TestKit(ActorSystem("mySystem")) with fixture.FunSu
     eclair.forceClose(Right(ShortChannelId("568749x2597x0")))
     register.expectMsg(Register.ForwardShortId(ShortChannelId("568749x2597x0"), CMD_FORCECLOSE))
   }
+
+  test("receive should have an optional fallback address and use millisatoshi") { f =>
+    import f._
+
+    val fallBackAddressRaw = "muhtvdmsnbQEPFuEmxcChX58fGvXaaUoVt"
+    val eclair = new EclairImpl(kit)
+    eclair.receive("some desc", Some(123L), Some(456), Some(fallBackAddressRaw))
+    val receive = paymentHandler.expectMsgType[ReceivePayment]
+
+    assert(receive.amountMsat_opt == Some(MilliSatoshi(123L)))
+    assert(receive.expirySeconds_opt == Some(456))
+    assert(receive.fallbackAddress == Some(fallBackAddressRaw))
+
+    // try with wrong address format
+    assertThrows[IllegalArgumentException](eclair.receive("some desc", Some(123L), Some(456), Some("wassa wassa")))
+  }
+
+
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -37,7 +37,8 @@ import fr.acinq.eclair.payment._
 import fr.acinq.eclair.router.{ChannelDesc, RouteResponse}
 import fr.acinq.eclair.wire.{ChannelUpdate, NodeAddress, NodeAnnouncement}
 import org.json4s.jackson.Serialization
-import org.scalatest.FunSuite
+import org.mockito.scalatest.IdiomaticMockito
+import org.scalatest.{FunSuite, Matchers}
 import scodec.bits.ByteVector
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -45,55 +46,7 @@ import scala.io.Source
 import scala.reflect.ClassTag
 import scala.util.Try
 
-class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
-
-  trait EclairMock extends Eclair {
-    override def connect(uri: String)(implicit timeout: Timeout): Future[String] = ???
-
-    override def open(nodeId: Crypto.PublicKey, fundingSatoshis: Long, pushMsat: Option[Long], fundingFeerateSatByte: Option[Long], flags: Option[Int], timeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[String] = ???
-
-    override def close(channelIdentifier: Either[ByteVector32, ShortChannelId], scriptPubKey: Option[ByteVector])(implicit timeout: Timeout): Future[String] = ???
-
-    override def forceClose(channelIdentifier: Either[ByteVector32, ShortChannelId])(implicit timeout: Timeout): Future[String] = ???
-
-    override def updateRelayFee(channelIdentifier: Either[ByteVector32, ShortChannelId], feeBaseMsat: Long, feeProportionalMillionths: Long)(implicit timeout: Timeout): Future[String] = ???
-
-    override def channelsInfo(toRemoteNode: Option[Crypto.PublicKey])(implicit timeout: Timeout): Future[Iterable[RES_GETINFO]] = ???
-
-    override def channelInfo(channelIdentifier: Either[ByteVector32, ShortChannelId])(implicit timeout: Timeout): Future[RES_GETINFO] = ???
-
-    override def peersInfo()(implicit timeout: Timeout): Future[Iterable[PeerInfo]] = ???
-
-    override def receive(description: String, amountMsat: Option[Long], expire: Option[Long], fallbackAddress: Option[String])(implicit timeout: Timeout): Future[PaymentRequest] = ???
-
-    override def receivedInfo(paymentHash: ByteVector32)(implicit timeout: Timeout): Future[Option[IncomingPayment]] = ???
-
-    override def send(recipientNodeId: Crypto.PublicKey, amountMsat: Long, paymentHash: ByteVector32, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]], minFinalCltvExpiry: Option[Long], maxAttempts: Option[Int])(implicit timeout: Timeout): Future[UUID] = ???
-
-    override def sentInfo(id: Either[UUID, ByteVector32])(implicit timeout: Timeout): Future[Seq[OutgoingPayment]] = ???
-
-    override def findRoute(targetNodeId: Crypto.PublicKey, amountMsat: Long, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]])(implicit timeout: Timeout): Future[RouteResponse] = ???
-
-    override def audit(from_opt: Option[Long], to_opt: Option[Long])(implicit timeout: Timeout): Future[AuditResponse] = ???
-
-    override def networkFees(from_opt: Option[Long], to_opt: Option[Long])(implicit timeout: Timeout): Future[Seq[NetworkFee]] = ???
-
-    override def channelStats()(implicit timeout: Timeout): Future[Seq[Stats]] = ???
-
-    override def getInvoice(paymentHash: ByteVector32)(implicit timeout: Timeout): Future[Option[PaymentRequest]] = ???
-
-    override def pendingInvoices(from_opt: Option[Long], to_opt: Option[Long])(implicit timeout: Timeout): Future[Seq[PaymentRequest]] = ???
-
-    override def allInvoices(from_opt: Option[Long], to_opt: Option[Long])(implicit timeout: Timeout): Future[Seq[PaymentRequest]] = ???
-
-    override def allNodes()(implicit timeout: Timeout): Future[Iterable[NodeAnnouncement]] = ???
-
-    override def allChannels()(implicit timeout: Timeout): Future[Iterable[ChannelDesc]] = ???
-
-    override def allUpdates(nodeId: Option[Crypto.PublicKey])(implicit timeout: Timeout): Future[Iterable[ChannelUpdate]] = ???
-
-    override def getInfoResponse()(implicit timeout: Timeout): Future[GetInfoResponse] = ???
-  }
+class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMockito with Matchers {
 
   implicit val formats = JsonSupport.formats
   implicit val serialization = JsonSupport.serialization
@@ -112,7 +65,7 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
   }
 
   test("API service should handle failures correctly") {
-    val mockService = new MockService(new EclairMock {})
+    val mockService = new MockService(mock[Eclair])
 
     // no auth
     Post("/getinfo") ~>
@@ -164,19 +117,19 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
 
   test("'peers' should ask the switchboard for current known peers") {
 
-    val mockService = new MockService(new EclairMock {
-      override def peersInfo()(implicit timeout: Timeout): Future[Iterable[PeerInfo]] = Future.successful(List(
-        PeerInfo(
-          nodeId = Alice.nodeParams.nodeId,
-          state = "CONNECTED",
-          address = Some(Alice.nodeParams.publicAddresses.head.socketAddress),
-          channels = 1),
-        PeerInfo(
-          nodeId = Bob.nodeParams.nodeId,
-          state = "DISCONNECTED",
-          address = None,
-          channels = 1)))
-    })
+    val eclair = mock[Eclair]
+    val mockService = new MockService(eclair)
+    eclair.peersInfo()(any[Timeout]) returns Future.successful(List(
+      PeerInfo(
+        nodeId = Alice.nodeParams.nodeId,
+        state = "CONNECTED",
+        address = Some(Alice.nodeParams.publicAddresses.head.socketAddress),
+        channels = 1),
+      PeerInfo(
+        nodeId = Bob.nodeParams.nodeId,
+        state = "DISCONNECTED",
+        address = None,
+        channels = 1)))
 
     Post("/peers") ~>
       addCredentials(BasicHttpCredentials("", mockService.password)) ~>
@@ -185,21 +138,22 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
         assert(handled)
         assert(status == OK)
         val response = entityAs[String]
+        eclair.peersInfo()(any[Timeout]).wasCalled(once)
         matchTestJson("peers", response)
       }
   }
 
   test("'getinfo' response should include this node ID") {
 
-    val mockService = new MockService(new EclairMock {
-      override def getInfoResponse()(implicit timeout: Timeout): Future[GetInfoResponse] = Future.successful(GetInfoResponse(
-        nodeId = Alice.nodeParams.nodeId,
-        alias = Alice.nodeParams.alias,
-        chainHash = Alice.nodeParams.chainHash,
-        blockHeight = 9999,
-        publicAddresses = NodeAddress.fromParts("localhost", 9731).get :: Nil
-      ))
-    })
+    val eclair = mock[Eclair]
+    val mockService = new MockService(eclair)
+    eclair.getInfoResponse()(any[Timeout]) returns Future.successful(GetInfoResponse(
+      nodeId = Alice.nodeParams.nodeId,
+      alias = Alice.nodeParams.alias,
+      chainHash = Alice.nodeParams.chainHash,
+      blockHeight = 9999,
+      publicAddresses = NodeAddress.fromParts("localhost", 9731).get :: Nil
+    ))
 
     Post("/getinfo") ~>
       addCredentials(BasicHttpCredentials("", mockService.password)) ~>
@@ -209,6 +163,7 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
         assert(status == OK)
         val resp = entityAs[String]
         assert(resp.toString.contains(Alice.nodeParams.nodeId.toString))
+        eclair.getInfoResponse()(any[Timeout]).wasCalled(once)
         matchTestJson("getinfo", resp)
       }
   }
@@ -218,11 +173,9 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
     val shortChannelIdSerialized = "42000x27x3"
     val channelId = "56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e"
 
-    val mockService = new MockService(new EclairMock {
-      override def close(channelIdentifier: Either[ByteVector32, ShortChannelId], scriptPubKey: Option[ByteVector])(implicit timeout: Timeout): Future[String] = {
-        Future.successful(Alice.nodeParams.nodeId.toString())
-      }
-    })
+    val eclair = mock[Eclair]
+    eclair.close(any, any)(any[Timeout]) returns Future.successful(Alice.nodeParams.nodeId.toString())
+    val mockService = new MockService(eclair)
 
     Post("/close", FormData("shortChannelId" -> shortChannelIdSerialized).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockService.password)) ~>
@@ -233,6 +186,7 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
         assert(status == OK)
         val resp = entityAs[String]
         assert(resp.contains(Alice.nodeParams.nodeId.toString))
+        eclair.close(Right(ShortChannelId(shortChannelIdSerialized)), None)(any[Timeout]).wasCalled(once)
         matchTestJson("close", resp)
       }
 
@@ -245,6 +199,7 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
         assert(status == OK)
         val resp = entityAs[String]
         assert(resp.contains(Alice.nodeParams.nodeId.toString))
+        eclair.close(Left(ByteVector32.fromValidHex(channelId)), None)(any[Timeout]).wasCalled(once)
         matchTestJson("close", resp)
       }
   }
@@ -255,9 +210,9 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
     val remoteHost = "93.137.102.239"
     val remoteUri = "030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87@93.137.102.239:9735"
 
-    val mockService = new MockService(new EclairMock {
-      override def connect(uri: String)(implicit timeout: Timeout): Future[String] = Future.successful("connected")
-    })
+    val eclair = mock[Eclair]
+    eclair.connect(any[String])(any[Timeout]) returns Future.successful("connected")
+    val mockService = new MockService(eclair)
 
     Post("/connect", FormData("nodeId" -> remoteNodeId, "host" -> remoteHost).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockService.password)) ~>
@@ -266,6 +221,7 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
         assert(handled)
         assert(status == OK)
         assert(entityAs[String] == "\"connected\"")
+        eclair.connect(remoteUri)(any[Timeout]).wasCalled(once)
       }
 
     Post("/connect", FormData("uri" -> remoteUri).toEntity) ~>
@@ -275,21 +231,17 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
         assert(handled)
         assert(status == OK)
         assert(entityAs[String] == "\"connected\"")
+        eclair.connect(remoteUri)(any[Timeout]).wasCalled(twice) // must account for the previous, identical, invocation
       }
   }
 
-  test("'send' method should return the UUID of the outgoing payment") {
+  test("'send' method should correctly forward amount parameters to EclairImpl") {
 
     val invoice = "lnbc12580n1pw2ywztpp554ganw404sh4yjkwnysgn3wjcxfcq7gtx53gxczkjr9nlpc3hzvqdq2wpskwctddyxqr4rqrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glc7z9rtvqqwngqqqqqqqlgqqqqqeqqjqrrt8smgjvfj7sg38dwtr9kc9gg3era9k3t2hvq3cup0jvsrtrxuplevqgfhd3rzvhulgcxj97yjuj8gdx8mllwj4wzjd8gdjhpz3lpqqvk2plh"
-    val idsAndAmounts = new collection.mutable.HashMap[UUID, Long]()
 
-    val mockService = new MockService(new EclairMock {
-      override def send(recipientNodeId: Crypto.PublicKey, amountMsat: Long, paymentHash: ByteVector32, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]], minFinalCltvExpiry: Option[Long], maxAttempts: Option[Int] = None)(implicit timeout: Timeout): Future[UUID] = Future.successful {
-        val id = UUID.randomUUID()
-        idsAndAmounts.put(id, amountMsat)
-        id
-      }
-    })
+    val eclair = mock[Eclair]
+    eclair.send(any, any, any, any, any, any)(any[Timeout]) returns Future.successful(UUID.randomUUID())
+    val mockService = new MockService(eclair)
 
     Post("/payinvoice", FormData("invoice" -> invoice).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockService.password)) ~>
@@ -297,9 +249,7 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
       check {
         assert(handled)
         assert(status == OK)
-        val rawId = entityAs[String].drop(1).dropRight(1) // remove trailing double-quotes
-        val id = UUID.fromString(rawId)
-        idsAndAmounts(id) === 12580
+        eclair.send(any, 1258000, any, any, any, any)(any[Timeout]).wasCalled(once)
       }
 
 
@@ -309,18 +259,16 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
       check {
         assert(handled)
         assert(status == OK)
-        val rawId = entityAs[String].drop(1).dropRight(1) // remove trailing double-quotes
-        val id = UUID.fromString(rawId)
-        idsAndAmounts(id) === 123
+        eclair.send(any, 123, any, any, any, any)(any[Timeout]).wasCalled(once)
       }
 
   }
 
-  test("'receivedinfo' method should respond HTTP 404 with a JSON encoded response if the element is not found") {
+  test("'getreceivedinfo' method should respond HTTP 404 with a JSON encoded response if the element is not found") {
 
-    val mockService = new MockService(new EclairMock {
-      override def receivedInfo(paymentHash: ByteVector32)(implicit timeout: Timeout): Future[Option[IncomingPayment]] = Future.successful(None) // element not found
-    })
+    val eclair = mock[Eclair]
+    eclair.receivedInfo(any[ByteVector32])(any) returns Future.successful(None)
+    val mockService = new MockService(eclair)
 
     Post("/getreceivedinfo", FormData("paymentHash" -> ByteVector32.Zeroes.toHex).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockService.password)) ~>
@@ -330,34 +278,29 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
         assert(status == NotFound)
         val resp = entityAs[ErrorResponse](JsonSupport.unmarshaller, ClassTag(classOf[ErrorResponse]))
         assert(resp == ErrorResponse("Not found"))
+        eclair.receivedInfo(ByteVector32.Zeroes)(any[Timeout]).wasCalled(once)
       }
   }
 
   test("'updaterelayfee' should use named parameters") {
 
-    val mockService = new MockService(new EclairMock {
-      override def updateRelayFee(channelIdentifier: Either[ByteVector32, ShortChannelId], feeBaseMsat: Long, feeProportionalMillionths: Long)(implicit timeout: Timeout): Future[String] = Future.successful(
-        s"$channelIdentifier:::$feeBaseMsat:::$feeProportionalMillionths"
-      )
-    })
-
+    val eclair = mock[Eclair]
+    eclair.updateRelayFee(any, any[Long], any[Long])(timeout = any[Timeout]) returns Future.successful("done")
+    val service = new MockService(eclair)
 
     Post("/updaterelayfee", FormData("channelId" -> ByteVector32.Zeroes.toHex, "feeBaseMsat" -> "123", "feeProportionalMillionths" -> "456").toEntity) ~>
-      addCredentials(BasicHttpCredentials("", mockService.password)) ~>
-      Route.seal(mockService.route) ~>
+      addCredentials(BasicHttpCredentials("", service.password)) ~>
+      Route.seal(service.route) ~>
       check {
         assert(handled)
         assert(status == OK)
-        val Array(channelId, feeBase, feeProportional) = entityAs[String].drop(1).dropRight(1).split(":::")
-        assert(channelId == Left(ByteVector32.Zeroes.toHex).toString)
-        assert(feeBase == "123")
-        assert(feeProportional == "456")
+        eclair.updateRelayFee(Left(ByteVector32.Zeroes), 123, 456)(any[Timeout]).wasCalled(once)
       }
   }
 
   test("the websocket should return typed objects") {
 
-    val mockService = new MockService(new EclairMock {})
+    val mockService = new MockService(mock[Eclair])
     val fixedUUID = UUID.fromString("487da196-a4dc-4b1e-92b4-3e5e905e9f3f")
 
     val wsClient = WSProbe()


### PR DESCRIPTION
Improves the API test to match the ~80% test coverage that we have on eclair, it also add the test-scoped dependency of [mockito](https://github.com/mockito/mockito-scala) to simplify mocking services in the tests.