### PR TITLE
Peer reconnection address from node announcements

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
@@ -23,8 +23,10 @@ import akka.util.Timeout
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.ShortChannelId
+import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.PaymentRequest
 import scodec.bits.ByteVector
+
 import scala.concurrent.duration._
 
 object FormParamExtractors {
@@ -55,6 +57,10 @@ object FormParamExtractors {
 
   implicit val timeoutSecondsUnmarshaller: Unmarshaller[String, Timeout] = Unmarshaller.strict { str =>
     Timeout(str.toInt.seconds)
+  }
+
+  implicit val nodeURIUnmarshaller: Unmarshaller[String, NodeURI] = Unmarshaller.strict { str =>
+    NodeURI.parse(str)
   }
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -30,6 +30,7 @@ import akka.http.scaladsl.server.directives.Credentials
 import akka.stream.scaladsl.{BroadcastHub, Flow, Keep, Source}
 import akka.stream.{ActorMaterializer, OverflowStrategy}
 import akka.util.Timeout
+import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.api.FormParamExtractors._
@@ -41,6 +42,7 @@ import fr.acinq.eclair.{Eclair, ShortChannelId}
 import grizzled.slf4j.Logging
 import org.json4s.jackson.Serialization
 import scodec.bits.ByteVector
+
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
@@ -138,7 +140,7 @@ trait Service extends ExtraDirectives with Logging {
                         formFields("uri".as[NodeURI]) { uri =>
                           complete(eclairApi.connect(Left(uri)))
                         } ~ formFields(nodeIdFormParam, "host".as[String], "port".as[Int].?) { (nodeId, host, port_opt) =>
-complete(eclairApi.connect(Left(NodeURI(nodeId, HostAndPort.fromParts(host, port_opt.getOrElse(NodeURI.DEFAULT_PORT))))))
+                          complete(eclairApi.connect(Left(NodeURI(nodeId, HostAndPort.fromParts(host, port_opt.getOrElse(NodeURI.DEFAULT_PORT))))))
                         } ~ formFields(nodeIdFormParam) { nodeId =>
                           complete(eclairApi.connect(Right(nodeId)))
                         }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -138,7 +138,7 @@ trait Service extends ExtraDirectives with Logging {
                         formFields("uri".as[NodeURI]) { uri =>
                           complete(eclairApi.connect(Left(uri)))
                         } ~ formFields(nodeIdFormParam, "host".as[String], "port".as[Int].?) { (nodeId, host, port_opt) =>
-                          complete(eclairApi.connect(Left(NodeURI.parse(s"$nodeId@$host:${port_opt.getOrElse(NodeURI.DEFAULT_PORT)}"))))
+complete(eclairApi.connect(Left(NodeURI(nodeId, HostAndPort.fromParts(host, port_opt.getOrElse(NodeURI.DEFAULT_PORT))))))
                         } ~ formFields(nodeIdFormParam) { nodeId =>
                           complete(eclairApi.connect(Right(nodeId)))
                         }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -143,6 +143,11 @@ trait Service extends ExtraDirectives with Logging {
                           complete(eclairApi.connect(Right(nodeId)))
                         }
                       } ~
+                      path("disconnect") {
+                        formFields(nodeIdFormParam) { nodeId =>
+                          complete(eclairApi.disconnect(nodeId))
+                        }
+                      } ~
                       path("open") {
                         formFields(nodeIdFormParam, "fundingSatoshis".as[Long], "pushMsat".as[Long].?, "fundingFeerateSatByte".as[Long].?, "channelFlags".as[Int].?, "openTimeoutSeconds".as[Timeout].?) {
                           (nodeId, fundingSatoshis, pushMsat, fundingFeerateSatByte, channelFlags, openTimeout_opt) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -135,10 +135,12 @@ trait Service extends ExtraDirectives with Logging {
                       complete(eclairApi.getInfoResponse())
                     } ~
                       path("connect") {
-                        formFields("uri".as[String]) { uri =>
-                          complete(eclairApi.connect(uri))
+                        formFields("uri".as[NodeURI]) { uri =>
+                          complete(eclairApi.connect(Left(uri)))
                         } ~ formFields(nodeIdFormParam, "host".as[String], "port".as[Int].?) { (nodeId, host, port_opt) =>
-                          complete(eclairApi.connect(s"$nodeId@$host:${port_opt.getOrElse(NodeURI.DEFAULT_PORT)}"))
+                          complete(eclairApi.connect(Left(NodeURI.parse(s"$nodeId@$host:${port_opt.getOrElse(NodeURI.DEFAULT_PORT)}"))))
+                        } ~ formFields(nodeIdFormParam) { nodeId =>
+                          complete(eclairApi.connect(Right(nodeId)))
                         }
                       } ~
                       path("open") {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
@@ -27,6 +27,8 @@ trait NetworkDb {
 
   def updateNode(n: NodeAnnouncement)
 
+  def getNode(nodeId: PublicKey): Option[NodeAnnouncement]
+
   def removeNode(nodeId: PublicKey)
 
   def listNodes(): Seq[NodeAnnouncement]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -59,6 +59,14 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
     }
   }
 
+  override def getNode(nodeId: Crypto.PublicKey): Option[NodeAnnouncement] = {
+    using(sqlite.prepareStatement("SELECT data FROM nodes WHERE node_id=?")) { statement =>
+      statement.setBytes(1, nodeId.toBin.toArray)
+      val rs = statement.executeQuery()
+      codecSequence(rs, nodeAnnouncementCodec).headOption
+    }
+  }
+
   override def removeNode(nodeId: Crypto.PublicKey): Unit = {
     using(sqlite.prepareStatement("DELETE FROM nodes WHERE node_id=?")) { statement =>
       statement.setBytes(1, nodeId.toBin.toArray)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -81,7 +81,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
       }
 
     case Event(Reconnect, d: DisconnectedData) =>
-      if(d.channels.isEmpty) stay
+      if (d.channels.isEmpty) stay
 
       d.address_opt.orElse(getPeerAddressFromNodeAnnouncement()) match {
         case None =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -85,7 +85,6 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
           log.warning(s"Unable to reconnect to peer, no address known")
           stay
         case Some(address) =>
-          // InetAddress.getHostAddress returns the IP address as string
           context.actorOf(Client.props(nodeParams, authenticator, address, remoteNodeId, origin_opt = None))
           log.info(s"reconnecting to $address")
           // exponential backoff retry with a finite max

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -87,7 +87,8 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
           stay
         case Some(address) =>
           // InetAddress.getHostAddress returns the IP address as string
-          context.actorOf(Client.props(nodeParams, authenticator, address, remoteNodeId, origin_opt = None), s"${d.attempts}-client-${address.getAddress.getHostAddress}:${address.getPort}")
+          context.actorOf(Client.props(nodeParams, authenticator, address, remoteNodeId, origin_opt = None))
+          log.info(s"reconnecting to $address")
           // exponential backoff retry with a finite max
           setTimer(RECONNECT_TIMER, Reconnect, Math.min(10 + Math.pow(2, d.attempts), 3600) seconds, repeat = false)
           stay using d.copy(attempts = d.attempts + 1)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -63,11 +63,10 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
         getPeerAddressFromNodeAnnouncement()
       } match {
         case None =>
-          log.warning(s"Unable to connect to $remoteNodeId no address found")
-          sender() ! s"Unable to connect to $remoteNodeId no address found"
+          sender ! "no address found"
           stopPeer()
         case Some(address) =>
-          if (d.address_opt.contains(address)) { // TODO check if we received a Connect for the same peer but with a different address
+          if (d.address_opt.contains(address)) {
             // we already know this address, we'll reconnect automatically
             sender ! "reconnection in progress"
             stay

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -89,7 +89,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
           stay
         case Some(address) =>
           context.actorOf(Client.props(nodeParams, authenticator, address, remoteNodeId, origin_opt = None))
-          // exponential backoff retry with a finite max
+          // exponential backoff retry with a finite max, the minimum MUST be above the tcp connect timeout.
           setTimer(RECONNECT_TIMER, Reconnect, Math.min(20 + Math.pow(2, d.attempts), 90) seconds, repeat = false)
           stay using d.copy(attempts = d.attempts + 1)
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -103,7 +103,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
         case Some((gf, lf)) => wire.Init(globalFeatures = gf, localFeatures = lf)
         case None => wire.Init(globalFeatures = nodeParams.globalFeatures, localFeatures = nodeParams.localFeatures)
       }
-      log.debug(s"using globalFeatures={} and localFeatures={}", localInit.globalFeatures.toBin, localInit.localFeatures.toBin)
+      log.info(s"using globalFeatures=${localInit.globalFeatures.toBin} and localFeatures=${localInit.localFeatures.toBin}")
       transport ! localInit
 
       val address_opt = if (outgoing) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -69,14 +69,14 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
           sender() ! s"Unable to connect to $remoteNodeId no address found"
           stopPeer()
         case Some(address) =>
-          if (d.address_opt.contains(address)) {
+          if (d.address_opt.contains(address)) { // TODO check if we received a Connect for the same peer but with a different address
             // we already know this address, we'll reconnect automatically
             sender ! "reconnection in progress"
             stay
           } else {
             // we immediately process explicit connection requests to new addresses
             context.actorOf(Client.props(nodeParams, authenticator, address, remoteNodeId, origin_opt = Some(sender())))
-            stay
+            stay using d.copy(address_opt = Some(address))
           }
       }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -89,8 +89,8 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
           stay
         case Some(address) =>
           context.actorOf(Client.props(nodeParams, authenticator, address, remoteNodeId, origin_opt = None))
-          // exponential backoff retry with a finite max, the minimum MUST be above the tcp connect timeout.
-          setTimer(RECONNECT_TIMER, Reconnect, Math.min(20 + Math.pow(2, d.attempts), 90) seconds, repeat = false)
+          // exponential backoff retry with a finite max
+          setTimer(RECONNECT_TIMER, Reconnect, Math.min(10 + Math.pow(2, d.attempts), 3600) seconds, repeat = false)
           stay using d.copy(attempts = d.attempts + 1)
       }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -64,7 +64,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
       } match {
         case None =>
           sender ! "no address found"
-          stopPeer()
+          stay
         case Some(address) =>
           if (d.address_opt.contains(address)) {
             // we already know this address, we'll reconnect automatically

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -185,7 +185,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
         stay using d.copy(channels = channels1)
       }
 
-    case Event(Disconnect(nodeId), d: ConnectedData) if nodeId == remoteNodeId =>
+    case Event(Disconnect(nodeId), d: InitializingData) if nodeId == remoteNodeId =>
       log.info("disconnecting")
       sender ! "disconnecting"
       d.transport ! PoisonPill

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -106,8 +106,6 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
 
   }
 
-  def peerActorName(remoteNodeId: PublicKey): String = s"peer-$remoteNodeId"
-
   /**
     * Retrieves a peer based on its public key.
     *
@@ -148,6 +146,8 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
 object Switchboard extends Logging {
 
   def props(nodeParams: NodeParams, authenticator: ActorRef, watcher: ActorRef, router: ActorRef, relayer: ActorRef, wallet: EclairWallet) = Props(new Switchboard(nodeParams, authenticator, watcher, router, relayer, wallet))
+
+  def peerActorName(remoteNodeId: PublicKey): String = s"peer-$remoteNodeId"
 
   /**
     * If we have stopped eclair while it was forwarding HTLCs, it is possible that we are in a state were an incoming HTLC

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -112,6 +112,8 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
 
   }
 
+  def peerActorName(remoteNodeId: PublicKey): String = s"peer-$remoteNodeId"
+
   /**
     * Retrieves a peer based on its public key.
     *
@@ -152,8 +154,6 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
 object Switchboard extends Logging {
 
   def props(nodeParams: NodeParams, authenticator: ActorRef, watcher: ActorRef, router: ActorRef, relayer: ActorRef, wallet: EclairWallet) = Props(new Switchboard(nodeParams, authenticator, watcher, router, relayer, wallet))
-
-  def peerActorName(remoteNodeId: PublicKey): String = s"peer-$remoteNodeId"
 
   /**
     * If we have stopped eclair while it was forwarding HTLCs, it is possible that we are in a state were an incoming HTLC

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -81,12 +81,12 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
 
   def receive: Receive = {
 
-    case Peer.Connect(NodeURI(publicKey, _)) if publicKey == nodeParams.nodeId =>
+    case Peer.Connect(publicKey, _) if publicKey == nodeParams.nodeId =>
       sender ! Status.Failure(new RuntimeException("cannot open connection with oneself"))
 
     case c: Peer.Connect =>
       // we create a peer if it doesn't exist
-      val peer = createOrGetPeer(c.uri.nodeId, previousKnownAddress = None, offlineChannels = Set.empty)
+      val peer = createOrGetPeer(c.nodeId, previousKnownAddress = None, offlineChannels = Set.empty)
       peer forward c
 
     case o: Peer.OpenChannel =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -89,6 +89,12 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
       val peer = createOrGetPeer(c.nodeId, previousKnownAddress = None, offlineChannels = Set.empty)
       peer forward c
 
+    case d: Peer.Disconnect =>
+      getPeer(d.nodeId) match {
+        case Some(peer) => peer forward d
+        case None       => sender ! Status.Failure(new RuntimeException("peer not found"))
+      }
+
     case o: Peer.OpenChannel =>
       getPeer(o.remoteNodeId) match {
         case Some(peer) => peer forward o

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -65,7 +65,11 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
     channels
       .groupBy(_.commitments.remoteParams.nodeId)
       .map {
-        case (remoteNodeId, states) => (remoteNodeId, states, peers.get(remoteNodeId))
+        case (remoteNodeId, states) =>
+          val address_opt = peers.get(remoteNodeId).orElse {
+            nodeParams.db.network.getNode(remoteNodeId).flatMap(_.addresses.headOption) // gets the first of the list! TODO improve selection?
+          }
+          (remoteNodeId, states, address_opt)
       }
       .foreach {
         case (remoteNodeId, states, nodeaddress_opt) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
@@ -28,7 +28,29 @@ import scala.concurrent.Await
   * This base class kills all actor between each tests.
   * Created by PM on 06/09/2016.
   */
-abstract class TestkitBaseClass extends TestKit(ActorSystem("test", ConfigFactory.parseString("""akka.loggers = ["akka.testkit.TestEventListener"]"""))) with fixture.FunSuiteLike with BeforeAndAfterEach with BeforeAndAfterAll {
+abstract class TestkitBaseClass extends TestKit(ActorSystem("test")) with fixture.FunSuiteLike with BeforeAndAfterEach with BeforeAndAfterAll {
+
+  override def beforeAll {
+    Globals.blockCount.set(400000)
+    Globals.feeratesPerKw.set(FeeratesPerKw.single(TestConstants.feeratePerKw))
+  }
+
+  override def afterEach() {
+    system.actorSelection(system / "*") ! PoisonPill
+    intercept[ActorNotFound] {
+      import scala.concurrent.duration._
+      Await.result(system.actorSelection(system / "*").resolveOne(42 days), 42 days)
+    }
+  }
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+    Globals.feeratesPerKw.set(FeeratesPerKw.single(1))
+  }
+
+}
+
+abstract class LoggingTestkitBaseClass extends TestKit(ActorSystem("test", ConfigFactory.parseString("""akka.loggers = ["akka.testkit.TestEventListener"]"""))) with fixture.FunSuiteLike with BeforeAndAfterEach with BeforeAndAfterAll {
 
   override def beforeAll {
     Globals.blockCount.set(400000)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
@@ -18,6 +18,7 @@ package fr.acinq.eclair
 
 import akka.actor.{ActorNotFound, ActorSystem, PoisonPill}
 import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
 import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, fixture}
 
@@ -27,7 +28,7 @@ import scala.concurrent.Await
   * This base class kills all actor between each tests.
   * Created by PM on 06/09/2016.
   */
-abstract class TestkitBaseClass extends TestKit(ActorSystem("test")) with fixture.FunSuiteLike with BeforeAndAfterEach with BeforeAndAfterAll {
+abstract class TestkitBaseClass extends TestKit(ActorSystem("test", ConfigFactory.parseString("""akka.loggers = ["akka.testkit.TestEventListener"]"""))) with fixture.FunSuiteLike with BeforeAndAfterEach with BeforeAndAfterAll {
 
   override def beforeAll {
     Globals.blockCount.set(400000)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestkitBaseClass.scala
@@ -49,25 +49,3 @@ abstract class TestkitBaseClass extends TestKit(ActorSystem("test")) with fixtur
   }
 
 }
-
-abstract class LoggingTestkitBaseClass extends TestKit(ActorSystem("test", ConfigFactory.parseString("""akka.loggers = ["akka.testkit.TestEventListener"]"""))) with fixture.FunSuiteLike with BeforeAndAfterEach with BeforeAndAfterAll {
-
-  override def beforeAll {
-    Globals.blockCount.set(400000)
-    Globals.feeratesPerKw.set(FeeratesPerKw.single(TestConstants.feeratePerKw))
-  }
-
-  override def afterEach() {
-    system.actorSelection(system / "*") ! PoisonPill
-    intercept[ActorNotFound] {
-      import scala.concurrent.duration._
-      Await.result(system.actorSelection(system / "*").resolveOne(42 days), 42 days)
-    }
-  }
-
-  override def afterAll {
-    TestKit.shutdownActorSystem(system)
-    Globals.feeratesPerKw.set(FeeratesPerKw.single(1))
-  }
-
-}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -31,6 +31,7 @@ import fr.acinq.eclair.TestConstants._
 import fr.acinq.eclair._
 import fr.acinq.eclair.channel.RES_GETINFO
 import fr.acinq.eclair.db.{IncomingPayment, NetworkFee, OutgoingPayment, Stats}
+import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.io.Peer.PeerInfo
 import fr.acinq.eclair.payment.PaymentLifecycle.PaymentFailed
 import fr.acinq.eclair.payment._
@@ -49,7 +50,7 @@ import scala.util.Try
 class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
 
   trait EclairMock extends Eclair {
-    override def connect(uri: String)(implicit timeout: Timeout): Future[String] = ???
+    override def connect(target: Either[NodeURI, Crypto.PublicKey])(implicit timeout: Timeout): Future[String] = ???
 
     override def open(nodeId: Crypto.PublicKey, fundingSatoshis: Long, pushMsat: Option[Long], fundingFeerateSatByte: Option[Long], flags: Option[Int], timeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[String] = ???
 
@@ -257,7 +258,7 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest {
     val remoteUri = "030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87@93.137.102.239:9735"
 
     val mockService = new MockService(new EclairMock {
-      override def connect(uri: String)(implicit timeout: Timeout): Future[String] = Future.successful("connected")
+      override def connect(target: Either[NodeURI, Crypto.PublicKey])(implicit timeout: Timeout): Future[String] = Future.successful("connected")
     })
 
     Post("/connect", FormData("nodeId" -> remoteNodeId, "host" -> remoteHost).toEntity) ~>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
@@ -47,6 +47,7 @@ class SqliteNetworkDbSpec extends FunSuite {
     assert(db.listNodes().toSet === Set.empty)
     db.addNode(node_1)
     db.addNode(node_1) // duplicate is ignored
+    assert(db.getNode(node_1.nodeId) == Some(node_1))
     assert(db.listNodes().size === 1)
     db.addNode(node_2)
     db.addNode(node_3)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -486,7 +486,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     sender.send(nodes("F1").switchboard, 'peers)
     val peers = sender.expectMsgType[Iterable[ActorRef]]
     // F's only node is C
-    peers.head ! Disconnect
+    peers.head ! Peer.Disconnect(nodes("C").nodeParams.nodeId)
     // we then wait for F to be in disconnected state
     awaitCond({
       sender.send(nodes("F1").register, Forward(htlc.channelId, CMD_GETSTATE))
@@ -567,7 +567,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     sender.send(nodes("F2").switchboard, 'peers)
     val peers = sender.expectMsgType[Iterable[ActorRef]]
     // F's only node is C
-    peers.head ! Disconnect
+    peers.head ! Disconnect(nodes("C").nodeParams.nodeId)
     // we then wait for F to be in disconnected state
     awaitCond({
       sender.send(nodes("F2").register, Forward(htlc.channelId, CMD_GETSTATE))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -159,9 +159,10 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
   def connect(node1: Kit, node2: Kit, fundingSatoshis: Long, pushMsat: Long) = {
     val sender = TestProbe()
     val address = node2.nodeParams.publicAddresses.head
-    sender.send(node1.switchboard, Peer.Connect(NodeURI(
+    sender.send(node1.switchboard, Peer.Connect(
       nodeId = node2.nodeParams.nodeId,
-      address = HostAndPort.fromParts(address.socketAddress.getHostString, address.socketAddress.getPort))))
+      address_opt = Some(HostAndPort.fromParts(address.socketAddress.getHostString, address.socketAddress.getPort))
+    ))
     sender.expectMsgAnyOf(10 seconds, "connected", "already connected")
     sender.send(node1.switchboard, Peer.OpenChannel(
       remoteNodeId = node2.nodeParams.nodeId,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -21,7 +21,6 @@ import java.net.{Inet4Address, InetSocketAddress}
 import akka.actor.{ActorRef, ActorSystem}
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.testkit.{EventFilter, TestFSMRef, TestKit, TestProbe}
-import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.TestConstants._
 import fr.acinq.eclair._
@@ -38,7 +37,7 @@ import org.scalatest.{Outcome, Tag}
 import scodec.bits.ByteVector
 import scala.concurrent.duration._
 
-class PeerSpec extends LoggingTestkitBaseClass {
+class PeerSpec extends TestkitBaseClass {
 
   def ipv4FromInet4(address: InetSocketAddress) = IPv4.apply(address.getAddress.asInstanceOf[Inet4Address], address.getPort)
 
@@ -150,18 +149,6 @@ class PeerSpec extends LoggingTestkitBaseClass {
     probe.send(peer, Peer.Init(Some(previouslyKnownAddress), Set.empty))
     probe.send(peer, Peer.Reconnect)
     probe.expectNoMsg()
-  }
-
-  test("reconnect using the address from node_announcement", Tag("with_node_announcements")) { f =>
-    import f._
-
-    val probe = TestProbe()
-    awaitCond({peer.stateName.toString == "INSTANTIATING"}, 10 seconds)
-    probe.send(peer, Peer.Init(None, Set(ChannelStateSpec.normal)))
-    awaitCond({peer.stateName.toString == "DISCONNECTED" && peer.stateData.address_opt.isEmpty}, 10 seconds)
-    EventFilter.info(message = s"reconnecting to ${fakeIPAddress.socketAddress}", occurrences = 1) intercept {
-      probe.send(peer, Peer.Reconnect)
-    }
   }
 
   test("count reconnections") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -38,7 +38,7 @@ import org.scalatest.{Outcome, Tag}
 import scodec.bits.ByteVector
 import scala.concurrent.duration._
 
-class PeerSpec extends TestkitBaseClass {
+class PeerSpec extends LoggingTestkitBaseClass {
 
   def ipv4FromInet4(address: InetSocketAddress) = IPv4.apply(address.getAddress.asInstanceOf[Inet4Address], address.getPort)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -97,7 +97,7 @@ class PeerSpec extends TestkitBaseClass {
     probe.expectMsg(PeerInfo(remoteNodeId, "CONNECTED", Some(fakeIPAddress.socketAddress), 1))
   }
 
-  test("fail if no address was specified during connection and no address was found in node_announcement") { f =>
+  test("fail to connect if no address provided or found") { f =>
     import f._
 
     val probe = TestProbe()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -107,8 +107,7 @@ class PeerSpec extends LoggingTestkitBaseClass {
     val CurrentState(_, INSTANTIATING) = monitor.expectMsgType[CurrentState[_]]
     val Transition(_, INSTANTIATING, DISCONNECTED) = monitor.expectMsgType[Transition[_]]
     probe.send(peer, Peer.Connect(remoteNodeId, address_opt = None))
-    probe.expectMsg(s"Unable to connect to $remoteNodeId no address found")
-    //monitor.expectMsgType[Transition[_]]
+    probe.expectMsg(s"no address found")
   }
 
   test("if no address was specified during connection use the one from node_announcement", Tag("with_node_announcements")) { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -16,13 +16,14 @@
 
 package fr.acinq.eclair.io
 
-import java.net.{Inet4Address, InetAddress, InetSocketAddress}
+import java.net.{Inet4Address, InetSocketAddress}
 
+import akka.actor.ActorRef
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
-import akka.actor.{ActorRef, PoisonPill, Terminated}
 import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.TestConstants._
+import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.EclairWallet
 import fr.acinq.eclair.channel.HasCommitments
 import fr.acinq.eclair.crypto.TransportHandler
@@ -32,10 +33,8 @@ import fr.acinq.eclair.router.RoutingSyncSpec.makeFakeRoutingInfo
 import fr.acinq.eclair.router.{ChannelRangeQueries, ChannelRangeQueriesSpec, Rebroadcast}
 import fr.acinq.eclair.wire.LightningMessageCodecsSpec.randomSignature
 import fr.acinq.eclair.wire.{Color, Error, IPv4, NodeAddress, NodeAnnouncement, Ping, Pong}
-import fr.acinq.eclair._
 import org.scalatest.{Outcome, Tag}
 import scodec.bits.ByteVector
-
 import scala.concurrent.duration._
 
 
@@ -164,7 +163,7 @@ class PeerSpec extends TestkitBaseClass {
     probe.send(peer, Peer.Reconnect)
     awaitCond({
       peer.children.exists { actor =>
-        actor.path.name == s"client-${fakeIPAddress.socketAddress.getAddress.getHostAddress}:${fakeIPAddress.socketAddress.getPort}"
+        actor.path.name == s"0-client-${fakeIPAddress.socketAddress.getAddress.getHostAddress}:${fakeIPAddress.socketAddress.getPort}"
       }
     }, 10 seconds)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpecWithLogging.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpecWithLogging.scala
@@ -1,0 +1,43 @@
+package fr.acinq.eclair.io
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.{EventFilter, TestFSMRef, TestKit, TestProbe}
+import com.typesafe.config.ConfigFactory
+import fr.acinq.eclair.db.ChannelStateSpec
+import org.scalatest.{FunSuiteLike, Outcome, Tag}
+import scala.concurrent.duration._
+import akka.testkit.{TestFSMRef, TestProbe}
+import fr.acinq.eclair.TestConstants.{Alice, Bob}
+import fr.acinq.eclair.blockchain.EclairWallet
+import fr.acinq.eclair.wire.LightningMessageCodecsSpec.randomSignature
+import fr.acinq.eclair.wire.{Color, IPv4, NodeAddress, NodeAnnouncement}
+import scodec.bits.ByteVector
+
+class PeerSpecWithLogging extends TestKit(ActorSystem("test", ConfigFactory.parseString("""akka.loggers = ["akka.testkit.TestEventListener"]"""))) with FunSuiteLike {
+
+  val fakeIPAddress = NodeAddress.fromParts("1.2.3.4", 42000).get
+
+  test("reconnect using the address from node_announcement") {
+    val aliceParams = Alice.nodeParams
+    val aliceAnnouncement = NodeAnnouncement(randomSignature, ByteVector.empty, 1, Bob.nodeParams.nodeId, Color(100.toByte, 200.toByte, 300.toByte), "node-alias", fakeIPAddress :: Nil)
+    aliceParams.db.network.addNode(aliceAnnouncement)
+    val authenticator = TestProbe()
+    val watcher = TestProbe()
+    val router = TestProbe()
+    val relayer = TestProbe()
+    val wallet: EclairWallet = null // unused
+    val remoteNodeId = Bob.nodeParams.nodeId
+    val peer: TestFSMRef[Peer.State, Peer.Data, Peer] = TestFSMRef(new Peer(aliceParams, remoteNodeId, authenticator.ref, watcher.ref, router.ref, relayer.ref, wallet))
+
+
+    val probe = TestProbe()
+    awaitCond({peer.stateName.toString == "INSTANTIATING"}, 10 seconds)
+    probe.send(peer, Peer.Init(None, Set(ChannelStateSpec.normal)))
+    awaitCond({peer.stateName.toString == "DISCONNECTED" && peer.stateData.address_opt.isEmpty}, 10 seconds)
+    EventFilter.info(message = s"reconnecting to ${fakeIPAddress.socketAddress}", occurrences = 1) intercept {
+      probe.send(peer, Peer.Reconnect)
+    }
+  }
+
+
+}


### PR DESCRIPTION
Currently the node address information in `node_announcement` messages is not used when establishing a connection. Peer's addresses are known only when the user initiated the connection providing a destination address, in case of incoming connection the peer's address is blanked out and we can't reconnect. According to the [spec](https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#the-node_announcement-message) the `addresses` field of `node_announcement` should contain the network addresses where a peer expects an incoming connection, this PR leverages this information to provide the following enhancements:

- Connect-to a pubkey (no address specified, will use `node_announcements`)
- Reconnect to peers using their `node_announcements` address as fallback in case we don't know the address

Fixes #1003 
