### PR TITLE
Make sure that ids chunks strictly cover the requested range, without gaps

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -1256,14 +1256,15 @@ object Router {
           else {
             // we always prepend because it's more efficient so we have to reverse the current chunk
             // for the first chunk, we make sure that we start at the request first block
-            val first = if (acc.isEmpty) firstBlockNum else currentChunk.last.blockHeight
+            // for the next chunks we start at the end of the range covered by the last chunk
+            val first = if (acc.isEmpty) firstBlockNum else acc.head.firstBlock + acc.head.numBlocks
             val count = currentChunk.head.blockHeight - first + 1
             loop(id :: Nil, ShortChannelIdsChunk(first, count, currentChunk.reverse) :: acc)
           }
         }
         else {
-          // for the last chunk, we make sure that we cover the request block range
-          val first = if (acc.isEmpty) firstBlockNum else currentChunk.last.blockHeight
+          // for the last chunk, we make sure that we cover the requested block range
+          val first = if (acc.isEmpty) firstBlockNum else acc.head.firstBlock + acc.head.numBlocks
           val count = numberOfBlocks - first + firstBlockNum
           (ShortChannelIdsChunk(first, count, currentChunk.reverse) :: acc).reverse
         }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -152,13 +152,14 @@ class ChannelRangeQueriesSpec extends FunSuite {
     require(chunk.shortChannelIds.forall(Router.keep(chunk.firstBlock, chunk.numBlocks, _)))
   }
 
-  // check that chunks do not overlap and contain exactly the ids they were built from
+  // check that chunks contain exactly the ids they were built from are are consistent i.e each chunk covers a range that immediately follows
+  // the previous one even if there are gaps in block heights
   def validate(ids: SortedSet[ShortChannelId], firstBlockNum: Long, numberOfBlocks: Long, chunks: List[ShortChannelIdsChunk]): Unit = {
 
     @tailrec
     def noOverlap(chunks: List[ShortChannelIdsChunk]): Boolean = chunks match {
       case Nil => true
-      case a :: b :: _ if b.firstBlock < a.firstBlock + a.numBlocks => false
+      case a :: b :: _ if b.firstBlock != a.firstBlock + a.numBlocks => false
       case _ => noOverlap(chunks.tail)
     }
 
@@ -240,27 +241,27 @@ class ChannelRangeQueriesSpec extends FunSuite {
 
     // all ids in different blocks, chunk size == 2
     {
-      val ids = List(id(1000), id(1001), id(1002), id(1003), id(1004), id(1005))
+      val ids = List(id(1000), id(1005), id(1012), id(1013), id(1040), id(1050))
       val firstBlockNum = 900
       val numberOfBlocks = 200
       val chunks = Router.split(SortedSet.empty[ShortChannelId] ++ ids, firstBlockNum, numberOfBlocks, 2)
       assert(chunks == List(
-        ShortChannelIdsChunk(firstBlockNum, 100 + 2, List(ids(0), ids(1))),
-        ShortChannelIdsChunk(1002, 2, List(ids(2), ids(3))),
-        ShortChannelIdsChunk(1004, numberOfBlocks - 1004 + firstBlockNum, List(ids(4), ids(5)))
+        ShortChannelIdsChunk(firstBlockNum, 100 + 6, List(ids(0), ids(1))),
+        ShortChannelIdsChunk(1006, 8, List(ids(2), ids(3))),
+        ShortChannelIdsChunk(1014, numberOfBlocks - 1014 + firstBlockNum, List(ids(4), ids(5)))
       ))
     }
 
     // all ids in different blocks, chunk size == 2, first id outside of range
     {
-      val ids = List(id(1000), id(1001), id(1002), id(1003), id(1004), id(1005))
+      val ids = List(id(1000), id(1005), id(1012), id(1013), id(1040), id(1050))
       val firstBlockNum = 1001
       val numberOfBlocks = 200
       val chunks = Router.split(SortedSet.empty[ShortChannelId] ++ ids, firstBlockNum, numberOfBlocks, 2)
       assert(chunks == List(
-        ShortChannelIdsChunk(firstBlockNum, 2, List(ids(1), ids(2))),
-        ShortChannelIdsChunk(1003, 2, List(ids(3), ids(4))),
-        ShortChannelIdsChunk(1005, numberOfBlocks - 1005 + firstBlockNum, List(ids(5)))
+        ShortChannelIdsChunk(firstBlockNum, 12, List(ids(1), ids(2))),
+        ShortChannelIdsChunk(1013, 1040 - 1013 + 1, List(ids(3), ids(4))),
+        ShortChannelIdsChunk(1041, numberOfBlocks - 1041 + firstBlockNum, List(ids(5)))
       ))
     }
 
@@ -312,7 +313,7 @@ class ChannelRangeQueriesSpec extends FunSuite {
   }
 
   test("split short channel ids correctly (comprehensive tests)") {
-    val ids = SortedSet.empty[ShortChannelId] ++ makeShortChannelIds(42, 100) ++ makeShortChannelIds(43, 70) ++ makeShortChannelIds(44, 50) ++ makeShortChannelIds(45, 30) ++ makeShortChannelIds(50, 120)
+    val ids = SortedSet.empty[ShortChannelId] ++ makeShortChannelIds(42, 100) ++ makeShortChannelIds(43, 70) ++ makeShortChannelIds(45, 50) ++ makeShortChannelIds(47, 30) ++ makeShortChannelIds(50, 120)
     for (firstBlockNum <- 0 to 60) {
       for (numberOfBlocks <- 1 to 60) {
         for (chunkSize <- 1 :: 2 :: 20 :: 50 :: 100 :: 1000 :: Nil) {


### PR DESCRIPTION
lnd expects ids ranges in reply_channel_range messages to strictly follow each other, without gaps.
For example, using block heights and not ids, [1,2,4,5] would be split into (first=1, num=2, [1,2]) :: (first=3, num=2, [4, 5])

This is arguably a limitation of lnd (c-lightning does not requires this and it's not needed to properly process replies) but is easy to implement.