### PR TITLE
Add synchronization when locking database connection

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
@@ -21,6 +21,7 @@ import java.sql.{Connection, DriverManager}
 
 import fr.acinq.eclair.db.sqlite._
 import grizzled.slf4j.Logging
+import org.sqlite.SQLiteException
 
 trait Databases {
 
@@ -49,12 +50,26 @@ object Databases extends Logging {
     */
   def sqliteJDBC(dbdir: File): Databases = {
     dbdir.mkdir()
-    val sqliteEclair = DriverManager.getConnection(s"jdbc:sqlite:${new File(dbdir, "eclair.sqlite")}")
-    val sqliteNetwork = DriverManager.getConnection(s"jdbc:sqlite:${new File(dbdir, "network.sqlite")}")
-    val sqliteAudit = DriverManager.getConnection(s"jdbc:sqlite:${new File(dbdir, "audit.sqlite")}")
-    SqliteUtils.obtainExclusiveLock(sqliteEclair) // there should only be one process writing to this file
-    logger.info("successful lock on eclair.sqlite")
-    databaseByConnections(sqliteAudit, sqliteNetwork, sqliteEclair)
+    var sqliteEclair: Connection = null
+    var sqliteNetwork: Connection = null
+    var sqliteAudit: Connection = null
+    try {
+      sqliteEclair = DriverManager.getConnection(s"jdbc:sqlite:${new File(dbdir, "eclair.sqlite")}")
+      sqliteNetwork = DriverManager.getConnection(s"jdbc:sqlite:${new File(dbdir, "network.sqlite")}")
+      sqliteAudit = DriverManager.getConnection(s"jdbc:sqlite:${new File(dbdir, "audit.sqlite")}")
+      SqliteUtils.obtainExclusiveLock(sqliteEclair) // there should only be one process writing to this file
+      logger.info("successful lock on eclair.sqlite")
+      databaseByConnections(sqliteAudit, sqliteNetwork, sqliteEclair)
+    } catch {
+      case t: Throwable => {
+        logger.error("could not create connection to sqlite databases: ", t)
+        if (sqliteEclair != null) sqliteEclair.close()
+        if (sqliteNetwork != null) sqliteNetwork.close()
+        if (sqliteAudit != null) sqliteAudit.close()
+        throw t
+      }
+    }
+
   }
 
   def databaseByConnections(auditJdbc: Connection, networkJdbc: Connection, eclairJdbc: Connection) = new Databases {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
@@ -99,7 +99,7 @@ object SqliteUtils {
    *
    * The lock will be kept until the database is closed, or if the locking mode is explicitly reset.
    */
-  def obtainExclusiveLock(sqlite: Connection) {
+  def obtainExclusiveLock(sqlite: Connection) = synchronized {
     val statement = sqlite.createStatement()
     statement.execute("PRAGMA locking_mode = EXCLUSIVE")
     // we have to make a write to actually obtain the lock


### PR DESCRIPTION
This pull request fixes an issue where creating concurrent database connection could deadlock.

### Context

An exclusive lock was added to `eclair.sqlite` to prevent running several instances of eclair using the same sqlite database. The code obtaining the exclusive lock is a succession of [three SQL queries](https://github.com/ACINQ/eclair/blob/synchronized-exclusive-lock/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala#L102-L108), and is not thread-safe. If two threads try to obtain the lock at the same time, none of these locks will succeed, and subsequent locks will fail because the database is deadlocked.

This can happen on the eclair mobile application where several background jobs (that need exclusive lock on the `eclair.sqlite` db) may be launched at the exact same time by the OS due to battery optimization.

See: 
- https://github.com/ACINQ/eclair-mobile/issues/230
- https://github.com/ACINQ/eclair-mobile/issues/227

### Proposed change

This PR changes the `SqliteUtils.obtainExclusiveLock` method into a synchronized statement. Also, if the SQL connections creation fails, db connections will be closed if needed.



