### PR TITLE
Always encode empty list of scids as uncompressed

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
@@ -225,8 +225,14 @@ object LightningMessageCodecs {
 
   val encodedShortChannelIdsCodec: Codec[EncodedShortChannelIds] =
     discriminated[EncodedShortChannelIds].by(byte)
-      .\(0) { case a@EncodedShortChannelIds(EncodingType.UNCOMPRESSED, _) => a }((provide[EncodingType](EncodingType.UNCOMPRESSED) :: list(shortchannelid)).as[EncodedShortChannelIds])
-      .\(1) { case a@EncodedShortChannelIds(EncodingType.COMPRESSED_ZLIB, _) => a }((provide[EncodingType](EncodingType.COMPRESSED_ZLIB) :: zlib(list(shortchannelid))).as[EncodedShortChannelIds])
+      .\(0) {
+        case a@EncodedShortChannelIds(_, Nil) => a
+        case a@EncodedShortChannelIds(EncodingType.UNCOMPRESSED, _) => a
+      }((provide[EncodingType](EncodingType.UNCOMPRESSED) :: list(shortchannelid)).as[EncodedShortChannelIds])
+      .\(1) {
+        case a@EncodedShortChannelIds(EncodingType.COMPRESSED_ZLIB, _) => a
+      }((provide[EncodingType](EncodingType.COMPRESSED_ZLIB) :: zlib(list(shortchannelid))).as[EncodedShortChannelIds])
+
 
   val queryShortChannelIdsCodec: Codec[QueryShortChannelIds] = {
     Codec(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
@@ -226,7 +226,7 @@ object LightningMessageCodecs {
   val encodedShortChannelIdsCodec: Codec[EncodedShortChannelIds] =
     discriminated[EncodedShortChannelIds].by(byte)
       .\(0) {
-        case a@EncodedShortChannelIds(_, Nil) => a
+        case a@EncodedShortChannelIds(_, Nil) => a // empty list is always encoded with encoding type 'uncompressed' for compatibility with other implementations
         case a@EncodedShortChannelIds(EncodingType.UNCOMPRESSED, _) => a
       }((provide[EncodingType](EncodingType.UNCOMPRESSED) :: list(shortchannelid)).as[EncodedShortChannelIds])
       .\(1) {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ExtendedQueriesCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ExtendedQueriesCodecsSpec.scala
@@ -22,9 +22,46 @@ import fr.acinq.eclair.wire.LightningMessageCodecs._
 import fr.acinq.eclair.wire.ReplyChannelRangeTlv._
 import fr.acinq.eclair.{CltvExpiryDelta, LongToBtcAmount, ShortChannelId, UInt64}
 import org.scalatest.FunSuite
-import scodec.bits.ByteVector
+import scodec.bits.{ByteVector, _}
 
 class ExtendedQueriesCodecsSpec extends FunSuite {
+
+  test("encode a list of short channel ids") {
+    {
+      // encode/decode with encoding 'uncompressed'
+      val ids = EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List(ShortChannelId(142), ShortChannelId(15465), ShortChannelId(4564676)))
+      val encoded = encodedShortChannelIdsCodec.encode(ids).require
+      val decoded = encodedShortChannelIdsCodec.decode(encoded).require.value
+      assert(decoded === ids)
+    }
+
+    {
+      // encode/decode with encoding 'zlib'
+      val ids = EncodedShortChannelIds(EncodingType.COMPRESSED_ZLIB, List(ShortChannelId(142), ShortChannelId(15465), ShortChannelId(4564676)))
+      val encoded = encodedShortChannelIdsCodec.encode(ids).require
+      val decoded = encodedShortChannelIdsCodec.decode(encoded).require.value
+      assert(decoded === ids)
+    }
+
+    {
+      // encode/decode empty list with encoding 'uncompressed'
+      val ids = EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List.empty)
+      val encoded = encodedShortChannelIdsCodec.encode(ids).require
+      assert(encoded.bytes === hex"00")
+      val decoded = encodedShortChannelIdsCodec.decode(encoded).require.value
+      assert(decoded === ids)
+    }
+
+    {
+      // encode/decode empty list with encoding 'zlib'
+      val ids = EncodedShortChannelIds(EncodingType.COMPRESSED_ZLIB, List.empty)
+      val encoded = encodedShortChannelIdsCodec.encode(ids).require
+      assert(encoded.bytes === hex"00") // NB: empty list is always encoded with encoding type 'uncompressed'
+      val decoded = encodedShortChannelIdsCodec.decode(encoded).require.value
+      assert(decoded === EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List.empty))
+    }
+  }
+
   test("encode query_short_channel_ids (no optional data)") {
     val query_short_channel_id = QueryShortChannelIds(
       Block.RegtestGenesisBlock.blockId,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ExtendedQueriesCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ExtendedQueriesCodecsSpec.scala
@@ -22,7 +22,7 @@ import fr.acinq.eclair.wire.LightningMessageCodecs._
 import fr.acinq.eclair.wire.ReplyChannelRangeTlv._
 import fr.acinq.eclair.{CltvExpiryDelta, LongToBtcAmount, ShortChannelId, UInt64}
 import org.scalatest.FunSuite
-import scodec.bits.{ByteVector, _}
+import scodec.bits._
 
 class ExtendedQueriesCodecsSpec extends FunSuite {
 


### PR DESCRIPTION
For compatibility with c-lightning & lnd.

This is a simpler alternative to #1275.