### PR TITLE
Initialize global feerate with default from conf

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -179,14 +179,19 @@ class Setup(datadir: File,
       tcpBound = Promise[Done]()
       routerInitialized = Promise[Done]()
 
-      defaultFeerates = FeeratesPerKB(
-        block_1 = config.getLong("default-feerates.delay-blocks.1"),
-        blocks_2 = config.getLong("default-feerates.delay-blocks.2"),
-        blocks_6 = config.getLong("default-feerates.delay-blocks.6"),
-        blocks_12 = config.getLong("default-feerates.delay-blocks.12"),
-        blocks_36 = config.getLong("default-feerates.delay-blocks.36"),
-        blocks_72 = config.getLong("default-feerates.delay-blocks.72")
-      )
+      defaultFeerates = {
+        val confDefaultFeerates = FeeratesPerKB(
+          block_1 = config.getLong("default-feerates.delay-blocks.1"),
+          blocks_2 = config.getLong("default-feerates.delay-blocks.2"),
+          blocks_6 = config.getLong("default-feerates.delay-blocks.6"),
+          blocks_12 = config.getLong("default-feerates.delay-blocks.12"),
+          blocks_36 = config.getLong("default-feerates.delay-blocks.36"),
+          blocks_72 = config.getLong("default-feerates.delay-blocks.72")
+        )
+        Globals.feeratesPerKB.set(confDefaultFeerates)
+        Globals.feeratesPerKw.set(FeeratesPerKw(confDefaultFeerates))
+        confDefaultFeerates
+      }
       minFeeratePerByte = config.getLong("min-feerate")
       smoothFeerateWindow = config.getInt("smooth-feerate-window")
       feeProvider = (nodeParams.chainHash, bitcoin) match {


### PR DESCRIPTION
`Globals.feeratePerKB` is an [atomic reference initialized to `null`](https://github.com/ACINQ/eclair/blob/master/eclair-core/src/main/scala/fr/acinq/eclair/Globals.scala#L39) and is asynchronously set by the fee provider handler only once the provider is ready. This means that it is possible to retrieve a null object from `feeratePerKB`, scenario that must be handled separately to prevent any issues.

This PR initializes `Globals.feeratePerKB` with the default fee rates retrieved from the configuration file. This makes sure that the node's fee rate is always set to a meaningful value.