### PR TITLE
Allow Peer.Connect messages to force reconnection to remote.

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -74,15 +74,9 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
           sender ! "no address found"
           stay
         case Some(address) =>
-          if (d.address_opt.contains(address)) {
-            // we already know this address, we'll reconnect automatically
-            sender ! "reconnection in progress"
-            stay
-          } else {
-            // we immediately process explicit connection requests to new addresses
-            context.actorOf(Client.props(nodeParams, authenticator, address, remoteNodeId, origin_opt = Some(sender())))
-            stay using d.copy(address_opt = Some(address))
-          }
+          // we immediately process explicit connection requests to new addresses
+          context.actorOf(Client.props(nodeParams, authenticator, address, remoteNodeId, origin_opt = Some(sender())))
+          stay using d.copy(address_opt = Some(address))
       }
 
     case Event(Reconnect, d: DisconnectedData) =>


### PR DESCRIPTION
Currently the Peer class schedules reconnections to remote and while waiting for the reconnection trigger it ignores `Peer.Connect` messages, this PR fixes the behavior by allowing connect messages to initiate a connection even if tere is already a known address for it.

Fixes #1242 