### PR TITLE
Use bitcoin 0.18.1 in the test

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -79,10 +79,10 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoin.org/bin/bitcoin-core-0.17.1/bitcoin-0.17.1-x86_64-linux-gnu.tar.gz
+                <bitcoind.url>https://bitcoin.org/bin/bitcoin-core-0.18.1/bitcoin-0.18.1-x86_64-linux-gnu.tar.gz
                 </bitcoind.url>
-                <bitcoind.md5>724043999e2b5ed0c088e8db34f15d43</bitcoind.md5>
-                <bitcoind.sha1>546ee35d4089c7ccc040a01cdff3362599b8bc53</bitcoind.sha1>
+                <bitcoind.md5>d3159a28702ca0cba2e0459e83219dfb</bitcoind.md5>
+                <bitcoind.sha1>969020835c1f0c759032def0d7b99669db06d8f7</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -93,10 +93,10 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoin.org/bin/bitcoin-core-0.17.1/bitcoin-0.17.1-osx64.tar.gz
+                <bitcoind.url>https://bitcoin.org/bin/bitcoin-core-0.18.1/bitcoin-0.18.1-osx64.tar.gz
                 </bitcoind.url>
-                <bitcoind.md5>b5a792c6142995faa42b768273a493bd</bitcoind.md5>
-                <bitcoind.sha1>8bd51c7024d71de07df381055993e9f472013db8</bitcoind.sha1>
+                <bitcoind.md5>0334b1024f28e83341c89df14e622bb6</bitcoind.md5>
+                <bitcoind.sha1>80354b40b409f342f5d35acd6b2c0e71f689285b</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -107,9 +107,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoin.org/bin/bitcoin-core-0.17.1/bitcoin-0.17.1-win64.zip</bitcoind.url>
-                <bitcoind.md5>b0e824e9dd02580b5b01f073f3c89858</bitcoind.md5>
-                <bitcoind.sha1>4e17bad7d08c465b444143a93cd6eb1c95076e3f</bitcoind.sha1>
+                <bitcoind.url>https://bitcoin.org/bin/bitcoin-core-0.18.1/bitcoin-0.18.1-win64.zip</bitcoind.url>
+                <bitcoind.md5>637776ca50b4354ca2f523bdee576bdb</bitcoind.md5>
+                <bitcoind.sha1>44771cc2161853b5230a7a159278dc8f27e7d4c2</bitcoind.sha1>
             </properties>
         </profile>
     </profiles>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -28,8 +28,8 @@ import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, JsonR
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.{LongToBtcAmount, addressToPublicKeyScript, randomKey}
 import grizzled.slf4j.Logging
-import org.json4s.JsonAST._
-import org.json4s.{DefaultFormats, JString}
+import org.json4s.JsonAST.{JString, _}
+import org.json4s.{DefaultFormats}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.collection.JavaConversions._
@@ -275,7 +275,9 @@ class BitcoinCoreWalletSpec extends TestKit(ActorSystem("test")) with BitcoindSe
     wallet.doubleSpent(tx1).pipeTo(sender.ref)
     sender.expectMsg(false)
     // let's confirm tx2
-    sender.send(bitcoincli, BitcoinReq("generate", 1))
+    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
+    val JString(generatingAddress) = sender.expectMsgType[JValue]
+    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 1, generatingAddress))
     sender.expectMsgType[JValue](10 seconds)
     // this time tx1 has been double spent
     wallet.doubleSpent(tx1).pipeTo(sender.ref)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -26,10 +26,10 @@ import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.FundTransactionResponse
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, JsonRPCError}
 import fr.acinq.eclair.transactions.Scripts
-import fr.acinq.eclair.{LongToBtcAmount, addressToPublicKeyScript, randomKey}
+import fr.acinq.eclair.{LongToBtcAmount, TestConstants, addressToPublicKeyScript, randomKey}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST.{JString, _}
-import org.json4s.{DefaultFormats}
+import org.json4s.DefaultFormats
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.collection.JavaConversions._
@@ -275,10 +275,7 @@ class BitcoinCoreWalletSpec extends TestKit(ActorSystem("test")) with BitcoindSe
     wallet.doubleSpent(tx1).pipeTo(sender.ref)
     sender.expectMsg(false)
     // let's confirm tx2
-    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(generatingAddress) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 1, generatingAddress))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 1)
     // this time tx1 has been double spent
     wallet.doubleSpent(tx1).pipeTo(sender.ref)
     sender.expectMsg(true)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -107,16 +107,26 @@ trait BitcoindService extends Logging {
       }
     }, max = 3 minutes, interval = 2 seconds)
     logger.info(s"generating initial blocks...")
-    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(address) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 150, address))
-    val JArray(res) = sender.expectMsgType[JValue](3 minutes)
-    assert(res.size == 150)
+    generateBlocks(bitcoincli, 150)
     awaitCond({
       sender.send(bitcoincli, BitcoinReq("getbalance"))
       val JDecimal(balance) = sender.expectMsgType[JDecimal](30 seconds)
       balance > 100
     }, max = 3 minutes, interval = 2 second)
+  }
+
+  def generateBlocks(bitcoinCli: ActorRef, blockCount: Int, address: Option[String] = None, timeout: FiniteDuration = 10 seconds)(implicit system: ActorSystem): Unit = {
+    val sender = TestProbe()
+    val addressToUse = address match {
+      case Some(addr) => addr
+      case None =>
+        sender.send(bitcoinCli, BitcoinReq("getnewaddress"))
+        val JString(address) = sender.expectMsgType[JValue](timeout)
+        address
+    }
+    sender.send(bitcoinCli, BitcoinReq("generatetoaddress", blockCount, addressToUse))
+    val JArray(blocks) = sender.expectMsgType[JValue](timeout)
+    assert(blocks.size == blockCount)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -53,7 +53,7 @@ trait BitcoindService extends Logging {
   val INTEGRATION_TMP_DIR = new File(TestUtils.BUILD_DIRECTORY, s"integration-${UUID.randomUUID()}")
   logger.info(s"using tmp dir: $INTEGRATION_TMP_DIR")
 
-  val PATH_BITCOIND = new File(TestUtils.BUILD_DIRECTORY, "bitcoin-0.17.1/bin/bitcoind")
+  val PATH_BITCOIND = new File(TestUtils.BUILD_DIRECTORY, "bitcoin-0.18.1/bin/bitcoind")
   val PATH_BITCOIND_DATADIR = new File(INTEGRATION_TMP_DIR, "datadir-bitcoin")
 
   var bitcoind: Process = null
@@ -107,7 +107,9 @@ trait BitcoindService extends Logging {
       }
     }, max = 3 minutes, interval = 2 seconds)
     logger.info(s"generating initial blocks...")
-    sender.send(bitcoincli, BitcoinReq("generate", 150))
+    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
+    val JString(address) = sender.expectMsgType[JValue]
+    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 150, address))
     val JArray(res) = sender.expectMsgType[JValue](3 minutes)
     assert(res.size == 150)
     awaitCond({

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
@@ -24,8 +24,8 @@ import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, ExtendedBitcoinClient}
 import grizzled.slf4j.Logging
-import org.json4s.JsonAST._
-import org.json4s.{DefaultFormats, JString}
+import org.json4s.JsonAST.{JString, _}
+import org.json4s.{DefaultFormats}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
 import scala.collection.JavaConversions._
@@ -88,7 +88,9 @@ class ExtendedBitcoinClientSpec extends TestKit(ActorSystem("test")) with Bitcoi
     client.publishTransaction(tx).pipeTo(sender.ref)
     sender.expectMsg(txid)
     // let's confirm the tx
-    bitcoinClient.invoke("generate", 1).pipeTo(sender.ref)
+    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
+    val JString(generatingAddress) = sender.expectMsgType[JValue]
+    bitcoinClient.invoke("generatetoaddress", 1, generatingAddress).pipeTo(sender.ref)
     sender.expectMsgType[JValue]
     // and publish the tx a third time to test idempotence
     client.publishTransaction(tx).pipeTo(sender.ref)
@@ -110,7 +112,7 @@ class ExtendedBitcoinClientSpec extends TestKit(ActorSystem("test")) with Bitcoi
     client.publishTransaction(tx).pipeTo(sender.ref)
     sender.expectMsg(txid)
     // let's confirm the tx
-    bitcoinClient.invoke("generate", 1).pipeTo(sender.ref)
+    bitcoinClient.invoke("generatetoaddress", 1, generatingAddress).pipeTo(sender.ref)
     sender.expectMsgType[JValue]
     // and publish the tx a fifth time to test idempotence
     client.publishTransaction(tx).pipeTo(sender.ref)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
@@ -82,8 +82,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
       sender.receiveOne(5 second).isInstanceOf[JValue]
     }, max = 30 seconds, interval = 500 millis)
     logger.info(s"generating initial blocks...")
-    generateBlocks(bitcoincli, 150)
-    sender.expectMsgType[JValue](30 seconds)
+    generateBlocks(bitcoincli, 150, timeout = 30 seconds)
     DockerReadyChecker.LogLineContains("INFO:BlockProcessor:height: 151").looped(attempts = 15, delay = 1 second)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
@@ -82,9 +82,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
       sender.receiveOne(5 second).isInstanceOf[JValue]
     }, max = 30 seconds, interval = 500 millis)
     logger.info(s"generating initial blocks...")
-    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(address) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 150, address))
+    generateBlocks(bitcoincli, 150)
     sender.expectMsgType[JValue](30 seconds)
     DockerReadyChecker.LogLineContains("INFO:BlockProcessor:height: 151").looped(attempts = 15, delay = 1 second)
   }
@@ -119,11 +117,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     }, max = 30 seconds, interval = 1 second)
 
     // confirm our tx
-    probe.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(generatingAddress) = probe.expectMsgType[JValue]
-    probe.send(bitcoincli, BitcoinReq("generatetoaddress", 1, generatingAddress))
-    probe.expectMsgType[JValue]
-
+    generateBlocks(bitcoincli, 1)
     awaitCond({
       val GetBalanceResponse(confirmed1, unconfirmed1) = getBalance(probe)
       confirmed1 == confirmed + 100000000.sat
@@ -137,8 +131,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     logger.info(s"sending 0.5 btc to $address1")
     probe.send(bitcoincli, BitcoinReq("sendtoaddress", address1, 0.5))
     probe.expectMsgType[JValue]
-    probe.send(bitcoincli, BitcoinReq("generatetoaddress", 1, generatingAddress))
-    probe.expectMsgType[JValue]
+    generateBlocks(bitcoincli, 1)
 
     awaitCond({
       val GetBalanceResponse(confirmed1, _) = getBalance(probe)
@@ -173,11 +166,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
       unconfirmed1 == unconfirmed + amount + amount
     }, max = 30 seconds, interval = 1 second)
 
-    probe.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(generatingAddress) = probe.expectMsgType[JValue]
-    probe.send(bitcoincli, BitcoinReq("generatetoaddress", 1, generatingAddress))
-    probe.expectMsgType[JValue]
-
+    generateBlocks(bitcoincli, 1)
     awaitCond({
       val GetBalanceResponse(confirmed1, _) = getBalance(probe)
       confirmed1 == confirmed + amount + amount
@@ -207,11 +196,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     assert(received === 100000000.sat)
 
     logger.info("generating a new block")
-    probe.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(generatingAddress) = probe.expectMsgType[JValue]
-    probe.send(bitcoincli, BitcoinReq("generatetoaddress", 1, generatingAddress))
-    probe.expectMsgType[JValue]
-
+    generateBlocks(bitcoincli, 1)
     awaitCond({
       val GetBalanceResponse(confirmed1, _) = getBalance(probe)
       confirmed1 - confirmed === 100000000.sat
@@ -242,10 +227,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     probe.send(wallet, BroadcastTransaction(tx1))
     val BroadcastTransactionResponse(_, None) = probe.expectMsgType[BroadcastTransactionResponse]
 
-    probe.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(generatingAddress) = probe.expectMsgType[JValue]
-    probe.send(bitcoincli, BitcoinReq("generatetoaddress", 1, generatingAddress))
-    probe.expectMsgType[JValue]
+    generateBlocks(bitcoincli, 1)
 
     awaitCond({
       probe.send(bitcoincli, BitcoinReq("getreceivedbyaddress", address))
@@ -277,10 +259,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     probe.send(wallet, BroadcastTransaction(tx1))
     val BroadcastTransactionResponse(_, None) = probe.expectMsgType[BroadcastTransactionResponse]
 
-    probe.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(generatingAddress) = probe.expectMsgType[JValue]
-    probe.send(bitcoincli, BitcoinReq("generatetoaddress", 1, generatingAddress))
-    probe.expectMsgType[JValue]
+    generateBlocks(bitcoincli, 1)
 
     awaitCond({
       val GetBalanceResponse(confirmed1, _) = getBalance(probe)
@@ -337,10 +316,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     probe.send(wallet, IsDoubleSpent(tx2))
     probe.expectMsg(IsDoubleSpentResponse(tx2, false))
 
-    probe.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(generatingAddress) = probe.expectMsgType[JValue]
-    probe.send(bitcoincli, BitcoinReq("generatetoaddress", 2, generatingAddress))
-    probe.expectMsgType[JValue]
+    generateBlocks(bitcoincli, 2)
 
     awaitCond({
       probe.send(wallet, GetData)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
@@ -30,6 +30,7 @@ import fr.acinq.eclair.blockchain.electrum.ElectrumClientPool.ElectrumServerAddr
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel.{BITCOIN_FUNDING_DEPTHOK, BITCOIN_FUNDING_SPENT}
 import grizzled.slf4j.Logging
+import org.json4s
 import org.json4s.JsonAST.{JArray, JString, JValue}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 import scodec.bits._
@@ -72,9 +73,11 @@ class ElectrumWatcherSpec extends TestKit(ActorSystem("test")) with FunSuiteLike
 
     val listener = TestProbe()
     probe.send(watcher, WatchConfirmed(listener.ref, tx.txid, tx.txOut(0).publicKeyScript, 4, BITCOIN_FUNDING_DEPTHOK))
-    probe.send(bitcoincli, BitcoinReq("generate", 3))
+    probe.send(bitcoincli, BitcoinReq("getnewaddress"))
+    val JString(generatingAddress) = probe.expectMsgType[JValue]
+    probe.send(bitcoincli, BitcoinReq("generatetoaddress", 3, generatingAddress))
     listener.expectNoMsg(1 second)
-    probe.send(bitcoincli, BitcoinReq("generate", 2))
+    probe.send(bitcoincli, BitcoinReq("generatetoaddress", 2, generatingAddress))
     val confirmed = listener.expectMsgType[WatchEventConfirmed](20 seconds)
     assert(confirmed.tx.txid.toHex === txid)
     system.stop(watcher)
@@ -119,7 +122,9 @@ class ElectrumWatcherSpec extends TestKit(ActorSystem("test")) with FunSuiteLike
     listener.expectNoMsg(1 second)
     probe.send(bitcoincli, BitcoinReq("sendrawtransaction", spendingTx.toString))
     probe.expectMsgType[JValue]
-    probe.send(bitcoincli, BitcoinReq("generate", 2))
+    probe.send(bitcoincli, BitcoinReq("getnewaddress"))
+    val JString(generatingAddress) = probe.expectMsgType[JValue]
+    probe.send(bitcoincli, BitcoinReq("generatetoaddress", 2, generatingAddress))
     val blocks = probe.expectMsgType[JValue]
     val JArray(List(JString(block1), JString(block2))) = blocks
     val spent = listener.expectMsgType[WatchEventSpent](20 seconds)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -43,10 +43,10 @@ import fr.acinq.eclair.router.{Announcements, AnnouncementsBatchValidationSpec, 
 import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.transactions.Transactions.{HtlcSuccessTx, HtlcTimeoutTx}
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.{CltvExpiryDelta, Kit, LongToBtcAmount, MilliSatoshi, Setup, ShortChannelId, randomBytes32}
+import fr.acinq.eclair.{CltvExpiryDelta, Kit, LongToBtcAmount, MilliSatoshi, Setup, ShortChannelId, TestConstants, randomBytes32}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST.{JString, JValue}
-import org.json4s.{DefaultFormats}
+import org.json4s.DefaultFormats
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 import scodec.bits.ByteVector
 
@@ -115,10 +115,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
       sender.receiveOne(5 second).isInstanceOf[JValue]
     }, max = 30 seconds, interval = 500 millis)
     logger.info(s"generating initial blocks...")
-    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(address) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 150, address))
-    sender.expectMsgType[JValue](30 seconds)
+    generateBlocks(bitcoincli, 150, timeout = 30 seconds)
   }
 
   def instantiateEclairNode(name: String, config: Config) = {
@@ -216,10 +213,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     }, max = 20 seconds, interval = 1 second)
 
     // confirming the funding tx
-    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(address) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 2, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 2)
 
     within(60 seconds) {
       var count = 0
@@ -251,10 +245,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
   test("wait for network announcements") {
     val sender = TestProbe()
     // generating more blocks so that all funding txes are buried under at least 6 blocks
-    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(address) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 4, address))
-    sender.expectMsgType[JValue]
+    generateBlocks(bitcoincli, 4)
     // A requires private channels, as a consequence:
     // - only A and B know about channel A-B (and there is no channel_announcement)
     // - A is not announced (no node_announcement)
@@ -506,10 +497,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     // we then fulfill the htlc, which will make F redeem it on-chain
     sender.send(nodes("F1").register, Forward(htlc.channelId, CMD_FULFILL_HTLC(htlc.id, preimage)))
     // we then generate one block so that the htlc success tx gets written to the blockchain
-    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(address) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 1, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 1)
     // C will extract the preimage from the blockchain and fulfill the payment upstream
     paymentSender.expectMsgType[PaymentSent](30 seconds)
     // at this point F should have 1 recv transactions: the redeemed htlc
@@ -519,8 +507,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
       res.filter(_ \ "address" == JString(finalAddressF)).flatMap(_ \ "txids" \\ classOf[JString]).size == 1
     }, max = 30 seconds, interval = 1 second)
     // we then generate enough blocks so that C gets its main delayed output
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 145, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 145)
     // and C will have its main output
     awaitCond({
       sender.send(bitcoincli, BitcoinReq("listreceivedbyaddress", 0))
@@ -529,8 +516,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
       (receivedByC diff previouslyReceivedByC).size == 1
     }, max = 30 seconds, interval = 1 second)
     // we generate blocks to make tx confirm
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 2, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 2)
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     awaitAnnouncements(nodes.filterKeys(_ == "A"), 9, 11, 24)
@@ -592,14 +578,12 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     // we then generate one block so that the htlc success tx gets written to the blockchain
     sender.send(bitcoincli, BitcoinReq("getnewaddress"))
     val JString(address) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 1, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 1, Some(address))
     // C will extract the preimage from the blockchain and fulfill the payment upstream
     paymentSender.expectMsgType[PaymentSent](30 seconds)
     // at this point F should have 1 recv transactions: the redeemed htlc
     // we then generate enough blocks so that F gets its htlc-success delayed output
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 145, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 145, Some(address))
     // at this point F should have 1 recv transactions: the redeemed htlc
     awaitCond({
       sender.send(bitcoincli, BitcoinReq("listreceivedbyaddress", 0))
@@ -614,8 +598,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
       (receivedByC diff previouslyReceivedByC).size == 1
     }, max = 30 seconds, interval = 1 second)
     // we generate blocks to make tx confirm
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 2, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 2, Some(address))
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     awaitAnnouncements(nodes.filterKeys(_ == "A"), 8, 10, 22)
@@ -652,12 +635,10 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     // we then generate enough blocks to make the htlc timeout
     sender.send(bitcoincli, BitcoinReq("getnewaddress"))
     val JString(address) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 11, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 11, Some(address))
     // we generate more blocks for the htlc-timeout to reach enough confirmations
     awaitCond({
-      sender.send(bitcoincli, BitcoinReq("generatetoaddress", 1, address))
-      sender.expectMsgType[JValue](10 seconds)
+      generateBlocks(bitcoincli, 1, Some(address))
       paymentSender.msgAvailable
     }, max = 30 seconds, interval = 1 second)
     // this will fail the htlc
@@ -667,8 +648,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     assert(failed.failures.size === 1)
     assert(failed.failures.head.asInstanceOf[RemoteFailure].e === DecryptedFailurePacket(nodes("C").nodeParams.nodeId, PermanentChannelFailure))
     // we then generate enough blocks to confirm all delayed transactions
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 150, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 150, Some(address))
     // at this point C should have 2 recv transactions: its main output and the htlc timeout
     awaitCond({
       sender.send(bitcoincli, BitcoinReq("listreceivedbyaddress", 0))
@@ -677,8 +657,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
       (receivedByC diff previouslyReceivedByC).size == 2
     }, max = 30 seconds, interval = 1 second)
     // we generate blocks to make tx confirm
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 2, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 2, Some(address))
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     awaitAnnouncements(nodes.filterKeys(_ == "A"), 7, 9, 20)
@@ -719,12 +698,10 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     // we then generate enough blocks to make the htlc timeout
     sender.send(bitcoincli, BitcoinReq("getnewaddress"))
     val JString(address) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 11, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 11, Some(address))
     // we generate more blocks for the claim-htlc-timeout to reach enough confirmations
     awaitCond({
-      sender.send(bitcoincli, BitcoinReq("generatetoaddress", 1, address))
-      sender.expectMsgType[JValue](10 seconds)
+      generateBlocks(bitcoincli, 1, Some(address))
       paymentSender.msgAvailable
     }, max = 30 seconds, interval = 1 second)
     // this will fail the htlc
@@ -734,8 +711,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     assert(failed.failures.size === 1)
     assert(failed.failures.head.asInstanceOf[RemoteFailure].e === DecryptedFailurePacket(nodes("C").nodeParams.nodeId, PermanentChannelFailure))
     // we then generate enough blocks to confirm all delayed transactions
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 145, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 145, Some(address))
     // at this point C should have 2 recv transactions: its main output and the htlc timeout
     awaitCond({
       sender.send(bitcoincli, BitcoinReq("listreceivedbyaddress", 0))
@@ -744,8 +720,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
       (receivedByC diff previouslyReceivedByC).size == 2
     }, max = 30 seconds, interval = 1 second)
     // we generate blocks to make tx confirm
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 2, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 2, Some(address))
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     awaitAnnouncements(nodes.filterKeys(_ == "A"), 6, 8, 18)
@@ -851,10 +826,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     Transaction.correctlySpends(htlcSuccess, Seq(revokedCommitTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     Transaction.correctlySpends(htlcTimeout, Seq(revokedCommitTx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
     // we then generate blocks to make the htlc timeout (nothing will happen in the channel because all of them have already been fulfilled)
-    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(address) = sender.expectMsgType[JValue]
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 20, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 20)
     // then we publish F's revoked transactions
     sender.send(bitcoincli, BitcoinReq("sendrawtransaction", revokedCommitTx.toString()))
     sender.expectMsgType[JValue](10000 seconds)
@@ -870,7 +842,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
       (receivedByC diff previouslyReceivedByC).size == 6
     }, max = 30 seconds, interval = 1 second)
     // we generate blocks to make tx confirm
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 2, address))
+    generateBlocks(bitcoincli, 2)
     sender.expectMsgType[JValue](10 seconds)
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
@@ -888,13 +860,11 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     val channels = for (i <- 0 until 242) yield {
       // let's generate a block every 10 txs so that we can compute short ids
       if (i % 10 == 0) {
-        sender.send(bitcoincli, BitcoinReq("generatetoaddress", 1, address))
-        sender.expectMsgType[JValue](10 seconds)
+        generateBlocks(bitcoincli, 1, Some(address))
       }
       AnnouncementsBatchValidationSpec.simulateChannel
     }
-    sender.send(bitcoincli, BitcoinReq("generatetoaddress", 1, address))
-    sender.expectMsgType[JValue](10 seconds)
+    generateBlocks(bitcoincli, 1, Some(address))
     logger.info(s"simulated ${channels.size} channels")
 
     val remoteNodeId = PrivateKey(ByteVector32(ByteVector.fill(32)(1))).publicKey

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -843,7 +843,6 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     }, max = 30 seconds, interval = 1 second)
     // we generate blocks to make tx confirm
     generateBlocks(bitcoincli, 2)
-    sender.expectMsgType[JValue](10 seconds)
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     // this will remove the channel

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsBatchValidationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsBatchValidationSpec.scala
@@ -28,6 +28,8 @@ import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, Exten
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate}
 import fr.acinq.eclair.{CltvExpiryDelta, LongToBtcAmount, ShortChannelId, randomKey}
+import org.json4s
+import org.json4s.JsonAST.{JString, JValue}
 import org.scalatest.FunSuite
 import scodec.bits.ByteVector
 
@@ -76,8 +78,13 @@ object AnnouncementsBatchValidationSpec {
 
   case class SimulatedChannel(node1Key: PrivateKey, node2Key: PrivateKey, node1FundingKey: PrivateKey, node2FundingKey: PrivateKey, amount: Satoshi, fundingTx: Transaction, fundingOutputIndex: Int)
 
-  def generateBlocks(numBlocks: Int)(implicit extendedBitcoinClient: ExtendedBitcoinClient, ec: ExecutionContext) =
-    Await.result(extendedBitcoinClient.rpcClient.invoke("generate", numBlocks), 10 seconds)
+  def generateBlocks(numBlocks: Int)(implicit extendedBitcoinClient: ExtendedBitcoinClient, ec: ExecutionContext) = {
+    val generatedF = for {
+      JString(address) <- extendedBitcoinClient.rpcClient.invoke("getnewaddress")
+      _ <- extendedBitcoinClient.rpcClient.invoke("generatetoaddress", numBlocks, address)
+    } yield ()
+    Await.result(generatedF, 10 seconds)
+  }
 
   def simulateChannel()(implicit extendedBitcoinClient: ExtendedBitcoinClient, ec: ExecutionContext): SimulatedChannel = {
     val node1Key = randomKey


### PR DESCRIPTION
Upgrade the version of bitcoin used in the test, this is preparation work to drop support for bitcoin 0.17. The most notable change is the deprecation of `generate` RPC call which is replaced by `generatetoaddress`, all the test have been updated accordingly.