### PR TITLE
Turn off SSL when custom Electrum server address is a hidden service

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -182,15 +182,11 @@ class Setup(datadir: File,
           val host = config.getString("electrum.host")
           val port = config.getInt("electrum.port")
           val address = InetSocketAddress.createUnresolved(host, port)
-          val ssl = if (address.getHostName.endsWith(".onion")) {
-            // Tor already adds end-to-end encryption, adding TLS on top doesn't add anything
-            SSL.OFF
-          } else {
-            config.getString("electrum.ssl") match {
+          val ssl = config.getString("electrum.ssl") match {
+              case _ if address.getHostName.endsWith(".onion") => SSL.OFF // Tor already adds end-to-end encryption, adding TLS on top doesn't add anything
               case "off" => SSL.OFF
               case "loose" => SSL.LOOSE
               case _ => SSL.STRICT // strict mode is the default when we specify a custom electrum server, we don't want to be MITMed
-            }
           }
 
           logger.info(s"override electrum default with server=$address ssl=$ssl")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -182,15 +182,15 @@ class Setup(datadir: File,
           val host = config.getString("electrum.host")
           val port = config.getInt("electrum.port")
           val address = InetSocketAddress.createUnresolved(host, port)
-          val ssl = config.getString("electrum.ssl") match {
-            case "off" => SSL.OFF
-            case "loose" => SSL.LOOSE
-            case _ => SSL.STRICT // strict mode is the default when we specify a custom electrum server, we don't want to be MITMed
-          }
-
-          // turn SSL verification off for a Tor hidden service
-          if (address.getHostName().endsWith(".onion")) {
-            ssl = SSL.OFF
+          val ssl = if (address.getHostName.endsWith(".onion")) {
+            // Tor already adds end-to-end encryption, adding TLS on top doesn't add anything
+            SSL.OFF
+          } else {
+            config.getString("electrum.ssl") match {
+              case "off" => SSL.OFF
+              case "loose" => SSL.LOOSE
+              case _ => SSL.STRICT // strict mode is the default when we specify a custom electrum server, we don't want to be MITMed
+            }
           }
 
           logger.info(s"override electrum default with server=$address ssl=$ssl")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -181,12 +181,18 @@ class Setup(datadir: File,
         case true =>
           val host = config.getString("electrum.host")
           val port = config.getInt("electrum.port")
+          val address = InetSocketAddress.createUnresolved(host, port)
           val ssl = config.getString("electrum.ssl") match {
             case "off" => SSL.OFF
             case "loose" => SSL.LOOSE
             case _ => SSL.STRICT // strict mode is the default when we specify a custom electrum server, we don't want to be MITMed
           }
-          val address = InetSocketAddress.createUnresolved(host, port)
+
+          // turn SSL verification off for a Tor hidden service
+          if (address.getHostName().endsWith(".onion")) {
+            ssl = SSL.OFF
+          }
+
           logger.info(s"override electrum default with server=$address ssl=$ssl")
           Set(ElectrumServerAddress(address, ssl))
         case false =>


### PR DESCRIPTION
It would be great if I could connect the Eclair mobile wallet to my Tor only electrs server using Orbot. Sadly I can't because it requires a valid SSL certificate. Please make an exception if the custom Electrum server address is an onion domain.

As suggested from others in my initial PR https://github.com/ACINQ/eclair-mobile/pull/229, I created this PR to cover up eclair-core and not only eclair-mobile.