### PR TITLE
Add execution time limit

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,5 +25,5 @@ blocks:
             - checkout
             - cache restore maven
             - mvn scoverage:report
-            - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN -v
+            - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
             - cache store maven .m2

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,5 +25,5 @@ blocks:
             - checkout
             - cache restore maven
             - mvn scoverage:report
-            - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
+            - bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN -v
             - cache store maven .m2

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,6 +4,8 @@ agent:
   machine:
     type: e1-standard-4
     os_image: ubuntu1804
+execution-time-limit:
+  minutes: 15
 
 blocks:
   - name: Build & Test

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,7 +4,7 @@ agent:
   machine:
     type: e1-standard-4
     os_image: ubuntu1804
-execution-time-limit:
+execution_time_limit:
   minutes: 15
 
 blocks:


### PR DESCRIPTION
We have a few flaky tests that sometimes block the build.
The default expiry in that case is 1 hour, so we pay for a semaphore VM for no reason.
We should fail earlier than that (15 minutes sounds reasonable).
We should also fix the flaky tests, but that's for another PR :innocent: 