### PR TITLE
Don't put the encoding type if there is no channel

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
@@ -22,7 +22,7 @@ import kamon.Kamon
 import kamon.tag.TagSet
 import scodec.bits.{BitVector, ByteVector}
 import scodec.codecs._
-import scodec.{Attempt, Codec}
+import scodec.{Attempt, Codec, DecodeResult}
 
 /**
  * Created by PM on 15/11/2016.
@@ -227,11 +227,15 @@ object LightningMessageCodecs {
     val innerCodec = discriminated[EncodedShortChannelIds].by(byte)
       .\(0) { case a@EncodedShortChannelIds(EncodingType.UNCOMPRESSED, _) => a }((provide[EncodingType](EncodingType.UNCOMPRESSED) :: list(shortchannelid)).as[EncodedShortChannelIds])
       .\(1) { case a@EncodedShortChannelIds(EncodingType.COMPRESSED_ZLIB, _) => a }((provide[EncodingType](EncodingType.COMPRESSED_ZLIB) :: zlib(list(shortchannelid))).as[EncodedShortChannelIds])
-    Codec[EncodedShortChannelIds]({
+    Codec[EncodedShortChannelIds](
+      (e: EncodedShortChannelIds) =>
         // if the list of channel id is empty, we don't encode anything (as opposed as indicating an encoding type without any data)
-      case e if e.array.isEmpty => Attempt.successful(BitVector.empty)
-      case e => innerCodec.encode(e)
-    }, bits => innerCodec.decode(bits))
+        if (e.array.isEmpty) Attempt.successful(BitVector.empty) else innerCodec.encode(e)
+      ,
+      (bits: BitVector) =>
+        // if data is empty, then we assume an empty list with a default encoding
+        if (bits.isEmpty) Attempt.successful(DecodeResult(EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List.empty), BitVector.empty)) else innerCodec.decode(bits)
+    )
   }
 
   val queryShortChannelIdsCodec: Codec[QueryShortChannelIds] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
@@ -223,10 +223,16 @@ object LightningMessageCodecs {
     ("signature" | bytes64) ::
       channelUpdateWitnessCodec).as[ChannelUpdate]
 
-  val encodedShortChannelIdsCodec: Codec[EncodedShortChannelIds] =
-    discriminated[EncodedShortChannelIds].by(byte)
+  val encodedShortChannelIdsCodec: Codec[EncodedShortChannelIds] = {
+    val innerCodec = discriminated[EncodedShortChannelIds].by(byte)
       .\(0) { case a@EncodedShortChannelIds(EncodingType.UNCOMPRESSED, _) => a }((provide[EncodingType](EncodingType.UNCOMPRESSED) :: list(shortchannelid)).as[EncodedShortChannelIds])
       .\(1) { case a@EncodedShortChannelIds(EncodingType.COMPRESSED_ZLIB, _) => a }((provide[EncodingType](EncodingType.COMPRESSED_ZLIB) :: zlib(list(shortchannelid))).as[EncodedShortChannelIds])
+    Codec[EncodedShortChannelIds]({
+        // if the list of channel id is empty, we don't encode anything (as opposed as indicating an encoding type without any data)
+      case e if e.array.isEmpty => Attempt.successful(BitVector.empty)
+      case e => innerCodec.encode(e)
+    }, bits => innerCodec.decode(bits))
+  }
 
   val queryShortChannelIdsCodec: Codec[QueryShortChannelIds] = {
     Codec(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
@@ -294,6 +294,7 @@ case class GossipTimestampFilter(chainHash: ByteVector32,
 
 //
 
+
 //
 
 //

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ExtendedQueriesCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ExtendedQueriesCodecsSpec.scala
@@ -22,9 +22,29 @@ import fr.acinq.eclair.wire.LightningMessageCodecs._
 import fr.acinq.eclair.wire.ReplyChannelRangeTlv._
 import fr.acinq.eclair.{CltvExpiryDelta, LongToBtcAmount, ShortChannelId, UInt64}
 import org.scalatest.FunSuite
-import scodec.bits.ByteVector
+import scodec.bits.{ByteVector, _}
 
 class ExtendedQueriesCodecsSpec extends FunSuite {
+
+  test("encode a list of short channel ids") {
+    {
+      // empty list
+      val ids = EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List.empty)
+      val encoded = encodedShortChannelIdsCodec.encode(ids).require
+      assert(encoded.bytes === hex"")
+      val decoded = encodedShortChannelIdsCodec.decode(encoded).require.value
+      assert(decoded === ids)
+    }
+
+    {
+      // encoded as uncompressed
+      val ids = EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List(ShortChannelId(142), ShortChannelId(15465), ShortChannelId(4564676)))
+      val encoded = encodedShortChannelIdsCodec.encode(ids).require
+      val decoded = encodedShortChannelIdsCodec.decode(encoded).require.value
+      assert(decoded === ids)
+    }
+  }
+
   test("encode query_short_channel_ids (no optional data)") {
     val query_short_channel_id = QueryShortChannelIds(
       Block.RegtestGenesisBlock.blockId,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ExtendedQueriesCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ExtendedQueriesCodecsSpec.scala
@@ -27,8 +27,25 @@ import scodec.bits.{ByteVector, _}
 class ExtendedQueriesCodecsSpec extends FunSuite {
 
   test("encode a list of short channel ids") {
+
     {
-      // empty list
+      // encode/decode with encoding 'uncompressed'
+      val ids = EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List(ShortChannelId(142), ShortChannelId(15465), ShortChannelId(4564676)))
+      val encoded = encodedShortChannelIdsCodec.encode(ids).require
+      val decoded = encodedShortChannelIdsCodec.decode(encoded).require.value
+      assert(decoded === ids)
+    }
+
+    {
+      // encode/decode with encoding 'zlib'
+      val ids = EncodedShortChannelIds(EncodingType.COMPRESSED_ZLIB, List(ShortChannelId(142), ShortChannelId(15465), ShortChannelId(4564676)))
+      val encoded = encodedShortChannelIdsCodec.encode(ids).require
+      val decoded = encodedShortChannelIdsCodec.decode(encoded).require.value
+      assert(decoded === ids)
+    }
+
+    {
+      // empty list with no encoding
       val ids = EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List.empty)
       val encoded = encodedShortChannelIdsCodec.encode(ids).require
       assert(encoded.bytes === hex"")
@@ -37,12 +54,19 @@ class ExtendedQueriesCodecsSpec extends FunSuite {
     }
 
     {
-      // encoded as uncompressed
-      val ids = EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List(ShortChannelId(142), ShortChannelId(15465), ShortChannelId(4564676)))
-      val encoded = encodedShortChannelIdsCodec.encode(ids).require
+      // decode empty list with encoding 'uncompressed'
+      val encoded = hex"00".bits
       val decoded = encodedShortChannelIdsCodec.decode(encoded).require.value
-      assert(decoded === ids)
+      assert(decoded === EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List.empty))
     }
+
+    {
+      // decode empty list with encoding 'zlib'
+      val encoded = hex"01".bits
+      val decoded = encodedShortChannelIdsCodec.decode(encoded).require.value
+      assert(decoded === EncodedShortChannelIds(EncodingType.COMPRESSED_ZLIB, List.empty))
+    }
+
   }
 
   test("encode query_short_channel_ids (no optional data)") {


### PR DESCRIPTION
If the list of channel ids is empty, we don't encode anything (as
opposed as indicating an encoding type without any data).

This fixes a compatibility issue with lnd.

TODO: refine the spec