### PR TITLE
Rework truncated integers codecs

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
@@ -140,9 +140,9 @@ object OnionCodecs {
   val payloadLengthDecoder = Decoder[Long]((bits: BitVector) =>
     varintoverflow.decode(bits).map(d => DecodeResult(d.value + (bits.length - d.remainder.length) / 8, d.remainder)))
 
-  private val amountToForward: Codec[AmountToForward] = ("amount_msat" | tmillisatoshi).as[AmountToForward]
+  private val amountToForward: Codec[AmountToForward] = ("amount_msat" | ltmillisatoshi).as[AmountToForward]
 
-  private val outgoingCltv: Codec[OutgoingCltv] = ("cltv" | tu32).xmap(cltv => OutgoingCltv(CltvExpiry(cltv)), (c: OutgoingCltv) => c.cltv.toLong)
+  private val outgoingCltv: Codec[OutgoingCltv] = ("cltv" | ltu32).xmap(cltv => OutgoingCltv(CltvExpiry(cltv)), (c: OutgoingCltv) => c.cltv.toLong)
 
   private val outgoingChannelId: Codec[OutgoingChannelId] = variableSizeBytesLong(varintoverflow, "short_channel_id" | shortchannelid).as[OutgoingChannelId]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/TlvCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/TlvCodecs.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.wire
 import fr.acinq.eclair.UInt64.Conversions._
 import fr.acinq.eclair.wire.CommonCodecs._
 import fr.acinq.eclair.{MilliSatoshi, UInt64}
+import scodec.bits.ByteVector
 import scodec.codecs._
 import scodec.{Attempt, Codec, Err}
 
@@ -28,24 +29,41 @@ import scodec.{Attempt, Codec, Err}
 
 object TlvCodecs {
 
-  private def variableSizeUInt64(size: Int, min: UInt64): Codec[UInt64] = minimalvalue(bytes(size).xmap(UInt64(_), _.toByteVector.takeRight(size)), min)
-
   /**
-   * Length-prefixed truncated uint64 (1 to 9 bytes unsigned integer).
+   * Truncated uint64 (0 to 8 bytes unsigned integer).
+   * The encoder minimally-encodes every value, and the decoder verifies that values are minimally-encoded.
+   * Note that this codec can only be used at the very end of a TLV record.
    */
-  val tu64: Codec[UInt64] = discriminated[UInt64].by(uint8)
-    .\(0x00) { case i if i < 0x01 => i }(variableSizeUInt64(0, 0x00))
-    .\(0x01) { case i if i < 0x0100 => i }(variableSizeUInt64(1, 0x01))
-    .\(0x02) { case i if i < 0x010000 => i }(variableSizeUInt64(2, 0x0100))
-    .\(0x03) { case i if i < 0x01000000 => i }(variableSizeUInt64(3, 0x010000))
-    .\(0x04) { case i if i < 0x0100000000L => i }(variableSizeUInt64(4, 0x01000000))
-    .\(0x05) { case i if i < 0x010000000000L => i }(variableSizeUInt64(5, 0x0100000000L))
-    .\(0x06) { case i if i < 0x01000000000000L => i }(variableSizeUInt64(6, 0x010000000000L))
-    .\(0x07) { case i if i < 0x0100000000000000L => i }(variableSizeUInt64(7, 0x01000000000000L))
-    .\(0x08) { case i if i <= UInt64.MaxValue => i }(variableSizeUInt64(8, 0x0100000000000000L))
+  val tu64: Codec[UInt64] = Codec(
+    (u: UInt64) => {
+      val b = u match {
+        case u if u < 0x01 => ByteVector.empty
+        case u if u < 0x0100 => u.toByteVector.takeRight(1)
+        case u if u < 0x010000 => u.toByteVector.takeRight(2)
+        case u if u < 0x01000000 => u.toByteVector.takeRight(3)
+        case u if u < 0x0100000000L => u.toByteVector.takeRight(4)
+        case u if u < 0x010000000000L => u.toByteVector.takeRight(5)
+        case u if u < 0x01000000000000L => u.toByteVector.takeRight(6)
+        case u if u < 0x0100000000000000L => u.toByteVector.takeRight(7)
+        case u if u <= UInt64.MaxValue => u.toByteVector.takeRight(8)
+      }
+      Attempt.successful(b.bits)
+    },
+    b => b.length match {
+      case l if l <= 0 => minimalvalue(uint64, UInt64(0x00)).decode(b.padLeft(64))
+      case l if l <= 8 => minimalvalue(uint64, UInt64(0x01)).decode(b.padLeft(64))
+      case l if l <= 16 => minimalvalue(uint64, UInt64(0x0100)).decode(b.padLeft(64))
+      case l if l <= 24 => minimalvalue(uint64, UInt64(0x010000)).decode(b.padLeft(64))
+      case l if l <= 32 => minimalvalue(uint64, UInt64(0x01000000)).decode(b.padLeft(64))
+      case l if l <= 40 => minimalvalue(uint64, UInt64(0x0100000000L)).decode(b.padLeft(64))
+      case l if l <= 48 => minimalvalue(uint64, UInt64(0x010000000000L)).decode(b.padLeft(64))
+      case l if l <= 56 => minimalvalue(uint64, UInt64(0x01000000000000L)).decode(b.padLeft(64))
+      case l if l <= 64 => minimalvalue(uint64, UInt64(0x0100000000000000L)).decode(b.padLeft(64))
+      case _ => Attempt.failure(Err(s"too many bytes to decode for truncated uint64 (${b.toHex})"))
+    })
 
   /**
-   * Length-prefixed truncated long (1 to 9 bytes unsigned integer).
+   * Truncated long (0 to 8 bytes unsigned integer).
    * This codec can be safely used for values < `2^63` and will fail otherwise.
    */
   val tu64overflow: Codec[Long] = tu64.exmap(
@@ -53,26 +71,37 @@ object TlvCodecs {
     l => if (l >= 0) Attempt.Successful(UInt64(l)) else Attempt.Failure(Err(s"uint64 must be positive (actual=$l)")))
 
   /**
-   * Length-prefixed truncated millisatoshi (1 to 9 bytes unsigned integer).
+   * Truncated millisatoshi (0 to 8 bytes unsigned).
    * This codec can be safely used for values < `2^63` and will fail otherwise.
    */
   val tmillisatoshi: Codec[MilliSatoshi] = tu64overflow.xmap(l => MilliSatoshi(l), m => m.toLong)
 
-  /**
-   * Length-prefixed truncated uint32 (1 to 5 bytes unsigned integer).
-   */
+  /** Truncated uint32 (0 to 4 bytes unsigned integer). */
   val tu32: Codec[Long] = tu64.exmap({
     case i if i > 0xffffffffL => Attempt.Failure(Err("tu32 overflow"))
     case i => Attempt.Successful(i.toBigInt.toLong)
   }, l => Attempt.Successful(l))
 
-  /**
-   * Length-prefixed truncated uint16 (1 to 3 bytes unsigned integer).
-   */
+  /** Truncated uint16 (0 to 2 bytes unsigned integer). */
   val tu16: Codec[Int] = tu32.exmap({
     case i if i > 0xffff => Attempt.Failure(Err("tu16 overflow"))
     case i => Attempt.Successful(i.toInt)
   }, l => Attempt.Successful(l))
+
+  /** Length-prefixed truncated uint64 (1 to 9 bytes unsigned integer). */
+  val ltu64: Codec[UInt64] = variableSizeBytes(uint8, tu64)
+
+  /** Length-prefixed truncated long (1 to 9 bytes unsigned integer). */
+  val ltu64overflow: Codec[Long] = variableSizeBytes(uint8, tu64overflow)
+
+  /** Length-prefixed truncated millisatoshi (1 to 9 bytes unsigned). */
+  val ltmillisatoshi: Codec[MilliSatoshi] = variableSizeBytes(uint8, tmillisatoshi)
+
+  /** Length-prefixed truncated uint32 (1 to 5 bytes unsigned integer). */
+  val ltu32: Codec[Long] = variableSizeBytes(uint8, tu32)
+
+  /** Length-prefixed truncated uint16 (1 to 3 bytes unsigned integer). */
+  val ltu16: Codec[Int] = variableSizeBytes(uint8, tu16)
 
   private def validateGenericTlv(g: GenericTlv): Attempt[GenericTlv] = {
     if (g.tag.toBigInt % 2 == 0) {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/OnionCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/OnionCodecsSpec.scala
@@ -115,9 +115,11 @@ class OnionCodecsSpec extends FunSuite {
   test("encode/decode variable-length (tlv) final per-hop payload") {
     val testCases = Map(
       TlvStream[OnionTlv](AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42))) -> hex"07 02020231 04012a",
-      TlvStream[OnionTlv](AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42)), PaymentData(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"), 0 msat)) -> hex"2a 02020231 04012a 0821eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900",
-      TlvStream[OnionTlv](AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42)), PaymentData(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"), 1105 msat)) -> hex"2c 02020231 04012a 0823eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619020451",
-      TlvStream[OnionTlv](AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42)), PaymentData(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"), 1099511627775L msat)) -> hex"2f 02020231 04012a 0826eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661905ffffffffff",
+      TlvStream[OnionTlv](AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42)), PaymentData(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"), 0 msat)) -> hex"29 02020231 04012a 0820eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619",
+      TlvStream[OnionTlv](AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42)), PaymentData(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"), 1105 msat)) -> hex"2b 02020231 04012a 0822eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f2836866190451",
+      TlvStream[OnionTlv](AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42)), PaymentData(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"), 4294967295L msat)) -> hex"2d 02020231 04012a 0824eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619ffffffff",
+      TlvStream[OnionTlv](AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42)), PaymentData(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"), 4294967296L msat)) -> hex"2e 02020231 04012a 0825eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f2836866190100000000",
+      TlvStream[OnionTlv](AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42)), PaymentData(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"), 1099511627775L msat)) -> hex"2e 02020231 04012a 0825eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619ffffffffff",
       TlvStream[OnionTlv](AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42)), OutgoingChannelId(ShortChannelId(1105))) -> hex"11 02020231 04012a 06080000000000000451",
       TlvStream[OnionTlv](Seq(AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42))), Seq(GenericTlv(65535, hex"06c1"))) -> hex"0d 02020231 04012a fdffff0206c1"
     )
@@ -138,13 +140,13 @@ class OnionCodecsSpec extends FunSuite {
     assert(notMultiPart.totalAmount === 561.msat)
     assert(notMultiPart.paymentSecret === None)
 
-    val multiPart = finalPerHopPayloadCodec.decode(hex"2c 02020231 04012a 0823eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619020451".bits).require.value
+    val multiPart = finalPerHopPayloadCodec.decode(hex"2b 02020231 04012a 0822eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f2836866190451".bits).require.value
     assert(multiPart.amount === 561.msat)
     assert(multiPart.expiry === CltvExpiry(42))
     assert(multiPart.totalAmount === 1105.msat)
     assert(multiPart.paymentSecret === Some(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619")))
 
-    val multiPartNoTotalAmount = finalPerHopPayloadCodec.decode(hex"2a 02020231 04012a 0821eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661900".bits).require.value
+    val multiPartNoTotalAmount = finalPerHopPayloadCodec.decode(hex"29 02020231 04012a 0820eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619".bits).require.value
     assert(multiPartNoTotalAmount.amount === 561.msat)
     assert(multiPartNoTotalAmount.expiry === CltvExpiry(42))
     assert(multiPartNoTotalAmount.totalAmount === 561.msat)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/TlvCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/TlvCodecsSpec.scala
@@ -27,8 +27,8 @@ import scodec.bits.HexStringSyntax
 import scodec.codecs._
 
 /**
-  * Created by t-bast on 20/06/2019.
-  */
+ * Created by t-bast on 20/06/2019.
+ */
 
 class TlvCodecsSpec extends FunSuite {
 
@@ -36,116 +36,135 @@ class TlvCodecsSpec extends FunSuite {
 
   test("encode/decode truncated uint16") {
     val testCases = Seq(
-      (hex"00", 0),
-      (hex"01 01", 1),
-      (hex"01 2a", 42),
-      (hex"01 ff", 255),
-      (hex"02 0100", 256),
-      (hex"02 0231", 561),
-      (hex"02 ffff", 65535)
+      (hex"", hex"00", 0),
+      (hex"01", hex"01 01", 1),
+      (hex"2a", hex"01 2a", 42),
+      (hex"ff", hex"01 ff", 255),
+      (hex"0100", hex"02 0100", 256),
+      (hex"0231", hex"02 0231", 561),
+      (hex"ffff", hex"02 ffff", 65535)
     )
 
-    for ((bin, expected) <- testCases) {
+    for ((bin, lengthPrefixedBin, expected) <- testCases) {
       val decoded = tu16.decode(bin.bits).require.value
+      val decoded1 = ltu16.decode(lengthPrefixedBin.bits).require.value
       assert(decoded === expected)
+      assert(decoded1 === expected)
 
       val encoded = tu16.encode(expected).require.bytes
+      val encoded1 = ltu16.encode(expected).require.bytes
       assert(encoded === bin)
+      assert(encoded1 === lengthPrefixedBin)
     }
   }
 
   test("encode/decode truncated uint32") {
     val testCases = Seq(
-      (hex"00", 0L),
-      (hex"01 01", 1L),
-      (hex"01 2a", 42L),
-      (hex"01 ff", 255L),
-      (hex"02 0100", 256L),
-      (hex"02 0231", 561L),
-      (hex"02 ffff", 65535L),
-      (hex"03 010000", 65536L),
-      (hex"03 ffffff", 16777215L),
-      (hex"04 01000000", 16777216L),
-      (hex"04 01020304", 16909060L),
-      (hex"04 ffffffff", 4294967295L)
+      (hex"", hex"00", 0L),
+      (hex"01", hex"01 01", 1L),
+      (hex"2a", hex"01 2a", 42L),
+      (hex"ff", hex"01 ff", 255L),
+      (hex"0100", hex"02 0100", 256L),
+      (hex"0231", hex"02 0231", 561L),
+      (hex"ffff", hex"02 ffff", 65535L),
+      (hex"010000", hex"03 010000", 65536L),
+      (hex"ffffff", hex"03 ffffff", 16777215L),
+      (hex"01000000", hex"04 01000000", 16777216L),
+      (hex"01020304", hex"04 01020304", 16909060L),
+      (hex"ffffffff", hex"04 ffffffff", 4294967295L)
     )
 
-    for ((bin, expected) <- testCases) {
+    for ((bin, lengthPrefixedBin, expected) <- testCases) {
       val decoded = tu32.decode(bin.bits).require.value
+      val decoded1 = ltu32.decode(lengthPrefixedBin.bits).require.value
       assert(decoded === expected)
+      assert(decoded1 === expected)
 
       val encoded = tu32.encode(expected).require.bytes
+      val encoded1 = ltu32.encode(expected).require.bytes
       assert(encoded === bin)
+      assert(encoded1 === lengthPrefixedBin)
     }
   }
 
   test("encode/decode truncated uint64") {
     val testCases = Seq(
-      (hex"00", UInt64(0)),
-      (hex"01 01", UInt64(1)),
-      (hex"01 2a", UInt64(42)),
-      (hex"01 ff", UInt64(255)),
-      (hex"02 0100", UInt64(256)),
-      (hex"02 0231", UInt64(561)),
-      (hex"02 ffff", UInt64(65535)),
-      (hex"03 010000", UInt64(65536)),
-      (hex"03 ffffff", UInt64(16777215)),
-      (hex"04 01000000", UInt64(16777216)),
-      (hex"04 01020304", UInt64(16909060)),
-      (hex"04 ffffffff", UInt64(4294967295L)),
-      (hex"05 0100000000", UInt64(4294967296L)),
-      (hex"05 0102030405", UInt64(4328719365L)),
-      (hex"05 ffffffffff", UInt64(1099511627775L)),
-      (hex"06 010000000000", UInt64(1099511627776L)),
-      (hex"06 010203040506", UInt64(1108152157446L)),
-      (hex"06 ffffffffffff", UInt64(281474976710655L)),
-      (hex"07 01000000000000", UInt64(281474976710656L)),
-      (hex"07 01020304050607", UInt64(283686952306183L)),
-      (hex"07 ffffffffffffff", UInt64(72057594037927935L)),
-      (hex"08 0100000000000000", UInt64(72057594037927936L)),
-      (hex"08 0102030405060708", UInt64(72623859790382856L)),
-      (hex"08 ffffffffffffffff", UInt64.MaxValue)
+      (hex"", hex"00", UInt64(0)),
+      (hex"01", hex"01 01", UInt64(1)),
+      (hex"2a", hex"01 2a", UInt64(42)),
+      (hex"ff", hex"01 ff", UInt64(255)),
+      (hex"0100", hex"02 0100", UInt64(256)),
+      (hex"0231", hex"02 0231", UInt64(561)),
+      (hex"ffff", hex"02 ffff", UInt64(65535)),
+      (hex"010000", hex"03 010000", UInt64(65536)),
+      (hex"ffffff", hex"03 ffffff", UInt64(16777215)),
+      (hex"01000000", hex"04 01000000", UInt64(16777216)),
+      (hex"01020304", hex"04 01020304", UInt64(16909060)),
+      (hex"ffffffff", hex"04 ffffffff", UInt64(4294967295L)),
+      (hex"0100000000", hex"05 0100000000", UInt64(4294967296L)),
+      (hex"0102030405", hex"05 0102030405", UInt64(4328719365L)),
+      (hex"ffffffffff", hex"05 ffffffffff", UInt64(1099511627775L)),
+      (hex"010000000000", hex"06 010000000000", UInt64(1099511627776L)),
+      (hex"010203040506", hex"06 010203040506", UInt64(1108152157446L)),
+      (hex"ffffffffffff", hex"06 ffffffffffff", UInt64(281474976710655L)),
+      (hex"01000000000000", hex"07 01000000000000", UInt64(281474976710656L)),
+      (hex"01020304050607", hex"07 01020304050607", UInt64(283686952306183L)),
+      (hex"ffffffffffffff", hex"07 ffffffffffffff", UInt64(72057594037927935L)),
+      (hex"0100000000000000", hex"08 0100000000000000", UInt64(72057594037927936L)),
+      (hex"0102030405060708", hex"08 0102030405060708", UInt64(72623859790382856L)),
+      (hex"ffffffffffffffff", hex"08 ffffffffffffffff", UInt64.MaxValue)
     )
 
-    for ((bin, expected) <- testCases) {
+    for ((bin, lengthPrefixedBin, expected) <- testCases) {
       val decoded = tu64.decode(bin.bits).require.value
+      val decoded1 = ltu64.decode(lengthPrefixedBin.bits).require.value
       assert(decoded === expected)
+      assert(decoded1 === expected)
 
       val encoded = tu64.encode(expected).require.bytes
+      val encoded1 = ltu64.encode(expected).require.bytes
       assert(encoded === bin)
+      assert(encoded1 === lengthPrefixedBin)
     }
   }
 
   test("encode/decode truncated uint64 overflow") {
-    assert(tu64overflow.encode(Long.MaxValue).require.toByteVector === hex"087fffffffffffffff")
-    assert(tu64overflow.decode(hex"087fffffffffffffff".bits).require.value === Long.MaxValue)
+    assert(tu64overflow.encode(Long.MaxValue).require.toByteVector === hex"7fffffffffffffff")
+    assert(tu64overflow.decode(hex"7fffffffffffffff".bits).require.value === Long.MaxValue)
 
-    assert(tu64overflow.encode(42L).require.toByteVector === hex"012a")
-    assert(tu64overflow.decode(hex"012a".bits).require.value === 42L)
+    assert(tu64overflow.encode(42L).require.toByteVector === hex"2a")
+    assert(tu64overflow.decode(hex"2a".bits).require.value === 42L)
 
     assert(tu64overflow.encode(-1L).isFailure)
-    assert(tu64overflow.decode(hex"088000000000000000".bits).isFailure)
+    assert(tu64overflow.decode(hex"8000000000000000".bits).isFailure)
+  }
+
+  test("decode length-prefixed truncated uint64 ignores trailing bytes") {
+    assert(ltu64.decode(hex"00 1234".bits).require.value === UInt64(0))
+    assert(ltu64.decode(hex"01 2a ff".bits).require.value === UInt64(42))
+    assert(ltu64.decode(hex"02 0451 1234".bits).require.value === UInt64(1105))
+    assert(ltu64.decode(hex"03 010000 0000".bits).require.value === UInt64(65536))
   }
 
   test("decode invalid truncated integers") {
     val testCases = Seq(
-      (tu16, hex"01 00"), // not minimal
-      (tu16, hex"02 0001"), // not minimal
-      (tu16, hex"03 ffffff"), // length too big
-      (tu32, hex"01 00"), // not minimal
-      (tu32, hex"02 0001"), // not minimal
-      (tu32, hex"03 000100"), // not minimal
-      (tu32, hex"04 00010000"), // not minimal
-      (tu32, hex"05 ffffffffff"), // length too big
-      (tu64, hex"01 00"), // not minimal
-      (tu64, hex"02 0001"), // not minimal
-      (tu64, hex"03 000100"), // not minimal
-      (tu64, hex"04 00010000"), // not minimal
-      (tu64, hex"05 0001000000"), // not minimal
-      (tu64, hex"06 000100000000"), // not minimal
-      (tu64, hex"07 00010000000000"), // not minimal
-      (tu64, hex"08 0001000000000000"), // not minimal
-      (tu64, hex"09 ffffffffffffffffff") // length too big
+      (tu16, hex"00"), // not minimal
+      (tu16, hex"0001"), // not minimal
+      (tu16, hex"ffffff"), // length too big
+      (tu32, hex"00"), // not minimal
+      (tu32, hex"0001"), // not minimal
+      (tu32, hex"000100"), // not minimal
+      (tu32, hex"00010000"), // not minimal
+      (tu32, hex"ffffffffff"), // length too big
+      (tu64, hex"00"), // not minimal
+      (tu64, hex"0001"), // not minimal
+      (tu64, hex"000100"), // not minimal
+      (tu64, hex"00010000"), // not minimal
+      (tu64, hex"0001000000"), // not minimal
+      (tu64, hex"000100000000"), // not minimal
+      (tu64, hex"00010000000000"), // not minimal
+      (tu64, hex"0001000000000000"), // not minimal
+      (tu64, hex"ffffffffffffffffff") // length too big
     )
 
     for ((codec, bin) <- testCases) {
@@ -307,9 +326,9 @@ class TlvCodecsSpec extends FunSuite {
 
   test("get optional TLV field") {
     val stream = TlvStream[TestTlv](Seq(TestType254(42), TestType1(42)), Seq(GenericTlv(13, hex"2a"), GenericTlv(11, hex"2b")))
-    assert(stream.get[TestType254] == Some(TestType254(42)))
-    assert(stream.get[TestType1] == Some(TestType1(42)))
-    assert(stream.get[TestType2] == None)
+    assert(stream.get[TestType254] === Some(TestType254(42)))
+    assert(stream.get[TestType1] === Some(TestType1(42)))
+    assert(stream.get[TestType2] === None)
   }
 }
 
@@ -324,7 +343,7 @@ object TlvCodecsSpec {
   case class TestType3(nodeId: PublicKey, value1: UInt64, value2: UInt64) extends TestTlv
   case class TestType254(intValue: Int) extends TestTlv
 
-  private val testCodec1: Codec[TestType1] = ("value" | tu64).as[TestType1]
+  private val testCodec1: Codec[TestType1] = ("value" | ltu64).as[TestType1]
   private val testCodec2: Codec[TestType2] = (("length" | constant(hex"08")) :: ("short_channel_id" | shortchannelid)).as[TestType2]
   private val testCodec3: Codec[TestType3] = (("length" | constant(hex"31")) :: ("node_id" | publicKey) :: ("value_1" | uint64) :: ("value_2" | uint64)).as[TestType3]
   private val testCodec254: Codec[TestType254] = (("length" | constant(hex"02")) :: ("value" | uint16)).as[TestType254]
@@ -342,8 +361,8 @@ object TlvCodecsSpec {
   case class OtherType1(uintValue: UInt64) extends OtherTlv
   case class OtherType2(smallValue: Long) extends OtherTlv
 
-  val otherCodec1: Codec[OtherType1] = ("value" | tu64).as[OtherType1]
-  val otherCodec2: Codec[OtherType2] = ("value" | tu32).as[OtherType2]
+  val otherCodec1: Codec[OtherType1] = ("value" | ltu64).as[OtherType1]
+  val otherCodec2: Codec[OtherType2] = ("value" | ltu32).as[OtherType2]
   val otherTlvStreamCodec = tlvStream(discriminated[OtherTlv].by(varint)
     .typecase(10, otherCodec1)
     .typecase(11, otherCodec2))


### PR DESCRIPTION
The spec defines tu64 (and friends) without the length prefix.
Multi-part uses a tu64 without a length prefix inside the PaymentData record.

Our previous implementation only supported using tu64 alone in a TLV record.
We make this more flexible by separating the length encoding.