### PR TITLE
Update string to match on bitcoind while it's indexing

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -156,6 +156,11 @@ class Setup(datadir: File,
             .filter(value => (value \ "spendable").extract[Boolean])
             .map(value => (value \ "address").extract[String])
         }
+        _ <- chain match {
+          case "mainnet" => bitcoinClient.invoke("getrawtransaction", "2157b554dcfda405233906e461ee593875ae4b1b97615872db6a25130ecc1dd6") // coinbase of #500000
+          case "testnet" => bitcoinClient.invoke("getrawtransaction", "8f38a0dd41dc0ae7509081e262d791f8d53ed6f884323796d5ec7b0966dd3825") // coinbase of #1500000
+          case "regtest" => Future.successful(())
+        }
       } yield (progress, ibd, chainHash, bitcoinVersion, unspentAddresses, blocks, headers)
       // blocking sanity checks
       val (progress, initialBlockDownload, chainHash, bitcoinVersion, unspentAddresses, blocks, headers) = await(future, 30 seconds, "bicoind did not respond after 30 seconds")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
@@ -122,7 +122,7 @@ class BitcoinCoreWallet(rpcClient: BitcoinJsonRPCClient)(implicit ec: ExecutionC
     exists <- getTransaction(tx.txid)
       .map(_ => true) // we have found the transaction
       .recover {
-      case JsonRPCError(Error(_, message)) if message.contains("indexing") =>
+      case JsonRPCError(Error(_, message)) if message.contains("index") =>
         sys.error("Fatal error: bitcoind is indexing!!")
         System.exit(1) // bitcoind is indexing, that's a fatal error!!
         false // won't be reached


### PR DESCRIPTION
Since we can't check if bitcoind is indexing during setup we had a string based match to detect it during the execution. The check occurs only in the `doubleSpent()` call of `BitcoinCoreWallet`, and it's currently not working because the response from bitcoind does **not** contain the word "indexing" anymore [source](https://github.com/bitcoin/bitcoin/blob/v0.18.1/src/rpc/rawtransaction.cpp#L197). 
