### PR TITLE
Electrum: add id_from_pos

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -381,7 +381,7 @@ object ElectrumClient {
   case class BroadcastTransactionResponse(tx: Transaction, error: Option[Error]) extends Response
 
   case class GetTransactionIdFromPosition(height: Int, tx_pos: Int, merkle: Boolean = false) extends Request
-  case class GetTransactionIdFromPositionResponse(txid: ByteVector32, merkle: List[ByteVector32]) extends Response
+  case class GetTransactionIdFromPositionResponse(txid: ByteVector32, merkle: Seq[ByteVector32]) extends Response
 
   case class GetTransaction(txid: ByteVector32) extends Request
   case class GetTransactionResponse(tx: Transaction) extends Response
@@ -594,13 +594,13 @@ object ElectrumClient {
           })
           ScriptHashListUnspentResponse(scripthash, items)
         case GetTransactionIdFromPosition(_, _, false) =>
-          val JString(txid) = json.result
-          GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(txid), Nil)
+          val JString(tx_hash) = json.result
+          GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(tx_hash), Nil)
         case GetTransactionIdFromPosition(_, _, true) =>
-          val JString(txid) = json.result \ "tx_hash"
+          val JString(tx_hash) = json.result \ "tx_hash"
           val JArray(hashes) = json.result \ "merkle"
           val leaves = hashes collect { case JString(value) => ByteVector32.fromValidHex(value) }
-          GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(txid), leaves)
+          GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(tx_hash), leaves)
         case GetTransaction(_) =>
           val JString(hex) = json.result
           GetTransactionResponse(Transaction.read(hex))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -91,7 +91,7 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
 
   val channelOpenFuture = b.connect(serverAddress.getHostName, serverAddress.getPort)
 
-  def errorHandler(t: Throwable) = {
+  def errorHandler(t: Throwable): Unit = {
     log.info("server={} connection error (reason={})", serverAddress, t.getMessage)
     self ! Close
   }
@@ -169,6 +169,7 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
       val json = ("method" -> request.method) ~ ("params" -> request.params.map {
         case s: String => new JString(s)
         case b: ByteVector32 => new JString(b.toHex)
+        case b: Boolean => new JBool(b)
         case t: Int => new JInt(t)
         case t: Long => new JLong(t)
         case t: Double => new JDouble(t)
@@ -182,8 +183,6 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
 
   /**
     * Forwards incoming messages to the underlying actor
-    *
-    * @param actor
     */
   class ActorHandler(actor: ActorRef) extends ChannelInboundHandlerAdapter {
 
@@ -220,7 +219,7 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
       case PingResponse => ()
 
       case Close =>
-        statusListeners.map(_ ! ElectrumDisconnected)
+        statusListeners.foreach(_ ! ElectrumDisconnected)
         context.stop(self)
 
       case _ => log.warning("server={} unhandled message {}", serverAddress, message)
@@ -282,7 +281,7 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
     case Right(json: JsonRPCResponse) =>
       val (height, header) = parseBlockHeader(json.result)
       log.debug("connected to server={}, tip={} height={}", serverAddress, header.hash, height)
-      statusListeners.map(_ ! ElectrumReady(height, header, serverAddress))
+      statusListeners.foreach(_ ! ElectrumReady(height, header, serverAddress))
       context become connected(ctx, height, header, Map())
 
     case AddStatusListener(actor) => statusListeners += actor
@@ -322,11 +321,11 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
       }
       context become connected(ctx, height, tip, requests - json.id)
 
-    case Left(response: HeaderSubscriptionResponse) => headerSubscriptions.map(_ ! response)
+    case Left(response: HeaderSubscriptionResponse) => headerSubscriptions.foreach(_ ! response)
 
-    case Left(response: AddressSubscriptionResponse) => addressSubscriptions.get(response.address).map(listeners => listeners.map(_ ! response))
+    case Left(response: AddressSubscriptionResponse) => addressSubscriptions.get(response.address).foreach(listeners => listeners.foreach(_ ! response))
 
-    case Left(response: ScriptHashSubscriptionResponse) => scriptHashSubscriptions.get(response.scriptHash).map(listeners => listeners.map(_ ! response))
+    case Left(response: ScriptHashSubscriptionResponse) => scriptHashSubscriptions.get(response.scriptHash).foreach(listeners => listeners.foreach(_ ! response))
 
     case HeaderSubscriptionResponse(height, newtip) =>
       log.info("server={} new tip={}", serverAddress, newtip)
@@ -380,6 +379,9 @@ object ElectrumClient {
 
   case class BroadcastTransaction(tx: Transaction) extends Request
   case class BroadcastTransactionResponse(tx: Transaction, error: Option[Error]) extends Response
+
+  case class GetTransactionIdFromPosition(height: Int, tx_pos: Int, merkle: Boolean = false) extends Request
+  case class GetTransactionIdFromPositionResponse(txid: ByteVector32, merkle: List[ByteVector32]) extends Response
 
   case class GetTransaction(txid: ByteVector32) extends Request
   case class GetTransactionResponse(tx: Transaction) extends Response
@@ -533,10 +535,11 @@ object ElectrumClient {
     case AddressSubscription(address, _) => JsonRPCRequest(id = reqId, method = "blockchain.address.subscribe", params = address :: Nil)
     case ScriptHashSubscription(scriptHash, _) => JsonRPCRequest(id = reqId, method = "blockchain.scripthash.subscribe", params = scriptHash.toString() :: Nil)
     case BroadcastTransaction(tx) => JsonRPCRequest(id = reqId, method = "blockchain.transaction.broadcast", params = Transaction.write(tx).toHex :: Nil)
+    case GetTransactionIdFromPosition(height, tx_pos, merkle) => JsonRPCRequest(id = reqId, method = "blockchain.transaction.id_from_pos", params = height :: tx_pos :: merkle :: Nil)
     case GetTransaction(txid) => JsonRPCRequest(id = reqId, method = "blockchain.transaction.get", params = txid :: Nil)
     case HeaderSubscription(_) => JsonRPCRequest(id = reqId, method = "blockchain.headers.subscribe", params = Nil)
     case GetHeader(height) => JsonRPCRequest(id = reqId, method = "blockchain.block.header", params = height :: Nil)
-    case GetHeaders(start_height, count, cp_height) => JsonRPCRequest(id = reqId, method = "blockchain.block.headers", params = start_height :: count :: Nil)
+    case GetHeaders(start_height, count, _) => JsonRPCRequest(id = reqId, method = "blockchain.block.headers", params = start_height :: count :: Nil)
     case GetMerkle(txid, height) => JsonRPCRequest(id = reqId, method = "blockchain.transaction.get_merkle", params = txid :: height :: Nil)
   }
 
@@ -548,7 +551,7 @@ object ElectrumClient {
         case _ => ServerError(request, error)
       }
       case None => (request: @unchecked) match {
-        case s: ServerVersion =>
+        case _: ServerVersion =>
           val JArray(jitems) = json.result
           val JString(clientName) = jitems(0)
           val JString(protocolVersion) = jitems(1)
@@ -590,6 +593,14 @@ object ElectrumClient {
             UnspentItem(ByteVector32.fromValidHex(tx_hash), tx_pos, value, height)
           })
           ScriptHashListUnspentResponse(scripthash, items)
+        case GetTransactionIdFromPosition(_, _, false) =>
+          val JString(txid) = json.result
+          GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(txid), Nil)
+        case GetTransactionIdFromPosition(_, _, true) =>
+          val JString(txid) = json.result \ "tx_hash"
+          val JArray(hashes) = json.result \ "merkle"
+          val leaves = hashes collect { case JString(value) => ByteVector32.fromValidHex(value) }
+          GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(txid), leaves)
         case GetTransaction(_) =>
           val JString(hex) = json.result
           GetTransactionResponse(Transaction.read(hex))
@@ -614,16 +625,15 @@ object ElectrumClient {
         case GetHeader(height) =>
           val JString(hex) = json.result
           GetHeaderResponse(height, BlockHeader.read(hex))
-        case GetHeaders(start_height, count, cp_height) =>
-          val count = intField(json.result, "count")
+        case GetHeaders(start_height, _, _) =>
           val max = intField(json.result, "max")
           val JString(hex) = json.result \ "hex"
           val bin = ByteVector.fromValidHex(hex).toArray
           val blockHeaders = bin.grouped(80).map(BlockHeader.read).toList
           GetHeadersResponse(start_height, blockHeaders, max)
-        case GetMerkle(txid, height) =>
+        case GetMerkle(txid, _) =>
           val JArray(hashes) = json.result \ "merkle"
-          val leaves = hashes collect { case JString(value) => ByteVector32.fromValidHex((value)) }
+          val leaves = hashes collect { case JString(value) => ByteVector32.fromValidHex(value) }
           val blockHeight = intField(json.result, "block_height")
           val JInt(pos) = json.result \ "pos"
           GetMerkleResponse(txid, leaves, blockHeight, pos.toInt)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientSpec.scala
@@ -38,6 +38,9 @@ class ElectrumClientSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
   // this is tx #2690 of block #500000
   val referenceTx = Transaction.read("0200000001983c5b32ced1de5ae97d3ce9b7436f8bb0487d15bf81e5cae97b1e238dc395c6000000006a47304402205957c75766e391350eba2c7b752f0056cb34b353648ecd0992a8a81fc9bcfe980220629c286592842d152cdde71177cd83086619744a533f262473298cacf60193500121021b8b51f74dbf0ac1e766d162c8707b5e8d89fc59da0796f3b4505e7c0fb4cf31feffffff0276bd0101000000001976a914219de672ba773aa0bc2e15cdd9d2e69b734138fa88ac3e692001000000001976a914301706dede031e9fb4b60836e073a4761855f6b188ac09a10700")
   val scriptHash = Crypto.sha256(referenceTx.txOut(0).publicKeyScript).reverse
+  val height = 500000
+  val position = 2690
+  val merkleProof = List("b500cd85cd6c7e0e570b82728dd516646536a477b61cc82056505d84a5820dc3", "c98798c2e576566a92b23d2405f59d95c506966a6e26fecfb356d6447a199546", "930d95c428546812fd11f8242904a9a1ba05d2140cd3a83be0e2ed794821c9ec", "90c97965b12f4262fe9bf95bc37ff7d6362902745eaa822ecf0cf85801fa8b48", "23792d51fddd6e439ed4c92ad9f19a9b73fc9d5c52bdd69039be70ad6619a1aa", "4b73075f29a0abdcec2c83c2cfafc5f304d2c19dcacb50a88a023df725468760", "f80225a32a5ce4ef0703822c6aa29692431a816dec77d9b1baa5b09c3ba29bfb", "4858ac33f2022383d3b4dd674666a0880557d02a155073be93231a02ecbb81f4", "eb5b142030ed4e0b55a8ba5a7b5b783a0a24e0c2fd67c1cfa2f7b308db00c38a", "86858812c3837d209110f7ea79de485abdfd22039467a8aa15a8d85856ee7d30", "de20eb85f2e9ad525a6fb5c618682b6bdce2fa83df836a698f31575c4e5b3d38", "98bd1048e04ff1b0af5856d9890cd708d8d67ad6f3a01f777130fbc16810eeb3").map(ByteVector32.fromValidHex)
 
   override protected def beforeAll(): Unit = {
     client = system.actorOf(Props(new ElectrumClient(new InetSocketAddress("electrum.acinq.co", 50002), SSL.STRICT)), "electrum-client")
@@ -50,6 +53,20 @@ class ElectrumClientSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
   test("connect to an electrumx mainnet server") {
     probe.send(client, AddStatusListener(probe.ref))
     probe.expectMsgType[ElectrumReady](15 seconds)
+  }
+
+  test("get transaction id from position") {
+    probe.send(client, GetTransactionIdFromPosition(height, position))
+    val GetTransactionIdFromPositionResponse(txid, merkle) = probe.expectMsgType[GetTransactionIdFromPositionResponse]
+    assert(txid === referenceTx.txid)
+    assert(merkle === Nil)
+  }
+
+  test("get transaction id from position with merkle proof") {
+    probe.send(client, GetTransactionIdFromPosition(height, position, merkle = true))
+    val GetTransactionIdFromPositionResponse(txid, merkle) = probe.expectMsgType[GetTransactionIdFromPositionResponse]
+    assert(txid === referenceTx.txid)
+    assert(merkle === merkleProof)
   }
 
   test("get transaction") {
@@ -98,7 +115,7 @@ class ElectrumClientSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
   test("get scripthash history") {
     probe.send(client, GetScriptHashHistory(scriptHash))
     val GetScriptHashHistoryResponse(scriptHash1, history) = probe.expectMsgType[GetScriptHashHistoryResponse]
-    assert(history.contains((TransactionHistoryItem(500000, referenceTx.txid))))
+    assert(history.contains(TransactionHistoryItem(500000, referenceTx.txid)))
   }
 
   test("list script unspents") {
@@ -106,4 +123,5 @@ class ElectrumClientSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     val ScriptHashListUnspentResponse(scriptHash1, unspents) = probe.expectMsgType[ScriptHashListUnspentResponse]
     assert(unspents.isEmpty)
   }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientSpec.scala
@@ -28,7 +28,6 @@ import scodec.bits._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
-
 class ElectrumClientSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with Logging with BeforeAndAfterAll {
 
   import ElectrumClient._
@@ -40,7 +39,20 @@ class ElectrumClientSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
   val scriptHash = Crypto.sha256(referenceTx.txOut(0).publicKeyScript).reverse
   val height = 500000
   val position = 2690
-  val merkleProof = List("b500cd85cd6c7e0e570b82728dd516646536a477b61cc82056505d84a5820dc3", "c98798c2e576566a92b23d2405f59d95c506966a6e26fecfb356d6447a199546", "930d95c428546812fd11f8242904a9a1ba05d2140cd3a83be0e2ed794821c9ec", "90c97965b12f4262fe9bf95bc37ff7d6362902745eaa822ecf0cf85801fa8b48", "23792d51fddd6e439ed4c92ad9f19a9b73fc9d5c52bdd69039be70ad6619a1aa", "4b73075f29a0abdcec2c83c2cfafc5f304d2c19dcacb50a88a023df725468760", "f80225a32a5ce4ef0703822c6aa29692431a816dec77d9b1baa5b09c3ba29bfb", "4858ac33f2022383d3b4dd674666a0880557d02a155073be93231a02ecbb81f4", "eb5b142030ed4e0b55a8ba5a7b5b783a0a24e0c2fd67c1cfa2f7b308db00c38a", "86858812c3837d209110f7ea79de485abdfd22039467a8aa15a8d85856ee7d30", "de20eb85f2e9ad525a6fb5c618682b6bdce2fa83df836a698f31575c4e5b3d38", "98bd1048e04ff1b0af5856d9890cd708d8d67ad6f3a01f777130fbc16810eeb3").map(ByteVector32.fromValidHex)
+  val merkleProof = List(
+    hex"b500cd85cd6c7e0e570b82728dd516646536a477b61cc82056505d84a5820dc3",
+    hex"c98798c2e576566a92b23d2405f59d95c506966a6e26fecfb356d6447a199546",
+    hex"930d95c428546812fd11f8242904a9a1ba05d2140cd3a83be0e2ed794821c9ec",
+    hex"90c97965b12f4262fe9bf95bc37ff7d6362902745eaa822ecf0cf85801fa8b48",
+    hex"23792d51fddd6e439ed4c92ad9f19a9b73fc9d5c52bdd69039be70ad6619a1aa",
+    hex"4b73075f29a0abdcec2c83c2cfafc5f304d2c19dcacb50a88a023df725468760",
+    hex"f80225a32a5ce4ef0703822c6aa29692431a816dec77d9b1baa5b09c3ba29bfb",
+    hex"4858ac33f2022383d3b4dd674666a0880557d02a155073be93231a02ecbb81f4",
+    hex"eb5b142030ed4e0b55a8ba5a7b5b783a0a24e0c2fd67c1cfa2f7b308db00c38a",
+    hex"86858812c3837d209110f7ea79de485abdfd22039467a8aa15a8d85856ee7d30",
+    hex"de20eb85f2e9ad525a6fb5c618682b6bdce2fa83df836a698f31575c4e5b3d38",
+    hex"98bd1048e04ff1b0af5856d9890cd708d8d67ad6f3a01f777130fbc16810eeb3")
+    .map(ByteVector32(_))
 
   override protected def beforeAll(): Unit = {
     client = system.actorOf(Props(new ElectrumClient(new InetSocketAddress("electrum.acinq.co", 50002), SSL.STRICT)), "electrum-client")


### PR DESCRIPTION
This allows getting a transaction id from a short channel id.
Also cleaned up some nit static analyzer warnings.