### PR TITLE
Disable Trampoline-MPP to non-Phoenix recipients

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
@@ -254,7 +254,8 @@ class NodeRelayerSpec extends TestkitBaseClass {
     commandBuffer.expectNoMsg(100 millis)
   }
 
-  test("relay to non-trampoline recipient supporting multi-part") { f =>
+  // TODO: re-activate this test once we have better MPP split to remote legacy recipients
+  ignore("relay to non-trampoline recipient supporting multi-part") { f =>
     import f._
 
     // Receive an upstream multi-part payment.


### PR DESCRIPTION
This is safer for now since the splitting algorithm isn't working
well on nodes with a large number of channels and we don't
expect too many payments from Phoenix to non-Phoenix to
actually need MPP in the short term.