### PR TITLE
Use guava to compute CRC32C checksums

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -16,8 +16,6 @@
 
 package fr.acinq.eclair.router
 
-import java.util.zip.CRC32C
-
 import akka.Done
 import akka.actor.{ActorRef, Props, Status}
 import akka.event.Logging.MDC
@@ -38,6 +36,7 @@ import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
 import kamon.Kamon
 import kamon.context.Context
+import scodec.bits.ByteVector
 import shapeless.HNil
 
 import scala.annotation.tailrec
@@ -1131,12 +1130,16 @@ object Router {
     (ReplyChannelRangeTlv.Timestamps(timestamp1 = timestamp1, timestamp2 = timestamp2), ReplyChannelRangeTlv.Checksums(checksum1 = checksum1, checksum2 = checksum2))
   }
 
+  def crc32c(data: ByteVector): Long = {
+    import com.google.common.hash.Hashing
+    Hashing.crc32c().hashBytes(data.toArray).asInt() & 0xFFFFFFFFL
+  }
+
   def getChecksum(u: ChannelUpdate): Long = {
     import u._
+
     val data = serializationResult(LightningMessageCodecs.channelUpdateChecksumCodec.encode(chainHash :: shortChannelId :: messageFlags :: channelFlags :: cltvExpiryDelta :: htlcMinimumMsat :: feeBaseMsat :: feeProportionalMillionths :: htlcMaximumMsat :: HNil))
-    val checksum = new CRC32C()
-    checksum.update(data.toArray)
-    checksum.getValue
+    crc32c(data)
   }
 
   case class ShortChannelIdsChunk(firstBlock: Long, numBlocks: Long, shortChannelIds: List[ShortChannelId])

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -20,6 +20,7 @@ import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.wire.ReplyChannelRangeTlv._
 import fr.acinq.eclair.{LongToBtcAmount, randomKey}
 import org.scalatest.FunSuite
+import scodec.bits.ByteVector
 
 import scala.collection.immutable.SortedMap
 import scala.compat.Platform
@@ -67,6 +68,13 @@ class ChannelRangeQueriesSpec extends FunSuite {
 
     // they just provided a different checksum that is the same as us => ask
     assert(Router.shouldRequestUpdate(now, 1234, None, Some(1235)))
+  }
+
+  test("compute checksums") {
+    assert(Router.crc32c(ByteVector.fromValidHex("00" * 32)) == 0x8a9136aaL)
+    assert(Router.crc32c(ByteVector.fromValidHex("FF" * 32)) == 0x62a8ab43L)
+    assert(Router.crc32c(ByteVector((0 to 31).map(_.toByte))) == 0x46dd794eL)
+    assert(Router.crc32c(ByteVector((31 to 0 by -1).map(_.toByte))) == 0x113fdb5cL)
   }
 
   test("compute flag tests") {


### PR DESCRIPTION
CRC32C is not available in JDK 7 which we target on Android.