### PR TITLE
Upgrade new unit tests to bitcoin 0.18.1 API

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
@@ -342,8 +342,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     probe.send(wallet, BroadcastTransaction(tx))
     val BroadcastTransactionResponse(`tx`, None) = probe.expectMsgType[BroadcastTransactionResponse]
 
-    probe.send(bitcoincli, BitcoinReq("generate", 1))
-    probe.expectMsgType[JValue]
+    generateBlocks(bitcoincli, 1)
 
     awaitCond({
       probe.send(wallet, GetData)
@@ -360,8 +359,7 @@ class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     probe.send(wallet, BroadcastTransaction(tx1))
     val BroadcastTransactionResponse(`tx1`, None) = probe.expectMsgType[BroadcastTransactionResponse]
 
-    probe.send(bitcoincli, BitcoinReq("generate", 1))
-    probe.expectMsgType[JValue]
+    generateBlocks(bitcoincli, 1)
 
     awaitCond({
       probe.send(wallet, GetData)


### PR DESCRIPTION
We had 2 open PRs, one that added new tests using the 0.API, one that switched to 0.18.1, when they
were merged the new tests failed since they had not been upgraded....