### PR TITLE
Check TLS version support in ElectrumClient

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -71,7 +71,12 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL)(implicit val ec
           val sslParameters = handler.engine().getSSLParameters
           sslParameters.setEndpointIdentificationAlgorithm("HTTPS")
           handler.engine().setSSLParameters(sslParameters)
-          handler.engine().setEnabledProtocols(Array[String]("TLSv1.2", "TLSv1.3"))
+          val enabledProtocols = if (handler.engine().getSupportedProtocols.contains("TLSv1.3")) {
+            "TLSv1.2" :: "TLSv1.3" :: Nil
+          } else {
+            "TLSv1.2" :: Nil
+          }
+          handler.engine().setEnabledProtocols(enabledProtocols.toArray)
           ch.pipeline.addLast(handler)
         case SSL.LOOSE =>
           // INSECURE VERSION THAT DOESN'T CHECK CERTIFICATE


### PR DESCRIPTION
#1160 updated netty, and `ElectrumClient` now uses `TLSv1.3` when using the custom electrum server feature. However mobile devices may not support TLS 1.3 (for android, only from 10/API 29):

- https://developer.android.com/reference/javax/net/ssl/SSLContext.html
- https://developer.android.com/about/versions/10/features

As such trying to enable `TLSv1.3` in `ElectrumClient` raises an exception on older Android. It does not gracefully fallback to `TLSv1.2` as was expected.

This PR fixes that by checking support beforehand.