### PR TITLE
Drop support for Java 8

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -6,8 +6,6 @@
 - [Maven](https://maven.apache.org/download.cgi) 3.6.0 or newer
 - [Docker](https://www.docker.com/) 18.03 or newer (optional) if you want to run all tests
 
-:warning: You can also use [Oracle JDK 1.8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html) to build and run eclair, but we recommend you use OpenJDK 11.
-
 ## Build
 
 To build the project and run the tests, simply run:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Eclair is developed in [Scala](https://www.scala-lang.org/), a powerful function
 * eclair-node, which is a headless application that you can run on servers and desktops, and control from the command line
 * eclair-node-gui, which also includes a JavaFX GUI
 
-To run Eclair, you first need to install Java, we recommend that you use [OpenJDK 11](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot). Eclair will also run on Oracle JDK 1.8, Oracle JDK 11, and other versions of OpenJDK but we don't recommend using them.
+To run Eclair, you first need to install Java, we recommend that you use [OpenJDK 11](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot). Other runtimes also work but we don't recommend using them.
 
 Then download our latest [release](https://github.com/ACINQ/eclair/releases) and depending on whether or not you want a GUI run the following command:
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <scala.version>2.11.12</scala.version>
         <scala.version.short>2.11</scala.version.short>
         <akka.version>2.4.20</akka.version>


### PR DESCRIPTION
We already have Java 7 (for Android) and Java 11. Supporting Java 8
would require crossbuilding, which we are not doing (two recent PRs
broke the build on Java 8).