### PR TITLE
Sphinx: accept invalid downstream errors

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Sphinx.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Sphinx.scala
@@ -325,6 +325,8 @@ object Sphinx extends Logging {
       val stream = generateStream(key, PacketLength)
       logger.debug(s"ammag key: $key")
       logger.debug(s"error stream: $stream")
+      // If we received a packet with an invalid length, we trim and pad to forward a packet with a normal length upstream.
+      // This is a poor man's attempt at increasing the likelihood of the sender receiving the error.
       packet.take(PacketLength).padLeft(PacketLength) xor stream
     }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Sphinx.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Sphinx.scala
@@ -318,12 +318,14 @@ object Sphinx extends Logging {
       * @return an encrypted failure packet that can be sent to the destination node.
       */
     def wrap(packet: ByteVector, sharedSecret: ByteVector32): ByteVector = {
-      require(packet.length == PacketLength, s"invalid error packet length ${packet.length}, must be $PacketLength")
+      if (packet.length != PacketLength) {
+        logger.warn(s"invalid error packet length ${packet.length}, must be $PacketLength (malicious or buggy downstream node)")
+      }
       val key = generateKey("ammag", sharedSecret)
       val stream = generateStream(key, PacketLength)
       logger.debug(s"ammag key: $key")
       logger.debug(s"error stream: $stream")
-      packet xor stream
+      packet.take(PacketLength).padLeft(PacketLength) xor stream
     }
 
     /**

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -1337,14 +1337,9 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     sender.send(bob, CMD_FAIL_HTLC(htlc.id, Left(ByteVector.fill(260)(42))))
     sender.expectMsg("ok")
     val fail = bob2alice.expectMsgType[UpdateFailHtlc]
-
-    // actual test begins
-    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-    bob2alice.forward(alice)
-    awaitCond(alice.stateData == initialState.copy(
-      commitments = initialState.commitments.copy(remoteChanges = initialState.commitments.remoteChanges.copy(initialState.commitments.remoteChanges.proposed :+ fail))))
-    // alice won't forward the fail before it is cross-signed
-    relayerA.expectNoMsg()
+    assert(fail.id === htlc.id)
+    // We should rectify the packet length before forwarding upstream.
+    assert(fail.reason.length === Sphinx.FailurePacket.PacketLength)
   }
 
   test("recv CMD_UPDATE_FEE") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/SphinxSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/SphinxSpec.scala
@@ -18,16 +18,16 @@ package fr.acinq.eclair.crypto
 
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
-import fr.acinq.eclair.{UInt64, wire}
 import fr.acinq.eclair.wire._
+import fr.acinq.eclair.{UInt64, wire}
 import org.scalatest.FunSuite
 import scodec.bits._
 
 import scala.util.Success
 
 /**
-  * Created by fabrice on 10/01/17.
-  */
+ * Created by fabrice on 10/01/17.
+ */
 class SphinxSpec extends FunSuite {
 
   import Sphinx._
@@ -296,6 +296,20 @@ class SphinxSpec extends FunSuite {
       val Success(DecryptedFailurePacket(pubkey, failure)) = FailurePacket.decrypt(error4, sharedSecrets)
       assert(pubkey === publicKeys(4))
       assert(failure === TemporaryNodeFailure)
+    }
+  }
+
+  test("intermediate node replies with an invalid onion payload length") {
+    // The error will not be recoverable by the sender, but we must still forward it.
+    val sharedSecret = ByteVector32(hex"4242424242424242424242424242424242424242424242424242424242424242")
+    val errors = Seq(
+      ByteVector.fill(FailurePacket.PacketLength - MacLength)(13),
+      ByteVector.fill(FailurePacket.PacketLength + MacLength)(13)
+    )
+
+    for (error <- errors) {
+      val wrapped = FailurePacket.wrap(error, sharedSecret)
+      assert(wrapped.length === FailurePacket.PacketLength)
     }
   }
 


### PR DESCRIPTION
When a downstream node sends us an onion error with an invalid length, we must forward the failure.
The recipient won't be able to extract the error but at least it knows the payment failed.

Fixes #1110 (I'm having a quick look at lnd and c-lightning to see which one has the bug of creating these invalid errors in the first place)