### PR TITLE
Fix ignored duplicate amounts in htlc-value-in-flight

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -188,7 +188,8 @@ object Commitments {
       }
     }
 
-    val htlcValueInFlight = outgoingHtlcs.map(_.add.amountMsat).sum
+    // NB: we need the `toSeq` because otherwise duplicate amountMsat would be removed (since outgoingHtlcs is a Set).
+    val htlcValueInFlight = outgoingHtlcs.toSeq.map(_.add.amountMsat).sum
     if (commitments1.remoteParams.maxHtlcValueInFlightMsat < htlcValueInFlight) {
       // TODO: this should be a specific UPDATE error
       return Left(HtlcValueTooHighInFlight(commitments.channelId, maximum = commitments1.remoteParams.maxHtlcValueInFlightMsat, actual = htlcValueInFlight))
@@ -229,7 +230,8 @@ object Commitments {
       }
     }
 
-    val htlcValueInFlight = incomingHtlcs.map(_.add.amountMsat).sum
+    // NB: we need the `toSeq` because otherwise duplicate amountMsat would be removed (since incomingHtlcs is a Set).
+    val htlcValueInFlight = incomingHtlcs.toSeq.map(_.add.amountMsat).sum
     if (commitments1.localParams.maxHtlcValueInFlightMsat < htlcValueInFlight) {
       throw HtlcValueTooHighInFlight(commitments.channelId, maximum = commitments1.localParams.maxHtlcValueInFlightMsat, actual = htlcValueInFlight)
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/CommitmentSpec.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/CommitmentSpec.scala
@@ -20,8 +20,8 @@ import fr.acinq.eclair.MilliSatoshi
 import fr.acinq.eclair.wire._
 
 /**
-  * Created by PM on 07/12/2016.
-  */
+ * Created by PM on 07/12/2016.
+ */
 
 // @formatter:off
 sealed trait Direction { def opposite: Direction }
@@ -36,10 +36,10 @@ final case class CommitmentSpec(htlcs: Set[DirectedHtlc], feeratePerKw: Long, to
 }
 
 object CommitmentSpec {
-  def removeHtlc(changes: List[UpdateMessage], id: Long): List[UpdateMessage] = changes.filterNot(_ match {
+  def removeHtlc(changes: List[UpdateMessage], id: Long): List[UpdateMessage] = changes.filterNot {
     case u: UpdateAddHtlc if u.id == id => true
     case _ => false
-  })
+  }
 
   def addHtlc(spec: CommitmentSpec, direction: Direction, update: UpdateAddHtlc): CommitmentSpec = {
     val htlc = DirectedHtlc(direction, update)
@@ -54,7 +54,7 @@ object CommitmentSpec {
     spec.htlcs.find(htlc => htlc.direction != direction && htlc.add.id == htlcId) match {
       case Some(htlc) if direction == OUT => spec.copy(toLocal = spec.toLocal + htlc.add.amountMsat, htlcs = spec.htlcs - htlc)
       case Some(htlc) if direction == IN => spec.copy(toRemote = spec.toRemote + htlc.add.amountMsat, htlcs = spec.htlcs - htlc)
-      case None => throw new RuntimeException(s"cannot find htlc id=${htlcId}")
+      case None => throw new RuntimeException(s"cannot find htlc id=$htlcId")
     }
   }
 
@@ -63,7 +63,7 @@ object CommitmentSpec {
     spec.htlcs.find(htlc => htlc.direction != direction && htlc.add.id == htlcId) match {
       case Some(htlc) if direction == OUT => spec.copy(toRemote = spec.toRemote + htlc.add.amountMsat, htlcs = spec.htlcs - htlc)
       case Some(htlc) if direction == IN => spec.copy(toLocal = spec.toLocal + htlc.add.amountMsat, htlcs = spec.htlcs - htlc)
-      case None => throw new RuntimeException(s"cannot find htlc id=${htlcId}")
+      case None => throw new RuntimeException(s"cannot find htlc id=$htlcId")
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/CommitmentSpec.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/CommitmentSpec.scala
@@ -37,7 +37,7 @@ final case class CommitmentSpec(htlcs: Set[DirectedHtlc], feeratePerKw: Long, to
 
 object CommitmentSpec {
   def removeHtlc(changes: List[UpdateMessage], id: Long): List[UpdateMessage] = changes.filterNot {
-    case u: UpdateAddHtlc if u.id == id => true
+    case u: UpdateAddHtlc => u.id == id
     case _ => false
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -244,6 +244,21 @@ class NormalStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     bob2alice.expectNoMsg(200 millis)
   }
 
+  test("recv CMD_ADD_HTLC (over max inflight htlc value with duplicate amounts)") { f =>
+    import f._
+    val sender = TestProbe()
+    val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
+    val add = CMD_ADD_HTLC(75500000 msat, randomBytes32, CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, upstream = Left(UUID.randomUUID()))
+    sender.send(bob, add)
+    sender.expectMsg("ok")
+    bob2alice.expectMsgType[UpdateAddHtlc]
+    val add1 = CMD_ADD_HTLC(75500000 msat, randomBytes32, CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, upstream = Left(UUID.randomUUID()))
+    sender.send(bob, add1)
+    val error = HtlcValueTooHighInFlight(channelId(bob), maximum = 150000000, actual = 151000000 msat)
+    sender.expectMsg(Failure(AddHtlcFailed(channelId(bob), add1.paymentHash, error, Local(add1.upstream.left.get, Some(sender.ref)), Some(initialState.channelUpdate), Some(add1))))
+    bob2alice.expectNoMsg(200 millis)
+  }
+
   test("recv CMD_ADD_HTLC (over max accepted htlcs)") { f =>
     import f._
     val sender = TestProbe()


### PR DESCRIPTION
Using `.map()` on a `Set` can have surprising results: in our case we end up ignoring htlcs that have the same amount, so the htlc-value-in-flight may be less than what it should be.

Credits to @btcontract for finding the bug (this PR supercedes #1163 because of build issues)