### PR TITLE
Check configuration for obsolete keys in startup

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -93,14 +93,6 @@ object NodeParams {
 
   object ELECTRUM extends WatcherType
 
-  def checkConfiguration(config: Config): Config = {
-    // this check is needed because somme keys were moved to a new section in v0.3.2
-    if (config.hasPath("eclair.default-feerates") || config.hasPath("eclair.max-feerate-mismatch") || config.hasPath("eclair.update-fee_min-diff-ratio")) {
-      throw new IllegalArgumentException("Your configuration uses keys that have moved to a new section, please check our release notes for more details")
-    }
-    config
-  }
-
   /**
    * Order of precedence for the configuration parameters:
    * 1) Java environment variables (-D...)
@@ -108,13 +100,11 @@ object NodeParams {
    * 3) Optionally provided config
    * 4) Default values in reference.conf
    */
-  def loadConfiguration(datadir: File, overrideDefaults: Config = ConfigFactory.empty()) = {
-    val conf = ConfigFactory.parseProperties(System.getProperties)
+  def loadConfiguration(datadir: File, overrideDefaults: Config = ConfigFactory.empty()) =
+    ConfigFactory.parseProperties(System.getProperties)
       .withFallback(ConfigFactory.parseFile(new File(datadir, "eclair.conf")))
       .withFallback(overrideDefaults)
       .withFallback(ConfigFactory.load())
-    checkConfiguration(conf)
-  }
 
   def getSeed(datadir: File): ByteVector = {
     val seedPath = new File(datadir, "seed.dat")
@@ -138,6 +128,8 @@ object NodeParams {
   }
 
   def makeNodeParams(config: Config, keyManager: KeyManager, torAddress_opt: Option[NodeAddress], database: Databases, blockCount: AtomicLong, feeEstimator: FeeEstimator): NodeParams = {
+    val keyPaths = Seq("default-feerates", "max-feerate-mismatch", "update-fee_min-diff-ratio")
+    keyPaths.foreach(keyPath => require(!config.hasPath(keyPath), s"configuration key $keyPath has been renamed/moved to a new section"))
 
     val chain = config.getString("chain")
     val chainHash = makeChainHash(chain)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -128,8 +128,15 @@ object NodeParams {
   }
 
   def makeNodeParams(config: Config, keyManager: KeyManager, torAddress_opt: Option[NodeAddress], database: Databases, blockCount: AtomicLong, feeEstimator: FeeEstimator): NodeParams = {
-    val keyPaths = Seq("default-feerates", "max-feerate-mismatch", "update-fee_min-diff-ratio")
-    keyPaths.foreach(keyPath => require(!config.hasPath(keyPath), s"configuration key $keyPath has been renamed/moved to a new section"))
+    // check configuration for keys that have been renamed in v0.3.2
+    val deprecatedKeyPaths = Map(
+      "default-feerates" -> "on-chain-fees.default-feerates",
+      "max-feerate-mismatch" -> "on-chain-fees.max-feerate-mismatch",
+      "update-fee_min-diff-ratio" -> "on-chain-fees.update-fee-min-diff-ratio"
+    )
+    deprecatedKeyPaths.foreach {
+      case (old, new_) => require(!config.hasPath(old), s"configuration key '$old' has been replaced by '$new_'")
+    }
 
     val chain = config.getString("chain")
     val chainHash = makeChainHash(chain)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -29,12 +29,14 @@ import scala.util.Try
 class StartupSpec extends FunSuite {
 
   test("check configuration") {
-    val conf = ConfigFactory.load()
-    assert(NodeParams.checkConfiguration(conf) == conf)
+    val blockCount = new AtomicLong(0)
+    val keyManager = new LocalKeyManager(seed = randomBytes32, chainHash = Block.TestnetGenesisBlock.hash)
+    val conf = ConfigFactory.load().getConfig("eclair")
+    assert(Try(NodeParams.makeNodeParams(conf, keyManager, None, TestConstants.inMemoryDb(), blockCount, new TestConstants.TestFeeEstimator)).isSuccess)
 
-    val conf1 = conf.withFallback(ConfigFactory.parseMap(Map("eclair.max-feerate-mismatch" -> 42)))
+    val conf1 = conf.withFallback(ConfigFactory.parseMap(Map("max-feerate-mismatch" -> 42)))
     intercept[RuntimeException] {
-      NodeParams.checkConfiguration(conf1)
+      NodeParams.makeNodeParams(conf1, keyManager, None, TestConstants.inMemoryDb(), blockCount, new TestConstants.TestFeeEstimator)
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -18,14 +18,25 @@ package fr.acinq.eclair
 
 import java.util.concurrent.atomic.AtomicLong
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ConfigFactory, ConfigValue}
 import fr.acinq.bitcoin.Block
 import fr.acinq.eclair.crypto.LocalKeyManager
 import org.scalatest.FunSuite
 
+import scala.collection.JavaConversions._
 import scala.util.Try
 
 class StartupSpec extends FunSuite {
+
+  test("check configuration") {
+    val conf = ConfigFactory.load()
+    assert(NodeParams.checkConfiguration(conf) == conf)
+
+    val conf1 = conf.withFallback(ConfigFactory.parseMap(Map("eclair.max-feerate-mismatch" -> 42)))
+    intercept[RuntimeException] {
+      NodeParams.checkConfiguration(conf1)
+    }
+  }
 
   test("NodeParams should fail if the alias is illegal (over 32 bytes)") {
 


### PR DESCRIPTION
We now check the loaded configuration for obsolete keys (that have been moved to a new section)
and throw an error if any are found, which will prevent eclair from starting.