### PR TITLE
Output txid and serialized tx in transaction json serializer

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -85,11 +85,17 @@ class ScalarSerializer extends CustomSerializer[Scalar](format => ({ null }, {
 }))
 
 class TransactionSerializer extends CustomSerializer[TransactionWithInputInfo](ser = format => ({ null }, {
-  case x: Transaction => JString(x.toString())
+  case x: Transaction => JObject(List(
+    JField("txid", JString(x.txid.toHex)),
+    JField("tx", JString(x.toString()))
+  ))
 }))
 
 class TransactionWithInputInfoSerializer extends CustomSerializer[TransactionWithInputInfo](ser = format => ({ null }, {
-  case x: TransactionWithInputInfo => JString(x.tx.toString())
+  case x: TransactionWithInputInfo => JObject(List(
+    JField("txid", JString(x.tx.txid.toHex)),
+    JField("tx", JString(x.tx.toString()))
+  ))
 }))
 
 class InetSocketAddressSerializer extends CustomSerializer[InetSocketAddress](format => ({ null }, {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/api/JsonSerializersSpec.scala
@@ -19,10 +19,9 @@ package fr.acinq.eclair.api
 import java.net.InetAddress
 import java.util.UUID
 
-import fr.acinq.bitcoin.{MilliSatoshi, OutPoint}
+import fr.acinq.bitcoin.{ByteVector32, MilliSatoshi, OutPoint, Transaction}
 import fr.acinq.eclair._
 import fr.acinq.eclair.payment.{PaymentRequest, PaymentSettlingOnChain}
-import fr.acinq.bitcoin.{ByteVector32, OutPoint}
 import fr.acinq.eclair.api.JsonSupport.CustomTypeHints
 import fr.acinq.eclair.payment.PaymentRequest
 import fr.acinq.eclair.transactions.{IN, OUT}
@@ -81,5 +80,14 @@ class JsonSerializersSpec extends FunSuite with Matchers {
     implicit val formats = JsonSupport.formats.withTypeHintFieldName("type") + CustomTypeHints(Map(classOf[PaymentSettlingOnChain] -> "payment-settling-onchain")) + new MilliSatoshiSerializer
     val e1 = PaymentSettlingOnChain(UUID.randomUUID, MilliSatoshi(42), randomBytes32)
     assert(Serialization.writePretty(e1).contains("\"type\" : \"payment-settling-onchain\""))
+  }
+
+  test("transaction serializer") {
+    implicit val formats = JsonSupport.formats
+
+    val tx = Transaction.read("0200000001c8a8934fb38a44b969528252bc37be66ee166c7897c57384d1e561449e110c93010000006b483045022100dc6c50f445ed53d2fb41067fdcb25686fe79492d90e6e5db43235726ace247210220773d35228af0800c257970bee9cf75175d75217de09a8ecd83521befd040c4ca012102082b751372fe7e3b012534afe0bb8d1f2f09c724b1a10a813ce704e5b9c217ccfdffffff0247ba2300000000001976a914f97a7641228e6b17d4b0b08252ae75bd62a95fe788ace3de24000000000017a914a9fefd4b9a9282a1d7a17d2f14ac7d1eb88141d287f7d50800")
+
+    assert(JsonSupport.serialization.write(tx) == "{\"txid\":\"3ef63b5d297c9dcf93f33b45b9f102733c36e8ef61da1ccf2bc132a10584be18\",\"tx\":\"0200000001c8a8934fb38a44b969528252bc37be66ee166c7897c57384d1e561449e110c93010000006b483045022100dc6c50f445ed53d2fb41067fdcb25686fe79492d90e6e5db43235726ace247210220773d35228af0800c257970bee9cf75175d75217de09a8ecd83521befd040c4ca012102082b751372fe7e3b012534afe0bb8d1f2f09c724b1a10a813ce704e5b9c217ccfdffffff0247ba2300000000001976a914f97a7641228e6b17d4b0b08252ae75bd62a95fe788ace3de24000000000017a914a9fefd4b9a9282a1d7a17d2f14ac7d1eb88141d287f7d50800\"}")
+
   }
 }


### PR DESCRIPTION
For ease of use this PR improves the transaction serializer to output the transaction id along with the serialized transaction, previously we outputted only the serialized transaction.