### PR TITLE
Better handling of bitcoind failures

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -27,6 +27,7 @@ eclair {
     rpcpassword = "bar"
     zmqblock = "tcp://127.0.0.1:29000"
     zmqtx = "tcp://127.0.0.1:29000"
+    disconnect-grace-seconds = 60
   }
 
   min-feerate = 3 // minimum feerate in satoshis per byte

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -263,7 +263,7 @@ class Setup(datadir: File,
       server = system.actorOf(SimpleSupervisor.props(Server.props(nodeParams, authenticator, serverBindingAddress, Some(tcpBound)), "server", SupervisorStrategy.Restart))
       paymentInitiator = system.actorOf(SimpleSupervisor.props(PaymentInitiator.props(nodeParams, router, register), "payment-initiator", SupervisorStrategy.Restart))
       _ = for (i <- 0 until config.getInt("autoprobe-count")) yield system.actorOf(SimpleSupervisor.props(Autoprobe.props(nodeParams, router, paymentInitiator), s"payment-autoprobe-$i", SupervisorStrategy.Restart))
-      _ = system.actorOf(SimpleSupervisor.props(Props(new FatalErrorMonitor), "fatal-error-actor", SupervisorStrategy.Restart))
+      _ = system.actorOf(SimpleSupervisor.props(Props(new FatalErrorMonitor(config.getLong("bitcoind.disconnect-grace-seconds").seconds)), "fatal-error-actor", SupervisorStrategy.Restart))
       kit = Kit(
         nodeParams = nodeParams,
         system = system,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -31,7 +31,7 @@ import fr.acinq.bitcoin.{Block, ByteVector32}
 import fr.acinq.eclair.NodeParams.{BITCOIND, ELECTRUM}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, BatchingBitcoinJsonRPCClient, ExtendedBitcoinClient}
 import fr.acinq.eclair.blockchain.bitcoind.zmq.ZMQActor
-import fr.acinq.eclair.blockchain.bitcoind.{BitcoinCoreWallet, ZmqWatcher}
+import fr.acinq.eclair.blockchain.bitcoind.{BitcoinCoreWallet, FatalErrorMonitor, ZmqWatcher}
 import fr.acinq.eclair.blockchain.electrum.ElectrumClient.SSL
 import fr.acinq.eclair.blockchain.electrum.ElectrumClientPool.ElectrumServerAddress
 import fr.acinq.eclair.blockchain.electrum._
@@ -263,7 +263,7 @@ class Setup(datadir: File,
       server = system.actorOf(SimpleSupervisor.props(Server.props(nodeParams, authenticator, serverBindingAddress, Some(tcpBound)), "server", SupervisorStrategy.Restart))
       paymentInitiator = system.actorOf(SimpleSupervisor.props(PaymentInitiator.props(nodeParams, router, register), "payment-initiator", SupervisorStrategy.Restart))
       _ = for (i <- 0 until config.getInt("autoprobe-count")) yield system.actorOf(SimpleSupervisor.props(Autoprobe.props(nodeParams, router, paymentInitiator), s"payment-autoprobe-$i", SupervisorStrategy.Restart))
-
+      _ = system.actorOf(SimpleSupervisor.props(Props(new FatalErrorMonitor), "fatal-error-actor", SupervisorStrategy.Restart))
       kit = Kit(
         nodeParams = nodeParams,
         system = system,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/FatalErrorMonitor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/FatalErrorMonitor.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.blockchain.bitcoind
+
+import akka.actor.{Actor, ActorLogging}
+import fr.acinq.eclair.blockchain.bitcoind.zmq.ZMQActor.{ZMQDisconnected, ZMQEvent}
+
+/**
+  * This actor is responsible for monitoring fatal errors and halt the execution.
+  */
+class FatalErrorMonitor extends Actor with ActorLogging {
+
+  context.system.eventStream.subscribe(self, classOf[ZMQEvent])
+
+  override def receive: Receive = {
+    case ZMQDisconnected =>
+      log.error("fatal error: bitcoind's ZMQ disconnected, unable to continue")
+      System.exit(1)
+  }
+
+}


### PR DESCRIPTION
Currently eclair checks for bitcoin connectivity only at startup but if for any reason bitcoin _becomes_ unreachable eclair won't stop the channel operations, this is dangerous and can lead to fund loss (undetected channel breaches). This PR introduces a `FatalErrorMonitor` actor that will monitor for unrecoverable/fatal errors and halt eclair when they are detected, currently only the ZMQ disconnection is handled.