### PR TITLE
Improve NodeRelayer errors

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -248,7 +248,7 @@ class EclairImpl(appKit: Kit) extends Eclair {
 
   override def sendToTrampoline(invoice: PaymentRequest, trampolineId: PublicKey, trampolineFees: MilliSatoshi, trampolineExpiryDelta: CltvExpiryDelta)(implicit timeout: Timeout): Future[UUID] = {
     val defaultRouteParams = Router.getDefaultRouteParams(appKit.nodeParams.routerConf)
-    val sendPayment = SendTrampolinePaymentRequest(invoice.amount.get, trampolineFees, invoice, trampolineId, invoice.minFinalCltvExpiryDelta.getOrElse(Channel.MIN_CLTV_EXPIRY_DELTA), trampolineExpiryDelta, Some(defaultRouteParams))
+    val sendPayment = SendTrampolinePaymentRequest(invoice.amount.get, invoice, trampolineId, Seq((trampolineFees, trampolineExpiryDelta)), invoice.minFinalCltvExpiryDelta.getOrElse(Channel.MIN_CLTV_EXPIRY_DELTA), Some(defaultRouteParams))
     (appKit.paymentInitiator ? sendPayment).mapTo[UUID]
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
@@ -91,6 +91,7 @@ class NodeRelayer(nodeParams: NodeParams, relayer: ActorRef, router: ActorRef, c
           case Some(failure) =>
             log.warning(s"rejecting trampoline payment (amountIn=${upstream.amountIn} expiryIn=${upstream.expiryIn} amountOut=${nextPayload.amountToForward} expiryOut=${nextPayload.outgoingCltv} htlcCount=${parts.length} reason=$failure)")
             rejectPayment(upstream, Some(failure))
+            context become main(pendingIncoming - paymentHash, pendingOutgoing)
           case None =>
             log.info(s"relaying trampoline payment (amountIn=${upstream.amountIn} expiryIn=${upstream.expiryIn} amountOut=${nextPayload.amountToForward} expiryOut=${nextPayload.outgoingCltv} htlcCount=${parts.length})")
             val paymentId = relay(paymentHash, upstream, nextPayload, nextPacket)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
@@ -21,14 +21,15 @@ import java.util.UUID
 import akka.actor.{Actor, ActorRef, DiagnosticActorLogging, PoisonPill, Props}
 import akka.event.Logging.MDC
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FULFILL_HTLC, Upstream}
+import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.SendMultiPartPayment
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentConfig
 import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPayment
 import fr.acinq.eclair.payment.send.{MultiPartPaymentLifecycle, PaymentLifecycle}
-import fr.acinq.eclair.payment.{IncomingPacket, PaymentFailed, PaymentSent, TrampolinePaymentRelayed}
-import fr.acinq.eclair.router.{RouteParams, Router}
+import fr.acinq.eclair.router.{RouteNotFound, RouteParams, Router}
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{CltvExpiry, Logs, MilliSatoshi, NodeParams, nodeFee, randomBytes32}
 
@@ -44,9 +45,6 @@ import scala.collection.immutable.Queue
  * router to find a route to the remote node and potentially splitting the payment using multi-part).
  */
 class NodeRelayer(nodeParams: NodeParams, relayer: ActorRef, router: ActorRef, commandBuffer: ActorRef, register: ActorRef) extends Actor with DiagnosticActorLogging {
-
-  // TODO: @t-bast: if fees/cltv insufficient (could not find route) send special error (sender should retry with higher fees/cltv)?
-  // TODO: @t-bast: add Kamon counters to monitor the size of pendingIncoming/Outgoing?
 
   import NodeRelayer._
 
@@ -112,12 +110,9 @@ class NodeRelayer(nodeParams: NodeParams, relayer: ActorRef, router: ActorRef, c
       }
       context become main(pendingIncoming, pendingOutgoing - id)
 
-    case PaymentFailed(id, _, _, _) =>
-      // TODO: @t-bast: try to extract the most meaningful error to return upstream (from the downstream failures)
-      //  - if local failure because balance too low: we should send a TEMPORARY failure upstream (they should retry when we have more balance available)
-      //  - if local failure because route not found: sender probably need to raise fees/cltv?
+    case PaymentFailed(id, _, failures, _) =>
       log.debug("trampoline payment failed")
-      pendingOutgoing.get(id).foreach { case PendingResult(upstream, _) => rejectPayment(upstream) }
+      pendingOutgoing.get(id).foreach { case PendingResult(upstream, nextPayload) => rejectPayment(upstream, translateError(failures, nextPayload.outgoingNodeId)) }
       context become main(pendingIncoming, pendingOutgoing - id)
 
     case ack: CommandBuffer.CommandAck => commandBuffer forward ack
@@ -207,21 +202,19 @@ object NodeRelayer {
    */
   case class PendingResult(upstream: Upstream.TrampolineRelayed, nextPayload: Onion.NodeRelayPayload)
 
-  def validateRelay(nodeParams: NodeParams, upstream: Upstream.TrampolineRelayed, payloadOut: Onion.NodeRelayPayload): Option[FailureMessage] = {
+  private def validateRelay(nodeParams: NodeParams, upstream: Upstream.TrampolineRelayed, payloadOut: Onion.NodeRelayPayload): Option[FailureMessage] = {
     val fee = nodeFee(nodeParams.feeBase, nodeParams.feeProportionalMillionth, payloadOut.amountToForward)
     if (upstream.amountIn - payloadOut.amountToForward < fee) {
-      // TODO: @t-bast: should be a TrampolineFeeInsufficient(upstream.amountIn, myLatestNodeUpdate)
-      Some(IncorrectOrUnknownPaymentDetails(upstream.amountIn, nodeParams.currentBlockHeight))
+      Some(TrampolineFeeInsufficient)
     } else if (upstream.expiryIn - payloadOut.outgoingCltv < nodeParams.expiryDeltaBlocks) {
-      // TODO: @t-bast: should be a TrampolineExpiryTooSoon(myLatestNodeUpdate)
-      Some(IncorrectOrUnknownPaymentDetails(upstream.amountIn, nodeParams.currentBlockHeight))
+      Some(TrampolineExpiryTooSoon)
     } else {
       None
     }
   }
 
   /** Compute route params that honor our fee and cltv requirements. */
-  def computeRouteParams(nodeParams: NodeParams, amountIn: MilliSatoshi, expiryIn: CltvExpiry, amountOut: MilliSatoshi, expiryOut: CltvExpiry): RouteParams = {
+  private def computeRouteParams(nodeParams: NodeParams, amountIn: MilliSatoshi, expiryIn: CltvExpiry, amountOut: MilliSatoshi, expiryOut: CltvExpiry): RouteParams = {
     val routeMaxCltv = expiryIn - expiryOut - nodeParams.expiryDeltaBlocks
     val routeMaxFee = amountIn - amountOut - nodeFee(nodeParams.feeBase, nodeParams.feeProportionalMillionth, amountOut)
     Router.getDefaultRouteParams(nodeParams.routerConf).copy(
@@ -229,6 +222,29 @@ object NodeRelayer {
       routeMaxCltv = routeMaxCltv,
       maxFeePct = 0 // we disable percent-based max fee calculation, we're only interested in collecting our node fee
     )
+  }
+
+  /**
+   * This helper method translates relaying errors (returned by the downstream nodes) to a BOLT 4 standard error that we
+   * should return upstream.
+   */
+  private def translateError(failures: Seq[PaymentFailure], outgoingNodeId: PublicKey): Option[FailureMessage] = {
+    def tooManyRouteNotFound(failures: Seq[PaymentFailure]): Boolean = {
+      val routeNotFoundCount = failures.count(_ == LocalFailure(RouteNotFound))
+      routeNotFoundCount > failures.length / 2
+    }
+
+    failures match {
+      case Nil => None
+      case LocalFailure(MultiPartPaymentLifecycle.BalanceTooLow) :: Nil => Some(TemporaryNodeFailure) // we don't have enough outgoing liquidity at the moment
+      case _ if tooManyRouteNotFound(failures) => Some(TrampolineFeeInsufficient) // if we couldn't find routes, it's likely that the fee/cltv was insufficient
+      case _ =>
+        // Otherwise, we try to find a downstream error that we could decrypt.
+        val outgoingNodeFailure = failures.collectFirst { case RemoteFailure(_, e) if e.originNode == outgoingNodeId => e.failureMessage }
+        val otherNodeFailure = failures.collectFirst { case RemoteFailure(_, e) => e.failureMessage }
+        val failure = outgoingNodeFailure.getOrElse(otherNodeFailure.getOrElse(TemporaryNodeFailure))
+        Some(failure)
+    }
   }
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -234,7 +234,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
     // This is hackish and won't work if the first child payment fails and is retried, but it's okay-ish for an MVP.
     // We will update the DB schema to contain accurate Trampoline reporting, which will fix that in the future.
     // TODO: @t-bast: fix that once the DB schema is updated
-    val trampolineData = if (includeTrampolineFees) cfg.trampolineData else cfg.trampolineData.map(_.copy(trampolineFees = 0 msat))
+    val trampolineData = if (includeTrampolineFees) cfg.trampolineData else cfg.trampolineData.map(_.copy(trampolineAttempts = Nil))
     val childCfg = cfg.copy(id = childId, publishEvent = false, upstream = upstream, trampolineData = trampolineData)
     context.actorOf(PaymentLifecycle.props(nodeParams, childCfg, router, register))
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -26,10 +26,10 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.SendMultiPartPayment
 import fr.acinq.eclair.payment.send.PaymentLifecycle.{SendPayment, SendPaymentToRoute}
-import fr.acinq.eclair.payment.{LocalFailure, OutgoingPacket, PaymentFailed, PaymentRequest}
+import fr.acinq.eclair.payment._
 import fr.acinq.eclair.router.{NodeHop, RouteParams}
 import fr.acinq.eclair.wire.Onion.FinalLegacyPayload
-import fr.acinq.eclair.wire.{Onion, OnionTlv}
+import fr.acinq.eclair.wire.{Onion, OnionTlv, TrampolineExpiryTooSoon, TrampolineFeeInsufficient}
 import fr.acinq.eclair.{CltvExpiryDelta, LongToBtcAmount, MilliSatoshi, NodeParams, randomBytes32}
 
 /**
@@ -39,7 +39,9 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, relayer: ActorR
 
   import PaymentInitiator._
 
-  override def receive: Receive = {
+  override def receive: Receive = main(Map.empty)
+
+  def main(pending: Map[UUID, PendingPayment]): Receive = {
     case r: SendPaymentRequest =>
       val paymentId = UUID.randomUUID()
       sender ! paymentId
@@ -67,34 +69,64 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, relayer: ActorR
     case r: SendTrampolinePaymentRequest =>
       val paymentId = UUID.randomUUID()
       sender ! paymentId
-      if (!r.paymentRequest.features.allowTrampoline && r.paymentRequest.amount.isEmpty) {
+      if (r.trampolineAttempts.isEmpty) {
+        sender ! PaymentFailed(paymentId, r.paymentRequest.paymentHash, LocalFailure(new IllegalArgumentException("trampoline fees and cltv expiry delta are missing")) :: Nil)
+      } else if (!r.paymentRequest.features.allowTrampoline && r.paymentRequest.amount.isEmpty) {
         sender ! PaymentFailed(paymentId, r.paymentRequest.paymentHash, LocalFailure(new IllegalArgumentException("cannot pay a 0-value invoice via trampoline-to-legacy (trampoline may steal funds)")) :: Nil)
       } else {
-        val paymentCfg = SendPaymentConfig(paymentId, paymentId, None, r.paymentRequest.paymentHash, r.trampolineNodeId, Upstream.Local(paymentId), Some(r.paymentRequest), storeInDb = true, publishEvent = true, Some(r))
-        val finalPayload = if (r.paymentRequest.features.allowMultiPart) {
-          Onion.createMultiPartPayload(r.finalAmount, r.finalAmount, r.finalExpiry(nodeParams.currentBlockHeight), r.paymentRequest.paymentSecret.get)
-        } else {
-          Onion.createSinglePartPayload(r.finalAmount, r.finalExpiry(nodeParams.currentBlockHeight), r.paymentRequest.paymentSecret)
-        }
-        val trampolineRoute = Seq(
-          NodeHop(nodeParams.nodeId, r.trampolineNodeId, nodeParams.expiryDeltaBlocks, 0 msat),
-          NodeHop(r.trampolineNodeId, r.paymentRequest.nodeId, r.trampolineExpiryDelta, r.trampolineFees) // for now we only use a single trampoline hop
-        )
-        // We assume that the trampoline node supports multi-part payments (it should).
-        val (trampolineAmount, trampolineExpiry, trampolineOnion) = if (r.paymentRequest.features.allowTrampoline) {
-          OutgoingPacket.buildPacket(Sphinx.TrampolinePacket)(r.paymentRequest.paymentHash, trampolineRoute, finalPayload)
-        } else {
-          OutgoingPacket.buildTrampolineToLegacyPacket(r.paymentRequest, trampolineRoute, finalPayload)
-        }
-        // We generate a random secret for this payment to avoid leaking the invoice secret to the first trampoline node.
-        val trampolineSecret = randomBytes32
-        spawnMultiPartPaymentFsm(paymentCfg) forward SendMultiPartPayment(r.paymentRequest.paymentHash, trampolineSecret, r.trampolineNodeId, trampolineAmount, trampolineExpiry, 1, r.paymentRequest.routingInfo, r.routeParams, Seq(OnionTlv.TrampolineOnion(trampolineOnion.packet)))
+        val (trampolineFees, trampolineExpiryDelta) =  r.trampolineAttempts.head
+        log.info(s"sending trampoline payment with trampoline fees=$trampolineFees and expiry delta=$trampolineExpiryDelta")
+        sendTrampolinePayment(paymentId, r, r.trampolineAttempts.head._1, r.trampolineAttempts.head._2)
+        context become main(pending + (paymentId -> PendingPayment(sender, r.trampolineAttempts.tail, r)))
       }
+
+    case pf: PaymentFailed => pending.get(pf.id).foreach(pp => {
+      val decryptedFailures = pf.failures.collect { case RemoteFailure(_, Sphinx.DecryptedFailurePacket(_, f)) => f }
+      val shouldRetry = pp.remainingAttempts.nonEmpty && (decryptedFailures.contains(TrampolineFeeInsufficient) || decryptedFailures.contains(TrampolineExpiryTooSoon))
+      if (shouldRetry) {
+        val (trampolineFees, trampolineExpiryDelta) =  pp.remainingAttempts.head
+        log.info(s"retrying trampoline payment with trampoline fees=$trampolineFees and expiry delta=$trampolineExpiryDelta")
+        sendTrampolinePayment(pf.id, pp.r, trampolineFees, trampolineExpiryDelta)
+        context become main(pending + (pf.id -> pp.copy(remainingAttempts = pp.remainingAttempts.tail)))
+      } else {
+        pp.sender ! pf
+        context.system.eventStream.publish(pf)
+        context become main(pending - pf.id)
+      }
+    })
+
+    case ps: PaymentSent => pending.get(ps.id).foreach(pp => {
+      pp.sender ! ps
+      context.system.eventStream.publish(ps)
+      context become main(pending - ps.id)
+    })
   }
 
   def spawnPaymentFsm(paymentCfg: SendPaymentConfig): ActorRef = context.actorOf(PaymentLifecycle.props(nodeParams, paymentCfg, router, register))
 
   def spawnMultiPartPaymentFsm(paymentCfg: SendPaymentConfig): ActorRef = context.actorOf(MultiPartPaymentLifecycle.props(nodeParams, paymentCfg, relayer, router, register))
+
+  private def sendTrampolinePayment(paymentId: UUID, r: SendTrampolinePaymentRequest, trampolineFees: MilliSatoshi, trampolineExpiryDelta: CltvExpiryDelta): Unit = {
+    val paymentCfg = SendPaymentConfig(paymentId, paymentId, None, r.paymentRequest.paymentHash, r.trampolineNodeId, Upstream.Local(paymentId), Some(r.paymentRequest), storeInDb = true, publishEvent = false, Some(r.copy(trampolineAttempts = Seq((trampolineFees, trampolineExpiryDelta)))))
+    val finalPayload = if (r.paymentRequest.features.allowMultiPart) {
+      Onion.createMultiPartPayload(r.finalAmount, r.finalAmount, r.finalExpiry(nodeParams.currentBlockHeight), r.paymentRequest.paymentSecret.get)
+    } else {
+      Onion.createSinglePartPayload(r.finalAmount, r.finalExpiry(nodeParams.currentBlockHeight), r.paymentRequest.paymentSecret)
+    }
+    val trampolineRoute = Seq(
+      NodeHop(nodeParams.nodeId, r.trampolineNodeId, nodeParams.expiryDeltaBlocks, 0 msat),
+      NodeHop(r.trampolineNodeId, r.paymentRequest.nodeId, trampolineExpiryDelta, trampolineFees) // for now we only use a single trampoline hop
+    )
+    // We assume that the trampoline node supports multi-part payments (it should).
+    val (trampolineAmount, trampolineExpiry, trampolineOnion) = if (r.paymentRequest.features.allowTrampoline) {
+      OutgoingPacket.buildPacket(Sphinx.TrampolinePacket)(r.paymentRequest.paymentHash, trampolineRoute, finalPayload)
+    } else {
+      OutgoingPacket.buildTrampolineToLegacyPacket(r.paymentRequest, trampolineRoute, finalPayload)
+    }
+    // We generate a random secret for this payment to avoid leaking the invoice secret to the first trampoline node.
+    val trampolineSecret = randomBytes32
+    spawnMultiPartPaymentFsm(paymentCfg) ! SendMultiPartPayment(r.paymentRequest.paymentHash, trampolineSecret, r.trampolineNodeId, trampolineAmount, trampolineExpiry, 1, r.paymentRequest.routingInfo, r.routeParams, Seq(OnionTlv.TrampolineOnion(trampolineOnion.packet)))
+  }
 
 }
 
@@ -102,19 +134,28 @@ object PaymentInitiator {
 
   def props(nodeParams: NodeParams, router: ActorRef, relayer: ActorRef, register: ActorRef) = Props(classOf[PaymentInitiator], nodeParams, router, relayer, register)
 
+  case class PendingPayment(sender: ActorRef, remainingAttempts: Seq[(MilliSatoshi, CltvExpiryDelta)], r: SendTrampolinePaymentRequest)
+
   /**
    * We temporarily let the caller decide to use Trampoline (instead of a normal payment) and set the fees/cltv.
-   * It's the caller's responsibility to retry with a higher fee/cltv on certain failures.
    * Once we have trampoline fee estimation built into the router, the decision to use Trampoline or not should be done
    * automatically by the router instead of the caller.
-   * TODO: @t-bast: remove this message once full Trampoline is implemented.
+   *
+   * @param finalAmount        amount that should be received by the final recipient (usually from a Bolt 11 invoice).
+   * @param paymentRequest     Bolt 11 invoice.
+   * @param trampolineNodeId   id of the trampoline node.
+   * @param trampolineAttempts fees and expiry delta for the trampoline node. If this list contains multiple entries,
+   *                           the payment will automatically be retried in case of TrampolineFeeInsufficient errors.
+   *                           For example, [(10 msat, 144), (15 msat, 288)] will first send a payment with a fee of 10
+   *                           msat and cltv of 144, and retry with 15 msat and 288 in case an error occurs.
+   * @param finalExpiryDelta   expiry delta for the final recipient.
+   * @param routeParams        (optional) parameters to fine-tune the routing algorithm.
    */
   case class SendTrampolinePaymentRequest(finalAmount: MilliSatoshi,
-                                          trampolineFees: MilliSatoshi,
                                           paymentRequest: PaymentRequest,
                                           trampolineNodeId: PublicKey,
+                                          trampolineAttempts: Seq[(MilliSatoshi, CltvExpiryDelta)],
                                           finalExpiryDelta: CltvExpiryDelta = Channel.MIN_CLTV_EXPIRY_DELTA,
-                                          trampolineExpiryDelta: CltvExpiryDelta,
                                           routeParams: Option[RouteParams] = None) {
     // We add one block in order to not have our htlcs fail when a new block has just been found.
     def finalExpiry(currentBlockHeight: Long) = finalExpiryDelta.toCltvExpiry(currentBlockHeight + 1)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
@@ -27,9 +27,10 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.PaymentRequest.{ExtraHop, Features}
 import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM
 import fr.acinq.eclair.payment.relay.{CommandBuffer, NodeRelayer}
-import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.SendMultiPartPayment
+import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.{BalanceTooLow, SendMultiPartPayment}
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentConfig
 import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPayment
+import fr.acinq.eclair.router.RouteNotFound
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, LongToBtcAmount, MilliSatoshi, NodeParams, ShortChannelId, TestConstants, TestkitBaseClass, nodeFee, randomBytes, randomBytes32, randomKey}
 import org.scalatest.Outcome
@@ -130,9 +131,7 @@ class NodeRelayerSpec extends TestkitBaseClass {
     val p = createValidIncomingPacket(2000000 msat, 2000000 msat, expiryIn, 1000000 msat, expiryOut)
     relayer.send(nodeRelayer, p)
 
-    // TODO: @t-bast: should be an Expiry failure
-    val failure = IncorrectOrUnknownPaymentDetails(2000000 msat, nodeParams.currentBlockHeight)
-    commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(failure), commit = true)))
+    commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineExpiryTooSoon), commit = true)))
     commandBuffer.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -144,14 +143,12 @@ class NodeRelayerSpec extends TestkitBaseClass {
     val expiryIn2 = CltvExpiry(500000) // not ok (delta = 100)
     val expiryOut = CltvExpiry(499900)
     val p = Seq(
-      createValidIncomingPacket(2000000 msat, 3000000 msat, expiryIn1, 2500000 msat, expiryOut),
-      createValidIncomingPacket(1000000 msat, 3000000 msat, expiryIn2, 2500000 msat, expiryOut)
+      createValidIncomingPacket(2000000 msat, 3000000 msat, expiryIn1, 2100000 msat, expiryOut),
+      createValidIncomingPacket(1000000 msat, 3000000 msat, expiryIn2, 2100000 msat, expiryOut)
     )
     p.foreach(p => relayer.send(nodeRelayer, p))
 
-    // TODO: @t-bast: should be an Expiry failure
-    val failure = IncorrectOrUnknownPaymentDetails(3000000 msat, nodeParams.currentBlockHeight)
-    p.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(failure), commit = true))))
+    p.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineExpiryTooSoon), commit = true))))
     commandBuffer.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -162,9 +159,7 @@ class NodeRelayerSpec extends TestkitBaseClass {
     val p = createValidIncomingPacket(2000000 msat, 2000000 msat, CltvExpiry(500000), 1999000 msat, CltvExpiry(490000))
     relayer.send(nodeRelayer, p)
 
-    // TODO: @t-bast: should be a Fee failure
-    val failure = IncorrectOrUnknownPaymentDetails(2000000 msat, nodeParams.currentBlockHeight)
-    commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(failure), commit = true)))
+    commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true)))
     commandBuffer.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -178,11 +173,39 @@ class NodeRelayerSpec extends TestkitBaseClass {
     )
     p.foreach(p => relayer.send(nodeRelayer, p))
 
-    // TODO: @t-bast: should be a Fee failure
-    val failure = IncorrectOrUnknownPaymentDetails(3000000 msat, nodeParams.currentBlockHeight)
-    p.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(failure), commit = true))))
+    p.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true))))
     commandBuffer.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
+  }
+
+  test("fail to relay because outgoing balance isn't sufficient") { f =>
+    import f._
+
+    // Receive an upstream multi-part payment.
+    incomingMultiPart.foreach(p => relayer.send(nodeRelayer, p))
+    val outgoingPaymentId = outgoingPayFSM.expectMsgType[SendPaymentConfig].id
+    outgoingPayFSM.expectMsgType[SendMultiPartPayment]
+
+    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, LocalFailure(BalanceTooLow) :: Nil))
+    incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TemporaryNodeFailure), commit = true))))
+    commandBuffer.expectNoMsg(100 millis)
+    eventListener.expectNoMsg(100 millis)
+  }
+
+  test("fail to relay because incoming fee isn't enough to find routes downstream") { f =>
+    import f._
+
+    // Receive an upstream multi-part payment.
+    incomingMultiPart.foreach(p => relayer.send(nodeRelayer, p))
+    val outgoingPaymentId = outgoingPayFSM.expectMsgType[SendPaymentConfig].id
+    outgoingPayFSM.expectMsgType[SendMultiPartPayment]
+
+    // If we're having a hard time finding routes, raising the fee/cltv will likely help.
+    val failures = LocalFailure(RouteNotFound) :: RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, PermanentNodeFailure)) :: LocalFailure(RouteNotFound) :: Nil
+    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, failures))
+    incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true))))
+    commandBuffer.expectNoMsg(100 millis)
+    eventListener.expectNoMsg(100 millis)
   }
 
   test("fail to relay because of downstream failures") { f =>
@@ -193,8 +216,9 @@ class NodeRelayerSpec extends TestkitBaseClass {
     val outgoingPaymentId = outgoingPayFSM.expectMsgType[SendPaymentConfig].id
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
-    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, Nil))
-    incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(IncorrectOrUnknownPaymentDetails(incomingAmount, nodeParams.currentBlockHeight)), commit = true))))
+    val failures = RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, FinalIncorrectHtlcAmount(42 msat))) :: UnreadableRemoteFailure(Nil) :: LocalFailure(RouteNotFound) :: Nil
+    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, failures))
+    incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(FinalIncorrectHtlcAmount(42 msat)), commit = true))))
     commandBuffer.expectNoMsg(100 millis)
     eventListener.expectNoMsg(100 millis)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -32,8 +32,8 @@ import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentConfig, SendPay
 import fr.acinq.eclair.payment.send.PaymentLifecycle.{SendPayment, SendPaymentToRoute}
 import fr.acinq.eclair.router.RouteParams
 import fr.acinq.eclair.wire.Onion.FinalLegacyPayload
-import fr.acinq.eclair.wire.{OnionCodecs, OnionTlv}
-import fr.acinq.eclair.{CltvExpiryDelta, LongToBtcAmount, NodeParams, TestConstants, randomKey}
+import fr.acinq.eclair.wire.{OnionCodecs, OnionTlv, TrampolineFeeInsufficient}
+import fr.acinq.eclair.{CltvExpiryDelta, LongToBtcAmount, NodeParams, TestConstants, randomBytes32, randomKey}
 import org.scalatest.{Outcome, fixture}
 import scodec.bits.HexStringSyntax
 
@@ -45,11 +45,13 @@ import scala.concurrent.duration._
 
 class PaymentInitiatorSpec extends TestKit(ActorSystem("test")) with fixture.FunSuiteLike {
 
-  case class FixtureParam(nodeParams: NodeParams, initiator: TestActorRef[PaymentInitiator], payFsm: TestProbe, multiPartPayFsm: TestProbe, sender: TestProbe)
+  case class FixtureParam(nodeParams: NodeParams, initiator: TestActorRef[PaymentInitiator], payFsm: TestProbe, multiPartPayFsm: TestProbe, sender: TestProbe, eventListener: TestProbe)
 
   override def withFixture(test: OneArgTest): Outcome = {
     val nodeParams = TestConstants.Alice.nodeParams
     val (sender, payFsm, multiPartPayFsm) = (TestProbe(), TestProbe(), TestProbe())
+    val eventListener = TestProbe()
+    system.eventStream.subscribe(eventListener.ref, classOf[PaymentEvent])
     class TestPaymentInitiator extends PaymentInitiator(nodeParams, TestProbe().ref, TestProbe().ref, TestProbe().ref) {
       // @formatter:off
       override def spawnPaymentFsm(cfg: SendPaymentConfig): ActorRef = {
@@ -63,7 +65,7 @@ class PaymentInitiatorSpec extends TestKit(ActorSystem("test")) with fixture.Fun
       // @formatter:on
     }
     val initiator = TestActorRef(new TestPaymentInitiator().asInstanceOf[PaymentInitiator])
-    withFixture(test.toNoArgTest(FixtureParam(nodeParams, initiator, payFsm, multiPartPayFsm, sender)))
+    withFixture(test.toNoArgTest(FixtureParam(nodeParams, initiator, payFsm, multiPartPayFsm, sender, eventListener)))
   }
 
   test("reject payment with unknown mandatory feature") { f =>
@@ -132,7 +134,7 @@ class PaymentInitiatorSpec extends TestKit(ActorSystem("test")) with fixture.Fun
     val ignoredRoutingHints = List(List(ExtraHop(b, channelUpdate_bc.shortChannelId, feeBase = 10 msat, feeProportionalMillionths = 1, cltvExpiryDelta = CltvExpiryDelta(12))))
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, "Some phoenix invoice", features = Some(features), extraHops = ignoredRoutingHints)
     val trampolineFees = 21000 msat
-    val req = SendTrampolinePaymentRequest(finalAmount, trampolineFees, pr, b, CltvExpiryDelta(9), CltvExpiryDelta(12))
+    val req = SendTrampolinePaymentRequest(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), CltvExpiryDelta(9))
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -172,7 +174,7 @@ class PaymentInitiatorSpec extends TestKit(ActorSystem("test")) with fixture.Fun
     import f._
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, "Some eclair-mobile invoice")
     val trampolineFees = 21000 msat
-    val req = SendTrampolinePaymentRequest(finalAmount, trampolineFees, pr, b, CltvExpiryDelta(9), CltvExpiryDelta(12))
+    val req = SendTrampolinePaymentRequest(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), CltvExpiryDelta(9))
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -205,7 +207,7 @@ class PaymentInitiatorSpec extends TestKit(ActorSystem("test")) with fixture.Fun
     val features = Features(VariableLengthOnion.optional, PaymentSecret.optional, BasicMultiPartPayment.optional)
     val pr = PaymentRequest(Block.RegtestGenesisBlock.hash, None, paymentHash, priv_a.privateKey, "#abittooreckless", None, None, routingHints, features = Some(features))
     val trampolineFees = 21000 msat
-    val req = SendTrampolinePaymentRequest(finalAmount, trampolineFees, pr, b, CltvExpiryDelta(9), CltvExpiryDelta(12))
+    val req = SendTrampolinePaymentRequest(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), CltvExpiryDelta(9))
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
@@ -214,6 +216,66 @@ class PaymentInitiatorSpec extends TestKit(ActorSystem("test")) with fixture.Fun
 
     multiPartPayFsm.expectNoMsg(50 millis)
     payFsm.expectNoMsg(50 millis)
+  }
+
+  test("retry trampoline payment") { f =>
+    import f._
+    val features = Features(VariableLengthOnion.optional, PaymentSecret.optional, BasicMultiPartPayment.optional, TrampolinePayment.optional)
+    val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, "Some phoenix invoice", features = Some(features))
+    val trampolineAttempts = (21000 msat, CltvExpiryDelta(12)) :: (25000 msat, CltvExpiryDelta(24)) :: Nil
+    val req = SendTrampolinePaymentRequest(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9))
+    sender.send(initiator, req)
+    sender.expectMsgType[UUID]
+    val cfg = multiPartPayFsm.expectMsgType[SendPaymentConfig]
+    assert(cfg.storeInDb)
+    assert(!cfg.publishEvent)
+
+    val msg1 = multiPartPayFsm.expectMsgType[SendMultiPartPayment]
+    assert(msg1.totalAmount === finalAmount + 21000.msat)
+
+    // Simulate a failure which should trigger a retry.
+    multiPartPayFsm.send(initiator, PaymentFailed(cfg.parentId, pr.paymentHash, Seq(RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(b, TrampolineFeeInsufficient)))))
+    multiPartPayFsm.expectMsgType[SendPaymentConfig]
+    val msg2 = multiPartPayFsm.expectMsgType[SendMultiPartPayment]
+    assert(msg2.totalAmount === finalAmount + 25000.msat)
+
+    // Simulate success which should publish the event and respond to the original sender.
+    val success = PaymentSent(cfg.parentId, pr.paymentHash, randomBytes32, Seq(PaymentSent.PartialPayment(UUID.randomUUID(), 1000 msat, 500 msat, randomBytes32, None)))
+    multiPartPayFsm.send(initiator, success)
+    sender.expectMsg(success)
+    eventListener.expectMsg(success)
+    sender.expectNoMsg(100 millis)
+    eventListener.expectNoMsg(100 millis)
+  }
+
+  test("retry trampoline payment and fail") { f =>
+    import f._
+    val features = Features(VariableLengthOnion.optional, PaymentSecret.optional, BasicMultiPartPayment.optional, TrampolinePayment.optional)
+    val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, "Some phoenix invoice", features = Some(features))
+    val trampolineAttempts = (21000 msat, CltvExpiryDelta(12)) :: (25000 msat, CltvExpiryDelta(24)) :: Nil
+    val req = SendTrampolinePaymentRequest(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9))
+    sender.send(initiator, req)
+    sender.expectMsgType[UUID]
+    val cfg = multiPartPayFsm.expectMsgType[SendPaymentConfig]
+    assert(cfg.storeInDb)
+    assert(!cfg.publishEvent)
+
+    val msg1 = multiPartPayFsm.expectMsgType[SendMultiPartPayment]
+    assert(msg1.totalAmount === finalAmount + 21000.msat)
+
+    // Simulate a failure which should trigger a retry.
+    val failed = PaymentFailed(cfg.parentId, pr.paymentHash, Seq(RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(b, TrampolineFeeInsufficient))))
+    multiPartPayFsm.send(initiator, failed)
+    multiPartPayFsm.expectMsgType[SendPaymentConfig]
+    val msg2 = multiPartPayFsm.expectMsgType[SendMultiPartPayment]
+    assert(msg2.totalAmount === finalAmount + 25000.msat)
+
+    // Simulate a failure that exhausts payment attempts.
+    multiPartPayFsm.send(initiator, failed)
+    sender.expectMsg(failed)
+    eventListener.expectMsg(failed)
+    sender.expectNoMsg(100 millis)
+    eventListener.expectNoMsg(100 millis)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.payment.PaymentPacketSpec._
 import fr.acinq.eclair.payment.PaymentRequest.{ExtraHop, Features}
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.SendMultiPartPayment
 import fr.acinq.eclair.payment.send.PaymentInitiator
-import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentConfig, SendPaymentRequest, SendTrampolinePaymentRequest}
+import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentConfig, SendPaymentRequest, SendTrampolinePaymentRequest, TrampolineLegacyAmountLessInvoice}
 import fr.acinq.eclair.payment.send.PaymentLifecycle.{SendPayment, SendPaymentToRoute}
 import fr.acinq.eclair.router.RouteParams
 import fr.acinq.eclair.wire.Onion.FinalLegacyPayload
@@ -212,7 +212,7 @@ class PaymentInitiatorSpec extends TestKit(ActorSystem("test")) with fixture.Fun
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
     assert(fail.id === id)
-    assert(fail.failures.head.isInstanceOf[LocalFailure])
+    assert(fail.failures === LocalFailure(TrampolineLegacyAmountLessInvoice) :: Nil)
 
     multiPartPayFsm.expectNoMsg(50 millis)
     payFsm.expectNoMsg(50 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/FailureMessageCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/FailureMessageCodecsSpec.scala
@@ -47,7 +47,8 @@ class FailureMessageCodecsSpec extends FunSuite {
         InvalidOnionVersion(randomBytes32) :: InvalidOnionHmac(randomBytes32) :: InvalidOnionKey(randomBytes32) ::
         TemporaryChannelFailure(channelUpdate) :: PermanentChannelFailure :: RequiredChannelFeatureMissing :: UnknownNextPeer ::
         AmountBelowMinimum(123456 msat, channelUpdate) :: FeeInsufficient(546463 msat, channelUpdate) :: IncorrectCltvExpiry(CltvExpiry(1211), channelUpdate) :: ExpiryTooSoon(channelUpdate) ::
-        IncorrectOrUnknownPaymentDetails(123456 msat, 1105) :: FinalIncorrectCltvExpiry(CltvExpiry(1234)) :: ChannelDisabled(0, 1, channelUpdate) :: ExpiryTooFar :: InvalidOnionPayload(UInt64(561), 1105) :: PaymentTimeout :: Nil
+        IncorrectOrUnknownPaymentDetails(123456 msat, 1105) :: FinalIncorrectCltvExpiry(CltvExpiry(1234)) :: ChannelDisabled(0, 1, channelUpdate) :: ExpiryTooFar :: InvalidOnionPayload(UInt64(561), 1105) :: PaymentTimeout ::
+        TrampolineFeeInsufficient :: TrampolineExpiryTooSoon :: Nil
 
     msgs.foreach {
       msg => {


### PR DESCRIPTION
We add new errors that let senders know they need to raise the trampoline fee/ctlv.
When the error is downstream, we select the best error to forward.