### PR TITLE
Do not include optional timestamp/checksum TLV if they are empty

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -648,7 +648,7 @@ class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[
           Kamon.runWithSpan(Kamon.spanBuilder("compute-timestamps-checksums").start(), finishSpan = true) {
             chunks.foreach { chunk =>
               val (timestamps, checksums) = routingMessage.queryFlags_opt match {
-                case Some(extension) if extension.wantChecksums | extension.wantTimestamps =>
+                case Some(extension) if chunk.shortChannelIds.nonEmpty && (extension.wantChecksums | extension.wantTimestamps) =>
                   // we always compute timestamps and checksums even if we don't need both, overhead is negligible
                   val (timestamps, checksums) = chunk.shortChannelIds.map(getChannelDigestInfo(d.channels)).unzip
                   val encodedTimestamps = if (extension.wantTimestamps) Some(ReplyChannelRangeTlv.EncodedTimestamps(nodeParams.routerConf.encodingType, timestamps)) else None


### PR DESCRIPTION
This change fixes an interop issue with c-lighting, which does not handle `reply_channel_range` messages that include an option `timestamps` TLV that contains an empty array of timestamps with a `ZLIB` encoding` and fails with a `connection-level error, failing all channels! reason=reply_channel_range 0 timestamps when 0 scids?` error

It is related to https://github.com/lightningnetwork/lightning-rfc/pull/729
