### PR TITLE
Make `htlc-reaper` a top-level actor

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -58,7 +58,7 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
     checkBrokenHtlcsLink(channels, nodeParams.privateKey) match {
       case Nil => ()
       case brokenHtlcs =>
-        val brokenHtlcKiller = context.actorOf(Props[HtlcReaper], name = "htlc-reaper")
+        val brokenHtlcKiller = context.system.actorOf(Props[HtlcReaper], name = "htlc-reaper")
         brokenHtlcKiller ! brokenHtlcs
     }
 


### PR DESCRIPTION
The way we handle requests to `Switchboard` assume that all children are `Peer`s. This led the `peer` API request to timeout.