### PR TITLE
Ignore NPE in tests

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -2236,7 +2236,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
     case Upstream.Relayed(u) => Origin.Relayed(u.channelId, u.id, u.amountMsat, c.amount) // this is a relayed payment to an outgoing channel
   }
 
-  def feePaid(fee: Satoshi, tx: Transaction, desc: String, channelId: ByteVector32): Unit = {
+  def feePaid(fee: Satoshi, tx: Transaction, desc: String, channelId: ByteVector32): Unit = Try { // this may fail with an NPE in tests because context has been cleaned up, but it's not a big deal
     log.info(s"paid feeSatoshi=${fee.toLong} for txid=${tx.txid} desc=$desc")
     context.system.eventStream.publish(NetworkFeePaid(self, remoteNodeId, channelId, tx, fee, desc))
   }


### PR DESCRIPTION
This is due to a callback being executed after the parent actor has been
cleaned up. We don't really care about the result anyway, so we can
safely ignore, even if the issue only arises in tests.

The root problem here is that we are making references to actor methods
from a callback, which we shouldn't do, because whatever we reference
may have disappeared by the time the callback tries to access it. A
better pattern would be to `pipe` the results of the `Future` to
oneself, but that would require more work and possibly change the FSM,
which seems overkill for the issue at hand.