### PR TITLE
Fix MPP flaky test

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -499,8 +499,6 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
       assert(remaining === 0.msat, fuzzParams)
       assert(payments.nonEmpty, fuzzParams)
       assert(payments.map(_.finalPayload.amount).sum === toSend, fuzzParams)
-      // Verify that we're not generating tiny HTLCs.
-      assert(payments.forall(_.finalPayload.amount > 50.msat), fuzzParams)
     }
   }
 


### PR DESCRIPTION
We can't guarantee with the current algorithm that the last HTLC won't be
a small one (the leftovers).
If we see that happen in real scenario, we'll need to add heuristics to avoid it.