### PR TITLE
Fix and expand channel keypath

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
@@ -112,9 +112,9 @@ object KeyManager {
     * @return a BIP32 path
     */
   def channelKeyPath(fundingPubKey: PublicKey) : DeterministicWallet.KeyPath = {
-    val buffer = fundingPubKey.hash160.take(8)
+    val buffer = fundingPubKey.hash160.take(16)
     val bis = new ByteArrayInputStream(buffer.toArray)
-    DeterministicWallet.KeyPath(Seq(Protocol.uint32(bis, ByteOrder.BIG_ENDIAN), Protocol.uint32(bis, ByteOrder.BIG_ENDIAN)))
+    DeterministicWallet.KeyPath(Seq(Protocol.uint32(bis, ByteOrder.BIG_ENDIAN), Protocol.uint32(bis, ByteOrder.BIG_ENDIAN), Protocol.uint32(bis, ByteOrder.BIG_ENDIAN), Protocol.uint32(bis, ByteOrder.BIG_ENDIAN)))
   }
 
   def channelKeyPath(fundingPubKey: DeterministicWallet.ExtendedPublicKey) : DeterministicWallet.KeyPath = channelKeyPath(fundingPubKey.publicKey)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
@@ -114,7 +114,7 @@ object KeyManager {
   def channelKeyPath(fundingPubKey: PublicKey) : DeterministicWallet.KeyPath = {
     val buffer = fundingPubKey.hash160.take(8)
     val bis = new ByteArrayInputStream(buffer.toArray)
-    DeterministicWallet.KeyPath(Seq(Protocol.uint32(bis, ByteOrder.BIG_ENDIAN), Protocol.uint32(bis, ByteOrder.BIG_ENDIAN), Protocol.uint32(bis, ByteOrder.BIG_ENDIAN), Protocol.uint32(bis, ByteOrder.BIG_ENDIAN)))
+    DeterministicWallet.KeyPath(Seq(Protocol.uint32(bis, ByteOrder.BIG_ENDIAN), Protocol.uint32(bis, ByteOrder.BIG_ENDIAN)))
   }
 
   def channelKeyPath(fundingPubKey: DeterministicWallet.ExtendedPublicKey) : DeterministicWallet.KeyPath = channelKeyPath(fundingPubKey.publicKey)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/LocalKeyManagerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/LocalKeyManagerSpec.scala
@@ -59,10 +59,10 @@ class LocalKeyManagerSpec extends FunSuite {
   }
 
   test("compute channel key path from funding keys") {
-    // if this test fails it means that we don't generate the same chanel key path from the same funding pubkey, which
+    // if this test fails it means that we don't generate the same channel key path from the same funding pubkey, which
     // will break existing channels !
     val pub = PrivateKey(ByteVector32.fromValidHex("01" * 32)).publicKey
     val keyPath = KeyManager.channelKeyPath(pub)
-    assert(keyPath.toString() == "m/2041577608/1982247572")
+    assert(keyPath.toString() == "m/2041577608/1982247572/689197082'/1288840885")
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/LocalKeyManagerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/LocalKeyManagerSpec.scala
@@ -16,9 +16,9 @@
 
 package fr.acinq.eclair.crypto
 
-import fr.acinq.bitcoin.{Block, ByteVector32, DeterministicWallet}
-import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.DeterministicWallet.KeyPath
+import fr.acinq.bitcoin.{Block, ByteVector32, DeterministicWallet}
 import org.scalatest.FunSuite
 import scodec.bits._
 
@@ -56,5 +56,13 @@ class LocalKeyManagerSpec extends FunSuite {
     val keyPath = KeyPath(1L :: Nil)
     assert(keyManager1.fundingPublicKey(keyPath) != keyManager2.fundingPublicKey(keyPath))
     assert(keyManager1.commitmentPoint(keyPath, 1) != keyManager2.commitmentPoint(keyPath, 1))
+  }
+
+  test("compute channel key path from funding keys") {
+    // if this test fails it means that we don't generate the same chanel key path from the same funding pubkey, which
+    // will break existing channels !
+    val pub = PrivateKey(ByteVector32.fromValidHex("01" * 32)).publicKey
+    val keyPath = KeyManager.channelKeyPath(pub)
+    assert(keyPath.toString() == "m/2041577608/1982247572")
   }
 }


### PR DESCRIPTION
We currently use 64 bits from the funding pubkey to compute a channel key path made of 4 uint32 values, so the last 2 are always 0. This PR fixes this by using 128 bits instead, and also includes a backward-compatibility check.