### PR TITLE
Remove mockito from switchboard tests

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -106,15 +106,19 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
    */
   def getPeer(remoteNodeId: PublicKey): Option[ActorRef] = context.child(peerActorName(remoteNodeId))
 
+  def createPeer(remoteNodeId: PublicKey): ActorRef = context.actorOf(
+    Peer.props(nodeParams, remoteNodeId, authenticator, watcher, router, relayer, paymentHandler, wallet),
+    name = peerActorName(remoteNodeId))
+
   /**
    * @param previousKnownAddress only to be set if we know for sure that this ip worked in the past
    */
-  def createOrGetPeer(remoteNodeId: PublicKey, previousKnownAddress: Option[InetSocketAddress], offlineChannels: Set[HasCommitments]) = {
+  def createOrGetPeer(remoteNodeId: PublicKey, previousKnownAddress: Option[InetSocketAddress], offlineChannels: Set[HasCommitments]): ActorRef = {
     getPeer(remoteNodeId) match {
       case Some(peer) => peer
       case None =>
         log.info(s"creating new peer current=${context.children.size}")
-        val peer = context.actorOf(Peer.props(nodeParams, remoteNodeId, authenticator, watcher, router, relayer, paymentHandler, wallet), name = peerActorName(remoteNodeId))
+        val peer = createPeer(remoteNodeId)
         peer ! Peer.Init(previousKnownAddress, offlineChannels)
         peer
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
@@ -1,99 +1,51 @@
 package fr.acinq.eclair.io
 
-import java.io.File
-
 import akka.actor.{ActorRef, ActorSystem}
-import akka.testkit.{TestKit, TestProbe}
+import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import fr.acinq.bitcoin.ByteVector64
 import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.TestConstants._
 import fr.acinq.eclair.blockchain.TestWallet
-import fr.acinq.eclair.db._
 import fr.acinq.eclair.wire._
-import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.FunSuiteLike
 import scodec.bits._
 
-class SwitchboardSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with IdiomaticMockito {
+class SwitchboardSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
+
+  class TestSwitchboard(nodeParams: NodeParams, remoteNodeId: PublicKey, remotePeer: TestProbe) extends Switchboard(nodeParams, TestProbe().ref, TestProbe().ref, TestProbe().ref, TestProbe().ref, TestProbe().ref, new TestWallet()) {
+    override def createPeer(remoteNodeId2: PublicKey): ActorRef = {
+      assert(remoteNodeId === remoteNodeId2)
+      remotePeer.ref
+    }
+  }
 
   test("on initialization create peers and send Reconnect to them") {
-    val mockNetworkDb = mock[NetworkDb]
-    val nodeParams = Alice.nodeParams.copy(
-      db = new Databases {
-        override val network: NetworkDb = mockNetworkDb
-        override val audit: AuditDb = Alice.nodeParams.db.audit
-        override val channels: ChannelsDb = Alice.nodeParams.db.channels
-        override val peers: PeersDb = Alice.nodeParams.db.peers
-        override val payments: PaymentsDb = Alice.nodeParams.db.payments
-        override val pendingRelay: PendingRelayDb = Alice.nodeParams.db.pendingRelay
-
-        override def backup(file: File): Unit = ()
-      }
-    )
-
+    val nodeParams = Alice.nodeParams
+    val peer = TestProbe()
     val remoteNodeId = ChannelCodecsSpec.normal.commitments.remoteParams.nodeId
-    val authenticator = TestProbe()
-    val watcher = TestProbe()
-    val router = TestProbe()
-    val relayer = TestProbe()
-    val paymentHandler = TestProbe()
-    val wallet = new TestWallet()
-    val probe = TestProbe()
-
-    // mock the call that will be done by the peer once it receives Peer.Reconnect
-    mockNetworkDb.getNode(remoteNodeId) returns Some(
-      NodeAnnouncement(ByteVector64.Zeroes, ByteVector.empty, 0, remoteNodeId, Color(0, 0, 0), "alias", List(NodeAddress.fromParts("127.0.0.1", 9735).get))
-    )
-
-    // add a channel to the db
+    val remoteNodeAddress = NodeAddress.fromParts("127.0.0.1", 9735).get
+    nodeParams.db.peers.addOrUpdatePeer(remoteNodeId, remoteNodeAddress)
+    nodeParams.db.network.addNode(NodeAnnouncement(ByteVector64.Zeroes, ByteVector.empty, 0, remoteNodeId, Color(0, 0, 0), "alias", remoteNodeAddress :: Nil))
+    // If we have a channel with that remote peer, we will automatically reconnect.
     nodeParams.db.channels.addOrUpdateChannel(ChannelCodecsSpec.normal)
 
-    val switchboard = system.actorOf(Switchboard.props(nodeParams, authenticator.ref, watcher.ref, router.ref, relayer.ref, paymentHandler.ref, wallet))
-
-    probe.send(switchboard, 'peers)
-    val List(peer) = probe.expectMsgType[Iterable[ActorRef]].toList
-    assert(peer.path.name == Switchboard.peerActorName(remoteNodeId))
-
-    // assert that the peer called `networkDb.getNode` - because it received a Peer.Reconnect
-    awaitAssert(mockNetworkDb.getNode(remoteNodeId).wasCalled(once))
+    val _ = TestActorRef(new TestSwitchboard(nodeParams, remoteNodeId, peer))
+    peer.expectMsg(Peer.Init(Some(remoteNodeAddress.socketAddress), Set(ChannelCodecsSpec.normal)))
+    peer.expectMsg(Peer.Reconnect)
   }
 
   test("when connecting to a new peer forward Peer.Connect to it") {
-    val mockNetworkDb = mock[NetworkDb]
-    val nodeParams = Alice.nodeParams.copy(
-      db = new Databases {
-        override val network: NetworkDb = mockNetworkDb
-        override val audit: AuditDb = Alice.nodeParams.db.audit
-        override val channels: ChannelsDb = Alice.nodeParams.db.channels
-        override val peers: PeersDb = Alice.nodeParams.db.peers
-        override val payments: PaymentsDb = Alice.nodeParams.db.payments
-        override val pendingRelay: PendingRelayDb = Alice.nodeParams.db.pendingRelay
-
-        override def backup(file: File): Unit = ()
-      }
-    )
-
+    val nodeParams = Alice.nodeParams
+    val (probe, peer) = (TestProbe(), TestProbe())
     val remoteNodeId = PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f")
-    val authenticator = TestProbe()
-    val watcher = TestProbe()
-    val router = TestProbe()
-    val relayer = TestProbe()
-    val paymentHandler = TestProbe()
-    val wallet = new TestWallet()
-    val probe = TestProbe()
+    val remoteNodeAddress = NodeAddress.fromParts("127.0.0.1", 9735).get
+    nodeParams.db.network.addNode(NodeAnnouncement(ByteVector64.Zeroes, ByteVector.empty, 0, remoteNodeId, Color(0, 0, 0), "alias", remoteNodeAddress :: Nil))
 
-    // mock the call that will be done by the peer once it receives Peer.Connect(remoteNodeId)
-    mockNetworkDb.getNode(remoteNodeId) returns Some(
-      NodeAnnouncement(ByteVector64.Zeroes, ByteVector.empty, 0, remoteNodeId, Color(0, 0, 0), "alias", List(NodeAddress.fromParts("127.0.0.1", 9735).get))
-    )
-
-    val switchboard = system.actorOf(Switchboard.props(nodeParams, authenticator.ref, watcher.ref, router.ref, relayer.ref, paymentHandler.ref, wallet))
-
-    // send Peer.Connect to switchboard, it will forward to the Peer and the peer will look up the address on the db
+    val switchboard = TestActorRef(new TestSwitchboard(nodeParams, remoteNodeId, peer))
     probe.send(switchboard, Peer.Connect(remoteNodeId, None))
-
-    // assert that the peer called `networkDb.getNode` - because it received a Peer.Connect(remoteNodeId, None)
-    awaitAssert(mockNetworkDb.getNode(remoteNodeId).wasCalled(once))
+    peer.expectMsg(Peer.Init(None, Set.empty))
+    peer.expectMsg(Peer.Connect(remoteNodeId, None))
   }
 
 }


### PR DESCRIPTION
Mockito sometimes throws an unnecessary stubbing exception.
I wasn't able to reproduce it frequently enough to troubleshoot
and it doesn't provide enough data for investigation.

I chose to re-write the tests without mockito to make them more flexible.
In case they randomly fail we should hopefully get more useful data
to help troubleshooting.