### PR TITLE
Added a 'category' in logs

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Logs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Logs.scala
@@ -34,13 +34,14 @@ import fr.acinq.eclair.wire.{ChannelReestablish, Ping, Pong, RoutingMessage, Upd
 
 object Logs {
 
-  def mdc(category_opt: Option[LogCategory], remoteNodeId_opt: Option[PublicKey] = None, channelId_opt: Option[ByteVector32] = None, parentPaymentId_opt: Option[UUID] = None, paymentId_opt: Option[UUID] = None): MDC =
+  def mdc(category_opt: Option[LogCategory] = None, remoteNodeId_opt: Option[PublicKey] = None, channelId_opt: Option[ByteVector32] = None, parentPaymentId_opt: Option[UUID] = None, paymentId_opt: Option[UUID] = None, paymentHash_opt: Option[ByteVector32] = None): MDC =
     Seq(
       category_opt.map(l => "category" -> s" ${l.category}"),
       remoteNodeId_opt.map(n => "nodeId" -> s" n:$n"), // nb: we preformat MDC values so that there is no white spaces in logs when they are not defined
       channelId_opt.map(c => "channelId" -> s" c:$c"),
       parentPaymentId_opt.map(p => "parentPaymentId" -> s" p:$p"),
-      paymentId_opt.map(i => "paymentId" -> s" i:$i")
+      paymentId_opt.map(i => "paymentId" -> s" i:$i"),
+      paymentHash_opt.map(h => "paymentHash" -> s" h:$h")
     ).flatten.toMap
 
   /**
@@ -49,7 +50,7 @@ object Logs {
     * This is useful in some cases where we can't rely on the `aroundReceive` trick to set the MDC before processing a
     * message because we don't have enough context. That's typically the case when handling `Terminated` messages.
     */
-  def withMdc(mdc: MDC)(f: => Any)(implicit log: DiagnosticLoggingAdapter) = {
+  def withMdc(log: DiagnosticLoggingAdapter)(mdc: MDC)(f: => Any) = {
     val mdc0 = log.mdc // backup the current mdc
     try {
       log.mdc(mdc0 ++ mdc) // add the new mdc to the current one

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Logs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Logs.scala
@@ -18,30 +18,108 @@ package fr.acinq.eclair
 
 import java.util.UUID
 
+import akka.actor.Terminated
 import akka.event.DiagnosticLoggingAdapter
 import akka.event.Logging.MDC
+import akka.io.Tcp
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.eclair.blockchain.ValidateResult
+import fr.acinq.eclair.channel.{LocalChannelDown, LocalChannelUpdate}
+import fr.acinq.eclair.crypto.TransportHandler.HandshakeCompleted
+import fr.acinq.eclair.io.Peer.PeerRoutingMessage
+import fr.acinq.eclair.io.{Authenticator, Peer}
+import fr.acinq.eclair.router.{ExcludeChannel, GetRoutingState, LiftChannelExclusion, Rebroadcast, RouteRequest, SyncProgress, TickBroadcast, TickPruneStaleChannels}
+import fr.acinq.eclair.wire.{ChannelReestablish, Ping, Pong, RoutingMessage, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFulfillHtlc}
 
 object Logs {
 
-  def mdc(remoteNodeId_opt: Option[PublicKey] = None, channelId_opt: Option[ByteVector32] = None, parentPaymentId_opt: Option[UUID] = None, paymentId_opt: Option[UUID] = None): MDC =
+  def mdc(category_opt: Option[LogCategory], remoteNodeId_opt: Option[PublicKey] = None, channelId_opt: Option[ByteVector32] = None, parentPaymentId_opt: Option[UUID] = None, paymentId_opt: Option[UUID] = None): MDC =
     Seq(
+      category_opt.map(l => "category" -> s" ${l.category}"),
       remoteNodeId_opt.map(n => "nodeId" -> s" n:$n"), // nb: we preformat MDC values so that there is no white spaces in logs when they are not defined
       channelId_opt.map(c => "channelId" -> s" c:$c"),
       parentPaymentId_opt.map(p => "parentPaymentId" -> s" p:$p"),
       paymentId_opt.map(i => "paymentId" -> s" i:$i")
     ).flatten.toMap
 
+  /**
+    * Temporarily add the provided MDC to the current one, and then restore the original one.
+    *
+    * This is useful in some cases where we can't rely on the `aroundReceive` trick to set the MDC before processing a
+    * message because we don't have enough context. That's typically the case when handling `Terminated` messages.
+    */
   def withMdc(mdc: MDC)(f: => Any)(implicit log: DiagnosticLoggingAdapter) = {
+    val mdc0 = log.mdc // backup the current mdc
     try {
-      log.mdc(mdc)
+      log.mdc(mdc0 ++ mdc) // add the new mdc to the current one
       f
     } finally {
-      log.clearMDC()
+      log.mdc(mdc0) // restore the original mdc
     }
   }
 
+  // @formatter: off
+  sealed trait LogCategory {
+    def category: String
+  }
+
+  object LogCategory {
+
+    case object CONNECTION extends LogCategory {
+      override def category: String = "CON"
+    }
+
+    case object ROUTING_SYNC extends LogCategory {
+      override def category: String = "SYN"
+    }
+
+    case object PAYMENT extends LogCategory {
+      override def category: String = "PAY"
+    }
+
+    def apply(currentMessage: Any): Option[LogCategory] = {
+      currentMessage match {
+        case _: Tcp.Event => Some(Logs.LogCategory.CONNECTION)
+        case _: Tcp.Message => Some(Logs.LogCategory.CONNECTION)
+        case _: ChannelReestablish => Some(LogCategory.CONNECTION)
+
+        case _: UpdateAddHtlc => Some(Logs.LogCategory.PAYMENT)
+        case _: UpdateFulfillHtlc => Some(Logs.LogCategory.PAYMENT)
+        case _: UpdateFailHtlc => Some(Logs.LogCategory.PAYMENT)
+        case _: UpdateFailMalformedHtlc => Some(Logs.LogCategory.PAYMENT)
+
+        case _: ExcludeChannel => Some(LogCategory.PAYMENT)
+        case _: LiftChannelExclusion => Some(LogCategory.PAYMENT)
+        case _: SyncProgress => Some(LogCategory.ROUTING_SYNC)
+        case GetRoutingState => Some(LogCategory.ROUTING_SYNC)
+        case _: LocalChannelUpdate => Some(LogCategory.ROUTING_SYNC)
+        case _: LocalChannelDown => Some(LogCategory.ROUTING_SYNC)
+        case _: ValidateResult => Some(LogCategory.ROUTING_SYNC)
+        case _: RouteRequest => Some(LogCategory.PAYMENT)
+        case _: PeerRoutingMessage => Some(LogCategory.ROUTING_SYNC)
+        case _: RoutingMessage => Some(LogCategory.ROUTING_SYNC)
+        case TickBroadcast => Some(LogCategory.ROUTING_SYNC)
+        case TickPruneStaleChannels => Some(LogCategory.ROUTING_SYNC)
+
+        case _: Authenticator.Authenticated => Some(LogCategory.CONNECTION)
+        case _: Authenticator.PendingAuth => Some(LogCategory.CONNECTION)
+        case _: HandshakeCompleted => Some(LogCategory.CONNECTION)
+        case _: Peer.Connect => Some(LogCategory.CONNECTION)
+        case _: Peer.Disconnect => Some(LogCategory.CONNECTION)
+        case _: Peer.DelayedRebroadcast => Some(LogCategory.ROUTING_SYNC)
+        case Peer.Reconnect => Some(LogCategory.CONNECTION)
+        case _: Ping => Some(LogCategory.CONNECTION)
+        case _: Pong => Some(LogCategory.CONNECTION)
+        case _: wire.Init => Some(LogCategory.CONNECTION)
+        case _: Rebroadcast => Some(LogCategory.ROUTING_SYNC)
+
+        case _ => None
+      }
+    }
+  }
+
+  // @formatter: on
 }
 
 // we use a dedicated class so that the logging can be independently adjusted

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -21,6 +21,7 @@ import akka.event.Logging.MDC
 import akka.pattern.pipe
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey, sha256}
 import fr.acinq.bitcoin.{ByteVector32, OutPoint, Satoshi, Script, ScriptFlags, Transaction}
+import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel.Helpers.{Closing, Funding}
@@ -99,7 +100,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
   import nodeParams.keyManager
 
   // we pass these to helpers classes so that they have the logging context
-  implicit def implicitLog: akka.event.LoggingAdapter = log
+  implicit def implicitLog: akka.event.DiagnosticLoggingAdapter = diagLog
 
   val forwarder = context.actorOf(Props(new Forwarder(nodeParams)), "forwarder")
 
@@ -1682,7 +1683,9 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
       (state, nextState, stateData, nextStateData) match {
         // ORDER MATTERS!
         case (WAIT_FOR_INIT_INTERNAL, OFFLINE, _, normal: DATA_NORMAL) =>
-          log.info(s"re-emitting channel_update={} enabled={} ", normal.channelUpdate, Announcements.isEnabled(normal.channelUpdate.channelFlags))
+          Logs.withMdc(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
+            log.info(s"re-emitting channel_update={} enabled={} ", normal.channelUpdate, Announcements.isEnabled(normal.channelUpdate.channelFlags))
+          }
           context.system.eventStream.publish(LocalChannelUpdate(self, normal.commitments.channelId, normal.shortChannelId, normal.commitments.remoteParams.nodeId, normal.channelAnnouncement, normal.channelUpdate, normal.commitments))
         case (_, _, d1: DATA_NORMAL, d2: DATA_NORMAL) if d1.channelUpdate == d2.channelUpdate && d1.channelAnnouncement == d2.channelAnnouncement =>
           // don't do anything if neither the channel_update nor the channel_announcement didn't change
@@ -2272,11 +2275,12 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
   def now = Platform.currentTime.milliseconds.toSeconds
 
   override def mdc(currentMessage: Any): MDC = {
+    val category_opt = LogCategory(currentMessage)
     val id = currentMessage match {
       case INPUT_RESTORED(data) => data.channelId
       case _ => Helpers.getChannelId(stateData)
     }
-    Logs.mdc(remoteNodeId_opt = Some(remoteNodeId), channelId_opt = Some(id))
+    Logs.mdc(category_opt, remoteNodeId_opt = Some(remoteNodeId), channelId_opt = Some(id))
   }
 
   // we let the peer decide what to do

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1683,7 +1683,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
       (state, nextState, stateData, nextStateData) match {
         // ORDER MATTERS!
         case (WAIT_FOR_INIT_INTERNAL, OFFLINE, _, normal: DATA_NORMAL) =>
-          Logs.withMdc(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
+          Logs.withMdc(diagLog)(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
             log.info(s"re-emitting channel_update={} enabled={} ", normal.channelUpdate, Announcements.isEnabled(normal.channelUpdate.channelFlags))
           }
           context.system.eventStream.publish(LocalChannelUpdate(self, normal.commitments.channelId, normal.shortChannelId, normal.commitments.remoteParams.nodeId, normal.channelAnnouncement, normal.channelUpdate, normal.commitments))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -16,7 +16,7 @@
 
 package fr.acinq.eclair.channel
 
-import akka.event.LoggingAdapter
+import akka.event.{DiagnosticLoggingAdapter, LoggingAdapter}
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey, ripemd160, sha256}
 import fr.acinq.bitcoin.Script._
 import fr.acinq.bitcoin._
@@ -163,10 +163,12 @@ object Helpers {
    * @param currentUpdateTimestamp
    * @return the delay until the next update
    */
-  def nextChannelUpdateRefresh(currentUpdateTimestamp: Long)(implicit log: LoggingAdapter): FiniteDuration = {
+  def nextChannelUpdateRefresh(currentUpdateTimestamp: Long)(implicit log: DiagnosticLoggingAdapter): FiniteDuration = {
     val age = Platform.currentTime.milliseconds - currentUpdateTimestamp.seconds
     val delay = 0.days.max(REFRESH_CHANNEL_UPDATE_INTERVAL - age)
-    log.info("current channel_update was created {} days ago, will refresh it in {} days", age.toDays, delay.toDays)
+    Logs.withMdc(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
+      log.info("current channel_update was created {} days ago, will refresh it in {} days", age.toDays, delay.toDays)
+    }
     delay
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -166,7 +166,7 @@ object Helpers {
   def nextChannelUpdateRefresh(currentUpdateTimestamp: Long)(implicit log: DiagnosticLoggingAdapter): FiniteDuration = {
     val age = Platform.currentTime.milliseconds - currentUpdateTimestamp.seconds
     val delay = 0.days.max(REFRESH_CHANNEL_UPDATE_INTERVAL - age)
-    Logs.withMdc(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
+    Logs.withMdc(log)(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
       log.info("current channel_update was created {} days ago, will refresh it in {} days", age.toDays, delay.toDays)
     }
     delay

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/TransportHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/TransportHandler.scala
@@ -25,6 +25,7 @@ import akka.io.Tcp
 import akka.util.ByteString
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.Protocol
+import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair.crypto.Noise._
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement, _}
 import fr.acinq.eclair.{Diagnostics, FSMDiagnosticActorLogging, Logs}
@@ -64,7 +65,9 @@ class TransportHandler[T: ClassTag](keyPair: KeyPair, rs: Option[ByteVector], co
       case _ => None
     }
 
-    wireLog.mdc(Logs.mdc(remoteNodeId_opt, channelId_opt))
+    val category_opt = LogCategory(message)
+
+    wireLog.mdc(Logs.mdc(category_opt, remoteNodeId_opt, channelId_opt))
     if (channelId_opt.isDefined) {
       // channel-related messages are logged as info
       wireLog.info(s"$direction msg={}", message)
@@ -266,7 +269,10 @@ class TransportHandler[T: ClassTag](keyPair: KeyPair, rs: Option[ByteVector], co
 
   initialize()
 
-  override def mdc(currentMessage: Any): MDC = Logs.mdc(remoteNodeId_opt = remoteNodeId_opt)
+  override def mdc(currentMessage: Any): MDC = {
+    val category_opt = LogCategory(currentMessage)
+    Logs.mdc(category_opt, remoteNodeId_opt = remoteNodeId_opt)
+  }
 
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Authenticator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Authenticator.scala
@@ -21,6 +21,7 @@ import java.net.InetSocketAddress
 import akka.actor.{Actor, ActorRef, DiagnosticActorLogging, OneForOneStrategy, Props, Status, SupervisorStrategy, Terminated}
 import akka.event.Logging.MDC
 import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair.crypto.Noise.KeyPair
 import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.crypto.TransportHandler.HandshakeCompleted
@@ -82,7 +83,7 @@ class Authenticator(nodeParams: NodeParams) extends Actor with DiagnosticActorLo
       case HandshakeCompleted(_, _, remoteNodeId) => Some(remoteNodeId)
       case _ => None
     }
-    Logs.mdc(remoteNodeId_opt = remoteNodeId_opt)
+    Logs.mdc(Some(LogCategory.CONNECTION), remoteNodeId_opt = remoteNodeId_opt)
   }
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Client.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Client.scala
@@ -102,12 +102,12 @@ class Client(nodeParams: NodeParams, authenticator: ActorRef, remoteAddress: Ine
   // we should not restart a failing socks client
   override val supervisorStrategy = OneForOneStrategy(loggingEnabled = false) {
     case t =>
-      Logs.withMdc(Logs.mdc(category_opt = Some(LogCategory.CONNECTION), remoteNodeId_opt = Some(remoteNodeId))) {
+      Logs.withMdc(log)(Logs.mdc(remoteNodeId_opt = Some(remoteNodeId))) {
         t match {
           case Socks5Error(msg) => log.info(s"SOCKS5 error: $msg")
           case _ => log.error(t, "")
         }
-      }(log)
+      }
       SupervisorStrategy.Stop
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Client.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Client.scala
@@ -23,6 +23,7 @@ import akka.event.Logging.MDC
 import akka.io.Tcp.SO.KeepAlive
 import akka.io.{IO, Tcp}
 import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair.io.Client.ConnectionFailed
 import fr.acinq.eclair.tor.Socks5Connection.{Socks5Connect, Socks5Connected, Socks5Error}
 import fr.acinq.eclair.tor.{Socks5Connection, Socks5ProxyParams}
@@ -101,7 +102,7 @@ class Client(nodeParams: NodeParams, authenticator: ActorRef, remoteAddress: Ine
   // we should not restart a failing socks client
   override val supervisorStrategy = OneForOneStrategy(loggingEnabled = false) {
     case t =>
-      Logs.withMdc(Logs.mdc(remoteNodeId_opt = Some(remoteNodeId))) {
+      Logs.withMdc(Logs.mdc(category_opt = Some(LogCategory.CONNECTION), remoteNodeId_opt = Some(remoteNodeId))) {
         t match {
           case Socks5Error(msg) => log.info(s"SOCKS5 error: $msg")
           case _ => log.error(t, "")
@@ -110,7 +111,7 @@ class Client(nodeParams: NodeParams, authenticator: ActorRef, remoteAddress: Ine
       SupervisorStrategy.Stop
   }
 
-  override def mdc(currentMessage: Any): MDC = Logs.mdc(remoteNodeId_opt = Some(remoteNodeId))
+  override def mdc(currentMessage: Any): MDC = Logs.mdc(Some(LogCategory.CONNECTION), remoteNodeId_opt = Some(remoteNodeId))
 
   private def str(address: InetSocketAddress): String = s"${address.getHostString}:${address.getPort}"
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -188,9 +188,9 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
       stay
 
     case Event(Terminated(actor), d: InitializingData) if actor == d.transport =>
-      Logs.withMdc(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
+      Logs.withMdc(diagLog)(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
         log.warning(s"lost connection to $remoteNodeId")
-      }(diagLog)
+      }
       goto(DISCONNECTED) using DisconnectedData(d.address_opt, d.channels)
 
     case Event(Terminated(actor), d: InitializingData) if d.channels.exists(_._2 == actor) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Server.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Server.scala
@@ -19,10 +19,12 @@ package fr.acinq.eclair.io
 import java.net.InetSocketAddress
 
 import akka.Done
-import akka.actor.{Actor, ActorLogging, ActorRef, Props}
+import akka.actor.{Actor, ActorLogging, ActorRef, DiagnosticActorLogging, Props}
+import akka.event.Logging.MDC
 import akka.io.Tcp.SO.KeepAlive
 import akka.io.{IO, Tcp}
-import fr.acinq.eclair.NodeParams
+import fr.acinq.eclair.Logs.LogCategory
+import fr.acinq.eclair.{Logs, NodeParams}
 import kamon.Kamon
 
 import scala.concurrent.Promise
@@ -30,7 +32,7 @@ import scala.concurrent.Promise
 /**
   * Created by PM on 27/10/2015.
   */
-class Server(nodeParams: NodeParams, authenticator: ActorRef, address: InetSocketAddress, bound: Option[Promise[Done]] = None) extends Actor with ActorLogging {
+class Server(nodeParams: NodeParams, authenticator: ActorRef, address: InetSocketAddress, bound: Option[Promise[Done]] = None) extends Actor with DiagnosticActorLogging {
 
   import Tcp._
   import context.system
@@ -59,7 +61,7 @@ class Server(nodeParams: NodeParams, authenticator: ActorRef, address: InetSocke
       listener ! ResumeAccepting(batchSize = 1)
   }
 
-  override def unhandled(message: Any): Unit = log.warning(s"unhandled message=$message")
+  override def mdc(currentMessage: Any): MDC = Logs.mdc(Some(LogCategory.CONNECTION))
 }
 
 object Server {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/ForwardHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/ForwardHandler.scala
@@ -18,11 +18,11 @@ package fr.acinq.eclair.payment.receive
 
 import akka.actor.Actor.Receive
 import akka.actor.{ActorContext, ActorRef}
-import akka.event.LoggingAdapter
+import akka.event.DiagnosticLoggingAdapter
 
 /**
  * Simple handler that forwards all messages to an actor
  */
 class ForwardHandler(actor: ActorRef) extends ReceiveHandler {
-  override def handle(implicit ctx: ActorContext, log: LoggingAdapter): Receive = { case msg => actor forward msg}
+  override def handle(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Receive = { case msg => actor forward msg}
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.payment.receive
 
 import akka.actor.Actor.Receive
 import akka.actor.{ActorContext, ActorRef, PoisonPill, Status}
-import akka.event.LoggingAdapter
+import akka.event.{DiagnosticLoggingAdapter, LoggingAdapter}
 import fr.acinq.bitcoin.{ByteVector32, Crypto}
 import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FULFILL_HTLC, Channel}
 import fr.acinq.eclair.db.{IncomingPayment, IncomingPaymentStatus, IncomingPaymentsDb}
@@ -26,7 +26,7 @@ import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.payment.relay.CommandBuffer
 import fr.acinq.eclair.payment.{IncomingPacket, PaymentReceived, PaymentRequest}
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.{CltvExpiry, Features, MilliSatoshi, NodeParams, randomBytes32}
+import fr.acinq.eclair.{CltvExpiry, Features, Logs, MilliSatoshi, NodeParams, randomBytes32}
 
 import scala.util.{Failure, Success, Try}
 
@@ -53,7 +53,7 @@ class MultiPartHandler(nodeParams: NodeParams, db: IncomingPaymentsDb, commandBu
    */
   def onSuccess(paymentReceived: PaymentReceived)(implicit log: LoggingAdapter): Unit = ()
 
-  override def handle(implicit ctx: ActorContext, log: LoggingAdapter): Receive = {
+  override def handle(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Receive = {
     case ReceivePayment(amount_opt, desc, expirySeconds_opt, extraHops, fallbackAddress_opt, paymentPreimage_opt, allowMultiPart) =>
       Try {
         val paymentPreimage = paymentPreimage_opt.getOrElse(randomBytes32)
@@ -76,56 +76,66 @@ class MultiPartHandler(nodeParams: NodeParams, db: IncomingPaymentsDb, commandBu
         case Failure(exception) => ctx.sender ! Status.Failure(exception)
       }
 
-    case p: IncomingPacket.FinalPacket if doHandle(p.add.paymentHash) => db.getIncomingPayment(p.add.paymentHash) match {
-      case Some(record) => validatePayment(p, record, nodeParams.currentBlockHeight) match {
-        case Some(cmdFail) =>
-          commandBuffer ! CommandBuffer.CommandSend(p.add.channelId, p.add.id, cmdFail)
-        case None =>
-          log.info(s"received payment for paymentHash=${p.add.paymentHash} amount=${p.add.amountMsat} totalAmount=${p.payload.totalAmount}")
-          pendingPayments.get(p.add.paymentHash) match {
-            case Some((_, handler)) =>
-              handler ! MultiPartPaymentFSM.MultiPartHtlc(p.payload.totalAmount, p.add)
+    case p: IncomingPacket.FinalPacket if doHandle(p.add.paymentHash) =>
+      Logs.withMdc(log)(Logs.mdc(paymentHash_opt = Some(p.add.paymentHash))) {
+        db.getIncomingPayment(p.add.paymentHash) match {
+          case Some(record) => validatePayment(p, record, nodeParams.currentBlockHeight) match {
+            case Some(cmdFail) =>
+              commandBuffer ! CommandBuffer.CommandSend(p.add.channelId, p.add.id, cmdFail)
             case None =>
-              val handler = ctx.actorOf(MultiPartPaymentFSM.props(nodeParams, p.add.paymentHash, p.payload.totalAmount, ctx.self))
-              handler ! MultiPartPaymentFSM.MultiPartHtlc(p.payload.totalAmount, p.add)
-              pendingPayments = pendingPayments + (p.add.paymentHash -> (record.paymentPreimage, handler))
+              log.info(s"received payment for amount=${p.add.amountMsat} totalAmount=${p.payload.totalAmount}")
+              pendingPayments.get(p.add.paymentHash) match {
+                case Some((_, handler)) =>
+                  handler ! MultiPartPaymentFSM.MultiPartHtlc(p.payload.totalAmount, p.add)
+                case None =>
+                  val handler = ctx.actorOf(MultiPartPaymentFSM.props(nodeParams, p.add.paymentHash, p.payload.totalAmount, ctx.self))
+                  handler ! MultiPartPaymentFSM.MultiPartHtlc(p.payload.totalAmount, p.add)
+                  pendingPayments = pendingPayments + (p.add.paymentHash -> (record.paymentPreimage, handler))
+              }
           }
+          case None =>
+            val cmdFail = CMD_FAIL_HTLC(p.add.id, Right(IncorrectOrUnknownPaymentDetails(p.payload.totalAmount, nodeParams.currentBlockHeight)), commit = true)
+            commandBuffer ! CommandBuffer.CommandSend(p.add.channelId, p.add.id, cmdFail)
+        }
       }
-      case None =>
-        val cmdFail = CMD_FAIL_HTLC(p.add.id, Right(IncorrectOrUnknownPaymentDetails(p.payload.totalAmount, nodeParams.currentBlockHeight)), commit = true)
-        commandBuffer ! CommandBuffer.CommandSend(p.add.channelId, p.add.id, cmdFail)
-    }
 
     case MultiPartPaymentFSM.MultiPartHtlcFailed(paymentHash, failure, parts) if doHandle(paymentHash) =>
-      log.warning(s"payment with paymentHash=$paymentHash paidAmount=${parts.map(_.payment.amount).sum} failed ($failure)")
-      pendingPayments.get(paymentHash).foreach { case (_, handler: ActorRef) => handler ! PoisonPill }
-      parts.foreach(p => commandBuffer ! CommandBuffer.CommandSend(p.payment.fromChannelId, p.htlcId, CMD_FAIL_HTLC(p.htlcId, Right(failure), commit = true)))
-      pendingPayments = pendingPayments - paymentHash
+      Logs.withMdc(log)(Logs.mdc(paymentHash_opt = Some(paymentHash))) {
+        log.warning(s"payment with paidAmount=${parts.map(_.payment.amount).sum} failed ($failure)")
+        pendingPayments.get(paymentHash).foreach { case (_, handler: ActorRef) => handler ! PoisonPill }
+        parts.foreach(p => commandBuffer ! CommandBuffer.CommandSend(p.payment.fromChannelId, p.htlcId, CMD_FAIL_HTLC(p.htlcId, Right(failure), commit = true)))
+        pendingPayments = pendingPayments - paymentHash
+      }
 
     case MultiPartPaymentFSM.MultiPartHtlcSucceeded(paymentHash, parts) if doHandle(paymentHash) =>
-      val received = PaymentReceived(paymentHash, parts.map(_.payment))
-      log.info(s"received complete payment for paymentHash=$paymentHash amount=${received.amount}")
-      // The first thing we do is store the payment. This allows us to reconcile pending HTLCs after a restart.
-      db.receiveIncomingPayment(paymentHash, received.amount, received.timestamp)
-      pendingPayments.get(paymentHash).foreach {
-        case (preimage: ByteVector32, handler: ActorRef) =>
-          handler ! PoisonPill
-          parts.foreach(p => commandBuffer ! CommandBuffer.CommandSend(p.payment.fromChannelId, p.htlcId, CMD_FULFILL_HTLC(p.htlcId, preimage, commit = true)))
+      Logs.withMdc(log)(Logs.mdc(paymentHash_opt = Some(paymentHash))) {
+        val received = PaymentReceived(paymentHash, parts.map(_.payment))
+        log.info(s"received complete payment for amount=${received.amount}")
+        // The first thing we do is store the payment. This allows us to reconcile pending HTLCs after a restart.
+        db.receiveIncomingPayment(paymentHash, received.amount, received.timestamp)
+        pendingPayments.get(paymentHash).foreach {
+          case (preimage: ByteVector32, handler: ActorRef) =>
+            handler ! PoisonPill
+            parts.foreach(p => commandBuffer ! CommandBuffer.CommandSend(p.payment.fromChannelId, p.htlcId, CMD_FULFILL_HTLC(p.htlcId, preimage, commit = true)))
+        }
+        ctx.system.eventStream.publish(received)
+        pendingPayments = pendingPayments - paymentHash
+        onSuccess(received)
       }
-      ctx.system.eventStream.publish(received)
-      pendingPayments = pendingPayments - paymentHash
-      onSuccess(received)
 
-    case MultiPartPaymentFSM.ExtraHtlcReceived(paymentHash, p, failure) if doHandle(paymentHash) => failure match {
-      case Some(failure) => commandBuffer ! CommandBuffer.CommandSend(p.payment.fromChannelId, p.htlcId, CMD_FAIL_HTLC(p.htlcId, Right(failure), commit = true))
-      // NB: this case shouldn't happen unless the sender violated the spec, so it's ok that we take a slightly more
-      // expensive code path by fetching the preimage from DB.
-      case None => db.getIncomingPayment(paymentHash).foreach(record => {
-        commandBuffer ! CommandBuffer.CommandSend(p.payment.fromChannelId, p.htlcId, CMD_FULFILL_HTLC(p.htlcId, record.paymentPreimage, commit = true))
-        db.receiveIncomingPayment(paymentHash, p.payment.amount, p.payment.timestamp)
-        ctx.system.eventStream.publish(PaymentReceived(paymentHash, p.payment :: Nil))
-      })
-    }
+    case MultiPartPaymentFSM.ExtraHtlcReceived(paymentHash, p, failure) if doHandle(paymentHash) =>
+      Logs.withMdc(log)(Logs.mdc(paymentHash_opt = Some(paymentHash))) {
+        failure match {
+          case Some(failure) => commandBuffer ! CommandBuffer.CommandSend(p.payment.fromChannelId, p.htlcId, CMD_FAIL_HTLC(p.htlcId, Right(failure), commit = true))
+          // NB: this case shouldn't happen unless the sender violated the spec, so it's ok that we take a slightly more
+          // expensive code path by fetching the preimage from DB.
+          case None => db.getIncomingPayment(paymentHash).foreach(record => {
+            commandBuffer ! CommandBuffer.CommandSend(p.payment.fromChannelId, p.htlcId, CMD_FULFILL_HTLC(p.htlcId, record.paymentPreimage, commit = true))
+            db.receiveIncomingPayment(paymentHash, p.payment.amount, p.payment.timestamp)
+            ctx.system.eventStream.publish(PaymentReceived(paymentHash, p.payment :: Nil))
+          })
+        }
+      }
 
     case GetPendingPayments => ctx.sender ! PendingPayments(pendingPayments.keySet)
 
@@ -164,10 +174,10 @@ object MultiPartHandler {
 
   private def validatePaymentStatus(payment: IncomingPacket.FinalPacket, record: IncomingPayment)(implicit log: LoggingAdapter): Boolean = {
     if (record.status.isInstanceOf[IncomingPaymentStatus.Received]) {
-      log.warning(s"ignoring incoming payment for paymentHash=${payment.add.paymentHash} which has already been paid")
+      log.warning(s"ignoring incoming payment for which has already been paid")
       false
     } else if (record.paymentRequest.isExpired) {
-      log.warning(s"received payment for expired paymentHash=${payment.add.paymentHash} amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
+      log.warning(s"received payment for expired amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
       false
     } else {
       true
@@ -179,10 +189,10 @@ object MultiPartHandler {
     // it must not be greater than two times the requested amount.
     // see https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#failure-messages
     if (payment.payload.totalAmount < expectedAmount) {
-      log.warning(s"received payment with amount too small for paymentHash=${payment.add.paymentHash} amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
+      log.warning(s"received payment with amount too small for amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
       false
     } else if (payment.payload.totalAmount > expectedAmount * 2) {
-      log.warning(s"received payment with amount too large for paymentHash=${payment.add.paymentHash} amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
+      log.warning(s"received payment with amount too large for amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
       false
     } else {
       true
@@ -191,7 +201,7 @@ object MultiPartHandler {
 
   private def validatePaymentCltv(payment: IncomingPacket.FinalPacket, minExpiry: CltvExpiry)(implicit log: LoggingAdapter): Boolean = {
     if (payment.add.cltvExpiry < minExpiry) {
-      log.warning(s"received payment with expiry too small for paymentHash=${payment.add.paymentHash} amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
+      log.warning(s"received payment with expiry too small for amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
       false
     } else {
       true
@@ -200,13 +210,13 @@ object MultiPartHandler {
 
   private def validateInvoiceFeatures(payment: IncomingPacket.FinalPacket, pr: PaymentRequest)(implicit log: LoggingAdapter): Boolean = {
     if (payment.payload.amount < payment.payload.totalAmount && !pr.features.allowMultiPart) {
-      log.warning(s"received multi-part payment but invoice doesn't support it for paymentHash=${payment.add.paymentHash} amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
+      log.warning(s"received multi-part payment but invoice doesn't support it for amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
       false
     } else if (payment.payload.amount < payment.payload.totalAmount && pr.paymentSecret != payment.payload.paymentSecret) {
-      log.warning(s"received multi-part payment with invalid secret=${payment.payload.paymentSecret} for paymentHash=${payment.add.paymentHash} amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
+      log.warning(s"received multi-part payment with invalid secret=${payment.payload.paymentSecret} for amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
       false
     } else if (payment.payload.paymentSecret.isDefined && pr.paymentSecret != payment.payload.paymentSecret) {
-      log.warning(s"received payment with invalid secret=${payment.payload.paymentSecret} for paymentHash=${payment.add.paymentHash} amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
+      log.warning(s"received payment with invalid secret=${payment.payload.paymentSecret} for amount=${payment.add.amountMsat} totalAmount=${payment.payload.totalAmount}")
       false
     } else {
       true

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -264,7 +264,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
   }
 
   override def mdc(currentMessage: Any): MDC = {
-    Logs.mdc(parentPaymentId_opt = Some(cfg.parentId), paymentId_opt = Some(id))
+    Logs.mdc(category_opt = Some(Logs.LogCategory.PAYMENT), parentPaymentId_opt = Some(cfg.parentId), paymentId_opt = Some(id))
   }
 
   initialize()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -264,7 +264,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
   }
 
   override def mdc(currentMessage: Any): MDC = {
-    Logs.mdc(category_opt = Some(Logs.LogCategory.PAYMENT), parentPaymentId_opt = Some(cfg.parentId), paymentId_opt = Some(id))
+    Logs.mdc(category_opt = Some(Logs.LogCategory.PAYMENT), parentPaymentId_opt = Some(cfg.parentId), paymentId_opt = Some(id), paymentHash_opt = Some(cfg.paymentHash))
   }
 
   initialize()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -262,7 +262,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
   }
 
   override def mdc(currentMessage: Any): MDC = {
-    Logs.mdc(parentPaymentId_opt = Some(cfg.parentId), paymentId_opt = Some(id))
+    Logs.mdc(category_opt = Some(Logs.LogCategory.PAYMENT), parentPaymentId_opt = Some(cfg.parentId), paymentId_opt = Some(id))
   }
 
   initialize()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -262,7 +262,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
   }
 
   override def mdc(currentMessage: Any): MDC = {
-    Logs.mdc(category_opt = Some(Logs.LogCategory.PAYMENT), parentPaymentId_opt = Some(cfg.parentId), paymentId_opt = Some(id))
+    Logs.mdc(category_opt = Some(Logs.LogCategory.PAYMENT), parentPaymentId_opt = Some(cfg.parentId), paymentId_opt = Some(id), paymentHash_opt = Some(cfg.paymentHash))
   }
 
   initialize()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -23,6 +23,7 @@ import akka.event.LoggingAdapter
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.Script.{pay2wsh, write}
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
+import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel._
@@ -925,10 +926,14 @@ class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[
       d
     }
 
-  override def mdc(currentMessage: Any): MDC = currentMessage match {
-    case SendChannelQuery(remoteNodeId, _, _) => Logs.mdc(remoteNodeId_opt = Some(remoteNodeId))
-    case PeerRoutingMessage(_, remoteNodeId, _) => Logs.mdc(remoteNodeId_opt = Some(remoteNodeId))
-    case _ => akka.event.Logging.emptyMDC
+  override def mdc(currentMessage: Any): MDC = {
+    val category_opt = LogCategory(currentMessage)
+    currentMessage match {
+      case SendChannelQuery(remoteNodeId, _, _) => Logs.mdc(category_opt, remoteNodeId_opt = Some(remoteNodeId))
+      case PeerRoutingMessage(_, remoteNodeId, _) => Logs.mdc(category_opt, remoteNodeId_opt = Some(remoteNodeId))
+      case LocalChannelUpdate(_, _, _, remoteNodeId, _, _, _) => Logs.mdc(category_opt, remoteNodeId_opt = Some(remoteNodeId))
+      case _ => Logs.mdc(category_opt)
+    }
   }
 }
 

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -20,7 +20,7 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>
         <encoder>
-            <pattern>%date{HH:mm:ss.SSS} %highlight(%-5level) %logger{0}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
+            <pattern>%date{HH:mm:ss.SSS} %highlight(%-5level) %logger{0}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
         </encoder>
     </appender>
 

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -20,28 +20,27 @@
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>
         <encoder>
-            <pattern>%date{HH:mm:ss.SSS} %highlight(%-5level) %logger{0}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n
-            </pattern>
+            <pattern>%date{HH:mm:ss.SSS} %highlight(%-5level) %logger{0}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
         </encoder>
     </appender>
 
-    <!--<appender name="CONSOLEWARN" class="ch.qos.logback.core.ConsoleAppender">
+    <!--appender name="CONSOLEWARN" class="ch.qos.logback.core.ConsoleAppender">
         <target>System.out</target>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>WARN</level>
         </filter>
         <encoder>
-            <pattern>%date{HH:mm:ss.SSS} %highlight(%-5level) %logger{0}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
+            <pattern>%-5level %X{akkaSource} - %msg%ex{12}%n</pattern>
         </encoder>
-    </appender>-->
+    </appender-->
 
-    <!--<appender name="FILE" class="ch.qos.logback.core.FileAppender">
+    <!--appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>eclair.log</file>
         <append>false</append>
         <encoder>
-            <pattern>%date{HH:mm:ss.SSS} %highlight(%-5level) %logger{0}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
+            <pattern>%-5level %X{akkaSource} - %msg%ex{12}%n</pattern>
         </encoder>
-    </appender>-->
+    </appender-->
 
     <!--logger name="fr.acinq.eclair.channel" level="DEBUG"/-->
     <logger name="fr.acinq.eclair.router" level="WARN"/>
@@ -51,9 +50,9 @@
     <logger name="fr.acinq.eclair.db.BackupHandler" level="OFF"/>
 
     <root level="INFO">
-        <!--<appender-ref ref="FILE"/>
+        <!--appender-ref ref="FILE"/>
         <appender-ref ref="CONSOLEWARN"/>
-        <appender-ref ref="CONSOLE"/>-->
+        <appender-ref ref="CONSOLE"/-->
     </root>
 
 </configuration>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestUtils.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestUtils.scala
@@ -19,6 +19,8 @@ package fr.acinq.eclair
 import java.io.File
 import java.net.ServerSocket
 
+import akka.event.DiagnosticLoggingAdapter
+
 object TestUtils {
 
   /**
@@ -39,6 +41,19 @@ object TestUtils {
         serverSocket.close()
       }
     }
+  }
+
+  object NoLoggingDiagnostics extends DiagnosticLoggingAdapter {
+    override def isErrorEnabled: Boolean = false
+    override def isWarningEnabled: Boolean = false
+    override def isInfoEnabled: Boolean = false
+    override def isDebugEnabled: Boolean = false
+
+    override protected def notifyError(message: String): Unit = ()
+    override protected def notifyError(cause: Throwable, message: String): Unit = ()
+    override protected def notifyWarning(message: String): Unit = ()
+    override protected def notifyInfo(message: String): Unit = ()
+    override protected def notifyDebug(message: String): Unit = ()
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
@@ -17,6 +17,7 @@
 package fr.acinq.eclair.channel
 
 import fr.acinq.bitcoin.Transaction
+import fr.acinq.eclair.TestUtils.NoLoggingDiagnostics
 import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel.Helpers.Closing._
 import org.scalatest.FunSuite
@@ -28,7 +29,7 @@ class HelpersSpec extends FunSuite {
 
   test("compute refresh delay") {
     import org.scalatest.Matchers._
-    implicit val log = akka.event.NoLogging
+    implicit val log = NoLoggingDiagnostics
     Helpers.nextChannelUpdateRefresh(1544400000).toSeconds should equal(0)
     Helpers.nextChannelUpdateRefresh((Platform.currentTime.milliseconds - 9.days).toSeconds).toSeconds should equal(24 * 3600L +- 100)
     Helpers.nextChannelUpdateRefresh((Platform.currentTime.milliseconds - 3.days).toSeconds).toSeconds should equal(7 * 24 * 3600L +- 100)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentHandlerSpec.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.payment
 
 import akka.actor.Actor.Receive
 import akka.actor.{ActorContext, ActorSystem}
-import akka.event.LoggingAdapter
+import akka.event.{DiagnosticLoggingAdapter, LoggingAdapter}
 import akka.testkit.{TestKit, TestProbe}
 import fr.acinq.eclair.TestConstants.Alice
 import fr.acinq.eclair.payment.receive.{PaymentHandler, ReceiveHandler}
@@ -32,13 +32,13 @@ class PaymentHandlerSpec extends TestKit(ActorSystem("test")) with FunSuiteLike 
     val handler = system.actorOf(PaymentHandler.props(Alice.nodeParams, TestProbe().ref))
 
     val intHandler = new ReceiveHandler {
-      override def handle(implicit ctx: ActorContext, log: LoggingAdapter): Receive = {
+      override def handle(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Receive = {
         case i: Int => ctx.sender ! -i
       }
     }
 
     val stringHandler = new ReceiveHandler {
-      override def handle(implicit ctx: ActorContext, log: LoggingAdapter): Receive = {
+      override def handle(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Receive = {
         case s: String => ctx.sender ! s.reverse
       }
     }

--- a/eclair-node/src/main/resources/logback.xml
+++ b/eclair-node/src/main/resources/logback.xml
@@ -21,7 +21,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -35,7 +35,7 @@
             <totalSizeCap>5GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>%d %-5level %logger{24}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{24}%n</pattern>
+            <pattern>%d %-5level %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{24}%n</pattern>
         </encoder>
     </appender>
 
@@ -50,7 +50,7 @@
         <then>
             <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder>
-                    <pattern>%d %-5level %logger{24}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{24}%n</pattern>
+                    <pattern>%d %-5level %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{24}%n</pattern>
                 </encoder>
             </appender>
             <root>

--- a/eclair-node/src/main/resources/logback.xml
+++ b/eclair-node/src/main/resources/logback.xml
@@ -21,7 +21,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -35,7 +35,7 @@
             <totalSizeCap>5GB</totalSizeCap>
         </rollingPolicy>
         <encoder>
-            <pattern>%d %-5level %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{24}%n</pattern>
+            <pattern>%d %-5level %logger{24}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{24}%n</pattern>
         </encoder>
     </appender>
 
@@ -50,7 +50,7 @@
         <then>
             <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder>
-                    <pattern>%d %-5level %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{24}%n</pattern>
+                    <pattern>%d %-5level %logger{24}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{24}%n</pattern>
                 </encoder>
             </appender>
             <root>

--- a/eclair-node/src/main/resources/logback_colors.xml
+++ b/eclair-node/src/main/resources/logback_colors.xml
@@ -21,7 +21,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -29,7 +29,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %yellow(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %yellow(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -37,7 +37,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %red(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %red(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -45,7 +45,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %blue(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %blue(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -53,7 +53,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %cyan(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %cyan(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -61,7 +61,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %green(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %green(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -69,7 +69,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %magenta(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %magenta(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 

--- a/eclair-node/src/main/resources/logback_colors.xml
+++ b/eclair-node/src/main/resources/logback_colors.xml
@@ -21,7 +21,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -29,7 +29,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %yellow(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %yellow(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -37,7 +37,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %red(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %red(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -45,7 +45,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %blue(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %blue(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -53,7 +53,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %cyan(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %cyan(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -61,7 +61,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %green(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %green(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 
@@ -69,7 +69,7 @@
         <target>System.out</target>
         <withJansi>false</withJansi>
         <encoder>
-            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%.-11X{parentPaymentId}%.-11X{paymentId} - %magenta(%msg) %ex{12}%n</pattern>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %logger{24}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %magenta(%msg) %ex{12}%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Filtering by package is sometimes not enough because some events (e.g. routing table sync) spans over multiple packages.