### PR TITLE
Handle chain re-org in balance computation

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -872,7 +872,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
       val channelUpdate = if (shortChannelId != d.shortChannelId) {
         log.info(s"short channel id changed, probably due to a chain reorg: old=${d.shortChannelId} new=$shortChannelId")
         // we need to re-announce this shortChannelId
-        context.system.eventStream.publish(ShortChannelIdAssigned(self, d.channelId, shortChannelId))
+        context.system.eventStream.publish(ShortChannelIdAssigned(self, d.channelId, shortChannelId, Some(d.shortChannelId)))
         // we re-announce the channelUpdate for the same reason
         Announcements.makeChannelUpdate(nodeParams.chainHash, nodeParams.privateKey, remoteNodeId, shortChannelId, d.channelUpdate.cltvExpiryDelta, d.channelUpdate.htlcMinimumMsat, d.channelUpdate.feeBaseMsat, d.channelUpdate.feeProportionalMillionths, d.commitments.localCommit.spec.totalFunds, enable = Helpers.aboveReserve(d.commitments))
       } else d.channelUpdate

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -36,7 +36,7 @@ case class ChannelRestored(channel: ActorRef, peer: ActorRef, remoteNodeId: Publ
 
 case class ChannelIdAssigned(channel: ActorRef, remoteNodeId: PublicKey, temporaryChannelId: ByteVector32, channelId: ByteVector32) extends ChannelEvent
 
-case class ShortChannelIdAssigned(channel: ActorRef, channelId: ByteVector32, shortChannelId: ShortChannelId) extends ChannelEvent
+case class ShortChannelIdAssigned(channel: ActorRef, channelId: ByteVector32, shortChannelId: ShortChannelId, previousShortChannelId: Option[ShortChannelId] = None) extends ChannelEvent
 
 case class LocalChannelUpdate(channel: ActorRef, channelId: ByteVector32, shortChannelId: ShortChannelId, remoteNodeId: PublicKey, channelAnnouncement_opt: Option[ChannelAnnouncement], channelUpdate: ChannelUpdate, commitments: Commitments) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -36,7 +36,7 @@ case class ChannelRestored(channel: ActorRef, peer: ActorRef, remoteNodeId: Publ
 
 case class ChannelIdAssigned(channel: ActorRef, remoteNodeId: PublicKey, temporaryChannelId: ByteVector32, channelId: ByteVector32) extends ChannelEvent
 
-case class ShortChannelIdAssigned(channel: ActorRef, channelId: ByteVector32, shortChannelId: ShortChannelId, previousShortChannelId: Option[ShortChannelId] = None) extends ChannelEvent
+case class ShortChannelIdAssigned(channel: ActorRef, channelId: ByteVector32, shortChannelId: ShortChannelId, previousShortChannelId: Option[ShortChannelId]) extends ChannelEvent
 
 case class LocalChannelUpdate(channel: ActorRef, channelId: ByteVector32, shortChannelId: ShortChannelId, remoteNodeId: PublicKey, channelAnnouncement_opt: Option[ChannelAnnouncement], channelUpdate: ChannelUpdate, commitments: Commitments) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -24,8 +24,8 @@ import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.channel.Register._
 
 /**
-  * Created by PM on 26/01/2016.
-  */
+ * Created by PM on 26/01/2016.
+ */
 
 class Register extends Actor with ActorLogging {
 
@@ -48,7 +48,7 @@ class Register extends Actor with ActorLogging {
     case ChannelIdAssigned(channel, remoteNodeId, temporaryChannelId, channelId) =>
       context become main(channels + (channelId -> channel) - temporaryChannelId, shortIds, channelsTo + (channelId -> remoteNodeId) - temporaryChannelId)
 
-    case ShortChannelIdAssigned(_, channelId, shortChannelId) =>
+    case ShortChannelIdAssigned(_, channelId, shortChannelId, _) =>
       context become main(channels, shortIds + (shortChannelId -> channelId), channelsTo)
 
     case Terminated(actor) if channels.values.toSet.contains(actor) =>
@@ -69,7 +69,7 @@ class Register extends Actor with ActorLogging {
       }
 
     case fwd@ForwardShortId(shortChannelId, msg) =>
-      shortIds.get(shortChannelId).flatMap(channels.get(_)) match {
+      shortIds.get(shortChannelId).flatMap(channels.get) match {
         case Some(channel) => channel forward msg
         case None => sender ! Failure(ForwardShortIdFailure(fwd))
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -66,6 +66,7 @@ class Relayer(nodeParams: NodeParams, register: ActorRef, commandBuffer: ActorRe
   context.system.eventStream.subscribe(self, classOf[LocalChannelUpdate])
   context.system.eventStream.subscribe(self, classOf[LocalChannelDown])
   context.system.eventStream.subscribe(self, classOf[AvailableBalanceChanged])
+  context.system.eventStream.subscribe(self, classOf[ShortChannelIdAssigned])
 
   private val channelRelayer = context.actorOf(ChannelRelayer.props(nodeParams, self, register, commandBuffer))
 
@@ -95,6 +96,17 @@ class Relayer(nodeParams: NodeParams, register: ActorRef, commandBuffer: ActorRe
         case None => channelUpdates // we only consider the balance if we have the channel_update
       }
       context become main(channelUpdates1, node2channels)
+
+    case ShortChannelIdAssigned(_, channelId, shortChannelId, previousShortChannelId) =>
+      previousShortChannelId.foreach(previousShortChannelId => {
+        log.debug(s"shortChannelId changed for channelId=$channelId ($previousShortChannelId->$shortChannelId, probably due to chain re-org)")
+        // We simply remove the old entry: we should receive a LocalChannelUpdate with the new shortChannelId shortly.
+        val node2channels1 = channelUpdates.get(previousShortChannelId).map(_.nextNodeId) match {
+          case Some(remoteNodeId) => node2channels.removeBinding(remoteNodeId, previousShortChannelId)
+          case None => node2channels
+        }
+        context become main(channelUpdates - previousShortChannelId, node2channels1)
+      })
 
     case ForwardAdd(add, previousFailures) =>
       log.debug(s"received forwarding request for htlc #${add.id} paymentHash=${add.paymentHash} from channelId=${add.channelId}")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -591,6 +591,13 @@ class RelayerSpec extends TestkitBaseClass {
     val OutgoingChannels(channels6) = sender.expectMsgType[OutgoingChannels]
     assert(channels6.size === 1)
 
+    // We should ignore faulty events that don't really change the shortChannelId:
+    relayer ! ShortChannelIdAssigned(null, channelId_ab, channelUpdate_ab.shortChannelId, Some(channelUpdate_ab.shortChannelId))
+    sender.send(relayer, GetOutgoingChannels())
+    val OutgoingChannels(channels7) = sender.expectMsgType[OutgoingChannels]
+    assert(channels7.size === 1)
+    assert(channels7.head.channelUpdate.shortChannelId === channelUpdate_ab.shortChannelId)
+
     // Simulate a chain re-org that changes the shortChannelId:
     relayer ! ShortChannelIdAssigned(null, channelId_ab, ShortChannelId(42), Some(channelUpdate_ab.shortChannelId))
     sender.send(relayer, GetOutgoingChannels())
@@ -599,9 +606,9 @@ class RelayerSpec extends TestkitBaseClass {
     // We should receive the updated channel update containing the new shortChannelId:
     relayer ! LocalChannelUpdate(null, channelId_ab, ShortChannelId(42), a, None, channelUpdate_ab.copy(shortChannelId = ShortChannelId(42)), makeCommitments(channelId_ab, 100000 msat, 200000 msat))
     sender.send(relayer, GetOutgoingChannels())
-    val OutgoingChannels(channels7) = sender.expectMsgType[OutgoingChannels]
-    assert(channels7.size === 1)
-    assert(channels7.head.channelUpdate.shortChannelId === ShortChannelId(42))
+    val OutgoingChannels(channels8) = sender.expectMsgType[OutgoingChannels]
+    assert(channels8.size === 1)
+    assert(channels8.head.channelUpdate.shortChannelId === ShortChannelId(42))
   }
 
   test("replay pending commands after restart") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -590,6 +590,18 @@ class RelayerSpec extends TestkitBaseClass {
     sender.send(relayer, GetOutgoingChannels())
     val OutgoingChannels(channels6) = sender.expectMsgType[OutgoingChannels]
     assert(channels6.size === 1)
+
+    // Simulate a chain re-org that changes the shortChannelId:
+    relayer ! ShortChannelIdAssigned(null, channelId_ab, ShortChannelId(42), Some(channelUpdate_ab.shortChannelId))
+    sender.send(relayer, GetOutgoingChannels())
+    sender.expectMsg(OutgoingChannels(Nil))
+
+    // We should receive the updated channel update containing the new shortChannelId:
+    relayer ! LocalChannelUpdate(null, channelId_ab, ShortChannelId(42), a, None, channelUpdate_ab.copy(shortChannelId = ShortChannelId(42)), makeCommitments(channelId_ab, 100000 msat, 200000 msat))
+    sender.send(relayer, GetOutgoingChannels())
+    val OutgoingChannels(channels7) = sender.expectMsgType[OutgoingChannels]
+    assert(channels7.size === 1)
+    assert(channels7.head.channelUpdate.shortChannelId === ShortChannelId(42))
   }
 
   test("replay pending commands after restart") { f =>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -94,7 +94,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
       })
       context.become(main(m1))
 
-    case ShortChannelIdAssigned(channel, _, shortChannelId) if m.contains(channel) =>
+    case ShortChannelIdAssigned(channel, _, shortChannelId, _) if m.contains(channel) =>
       val channelPaneController = m(channel)
       runInGuiThread(() => channelPaneController.shortChannelId.setText(shortChannelId.toString))
 


### PR DESCRIPTION
If a chain re-org happens and a new ShortChannelId is assigned,
the `Relayer` kept both entries (new and old).

This resulted in an incorrect balance because we effectively counted this channel twice.