### PR TITLE
Fixed race condition in payment handler init

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/PaymentHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/PaymentHandler.scala
@@ -30,9 +30,10 @@ trait ReceiveHandler {
  */
 class PaymentHandler(nodeParams: NodeParams) extends Actor with ActorLogging {
 
-  self ! new MultiPartHandler(nodeParams, nodeParams.db.payments)
+  // we do this instead of sending it to ourselves, otherwise there is no guarantee that this would be the first processed message
+  private val defaultHandler = new MultiPartHandler(nodeParams, nodeParams.db.payments)
 
-  override def receive: Receive = normal(PartialFunction.empty[Any, Unit])
+  override def receive: Receive = normal(defaultHandler.handle(context, log))
 
   def normal(handle: Receive): Receive = handle orElse {
     case handler: ReceiveHandler =>


### PR DESCRIPTION
When an actor sends a message to itself as part of its class definition,
there is no guarantee that this message will be processed first. Relying
on that to set the default payment handler is problematic and causes
race conditions in tests.