### PR TITLE
Removed `PaymentRequest.MAX_AMOUNT`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
@@ -41,7 +41,7 @@ import scala.util.Try
   */
 case class PaymentRequest(prefix: String, amount: Option[MilliSatoshi], timestamp: Long, nodeId: PublicKey, tags: List[PaymentRequest.TaggedField], signature: ByteVector) {
 
-  amount.map(a => require(a.amount > 0 && a.amount <= PaymentRequest.MAX_AMOUNT.amount, s"amount is not valid"))
+  amount.map(a => require(a.amount > 0, s"amount is not valid"))
   require(tags.collect { case _: PaymentRequest.PaymentHash => {} }.size == 1, "there must be exactly one payment hash tag")
   require(tags.collect { case PaymentRequest.Description(_) | PaymentRequest.DescriptionHash(_) => {} }.size == 1, "there must be exactly one description tag or one description hash tag")
 
@@ -105,9 +105,6 @@ case class PaymentRequest(prefix: String, amount: Option[MilliSatoshi], timestam
 }
 
 object PaymentRequest {
-
-  // https://github.com/lightningnetwork/lightning-rfc/blob/master/02-peer-protocol.md#adding-an-htlc-update_add_htlc
-  val MAX_AMOUNT = MilliSatoshi(4294967296L)
 
   val prefixes = Map(
     Block.RegtestGenesisBlock.hash -> "lnbcrt",

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
@@ -105,11 +105,6 @@ class PaymentHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     val zeroError = sender.expectMsgType[Failure]
     assert(zeroError.cause.getMessage.contains("amount is not valid"))
 
-    // large amount should fail (> 42.95 mBTC)
-    sender.send(handler, ReceivePayment(Some(Satoshi(1) + PaymentRequest.MAX_AMOUNT), "1 coffee"))
-    val largeAmountError = sender.expectMsgType[Failure]
-    assert(largeAmountError.cause.getMessage.contains("amount is not valid"))
-
     // success with 1 mBTC
     sender.send(handler, ReceivePayment(Some(MilliSatoshi(100000000L)), "1 coffee"))
     val pr = sender.expectMsgType[PaymentRequest]

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/ReceivePaymentController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/ReceivePaymentController.scala
@@ -73,8 +73,6 @@ class ReceivePaymentController(val handlers: Handlers, val stage: Stage) extends
         Try(CoinUtils.convertStringAmountToMsat(amount.getText, unit.getValue)) match {
           case Success(amountMsat) if amountMsat.amount < 0 =>
             handleError("Amount must be greater than 0")
-          case Success(amountMsat) if amountMsat.amount >= PaymentRequest.MAX_AMOUNT.amount =>
-            handleError(s"Amount must be less than ${CoinUtils.formatAmountInUnit(PaymentRequest.MAX_AMOUNT, FxApp.getUnit, withUnit = true)}")
           case Failure(_) =>
             handleError("Amount is incorrect")
           case Success(amountMsat) => createPaymentRequest(Some(amountMsat))


### PR DESCRIPTION
It was obsole since
https://github.com/lightningnetwork/lightning-rfc/commit/068b0bccf94e8cdaf5f298dade0fcc8cc8421ef6.

Note that we use a signed long, but it doesn't matter since 2^64
milli-satoshis is greater than the total number of bitcoins.