### PR TITLE
Fix codecov unknown tag

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,5 @@
 coverage:
-  ci:
-    - pm47.semaphoreci.com
+  range: 70..90
   status:
     project: off
     patch: off

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,4 @@
 coverage:
-  range: 70..90
   status:
     project: off
     patch: off


### PR DESCRIPTION
The `ci` tag was unknown to codecov and I suspect that's why they weren't honoring the `ignore` on eclair-node and GUI.
I also changed our target range to 70-90% (impacts the colors of the badge, it's nit).