### PR TITLE
Halt on fatal validation errors

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinJsonRPCClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinJsonRPCClient.scala
@@ -30,7 +30,9 @@ trait BitcoinJsonRPCClient {
 
 // @formatter:off
 case class JsonRPCRequest(jsonrpc: String = "1.0", id: String = "scala-client", method: String, params: Seq[Any])
-case class Error(code: Int, message: String)
+case class Error(code: Int, message: String) {
+  def isFatal: Boolean = message.contains("Blockchain transactions are still in the process of being indexed")
+}
 case class JsonRPCResponse(result: JValue, error: Option[Error], id: String)
 case class JsonRPCError(error: Error) extends IOException(s"${error.message} (code: ${error.code})")
 // @formatter:on


### PR DESCRIPTION
This PR aims at improving the error handling when we can't validate channel announcements, the behavior is now to halt completely to avoid continuing without being able to validate the network updates.