### PR TITLE
High level call aggregating payments

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -28,6 +28,8 @@ trait ChannelsDb {
 
   def listLocalChannels(): Seq[HasCommitments]
 
+  def listClosedLocalChannels(): Seq[HasCommitments]
+
   def addOrUpdateHtlcInfo(channelId: ByteVector32, commitmentNumber: Long, paymentHash: ByteVector32, cltvExpiry: CltvExpiry)
 
   def listHtlcInfos(channelId: ByteVector32, commitmentNumber: Long): Seq[(ByteVector32, CltvExpiry)]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -209,9 +209,15 @@ object PaymentDirection {
 }
 
 /**
-  * Describes a generic payment, incoming or outgoing. Useful for high level requests.
+  * Generic payment trait, can be extended by external classes. Useful for high level requests aggregating
+  * payments of different origins.
   */
-case class Payment(direction: PaymentDirection,
+trait Payment
+
+/**
+  * Describes a generic Lightning payment, be it incoming or outgoing.
+  */
+case class LightningPayment(direction: PaymentDirection,
                    id: Option[UUID],
                    paymentHash: ByteVector32,
                    preimage: Option[ByteVector32],
@@ -220,4 +226,4 @@ case class Payment(direction: PaymentDirection,
                    status: PaymentStatus,
                    createdAt: Long,
                    completedAt: Option[Long],
-                   expireAt: Option[Long])
+                   expireAt: Option[Long]) extends Payment

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -98,26 +98,6 @@ case class IncomingPayment(paymentRequest: PaymentRequest,
                            createdAt: Long,
                            status: IncomingPaymentStatus)
 
-sealed trait IncomingPaymentStatus extends PaymentStatus
-
-object IncomingPaymentStatus {
-
-  /** Payment is pending (waiting to receive). */
-  case object Pending extends IncomingPaymentStatus
-
-  /** Payment has expired. */
-  case object Expired extends IncomingPaymentStatus
-
-  /**
-   * Payment has been successfully received.
-   *
-   * @param amount     amount of the payment received, in milli-satoshis (may exceed the payment request amount).
-   * @param receivedAt absolute time in milli-seconds since UNIX epoch when the payment was received.
-   */
-  case class Received(amount: MilliSatoshi, receivedAt: Long) extends IncomingPaymentStatus
-
-}
-
 /**
  * An outgoing payment sent by this node.
  * At first it is in a pending state, then will become either a success or a failure.
@@ -142,9 +122,28 @@ case class OutgoingPayment(id: UUID,
                            paymentRequest: Option[PaymentRequest],
                            status: OutgoingPaymentStatus)
 
-sealed trait PaymentStatus
 
+sealed trait PaymentStatus
+sealed trait IncomingPaymentStatus extends PaymentStatus
 sealed trait OutgoingPaymentStatus extends PaymentStatus
+
+object IncomingPaymentStatus {
+
+  /** Payment is pending (waiting to receive). */
+  case object Pending extends IncomingPaymentStatus
+
+  /** Payment has expired. */
+  case object Expired extends IncomingPaymentStatus
+
+  /**
+    * Payment has been successfully received.
+    *
+    * @param amount     amount of the payment received, in milli-satoshis (may exceed the payment request amount).
+    * @param receivedAt absolute time in milli-seconds since UNIX epoch when the payment was received.
+    */
+  case class Received(amount: MilliSatoshi, receivedAt: Long) extends IncomingPaymentStatus
+
+}
 
 object OutgoingPaymentStatus {
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -73,6 +73,14 @@ trait PaymentsDb {
   /** List all received (paid) incoming payments in the given time range (milli-seconds). */
   def listReceivedIncomingPayments(from: Long, to: Long): Seq[IncomingPayment]
 
+  /**
+    * List all incoming or outgoing payments within a given size limit, ordered by descending date.
+    * This method should only return incoming payments that have been received (not pending or failed).
+    *
+    * This is a high level method intended for front-end usage.
+    */
+  def listPayments(limit: Int): Seq[Payment]
+
 }
 
 /**
@@ -90,7 +98,7 @@ case class IncomingPayment(paymentRequest: PaymentRequest,
                            createdAt: Long,
                            status: IncomingPaymentStatus)
 
-sealed trait IncomingPaymentStatus
+sealed trait IncomingPaymentStatus extends PaymentStatus
 
 object IncomingPaymentStatus {
 
@@ -134,7 +142,9 @@ case class OutgoingPayment(id: UUID,
                            paymentRequest: Option[PaymentRequest],
                            status: OutgoingPaymentStatus)
 
-sealed trait OutgoingPaymentStatus
+sealed trait PaymentStatus
+
+sealed trait OutgoingPaymentStatus extends PaymentStatus
 
 object OutgoingPaymentStatus {
 
@@ -190,3 +200,24 @@ object FailureSummary {
     case UnreadableRemoteFailure(route) => FailureSummary(FailureType.UNREADABLE_REMOTE, "could not decrypt failure onion", route.map(h => HopSummary(h)).toList)
   }
 }
+
+sealed trait PaymentDirection
+
+object PaymentDirection {
+  case object IncomingPaymentDirection extends PaymentDirection
+  case object OutgoingPaymentDirection extends PaymentDirection
+}
+
+/**
+  * Describes a generic payment, incoming or outgoing. Useful for high level requests.
+  */
+case class Payment(direction: PaymentDirection,
+                   id: Option[UUID],
+                   paymentHash: ByteVector32,
+                   preimage: Option[ByteVector32],
+                   finalAmount: Option[MilliSatoshi],
+                   paymentRequest: Option[String],
+                   status: PaymentStatus,
+                   createdAt: Long,
+                   completedAt: Option[Long],
+                   expireAt: Option[Long])

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -53,9 +53,9 @@ trait PaymentsDb {
   def addIncomingPayment(pr: PaymentRequest, preimage: ByteVector32): Unit
 
   /**
-   * Mark an incoming payment as received (paid). The received amount may exceed the payment request amount.
-   * Note that this function assumes that there is a matching payment request in the DB.
-   */
+    * Mark an incoming payment as received (paid). The received amount may exceed the payment request amount.
+    * Note that this function assumes that there is a matching payment request in the DB.
+    */
   def receiveIncomingPayment(paymentHash: ByteVector32, amount: MilliSatoshi, receivedAt: Long = Platform.currentTime): Unit
 
   /** Get information about the incoming payment (paid or not) for the given payment hash, if any. */
@@ -84,34 +84,34 @@ trait PaymentsDb {
 }
 
 /**
- * An incoming payment received by this node.
- * At first it is in a pending state once the payment request has been generated, then will become either a success (if
- * we receive a valid HTLC) or a failure (if the payment request expires).
- *
- * @param paymentRequest  Bolt 11 payment request.
- * @param paymentPreimage pre-image associated with the payment request's payment_hash.
- * @param createdAt       absolute time in milli-seconds since UNIX epoch when the payment request was generated.
- * @param status          current status of the payment.
- */
+  * An incoming payment received by this node.
+  * At first it is in a pending state once the payment request has been generated, then will become either a success (if
+  * we receive a valid HTLC) or a failure (if the payment request expires).
+  *
+  * @param paymentRequest  Bolt 11 payment request.
+  * @param paymentPreimage pre-image associated with the payment request's payment_hash.
+  * @param createdAt       absolute time in milli-seconds since UNIX epoch when the payment request was generated.
+  * @param status          current status of the payment.
+  */
 case class IncomingPayment(paymentRequest: PaymentRequest,
                            paymentPreimage: ByteVector32,
                            createdAt: Long,
                            status: IncomingPaymentStatus)
 
 /**
- * An outgoing payment sent by this node.
- * At first it is in a pending state, then will become either a success or a failure.
- *
- * @param id             internal payment identifier.
- * @param parentId       internal identifier of a parent payment, or [[id]] if single-part payment.
- * @param externalId     external payment identifier: lets lightning applications reconcile payments with their own db.
- * @param paymentHash    payment_hash.
- * @param amount         amount of the payment, in milli-satoshis.
- * @param targetNodeId   node ID of the payment recipient.
- * @param createdAt      absolute time in milli-seconds since UNIX epoch when the payment was created.
- * @param paymentRequest Bolt 11 payment request (if paying from an invoice).
- * @param status         current status of the payment.
- */
+  * An outgoing payment sent by this node.
+  * At first it is in a pending state, then will become either a success or a failure.
+  *
+  * @param id             internal payment identifier.
+  * @param parentId       internal identifier of a parent payment, or [[id]] if single-part payment.
+  * @param externalId     external payment identifier: lets lightning applications reconcile payments with their own db.
+  * @param paymentHash    payment_hash.
+  * @param amount         amount of the payment, in milli-satoshis.
+  * @param targetNodeId   node ID of the payment recipient.
+  * @param createdAt      absolute time in milli-seconds since UNIX epoch when the payment was created.
+  * @param paymentRequest Bolt 11 payment request (if paying from an invoice).
+  * @param status         current status of the payment.
+  */
 case class OutgoingPayment(id: UUID,
                            parentId: UUID,
                            externalId: Option[String],
@@ -124,7 +124,9 @@ case class OutgoingPayment(id: UUID,
 
 
 sealed trait PaymentStatus
+
 sealed trait IncomingPaymentStatus extends PaymentStatus
+
 sealed trait OutgoingPaymentStatus extends PaymentStatus
 
 object IncomingPaymentStatus {
@@ -151,22 +153,22 @@ object OutgoingPaymentStatus {
   case object Pending extends OutgoingPaymentStatus
 
   /**
-   * Payment has been successfully sent and the recipient released the pre-image.
-   * We now have a valid proof-of-payment.
-   *
-   * @param paymentPreimage the preimage of the payment_hash.
-   * @param feesPaid        total amount of fees paid to intermediate routing nodes.
-   * @param route           payment route.
-   * @param completedAt     absolute time in milli-seconds since UNIX epoch when the payment was completed.
-   */
+    * Payment has been successfully sent and the recipient released the pre-image.
+    * We now have a valid proof-of-payment.
+    *
+    * @param paymentPreimage the preimage of the payment_hash.
+    * @param feesPaid        total amount of fees paid to intermediate routing nodes.
+    * @param route           payment route.
+    * @param completedAt     absolute time in milli-seconds since UNIX epoch when the payment was completed.
+    */
   case class Succeeded(paymentPreimage: ByteVector32, feesPaid: MilliSatoshi, route: Seq[HopSummary], completedAt: Long) extends OutgoingPaymentStatus
 
   /**
-   * Payment has failed and may be retried.
-   *
-   * @param failures    failed payment attempts.
-   * @param completedAt absolute time in milli-seconds since UNIX epoch when the payment was completed.
-   */
+    * Payment has failed and may be retried.
+    *
+    * @param failures    failed payment attempts.
+    * @param completedAt absolute time in milli-seconds since UNIX epoch when the payment was completed.
+    */
   case class Failed(failures: Seq[FailureSummary], completedAt: Long) extends OutgoingPaymentStatus
 
 }
@@ -203,8 +205,11 @@ object FailureSummary {
 sealed trait PaymentDirection
 
 object PaymentDirection {
+
   case object IncomingPaymentDirection extends PaymentDirection
+
   case object OutgoingPaymentDirection extends PaymentDirection
+
 }
 
 /**
@@ -217,12 +222,12 @@ trait Payment
   * Describes a generic Lightning payment, be it incoming or outgoing.
   */
 case class LightningPayment(direction: PaymentDirection,
-                   id: Option[UUID],
-                   paymentHash: ByteVector32,
-                   preimage: Option[ByteVector32],
-                   finalAmount: Option[MilliSatoshi],
-                   paymentRequest: Option[String],
-                   status: PaymentStatus,
-                   createdAt: Long,
-                   completedAt: Option[Long],
-                   expireAt: Option[Long]) extends Payment
+                            parentId: Option[UUID],
+                            paymentHash: ByteVector32,
+                            preimage: Option[ByteVector32],
+                            finalAmount: Option[MilliSatoshi],
+                            paymentRequest: Option[String],
+                            status: PaymentStatus,
+                            createdAt: Long,
+                            completedAt: Option[Long],
+                            expireAt: Option[Long]) extends Payment

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -75,7 +75,7 @@ trait PaymentsDb {
 
   /**
     * List all incoming or outgoing payments within a given size limit, ordered by descending date.
-    * This method should only return incoming payments that have been received (not pending or failed).
+    * This method should only return incoming payments that have been received (not pending or expired).
     *
     * This is a high level method intended for front-end usage.
     */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -101,6 +101,13 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
     }
   }
 
+  override def listClosedLocalChannels(): Seq[HasCommitments] = {
+    using(sqlite.createStatement) { statement =>
+      val rs = statement.executeQuery("SELECT data FROM local_channels WHERE is_closed=1")
+      codecSequence(rs, stateDataCodec)
+    }
+  }
+
   def addOrUpdateHtlcInfo(channelId: ByteVector32, commitmentNumber: Long, paymentHash: ByteVector32, cltvExpiry: CltvExpiry): Unit = {
     using(sqlite.prepareStatement("INSERT OR IGNORE INTO htlc_infos VALUES (?, ?, ?, ?)")) { statement =>
       statement.setBytes(1, channelId.toArray)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -23,7 +23,7 @@ import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.eclair.MilliSatoshi
 import fr.acinq.eclair.db._
-import fr.acinq.eclair.db.sqlite.SqliteUtils.{getNullableLong, _}
+import fr.acinq.eclair.db.sqlite.SqliteUtils._
 import fr.acinq.eclair.payment.{PaymentFailed, PaymentRequest, PaymentSent}
 import fr.acinq.eclair.wire.CommonCodecs
 import grizzled.slf4j.Logging
@@ -153,7 +153,7 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
       rs.getStringNullable("payment_request").map(PaymentRequest.read),
       OutgoingPaymentStatus.Pending
     )
-    parseOutgoingPaymentStatus(rs.getByteVector32Nullable("payment_preimage"), rs.getMilliSatoshiNullable("fees_msat"), rs.getBitVectorOpt("payment_route"), getNullableLong(rs, "completed_at"), rs.getBitVectorOpt("failures")) match {
+    parseOutgoingPaymentStatus(rs.getByteVector32Nullable("payment_preimage"), rs.getMilliSatoshiNullable("fees_msat"), rs.getBitVectorOpt("payment_route"), rs.getLongNullable("completed_at"), rs.getBitVectorOpt("failures")) match {
       case Some(status) => result.copy(status = status)
       case None => result
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -354,7 +354,6 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
         |    completed_at,
         |    NULL as expire_at
         |	 FROM sent_payments
-        |	 GROUP BY payment_hash, target_node_id
         |)
         |ORDER BY CASE
         |  WHEN completed_at IS NULL THEN created_at

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
@@ -17,8 +17,10 @@
 package fr.acinq.eclair.db.sqlite
 
 import java.sql.{Connection, ResultSet, Statement}
+import java.util.UUID
 
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.eclair.MilliSatoshi
 import scodec.Codec
 import scodec.bits.{BitVector, ByteVector}
 
@@ -128,6 +130,21 @@ object SqliteUtils {
     def getStringNullable(columnLabel: String): Option[String] = {
       val result = rs.getString(columnLabel)
       if (rs.wasNull()) None else Some(result)
+    }
+
+    def getLongNullable(columnLabel: String): Option[Long] = {
+      val result = rs.getLong(columnLabel)
+      if (rs.wasNull()) None else Some(result)
+    }
+
+    def getUUIDNullable(label: String) : Option[UUID] = {
+      val result = rs.getString(label)
+      if (rs.wasNull()) None else Some(UUID.fromString(result))
+    }
+
+    def getMilliSatoshiNullable(label: String) : Option[MilliSatoshi] = {
+      val result = rs.getLong(label)
+      if (rs.wasNull()) None else Some(MilliSatoshi(result))
     }
 
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
@@ -86,16 +86,6 @@ object SqliteUtils {
   }
 
   /**
-   * This helper retrieves the value from a nullable integer column and interprets it as an option. This is needed
-   * because `rs.getLong` would return `0` for a null value.
-   * It is used on Android only
-   */
-  def getNullableLong(rs: ResultSet, label: String): Option[Long] = {
-    val result = rs.getLong(label)
-    if (rs.wasNull()) None else Some(result)
-  }
-
-  /**
    * Obtain an exclusive lock on a sqlite database. This is useful when we want to make sure that only one process
    * accesses the database file (see https://www.sqlite.org/pragma.html).
    *

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
@@ -463,6 +463,46 @@ object PaymentRequest {
     )
   }
 
+  private def readBoltData(input: String): Bolt11Data = {
+    val lowercaseInput = input.toLowerCase
+    val separatorIndex = lowercaseInput.lastIndexOf('1')
+    val hrp = lowercaseInput.take(separatorIndex)
+    prefixes.values.find(prefix => hrp.startsWith(prefix)).getOrElse(throw new RuntimeException("unknown prefix"))
+    val data = string2Bits(lowercaseInput.slice(separatorIndex + 1, lowercaseInput.length - 6)) // 6 == checksum size
+    Codecs.bolt11DataCodec.decode(data).require.value
+  }
+
+  /**
+    * Extract description from a serialized payment request that is expected to be valid. Throws an error if the payment request is not valid.
+    *
+    * @param input valid serialized payment request
+    * @return description as a String. If the description is a hash, returns the hash value as a String.
+    */
+  def fastReadDescription(input: String): String = {
+    readBoltData(input).taggedFields.collectFirst {
+      case PaymentRequest.Description(d) => d
+      case PaymentRequest.DescriptionHash(h) => h.toString()
+    }.get
+  }
+
+  def fastReadPaymentHash(input: String): ByteVector32 = {
+    readBoltData(input).taggedFields.collectFirst {
+      case p: PaymentRequest.PaymentHash => p
+    }.get.hash
+  }
+
+  def fastHasExpired(input: String): Boolean = {
+    val bolt11Data = readBoltData(input)
+    val expiry_opt = bolt11Data.taggedFields.collectFirst {
+      case p: PaymentRequest.Expiry => p
+    }
+    val timestamp = bolt11Data.timestamp
+    expiry_opt match {
+      case Some(expiry) => timestamp + expiry.toLong <= Platform.currentTime.milliseconds.toSeconds
+      case None => timestamp + DEFAULT_EXPIRY_SECONDS <= Platform.currentTime.milliseconds.toSeconds
+    }
+  }
+
   /**
    * @param pr payment request
    * @return a bech32-encoded payment request

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -50,18 +50,18 @@ class SqliteChannelsDbSpec extends FunSuite {
     intercept[SQLiteException](db.addOrUpdateHtlcInfo(channel.channelId, commitNumber, paymentHash1, cltvExpiry1)) // no related channel
 
     assert(db.listLocalChannels().toSet === Set.empty)
-    assert(db.listClosedLocalChannels() === Set.empty)
+    assert(db.listClosedLocalChannels().toSet === Set.empty)
     db.addOrUpdateChannel(channel)
     db.addOrUpdateChannel(channel)
     assert(db.listLocalChannels() === List(channel))
-    assert(db.listClosedLocalChannels() === Set.empty)
+    assert(db.listClosedLocalChannels().toSet === Set.empty)
 
     assert(db.listHtlcInfos(channel.channelId, commitNumber).toList == Nil)
     db.addOrUpdateHtlcInfo(channel.channelId, commitNumber, paymentHash1, cltvExpiry1)
     db.addOrUpdateHtlcInfo(channel.channelId, commitNumber, paymentHash2, cltvExpiry2)
     assert(db.listHtlcInfos(channel.channelId, commitNumber).toList == List((paymentHash1, cltvExpiry1), (paymentHash2, cltvExpiry2)))
     assert(db.listHtlcInfos(channel.channelId, 43).toList == Nil)
-    assert(db.listClosedLocalChannels() === Set.empty)
+    assert(db.listClosedLocalChannels().toSet === Set.empty)
 
     db.removeChannel(channel.channelId)
     assert(db.listLocalChannels() === Nil)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -50,19 +50,23 @@ class SqliteChannelsDbSpec extends FunSuite {
     intercept[SQLiteException](db.addOrUpdateHtlcInfo(channel.channelId, commitNumber, paymentHash1, cltvExpiry1)) // no related channel
 
     assert(db.listLocalChannels().toSet === Set.empty)
+    assert(db.listClosedLocalChannels() === Set.empty)
     db.addOrUpdateChannel(channel)
     db.addOrUpdateChannel(channel)
     assert(db.listLocalChannels() === List(channel))
+    assert(db.listClosedLocalChannels() === Set.empty)
 
     assert(db.listHtlcInfos(channel.channelId, commitNumber).toList == Nil)
     db.addOrUpdateHtlcInfo(channel.channelId, commitNumber, paymentHash1, cltvExpiry1)
     db.addOrUpdateHtlcInfo(channel.channelId, commitNumber, paymentHash2, cltvExpiry2)
     assert(db.listHtlcInfos(channel.channelId, commitNumber).toList == List((paymentHash1, cltvExpiry1), (paymentHash2, cltvExpiry2)))
     assert(db.listHtlcInfos(channel.channelId, 43).toList == Nil)
+    assert(db.listClosedLocalChannels() === Set.empty)
 
     db.removeChannel(channel.channelId)
     assert(db.listLocalChannels() === Nil)
     assert(db.listHtlcInfos(channel.channelId, commitNumber).toList == Nil)
+    assert(db.listClosedLocalChannels().size == 1)
   }
 
   test("migrate channel database v1 -> v2") {


### PR DESCRIPTION
This PR adds a way to retrieve a functional, aggregated, and sorted list of payments (received or sent) from the `PaymentDb` with a single SQL query. The aim is to be able to get a high level view of recent payments within a single efficient call.

To do so we add a high level SQL query in `PaymentDb` that return a list of generic `Payment` object. This `Payment` trait can be a lightning payment (incoming or outgoing) and is not sealed so that it can be extended for maximum flexibility.

#### Efficient payment request reading

This PR also adds several methods in `PaymentRequest` to efficiently extract the description/payment hash/expiry from a **serialized** payment request (i.e a `String`). The rationale is that deserializing a `PaymentRequest` is costly since the signature is checked, and thus reading a large list of payment requests can be slow on a constrained device.

#### Closed channels

This PR also adds a method to list closed channels from the channels database.
