### PR TITLE
Strict linting

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/DBCompatChecker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/DBCompatChecker.scala
@@ -39,7 +39,7 @@ object DBCompatChecker extends Logging {
     * @param nodeParams
     */
   def checkNetworkDBCompatibility(nodeParams: NodeParams): Unit =
-    Try(nodeParams.db.network.listChannels(), nodeParams.db.network.listNodes(), nodeParams.db.network.listChannelUpdates()) match {
+    Try((nodeParams.db.network.listChannels(), nodeParams.db.network.listNodes(), nodeParams.db.network.listChannelUpdates())) match {
       case Success(_) => {}
       case Failure(_) => throw IncompatibleNetworkDBException
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -156,7 +156,7 @@ object NodeParams {
       val p = PublicKey(ByteVector.fromValidHex(e.getString("nodeid")))
       val gf = ByteVector.fromValidHex(e.getString("global-features"))
       val lf = ByteVector.fromValidHex(e.getString("local-features"))
-      (p -> (gf, lf))
+      p -> ((gf, lf))
     }.toMap
 
     val socksProxy_opt = if (config.getBoolean("socks5.enabled")) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/ExtraDirectives.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/ExtraDirectives.scala
@@ -49,7 +49,7 @@ trait ExtraDirectives extends Directives {
     case Failure(_) => reject
   }
 
-  def withChannelIdentifier: Directive1[Either[ByteVector32, ShortChannelId]] = formFields(channelIdFormParam.?, shortChannelIdFormParam.?).tflatMap {
+  def withChannelIdentifier: Directive1[Either[ByteVector32, ShortChannelId]] = formFields((channelIdFormParam.?, shortChannelIdFormParam.?)).tflatMap {
     case (None, None) => reject(MalformedFormFieldRejection("channelId/shortChannelId", "Must specify either the channelId or shortChannelId"))
     case (Some(channelId), None) => provide(Left(channelId))
     case (None, Some(shortChannelId)) => provide(Right(shortChannelId))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -73,7 +73,7 @@ trait Service extends ExtraDirectives with Logging {
   val apiExceptionHandler = ExceptionHandler {
     case t: Throwable =>
       logger.error(s"API call failed with cause=${t.getMessage}", t)
-      complete(StatusCodes.InternalServerError, ErrorResponse(t.getMessage))
+      complete((StatusCodes.InternalServerError, ErrorResponse(t.getMessage)))
   }
 
   // map all the rejections to a JSON error object ErrorResponse

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
@@ -50,18 +50,18 @@ class ZMQActor(address: String, connected: Option[Promise[Done]] = None) extends
 
   // we check messages in a non-blocking manner with an interval, making sure to retrieve all messages before waiting again
   @tailrec
-  final def checkEvent: Unit = Option(Event.recv(monitor, ZMQ.DONTWAIT)) match {
+  final def checkEvent(): Unit = Option(Event.recv(monitor, ZMQ.DONTWAIT)) match {
     case Some(event) =>
       self ! event
-      checkEvent
+      checkEvent()
     case None => ()
   }
 
   @tailrec
-  final def checkMsg: Unit = Option(ZMsg.recvMsg(subscriber, ZMQ.DONTWAIT)) match {
+  final def checkMsg(): Unit = Option(ZMsg.recvMsg(subscriber, ZMQ.DONTWAIT)) match {
     case Some(msg) =>
       self ! msg
-      checkMsg
+      checkMsg()
     case None => ()
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -308,7 +308,7 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
           context watch actor
         case _ => ()
       }
-      context become connected(ctx, height, tip, requests + (curReqId -> (request, sender())))
+      context become connected(ctx, height, tip, requests + (curReqId -> ((request, sender()))))
 
     case Right(json: JsonRPCResponse) =>
       requests.get(json.id) match {
@@ -317,7 +317,7 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
           log.debug("server={} sent response for reqId={} request={} response={}", serverAddress, json.id, request, response)
           requestor ! response
         case None =>
-          log.warning("server={} could not find requestor for reqId=${} response={}", serverAddress, json.id, json)
+          log.warning("server={} could not find requestor for reqId={} response={}", serverAddress, json.id, json)
       }
       context become connected(ctx, height, tip, requests - json.id)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPool.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClientPool.scala
@@ -143,7 +143,7 @@ class ElectrumClientPool(serverAddresses: Set[ElectrumServerAddress])(implicit v
         log.info("selecting master {} at {}", remoteAddress, tip)
         statusListeners.foreach(_ ! ElectrumClient.ElectrumReady(height, tip, remoteAddress))
         context.system.eventStream.publish(ElectrumClient.ElectrumReady(height, tip, remoteAddress))
-        goto(Connected) using ConnectedData(connection, Map(connection -> (height, tip)))
+        goto(Connected) using ConnectedData(connection, Map(connection -> ((height, tip))))
       case Some(d) if connection != d.master && height >= d.blockHeight + 2L =>
         // we only switch to a new master if there is a significant difference with our current master, because
         // we don't want to switch to a new master every time a new block arrives (some servers will be notified before others)
@@ -157,10 +157,10 @@ class ElectrumClientPool(serverAddresses: Set[ElectrumServerAddress])(implicit v
         context.system.eventStream.publish(ElectrumClient.ElectrumDisconnected)
         statusListeners.foreach(_ ! ElectrumClient.ElectrumReady(height, tip, remoteAddress))
         context.system.eventStream.publish(ElectrumClient.ElectrumReady(height, tip, remoteAddress))
-        goto(Connected) using d.copy(master = connection, tips = d.tips + (connection -> (height, tip)))
+        goto(Connected) using d.copy(master = connection, tips = d.tips + (connection -> ((height, tip))))
       case Some(d) =>
         log.debug("received tip {} from {} at {}", tip, remoteAddress, height)
-        stay using d.copy(tips = d.tips + (connection -> (height, tip)))
+        stay using d.copy(tips = d.tips + (connection -> ((height, tip))))
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
@@ -288,7 +288,7 @@ class ElectrumWallet(seed: ByteVector, client: ActorRef, params: ElectrumWallet.
       val pendingHeadersRequests1 = collection.mutable.HashSet.empty[GetHeaders]
       pendingHeadersRequests1 ++= data.pendingHeadersRequests
 
-      /**
+      /*
         * If we don't already have a header at this height, or a pending request to download the header chunk it's in,
         * download this header chunk.
         * We don't have this header because it's most likely older than our current checkpoint, downloading the whole header

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -692,7 +692,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
         case Failure(cause) => handleLocalError(cause, d, Some(fee))
       }
 
-    case Event(c@CMD_SIGN, d: DATA_NORMAL) =>
+    case Event(c: CMD_SIGN.type , d: DATA_NORMAL) =>
       d.commitments.remoteNextCommitInfo match {
         case _ if !Commitments.localHasChanges(d.commitments) =>
           log.debug("ignoring CMD_SIGN (nothing to sign)")
@@ -1051,7 +1051,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
         case Failure(cause) => handleLocalError(cause, d, Some(fee))
       }
 
-    case Event(c@CMD_SIGN, d: DATA_SHUTDOWN) =>
+    case Event(c: CMD_SIGN.type, d: DATA_SHUTDOWN) =>
       d.commitments.remoteNextCommitInfo match {
         case _ if !Commitments.localHasChanges(d.commitments) =>
           log.debug("ignoring CMD_SIGN (nothing to sign)")
@@ -1617,7 +1617,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
 
     case Event(c: CMD_CLOSE, d) => handleCommandError(CommandUnavailableInThisState(Helpers.getChannelId(d), "close", stateName), c)
 
-    case Event(c@CMD_FORCECLOSE, d) =>
+    case Event(c: CMD_FORCECLOSE.type, d) =>
       d match {
         case data: HasCommitments => handleLocalError(ForcedLocalCommit(data.channelId), data, Some(c)) replying "ok"
         case _ => handleCommandError(CommandUnavailableInThisState(Helpers.getChannelId(d), "forceclose", stateName), c)
@@ -2056,7 +2056,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
     log.debug(s"localNextHtlcId=${d.commitments.localNextHtlcId}->${commitments1.localNextHtlcId}")
     log.debug(s"remoteNextHtlcId=${d.commitments.remoteNextHtlcId}->${commitments1.remoteNextHtlcId}")
 
-    def resendRevocation = {
+    def resendRevocation() = {
       // let's see the state of remote sigs
       if (commitments1.localCommit.index == channelReestablish.nextRemoteRevocationNumber) {
         // nothing to do

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -146,7 +146,7 @@ object Commitments {
       return Left(InsufficientFunds(commitments.channelId, amountMsat = cmd.amountMsat, missingSatoshis = -1 * missing, reserveSatoshis = commitments1.remoteParams.channelReserveSatoshis, feesSatoshis = fees))
     }
 
-    Right(commitments1, add)
+    Right((commitments1, add))
   }
 
   def receiveAdd(commitments: Commitments, add: UpdateAddHtlc): Commitments = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -1128,7 +1128,7 @@ object Helpers {
             d.revokedCommitPublished.flatMap(_.htlcPenaltyTxs).map(_ -> "revoked-htlc-penalty") ++
             d.revokedCommitPublished.flatMap(_.claimHtlcDelayedPenaltyTxs).map(_ -> "revoked-htlc-penalty-delayed")
           )
-          .map { case (tx, desc) => tx.txid -> (tx, desc) } // will allow easy lookup of parent transaction
+          .map { case (tx, desc) => tx.txid -> ((tx, desc)) } // will allow easy lookup of parent transaction
           .toMap
 
         def fee(child: Transaction): Option[Satoshi] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -47,7 +47,7 @@ trait AuditDb {
 
   def stats: Seq[Stats]
 
-  def close: Unit
+  def close(): Unit
 
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -110,7 +110,7 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
       val rs = statement.executeQuery
       var q: Queue[(ByteVector32, Long)] = Queue()
       while (rs.next()) {
-        q = q :+ (ByteVector32(rs.getByteVector32("payment_hash")), rs.getLong("cltv_expiry"))
+        q = q :+ ((ByteVector32(rs.getByteVector32("payment_hash")), rs.getLong("cltv_expiry")))
       }
       q
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -113,7 +113,7 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb {
       var m: Map[ChannelAnnouncement, (ByteVector32, Satoshi)] = Map()
       while (rs.next()) {
         m += (channelAnnouncementCodec.decode(BitVector(rs.getBytes("data"))).require.value ->
-          (ByteVector32.fromValidHex(rs.getString("txid")), Satoshi(rs.getLong("capacity_sat"))))
+          ((ByteVector32.fromValidHex(rs.getString("txid")), Satoshi(rs.getLong("capacity_sat")))))
       }
       m
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -161,7 +161,7 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
       if (rs.next()) {
         val preimage = rs.getByteVector32("preimage")
         val pr = PaymentRequest.read(rs.getString("payment_request"))
-        Some(preimage, pr)
+        Some((preimage, pr))
       } else {
         None
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
@@ -69,7 +69,7 @@ class SqlitePendingRelayDb(sqlite: Connection) extends PendingRelayDb {
       val rs = statement.executeQuery()
       var q: Queue[(ByteVector32, Long)] = Queue()
       while (rs.next()) {
-        q = q :+ (rs.getByteVector32("channel_id"), rs.getLong("htlc_id"))
+        q = q :+ ((rs.getByteVector32("channel_id"), rs.getLong("htlc_id")))
       }
       q.toSet
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -341,7 +341,7 @@ class Peer(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: Actor
 
     case Event(DelayedRebroadcast(rebroadcast), d: ConnectedData) =>
 
-      /**
+      /*
         * Send and count in a single iteration
         */
       def sendAndCount(msgs: Map[_ <: RoutingMessage, Set[ActorRef]]): Int = msgs.foldLeft(0) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Server.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Server.scala
@@ -36,7 +36,7 @@ class Server(nodeParams: NodeParams, authenticator: ActorRef, address: InetSocke
 
   IO(Tcp) ! Bind(self, address, options = KeepAlive(true) :: Nil, pullMode = true)
 
-  def receive() = {
+  def receive = {
     case Bound(localAddress) =>
       bound.map(_.success(Done))
       log.info(s"bound on $localAddress")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -256,7 +256,7 @@ class BitcoinCoreWalletSpec extends TestKit(ActorSystem("test")) with BitcoindSe
     val JString(signedTx1) = sender.expectMsgType[JValue] \ "hex"
     val tx1 = Transaction.read(signedTx1)
     // let's then generate another tx that double spends the first one
-    val inputs = tx1.txIn.map(txIn => Map("txid" -> txIn.outPoint.txid.toString, "vout" -> txIn.outPoint.index)).toArray
+    val inputs = tx1.txIn.map(txIn => Map[String, Any]("txid" -> txIn.outPoint.txid.toString, "vout" -> txIn.outPoint.index)).toArray
     bitcoinClient.invoke("createrawtransaction", inputs, Map(address -> tx1.txOut.map(_.amount.toLong).sum * 1.0 / 1e8)).pipeTo(sender.ref)
     val JString(unsignedtx2) = sender.expectMsgType[JValue]
     bitcoinClient.invoke("signrawtransactionwithwallet", unsignedtx2).pipeTo(sender.ref)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
@@ -176,7 +176,7 @@ class ElectrumWalletBasicSpec extends FunSuite with Logging {
     val state2 = addFunds(state1, state1.accountKeys(1), 2 btc)
     val state3 = addFunds(state2, state2.changeKeys(0), 0.5 btc)
     assert(state3.utxos.length == 3)
-    assert(state3.balance == (Satoshi(350000000),Satoshi(0)))
+    assert(state3.balance == ((Satoshi(350000000),Satoshi(0))))
 
     val (tx, fee) = state3.spendAll(Script.pay2wpkh(ByteVector.fill(20)(1)), feeRatePerKw)
     val Some((received, sent, Some(fee1))) = state3.computeTransactionDelta(tx)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -69,7 +69,7 @@ class FuzzySpec extends TestkitBaseClass with StateTestsHelperMethods with Loggi
       // no announcements
       alice ! INPUT_INIT_FUNDER(ByteVector32.Zeroes, TestConstants.fundingSatoshis, TestConstants.pushMsat, TestConstants.feeratePerKw, TestConstants.feeratePerKw, Alice.channelParams, pipe, bobInit, channelFlags = 0x00.toByte)
       bob ! INPUT_INIT_FUNDEE(ByteVector32.Zeroes, Bob.channelParams, pipe, aliceInit)
-      pipe ! (alice, bob)
+      pipe ! ((alice, bob))
       alice2blockchain.expectMsgType[WatchSpent]
       alice2blockchain.expectMsgType[WatchConfirmed]
       bob2blockchain.expectMsgType[WatchSpent]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/ThroughputSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/ThroughputSpec.scala
@@ -82,7 +82,7 @@ class ThroughputSpec extends FunSuite {
     }), "listener")
     system.eventStream.subscribe(listener, classOf[ChannelEvent])
 
-    pipe ! (alice, bob)
+    pipe ! ((alice, bob))
     latch.await()
 
     var i = new AtomicLong(0)
@@ -95,10 +95,10 @@ class ThroughputSpec extends FunSuite {
 
     import scala.concurrent.ExecutionContext.Implicits.global
     system.scheduler.schedule(0 seconds, 50 milliseconds, new Runnable() {
-      override def run(): Unit = paymentHandler ! (msg, alice)
+      override def run(): Unit = paymentHandler ! ((msg, alice))
     })
     system.scheduler.schedule(5 seconds, 70 milliseconds, new Runnable() {
-      override def run(): Unit = paymentHandler ! (msg, bob)
+      override def run(): Unit = paymentHandler ! ((msg, bob))
     })
 
     Thread.sleep(Long.MaxValue)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/NoiseDemo.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/NoiseDemo.scala
@@ -119,7 +119,7 @@ object NoiseDemo extends App {
   val fooHandler = system.actorOf(Props(new NoiseHandler(Initiator.s, Some(Responder.s.pub), pipe, true, foo)), "foohandler")
   val bar = system.actorOf(Props[MyActor], "bar")
   val barHandler = system.actorOf(Props(new NoiseHandler(Responder.s, None, pipe, false, bar)), "barhandler")
-  pipe ! (fooHandler, barHandler)
+  pipe ! ((fooHandler, barHandler))
 
   bar.tell(ByteVector("hello".getBytes()), foo)
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/NoiseSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/NoiseSpec.scala
@@ -30,7 +30,7 @@ class NoiseSpec extends FunSuite {
   test("hash tests") {
     // see https://tools.ietf.org/html/rfc4231
     assert(SHA256HashFunctions.hmacHash(hex"0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", hex"4869205468657265") == hex"b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7")
-    assert(SHA256HashFunctions.hkdf(hex"4e6f6973655f4e4e5f32353531395f436861436861506f6c795f534841323536", hex"37e0e7daacbd6bfbf669a846196fd44d1c8745d33f2be42e31d4674199ad005e") == (hex"f6f78327c10316fdad06633fb965e03182e9a8b1f755d613f7980fbb85ebf46d", hex"4ee4220f31dbd3c9e2367e66a87f1e98a2433e4b9fbecfd986d156dcf027b937"))
+    assert(SHA256HashFunctions.hkdf(hex"4e6f6973655f4e4e5f32353531395f436861436861506f6c795f534841323536", hex"37e0e7daacbd6bfbf669a846196fd44d1c8745d33f2be42e31d4674199ad005e") == ((hex"f6f78327c10316fdad06633fb965e03182e9a8b1f755d613f7980fbb85ebf46d", hex"4ee4220f31dbd3c9e2367e66a87f1e98a2433e4b9fbecfd986d156dcf027b937")))
   }
 
   test("25519 DH test") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/TransportHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/TransportHandlerSpec.scala
@@ -51,7 +51,7 @@ class TransportHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLik
     val probe2 = TestProbe()
     val initiator = TestFSMRef(new TransportHandler(Initiator.s, Some(Responder.s.pub), pipe, LightningMessageCodecs.varsizebinarydata))
     val responder = TestFSMRef(new TransportHandler(Responder.s, None, pipe, LightningMessageCodecs.varsizebinarydata))
-    pipe ! (initiator, responder)
+    pipe ! ((initiator, responder))
 
     awaitCond(initiator.stateName == TransportHandler.WaitingForListener)
     awaitCond(responder.stateName == TransportHandler.WaitingForListener)
@@ -83,7 +83,7 @@ class TransportHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLik
     val probe2 = TestProbe()
     val initiator = TestFSMRef(new TransportHandler(Initiator.s, Some(Responder.s.pub), pipe, mycodec))
     val responder = TestFSMRef(new TransportHandler(Responder.s, None, pipe, mycodec))
-    pipe ! (initiator, responder)
+    pipe ! ((initiator, responder))
 
     awaitCond(initiator.stateName == TransportHandler.WaitingForListener)
     awaitCond(responder.stateName == TransportHandler.WaitingForListener)
@@ -113,7 +113,7 @@ class TransportHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLik
     val probe2 = TestProbe()
     val initiator = TestFSMRef(new TransportHandler(Initiator.s, Some(Responder.s.pub), pipe, LightningMessageCodecs.varsizebinarydata))
     val responder = TestFSMRef(new TransportHandler(Responder.s, None, pipe, LightningMessageCodecs.varsizebinarydata))
-    pipe ! (initiator, responder)
+    pipe ! ((initiator, responder))
 
     awaitCond(initiator.stateName == TransportHandler.WaitingForListener)
     awaitCond(responder.stateName == TransportHandler.WaitingForListener)
@@ -144,7 +144,7 @@ class TransportHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLik
     val initiator = TestFSMRef(new TransportHandler(Initiator.s, Some(Initiator.s.pub), pipe, LightningMessageCodecs.varsizebinarydata), supervisor, "ini")
     val responder = TestFSMRef(new TransportHandler(Responder.s, None, pipe, LightningMessageCodecs.varsizebinarydata), supervisor, "res")
     probe1.watch(responder)
-    pipe ! (initiator, responder)
+    pipe ! ((initiator, responder))
 
     probe1.expectTerminated(responder, 3 seconds)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
@@ -61,7 +61,7 @@ class RustyTestsSpec extends TestKit(ActorSystem("test")) with Matchers with fix
     Globals.feeratesPerKw.set(FeeratesPerKw.single(10000))
     alice ! INPUT_INIT_FUNDER(ByteVector32.Zeroes, 2000000, 1000000000, Globals.feeratesPerKw.get.blocks_2, Globals.feeratesPerKw.get.blocks_6, Alice.channelParams, pipe, bobInit, ChannelFlags.Empty)
     bob ! INPUT_INIT_FUNDEE(ByteVector32.Zeroes, Bob.channelParams, pipe, aliceInit)
-    pipe ! (alice, bob)
+    pipe ! ((alice, bob))
     within(30 seconds) {
       alice2blockchain.expectMsgType[WatchSpent]
       alice2blockchain.expectMsgType[WatchConfirmed]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -81,10 +81,10 @@ class RouterSpec extends BaseRouterSpec {
     watcher.expectMsg(ValidateRequest(chan_ax))
     watcher.expectMsg(ValidateRequest(chan_ay))
     watcher.expectMsg(ValidateRequest(chan_az))
-    watcher.send(router, ValidateResult(chan_ac, Right(Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(1000000), write(pay2wsh(Scripts.multiSig2of2(funding_a, funding_c)))) :: Nil, lockTime = 0), UtxoStatus.Unspent)))
+    watcher.send(router, ValidateResult(chan_ac, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(1000000), write(pay2wsh(Scripts.multiSig2of2(funding_a, funding_c)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
     watcher.send(router, ValidateResult(chan_ax, Left(new RuntimeException(s"funding tx not found"))))
-    watcher.send(router, ValidateResult(chan_ay, Right(Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(1000000), write(pay2wsh(Scripts.multiSig2of2(funding_a, randomKey.publicKey)))) :: Nil, lockTime = 0), UtxoStatus.Unspent)))
-    watcher.send(router, ValidateResult(chan_az, Right(Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(1000000), write(pay2wsh(Scripts.multiSig2of2(funding_a, priv_funding_z.publicKey)))) :: Nil, lockTime = 0), UtxoStatus.Spent(spendingTxConfirmed = true))))
+    watcher.send(router, ValidateResult(chan_ay, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(1000000), write(pay2wsh(Scripts.multiSig2of2(funding_a, randomKey.publicKey)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
+    watcher.send(router, ValidateResult(chan_az, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(Satoshi(1000000), write(pay2wsh(Scripts.multiSig2of2(funding_a, priv_funding_z.publicKey)))) :: Nil, lockTime = 0), UtxoStatus.Spent(spendingTxConfirmed = true)))))
     watcher.expectMsgType[WatchSpentBasic]
     watcher.expectNoMsg(1 second)
 

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/FxApp.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/FxApp.scala
@@ -53,17 +53,17 @@ class FxApp extends Application with Logging {
   def onError(t: Throwable): Unit = t match {
     case e@TCPBindException(port) =>
       notifyPreloader(new ErrorNotification("Setup", s"Could not bind to port $port", e))
-    case e@BitcoinRPCConnectionException =>
+    case e: BitcoinRPCConnectionException.type =>
       notifyPreloader(new ErrorNotification("Setup", "Could not connect to Bitcoin Core using JSON-RPC.", e))
       notifyPreloader(new AppNotification(InfoAppNotification, "Make sure that Bitcoin Core is up and running and RPC parameters are correct."))
-    case e@BitcoinZMQConnectionTimeoutException =>
+    case e: BitcoinZMQConnectionTimeoutException.type =>
       notifyPreloader(new ErrorNotification("Setup", "Could not connect to Bitcoin Core using ZMQ.", e))
       notifyPreloader(new AppNotification(InfoAppNotification, "Make sure that Bitcoin Core is up and running and ZMQ parameters are correct."))
-    case e@IncompatibleDBException =>
+    case e: IncompatibleDBException.type =>
       notifyPreloader(new ErrorNotification("Setup", "Breaking changes!", e))
       notifyPreloader(new AppNotification(InfoAppNotification, "Eclair is still in alpha, and under heavy development. Last update was not backward compatible."))
       notifyPreloader(new AppNotification(InfoAppNotification, "Please reset your datadir."))
-    case e@IncompatibleNetworkDBException =>
+    case e: IncompatibleNetworkDBException.type =>
       notifyPreloader(new ErrorNotification("Setup", "Unreadable network database!", e))
       notifyPreloader(new AppNotification(InfoAppNotification, "Could not read the network database. Please remove the file and restart."))
     case t: Throwable =>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
@@ -80,7 +80,7 @@ class Handlers(fKit: Future[Kit])(implicit ec: ExecutionContext = ExecutionConte
     }
   }
 
-  def send(overrideAmountMsat_opt: Option[Long], req: PaymentRequest) = {
+  def send(overrideAmountMsat_opt: Option[Long], req: PaymentRequest): Future[Any] = {
     val amountMsat = overrideAmountMsat_opt
       .orElse(req.amount.map(_.amount))
       .getOrElse(throw new RuntimeException("you need to manually specify an amount for this payment request"))

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/AboutController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/AboutController.scala
@@ -29,15 +29,15 @@ class AboutController(hostServices: HostServices) extends Logging {
 
   @FXML var version: Text = _
 
-  @FXML def initialize = {
+  @FXML def initialize() = {
     version.setText(getClass.getPackage.getImplementationVersion)
   }
 
-  @FXML def openApacheLicencePage = hostServices.showDocument("https://www.apache.org/licenses/LICENSE-2.0")
+  @FXML def openApacheLicencePage() = hostServices.showDocument("https://www.apache.org/licenses/LICENSE-2.0")
 
-  @FXML def openACINQPage = hostServices.showDocument("https://acinq.co")
+  @FXML def openACINQPage() = hostServices.showDocument("https://acinq.co")
 
-  @FXML def openGithubPage = hostServices.showDocument("https://github.com/ACINQ/eclair")
+  @FXML def openGithubPage() = hostServices.showDocument("https://github.com/ACINQ/eclair")
 
-  @FXML def openLNRFCPage = hostServices.showDocument("https://github.com/lightningnetwork/lightning-rfc")
+  @FXML def openLNRFCPage() = hostServices.showDocument("https://github.com/lightningnetwork/lightning-rfc")
 }

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/MainController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/MainController.scala
@@ -544,7 +544,7 @@ class MainController(val handlers: Handlers, val hostServices: HostServices) ext
     t.play()
   }
 
-  def hideBlockerModal = {
+  def hideBlockerModal() = {
     val ftCover = new FadeTransition(Duration.millis(400))
     ftCover.setFromValue(1)
     ftCover.setToValue(0)

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/ReceivePaymentController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/ReceivePaymentController.scala
@@ -50,7 +50,7 @@ class ReceivePaymentController(val handlers: Handlers, val stage: Stage) extends
   @FXML var paymentRequestTextArea: TextArea = _
   @FXML var paymentRequestQRCode: ImageView = _
 
-  @FXML def initialize = {
+  @FXML def initialize() = {
     unit.setItems(Constants.FX_UNITS_ARRAY)
     unit.setValue(FxApp.getUnit.label)
     resultBox.managedProperty().bind(resultBox.visibleProperty())

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/SplashController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/SplashController.scala
@@ -41,7 +41,7 @@ class SplashController(hostServices: HostServices) extends Logging {
   /**
     * Start an animation when the splash window is initialized
     */
-  @FXML def initialize = {
+  @FXML def initialize() = {
     val timeline = new Timeline(
       new KeyFrame(Duration.ZERO,
         new KeyValue(img.opacityProperty, double2Double(0), Interpolator.EASE_IN),
@@ -52,9 +52,9 @@ class SplashController(hostServices: HostServices) extends Logging {
     timeline.play()
   }
 
-  @FXML def closeAndKill = System.exit(0)
+  @FXML def closeAndKill() = System.exit(0)
 
-  @FXML def openGithubPage = hostServices.showDocument("https://github.com/ACINQ/eclair/blob/master/README.md")
+  @FXML def openGithubPage() = hostServices.showDocument("https://github.com/ACINQ/eclair/blob/master/README.md")
 
   def addLog(message: String) = {
     val l = new Label
@@ -74,7 +74,7 @@ class SplashController(hostServices: HostServices) extends Logging {
   /**
     * Shows the error Box with a fade+translate transition.
     */
-  def showErrorBox = {
+  def showErrorBox() = {
     val fadeTransition = new FadeTransition(Duration.millis(400))
     fadeTransition.setFromValue(0)
     fadeTransition.setToValue(1)

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
                         <arg>140</arg>
 			<!-- needed to compile Scala code on JDK9+ -->
                         <arg>-nobootcp</arg>
+                        <arg>-Xlint</arg>
                     </args>
                     <scalaCompatVersion>${scala.version.short}</scalaCompatVersion>
                 </configuration>


### PR DESCRIPTION
Apply strict linting to the code as dictated by the `-Xlint` compiler option, this will prevent from doing a series of mistakes typically caused by auto-tupling or type inference by the scala compiler.