### PR TITLE
Add 'getnewaddress' API

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -80,6 +80,8 @@ trait Eclair {
 
   def receive(description: String, amount_opt: Option[MilliSatoshi], expire_opt: Option[Long], fallbackAddress_opt: Option[String], paymentPreimage_opt: Option[ByteVector32])(implicit timeout: Timeout): Future[PaymentRequest]
 
+  def depositAddress(): Future[String]
+
   def receivedInfo(paymentHash: ByteVector32)(implicit timeout: Timeout): Future[Option[IncomingPayment]]
 
   def send(externalId_opt: Option[String], recipientNodeId: PublicKey, amount: MilliSatoshi, paymentHash: ByteVector32, invoice_opt: Option[PaymentRequest] = None, maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None)(implicit timeout: Timeout): Future[UUID]
@@ -188,6 +190,8 @@ class EclairImpl(appKit: Kit) extends Eclair {
     fallbackAddress_opt.map { fa => fr.acinq.eclair.addressToPublicKeyScript(fa, appKit.nodeParams.chainHash) } // if it's not a bitcoin address throws an exception
     (appKit.paymentHandler ? ReceivePayment(description = description, amount_opt = amount_opt, expirySeconds_opt = expire_opt, fallbackAddress = fallbackAddress_opt, paymentPreimage = paymentPreimage_opt)).mapTo[PaymentRequest]
   }
+
+  override def depositAddress(): Future[String] = appKit.wallet.getFinalAddress
 
   override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] = {
     (appKit.router ? RouteRequest(appKit.nodeParams.nodeId, targetNodeId, amount, assistedRoutes)).mapTo[RouteResponse]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -23,8 +23,8 @@ import akka.pattern._
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi}
-import fr.acinq.eclair.NodeParams.ELECTRUM
 import fr.acinq.eclair.TimestampQueryFilters._
+import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet
 import fr.acinq.eclair.channel.Register.{Forward, ForwardShortId}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.{IncomingPayment, NetworkFee, OutgoingPayment, Stats}
@@ -193,11 +193,10 @@ class EclairImpl(appKit: Kit) extends Eclair {
   }
 
   override def newAddress(): Future[String] = {
-    if(appKit.nodeParams.watcherType == ELECTRUM){
-      return Future.failed(new IllegalArgumentException("Can't use this API with electrum backend"))
+    appKit.wallet match {
+      case w: BitcoinCoreWallet => w.getFinalAddress
+      case _ => Future.failed(new IllegalArgumentException("this call is only available with a bitcoin core backend"))
     }
-
-    appKit.wallet.getFinalAddress
   }
 
   override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -23,6 +23,7 @@ import akka.pattern._
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi}
+import fr.acinq.eclair.NodeParams.ELECTRUM
 import fr.acinq.eclair.TimestampQueryFilters._
 import fr.acinq.eclair.channel.Register.{Forward, ForwardShortId}
 import fr.acinq.eclair.channel._
@@ -80,7 +81,7 @@ trait Eclair {
 
   def receive(description: String, amount_opt: Option[MilliSatoshi], expire_opt: Option[Long], fallbackAddress_opt: Option[String], paymentPreimage_opt: Option[ByteVector32])(implicit timeout: Timeout): Future[PaymentRequest]
 
-  def depositAddress(): Future[String]
+  def newAddress(): Future[String]
 
   def receivedInfo(paymentHash: ByteVector32)(implicit timeout: Timeout): Future[Option[IncomingPayment]]
 
@@ -191,7 +192,13 @@ class EclairImpl(appKit: Kit) extends Eclair {
     (appKit.paymentHandler ? ReceivePayment(description = description, amount_opt = amount_opt, expirySeconds_opt = expire_opt, fallbackAddress = fallbackAddress_opt, paymentPreimage = paymentPreimage_opt)).mapTo[PaymentRequest]
   }
 
-  override def depositAddress(): Future[String] = appKit.wallet.getFinalAddress
+  override def newAddress(): Future[String] = {
+    if(appKit.nodeParams.watcherType == ELECTRUM){
+      return Future.failed(new IllegalArgumentException("Can't use this API with electrum backend"))
+    }
+
+    appKit.wallet.getFinalAddress
+  }
 
   override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] = {
     (appKit.router ? RouteRequest(appKit.nodeParams.nodeId, targetNodeId, amount, assistedRoutes)).mapTo[RouteResponse]

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -281,7 +281,7 @@ trait Service extends ExtraDirectives with Logging {
                           complete(eclairApi.usableBalances())
                         } ~
                         path("getnewaddress"){
-                          complete(eclairApi.depositAddress())
+                          complete(eclairApi.newAddress())
                         }
                     } ~ get {
                       path("ws") {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -280,7 +280,7 @@ trait Service extends ExtraDirectives with Logging {
                         path("usablebalances") {
                           complete(eclairApi.usableBalances())
                         } ~
-                        path("getdepositaddress"){
+                        path("getnewaddress"){
                           complete(eclairApi.depositAddress())
                         }
                     } ~ get {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -279,6 +279,9 @@ trait Service extends ExtraDirectives with Logging {
                         } ~
                         path("usablebalances") {
                           complete(eclairApi.usableBalances())
+                        } ~
+                        path("getdepositaddress"){
+                          complete(eclairApi.depositAddress())
                         }
                     } ~ get {
                       path("ws") {


### PR DESCRIPTION
Add a simple API that calls `getfinaladdress` on EclairWallet, this can be used to obtain a new on-chain deposit address from your bitcoin-core wallet. Fixes #1006 