### PR TITLE
Improve CommandSend type

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -118,12 +118,10 @@ object Upstream {
 }
 
 sealed trait Command
-sealed trait HasHtlcIdCommand extends Command {
-  def id: Long
-}
-final case class CMD_FULFILL_HTLC(id: Long, r: ByteVector32, commit: Boolean = false) extends HasHtlcIdCommand
-final case class CMD_FAIL_HTLC(id: Long, reason: Either[ByteVector, FailureMessage], commit: Boolean = false) extends HasHtlcIdCommand
-final case class CMD_FAIL_MALFORMED_HTLC(id: Long, onionHash: ByteVector32, failureCode: Int, commit: Boolean = false) extends HasHtlcIdCommand
+sealed trait HasHtlcId { def id: Long }
+final case class CMD_FULFILL_HTLC(id: Long, r: ByteVector32, commit: Boolean = false) extends Command with HasHtlcId
+final case class CMD_FAIL_HTLC(id: Long, reason: Either[ByteVector, FailureMessage], commit: Boolean = false) extends Command with HasHtlcId
+final case class CMD_FAIL_MALFORMED_HTLC(id: Long, onionHash: ByteVector32, failureCode: Int, commit: Boolean = false) extends Command with HasHtlcId
 final case class CMD_ADD_HTLC(amount: MilliSatoshi, paymentHash: ByteVector32, cltvExpiry: CltvExpiry, onion: OnionRoutingPacket, upstream: Upstream, commit: Boolean = false, previousFailures: Seq[AddHtlcFailed] = Seq.empty) extends Command
 final case class CMD_UPDATE_FEE(feeratePerKw: Long, commit: Boolean = false) extends Command
 case object CMD_SIGN extends Command

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.db
 
 import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.eclair.channel.HasHtlcIdCommand
+import fr.acinq.eclair.channel.{Command, HasHtlcId}
 
 /**
  * This database stores CMD_FULFILL_HTLC and CMD_FAIL_HTLC that we have received from downstream
@@ -33,11 +33,11 @@ import fr.acinq.eclair.channel.HasHtlcIdCommand
  */
 trait PendingRelayDb {
 
-  def addPendingRelay(channelId: ByteVector32, cmd: HasHtlcIdCommand)
+  def addPendingRelay(channelId: ByteVector32, cmd: Command with HasHtlcId)
 
   def removePendingRelay(channelId: ByteVector32, htlcId: Long)
 
-  def listPendingRelay(channelId: ByteVector32): Seq[HasHtlcIdCommand]
+  def listPendingRelay(channelId: ByteVector32): Seq[Command with HasHtlcId]
 
   def listPendingRelay(): Set[(ByteVector32, Long)]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingRelayDb.scala
@@ -19,10 +19,9 @@ package fr.acinq.eclair.db.sqlite
 import java.sql.Connection
 
 import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.eclair.channel.HasHtlcIdCommand
+import fr.acinq.eclair.channel.{Command, HasHtlcId}
 import fr.acinq.eclair.db.PendingRelayDb
 import fr.acinq.eclair.wire.CommandCodecs.cmdCodec
-import scodec.bits.BitVector
 
 import scala.collection.immutable.Queue
 
@@ -40,7 +39,7 @@ class SqlitePendingRelayDb(sqlite: Connection) extends PendingRelayDb {
     statement.executeUpdate("CREATE TABLE IF NOT EXISTS pending_relay (channel_id BLOB NOT NULL, htlc_id INTEGER NOT NULL, data BLOB NOT NULL, PRIMARY KEY(channel_id, htlc_id))")
   }
 
-  override def addPendingRelay(channelId: ByteVector32, cmd: HasHtlcIdCommand): Unit = {
+  override def addPendingRelay(channelId: ByteVector32, cmd: Command with HasHtlcId): Unit = {
     using(sqlite.prepareStatement("INSERT OR IGNORE INTO pending_relay VALUES (?, ?, ?)")) { statement =>
       statement.setBytes(1, channelId.toArray)
       statement.setLong(2, cmd.id)
@@ -57,7 +56,7 @@ class SqlitePendingRelayDb(sqlite: Connection) extends PendingRelayDb {
     }
   }
 
-  override def listPendingRelay(channelId: ByteVector32): Seq[HasHtlcIdCommand] = {
+  override def listPendingRelay(channelId: ByteVector32): Seq[Command with HasHtlcId] = {
     using(sqlite.prepareStatement("SELECT data FROM pending_relay WHERE channel_id=?")) { statement =>
       statement.setBytes(1, channelId.toArray)
       val rs = statement.executeQuery()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/CommandBuffer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/CommandBuffer.scala
@@ -62,7 +62,7 @@ class CommandBuffer(nodeParams: NodeParams, register: ActorRef) extends Actor wi
 
 object CommandBuffer {
 
-  case class CommandSend(channelId: ByteVector32, cmd: HasHtlcIdCommand)
+  case class CommandSend[T <: Command with HasHtlcId](channelId: ByteVector32, cmd: T)
 
   case class CommandAck(channelId: ByteVector32, htlcId: Long)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/CommandCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/CommandCodecs.scala
@@ -16,7 +16,7 @@
 
 package fr.acinq.eclair.wire
 
-import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FAIL_MALFORMED_HTLC, CMD_FULFILL_HTLC, HasHtlcIdCommand}
+import fr.acinq.eclair.channel._
 import fr.acinq.eclair.wire.CommonCodecs._
 import fr.acinq.eclair.wire.FailureMessageCodecs.failureMessageCodec
 import scodec.Codec
@@ -40,8 +40,9 @@ object CommandCodecs {
       ("failureCode" | uint16) ::
       ("commit" | provide(false))).as[CMD_FAIL_MALFORMED_HTLC]
 
-  val cmdCodec: Codec[HasHtlcIdCommand] = discriminated[HasHtlcIdCommand].by(uint16)
+  val cmdCodec: Codec[Command with HasHtlcId] = discriminated[Command with HasHtlcId].by(uint16)
     .typecase(0, cmdFulfillCodec)
     .typecase(1, cmdFailCodec)
     .typecase(2, cmdFailMalformedCodec)
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
@@ -283,7 +283,7 @@ class PostRestartHtlcCleanerSpec extends TestkitBaseClass {
 
     // This downstream HTLC has two upstream HTLCs.
     sender.send(relayer, buildForwardFail(testCase.downstream_1_1, testCase.upstream_1))
-    val fails = commandBuffer.expectMsgType[CommandBuffer.CommandSend] :: commandBuffer.expectMsgType[CommandBuffer.CommandSend] :: Nil
+    val fails = commandBuffer.expectMsgType[CommandBuffer.CommandSend[CMD_FAIL_HTLC]] :: commandBuffer.expectMsgType[CommandBuffer.CommandSend[CMD_FAIL_HTLC]] :: Nil
     assert(fails.toSet === testCase.upstream_1.origins.map {
       case (channelId, htlcId) => CommandBuffer.CommandSend(channelId, CMD_FAIL_HTLC(htlcId, Right(TemporaryNodeFailure), commit = true))
     }.toSet)
@@ -313,7 +313,7 @@ class PostRestartHtlcCleanerSpec extends TestkitBaseClass {
 
     // This downstream HTLC has two upstream HTLCs.
     sender.send(relayer, buildForwardFulfill(testCase.downstream_1_1, testCase.upstream_1, preimage1))
-    val fails = commandBuffer.expectMsgType[CommandBuffer.CommandSend] :: commandBuffer.expectMsgType[CommandBuffer.CommandSend] :: Nil
+    val fails = commandBuffer.expectMsgType[CommandBuffer.CommandSend[CMD_FULFILL_HTLC]] :: commandBuffer.expectMsgType[CommandBuffer.CommandSend[CMD_FULFILL_HTLC]] :: Nil
     assert(fails.toSet === testCase.upstream_1.origins.map {
       case (channelId, htlcId) => CommandBuffer.CommandSend(channelId, CMD_FULFILL_HTLC(htlcId, preimage1, commit = true))
     }.toSet)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/CommandCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/CommandCodecsSpec.scala
@@ -16,22 +16,22 @@
 
 package fr.acinq.eclair.wire
 
-import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FAIL_MALFORMED_HTLC, CMD_FULFILL_HTLC, Command, HasHtlcIdCommand}
+import fr.acinq.eclair.channel._
 import fr.acinq.eclair.{randomBytes, randomBytes32}
 import org.scalatest.FunSuite
 
 /**
-  * Created by PM on 31/05/2016.
-  */
+ * Created by PM on 31/05/2016.
+ */
 
 class CommandCodecsSpec extends FunSuite {
 
   test("encode/decode all channel messages") {
-    val msgs: List[HasHtlcIdCommand] =
+    val msgs: List[Command with HasHtlcId] =
       CMD_FULFILL_HTLC(1573L, randomBytes32) ::
-      CMD_FAIL_HTLC(42456L, Left(randomBytes(145))) ::
-      CMD_FAIL_HTLC(253, Right(TemporaryNodeFailure)) ::
-      CMD_FAIL_MALFORMED_HTLC(7984, randomBytes32, FailureMessageCodecs.BADONION) :: Nil
+        CMD_FAIL_HTLC(42456L, Left(randomBytes(145))) ::
+        CMD_FAIL_HTLC(253, Right(TemporaryNodeFailure)) ::
+        CMD_FAIL_MALFORMED_HTLC(7984, randomBytes32, FailureMessageCodecs.BADONION) :: Nil
 
     msgs.foreach {
       msg =>


### PR DESCRIPTION
Add type with upper bound to make `asInstanceOf` unnecessary.
Split `HasHtlcId` from `Command`: they are orthogonal traits.