### PR TITLE
Fix how we split channel ids in channel queries

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -123,7 +123,7 @@ eclair {
     sync {
       request-node-announcements = true // if true we will ask for node announcements when we receive channel ids that we don't know
       encoding-type = zlib // encoding for short_channel_ids and timestamps in query channel sync messages; other possible value is "uncompressed"
-      channel-range-chunk-size = 2500 // max number of short_channel_ids (+ timestamps + checksums) in reply_channel_range *do not change this unless you know what you are doing*
+      channel-range-chunk-size = 1500 // max number of short_channel_ids (+ timestamps + checksums) in reply_channel_range *do not change this unless you know what you are doing*
       channel-query-chunk-size = 100 // max number of short_channel_ids in query_short_channel_ids *do not change this unless you know what you are doing*
     }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -26,6 +26,8 @@ case class ShortChannelId(private val id: Long) extends Ordered[ShortChannelId] 
 
   def toLong: Long = id
 
+  def blockHeight = ShortChannelId.blockHeight(this)
+
   override def toString: String = {
     val TxCoordinates(blockHeight, txIndex, outputIndex) = ShortChannelId.coordinates(this)
     s"${blockHeight}x${txIndex}x${outputIndex}"
@@ -46,7 +48,16 @@ object ShortChannelId {
 
   def toShortId(blockHeight: Int, txIndex: Int, outputIndex: Int): Long = ((blockHeight & 0xFFFFFFL) << 40) | ((txIndex & 0xFFFFFFL) << 16) | (outputIndex & 0xFFFFL)
 
-  def coordinates(shortChannelId: ShortChannelId): TxCoordinates = TxCoordinates(((shortChannelId.id >> 40) & 0xFFFFFF).toInt, ((shortChannelId.id >> 16) & 0xFFFFFF).toInt, (shortChannelId.id & 0xFFFF).toInt)
+  @inline
+  def blockHeight(shortChannelId: ShortChannelId) = ((shortChannelId.id >> 40) & 0xFFFFFF).toInt
+
+  @inline
+  def txIndex(shortChannelId: ShortChannelId) = ((shortChannelId.id >> 16) & 0xFFFFFF).toInt
+
+  @inline
+  def outputIndex(shortChannelId: ShortChannelId) = (shortChannelId.id & 0xFFFF).toInt
+
+  def coordinates(shortChannelId: ShortChannelId): TxCoordinates = TxCoordinates(blockHeight(shortChannelId), txIndex(shortChannelId), outputIndex(shortChannelId))
 }
 
 case class TxCoordinates(blockHeight: Int, txIndex: Int, outputIndex: Int)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -1218,7 +1218,7 @@ object Router {
         // we use a random offset here, so even if shortChannelIds.size is much bigger than maximumSize (which should
         // not happen) peers will eventually receive info about all channels in this chunk
         val offset = Random.nextInt(shortChannelIds.size - maximumSize)
-        this.copy(shortChannelIds = this.shortChannelIds.drop(offset).take(maximumSize))
+        this.copy(shortChannelIds = this.shortChannelIds.slice(offset, offset + maximumSize))
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -71,6 +71,7 @@ case class RouterConf(randomizeRouteSelection: Boolean,
 
 // @formatter:off
 case class ChannelDesc(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey)
+
 case class PublicChannel(ann: ChannelAnnouncement, fundingTxid: ByteVector32, capacity: Satoshi, update_1_opt: Option[ChannelUpdate], update_2_opt: Option[ChannelUpdate]) {
   update_1_opt.foreach(u => assert(Announcements.isNode1(u.channelFlags)))
   update_2_opt.foreach(u => assert(!Announcements.isNode1(u.channelFlags)))
@@ -81,6 +82,7 @@ case class PublicChannel(ann: ChannelAnnouncement, fundingTxid: ByteVector32, ca
 
   def updateChannelUpdateSameSideAs(u: ChannelUpdate): PublicChannel = if (Announcements.isNode1(u.channelFlags)) copy(update_1_opt = Some(u)) else copy(update_2_opt = Some(u))
 }
+
 case class PrivateChannel(localNodeId: PublicKey, remoteNodeId: PublicKey, update_1_opt: Option[ChannelUpdate], update_2_opt: Option[ChannelUpdate]) {
   val (nodeId1, nodeId2) = if (Announcements.isNode1(localNodeId, remoteNodeId)) (localNodeId, remoteNodeId) else (remoteNodeId, localNodeId)
 
@@ -90,6 +92,7 @@ case class PrivateChannel(localNodeId: PublicKey, remoteNodeId: PublicKey, updat
 
   def updateChannelUpdateSameSideAs(u: ChannelUpdate): PrivateChannel = if (Announcements.isNode1(u.channelFlags)) copy(update_1_opt = Some(u)) else copy(update_2_opt = Some(u))
 }
+
 // @formatter:on
 
 case class AssistedChannel(extraHop: ExtraHop, nextNodeId: PublicKey, htlcMaximum: MilliSatoshi)
@@ -158,7 +161,9 @@ case class RouteResponse(hops: Seq[ChannelHop], ignoreNodes: Set[PublicKey], ign
 // @formatter:off
 /** This is used when we get a TemporaryChannelFailure, to give time for the channel to recover (note that exclusions are directed) */
 case class ExcludeChannel(desc: ChannelDesc)
+
 case class LiftChannelExclusion(desc: ChannelDesc)
+
 // @formatter:on
 
 case class SendChannelQuery(remoteNodeId: PublicKey, to: ActorRef, flags_opt: Option[QueryChannelRangeTlv])
@@ -194,11 +199,15 @@ case class Data(nodes: Map[PublicKey, NodeAnnouncement],
 
 // @formatter:off
 sealed trait State
+
 case object NORMAL extends State
 
 case object TickBroadcast
+
 case object TickPruneStaleChannels
+
 case object TickComputeNetworkStats
+
 // @formatter:on
 
 class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Promise[Done]] = None) extends FSMDiagnosticActorLogging[State, Data] {
@@ -1206,20 +1215,34 @@ object Router {
    * there could be several reply_channel_range messages for a single query
    */
   def split(shortChannelIds: SortedSet[ShortChannelId], channelRangeChunkSize: Int): List[ShortChannelIdsChunk] = {
-    // this algorithm can split blocks (meaning that we can in theory generate several replies with the same first_block/num_blocks
-    // and a different set of short_channel_ids) but it doesn't matter
     if (shortChannelIds.isEmpty) {
       List(ShortChannelIdsChunk(0, 0, List.empty))
     } else {
-      shortChannelIds
-        .grouped(channelRangeChunkSize)
-        .toList
-        .map { group =>
-          // NB: group is never empty
-          val firstBlock: Long = ShortChannelId.coordinates(group.head).blockHeight.toLong
-          val numBlocks: Long = ShortChannelId.coordinates(group.last).blockHeight.toLong - firstBlock + 1
-          ShortChannelIdsChunk(firstBlock, numBlocks, group.toList)
+
+      // we use an iterator for efficiency
+      val it = shortChannelIds.iterator
+
+      // we want to split ids in different chunks, with the following rules by order of priority
+      // ids that have the same block height must be grouped in the same chunk
+      // chunk should contain `channelRangeChunkSize` ids
+      @tailrec
+      def loop(currentHeight: Int, currentChunk: List[ShortChannelId], acc: List[ShortChannelIdsChunk]): List[ShortChannelIdsChunk] = {
+        if (it.hasNext) {
+          val id = it.next()
+          if (id.blockHeight == currentHeight)
+            loop(currentHeight, id :: currentChunk, acc) // same height => always add to the current chunk
+          else if (currentChunk.size < channelRangeChunkSize) // different height but we're under the size target => add to the current chunk
+            loop(id.blockHeight, id :: currentChunk, acc) // different height and over the size target => start a new chunk
+          else {
+            // we always prepend because it's more efficient so we have to reverse the current chunk
+            loop(id.blockHeight, id :: Nil, ShortChannelIdsChunk(currentChunk.last.blockHeight, currentChunk.head.blockHeight - currentChunk.last.blockHeight + 1, currentChunk.reverse) :: acc)
+          }
         }
+        else (ShortChannelIdsChunk(currentChunk.last.blockHeight, currentChunk.head.blockHeight - currentChunk.last.blockHeight + 1, currentChunk.reverse) :: acc).reverse
+      }
+
+      val first = it.next()
+      loop(ShortChannelId.coordinates(first).blockHeight, first :: Nil, Nil)
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -41,7 +41,7 @@ import scodec.bits.ByteVector
 import shapeless.HNil
 
 import scala.annotation.tailrec
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{Queue, SortedMap}
 import scala.collection.{SortedSet, mutable}
 import scala.compat.Platform
 import scala.concurrent.duration._
@@ -642,10 +642,11 @@ class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[
           val shortChannelIds: SortedSet[ShortChannelId] = d.channels.keySet.filter(keep(firstBlockNum, numberOfBlocks, _))
           log.info("replying with {} items for range=({}, {})", shortChannelIds.size, firstBlockNum, numberOfBlocks)
           val chunks = Kamon.runWithSpan(Kamon.spanBuilder("split-channel-ids").start(), finishSpan = true) {
-            split(shortChannelIds, firstBlockNum, numberOfBlocks, nodeParams.routerConf.channelRangeChunkSize)
+            enforceMaximumSize(
+              split(shortChannelIds, firstBlockNum, numberOfBlocks, nodeParams.routerConf.channelRangeChunkSize),
+              Random.nextBoolean())
           }
 
-          // we make sure that our replies cover the range specified in their queries
           Kamon.runWithSpan(Kamon.spanBuilder("compute-timestamps-checksums").start(), finishSpan = true) {
             chunks.foreach { chunk =>
               val (timestamps, checksums) = routingMessage.queryFlags_opt match {
@@ -944,6 +945,13 @@ object Router {
   val shortChannelIdKey = Context.key[ShortChannelId]("shortChannelId", ShortChannelId(0))
   val remoteNodeIdKey = Context.key[String]("remoteNodeId", "unknown")
 
+  // maximum number of ids we can keep in a single chunk and still have an encoded reply that is smaller than 65Kb
+  // please note that:
+  // - this is based on the worst case scenario where peer want timestamps and checksums and the reply is not compressed
+  // - the maximum number of public channels in a single block so far is less than 300, and the maximum number of tx per block
+  // almost never exceeds 2800 so this is not a real limitation yet
+  val MAXIMUM_CHUNK_SIZE = 3200
+
   def props(nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Promise[Done]] = None) = Props(new Router(nodeParams, watcher, initialized))
 
   def toFakeUpdate(extraHop: ExtraHop, htlcMaximum: MilliSatoshi): ChannelUpdate = {
@@ -1015,7 +1023,7 @@ object Router {
    * Filters channels that we want to send to nodes asking for a channel range
    */
   def keep(firstBlockNum: Long, numberOfBlocks: Long, id: ShortChannelId): Boolean = {
-    val TxCoordinates(height, _, _) = ShortChannelId.coordinates(id)
+    val height = id.blockHeight
     height >= firstBlockNum && height < (firstBlockNum + numberOfBlocks)
   }
 
@@ -1201,13 +1209,32 @@ object Router {
     crc32c(data)
   }
 
-  case class ShortChannelIdsChunk(firstBlock: Long, numBlocks: Long, shortChannelIds: List[ShortChannelId])
+  case class ShortChannelIdsChunk(firstBlock: Long, numBlocks: Long, shortChannelIds: List[ShortChannelId]) {
+    /**
+     *
+     * @param maximumSize maximum size of the short channel ids list
+     * @param keepFirst if true, keep the first elements, otherwise keep the last ones
+     * @return a chunk with at most `maximumSize` ids
+     */
+    def enforceMaximumSize(maximumSize: Int, keepFirst: Boolean) = {
+      if (shortChannelIds.size <= maximumSize) this else this.copy(shortChannelIds = if (keepFirst) this.shortChannelIds.take(maximumSize) else this.shortChannelIds.takeRight(maximumSize))
+    }
+  }
 
   /**
-   * Have to split ids because otherwise message could be too big
-   * there could be several reply_channel_range messages for a single query
+   * Split short channel ids into chunks, because otherwise message could be too big
+   * there could be several reply_channel_range messages for a single query, but we make sure that the returned
+   * chunks fully covers the [firstBlockNum, numberOfBlocks] range that was requested
+   *
+   * @param shortChannelIds list of short channel ids to split
+   * @param firstBlockNum first block height requested by our peers
+   * @param numberOfBlocks number of blocks requested by our peer
+   * @param channelRangeChunkSize target chunk size. All ids that have the same block height will be grouped together, so
+   *                              returned chunks may still contain more than `channelRangeChunkSize` elements
+   * @return a list of short channel id chunks
    */
   def split(shortChannelIds: SortedSet[ShortChannelId], firstBlockNum: Long, numberOfBlocks: Long, channelRangeChunkSize: Int): List[ShortChannelIdsChunk] = {
+    // see BOLT7: MUST encode a short_channel_id for every open channel it knows in blocks first_blocknum to first_blocknum plus number_of_blocks minus one
     val it = shortChannelIds.iterator.dropWhile(_.blockHeight < firstBlockNum).takeWhile(_.blockHeight < firstBlockNum + numberOfBlocks)
     if (it.isEmpty) {
       List(ShortChannelIdsChunk(firstBlockNum, numberOfBlocks, List.empty))
@@ -1244,6 +1271,14 @@ object Router {
       loop(first :: Nil, Nil)
     }
   }
+
+  /**
+   * Enforce max-size constraints for each chunk
+   * @param chunks list of short channel id chunks
+   * @param keepFirst flags that specifies wether to keep to first of last ids when there are too many of them
+   * @return a processed list of chunks
+   */
+  def enforceMaximumSize(chunks: List[ShortChannelIdsChunk], keepFirst: => Boolean) : List[ShortChannelIdsChunk] = chunks.map(_.enforceMaximumSize(MAXIMUM_CHUNK_SIZE, keepFirst))
 
   def addToSync(syncMap: Map[PublicKey, Sync], remoteNodeId: PublicKey, pending: List[RoutingMessage]): (Map[PublicKey, Sync], Option[RoutingMessage]) = {
     pending match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -1217,7 +1217,7 @@ object Router {
       if (shortChannelIds.size <= maximumSize) this else {
         // we use a random offset here, so even if shortChannelIds.size is much bigger than maximumSize (which should
         // not happen) peers will eventually receive info about all channels in this chunk
-        val offset = Random.nextInt(shortChannelIds.size - maximumSize)
+        val offset = Random.nextInt(shortChannelIds.size - maximumSize + 1)
         this.copy(shortChannelIds = this.shortChannelIds.slice(offset, offset + maximumSize))
       }
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -71,7 +71,6 @@ case class RouterConf(randomizeRouteSelection: Boolean,
 
 // @formatter:off
 case class ChannelDesc(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey)
-
 case class PublicChannel(ann: ChannelAnnouncement, fundingTxid: ByteVector32, capacity: Satoshi, update_1_opt: Option[ChannelUpdate], update_2_opt: Option[ChannelUpdate]) {
   update_1_opt.foreach(u => assert(Announcements.isNode1(u.channelFlags)))
   update_2_opt.foreach(u => assert(!Announcements.isNode1(u.channelFlags)))
@@ -82,7 +81,6 @@ case class PublicChannel(ann: ChannelAnnouncement, fundingTxid: ByteVector32, ca
 
   def updateChannelUpdateSameSideAs(u: ChannelUpdate): PublicChannel = if (Announcements.isNode1(u.channelFlags)) copy(update_1_opt = Some(u)) else copy(update_2_opt = Some(u))
 }
-
 case class PrivateChannel(localNodeId: PublicKey, remoteNodeId: PublicKey, update_1_opt: Option[ChannelUpdate], update_2_opt: Option[ChannelUpdate]) {
   val (nodeId1, nodeId2) = if (Announcements.isNode1(localNodeId, remoteNodeId)) (localNodeId, remoteNodeId) else (remoteNodeId, localNodeId)
 
@@ -92,7 +90,6 @@ case class PrivateChannel(localNodeId: PublicKey, remoteNodeId: PublicKey, updat
 
   def updateChannelUpdateSameSideAs(u: ChannelUpdate): PrivateChannel = if (Announcements.isNode1(u.channelFlags)) copy(update_1_opt = Some(u)) else copy(update_2_opt = Some(u))
 }
-
 // @formatter:on
 
 case class AssistedChannel(extraHop: ExtraHop, nextNodeId: PublicKey, htlcMaximum: MilliSatoshi)
@@ -161,9 +158,7 @@ case class RouteResponse(hops: Seq[ChannelHop], ignoreNodes: Set[PublicKey], ign
 // @formatter:off
 /** This is used when we get a TemporaryChannelFailure, to give time for the channel to recover (note that exclusions are directed) */
 case class ExcludeChannel(desc: ChannelDesc)
-
 case class LiftChannelExclusion(desc: ChannelDesc)
-
 // @formatter:on
 
 case class SendChannelQuery(remoteNodeId: PublicKey, to: ActorRef, flags_opt: Option[QueryChannelRangeTlv])
@@ -199,15 +194,11 @@ case class Data(nodes: Map[PublicKey, NodeAnnouncement],
 
 // @formatter:off
 sealed trait State
-
 case object NORMAL extends State
 
 case object TickBroadcast
-
 case object TickPruneStaleChannels
-
 case object TickComputeNetworkStats
-
 // @formatter:on
 
 class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[Promise[Done]] = None) extends FSMDiagnosticActorLogging[State, Data] {
@@ -1226,23 +1217,24 @@ object Router {
       // ids that have the same block height must be grouped in the same chunk
       // chunk should contain `channelRangeChunkSize` ids
       @tailrec
-      def loop(currentHeight: Int, currentChunk: List[ShortChannelId], acc: List[ShortChannelIdsChunk]): List[ShortChannelIdsChunk] = {
+      def loop(currentChunk: List[ShortChannelId], acc: List[ShortChannelIdsChunk]): List[ShortChannelIdsChunk] = {
         if (it.hasNext) {
           val id = it.next()
+          val currentHeight = currentChunk.head.blockHeight
           if (id.blockHeight == currentHeight)
-            loop(currentHeight, id :: currentChunk, acc) // same height => always add to the current chunk
+            loop(id :: currentChunk, acc) // same height => always add to the current chunk
           else if (currentChunk.size < channelRangeChunkSize) // different height but we're under the size target => add to the current chunk
-            loop(id.blockHeight, id :: currentChunk, acc) // different height and over the size target => start a new chunk
+            loop(id :: currentChunk, acc) // different height and over the size target => start a new chunk
           else {
             // we always prepend because it's more efficient so we have to reverse the current chunk
-            loop(id.blockHeight, id :: Nil, ShortChannelIdsChunk(currentChunk.last.blockHeight, currentChunk.head.blockHeight - currentChunk.last.blockHeight + 1, currentChunk.reverse) :: acc)
+            loop(id :: Nil, ShortChannelIdsChunk(currentChunk.last.blockHeight, currentChunk.head.blockHeight - currentChunk.last.blockHeight + 1, currentChunk.reverse) :: acc)
           }
         }
         else (ShortChannelIdsChunk(currentChunk.last.blockHeight, currentChunk.head.blockHeight - currentChunk.last.blockHeight + 1, currentChunk.reverse) :: acc).reverse
       }
 
       val first = it.next()
-      loop(ShortChannelId.coordinates(first).blockHeight, first :: Nil, Nil)
+      loop(first :: Nil, Nil)
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -1275,7 +1275,7 @@ object Router {
   /**
    * Enforce max-size constraints for each chunk
    * @param chunks list of short channel id chunks
-   * @param keepFirst flags that specifies wether to keep to first of last ids when there are too many of them
+   * @param keepFirst flags that specifies whether to keep first of last ids when there are too many of them
    * @return a processed list of chunks
    */
   def enforceMaximumSize(chunks: List[ShortChannelIdsChunk], keepFirst: => Boolean) : List[ShortChannelIdsChunk] = chunks.map(_.enforceMaximumSize(MAXIMUM_CHUNK_SIZE, keepFirst))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -186,7 +186,6 @@ class ChannelRangeQueriesSpec extends FunSuite {
       val chunks = Router.split(SortedSet.empty[ShortChannelId] ++ ids, firstBlockNum, numberOfBlocks, ids.size)
       assert(chunks == ShortChannelIdsChunk(firstBlockNum, numberOfBlocks, Nil) :: Nil)
     }
-    assert(Router.split(SortedSet.empty[ShortChannelId], 100, 1000, 100) == ShortChannelIdsChunk(100, 1000, Nil) :: Nil)
 
     // ids are all atfer the requested range
     {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -174,6 +174,19 @@ class ChannelRangeQueriesSpec extends FunSuite {
     require(noOverlap(chunks))
   }
 
+    test("limit channel ids chunk size") {
+    val ids = makeShortChannelIds(1, 3)
+    val chunk = ShortChannelIdsChunk(0, 10, ids)
+
+    val res1 = for (_ <- 0 until 100) yield chunk.enforceMaximumSize(1).shortChannelIds
+    assert(res1.toSet == Set(List(ids(0)), List(ids(1)), List(ids(2))))
+
+    val res2 = for (_ <- 0 until 100) yield chunk.enforceMaximumSize(2).shortChannelIds
+    assert(res2.toSet == Set(List(ids(0), ids(1)), List(ids(1), ids(2))))
+
+    val res3 = for (_ <- 0 until 100) yield chunk.enforceMaximumSize(3).shortChannelIds
+    assert(res3.toSet == Set(List(ids(0), ids(1), ids(2))))
+  }
   test("split short channel ids correctly (basic tests") {
 
     def id(blockHeight: Int, txIndex: Int = 0, outputIndex: Int = 0) = ShortChannelId(blockHeight, txIndex, outputIndex)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -149,7 +149,7 @@ class ChannelRangeQueriesSpec extends FunSuite {
   }
 
   def validate(chunk: ShortChannelIdsChunk) = {
-    require(!chunk.shortChannelIds.exists(!Router.keep(chunk.firstBlock, chunk.numBlocks, _)))
+    require(chunk.shortChannelIds.forall(Router.keep(chunk.firstBlock, chunk.numBlocks, _)))
   }
 
   // check that chunks do not overlap and contain exactly the ids they were built from

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -132,7 +132,7 @@ class ChannelRangeQueriesSpec extends FunSuite {
   test("split short channel ids correctly ") {
     def makeShortChannelIds(height: Int, count: Int): SortedSet[ShortChannelId] = SortedSet.empty[ShortChannelId] ++ (0 until count).map(c => ShortChannelId(height, c, 0))
 
-    val ids = makeShortChannelIds(42, 100) ++ makeShortChannelIds(43, 70) ++ makeShortChannelIds(44, 50) ++ makeShortChannelIds(45, 30) ++ makeShortChannelIds(46, 120)
+    val ids = makeShortChannelIds(42, 100) ++ makeShortChannelIds(43, 70) ++ makeShortChannelIds(44, 50) ++ makeShortChannelIds(45, 30) ++ makeShortChannelIds(50, 120)
 
     // check that chunks do not overlap
     def validate(chunks: List[ShortChannelIdsChunk]) : Boolean = chunks match {
@@ -141,9 +141,10 @@ class ChannelRangeQueriesSpec extends FunSuite {
       case _ => validate(chunks.tail)
     }
 
-    assert(validate(Router.split(ids, 100)))
-    assert(validate(Router.split(ids, 50)))
+    assert(validate(Router.split(ids, 1)))
     assert(validate(Router.split(ids, 20)))
+    assert(validate(Router.split(ids, 50)))
+    assert(validate(Router.split(ids, 100)))
     assert(validate(Router.split(ids, 1000)))
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -25,6 +25,7 @@ import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
 import scala.collection.immutable.{SortedMap, SortedSet}
+import scala.collection.mutable.ArrayBuffer
 import scala.compat.Platform
 import scala.util.Random
 
@@ -131,7 +132,21 @@ class ChannelRangeQueriesSpec extends FunSuite {
     assert(Router.computeFlag(channels)(ef.shortChannelId, None, None, true) === (INCLUDE_CHANNEL_ANNOUNCEMENT | INCLUDE_CHANNEL_UPDATE_1 | INCLUDE_CHANNEL_UPDATE_2 | INCLUDE_NODE_ANNOUNCEMENT_1 | INCLUDE_NODE_ANNOUNCEMENT_2))
   }
 
-  def makeShortChannelIds(height: Int, count: Int): List[ShortChannelId] = (0 until count).map(c => ShortChannelId(height, c, 0)).toList
+  def makeShortChannelIds(height: Int, count: Int): List[ShortChannelId] = {
+    val output = ArrayBuffer.empty[ShortChannelId]
+    var txIndex = 0
+    var outputIndex = 0
+    while (output.size < count) {
+      if (Random.nextBoolean()) {
+        txIndex = txIndex + 1
+        outputIndex = 0
+      } else {
+        outputIndex = outputIndex + 1
+      }
+      output += ShortChannelId(height, txIndex, outputIndex)
+    }
+    output.toList
+  }
 
   def validate(chunk: ShortChannelIdsChunk) = {
     require(!chunk.shortChannelIds.exists(!Router.keep(chunk.firstBlock, chunk.numBlocks, _)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -187,6 +187,7 @@ class ChannelRangeQueriesSpec extends FunSuite {
     val res3 = for (_ <- 0 until 100) yield chunk.enforceMaximumSize(3).shortChannelIds
     assert(res3.toSet == Set(List(ids(0), ids(1), ids(2))))
   }
+
   test("split short channel ids correctly (basic tests") {
 
     def id(blockHeight: Int, txIndex: Int = 0, outputIndex: Int = 0) = ShortChannelId(blockHeight, txIndex, outputIndex)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -163,7 +163,7 @@ class ChannelRangeQueriesSpec extends FunSuite {
     }
 
     // aggregate ids from all chunks, to check that they match our input ids exactly
-    val chunkIds = SortedSet.empty[ShortChannelId] ++ chunks.map(_.shortChannelIds).flatten.toSet
+    val chunkIds = SortedSet.empty[ShortChannelId] ++ chunks.flatMap(_.shortChannelIds).toSet
     val expected = ids.filter(Router.keep(firstBlockNum, numberOfBlocks, _))
 
     if (expected.isEmpty) require(chunks == List(ShortChannelIdsChunk(firstBlockNum, numberOfBlocks, Nil)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
@@ -169,7 +169,7 @@ class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
         sender.send(bob, PeerRoutingMessage(sender.ref, charlieId, na2))
     }
     awaitCond(bob.stateData.channels.size === fakeRoutingInfo.size && countUpdates(bob.stateData.channels) === 2 * fakeRoutingInfo.size, max = 60 seconds)
-    assert(BasicSyncResult(ranges = 3, queries = 12, channels = fakeRoutingInfo.size, updates = 2 * fakeRoutingInfo.size, nodes = 2 * fakeRoutingInfo.size) === sync(alice, bob, extendedQueryFlags_opt).counts)
+    assert(BasicSyncResult(ranges = 3, queries = 13, channels = fakeRoutingInfo.size, updates = 2 * fakeRoutingInfo.size, nodes = 2 * fakeRoutingInfo.size) === sync(alice, bob, extendedQueryFlags_opt).counts)
     awaitCond(alice.stateData.channels === bob.stateData.channels, max = 60 seconds)
   }
 
@@ -218,7 +218,7 @@ class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
         sender.send(bob, PeerRoutingMessage(sender.ref, charlieId, na2))
     }
     awaitCond(bob.stateData.channels.size === fakeRoutingInfo.size && countUpdates(bob.stateData.channels) === 2 * fakeRoutingInfo.size,  max = 60 seconds)
-    assert(BasicSyncResult(ranges = 3, queries = 10, channels = fakeRoutingInfo.size - 10, updates = 2 * (fakeRoutingInfo.size - 10), nodes = if (requestNodeAnnouncements) 2 * (fakeRoutingInfo.size - 10) else 0) === sync(alice, bob, extendedQueryFlags_opt).counts)
+    assert(BasicSyncResult(ranges = 3, queries = 11, channels = fakeRoutingInfo.size - 10, updates = 2 * (fakeRoutingInfo.size - 10), nodes = if (requestNodeAnnouncements) 2 * (fakeRoutingInfo.size - 10) else 0) === sync(alice, bob, extendedQueryFlags_opt).counts)
     awaitCond(alice.stateData.channels === bob.stateData.channels, max = 60 seconds)
 
     // bump random channel_updates


### PR DESCRIPTION
We currently split in fixed-size chunks, which means that channel ids with the same block height may end up in different replies. Though this is not explicitly forbidden in the specs, it is implicitly required otherwise it becomes difficult to know when you've received all the replies you asked for and send another query.