### PR TITLE
Add eclair-cli to eclair's docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,14 @@ RUN mvn package -pl eclair-node -am -DskipTests -Dgit.commit.id=notag -Dgit.comm
 # We currently use a debian image for runtime because of some jni-related issue with sqlite
 FROM openjdk:8u181-jre-slim
 WORKDIR /app
+
+# install jq for eclair-cli
+RUN apt-get update && apt-get install -y bash jq
+
+# copy and install eclair-cli executable
+COPY --from=BUILD /usr/src/eclair-core/eclair-cli .
+RUN chmod +x eclair-cli && mv eclair-cli /sbin/eclair-cli
+
 # Eclair only needs the eclair-node-*.jar to run
 COPY --from=BUILD /usr/src/eclair-node/target/eclair-node-*.jar .
 RUN ln `ls` eclair-node.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ FROM openjdk:8u181-jre-slim
 WORKDIR /app
 
 # install jq for eclair-cli
-RUN apt-get update && apt-get install -y bash jq
+RUN apt-get update && apt-get install -y bash jq curl
 
 # copy and install eclair-cli executable
 COPY --from=BUILD /usr/src/eclair-core/eclair-cli .

--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ If you want to persist the data directory, you can make the volume to your host 
 docker run -ti --rm -v "/path_on_host:/data" -e "JAVA_OPTS=-Declair.printToConsole" acinq/eclair
 ```
 
+If you enabled the API you can check the status of eclair using the command line tool:
+```
+docker exec <container_name> eclair-cli -p foobar getinfo
+```
+
 ## Plugins
 
 For advanced usage, Eclair supports plugins written in Scala, Java, or any JVM-compatible language.


### PR DESCRIPTION
Add the command line tool `eclair-cli` to the eclair docker image, this will allow users to easily interact with their eclair instance via `docker exec`.

cc: @Kukks 