### PR TITLE
Actor params: small refactoring

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -19,7 +19,6 @@ package fr.acinq.eclair
 import java.io.File
 import java.net.InetSocketAddress
 import java.nio.file.Files
-import java.sql.DriverManager
 import java.util.concurrent.TimeUnit
 
 import com.typesafe.config.{Config, ConfigFactory}
@@ -29,7 +28,6 @@ import fr.acinq.eclair.NodeParams.WatcherType
 import fr.acinq.eclair.channel.Channel
 import fr.acinq.eclair.crypto.KeyManager
 import fr.acinq.eclair.db._
-import fr.acinq.eclair.db.sqlite._
 import fr.acinq.eclair.router.RouterConf
 import fr.acinq.eclair.tor.Socks5ProxyParams
 import fr.acinq.eclair.wire.{Color, NodeAddress}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Authenticator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Authenticator.scala
@@ -86,7 +86,7 @@ class Authenticator(nodeId: PublicKey, privateKey: PrivateKey) extends Actor wit
 object Authenticator {
 
   // @formatter:off
-  def props(nodeId: PublicKey, privateKey: PrivateKey) = Props(new Authenticator(nodeId, privateKey))
+  def props(nodeId: PublicKey, privateKey: PrivateKey): Props = Props(new Authenticator(nodeId, privateKey))
   def props(nodeParams: NodeParams): Props = Props(new Authenticator(nodeParams.nodeId, nodeParams.privateKey))
   // @formatter:on
 


### PR DESCRIPTION
While it's convenient to be able to create most actors from a `NodeParams` instance it also breaks modularity (all actors depend on `NodeParams` which contains a lot of unrelated configuration fields).
It makes it very hard to use our code as a library.

I propose overloading the companion object's `props` and removing unused parameters from actor's constructors. The benefit is that changes are only scoped to each specific actor (by providing an overloaded `props`) and makes clearer what fields each actor really needs.