### PR TITLE
TLV improvements and full spec compatibility

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/CommonCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/CommonCodecs.scala
@@ -18,14 +18,15 @@ package fr.acinq.eclair.wire
 
 import java.net.{Inet4Address, Inet6Address, InetAddress}
 
-import fr.acinq.bitcoin.{ByteVector32, ByteVector64}
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
+import fr.acinq.bitcoin.{ByteVector32, ByteVector64}
 import fr.acinq.eclair.{ShortChannelId, UInt64}
 import org.apache.commons.codec.binary.Base32
-import scodec.{Attempt, Codec, DecodeResult, Err, SizeBound}
 import scodec.bits.{BitVector, ByteVector}
 import scodec.codecs._
+import scodec.{Attempt, Codec, DecodeResult, Err, SizeBound}
 
+import scala.Ordering.Implicits._
 import scala.util.Try
 
 /**
@@ -56,13 +57,14 @@ object CommonCodecs {
   val uint64L: Codec[UInt64] = bytes(8).xmap(b => UInt64(b.reverse), a => a.toByteVector.padLeft(8).reverse)
 
   /**
-    * We impose a minimal encoding on varint values to ensure that signed hashes can be reproduced easily.
-    * If a value could be encoded with less bytes, it's considered invalid and results in a failed decoding attempt.
+    * We impose a minimal encoding on varint and truncated int values to ensure that signed hashes can be reproduced
+    * easily. If a value could be encoded with less bytes, it's considered invalid and results in a failed decoding
+    * attempt.
     *
     * @param codec the integer codec (depends on the value).
     * @param min   the minimal value that should be encoded.
     */
-  def uint64min(codec: Codec[UInt64], min: UInt64): Codec[UInt64] = codec.exmap({
+  def minimalint[A : Ordering](codec: Codec[A], min: A): Codec[A] = codec.exmap({
     case i if i < min => Attempt.failure(Err("varint was not minimally encoded"))
     case i => Attempt.successful(i)
   }, Attempt.successful)
@@ -71,9 +73,9 @@ object CommonCodecs {
   // See https://bitcoin.org/en/developer-reference#compactsize-unsigned-integers for reference.
   val varint: Codec[UInt64] = discriminatorWithDefault(
     discriminated[UInt64].by(uint8L)
-      .\(0xff) { case i if i >= UInt64(0x100000000L) => i }(uint64min(uint64L, UInt64(0x100000000L)))
-      .\(0xfe) { case i if i >= UInt64(0x10000) => i }(uint64min(uint32L.xmap(UInt64(_), _.toBigInt.toLong), UInt64(0x10000)))
-      .\(0xfd) { case i if i >= UInt64(0xfd) => i }(uint64min(uint16L.xmap(UInt64(_), _.toBigInt.toInt), UInt64(0xfd))),
+      .\(0xff) { case i if i >= UInt64(0x100000000L) => i }(minimalint(uint64L, UInt64(0x100000000L)))
+      .\(0xfe) { case i if i >= UInt64(0x10000) => i }(minimalint(uint32L.xmap(UInt64(_), _.toBigInt.toLong), UInt64(0x10000)))
+      .\(0xfd) { case i if i >= UInt64(0xfd) => i }(minimalint(uint16L.xmap(UInt64(_), _.toBigInt.toInt), UInt64(0xfd))),
     uint8L.xmap(UInt64(_), _.toBigInt.toInt)
   )
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/TlvCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/TlvCodecs.scala
@@ -16,9 +16,11 @@
 
 package fr.acinq.eclair.wire
 
+import fr.acinq.eclair.UInt64
+import fr.acinq.eclair.UInt64.Conversions._
 import fr.acinq.eclair.wire.CommonCodecs._
-import scodec.{Attempt, Codec}
 import scodec.codecs._
+import scodec.{Attempt, Codec, Err}
 
 import scala.util.Try
 
@@ -27,6 +29,38 @@ import scala.util.Try
   */
 
 object TlvCodecs {
+
+  private def variableSizeUInt64(size: Int, min: UInt64): Codec[UInt64] = minimalint(bytes(size).xmap(UInt64(_), _.toByteVector.takeRight(size)), min)
+
+  /**
+    * Length-prefixed truncated uint64 (1 to 9 bytes unsigned integer).
+    */
+  val tu64: Codec[UInt64] = discriminated[UInt64].by(uint8)
+    .\(0x00) { case i if i < 0x01 => i }(variableSizeUInt64(0, 0x00))
+    .\(0x01) { case i if i < 0x0100 => i }(variableSizeUInt64(1, 0x01))
+    .\(0x02) { case i if i < 0x010000 => i }(variableSizeUInt64(2, 0x0100))
+    .\(0x03) { case i if i < 0x01000000 => i }(variableSizeUInt64(3, 0x010000))
+    .\(0x04) { case i if i < 0x0100000000L => i }(variableSizeUInt64(4, 0x01000000))
+    .\(0x05) { case i if i < 0x010000000000L => i }(variableSizeUInt64(5, 0x0100000000L))
+    .\(0x06) { case i if i < 0x01000000000000L => i }(variableSizeUInt64(6, 0x010000000000L))
+    .\(0x07) { case i if i < 0x0100000000000000L => i }(variableSizeUInt64(7, 0x01000000000000L))
+    .\(0x08) { case i if i <= UInt64.MaxValue => i }(variableSizeUInt64(8, 0x0100000000000000L))
+
+  /**
+    * Length-prefixed truncated uint32 (1 to 5 bytes unsigned integer).
+    */
+  val tu32: Codec[Long] = tu64.exmap({
+    case i if i > 0xffffffffL => Attempt.Failure(Err("tu32 overflow"))
+    case i => Attempt.Successful(i.toBigInt.toLong)
+  }, l => Attempt.Successful(l))
+
+  /**
+    * Length-prefixed truncated uint16 (1 to 3 bytes unsigned integer).
+    */
+  val tu16: Codec[Int] = tu32.exmap({
+    case i if i > 0xffff => Attempt.Failure(Err("tu16 overflow"))
+    case i => Attempt.Successful(i.toInt)
+  }, l => Attempt.Successful(l))
 
   private val genericTlv: Codec[GenericTlv] = (("type" | varint) :: variableSizeBytesLong(varintoverflow, bytes)).as[GenericTlv]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/CommonCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/CommonCodecsSpec.scala
@@ -20,8 +20,8 @@ import java.net.{Inet4Address, Inet6Address, InetAddress}
 
 import com.google.common.net.InetAddresses
 import fr.acinq.bitcoin.Crypto.PrivateKey
-import fr.acinq.eclair.{UInt64, randomBytes32}
 import fr.acinq.eclair.wire.CommonCodecs._
+import fr.acinq.eclair.{UInt64, randomBytes32}
 import org.scalatest.FunSuite
 import scodec.bits.{BitVector, HexStringSyntax}
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/TlvCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/TlvCodecsSpec.scala
@@ -17,14 +17,14 @@
 package fr.acinq.eclair.wire
 
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.eclair.{ShortChannelId, UInt64}
 import fr.acinq.eclair.UInt64.Conversions._
 import fr.acinq.eclair.wire.CommonCodecs.{publicKey, shortchannelid, uint64, varint}
 import fr.acinq.eclair.wire.TlvCodecs._
+import fr.acinq.eclair.{ShortChannelId, UInt64}
 import org.scalatest.FunSuite
+import scodec.Codec
 import scodec.bits.HexStringSyntax
 import scodec.codecs._
-import scodec.Codec
 
 /**
   * Created by t-bast on 20/06/2019.
@@ -34,9 +34,117 @@ class TlvCodecsSpec extends FunSuite {
 
   import TlvCodecsSpec._
 
+  test("encode/decode truncated uint16") {
+    val testCases = Seq(
+      (hex"00", 0),
+      (hex"01 01", 1),
+      (hex"01 2a", 42),
+      (hex"01 ff", 255),
+      (hex"02 0100", 256),
+      (hex"02 0231", 561),
+      (hex"02 ffff", 65535)
+    )
+
+    for ((bin, expected) <- testCases) {
+      val decoded = tu16.decode(bin.bits).require.value
+      assert(decoded === expected)
+
+      val encoded = tu16.encode(expected).require.bytes
+      assert(encoded === bin)
+    }
+  }
+
+  test("encode/decode truncated uint32") {
+    val testCases = Seq(
+      (hex"00", 0L),
+      (hex"01 01", 1L),
+      (hex"01 2a", 42L),
+      (hex"01 ff", 255L),
+      (hex"02 0100", 256L),
+      (hex"02 0231", 561L),
+      (hex"02 ffff", 65535L),
+      (hex"03 010000", 65536L),
+      (hex"03 ffffff", 16777215L),
+      (hex"04 01000000", 16777216L),
+      (hex"04 01020304", 16909060L),
+      (hex"04 ffffffff", 4294967295L)
+    )
+
+    for ((bin, expected) <- testCases) {
+      val decoded = tu32.decode(bin.bits).require.value
+      assert(decoded === expected)
+
+      val encoded = tu32.encode(expected).require.bytes
+      assert(encoded === bin)
+    }
+  }
+
+  test("encode/decode truncated uint64") {
+    val testCases = Seq(
+      (hex"00", UInt64(0)),
+      (hex"01 01", UInt64(1)),
+      (hex"01 2a", UInt64(42)),
+      (hex"01 ff", UInt64(255)),
+      (hex"02 0100", UInt64(256)),
+      (hex"02 0231", UInt64(561)),
+      (hex"02 ffff", UInt64(65535)),
+      (hex"03 010000", UInt64(65536)),
+      (hex"03 ffffff", UInt64(16777215)),
+      (hex"04 01000000", UInt64(16777216)),
+      (hex"04 01020304", UInt64(16909060)),
+      (hex"04 ffffffff", UInt64(4294967295L)),
+      (hex"05 0100000000", UInt64(4294967296L)),
+      (hex"05 0102030405", UInt64(4328719365L)),
+      (hex"05 ffffffffff", UInt64(1099511627775L)),
+      (hex"06 010000000000", UInt64(1099511627776L)),
+      (hex"06 010203040506", UInt64(1108152157446L)),
+      (hex"06 ffffffffffff", UInt64(281474976710655L)),
+      (hex"07 01000000000000", UInt64(281474976710656L)),
+      (hex"07 01020304050607", UInt64(283686952306183L)),
+      (hex"07 ffffffffffffff", UInt64(72057594037927935L)),
+      (hex"08 0100000000000000", UInt64(72057594037927936L)),
+      (hex"08 0102030405060708", UInt64(72623859790382856L)),
+      (hex"08 ffffffffffffffff", UInt64.MaxValue)
+    )
+
+    for ((bin, expected) <- testCases) {
+      val decoded = tu64.decode(bin.bits).require.value
+      assert(decoded === expected)
+
+      val encoded = tu64.encode(expected).require.bytes
+      assert(encoded === bin)
+    }
+  }
+
+  test("decode invalid truncated integers") {
+    val testCases = Seq(
+      (tu16, hex"01 00"), // not minimal
+      (tu16, hex"02 0001"), // not minimal
+      (tu16, hex"03 ffffff"), // length too big
+      (tu32, hex"01 00"), // not minimal
+      (tu32, hex"02 0001"), // not minimal
+      (tu32, hex"03 000100"), // not minimal
+      (tu32, hex"04 00010000"), // not minimal
+      (tu32, hex"05 ffffffffff"), // length too big
+      (tu64, hex"01 00"), // not minimal
+      (tu64, hex"02 0001"), // not minimal
+      (tu64, hex"03 000100"), // not minimal
+      (tu64, hex"04 00010000"), // not minimal
+      (tu64, hex"05 0001000000"), // not minimal
+      (tu64, hex"06 000100000000"), // not minimal
+      (tu64, hex"07 00010000000000"), // not minimal
+      (tu64, hex"08 0001000000000000"), // not minimal
+      (tu64, hex"09 ffffffffffffffffff") // length too big
+    )
+
+    for ((codec, bin) <- testCases) {
+      assert(codec.decode(bin.bits).isFailure, bin)
+    }
+  }
+
   test("encode/decode tlv") {
     val testCases = Seq(
-      (hex"01 08 000000000000002a", TestType1(42)),
+      (hex"01 01 2a", TestType1(42)),
       (hex"02 08 0000000000000226", TestType2(ShortChannelId(550))),
       (hex"03 31 02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619 0000000000000231 0000000000000451", TestType3(PublicKey(hex"02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"), 561, 1105))
     )
@@ -70,11 +178,11 @@ class TlvCodecsSpec extends FunSuite {
 
   test("decode invalid tlv stream") {
     val testCases = Seq(
-      hex"0108000000000000002a 02", // valid tlv record followed by invalid tlv record (only type, length and value are missing)
-      hex"02080000000000000226 0108000000000000002a", // valid tlv records but invalid ordering
+      hex"01012a 02", // valid tlv record followed by invalid tlv record (only type, length and value are missing)
+      hex"02080000000000000226 01012a", // valid tlv records but invalid ordering
       hex"02080000000000000231 02080000000000000451", // duplicate tlv type
-      hex"0108000000000000002a 2a0101", // unknown even type
-      hex"0a080000000000000231 0b0400000451" // valid tlv records but from different namespace
+      hex"01020100 2a0101", // unknown even type
+      hex"0a020231 0b020451" // valid tlv records but from different namespace
     )
 
     for (testCase <- testCases) {
@@ -89,13 +197,13 @@ class TlvCodecsSpec extends FunSuite {
     assertThrows[IllegalArgumentException](TlvStream(Seq(TestType2(ShortChannelId(1105)), TestType1(561)))) // invalid ordering
   }
 
-  test("encoded/decode empty tlv stream") {
+  test("encode/decode empty tlv stream") {
     assert(tlvStream(testTlvCodec).decode(hex"".bits).require.value === TlvStream(Nil))
     assert(tlvStream(testTlvCodec).encode(TlvStream(Nil)).require.bytes === hex"")
   }
 
   test("encode/decode tlv stream") {
-    val bin = hex"01080000000000000231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451"
+    val bin = hex"01020231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451"
     val expected = Seq(
       TestType1(561),
       TestType2(ShortChannelId(1105)),
@@ -110,10 +218,10 @@ class TlvCodecsSpec extends FunSuite {
   }
 
   test("encode/decode tlv stream with unknown odd type") {
-    val bin = hex"01080000000000000231 0b0400000451 0d02002a"
+    val bin = hex"01020231 0b020451 0d02002a"
     val expected = Seq(
       TestType1(561),
-      GenericTlv(11, hex"00000451"),
+      GenericTlv(11, hex"0451"),
       TestType13(42)
     )
 
@@ -127,8 +235,8 @@ class TlvCodecsSpec extends FunSuite {
   test("encode/decode length-prefixed tlv stream") {
     val codec = lengthPrefixedTlvStream(testTlvCodec)
     val testCases = Seq(
-      hex"47 01080000000000000231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451",
-      hex"fd5301 01080000000000000231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451 ff6543210987654321 fd0001 10101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010010101010101"
+      hex"41 01020231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451",
+      hex"fd4d01 01020231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451 ff6543210987654321 fd0001 10101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010010101010101"
     )
 
     for (testCase <- testCases) {
@@ -138,9 +246,9 @@ class TlvCodecsSpec extends FunSuite {
 
   test("decode invalid length-prefixed tlv stream") {
     val testCases = Seq(
-      hex"48 01080000000000000231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451",
-      hex"46 01080000000000000231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451",
-      hex"01080000000000000231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451"
+      hex"42 01020231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451",
+      hex"40 01020231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451",
+      hex"01020231 02080000000000000451 033102eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900000000000002310000000000000451"
     )
 
     for (testCase <- testCases) {
@@ -159,7 +267,7 @@ object TlvCodecsSpec {
   case class TestType3(nodeId: PublicKey, value1: UInt64, value2: UInt64) extends TestTlv { override val `type` = UInt64(3) }
   case class TestType13(intValue: Int) extends TestTlv { override val `type` = UInt64(13) }
 
-  val testCodec1: Codec[TestType1] = (("length" | constant(hex"08")) :: ("value" | uint64)).as[TestType1]
+  val testCodec1: Codec[TestType1] = ("value" | tu64).as[TestType1]
   val testCodec2: Codec[TestType2] = (("length" | constant(hex"08")) :: ("short_channel_id" | shortchannelid)).as[TestType2]
   val testCodec3: Codec[TestType3] = (("length" | constant(hex"31")) :: ("node_id" | publicKey) :: ("value_1" | uint64) :: ("value_2" | uint64)).as[TestType3]
   val testCodec13: Codec[TestType13] = (("length" | constant(hex"02")) :: ("value" | uint16)).as[TestType13]
@@ -173,8 +281,8 @@ object TlvCodecsSpec {
   case class OtherType1(uintValue: UInt64) extends OtherTlv { override val `type` = UInt64(10) }
   case class OtherType2(smallValue: Long) extends OtherTlv { override val `type` = UInt64(11) }
 
-  val otherCodec1: Codec[OtherType1] = (("length" | constant(hex"08")) :: ("value" | uint64)).as[OtherType1]
-  val otherCodec2: Codec[OtherType2] = (("length" | constant(hex"04")) :: ("value" | uint32)).as[OtherType2]
+  val otherCodec1: Codec[OtherType1] = ("value" | tu64).as[OtherType1]
+  val otherCodec2: Codec[OtherType2] = ("value" | tu32).as[OtherType2]
   val otherTlvCodec = discriminated[Tlv].by(varint)
     .typecase(10, otherCodec1)
     .typecase(11, otherCodec2)


### PR DESCRIPTION
This PR adds support for truncated integers as defined in the spec.
The test vectors are updated to include all test vectors from rusty's spec PR.
It also provides many changes to the tlv and tlv stream classes:

- The tlv trait doesn't need a `type` field, the codec should handle that
- A TLV stream should be scoped to a specific subtrait of `tlv`
- Stream validation is done inside the codec instead of the tlv stream: it makes it more convenient for application layers to create tlv streams and manipulate them

I'm starting a thread on `scodec`'s gitter to see if we can do something better than the `tag` function that encodes the tlv to extract the discriminator, if that yields something I'll update the PR.