### PR TITLE
Add a configurable time-out to onchain fee provider requests

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -31,6 +31,7 @@ eclair {
 
   min-feerate = 3 // minimum feerate in satoshis per byte
   smooth-feerate-window = 6 // 1 = no smoothing
+  feerate-provider-timeout = 5 seconds // max time we'll wait for answers from a fee provider before we fallback to the next one
 
   node-alias = "eclair"
   node-color = "49daaa"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -227,12 +227,13 @@ class Setup(datadir: File,
       }
       minFeeratePerByte = config.getLong("min-feerate")
       smoothFeerateWindow = config.getInt("smooth-feerate-window")
+      readTimeout = FiniteDuration(config.getDuration("feerate-provider-timeout", TimeUnit.SECONDS), TimeUnit.MILLISECONDS)
       feeProvider = (nodeParams.chainHash, bitcoin) match {
         case (Block.RegtestGenesisBlock.hash, _) => new FallbackFeeProvider(new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte)
         case (_, Bitcoind(bitcoinClient)) =>
-          new FallbackFeeProvider(new SmoothFeeProvider(new BitcoinCoreFeeProvider(bitcoinClient, defaultFeerates), smoothFeerateWindow) :: new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(), smoothFeerateWindow) :: new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte) // order matters!
+          new FallbackFeeProvider(new SmoothFeeProvider(new BitcoinCoreFeeProvider(bitcoinClient, defaultFeerates), smoothFeerateWindow) :: new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash, readTimeout), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(readTimeout), smoothFeerateWindow) :: new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte) // order matters!
         case _ =>
-          new FallbackFeeProvider(new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(), smoothFeerateWindow) :: new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte) // order matters!
+          new FallbackFeeProvider(new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash, readTimeout), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(readTimeout), smoothFeerateWindow) :: new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte) // order matters!
       }
       _ = system.scheduler.schedule(0 seconds, 10 minutes)(feeProvider.getFeerates.map {
         case feerates: FeeratesPerKB =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
@@ -26,7 +26,7 @@ import org.json4s.jackson.Serialization
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
-class BitgoFeeProvider(chainHash: ByteVector32, readTimeOut: Duration = 5 seconds)(implicit http: SttpBackend[Future, Nothing], ec: ExecutionContext) extends FeeProvider {
+class BitgoFeeProvider(chainHash: ByteVector32, readTimeOut: Duration)(implicit http: SttpBackend[Future, Nothing], ec: ExecutionContext) extends FeeProvider {
 
   import BitgoFeeProvider._
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
@@ -23,9 +23,10 @@ import org.json4s.DefaultFormats
 import org.json4s.JsonAST.{JInt, JValue}
 import org.json4s.jackson.Serialization
 
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
-class BitgoFeeProvider(chainHash: ByteVector32)(implicit http: SttpBackend[Future, Nothing], ec: ExecutionContext) extends FeeProvider {
+class BitgoFeeProvider(chainHash: ByteVector32, readTimeOut: Duration = 5 seconds)(implicit http: SttpBackend[Future, Nothing], ec: ExecutionContext) extends FeeProvider {
 
   import BitgoFeeProvider._
 
@@ -39,7 +40,7 @@ class BitgoFeeProvider(chainHash: ByteVector32)(implicit http: SttpBackend[Futur
 
   override def getFeerates: Future[FeeratesPerKB] =
     for {
-      res <- sttp.get(uri)
+      res <- sttp.readTimeout(readTimeOut).get(uri)
         .response(asJson[JValue])
         .send()
       feeRanges = parseFeeRanges(res.unsafeBody)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProvider.scala
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 /**
   * Created by PM on 16/11/2017.
   */
-class EarnDotComFeeProvider(readTimeOut: Duration = 5 seconds)(implicit http: SttpBackend[Future, Nothing], ec: ExecutionContext) extends FeeProvider {
+class EarnDotComFeeProvider(readTimeOut: Duration)(implicit http: SttpBackend[Future, Nothing], ec: ExecutionContext) extends FeeProvider {
 
   import EarnDotComFeeProvider._
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProvider.scala
@@ -22,12 +22,13 @@ import org.json4s.DefaultFormats
 import org.json4s.JsonAST.{JArray, JInt, JValue}
 import org.json4s.jackson.Serialization
 
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Created by PM on 16/11/2017.
   */
-class EarnDotComFeeProvider(implicit http: SttpBackend[Future, Nothing], ec: ExecutionContext) extends FeeProvider {
+class EarnDotComFeeProvider(readTimeOut: Duration = 5 seconds)(implicit http: SttpBackend[Future, Nothing], ec: ExecutionContext) extends FeeProvider {
 
   import EarnDotComFeeProvider._
 
@@ -38,7 +39,7 @@ class EarnDotComFeeProvider(implicit http: SttpBackend[Future, Nothing], ec: Exe
 
   override def getFeerates: Future[FeeratesPerKB] =
     for {
-      json <- sttp.get(uri)
+      json <- sttp.readTimeout(readTimeOut).get(uri)
         .response(asJson[JValue])
         .send()
       feeRanges = parseFeeRanges(json.unsafeBody)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProvider.scala
@@ -16,6 +16,8 @@
 
 package fr.acinq.eclair.blockchain.fee
 
+import grizzled.slf4j.Logging
+
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -24,7 +26,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * @param providers a sequence of providers; they will be tried one after the others until one of them succeeds
   * @param minFeeratePerByte a configurable minimum value for feerates
   */
-class FallbackFeeProvider(providers: Seq[FeeProvider], minFeeratePerByte: Long)(implicit ec: ExecutionContext) extends FeeProvider {
+class FallbackFeeProvider(providers: Seq[FeeProvider], minFeeratePerByte: Long)(implicit ec: ExecutionContext) extends FeeProvider with Logging {
 
   require(providers.size >= 1, "need at least one fee provider")
   require(minFeeratePerByte > 0, "minimum fee rate must be strictly greater than 0")
@@ -32,7 +34,7 @@ class FallbackFeeProvider(providers: Seq[FeeProvider], minFeeratePerByte: Long)(
   def getFeerates(fallbacks: Seq[FeeProvider]): Future[FeeratesPerKB] =
     fallbacks match {
       case last +: Nil => last.getFeerates
-      case head +: remaining => head.getFeerates.recoverWith { case _ => getFeerates(remaining) }
+      case head +: remaining => head.getFeerates.recoverWith { case error => logger.warn(s"$head failed, falling back to next fee provider", error); getFeerates(remaining) }
     }
 
   override def getFeerates: Future[FeeratesPerKB] = getFeerates(providers).map(FallbackFeeProvider.enforceMinimumFeerate(_, minFeeratePerByte))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProviderSpec.scala
@@ -73,8 +73,18 @@ class EarnDotComFeeProviderSpec extends FunSuite with Logging {
     import scala.concurrent.duration._
     implicit val sttpBackend  = OkHttpFutureBackend()
     implicit val timeout = Timeout(30 seconds)
-    val provider = new EarnDotComFeeProvider()
+    val provider = new EarnDotComFeeProvider(5 seconds)
     logger.info("earn.com livenet fees: " + Await.result(provider.getFeerates, 10 seconds))
   }
 
+  test("check that read timeout is enforced") {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    import scala.concurrent.duration._
+    implicit val sttpBackend  = OkHttpFutureBackend()
+    implicit val timeout = Timeout(5 second)
+    val provider = new EarnDotComFeeProvider(1 millisecond)
+    intercept[Exception] {
+      Await.result(provider.getFeerates, timeout.duration)
+    }
+  }
 }


### PR DESCRIPTION
We configure a timeout of 5 seconds, applicable to all fee providers. If a provider times out we switch to the next one in our list.
Our mobile app needs a feerate to start properly and currently waits too long when a fee provider is online but very slow to respond.