### PR TITLE
Minor: ignore "disconnecting" message in Channel

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1637,6 +1637,9 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
     // we receive this when we send command to ourselves
     case Event("ok", _) => stay
 
+    // we receive this when we tell the peer to disconnect
+    case Event("disconnecting", _) => stay
+
     // when we realize we need to update our network fees, we send a CMD_UPDATE_FEE to ourselves which may result in this error being sent back to ourselves, this can be ignored
     case Event(Status.Failure(_: CannotAffordFees), _) => stay
 


### PR DESCRIPTION
This message is sent by the `Peer` in answer to a `Peer.Disconnect` command.