### PR TITLE
Api: reject expired invoices

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -53,7 +53,6 @@ object TimestampQueryFilters {
   }
 }
 
-
 trait Eclair {
 
   def connect(target: Either[NodeURI, PublicKey])(implicit timeout: Timeout): Future[String]
@@ -78,7 +77,7 @@ trait Eclair {
 
   def receivedInfo(paymentHash: ByteVector32)(implicit timeout: Timeout): Future[Option[IncomingPayment]]
 
-  def send(recipientNodeId: PublicKey, amount: MilliSatoshi, paymentHash: ByteVector32, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, minFinalCltvExpiryDelta_opt: Option[CltvExpiryDelta] = None, maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None)(implicit timeout: Timeout): Future[UUID]
+  def send(recipientNodeId: PublicKey, amount: MilliSatoshi, paymentHash: ByteVector32, invoice_opt: Option[PaymentRequest] = None, maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None)(implicit timeout: Timeout): Future[UUID]
 
   def sentInfo(id: Either[UUID, ByteVector32])(implicit timeout: Timeout): Future[Seq[OutgoingPayment]]
 
@@ -190,7 +189,7 @@ class EclairImpl(appKit: Kit) extends Eclair {
     (appKit.paymentInitiator ? SendPaymentToRoute(amount, paymentHash, route, finalCltvExpiryDelta)).mapTo[UUID]
   }
 
-  override def send(recipientNodeId: PublicKey, amount: MilliSatoshi, paymentHash: ByteVector32, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, minFinalCltvExpiryDelta_opt: Option[CltvExpiryDelta], maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double])(implicit timeout: Timeout): Future[UUID] = {
+  override def send(recipientNodeId: PublicKey, amount: MilliSatoshi, paymentHash: ByteVector32, invoice_opt: Option[PaymentRequest], maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double])(implicit timeout: Timeout): Future[UUID] = {
     val maxAttempts = maxAttempts_opt.getOrElse(appKit.nodeParams.maxPaymentAttempts)
 
     val defaultRouteParams = Router.getDefaultRouteParams(appKit.nodeParams.routerConf)
@@ -199,11 +198,18 @@ class EclairImpl(appKit: Kit) extends Eclair {
       maxFeeBase = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeBase)
     )
 
-    val sendPayment = minFinalCltvExpiryDelta_opt match {
-      case Some(minCltv) => SendPayment(amount, paymentHash, recipientNodeId, assistedRoutes, finalCltvExpiryDelta = minCltv, maxAttempts = maxAttempts, routeParams = Some(routeParams))
-      case None => SendPayment(amount, paymentHash, recipientNodeId, assistedRoutes, maxAttempts = maxAttempts, routeParams = Some(routeParams))
+    invoice_opt match {
+      case Some(invoice) if invoice.isExpired => Future.failed(new IllegalArgumentException("invoice has expired"))
+      case Some(invoice) =>
+        val sendPayment = invoice.minFinalCltvExpiryDelta match {
+          case Some(minFinalCltvExpiryDelta) => SendPayment(amount, paymentHash, recipientNodeId, invoice.routingInfo, minFinalCltvExpiryDelta, maxAttempts = maxAttempts, routeParams = Some(routeParams))
+          case None => SendPayment(amount, paymentHash, recipientNodeId, invoice.routingInfo, maxAttempts = maxAttempts, routeParams = Some(routeParams))
+        }
+        (appKit.paymentInitiator ? sendPayment).mapTo[UUID]
+      case None =>
+        val sendPayment = SendPayment(amount, paymentHash, recipientNodeId, maxAttempts = maxAttempts, routeParams = Some(routeParams))
+        (appKit.paymentInitiator ? sendPayment).mapTo[UUID]
     }
-    (appKit.paymentInitiator ? sendPayment).mapTo[UUID]
   }
 
   override def sentInfo(id: Either[UUID, ByteVector32])(implicit timeout: Timeout): Future[Seq[OutgoingPayment]] = Future {
@@ -252,10 +258,10 @@ class EclairImpl(appKit: Kit) extends Eclair {
   }
 
   /**
-    * Sends a request to a channel and expects a response
-    *
-    * @param channelIdentifier either a shortChannelId (BOLT encoded) or a channelId (32-byte hex encoded)
-    */
+   * Sends a request to a channel and expects a response
+   *
+   * @param channelIdentifier either a shortChannelId (BOLT encoded) or a channelId (32-byte hex encoded)
+   */
   def sendToChannel(channelIdentifier: Either[ByteVector32, ShortChannelId], request: Any)(implicit timeout: Timeout): Future[Any] = channelIdentifier match {
     case Left(channelId) => appKit.register ? Forward(channelId, request)
     case Right(shortChannelId) => appKit.register ? ForwardShortId(shortChannelId, request)

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -25,10 +25,10 @@ import akka.http.scaladsl.model.headers.BasicHttpCredentials
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest, WSProbe}
 import akka.stream.ActorMaterializer
-import akka.util.{ByteString, Timeout}
+import akka.util.Timeout
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
+import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair._
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.io.Peer.PeerInfo
@@ -38,7 +38,8 @@ import fr.acinq.eclair.wire.NodeAddress
 import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.{FunSuite, Matchers}
 import scodec.bits._
-import scala.concurrent.{Await, Future}
+
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.io.Source
 import scala.reflect.ClassTag
@@ -113,7 +114,6 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
   }
 
   test("'peers' should ask the switchboard for current known peers") {
-
     val eclair = mock[Eclair]
     val mockService = new MockService(eclair)
     eclair.peersInfo()(any[Timeout]) returns Future.successful(List(
@@ -141,7 +141,6 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
   }
 
   test("'usablebalances' asks router for current usable balances") {
-
     val eclair = mock[Eclair]
     val mockService = new MockService(eclair)
     eclair.usableBalances()(any[Timeout]) returns Future.successful(List(
@@ -162,7 +161,6 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
   }
 
   test("'getinfo' response should include this node ID") {
-
     val eclair = mock[Eclair]
     val mockService = new MockService(eclair)
     eclair.getInfoResponse()(any[Timeout]) returns Future.successful(GetInfoResponse(
@@ -187,7 +185,6 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
   }
 
   test("'close' method should accept a channelId and shortChannelId") {
-
     val shortChannelIdSerialized = "42000x27x3"
     val channelId = "56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e"
 
@@ -223,7 +220,6 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
   }
 
   test("'connect' method should accept an URI and a triple with nodeId/host/port") {
-
     val remoteNodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
     val remoteUri = NodeURI.parse("030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87@93.137.102.239:9735")
 
@@ -252,13 +248,30 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
       }
   }
 
-
-  test("'send' method should correctly forward amount parameters to EclairImpl") {
+  test("'send' method should handle payment failures") {
+    val eclair = mock[Eclair]
+    eclair.send(any, any, any, any, any, any, any)(any[Timeout]) returns Future.failed(new IllegalArgumentException("invoice has expired"))
+    val mockService = new MockService(eclair)
 
     val invoice = "lnbc12580n1pw2ywztpp554ganw404sh4yjkwnysgn3wjcxfcq7gtx53gxczkjr9nlpc3hzvqdq2wpskwctddyxqr4rqrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glc7z9rtvqqwngqqqqqqqlgqqqqqeqqjqrrt8smgjvfj7sg38dwtr9kc9gg3era9k3t2hvq3cup0jvsrtrxuplevqgfhd3rzvhulgcxj97yjuj8gdx8mllwj4wzjd8gdjhpz3lpqqvk2plh"
 
+    Post("/payinvoice", FormData("invoice" -> invoice).toEntity) ~>
+      addCredentials(BasicHttpCredentials("", mockService.password)) ~>
+      Route.seal(mockService.route) ~>
+      check {
+        assert(handled)
+        assert(status == BadRequest)
+        val resp = entityAs[ErrorResponse](Json4sSupport.unmarshaller, ClassTag(classOf[ErrorResponse]))
+        assert(resp.error == "invoice has expired")
+        eclair.send(any, 1258000 msat, any, any, any, any, any)(any[Timeout]).wasCalled(once)
+      }
+  }
+
+  test("'send' method should correctly forward amount parameters to EclairImpl") {
+    val invoice = "lnbc12580n1pw2ywztpp554ganw404sh4yjkwnysgn3wjcxfcq7gtx53gxczkjr9nlpc3hzvqdq2wpskwctddyxqr4rqrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glc7z9rtvqqwngqqqqqqqlgqqqqqeqqjqrrt8smgjvfj7sg38dwtr9kc9gg3era9k3t2hvq3cup0jvsrtrxuplevqgfhd3rzvhulgcxj97yjuj8gdx8mllwj4wzjd8gdjhpz3lpqqvk2plh"
+
     val eclair = mock[Eclair]
-    eclair.send(any, any, any, any, any, any, any, any)(any[Timeout]) returns Future.successful(UUID.randomUUID())
+    eclair.send(any, any, any, any, any, any, any)(any[Timeout]) returns Future.successful(UUID.randomUUID())
     val mockService = new MockService(eclair)
 
     Post("/payinvoice", FormData("invoice" -> invoice).toEntity) ~>
@@ -267,9 +280,8 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
       check {
         assert(handled)
         assert(status == OK)
-        eclair.send(any, 1258000 msat, any, any, any, any, any, any)(any[Timeout]).wasCalled(once)
+        eclair.send(any, 1258000 msat, any, any, any, any, any)(any[Timeout]).wasCalled(once)
       }
-
 
     Post("/payinvoice", FormData("invoice" -> invoice, "amountMsat" -> "123", "feeThresholdSat" -> "112233", "maxFeePct" -> "2.34").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockService.password)) ~>
@@ -277,13 +289,12 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
       check {
         assert(handled)
         assert(status == OK)
-        eclair.send(any, 123 msat, any, any, any, any, Some(112233 sat), Some(2.34))(any[Timeout]).wasCalled(once)
+        eclair.send(any, 123 msat, any, any, any, Some(112233 sat), Some(2.34))(any[Timeout]).wasCalled(once)
       }
 
   }
 
   test("'getreceivedinfo' method should respond HTTP 404 with a JSON encoded response if the element is not found") {
-
     val eclair = mock[Eclair]
     eclair.receivedInfo(any[ByteVector32])(any) returns Future.successful(None)
     val mockService = new MockService(eclair)
@@ -301,7 +312,6 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
   }
 
   test("'sendtoroute' method should accept a both a json-encoded AND comma separaterd list of pubkeys") {
-
     val rawUUID = "487da196-a4dc-4b1e-92b4-3e5e905e9f3f"
     val paymentUUID = UUID.fromString(rawUUID)
     val expectedRoute = List(PublicKey(hex"0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9"), PublicKey(hex"0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3"), PublicKey(hex"026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28"))
@@ -319,7 +329,7 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
       check {
         assert(handled)
         assert(status == OK)
-        assert(entityAs[String] == "\""+rawUUID+"\"")
+        assert(entityAs[String] == "\"" + rawUUID + "\"")
         eclair.sendToRoute(expectedRoute, 1234 msat, ByteVector32.Zeroes, CltvExpiryDelta(190))(any[Timeout]).wasCalled(once)
       }
 
@@ -331,13 +341,12 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
       check {
         assert(handled)
         assert(status == OK)
-        assert(entityAs[String] == "\""+rawUUID+"\"")
+        assert(entityAs[String] == "\"" + rawUUID + "\"")
         eclair.sendToRoute(expectedRoute, 1234 msat, ByteVector32.One, CltvExpiryDelta(190))(any[Timeout]).wasCalled(once)
       }
   }
 
   test("the websocket should return typed objects") {
-
     val mockService = new MockService(mock[Eclair])
     val fixedUUID = UUID.fromString("487da196-a4dc-4b1e-92b4-3e5e905e9f3f")
 


### PR DESCRIPTION
https://github.com/ACINQ/eclair-mobile/issues/209 mentions that we don't check invoice expiry on the sender side.
I'm adding that check at the http API level, but I think it also needs to be added inside eclair-mobile (which directly uses the Java interface if I'm not mistaken).