### PR TITLE
Electrum: add data to TxIdFromPosResponse.

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -381,7 +381,7 @@ object ElectrumClient {
   case class BroadcastTransactionResponse(tx: Transaction, error: Option[Error]) extends Response
 
   case class GetTransactionIdFromPosition(height: Int, tx_pos: Int, merkle: Boolean = false) extends Request
-  case class GetTransactionIdFromPositionResponse(txid: ByteVector32, merkle: Seq[ByteVector32]) extends Response
+  case class GetTransactionIdFromPositionResponse(txid: ByteVector32, height: Int, tx_pos: Int, merkle: Seq[ByteVector32]) extends Response
 
   case class GetTransaction(txid: ByteVector32) extends Request
   case class GetTransactionResponse(tx: Transaction) extends Response
@@ -593,14 +593,14 @@ object ElectrumClient {
             UnspentItem(ByteVector32.fromValidHex(tx_hash), tx_pos, value, height)
           })
           ScriptHashListUnspentResponse(scripthash, items)
-        case GetTransactionIdFromPosition(_, _, false) =>
+        case GetTransactionIdFromPosition(height, tx_pos, false) =>
           val JString(tx_hash) = json.result
-          GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(tx_hash), Nil)
-        case GetTransactionIdFromPosition(_, _, true) =>
+          GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(tx_hash), height, tx_pos, Nil)
+        case GetTransactionIdFromPosition(height, tx_pos, true) =>
           val JString(tx_hash) = json.result \ "tx_hash"
           val JArray(hashes) = json.result \ "merkle"
           val leaves = hashes collect { case JString(value) => ByteVector32.fromValidHex(value) }
-          GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(tx_hash), leaves)
+          GetTransactionIdFromPositionResponse(ByteVector32.fromValidHex(tx_hash), height, tx_pos, leaves)
         case GetTransaction(_) =>
           val JString(hex) = json.result
           GetTransactionResponse(Transaction.read(hex))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientSpec.scala
@@ -69,15 +69,19 @@ class ElectrumClientSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
 
   test("get transaction id from position") {
     probe.send(client, GetTransactionIdFromPosition(height, position))
-    val GetTransactionIdFromPositionResponse(txid, merkle) = probe.expectMsgType[GetTransactionIdFromPositionResponse]
+    val GetTransactionIdFromPositionResponse(txid, height1, position1, merkle) = probe.expectMsgType[GetTransactionIdFromPositionResponse]
     assert(txid === referenceTx.txid)
+    assert(height1 === height)
+    assert(position1 === position)
     assert(merkle === Nil)
   }
 
   test("get transaction id from position with merkle proof") {
     probe.send(client, GetTransactionIdFromPosition(height, position, merkle = true))
-    val GetTransactionIdFromPositionResponse(txid, merkle) = probe.expectMsgType[GetTransactionIdFromPositionResponse]
+    val GetTransactionIdFromPositionResponse(txid, height1, position1, merkle) = probe.expectMsgType[GetTransactionIdFromPositionResponse]
     assert(txid === referenceTx.txid)
+    assert(height1 === height)
+    assert(position1 === position)
     assert(merkle === merkleProof)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientSpec.scala
@@ -69,20 +69,12 @@ class ElectrumClientSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
 
   test("get transaction id from position") {
     probe.send(client, GetTransactionIdFromPosition(height, position))
-    val GetTransactionIdFromPositionResponse(txid, height1, position1, merkle) = probe.expectMsgType[GetTransactionIdFromPositionResponse]
-    assert(txid === referenceTx.txid)
-    assert(height1 === height)
-    assert(position1 === position)
-    assert(merkle === Nil)
+    probe.expectMsg(GetTransactionIdFromPositionResponse(referenceTx.txid, height, position, Nil))
   }
 
   test("get transaction id from position with merkle proof") {
     probe.send(client, GetTransactionIdFromPosition(height, position, merkle = true))
-    val GetTransactionIdFromPositionResponse(txid, height1, position1, merkle) = probe.expectMsgType[GetTransactionIdFromPositionResponse]
-    assert(txid === referenceTx.txid)
-    assert(height1 === height)
-    assert(position1 === position)
-    assert(merkle === merkleProof)
+    probe.expectMsg(GetTransactionIdFromPositionResponse(referenceTx.txid, height, position, merkleProof))
   }
 
   test("get transaction") {


### PR DESCRIPTION
To make the response usable, we need to copy the request input (block height and transaction position).
Otherwise an actor receiving the response can't map the received transaction id to a set of short channel ids.