### PR TITLE
Electrum: improve coin selection (fixes #1146)

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWallet.scala
@@ -930,32 +930,6 @@ object ElectrumWallet {
 
     /**
      *
-     * @param amount                amount we want to pay
-     * @param allowSpendUnconfirmed if true, use unconfirmed utxos
-     * @return a set of utxos with a total value that is greater than amount
-     */
-    def chooseUtxos(amount: Satoshi, allowSpendUnconfirmed: Boolean): Seq[Utxo] = {
-      @tailrec
-      def select(chooseFrom: Seq[Utxo], selected: Set[Utxo]): Set[Utxo] = {
-        if (totalAmount(selected) >= amount) selected
-        else if (chooseFrom.isEmpty) throw new IllegalArgumentException("insufficient funds")
-        else select(chooseFrom.tail, selected + chooseFrom.head)
-      }
-
-      // select utxos that are not locked by pending txs
-      val lockedOutputs = locks.map(_.txIn.map(_.outPoint)).flatten
-      val unlocked = utxos.filterNot(utxo => lockedOutputs.contains(utxo.outPoint))
-      val unlocked1 = if (allowSpendUnconfirmed) unlocked else unlocked.filter(_.item.height > 0)
-
-      // sort utxos by amount, in increasing order
-      // this way we minimize the number of utxos in the wallet, and so we minimize the fees we'll pay for them
-      val unlocked2 = unlocked1.sortBy(_.item.value)
-      val selected = select(unlocked2, Set())
-      selected.toSeq
-    }
-
-    /**
-     *
      * @param tx           input tx that has no inputs
      * @param feeRatePerKw fee rate per kiloweight
      * @param minimumFee   minimum fee
@@ -971,35 +945,56 @@ object ElectrumWallet {
       val amount = tx.txOut.map(_.amount).sum
       require(amount > dustLimit, "amount to send is below dust limit")
 
-      // start with a hefty fee estimate
-      val utxos = chooseUtxos(amount + Transactions.weight2fee(feeRatePerKw, 1000), allowSpendUnconfirmed)
-      val spent = totalAmount(utxos)
+      // select utxos that are not locked by pending txs
+      val lockedOutputs = locks.map(_.txIn.map(_.outPoint)).flatten
+      val unlocked = utxos.filterNot(utxo => lockedOutputs.contains(utxo.outPoint))
+      val unlocked1 = if (allowSpendUnconfirmed) unlocked else unlocked.filter(_.item.height > 0)
 
-      // add utxos, and sign with dummy sigs
-      val tx1 = addUtxosWithDummySig(tx, utxos)
+      // sort utxos by amount, in increasing order
+      // this way we minimize the number of utxos in the wallet, and so we minimize the fees we'll pay for them
+      val unlocked2 = unlocked1.sortBy(_.item.value)
 
-      // compute the actual fee that we should pay
-      val fee1 = {
-        // add a dummy change output, which will be needed most of the time
-        val tx2 = tx1.addOutput(TxOut(amount, computePublicKeyScript(currentChangeKey.publicKey)))
+      def computeFee(candidates: Seq[Utxo], change: Option[TxOut]): Satoshi = {
+        val tx1 = addUtxosWithDummySig(tx, candidates)
+        val tx2 = change.map(o => tx1.addOutput(o)).getOrElse(tx1)
         Transactions.weight2fee(feeRatePerKw, tx2.weight())
       }
 
-      // add change output only if non-dust, otherwise change is added to the fee
-      val (tx2, fee2, pos) = (spent - amount - fee1) match {
-        case dustChange if dustChange < dustLimit => (tx1, fee1 + dustChange, -1) // if change is below dust we add it to fees
-        case change => (tx1.addOutput(TxOut(change, computePublicKeyScript(currentChangeKey.publicKey))), fee1, 1) // change output index is always 1
+      val dummyChange = TxOut(Satoshi(0), computePublicKeyScript(currentChangeKey.publicKey))
+
+      @tailrec
+      def loop(current: Seq[Utxo], remaining: Seq[Utxo]) : (Seq[Utxo], Option[TxOut]) = {
+        totalAmount(current) match {
+          case total if total - amount - computeFee(current, None) < Satoshi(0) && remaining.isEmpty =>
+            // not enough funds to send amount and pay fees even without a change output
+            throw new IllegalArgumentException("insufficient funds")
+          case total if total - amount - computeFee(current, None) < Satoshi(0) =>
+            loop(remaining.head +: current, remaining.tail)
+          case total if total - amount - computeFee(current, None) <= dustLimit =>
+            // change output would be below dust, we don't add one and just overpay fees
+            (current, None)
+          case total if total - amount - computeFee(current, Some(dummyChange)) <= dustLimit && remaining.isEmpty =>
+            // change output is above dust limit but cannot pay for it's own fee, and we have no more utxos => we overpay a bit
+            (current, None)
+          case total if total - amount - computeFee(current, Some(dummyChange)) <= dustLimit => loop(remaining.head +: current, remaining.tail)
+          case total =>
+            val fee = computeFee(current, Some(dummyChange))
+            val change = dummyChange.copy(amount = total - amount -fee) // TxOut(totalAmount(current) - amount - fee, computePublicKeyScript(currentChangeKey.publicKey))
+            (current, Some(change))
+        }
       }
 
+      val (selected, change_opt) = loop(Seq.empty[Utxo], unlocked2)
       // sign our tx
+      val tx1 = addUtxosWithDummySig(tx, selected)
+      val tx2 = change_opt.map(out => tx1.addOutput(out)).getOrElse(tx1)
       val tx3 = signTransaction(tx2)
-      //Transaction.correctlySpends(tx3, utxos.map(utxo => utxo.outPoint -> TxOut(Satoshi(utxo.item.value), computePublicKeyScript(utxo.key.publicKey))).toMap, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
 
       // and add the completed tx to the lokcs
       val data1 = this.copy(locks = this.locks + tx3)
-      val fee3 = spent - tx3.txOut.map(_.amount).sum
+      val fee = selected.map(s => Satoshi(s.item.value)).sum - tx3.txOut.map(_.amount).sum
 
-      (data1, tx3, fee3)
+      (data1, tx3, fee)
     }
 
     def signTransaction(tx: Transaction): Transaction = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
@@ -184,7 +184,7 @@ class ElectrumWalletBasicSpec extends FunSuite with Logging {
     assert(tx.txOut.map(_.amount).sum + fee == state3.balance._1 + state3.balance._2)
   }
 
-  test("issue eclair-mobile #211") {
+  test("check that issue #1146 is fixed") {
     val state3 = addFunds(state, state.changeKeys(0), 0.5 btc)
 
     val pub1 = state.accountKeys(0).publicKey
@@ -198,8 +198,7 @@ class ElectrumWalletBasicSpec extends FunSuite with Logging {
     assert(tx.txOut.map(_.amount).sum + fee == state3.balance._1 + state3.balance._2)
 
     val tx1 = Transaction(version = 2, txIn = Nil, txOut = TxOut(tx.txOut.map(_.amount).sum, pubkeyScript) :: Nil, lockTime = 0)
-    val (state4, tx2, fee2) = state3.completeTransaction(tx1, 750, 0 sat, dustLimit, true)
-    println(tx2.txOut)
+    assert(Try(state3.completeTransaction(tx1, 750, 0 sat, dustLimit, true)).isSuccess)
   }
 
   test("fuzzy test") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
@@ -22,7 +22,7 @@ import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.DeterministicWallet.{ExtendedPrivateKey, derivePrivateKey}
 import fr.acinq.bitcoin._
 import fr.acinq.eclair.blockchain.electrum.db.sqlite.SqliteWalletDb
-import fr.acinq.eclair.transactions.Transactions
+import fr.acinq.eclair.transactions.{Scripts, Transactions}
 import grizzled.slf4j.Logging
 import org.scalatest.FunSuite
 import scodec.bits.ByteVector
@@ -184,6 +184,24 @@ class ElectrumWalletBasicSpec extends FunSuite with Logging {
     assert(tx.txOut.map(_.amount).sum + fee == state3.balance._1 + state3.balance._2)
   }
 
+  test("issue eclair-mobile #211") {
+    val state3 = addFunds(state, state.changeKeys(0), 0.5 btc)
+
+    val pub1 = state.accountKeys(0).publicKey
+    val pub2 = state.accountKeys(1).publicKey
+    val redeemScript = Scripts.multiSig2of2(pub1, pub2)
+    val pubkeyScript = Script.pay2wsh(redeemScript)
+    val (tx, fee) = state3.spendAll(pubkeyScript, feeRatePerKw = 750)
+    val Some((received, sent, Some(fee1))) = state3.computeTransactionDelta(tx)
+    assert(received === 0.sat)
+    assert(fee == fee1)
+    assert(tx.txOut.map(_.amount).sum + fee == state3.balance._1 + state3.balance._2)
+
+    val tx1 = Transaction(version = 2, txIn = Nil, txOut = TxOut(tx.txOut.map(_.amount).sum, pubkeyScript) :: Nil, lockTime = 0)
+    val (state4, tx2, fee2) = state3.completeTransaction(tx1, 750, 0 sat, dustLimit, true)
+    println(tx2.txOut)
+  }
+
   test("fuzzy test") {
     val random = new Random()
     (0 to 10) foreach { _ =>
@@ -197,7 +215,8 @@ class ElectrumWalletBasicSpec extends FunSuite with Logging {
         val amount = dustLimit + random.nextInt(10000000).sat
         val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(amount, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
         Try(state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, true)) match {
-          case Success((state2, tx1, fee1)) => ()
+          case Success((state2, tx1, fee1)) =>
+            tx1.txOut.foreach(o => require(o.amount >= dustLimit, "output is below dust limit"))
           case Failure(cause) if cause.getMessage != null && cause.getMessage.contains("insufficient funds") => ()
           case Failure(cause) => logger.error(s"unexpected $cause")
         }


### PR DESCRIPTION
This PR changes how we select UTXOs when funding transactions, and fixes an issue where trying to use the amount returned by "spend all" with only 1 utxo and a low fee rate would result in an incorrect "insufficient funds" error (see #1146)