### PR TITLE
Route computation: fix fee check

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -170,6 +170,7 @@ package object eclair {
     def +(other: MilliSatoshi) = MilliSatoshi(amount + other.amount)
     def -(other: MilliSatoshi) = MilliSatoshi(amount - other.amount)
     def *(m: Long) = MilliSatoshi(amount * m)
+    def *(m: Double) = MilliSatoshi((amount * m).toLong)
     def /(d: Long) = MilliSatoshi(amount / d)
     def compare(other: MilliSatoshi): Int = if (amount == other.amount) 0 else if (amount < other.amount) -1 else 1
     def <= (that: MilliSatoshi): Boolean = compare(that) <= 0

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -867,7 +867,7 @@ object Router {
 
     val currentBlockHeight = Globals.blockCount.get()
 
-    def feeBaseOk(fee: MilliSatoshi): Boolean = fee < routeParams.maxFeeBase
+    def feeBaseOk(fee: MilliSatoshi): Boolean = fee <= routeParams.maxFeeBase
 
     def feePctOk(fee: MilliSatoshi, amount: MilliSatoshi): Boolean = {
       val maxFee = amount * routeParams.maxFeePct

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -871,7 +871,7 @@ object Router {
 
     def feePctOk(fee: MilliSatoshi, amount: MilliSatoshi): Boolean = {
       val maxFee = amount * routeParams.maxFeePct
-      fee < maxFee
+      fee <= maxFee
     }
 
     def feeOk(fee: MilliSatoshi, amount: MilliSatoshi): Boolean = feeBaseOk(fee) || feePctOk(fee, amount)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -19,9 +19,9 @@ package fr.acinq.eclair.router
 import akka.Done
 import akka.actor.{ActorRef, Props, Status}
 import akka.event.Logging.MDC
-import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.Script.{pay2wsh, write}
+import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel._
@@ -33,7 +33,6 @@ import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
 import fr.acinq.eclair.router.Graph.{RichWeight, WeightRatios}
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
-import scodec.bits.ByteVector
 
 import scala.collection.immutable.{SortedMap, TreeMap}
 import scala.collection.{SortedSet, mutable}
@@ -868,10 +867,21 @@ object Router {
 
     val currentBlockHeight = Globals.blockCount.get()
 
+    def feeBaseOk(fee: MilliSatoshi): Boolean = fee < routeParams.maxFeeBase
+
+    def feePctOk(fee: MilliSatoshi, amount: MilliSatoshi): Boolean = {
+      val maxFee = amount * routeParams.maxFeePct
+      fee < maxFee
+    }
+
+    def feeOk(fee: MilliSatoshi, amount: MilliSatoshi): Boolean = feeBaseOk(fee) || feePctOk(fee, amount)
+
+    def lengthOk(length: Int): Boolean = length <= routeParams.routeMaxLength && length <= ROUTE_MAX_LENGTH
+
+    def cltvOk(cltv: Int): Boolean = cltv <= routeParams.routeMaxCltv
+
     val boundaries: RichWeight => Boolean = { weight =>
-      ((weight.cost - amount) < routeParams.maxFeeBase || (weight.cost - amount) < amount * routeParams.maxFeePct.toLong) &&
-        weight.length <= routeParams.routeMaxLength && weight.length <= ROUTE_MAX_LENGTH &&
-        weight.cltv <= routeParams.routeMaxCltv
+      feeOk(weight.cost - amount, amount) && lengthOk(weight.length) && cltvOk(weight.cltv)
     }
 
     val foundRoutes = Graph.yenKshortestPaths(g, localNodeId, targetNodeId, amount, ignoredEdges, extraEdges, numRoutes, routeParams.ratios, currentBlockHeight, boundaries).toList match {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -944,7 +944,6 @@ class RouteCalculationSpec extends FunSuite {
     assert(route.size == 2)
     assert(route.last.nextNodeId == targetNode)
   }
-
 }
 
 object RouteCalculationSpec {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -62,8 +62,8 @@ class RouteCalculationSpec extends FunSuite {
     // - below our maximum fee base
     // - below our maximum fraction of the paid amount
 
-    // here we here a maximum fee base of 1 msat, and all our updates have a base fee of 10 msat
-    // so our fee will always be above the base fee, and we will always check that is is below our maximum percentage
+    // here we have a maximum fee base of 1 msat, and all our updates have a base fee of 10 msat
+    // so our fee will always be above the base fee, and we will always check that it is below our maximum percentage
     // of the amount being paid
 
     val updates = List(


### PR DESCRIPTION
Fee check during route computation is:
- fee is below maximum value
- OR fee is below amout * maximum percentage

The second check was buggy and route computation would fail when fees we above maximum value but below maximum percentage of amount being paid.