### PR TITLE
MPP: allow using unannounced channels

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -509,12 +509,11 @@ object MultiPartPaymentLifecycle {
     })
 
     // Otherwise we need to split the amount based on network statistics and pessimistic fees estimates.
-    // We filter out unannounced channels: they are very likely leading to a non-routing node.
     // Note that this will be handled more gracefully once this logic is migrated inside the router.
     val channels = if (randomize) {
-      Random.shuffle(localChannels.filter(p => p.commitments.announceChannel && p.nextNodeId != request.targetNodeId))
+      Random.shuffle(localChannels.filter(p => p.nextNodeId != request.targetNodeId))
     } else {
-      localChannels.filter(p => p.commitments.announceChannel && p.nextNodeId != request.targetNodeId).sortBy(_.commitments.availableBalanceForSend)
+      localChannels.filter(p => p.nextNodeId != request.targetNodeId).sortBy(_.commitments.availableBalanceForSend)
     }
     val remotePayments = split(toSend - directPayments.map(_.finalPayload.amount).sum, Seq.empty, channels, (remaining: MilliSatoshi, channel: OutgoingChannel) => {
       // We re-generate a split threshold for each channel to randomize the amounts.

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -310,23 +310,6 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(result.amount === payment.totalAmount)
   }
 
-  test("skip unannounced channels when sending to remote node") { f =>
-    import f._
-
-    // The channels to b are not announced: they should be ignored so the payment should fail.
-    val channels = OutgoingChannels(Seq(
-      OutgoingChannel(b, channelUpdate_ab_1.copy(channelFlags = ChannelFlags.Empty), makeCommitments(1000 * 1000 msat, 10, announceChannel = false)),
-      OutgoingChannel(b, channelUpdate_ab_2.copy(channelFlags = ChannelFlags.Empty), makeCommitments(1500 * 1000 msat, 10, announceChannel = false)),
-      OutgoingChannel(c, channelUpdate_ac_1, makeCommitments(500 * 1000 msat, 10))
-    ))
-    val payment = SendMultiPartPayment(paymentHash, randomBytes32, e, 1200 * 1000 msat, expiry, 3)
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), channels)
-
-    val result = sender.expectMsgType[PaymentFailed]
-    assert(result.id === paymentId)
-    assert(result.paymentHash === paymentHash)
-  }
-
   test("retry after error") { f =>
     import f._
     val payment = SendMultiPartPayment(paymentHash, randomBytes32, e, 3000 * 1000 msat, expiry, 3)


### PR DESCRIPTION
Otherwise eclair-mobile can't pay using MPP.
This heuristic was only here to help Trampoline nodes with a lot of
channels relay using MPP, but we disabled that in #1271 anyway.
We will reactivate Trampoline-MPP once split is done inside the router.