### PR TITLE
Close channel if funding tx times out

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1561,8 +1561,6 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
 
   when(ERR_INFORMATION_LEAK)(errorStateHandler)
 
-  when(ERR_FUNDING_TIMEOUT)(errorStateHandler)
-
   when(ERR_FUNDING_LOST)(errorStateHandler)
 
   whenUnhandled {
@@ -1728,7 +1726,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
     val exc = FundingTxTimedout(d.channelId)
     val error = Error(d.channelId, exc.getMessage)
     context.system.eventStream.publish(ChannelErrorOccured(self, Helpers.getChannelId(stateData), remoteNodeId, stateData, LocalError(exc), isFatal = true))
-    goto(ERR_FUNDING_TIMEOUT) sending error
+    goto(CLOSED) sending error
   }
 
   def handleRevocationTimeout(revocationTimeout: RevocationTimeout, d: HasCommitments) = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -63,7 +63,6 @@ case object OFFLINE extends State
 case object SYNCING extends State
 case object WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT extends State
 case object ERR_FUNDING_LOST extends State
-case object ERR_FUNDING_TIMEOUT extends State
 case object ERR_INFORMATION_LEAK extends State
 
 /*

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -89,7 +89,7 @@ class WaitForFundingConfirmedStateSpec extends TestkitBaseClass with StateTestsH
     import f._
     alice ! BITCOIN_FUNDING_TIMEOUT
     alice2bob.expectMsgType[Error]
-    awaitCond(alice.stateName == ERR_FUNDING_TIMEOUT)
+    awaitCond(alice.stateName == CLOSED)
   }
 
   test("recv BITCOIN_FUNDING_SPENT (remote commit)") { f =>


### PR DESCRIPTION
Instead of going to state `ERR_FUNDING_TIMEOUT`.

This only happens when we are fundee. We *could* have some funds at
stake if there was a non-zero `push_msat`, but we already allows 5 days
for the funding tx to confirm so the best option is probably to forget
about the channel.