### PR TITLE
Fix outgoing payments order in payments overview

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -359,7 +359,7 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
         |    external_id,
         |    payment_hash,
         |    payment_preimage,
-        |    sum(amount_msat) as final_amount,
+        |    sum(amount_msat + fees_msat) as final_amount,
         |    payment_request,
         |    target_node_id,
         |    created_at,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -349,7 +349,8 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
         |    NULL as target_node_id,
         |    created_at,
         |    received_at as completed_at,
-        |    expire_at
+        |    expire_at,
+        |    NULL as order_trick
         |  FROM received_payments
         |  WHERE final_amount > 0
         |UNION ALL
@@ -363,7 +364,8 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
         |    target_node_id,
         |    created_at,
         |    completed_at,
-        |    NULL as expire_at
+        |    NULL as expire_at,
+        |    MAX(coalesce(completed_at, created_at)) as order_trick
         |  FROM sent_payments
         |  GROUP BY parent_id
         |)


### PR DESCRIPTION
Payments overview aggregates outgoing payments by `parent_id` using a `group by`. If there are several attempts, there is no guarantee that the output aggregated payment will hold the most recent/pertinent status.

See SQLite doc on bare columns in aggregate queries: https://www.sqlite.org/lang_select.html#bareagg

By using the `max` function we can force the aggregate output to be the most recent attempt.