### PR TITLE
MPP routing improvements

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -108,12 +108,12 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
           // it in our payment attempts to avoid failing too fast.
           // However we don't want to test all of our channels either which would be expensive, so we only probabilistically
           // count the failure in our payment attempts.
-          // With the log-scale used, here are the probabilities:
-          //  * 10 channels -> refund 13% of failures
-          //  * 20 channels -> refund 32% of failures
-          //  * 50 channels -> refund 50% of failures
-          //  * 100 channels -> refund 56% of failures
-          //  * 1000 channels -> refund 70% of failures
+          // With the log-scale used, here are the probabilities and the corresponding number of retries:
+          //  *   10 channels -> refund 13% of failures -> with 5 initial retries we will actually try 5/(1-0.13) = ~6 times
+          //  *   20 channels -> refund 32% of failures -> with 5 initial retries we will actually try 5/(1-0.32) = ~7 times
+          //  *   50 channels -> refund 50% of failures -> with 5 initial retries we will actually try 5/(1-0.50) = ~10 times
+          //  *  100 channels -> refund 56% of failures -> with 5 initial retries we will actually try 5/(1-0.56) = ~11 times
+          //  * 1000 channels -> refund 70% of failures -> with 5 initial retries we will actually try 5/(1-0.70) = ~17 times
           // NB: this hack won't be necessary once multi-part is directly handled by the router.
           d.remainingAttempts + 1
         } else {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -42,27 +42,24 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, relayer: ActorR
   override def receive: Receive = {
     case r: SendPaymentRequest =>
       val paymentId = UUID.randomUUID()
+      sender ! paymentId
       val paymentCfg = SendPaymentConfig(paymentId, paymentId, r.externalId, r.paymentHash, r.targetNodeId, r.paymentRequest, storeInDb = true, publishEvent = true)
       val finalExpiry = r.finalExpiry(nodeParams.currentBlockHeight)
-      if (r.paymentRequest.exists(!_.features.supported)) {
-        sender ! paymentId
-        sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(new IllegalArgumentException(s"can't send payment: unknown invoice features (${r.paymentRequest.get.features})")) :: Nil)
-      } else {
-        r.paymentRequest match {
-          case Some(invoice) if invoice.features.allowMultiPart =>
-            r.predefinedRoute match {
-              case Nil => spawnMultiPartPaymentFsm(paymentCfg) forward SendMultiPartPayment(r.paymentHash, invoice.paymentSecret.get, r.targetNodeId, r.amount, finalExpiry, r.maxAttempts, r.assistedRoutes, r.routeParams)
-              case hops => spawnPaymentFsm(paymentCfg) forward SendPaymentToRoute(r.paymentHash, hops, Onion.createMultiPartPayload(r.amount, invoice.amount.getOrElse(r.amount), finalExpiry, invoice.paymentSecret.get))
-            }
-          case _ =>
-            val payFsm = spawnPaymentFsm(paymentCfg)
-            // NB: we only generate legacy payment onions for now for maximum compatibility.
-            r.predefinedRoute match {
-              case Nil => payFsm forward SendPayment(r.paymentHash, r.targetNodeId, FinalLegacyPayload(r.amount, finalExpiry), r.maxAttempts, r.assistedRoutes, r.routeParams)
-              case hops => payFsm forward SendPaymentToRoute(r.paymentHash, hops, FinalLegacyPayload(r.amount, finalExpiry))
-            }
-        }
-        sender ! paymentId
+      r.paymentRequest match {
+        case Some(invoice) if !invoice.features.supported =>
+          sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(new IllegalArgumentException(s"can't send payment: unknown invoice features (${r.paymentRequest.get.features})")) :: Nil)
+        case Some(invoice) if invoice.features.allowMultiPart =>
+          r.predefinedRoute match {
+            case Nil => spawnMultiPartPaymentFsm(paymentCfg) forward SendMultiPartPayment(r.paymentHash, invoice.paymentSecret.get, r.targetNodeId, r.amount, finalExpiry, r.maxAttempts, r.assistedRoutes, r.routeParams)
+            case hops => spawnPaymentFsm(paymentCfg) forward SendPaymentToRoute(r.paymentHash, hops, Onion.createMultiPartPayload(r.amount, invoice.amount.getOrElse(r.amount), finalExpiry, invoice.paymentSecret.get))
+          }
+        case _ =>
+          val payFsm = spawnPaymentFsm(paymentCfg)
+          // NB: we only generate legacy payment onions for now for maximum compatibility.
+          r.predefinedRoute match {
+            case Nil => payFsm forward SendPayment(r.paymentHash, r.targetNodeId, FinalLegacyPayload(r.amount, finalExpiry), r.maxAttempts, r.assistedRoutes, r.routeParams)
+            case hops => payFsm forward SendPaymentToRoute(r.paymentHash, hops, FinalLegacyPayload(r.amount, finalExpiry))
+          }
       }
 
     case r: SendTrampolinePaymentRequest =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -186,7 +186,9 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
       stay
 
     case Event(Status.Failure(t), WaitingForComplete(s, c, _, failures, _, ignoreNodes, ignoreChannels, hops)) =>
-      if (failures.size + 1 >= c.maxAttempts) {
+      // If the first hop was selected by the sender (in routePrefix) and it failed, it doesn't make sense to retry (we
+      // will end up retrying over that same faulty channel).
+      if (failures.size + 1 >= c.maxAttempts || c.routePrefix.nonEmpty) {
         onFailure(s, PaymentFailed(id, c.paymentHash, failures :+ LocalFailure(t)))
         stop(FSM.Normal)
       } else {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -100,8 +100,8 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(payFsm.stateName === WAIT_FOR_NETWORK_STATS)
     router.send(payFsm, GetNetworkStatsResponse(Some(emptyStats)))
     relayer.expectMsg(GetOutgoingChannels())
-    awaitCond(payFsm.stateName === RETRY_WITH_UPDATED_BALANCES)
-    assert(payFsm.stateData.asInstanceOf[PaymentProgress].networkStats === Some(emptyStats))
+    awaitCond(payFsm.stateName === WAIT_FOR_CHANNEL_BALANCES)
+    assert(payFsm.stateData.asInstanceOf[WaitingForChannelBalances].networkStats === Some(emptyStats))
   }
 
   test("get network statistics not available") { f =>
@@ -117,8 +117,8 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     // We should ask the router to compute statistics (for next payment attempts).
     router.expectMsg(TickComputeNetworkStats)
     relayer.expectMsg(GetOutgoingChannels())
-    awaitCond(payFsm.stateName === RETRY_WITH_UPDATED_BALANCES)
-    assert(payFsm.stateData.asInstanceOf[PaymentProgress].networkStats === None)
+    awaitCond(payFsm.stateName === WAIT_FOR_CHANNEL_BALANCES)
+    assert(payFsm.stateData.asInstanceOf[WaitingForChannelBalances].networkStats === None)
 
     relayer.send(payFsm, localChannels())
     awaitCond(payFsm.stateName === PAYMENT_IN_PROGRESS)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -25,8 +25,8 @@ import fr.acinq.bitcoin.{Block, Crypto, DeterministicWallet, Satoshi, Transactio
 import fr.acinq.eclair.TestConstants.TestFeeEstimator
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
-import fr.acinq.eclair.channel.Commitments
 import fr.acinq.eclair.channel.Helpers.Funding
+import fr.acinq.eclair.channel.{ChannelFlags, Commitments}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.PaymentSent.PartialPayment
 import fr.acinq.eclair.payment.relay.Relayer.{GetOutgoingChannels, OutgoingChannel, OutgoingChannels}
@@ -129,14 +129,22 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
 
   test("send to peer node via multiple channels") { f =>
     import f._
-    val payment = SendMultiPartPayment(paymentHash, randomBytes32, b, 2000 * 1000 msat, expiry, 1)
+    val payment = SendMultiPartPayment(paymentHash, randomBytes32, b, 2000 * 1000 msat, expiry, 3)
+    // When sending to a peer node, we should not filter out unannounced channels.
+    val channels = OutgoingChannels(Seq(
+      OutgoingChannel(c, channelUpdate_ac_2, makeCommitments(1000 * 1000 msat, 0)),
+      OutgoingChannel(c, channelUpdate_ac_3, makeCommitments(1500 * 1000 msat, 0)),
+      OutgoingChannel(b, channelUpdate_ab_1.copy(channelFlags = ChannelFlags.Empty), makeCommitments(1000 * 1000 msat, 0, announceChannel = false)),
+      OutgoingChannel(b, channelUpdate_ab_2.copy(channelFlags = ChannelFlags.Empty), makeCommitments(1500 * 1000 msat, 0, announceChannel = false)),
+      OutgoingChannel(d, channelUpdate_ad_1, makeCommitments(1000 * 1000 msat, 0))))
     // Network statistics should be ignored when sending to peer.
-    initPayment(f, payment, emptyStats, localChannels(0))
+    initPayment(f, payment, emptyStats, channels)
 
     // The payment should be split in two, using direct channels with b.
+    // MaxAttempts should be set to 1 when using direct channels to the destination.
     childPayFsm.expectMsgAllOf(
-      SendPayment(paymentHash, b, Onion.createMultiPartPayload(1000 * 1000 msat, payment.totalAmount, expiry, payment.paymentSecret), 1, routePrefix = Seq(ChannelHop(nodeParams.nodeId, b, channelUpdate_ab_1))),
-      SendPayment(paymentHash, b, Onion.createMultiPartPayload(1000 * 1000 msat, payment.totalAmount, expiry, payment.paymentSecret), 1, routePrefix = Seq(ChannelHop(nodeParams.nodeId, b, channelUpdate_ab_2)))
+      SendPayment(paymentHash, b, Onion.createMultiPartPayload(1000 * 1000 msat, payment.totalAmount, expiry, payment.paymentSecret), 1, routePrefix = Seq(ChannelHop(nodeParams.nodeId, b, channelUpdate_ab_1.copy(channelFlags = ChannelFlags.Empty)))),
+      SendPayment(paymentHash, b, Onion.createMultiPartPayload(1000 * 1000 msat, payment.totalAmount, expiry, payment.paymentSecret), 1, routePrefix = Seq(ChannelHop(nodeParams.nodeId, b, channelUpdate_ab_2.copy(channelFlags = ChannelFlags.Empty))))
     )
     childPayFsm.expectNoMsg(50 millis)
     val childIds = payFsm.stateData.asInstanceOf[PaymentProgress].pending.keys.toSeq
@@ -302,6 +310,23 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(result.amount === payment.totalAmount)
   }
 
+  test("skip unannounced channels when sending to remote node") { f =>
+    import f._
+
+    // The channels to b are not announced: they should be ignored so the payment should fail.
+    val channels = OutgoingChannels(Seq(
+      OutgoingChannel(b, channelUpdate_ab_1.copy(channelFlags = ChannelFlags.Empty), makeCommitments(1000 * 1000 msat, 10, announceChannel = false)),
+      OutgoingChannel(b, channelUpdate_ab_2.copy(channelFlags = ChannelFlags.Empty), makeCommitments(1500 * 1000 msat, 10, announceChannel = false)),
+      OutgoingChannel(c, channelUpdate_ac_1, makeCommitments(500 * 1000 msat, 10))
+    ))
+    val payment = SendMultiPartPayment(paymentHash, randomBytes32, e, 1200 * 1000 msat, expiry, 3)
+    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), channels)
+
+    val result = sender.expectMsgType[PaymentFailed]
+    assert(result.id === paymentId)
+    assert(result.paymentHash === paymentHash)
+  }
+
   test("retry after error") { f =>
     import f._
     val payment = SendMultiPartPayment(paymentHash, randomBytes32, e, 3000 * 1000 msat, expiry, 3)
@@ -310,20 +335,29 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), testChannels)
     waitUntilAmountSent(f, payment.totalAmount)
     val pending = payFsm.stateData.asInstanceOf[PaymentProgress].pending
-    val childIds = pending.keys.toSeq
     assert(pending.size > 2)
 
-    // Simulate two failures.
-    val failures = Seq(LocalFailure(new RuntimeException("418 I'm a teapot")), UnreadableRemoteFailure(Nil))
-    childPayFsm.send(payFsm, PaymentFailed(childIds.head, paymentHash, failures.slice(0, 1)))
-    childPayFsm.send(payFsm, PaymentFailed(childIds(1), paymentHash, failures.slice(1, 2)))
+    // Simulate a local channel failure and a remote failure.
+    val faultyLocalChannelId = getFirstHopShortChannelId(pending.head._2)
+    val faultyLocalPayments = pending.filter { case (_, p) => getFirstHopShortChannelId(p) == faultyLocalChannelId }
+    val faultyRemotePayment = pending.filter { case (_, p) => getFirstHopShortChannelId(p) != faultyLocalChannelId }.head
+    faultyLocalPayments.keys.foreach(id => {
+      childPayFsm.send(payFsm, PaymentFailed(id, paymentHash, LocalFailure(RouteNotFound) :: Nil))
+    })
+    childPayFsm.send(payFsm, PaymentFailed(faultyRemotePayment._1, paymentHash, UnreadableRemoteFailure(Nil) :: Nil))
+
     // We should ask for updated balance to take into account pending payments.
     relayer.expectMsg(GetOutgoingChannels())
     relayer.send(payFsm, testChannels.copy(channels = testChannels.channels.dropRight(2)))
 
+    // The channel that lead to a RouteNotFound should be ignored.
+    assert(payFsm.stateData.asInstanceOf[PaymentProgress].ignoreChannels === Set(faultyLocalChannelId))
+
     // New payments should be sent that match the failed amount.
-    waitUntilAmountSent(f, pending(childIds.head).finalPayload.amount + pending(childIds(1)).finalPayload.amount)
-    assert(payFsm.stateData.asInstanceOf[PaymentProgress].failures.toSet === failures.toSet)
+    waitUntilAmountSent(f, faultyRemotePayment._2.finalPayload.amount + faultyLocalPayments.values.map(_.finalPayload.amount).sum)
+    val stateData = payFsm.stateData.asInstanceOf[PaymentProgress]
+    assert(stateData.failures.toSet === Set(LocalFailure(RouteNotFound), UnreadableRemoteFailure(Nil)))
+    assert(stateData.pending.values.forall(p => getFirstHopShortChannelId(p) != faultyLocalChannelId))
   }
 
   test("cannot send (not enough capacity on local channels)") { f =>
@@ -338,7 +372,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(result.id === paymentId)
     assert(result.paymentHash === paymentHash)
     assert(result.failures.length === 1)
-    assert(result.failures.head.asInstanceOf[LocalFailure].t.getMessage === "balance is too low")
+    assert(result.failures.head.asInstanceOf[LocalFailure].t === BalanceTooLow)
   }
 
   test("cannot send (fee rate too high)") { f =>
@@ -353,7 +387,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(result.id === paymentId)
     assert(result.paymentHash === paymentHash)
     assert(result.failures.length === 1)
-    assert(result.failures.head.asInstanceOf[LocalFailure].t.getMessage === "balance is too low")
+    assert(result.failures.head.asInstanceOf[LocalFailure].t === BalanceTooLow)
   }
 
   test("payment timeout") { f =>
@@ -396,7 +430,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(result.paymentHash === paymentHash)
     assert(result.failures.length === 3)
     assert(result.failures.slice(0, 2) === failures)
-    assert(result.failures.last.asInstanceOf[LocalFailure].t.getMessage === "payment attempts exhausted without success")
+    assert(result.failures.last.asInstanceOf[LocalFailure].t === RetryExhausted)
   }
 
   test("receive partial failure after success (recipient spec violation)") { f =>
@@ -495,7 +529,7 @@ object MultiPartPaymentLifecycleSpec {
   val channelId_ac_2 = ShortChannelId(12)
   val channelId_ac_3 = ShortChannelId(13)
   val channelId_ad_1 = ShortChannelId(21)
-  val defaultChannelUpdate = ChannelUpdate(randomBytes64, Block.RegtestGenesisBlock.hash, ShortChannelId(0), 0, 1, 0, CltvExpiryDelta(12), 1 msat, 0 msat, 0, Some(2000 * 1000 msat))
+  val defaultChannelUpdate = ChannelUpdate(randomBytes64, Block.RegtestGenesisBlock.hash, ShortChannelId(0), 0, 1, ChannelFlags.AnnounceChannel, CltvExpiryDelta(12), 1 msat, 0 msat, 0, Some(2000 * 1000 msat))
   val channelUpdate_ab_1 = defaultChannelUpdate.copy(shortChannelId = channelId_ab_1, cltvExpiryDelta = CltvExpiryDelta(4), feeBaseMsat = 100 msat, feeProportionalMillionths = 70)
   val channelUpdate_ab_2 = defaultChannelUpdate.copy(shortChannelId = channelId_ab_2, cltvExpiryDelta = CltvExpiryDelta(4), feeBaseMsat = 100 msat, feeProportionalMillionths = 70)
   val channelUpdate_ac_1 = defaultChannelUpdate.copy(shortChannelId = channelId_ac_1, cltvExpiryDelta = CltvExpiryDelta(5), feeBaseMsat = 150 msat, feeProportionalMillionths = 40)
@@ -518,7 +552,7 @@ object MultiPartPaymentLifecycleSpec {
 
   val emptyStats = NetworkStats(0, 0, Stats(Seq(0), d => Satoshi(d.toLong)), Stats(Seq(0), d => CltvExpiryDelta(d.toInt)), Stats(Seq(0), d => MilliSatoshi(d.toLong)), Stats(Seq(0), d => d.toLong))
 
-  def makeCommitments(canSend: MilliSatoshi, feeRatePerKw: Long): Commitments = {
+  def makeCommitments(canSend: MilliSatoshi, feeRatePerKw: Long, announceChannel: Boolean = true): Commitments = {
     import fr.acinq.eclair.channel._
     import fr.acinq.eclair.crypto.ShaChain
     // We are only interested in availableBalanceForSend so we can put dummy values in most places.
@@ -529,7 +563,7 @@ object MultiPartPaymentLifecycleSpec {
       ChannelVersion.STANDARD,
       localParams,
       remoteParams,
-      channelFlags = 0x01.toByte,
+      channelFlags = if (announceChannel) ChannelFlags.AnnounceChannel else ChannelFlags.Empty,
       LocalCommit(0, CommitmentSpec(Set.empty, feeRatePerKw, canSend, 0 msat), PublishableTxs(CommitTx(commitmentInput, Transaction(2, Nil, Nil, 0)), Nil)),
       RemoteCommit(0, CommitmentSpec(Set.empty, feeRatePerKw, 0 msat, canSend), randomBytes32, randomKey.publicKey),
       LocalChanges(Nil, Nil, Nil),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -100,7 +100,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(payFsm.stateName === WAIT_FOR_NETWORK_STATS)
     router.send(payFsm, GetNetworkStatsResponse(Some(emptyStats)))
     relayer.expectMsg(GetOutgoingChannels())
-    awaitCond(payFsm.stateName === WAIT_FOR_CHANNEL_BALANCES)
+    awaitCond(payFsm.stateName === RETRY_WITH_UPDATED_BALANCES)
     assert(payFsm.stateData.asInstanceOf[PaymentProgress].networkStats === Some(emptyStats))
   }
 
@@ -117,7 +117,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     // We should ask the router to compute statistics (for next payment attempts).
     router.expectMsg(TickComputeNetworkStats)
     relayer.expectMsg(GetOutgoingChannels())
-    awaitCond(payFsm.stateName === WAIT_FOR_CHANNEL_BALANCES)
+    awaitCond(payFsm.stateName === RETRY_WITH_UPDATED_BALANCES)
     assert(payFsm.stateData.asInstanceOf[PaymentProgress].networkStats === None)
 
     relayer.send(payFsm, localChannels())

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -153,8 +153,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.send(paymentFSM, RouteResponse(Seq(ChannelHop(c, d, channelUpdate_cd)), Set(a, b), Set.empty))
     val Transition(_, WAITING_FOR_ROUTE, WAITING_FOR_PAYMENT_COMPLETE) = monitor.expectMsgClass(classOf[Transition[_]])
 
-    sender.send(paymentFSM, UpdateFailMalformedHtlc(randomBytes32, 0, randomBytes32, 0))
-    routerForwarder.expectMsg(RouteRequest(c, d, defaultAmountMsat, ignoreNodes = Set(a, b), ignoreChannels = Set(ChannelDesc(channelUpdate_ab.shortChannelId, a, b))))
+    sender.send(paymentFSM, UpdateFailHtlc(randomBytes32, 0, randomBytes(Sphinx.FailurePacket.PacketLength)))
+    routerForwarder.expectMsg(RouteRequest(c, d, defaultAmountMsat, ignoreNodes = Set(a, b, c)))
     val Transition(_, WAITING_FOR_PAYMENT_COMPLETE, WAITING_FOR_ROUTE) = monitor.expectMsgClass(classOf[Transition[_]])
     assert(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status == OutgoingPaymentStatus.Pending))
   }


### PR DESCRIPTION
I found a few things than can be improved in the MPP retry behavior.
Those will be particularly helpful for Trampoline-MPP to a remote peer (take into account the fact that a Trampoline node will likely have many channels).

### Improvement 1: sending to a direct peer should not retry

It doesn't make any sense to let the `PaymentLifecycle` retry when we're forcing the choice of the first hop and the recipient is on the other end of that channel.
This is fixed by setting `maxAttempts=1` when sending child payments via direct channels to the recipient.

### Improvement 2: only use public channels for remote recipients

When the recipient isn't a direct peer, it's very unlikely that choosing a route prefix with an unannounced channel will succeed. Most unannounced channels Endurance/Horizon has are with mobile wallets. We ignore them when sending to remote nodes.

### Improvement 3: handle RouteNotFound

We're choosing the first hop without looking at the graph. That means we may choose a first hop that can't yield a complete route to our recipient. When that happens, we should avoid retrying with that same hop.

If we have a lot of channels, it's likely that we'll often choose a bad first hop. Since we only retry 5 times, this will lead to many payment failures which is bad when we're relaying (Trampoline). So we add some randomness on whether to count a `LocalFailure` as a complete attempt or "refund" that attempt.

Note that this hack won't be necessary once we move the MPP logic inside the router: when that happens we will only select first hops that are on a potentially valid route to the recipient.

### Unrelated

I also fixed the random failure that was happening in one of the MPP IntegrationSpec test.
With the code that's running on master, the `PaymentInitiator` doesn't guarantee that it will send the `PaymentId` before payment events.
Now we guarantee that.