### PR TITLE
Provide additional information to KeyManager.sign

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
@@ -24,7 +24,7 @@ import fr.acinq.bitcoin.DeterministicWallet.ExtendedPublicKey
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Crypto, DeterministicWallet, Protocol}
 import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.channel.{ChannelVersion, LocalParams}
-import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo
+import fr.acinq.eclair.transactions.Transactions.{CommitTxInfo, TransactionWithInputInfo}
 import scodec.bits.ByteVector
 
 trait KeyManager {
@@ -64,7 +64,17 @@ trait KeyManager {
   def newFundingKeyPath(isFunder: Boolean) : DeterministicWallet.KeyPath
 
   /**
-    *
+    * Sign a commitment transaction
+    * @param tx        input transaction
+    * @param txInfo    additional transaction info for validation
+    * @param publicKey extended public key
+    * @return a signature generated with the private key that matches the input
+    *         extended public key
+    */
+  def sign(tx: TransactionWithInputInfo, txInfo: CommitTxInfo, publicKey: ExtendedPublicKey): ByteVector64
+
+    /**
+    * Sign a closing transaction
     * @param tx        input transaction
     * @param publicKey extended public key
     * @return a signature generated with the private key that matches the input

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
@@ -22,7 +22,7 @@ import fr.acinq.bitcoin.DeterministicWallet.{derivePrivateKey, _}
 import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Crypto, DeterministicWallet}
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.transactions.Transactions
-import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo
+import fr.acinq.eclair.transactions.Transactions.{CommitTxInfo, TransactionWithInputInfo}
 import fr.acinq.eclair.{ShortChannelId, secureRandom}
 import scodec.bits.ByteVector
 
@@ -101,7 +101,22 @@ class LocalKeyManager(seed: ByteVector, chainHash: ByteVector32) extends KeyMana
   override def commitmentPoint(channelKeyPath: DeterministicWallet.KeyPath, index: Long) = Generators.perCommitPoint(shaSeed(channelKeyPath), index)
 
   /**
-    *
+    * Sign commitment transaction
+    * @param tx        input transaction
+    * @param txInfo    additional transaction info for validation
+    * @param publicKey extended public key
+    * @return a signature generated with the private key that matches the input
+    *         extended public key
+    */
+  def sign(tx: TransactionWithInputInfo, txInfo: CommitTxInfo, publicKey: ExtendedPublicKey): ByteVector64 = {
+    require(tx.tx.txOut.size == txInfo.outputRedeemScripts.size)
+    val privateKey = privateKeys.get(publicKey.path)
+    Transactions.sign(tx, privateKey.privateKey)
+  }
+
+
+  /**
+    * Sign closing transaction
     * @param tx        input transaction
     * @param publicKey extended public key
     * @return a signature generated with the private key that matches the input

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TestVectorsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TestVectorsSpec.scala
@@ -183,7 +183,7 @@ class TestVectorsSpec extends FunSuite with Logging {
     logger.info(s"local_feerate_per_kw: ${spec.feeratePerKw}")
 
     val commitTx = {
-      val tx = Transactions.makeCommitTx(
+      val (tx, scripts) = Transactions.makeCommitTx(
         commitmentInput,
         Local.commitTxNumber, Local.payment_basepoint, Remote.payment_basepoint,
         true, Local.dustLimit,
@@ -192,6 +192,7 @@ class TestVectorsSpec extends FunSuite with Logging {
         Local.payment_privkey.publicKey, Remote.payment_privkey.publicKey, // note: we have payment_key = htlc_key
         spec)
 
+      assert(tx.tx.txOut.size == scripts.size)
       val local_sig = Transactions.sign(tx, Local.funding_privkey)
       val remote_sig = Transactions.sign(tx, Remote.funding_privkey)
 
@@ -213,7 +214,7 @@ class TestVectorsSpec extends FunSuite with Logging {
     })
 
     {
-      val tx = Transactions.makeCommitTx(
+      val (tx, scripts) = Transactions.makeCommitTx(
         commitmentInput,
         Local.commitTxNumber, Local.payment_basepoint, Remote.payment_basepoint,
         true, Local.dustLimit,
@@ -222,6 +223,7 @@ class TestVectorsSpec extends FunSuite with Logging {
         Local.payment_privkey.publicKey, Remote.payment_privkey.publicKey, // note: we have payment_key = htlc_key
         spec)
 
+      assert(tx.tx.txOut.size == scripts.size)
       val local_sig = Transactions.sign(tx, Local.funding_privkey)
       logger.info(s"# local_signature = ${local_sig.dropRight(1).toHex}")
       val remote_sig = Transactions.sign(tx, Remote.funding_privkey)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -204,10 +204,11 @@ class TransactionsSpec extends FunSuite with Logging {
 
     val commitTxNumber = 0x404142434445L
     val commitTx = {
-      val txinfo = makeCommitTx(commitInput, commitTxNumber, localPaymentPriv.publicKey, remotePaymentPriv.publicKey, true, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, remotePaymentPriv.publicKey, localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, spec)
-      val localSig = Transactions.sign(txinfo, localPaymentPriv)
-      val remoteSig = Transactions.sign(txinfo, remotePaymentPriv)
-      Transactions.addSigs(txinfo, localFundingPriv.publicKey, remoteFundingPriv.publicKey, localSig, remoteSig)
+      val (commitTx, scripts) = makeCommitTx(commitInput, commitTxNumber, localPaymentPriv.publicKey, remotePaymentPriv.publicKey, true, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, remotePaymentPriv.publicKey, localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, spec)
+      val localSig = Transactions.sign(commitTx, localPaymentPriv)
+      val remoteSig = Transactions.sign(commitTx, remotePaymentPriv)
+      assert(commitTx.tx.txOut.size == scripts.size)
+      Transactions.addSigs(commitTx, localFundingPriv.publicKey, remoteFundingPriv.publicKey, localSig, remoteSig)
     }
 
     {


### PR DESCRIPTION
This will allow an external signer to fully validate the transaction.

For example, providing the redeem scripts allows checking:

- the OP_CHECKSEQUENCEVERIFY delay
- that a remote transaction really sends funds to us
- etc.

For more background on the external signer strategy, see https://gitlab.com/ksedgwic/liposig/-/wikis/Lightning-Policy-Signing-PoC
