### PR TITLE
UpfrontShutdownScript field

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -153,7 +153,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
   startWith(WAIT_FOR_INIT_INTERNAL, Nothing)
 
   when(WAIT_FOR_INIT_INTERNAL)(handleExceptions {
-    case Event(initFunder@INPUT_INIT_FUNDER(temporaryChannelId, fundingSatoshis, pushMsat, initialFeeratePerKw, fundingTxFeeratePerKw, localParams, remote, remoteInit, channelFlags, channelVersion), Nothing) =>
+    case Event(initFunder@INPUT_INIT_FUNDER(temporaryChannelId, fundingSatoshis, pushMsat, initialFeeratePerKw, fundingTxFeeratePerKw, localParams, remote, _, channelFlags, channelVersion), Nothing) =>
       context.system.eventStream.publish(ChannelCreated(self, context.parent, remoteNodeId, isFunder = true, temporaryChannelId, initialFeeratePerKw, Some(fundingTxFeeratePerKw)))
       forwarder ! remote
       val fundingPubKey = keyManager.fundingPublicKey(localParams.fundingKeyPath).publicKey
@@ -175,11 +175,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
         delayedPaymentBasepoint = keyManager.delayedPaymentPoint(channelKeyPath).publicKey,
         htlcBasepoint = keyManager.htlcPoint(channelKeyPath).publicKey,
         firstPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 0),
-        channelFlags = channelFlags,
-        upfrontShutdownScript = None,
-        // Phoenix versions <= 1.1.0 are causing issues with OpenChannel encoding: we use the fact that they didn't send
-        // their networks to discriminate them and send them the legacy encoding.
-        tlvStream_opt = Some(TlvStream(OpenTlv.Encoding(remoteInit.networks.isEmpty))))
+        channelFlags = channelFlags)
       goto(WAIT_FOR_ACCEPT_CHANNEL) using DATA_WAIT_FOR_ACCEPT_CHANNEL(initFunder, open) sending open
 
     case Event(inputFundee@INPUT_INIT_FUNDEE(_, localParams, remote, _), Nothing) if !localParams.isFunder =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
@@ -84,7 +84,9 @@ case class OpenChannel(chainHash: ByteVector32,
                        delayedPaymentBasepoint: PublicKey,
                        htlcBasepoint: PublicKey,
                        firstPerCommitmentPoint: PublicKey,
-                       channelFlags: Byte) extends ChannelMessage with HasTemporaryChannelId with HasChainHash
+                       channelFlags: Byte,
+                       upfrontShutdownScript: Option[ByteVector] = None,
+                       tlvStream_opt: Option[TlvStream[OpenTlv]] = None) extends ChannelMessage with HasTemporaryChannelId with HasChainHash
 
 case class AcceptChannel(temporaryChannelId: ByteVector32,
                          dustLimitSatoshis: Satoshi,
@@ -99,7 +101,8 @@ case class AcceptChannel(temporaryChannelId: ByteVector32,
                          paymentBasepoint: PublicKey,
                          delayedPaymentBasepoint: PublicKey,
                          htlcBasepoint: PublicKey,
-                         firstPerCommitmentPoint: PublicKey) extends ChannelMessage with HasTemporaryChannelId
+                         firstPerCommitmentPoint: PublicKey,
+                         upfrontShutdownScript: Option[ByteVector] = None) extends ChannelMessage with HasTemporaryChannelId
 
 case class FundingCreated(temporaryChannelId: ByteVector32,
                           fundingTxid: ByteVector32,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/OpenTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/OpenTlv.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.wire
+
+import fr.acinq.eclair.UInt64
+import fr.acinq.eclair.wire.CommonCodecs._
+import fr.acinq.eclair.wire.TlvCodecs.tlvStream
+import scodec.Codec
+import scodec.codecs._
+
+sealed trait OpenTlv extends Tlv
+
+object OpenTlv {
+
+  // Phoenix versions <= 1.1.0 expect a TLV stream for pay-to-open, but no upfront_shutdown_script. This makes them
+  // incompatible with the latest update to the encoding of OpenChannel, so we discriminate them and send them the old
+  // encoding. We should remove that work-around as soon as enough users have updated to > 1.1.0.
+  case class Encoding(useLegacy: Boolean) extends OpenTlv
+
+  val openTlvCodec: Codec[TlvStream[OpenTlv]] = tlvStream(discriminated.by(varint)
+    .typecase(UInt64(0x47000001), variableSizeBytesLong(varintoverflow, bool).as[Encoding])
+  )
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/OpenTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/OpenTlv.scala
@@ -20,19 +20,17 @@ import fr.acinq.eclair.UInt64
 import fr.acinq.eclair.wire.CommonCodecs._
 import fr.acinq.eclair.wire.TlvCodecs.tlvStream
 import scodec.Codec
+import scodec.bits.ByteVector
 import scodec.codecs._
 
 sealed trait OpenTlv extends Tlv
 
 object OpenTlv {
 
-  // Phoenix versions <= 1.1.0 expect a TLV stream for pay-to-open, but no upfront_shutdown_script. This makes them
-  // incompatible with the latest update to the encoding of OpenChannel, so we discriminate them and send them the old
-  // encoding. We should remove that work-around as soon as enough users have updated to > 1.1.0.
-  case class Encoding(useLegacy: Boolean) extends OpenTlv
+  case class Placeholder(b: ByteVector) extends OpenTlv
 
   val openTlvCodec: Codec[TlvStream[OpenTlv]] = tlvStream(discriminated.by(varint)
-    .typecase(UInt64(0x47000001), variableSizeBytesLong(varintoverflow, bool).as[Encoding])
+    .typecase(UInt64(1), variableSizeBytesLong(varintoverflow, bytes).as[Placeholder])
   )
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/OpenTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/OpenTlv.scala
@@ -30,7 +30,7 @@ object OpenTlv {
   case class Placeholder(b: ByteVector) extends OpenTlv
 
   val openTlvCodec: Codec[TlvStream[OpenTlv]] = tlvStream(discriminated.by(varint)
-    .typecase(UInt64(1), variableSizeBytesLong(varintoverflow, bytes).as[Placeholder])
+    .typecase(UInt64(65717), variableSizeBytesLong(varintoverflow, bytes).as[Placeholder])
   )
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/LightningMessageCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/LightningMessageCodecsSpec.scala
@@ -87,6 +87,87 @@ class LightningMessageCodecsSpec extends FunSuite {
     assert(bin === bin2)
   }
 
+  test("encode/decode open_channel") {
+    val defaultOpen = OpenChannel(ByteVector32.Zeroes, ByteVector32.Zeroes, 1 sat, 1 msat, 1 sat, UInt64(1), 1 sat, 1 msat, 1, CltvExpiryDelta(1), 1, publicKey(1), point(2), point(3), point(4), point(5), point(6), 0.toByte)
+    // Default encoding that completely omits the upfront_shutdown_script (nodes were supposed to encode it only if both
+    // sides advertised support for option_upfront_shutdown_script).
+    // To allow extending all messages with TLV streams, the upfront_shutdown_script was made mandatory in https://github.com/lightningnetwork/lightning-rfc/pull/714
+    val defaultEncoded = hex"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000100010001031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076602531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe33703462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f703f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a00"
+    case class TestCase(encoded: ByteVector, decoded: OpenChannel, reEncoded: Option[ByteVector] = None)
+    val testCases = Seq(
+      TestCase(defaultEncoded, defaultOpen, Some(defaultEncoded ++ hex"0000")), // legacy encoding without upfront_shutdown_script
+      TestCase(defaultEncoded ++ hex"0000", defaultOpen), // empty upfront_shutdown_script
+      TestCase(defaultEncoded ++ hex"0004 01abcdef", defaultOpen.copy(upfrontShutdownScript = Some(hex"01abcdef"))), // non-empty upfront_shutdown_script
+      TestCase(defaultEncoded ++ hex"0000 0102002a 030102", defaultOpen.copy(tlvStream_opt = Some(TlvStream(Nil, Seq(GenericTlv(UInt64(1), hex"002a"), GenericTlv(UInt64(3), hex"02")))))), // empty upfront_shutdown_script + unknown odd tlv records
+      TestCase(defaultEncoded ++ hex"0002 1234 0303010203", defaultOpen.copy(upfrontShutdownScript = Some(hex"1234"), tlvStream_opt = Some(TlvStream(Nil, Seq(GenericTlv(UInt64(3), hex"010203")))))) // non-empty upfront_shutdown_script + unknown odd tlv records
+    )
+
+    for (testCase <- testCases) {
+      val decoded = openChannelCodec.decode(testCase.encoded.bits).require.value
+      assert(decoded === testCase.decoded)
+      val reEncoded = openChannelCodec.encode(decoded).require.bytes
+      assert(reEncoded === testCase.reEncoded.getOrElse(testCase.encoded))
+    }
+  }
+
+  test("decode invalid open_channel") {
+    val defaultEncoded = hex"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000100010001031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076602531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe33703462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f703f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a00"
+    val testCases = Seq(
+      defaultEncoded ++ hex"00", // truncated length
+      defaultEncoded ++ hex"01", // truncated length
+      defaultEncoded ++ hex"0004 123456", // truncated script
+      defaultEncoded ++ hex"0000 02012a", // invalid tlv stream (unknown even record)
+      defaultEncoded ++ hex"0000 01012a 030201", // invalid tlv stream (truncated)
+      defaultEncoded ++ hex"01012a" // missing upfront_shutdown_script before tlv stream
+    )
+
+    for (testCase <- testCases) {
+      assert(openChannelCodec.decode(testCase.bits).isFailure, testCase.toHex)
+    }
+  }
+
+  test("encode open_channel for Phoenix <= 1.1.0") {
+    val defaultOpen = OpenChannel(ByteVector32.Zeroes, ByteVector32.Zeroes, 1 sat, 1 msat, 1 sat, UInt64(1), 1 sat, 1 msat, 1, CltvExpiryDelta(1), 1, publicKey(1), point(2), point(3), point(4), point(5), point(6), 0.toByte)
+    // Default encoding that completely omits the upfront_shutdown_script (nodes were supposed to encode it only if both
+    // sides advertised support for option_upfront_shutdown_script).
+    val defaultEncoded = hex"0020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000100000000000000010000000000000001000000000000000100000000000000010000000100010001031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076602531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe33703462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f703f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a00"
+    val testCases = Map(
+      defaultOpen -> (defaultEncoded ++ hex"0000"),
+      defaultOpen.copy(tlvStream_opt = Some(TlvStream(OpenTlv.Encoding(useLegacy = true)))) -> defaultEncoded,
+      defaultOpen.copy(tlvStream_opt = Some(TlvStream(OpenTlv.Encoding(useLegacy = true) :: Nil, GenericTlv(UInt64(257), hex"012a") :: Nil))) -> (defaultEncoded ++ hex"fd010102012a"),
+      defaultOpen.copy(tlvStream_opt = Some(TlvStream(OpenTlv.Encoding(useLegacy = false)))) -> (defaultEncoded ++ hex"0000"),
+      defaultOpen.copy(tlvStream_opt = Some(TlvStream(OpenTlv.Encoding(useLegacy = false) :: Nil, GenericTlv(UInt64(257), hex"012a") :: Nil))) -> (defaultEncoded ++ hex"0000 fd010102012a")
+    )
+
+    for ((open, expected) <- testCases) {
+      val encoded = meteredLightningMessageCodec.encode(open).require.bytes
+      assert(encoded === expected)
+    }
+  }
+
+  test("encode/decode accept_channel") {
+    val defaultAccept = AcceptChannel(ByteVector32.Zeroes, 1 sat, UInt64(1), 1 sat, 1 msat, 1, CltvExpiryDelta(1), 1, publicKey(1), point(2), point(3), point(4), point(5), point(6))
+    // Default encoding that completely omits the upfront_shutdown_script (nodes were supposed to encode it only if both
+    // sides advertised support for option_upfront_shutdown_script).
+    // To allow extending all messages with TLV streams, the upfront_shutdown_script was made mandatory in https://github.com/lightningnetwork/lightning-rfc/pull/714
+    val defaultEncoded = hex"000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000001000000000000000100000000000000010000000100010001031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076602531fe6068134503d2723133227c867ac8fa6c83c537e9a44c3c5bdbdcb1fe33703462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f703f006a18d5653c4edf5391ff23a61f03ff83d237e880ee61187fa9f379a028e0a"
+    case class TestCase(encoded: ByteVector, decoded: AcceptChannel, reEncoded: Option[ByteVector] = None)
+    val testCases = Seq(
+      TestCase(defaultEncoded, defaultAccept, Some(defaultEncoded ++ hex"0000")), // legacy encoding without upfront_shutdown_script
+      TestCase(defaultEncoded ++ hex"0000", defaultAccept), // empty upfront_shutdown_script
+      TestCase(defaultEncoded ++ hex"0004 01abcdef", defaultAccept.copy(upfrontShutdownScript = Some(hex"01abcdef"))), // non-empty upfront_shutdown_script
+      TestCase(defaultEncoded ++ hex"0000 010202a 030102", defaultAccept, Some(defaultEncoded ++ hex"0000")), // empty upfront_shutdown_script + unknown odd tlv records
+      TestCase(defaultEncoded ++ hex"0002 1234 0303010203", defaultAccept.copy(upfrontShutdownScript = Some(hex"1234")), Some(defaultEncoded ++ hex"0002 1234")) // non-empty upfront_shutdown_script + unknown odd tlv records
+    )
+
+    for (testCase <- testCases) {
+      val decoded = acceptChannelCodec.decode(testCase.encoded.bits).require.value
+      assert(decoded === testCase.decoded)
+      val reEncoded = acceptChannelCodec.encode(decoded).require.bytes
+      assert(reEncoded === testCase.reEncoded.getOrElse(testCase.encoded))
+    }
+  }
+
   test("encode/decode all channel messages") {
     val open = OpenChannel(randomBytes32, randomBytes32, 3 sat, 4 msat, 5 sat, UInt64(6), 7 sat, 8 msat, 9, CltvExpiryDelta(10), 11, publicKey(1), point(2), point(3), point(4), point(5), point(6), 0.toByte)
     val accept = AcceptChannel(randomBytes32, 3 sat, UInt64(4), 5 sat, 6 msat, 7, CltvExpiryDelta(8), 9, publicKey(1), point(2), point(3), point(4), point(5), point(6))


### PR DESCRIPTION
We don't implement the `upfront_shutdown_script` feature yet.
However we update our encoding to always specify its field and support reading it.
This allows extending `OpenChannel`/`AcceptChannel` with tlv streams while staying compliant with the spec and other implementations (lnd just started to add the `upfront_shutdown_script` field to their `OpenChannel` message, even if we don't activate the feature bit).

There is one caveat: Phoenix shipped with a version that's incompatible because it interprets the `upfront_shutdown_script` fields as a TLV stream.
So we use a workaround to identify unpatched Phoenix versions and send them the old encoding.
This PR can be applied and deployed safely today.
Once Phoenix is upgraded with that code in the next release, and enough users have updated, we can remove that ugly switch and forget this ever happened :).

Tested against:

* [x] Eclair 0.3.2: ok
* [x] C-lightning master: ok
* [x] lnd 0.9.0-beta: ok 

TODO:

* [ ] Create an issue to remind ourselves to remove that code once Phoenix is updated