### PR TITLE
Support deterministic build of eclair-core artifact on ubuntu

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -11,7 +11,7 @@
 Eclair supports deterministic builds for the eclair-core submodule, this is the 'core' of the eclair application
 and its artifact can be deterministically built achieving byte-to-byte equality for each build. To build the exact 
 same artifacts that we release, you must use the build environment (OS, JDK, maven...) that we specify in our 
-release notes, to check if your artifact is correct please check out the release page for the latest published release.
+release notes.
 
 To build the project and run the tests, simply run:
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -10,10 +10,10 @@
 
 Eclair supports deterministic builds for the eclair-core submodule, this is the 'core' of the eclair application
 and its artifact can be deterministically built achieving byte-to-byte equality for each build. This process helps
-to ensure that the artifact you're building is exactly the same as the one published in the release, please note
-that the deterministic build is limited to eclair-core and is also OS dependent, only unix based builds might be
-published in the release page. To check if your artifact is correct please check out the release page for the latest 
-published release.
+to ensure the artifact you're building is exactly the same as the one published in the release, please note
+that the deterministic build is limited to eclair-core and is OS dependent, to build the artifact deterministically
+you must use Ubuntu 18.10, JDK11.0.4 and maven 3.6.0. To check if your artifact is correct please check out the release 
+page for the latest published release.
 
 To build the project and run the tests, simply run:
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -9,11 +9,9 @@
 ## Build
 
 Eclair supports deterministic builds for the eclair-core submodule, this is the 'core' of the eclair application
-and its artifact can be deterministically built achieving byte-to-byte equality for each build. This process helps
-to ensure the artifact you're building is exactly the same as the one published in the release, please note
-that the deterministic build is limited to eclair-core and is OS dependent, to build the artifact deterministically
-you must use Ubuntu 18.10, JDK11.0.4 and maven 3.6.0. To check if your artifact is correct please check out the release 
-page for the latest published release.
+and its artifact can be deterministically built achieving byte-to-byte equality for each build. To build the exact 
+same artifacts that we release, you must use the build environment (OS, JDK, maven...) that we specify in our 
+release notes, to check if your artifact is correct please check out the release page for the latest published release.
 
 To build the project and run the tests, simply run:
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -8,6 +8,13 @@
 
 ## Build
 
+Eclair supports deterministic builds for the eclair-core submodule, this is the 'core' of the eclair application
+and its artifact can be deterministically built achieving byte-to-byte equality for each build. This process helps
+to ensure that the artifact you're building is exactly the same as the one published in the release, please note
+that the deterministic build is limited to eclair-core and is also OS dependent, only unix based builds might be
+published in the release page. To check if your artifact is correct please check out the release page for the latest 
+published release.
+
 To build the project and run the tests, simply run:
 
 ```shell

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -69,21 +69,6 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>io.github.zlika</groupId>
-                <artifactId>reproducible-build-maven-plugin</artifactId>
-                <version>0.11</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>strip-jar</goal>
-                        </goals>
-                        <configuration>
-                            <fixZipExternalFileAttributes>true</fixZipExternalFileAttributes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -69,6 +69,21 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>io.github.zlika</groupId>
+                <artifactId>reproducible-build-maven-plugin</artifactId>
+                <version>0.11</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>strip-jar</goal>
+                        </goals>
+                        <configuration>
+                            <fixZipExternalFileAttributes>true</fixZipExternalFileAttributes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
     </developers>
 
     <properties>
+        <project.build.outputTimestamp>2020-01-01T00:00:00Z</project.build.outputTimestamp>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -84,7 +85,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.chrisdchristo</groupId>
@@ -162,7 +163,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>


### PR DESCRIPTION
This PR adds support for deterministic builds of the eclair-core artifact by updating the necessary maven plugins (maven-source-plugin and maven-jar-plugin) to version 3.2.0 which support deterministic builds and hardcoding the property `project.build.outputTimestamp` to a fixed date (this can be updated at each release) . The deterministic build only works with the submodule `eclair-core` due to some quirks with the maven-capsule plugin, also the build is *not* deterministic across different OSs because of the way maven packages files with system-dependent newline markers. The SHA256 of eclair core at commit 93c2683 is: `db3064fc4fc9e20c141770294186fbb82b50190ffc13f6bcc09379db2fb33b2b`. 

This is a first step toward deterministic builds for the mobile apps.