### PR TITLE
Fix MPP post-restart HTLC clean-up

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -26,9 +26,9 @@ import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.blockchain.EclairWallet
 import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel._
-import fr.acinq.eclair.db.PendingRelayDb
-import fr.acinq.eclair.payment.relay.{CommandBuffer, Origin}
+import fr.acinq.eclair.db.{IncomingPayment, IncomingPaymentStatus, IncomingPaymentsDb, PendingRelayDb}
 import fr.acinq.eclair.payment.IncomingPacket
+import fr.acinq.eclair.payment.relay.Origin
 import fr.acinq.eclair.router.Rebroadcast
 import fr.acinq.eclair.transactions.{IN, OUT}
 import fr.acinq.eclair.wire.{TemporaryNodeFailure, UpdateAddHtlc}
@@ -59,7 +59,7 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
     })
     val peers = nodeParams.db.peers.listPeers()
 
-    checkBrokenHtlcsLink(channels, nodeParams.privateKey, nodeParams.globalFeatures) match {
+    checkBrokenHtlcsLink(channels, nodeParams.db.payments, nodeParams.privateKey, nodeParams.globalFeatures) match {
       case Nil => ()
       case brokenHtlcs =>
         val brokenHtlcKiller = context.system.actorOf(Props[HtlcReaper], name = "htlc-reaper")
@@ -152,15 +152,16 @@ object Switchboard {
   def peerActorName(remoteNodeId: PublicKey): String = s"peer-$remoteNodeId"
 
   /**
-   * If we have stopped eclair while it was forwarding HTLCs, it is possible that we are in a state were an incoming HTLC
-   * was committed by both sides, but we didn't have time to send and/or sign the corresponding HTLC to the downstream node.
+   * If we have stopped eclair while it was handling HTLCs, it is possible that we are in a state were an incoming HTLC
+   * was committed by both sides, but we didn't have time to send and/or sign the corresponding HTLC to the downstream
+   * node (if we're an intermediate node) or didn't have time to fail/fulfill the payment (if we're the recipient).
    *
-   * In that case, if we do nothing, the incoming HTLC will eventually expire and we won't lose money, but the channel will
-   * get closed, which is a major inconvenience.
+   * In that case, if we do nothing, the incoming HTLC will eventually expire and we won't lose money, but the channel
+   * will get closed, which is a major inconvenience.
    *
-   * This check will detect this and will allow us to fast-fail HTLCs and thus preserve channels.
+   * This check will detect this and will allow us to fast-settle HTLCs and thus preserve channels.
    */
-  def checkBrokenHtlcsLink(channels: Seq[HasCommitments], privateKey: PrivateKey, features: ByteVector)(implicit log: LoggingAdapter): Seq[UpdateAddHtlc] = {
+  def checkBrokenHtlcsLink(channels: Seq[HasCommitments], paymentsDb: IncomingPaymentsDb, privateKey: PrivateKey, features: ByteVector)(implicit log: LoggingAdapter): Seq[(UpdateAddHtlc, Option[ByteVector32])] = {
     // We are interested in incoming HTLCs, that have been *cross-signed* (otherwise they wouldn't have been relayed).
     // They signed it first, so the HTLC will first appear in our commitment tx, and later on in their commitment when
     // we subsequently sign it. That's why we need to look in *their* commitment with direction=OUT.
@@ -169,7 +170,13 @@ object Switchboard {
       .filter(_.direction == OUT)
       .map(_.add)
       .map(IncomingPacket.decrypt(_, privateKey, features))
-      .collect { case Right(IncomingPacket.ChannelRelayPacket(add, _, _)) => add } // we only consider htlcs that are relayed, not the ones for which we are the final node
+      .collect {
+        case Right(IncomingPacket.ChannelRelayPacket(add, _, _)) => (add, None) // we consider all relayed htlcs
+        case Right(IncomingPacket.FinalPacket(add, _)) => paymentsDb.getIncomingPayment(add.paymentHash) match {
+          case Some(IncomingPayment(_, preimage, _, IncomingPaymentStatus.Received(_, _))) => (add, Some(preimage)) // incoming payment that succeeded
+          case _ => (add, None) // incoming payment that didn't succeed
+        }
+      }
 
     // TODO: @t-bast: will need to update this to take into account trampoline-relayed (and thoroughly test).
 
@@ -179,7 +186,9 @@ object Switchboard {
       .collect { case r: Origin.Relayed => r }
       .toSet
 
-    val htlcs_broken = htlcs_in.filterNot(htlc_in => relayed_out.exists(r => r.originChannelId == htlc_in.channelId && r.originHtlcId == htlc_in.id))
+    val htlcs_broken = htlcs_in.filterNot {
+      case (htlc_in, _) => relayed_out.exists(r => r.originChannelId == htlc_in.channelId && r.originHtlcId == htlc_in.id)
+    }
 
     log.info(s"htlcs_in=${htlcs_in.size} htlcs_out=${relayed_out.size} htlcs_broken=${htlcs_broken.size}")
 
@@ -229,25 +238,30 @@ class HtlcReaper extends Actor with ActorLogging {
   context.system.eventStream.subscribe(self, classOf[ChannelStateChanged])
 
   override def receive: Receive = {
-    case initialHtlcs: Seq[UpdateAddHtlc]@unchecked => context become main(initialHtlcs)
+    case initialHtlcs: Seq[(UpdateAddHtlc, Option[ByteVector32])]@unchecked => context become main(initialHtlcs)
   }
 
-  def main(htlcs: Seq[UpdateAddHtlc]): Receive = {
+  def main(htlcs: Seq[(UpdateAddHtlc, Option[ByteVector32])]): Receive = {
     case ChannelStateChanged(channel, _, _, WAIT_FOR_INIT_INTERNAL | OFFLINE | SYNCING, NORMAL | SHUTDOWN | CLOSING, data: HasCommitments) =>
       val acked = htlcs
-        .filter(_.channelId == data.channelId) // only consider htlcs related to this channel
+        .filter(_._1.channelId == data.channelId) // only consider htlcs related to this channel
         .filter {
-          case htlc if Commitments.getHtlcCrossSigned(data.commitments, IN, htlc.id).isDefined =>
-            // this htlc is cross signed in the current commitment, we can fail it
-            log.info(s"failing broken htlc=$htlc")
-            channel ! CMD_FAIL_HTLC(htlc.id, Right(TemporaryNodeFailure), commit = true)
+          case (htlc, preimage) if Commitments.getHtlcCrossSigned(data.commitments, IN, htlc.id).isDefined =>
+            // this htlc is cross signed in the current commitment, we can settle it
+            preimage match {
+              case Some(preimage) =>
+                log.info(s"fulfilling broken htlc=$htlc")
+                channel ! CMD_FULFILL_HTLC(htlc.id, preimage, commit = true)
+              case None =>
+                log.info(s"failing broken htlc=$htlc")
+                channel ! CMD_FAIL_HTLC(htlc.id, Right(TemporaryNodeFailure), commit = true)
+            }
             false // the channel may very well be disconnected before we sign (=ack) the fail, so we keep it for now
           case _ =>
             true // the htlc has already been failed, we can forget about it now
         }
-      acked.foreach(htlc => log.info(s"forgetting htlc id=${htlc.id} channelId=${htlc.channelId}"))
+      acked.foreach { case (htlc, _) => log.info(s"forgetting htlc id=${htlc.id} channelId=${htlc.channelId}") }
       context become main(htlcs diff acked)
   }
-
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -256,7 +256,7 @@ class HtlcReaper extends Actor with ActorLogging {
                 log.info(s"failing broken htlc=$htlc")
                 channel ! CMD_FAIL_HTLC(htlc.id, Right(TemporaryNodeFailure), commit = true)
             }
-            false // the channel may very well be disconnected before we sign (=ack) the fail, so we keep it for now
+            false // the channel may very well be disconnected before we sign (=ack) the fail/fulfill, so we keep it for now
           case _ =>
             true // the htlc has already been failed, we can forget about it now
         }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartPaymentFSM.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartPaymentFSM.scala
@@ -48,7 +48,7 @@ class MultiPartPaymentFSM(nodeParams: NodeParams, paymentHash: ByteVector32, tot
 
     case Event(MultiPartHtlc(totalAmount2, htlc), d: WaitingForHtlc) =>
       require(htlc.paymentHash == paymentHash, s"invalid payment hash (expected $paymentHash, received ${htlc.paymentHash}")
-      val pp = PendingPayment(htlc.id, PartialPayment(htlc.amountMsat, htlc.channelId), sender)
+      val pp = PendingPayment(htlc.id, PartialPayment(htlc.amountMsat, htlc.channelId))
       val updatedParts = d.parts :+ pp
       if (totalAmount != totalAmount2) {
         log.warning(s"multi-part payment total amount mismatch: previously $totalAmount, now $totalAmount2")
@@ -67,7 +67,7 @@ class MultiPartPaymentFSM(nodeParams: NodeParams, paymentHash: ByteVector32, tot
     case Event(MultiPartHtlc(_, htlc), _) =>
       require(htlc.paymentHash == paymentHash, s"invalid payment hash (expected $paymentHash, received ${htlc.paymentHash}")
       log.info(s"received extraneous htlc for payment hash $paymentHash")
-      parent ! ExtraHtlcReceived(paymentHash, PendingPayment(htlc.id, PartialPayment(htlc.amountMsat, htlc.channelId), sender), None)
+      parent ! ExtraHtlcReceived(paymentHash, PendingPayment(htlc.id, PartialPayment(htlc.amountMsat, htlc.channelId)), None)
       stay
   }
 
@@ -76,7 +76,7 @@ class MultiPartPaymentFSM(nodeParams: NodeParams, paymentHash: ByteVector32, tot
     // The LocalPaymentHandler will create a new instance of MultiPartPaymentHandler to handle a new attempt.
     case Event(MultiPartHtlc(_, htlc), PaymentFailed(failure, _)) =>
       require(htlc.paymentHash == paymentHash, s"invalid payment hash (expected $paymentHash, received ${htlc.paymentHash}")
-      parent ! ExtraHtlcReceived(paymentHash, PendingPayment(htlc.id, PartialPayment(htlc.amountMsat, htlc.channelId), sender), Some(failure))
+      parent ! ExtraHtlcReceived(paymentHash, PendingPayment(htlc.id, PartialPayment(htlc.amountMsat, htlc.channelId)), Some(failure))
       stay
   }
 
@@ -121,7 +121,7 @@ object MultiPartPaymentFSM {
 
   // @formatter:off
   /** A payment that we're currently holding until we decide to fulfill or fail it. */
-  case class PendingPayment(htlcId: Long, payment: PartialPayment, sender: ActorRef)
+  case class PendingPayment(htlcId: Long, payment: PartialPayment)
   /** An incoming partial payment. */
   case class MultiPartHtlc(totalAmount: MilliSatoshi, htlc: UpdateAddHtlc)
   /** We successfully received all parts of the payment. */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/PaymentHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/PaymentHandler.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.payment.receive
 
 import akka.actor.Actor.Receive
-import akka.actor.{Actor, ActorContext, ActorLogging, Props}
+import akka.actor.{Actor, ActorContext, ActorLogging, ActorRef, Props}
 import akka.event.LoggingAdapter
 import fr.acinq.eclair.NodeParams
 
@@ -28,10 +28,10 @@ trait ReceiveHandler {
 /**
  * Generic payment handler that delegates handling of incoming messages to a list of handlers.
  */
-class PaymentHandler(nodeParams: NodeParams) extends Actor with ActorLogging {
+class PaymentHandler(nodeParams: NodeParams, commandBuffer: ActorRef) extends Actor with ActorLogging {
 
   // we do this instead of sending it to ourselves, otherwise there is no guarantee that this would be the first processed message
-  private val defaultHandler = new MultiPartHandler(nodeParams, nodeParams.db.payments)
+  private val defaultHandler = new MultiPartHandler(nodeParams, nodeParams.db.payments, commandBuffer)
 
   override def receive: Receive = normal(defaultHandler.handle(context, log))
 
@@ -44,5 +44,5 @@ class PaymentHandler(nodeParams: NodeParams) extends Actor with ActorLogging {
 }
 
 object PaymentHandler {
-  def props(nodeParams: NodeParams): Props = Props(new PaymentHandler(nodeParams))
+  def props(nodeParams: NodeParams, commandBuffer: ActorRef): Props = Props(new PaymentHandler(nodeParams, commandBuffer))
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/CommandBuffer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/CommandBuffer.scala
@@ -22,40 +22,36 @@ import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.channel._
 
 /**
-  * We store [[CMD_FULFILL_HTLC]]/[[CMD_FAIL_HTLC]]/[[CMD_FAIL_MALFORMED_HTLC]]
-  * in a database because we don't want to lose preimages, or to forget to fail
-  * incoming htlcs, which would lead to unwanted channel closings.
-  */
+ * We store [[CMD_FULFILL_HTLC]]/[[CMD_FAIL_HTLC]]/[[CMD_FAIL_MALFORMED_HTLC]]
+ * in a database because we don't want to lose preimages, or to forget to fail
+ * incoming htlcs, which would lead to unwanted channel closings.
+ */
 class CommandBuffer(nodeParams: NodeParams, register: ActorRef) extends Actor with ActorLogging {
 
   import CommandBuffer._
-  import nodeParams.db._
+
+  val db = nodeParams.db.pendingRelay
 
   context.system.eventStream.subscribe(self, classOf[ChannelStateChanged])
 
   override def receive: Receive = {
 
     case CommandSend(channelId, htlcId, cmd) =>
-      // save command in db
       register forward Register.Forward(channelId, cmd)
-      // we also store the preimage in a db (note that this happens *after* forwarding the fulfill to the channel, so we don't add latency)
-      pendingRelay.addPendingRelay(channelId, htlcId, cmd)
+      // we store the command in a db (note that this happens *after* forwarding the command to the channel, so we don't add latency)
+      db.addPendingRelay(channelId, htlcId, cmd)
 
     case CommandAck(channelId, htlcId) =>
-      //delete from db
       log.debug(s"fulfill/fail acked for channelId=$channelId htlcId=$htlcId")
-      pendingRelay.removePendingRelay(channelId, htlcId)
+      db.removePendingRelay(channelId, htlcId)
 
     case ChannelStateChanged(channel, _, _, WAIT_FOR_INIT_INTERNAL | OFFLINE | SYNCING, NORMAL | SHUTDOWN | CLOSING, d: HasCommitments) =>
-      import d.channelId
-      // if channel is in a state where it can have pending htlcs, we send them the fulfills/fails we know of
-      pendingRelay.listPendingRelay(channelId) match {
+      db.listPendingRelay(d.channelId) match {
         case Nil => ()
         case cmds =>
-          log.info(s"re-sending ${cmds.size} unacked fulfills/fails to channel $channelId")
+          log.info(s"re-sending ${cmds.size} unacked fulfills/fails to channel ${d.channelId}")
           cmds.foreach(channel ! _) // they all have commit = false
-          // better to sign once instead of after each fulfill
-          channel ! CMD_SIGN
+          channel ! CMD_SIGN // so we can sign all of them at once
       }
 
     case _: ChannelStateChanged => () // ignored

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -56,7 +56,7 @@ object Origin {
  * It also receives channel HTLC events (fulfill / failed) and relays those to the appropriate handlers.
  * It also maintains an up-to-date view of local channel balances.
  */
-class Relayer(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorRef) extends Actor with ActorLogging {
+class Relayer(nodeParams: NodeParams, register: ActorRef, commandBuffer: ActorRef, paymentHandler: ActorRef) extends Actor with ActorLogging {
 
   import Relayer._
 
@@ -67,7 +67,6 @@ class Relayer(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorR
   context.system.eventStream.subscribe(self, classOf[LocalChannelDown])
   context.system.eventStream.subscribe(self, classOf[AvailableBalanceChanged])
 
-  private val commandBuffer = context.actorOf(Props(new CommandBuffer(nodeParams, register)))
   private val channelRelayer = context.actorOf(ChannelRelayer.props(nodeParams, self, register, commandBuffer))
 
   override def receive: Receive = main(Map.empty, new mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId])
@@ -211,7 +210,7 @@ class Relayer(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorR
 
 object Relayer extends Logging {
 
-  def props(nodeParams: NodeParams, register: ActorRef, paymentHandler: ActorRef) = Props(classOf[Relayer], nodeParams, register, paymentHandler)
+  def props(nodeParams: NodeParams, register: ActorRef, commandBuffer: ActorRef, paymentHandler: ActorRef) = Props(classOf[Relayer], nodeParams, register, commandBuffer, paymentHandler)
 
   type ChannelUpdates = Map[ShortChannelId, OutgoingChannel]
   type NodeChannels = mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -51,6 +51,7 @@ class EclairImplSpec extends TestKit(ActorSystem("test")) with fixture.FunSuiteL
     val watcher = TestProbe()
     val paymentHandler = TestProbe()
     val register = TestProbe()
+    val commandBuffer = TestProbe()
     val relayer = TestProbe()
     val router = TestProbe()
     val switchboard = TestProbe()
@@ -62,6 +63,7 @@ class EclairImplSpec extends TestKit(ActorSystem("test")) with fixture.FunSuiteL
       watcher.ref,
       paymentHandler.ref,
       register.ref,
+      commandBuffer.ref,
       relayer.ref,
       router.ref,
       switchboard.ref,
@@ -208,7 +210,7 @@ class EclairImplSpec extends TestKit(ActorSystem("test")) with fixture.FunSuiteL
     val capStat=Stats(30 sat, 12 sat, 14 sat, 20 sat, 40 sat, 46 sat, 48 sat)
     val cltvStat=Stats(CltvExpiryDelta(32), CltvExpiryDelta(11), CltvExpiryDelta(13), CltvExpiryDelta(22), CltvExpiryDelta(42), CltvExpiryDelta(51), CltvExpiryDelta(53))
     val feeBaseStat=Stats(32 msat, 11 msat, 13 msat, 22 msat, 42 msat, 51 msat, 53 msat)
-    val feePropStat=Stats(32l, 11l, 13l, 22l, 42l, 51l, 53l)
+    val feePropStat=Stats(32L, 11L, 13L, 22L, 42L, 51L, 53L)
     val eclair = new EclairImpl(kit)
     val fResp = eclair.networkStats()
     f.router.expectMsg(GetNetworkStats)
@@ -265,7 +267,7 @@ class EclairImplSpec extends TestKit(ActorSystem("test")) with fixture.FunSuiteL
   test("passing a payment_preimage to /createinvoice should result in an invoice with payment_hash=H(payment_preimage)") { f =>
     import f._
 
-    val kitWithPaymentHandler = kit.copy(paymentHandler = system.actorOf(PaymentHandler.props(Alice.nodeParams)))
+    val kitWithPaymentHandler = kit.copy(paymentHandler = system.actorOf(PaymentHandler.props(Alice.nodeParams, TestProbe().ref)))
     val eclair = new EclairImpl(kitWithPaymentHandler)
     val paymentPreimage = randomBytes32
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/ThroughputSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/ThroughputSpec.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
-import fr.acinq.eclair.payment.relay.Relayer
+import fr.acinq.eclair.payment.relay.{CommandBuffer, Relayer}
 import fr.acinq.eclair.wire.{Init, UpdateAddHtlc}
 import org.scalatest.FunSuite
 
@@ -65,8 +65,10 @@ class ThroughputSpec extends FunSuite {
     }), "payment-handler")
     val registerA = TestProbe()
     val registerB = TestProbe()
-    val relayerA = system.actorOf(Relayer.props(Alice.nodeParams, registerA.ref, paymentHandler))
-    val relayerB = system.actorOf(Relayer.props(Bob.nodeParams, registerB.ref, paymentHandler))
+    val commandBufferA = system.actorOf(Props(new CommandBuffer(Alice.nodeParams, registerA.ref)))
+    val commandBufferB = system.actorOf(Props(new CommandBuffer(Bob.nodeParams, registerB.ref)))
+    val relayerA = system.actorOf(Relayer.props(Alice.nodeParams, registerA.ref, commandBufferA, paymentHandler))
+    val relayerB = system.actorOf(Relayer.props(Bob.nodeParams, registerB.ref, commandBufferB, paymentHandler))
     val wallet = new TestWallet
     val alice = system.actorOf(Channel.props(Alice.nodeParams, wallet, Bob.nodeParams.nodeId, blockchain, ???, relayerA, None), "a")
     val bob = system.actorOf(Channel.props(Bob.nodeParams, wallet, Alice.nodeParams.nodeId, blockchain, ???, relayerB, None), "b")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -157,7 +157,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     instantiateEclairNode("G", ConfigFactory.parseMap(Map("eclair.node-alias" -> "G", "eclair.expiry-delta-blocks" -> 140, "eclair.server.port" -> 29740, "eclair.api.port" -> 28090, "eclair.fee-base-msat" -> 1010, "eclair.fee-proportional-millionths" -> 102)).withFallback(commonConfig))
 
     // by default C has a normal payment handler, but this can be overriden in tests
-    val paymentHandlerC = nodes("C").system.actorOf(PaymentHandler.props(nodes("C").nodeParams))
+    val paymentHandlerC = nodes("C").system.actorOf(PaymentHandler.props(nodes("C").nodeParams, nodes("C").commandBuffer))
     nodes("C").paymentHandler ! paymentHandlerC
   }
 
@@ -852,8 +852,8 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     val forwardHandlerF = TestProbe()
     nodes("F5").paymentHandler ! new ForwardHandler(forwardHandlerF.ref)
     // this is the actual payment handler that we will forward requests to
-    val paymentHandlerC = nodes("C").system.actorOf(PaymentHandler.props(nodes("C").nodeParams))
-    val paymentHandlerF = nodes("F5").system.actorOf(PaymentHandler.props(nodes("F5").nodeParams))
+    val paymentHandlerC = nodes("C").system.actorOf(PaymentHandler.props(nodes("C").nodeParams, nodes("C").commandBuffer))
+    val paymentHandlerF = nodes("F5").system.actorOf(PaymentHandler.props(nodes("F5").nodeParams, nodes("F5").commandBuffer))
     // first we make sure we are in sync with current blockchain height
     val currentBlockCount = getBlockCount
     awaitCond(getBlockCount == currentBlockCount, max = 20 seconds, interval = 1 second)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
@@ -49,7 +49,7 @@ class RustyTestsSpec extends TestKit(ActorSystem("test")) with Matchers with fix
     val pipe: ActorRef = system.actorOf(Props(new SynchronizationPipe(latch)))
     val alice2blockchain = TestProbe()
     val bob2blockchain = TestProbe()
-    val paymentHandler = system.actorOf(Props(new PaymentHandler(Bob.nodeParams)))
+    val paymentHandler = system.actorOf(Props(new PaymentHandler(Bob.nodeParams, TestProbe().ref)))
     paymentHandler ! new ForwardHandler(TestProbe().ref)
     // we just bypass the relayer for this test
     val relayer = paymentHandler

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration._
 class PaymentHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
 
   test("compose payment handlers") {
-    val handler = system.actorOf(PaymentHandler.props(Alice.nodeParams))
+    val handler = system.actorOf(PaymentHandler.props(Alice.nodeParams, TestProbe().ref))
 
     val intHandler = new ReceiveHandler {
       override def handle(implicit ctx: ActorContext, log: LoggingAdapter): Receive = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -18,17 +18,17 @@ package fr.acinq.eclair.payment
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, Status}
+import akka.actor.{ActorRef, Props, Status}
 import akka.testkit.TestProbe
 import fr.acinq.bitcoin.{ByteVector32, Crypto}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.db.{OutgoingPayment, OutgoingPaymentStatus}
 import fr.acinq.eclair.payment.IncomingPacket.FinalPacket
-import fr.acinq.eclair.payment.relay.Origin._
 import fr.acinq.eclair.payment.OutgoingPacket.{buildCommand, buildOnion, buildPacket}
-import fr.acinq.eclair.payment.relay.{Origin, Relayer}
+import fr.acinq.eclair.payment.relay.Origin._
 import fr.acinq.eclair.payment.relay.Relayer._
+import fr.acinq.eclair.payment.relay.{CommandBuffer, Origin, Relayer}
 import fr.acinq.eclair.router.{Announcements, ChannelHop, NodeHop}
 import fr.acinq.eclair.wire.Onion.{ChannelRelayTlvPayload, FinalLegacyPayload, FinalTlvPayload, PerHopPayload}
 import fr.acinq.eclair.wire._
@@ -52,9 +52,10 @@ class RelayerSpec extends TestkitBaseClass {
     within(30 seconds) {
       val nodeParams = TestConstants.Bob.nodeParams
       val register = TestProbe()
+      val commandBuffer = system.actorOf(Props(new CommandBuffer(nodeParams, register.ref)))
       val paymentHandler = TestProbe()
       // we are node B in the route A -> B -> C -> ....
-      val relayer = system.actorOf(Relayer.props(nodeParams, register.ref, paymentHandler.ref))
+      val relayer = system.actorOf(Relayer.props(nodeParams, register.ref, commandBuffer, paymentHandler.ref))
       withFixture(test.toNoArgTest(FixtureParam(nodeParams, relayer, register, paymentHandler, TestProbe())))
     }
   }
@@ -319,7 +320,8 @@ class RelayerSpec extends TestkitBaseClass {
     import f._
 
     val nodeParams = TestConstants.Bob.nodeParams.copy(enableTrampolinePayment = false)
-    val relayer = system.actorOf(Relayer.props(nodeParams, register.ref, paymentHandler.ref))
+    val commandBuffer = system.actorOf(Props(new CommandBuffer(nodeParams, register.ref)))
+    val relayer = system.actorOf(Relayer.props(nodeParams, register.ref, commandBuffer, paymentHandler.ref))
 
     // we use this to build a valid trampoline onion inside a normal onion
     val trampolineHops = NodeHop(a, b, channelUpdate_ab.cltvExpiryDelta, 0 msat) :: NodeHop(b, c, channelUpdate_bc.cltvExpiryDelta, fee_b) :: Nil
@@ -588,6 +590,55 @@ class RelayerSpec extends TestkitBaseClass {
     sender.send(relayer, GetOutgoingChannels())
     val OutgoingChannels(channels6) = sender.expectMsgType[OutgoingChannels]
     assert(channels6.size === 1)
+  }
+
+  test("replay pending commands after restart") { f =>
+    import f._
+
+    val channel = TestProbe()
+    val channelData = ChannelCodecsSpec.normal
+    val channelId = channelData.commitments.channelId
+    val remoteNodeId = channelData.commitments.remoteParams.nodeId
+    val (preimage1, preimage2) = (randomBytes32, randomBytes32)
+    val onionHash = randomBytes32
+
+    nodeParams.db.pendingRelay.addPendingRelay(channelId, 1, CMD_FULFILL_HTLC(1, preimage1, commit = true))
+    nodeParams.db.pendingRelay.addPendingRelay(channelId, 100, CMD_FULFILL_HTLC(100, preimage2, commit = true))
+    nodeParams.db.pendingRelay.addPendingRelay(channelId, 101, CMD_FAIL_HTLC(101, Right(TemporaryNodeFailure), commit = true))
+    nodeParams.db.pendingRelay.addPendingRelay(channelId, 102, CMD_FAIL_MALFORMED_HTLC(102, onionHash, 0x4001, commit = true))
+
+    // Channel comes online: we should replay pending commands.
+    system.eventStream.publish(ChannelStateChanged(channel.ref, system.deadLetters, remoteNodeId, OFFLINE, NORMAL, channelData))
+    val expected = Set(
+      CMD_FULFILL_HTLC(1, preimage1),
+      CMD_FULFILL_HTLC(100, preimage2),
+      CMD_FAIL_HTLC(101, Right(TemporaryNodeFailure)),
+      CMD_FAIL_MALFORMED_HTLC(102, onionHash, 0x4001)
+    )
+    val received = expected.map(_ => channel.expectMsgType[Command])
+    assert(received === expected)
+
+    channel.expectMsg(CMD_SIGN) // we should then ask to sign all the updates.
+    channel.expectNoMsg(100 millis)
+
+    // 3 of the 4 HTLCs were ack-ed (maybe the peer disconnected/reconnected again).
+    channel.send(relayer, CommandBuffer.CommandAck(channelId, 1))
+    channel.send(relayer, CommandBuffer.CommandAck(channelId, 100))
+    channel.send(relayer, CommandBuffer.CommandAck(channelId, 101))
+    // Once ack-ed, these commands should be removed from the DB.
+    awaitCond(nodeParams.db.pendingRelay.listPendingRelay(channelId).length === 1)
+
+    // The last failure wasn't ack-ed, so it's re-sent.
+    system.eventStream.publish(ChannelStateChanged(channel.ref, system.deadLetters, remoteNodeId, SYNCING, NORMAL, channelData))
+    channel.expectMsg(CMD_FAIL_MALFORMED_HTLC(102, onionHash, 0x4001))
+    channel.expectMsg(CMD_SIGN)
+    channel.expectNoMsg(100 millis)
+
+    channel.send(relayer, CommandBuffer.CommandAck(channelId, 102))
+    awaitCond(nodeParams.db.pendingRelay.listPendingRelay(channelId).isEmpty)
+
+    system.eventStream.publish(ChannelStateChanged(channel.ref, system.deadLetters, remoteNodeId, OFFLINE, NORMAL, channelData))
+    channel.expectNoMsg(100 millis)
   }
 
 }


### PR DESCRIPTION
We previously had some logic where we would fail incoming HTLCs
for which we were the final recipient when a channel would come online.

That made sense when we didn't have MPP, but with MPP we cannot do that.
There is a risk that we would be failing HTLCs that are considered received by the MPP FSM.
Instead we need to use the CommandBuffer when we are the final recipient.
This way pending commands cannot be lost and HTLCs are cleaned-up on restart.