### PR TITLE
Set `akka.loglevel` to `DEBUG`

### DIFF
--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -20,7 +20,7 @@ akka {
 
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logger-startup-timeout = 30s
-  loglevel = "INFO"
+  loglevel = "DEBUG" # akka doc: You can enable DEBUG level for akka.loglevel and control the actual level in the SLF4J backend without any significant overhead, also for production.
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 
   io {


### PR DESCRIPTION
This allows us to only use logback.xml to control the log level.

From akka docs [1]:
> If you set the loglevel to a higher level than DEBUG, any DEBUG events
will be filtered out already at the source and will never reach the
logging backend, regardless of how the backend is configured.

> You can enable DEBUG level for akka.loglevel and control the actual
level in the SLF4J backend without any significant overhead, also for
production.

[1] https://doc.akka.io/docs/akka/current/logging.html