### PR TITLE
Electrum: allow watcher to watch for mempool transactions

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
@@ -117,6 +117,7 @@ class ElectrumWatcher(blockCount: AtomicLong, client: ActorRef) extends Actor wi
 
     case ElectrumClient.GetScriptHashHistoryResponse(_, history) =>
       // we retrieve the transaction before checking watches
+      // NB: height=-1 means that the tx is unconfirmed and at least one of its inputs is also unconfirmed. we need to take them into consideration if we want to handle unconfirmed txes (which is the case for turbo channels)
       history.filter(_.height >= -1).foreach { item => client ! ElectrumClient.GetTransaction(item.tx_hash, Some(item)) }
 
     case ElectrumClient.GetTransactionResponse(tx, Some(item: ElectrumClient.TransactionHistoryItem)) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
@@ -233,7 +233,11 @@ object ElectrumWatcher {
   def makeDummyShortChannelId(txid: ByteVector32): (Int, Int) = {
     // we use a height of 0
     // - to make sure that the tx will be marked as "confirmed"
-    // - to identify scids linked to 0-conf channels
+    // - to easily identify scids linked to 0-conf channels
+    //
+    // this gives us a probability of collisions of 0.1% for 5 0-conf channels and 1% for 20
+    // collisions mean that users may temporarily see incorrect numbers for their 0-conf channels (until they've been confirmed)
+    // if this ever becomes a problem we could just extract some bits for our dummy height instead of just returning 0
     val height = 0
     val txIndex = txid.bits.sliceToInt(0, 16, false)
     (height, txIndex)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
@@ -35,6 +35,7 @@ import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 import scodec.bits._
 
 import scala.concurrent.duration._
+import scala.util.Random
 
 class ElectrumWatcherSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with BitcoindService with ElectrumxService with BeforeAndAfterAll with Logging {
 
@@ -226,6 +227,17 @@ class ElectrumWatcherSpec extends TestKit(ActorSystem("test")) with FunSuiteLike
     val confirmed = listener.expectMsgType[WatchEventConfirmed](20 seconds)
     assert(confirmed.tx.txid === tx2.txid)
     system.stop(watcher)
+  }
+
+  test("compute dummy height/txindex for 0-conf channels") {
+    val currentHeight = 500000
+    val buffer = new Array[Byte](32)
+    val dummies = (0 to 1000).map { _ =>
+      val txid = Random.nextBytes(buffer)
+      ElectrumWatcher.makeDummyShortChannelId(currentHeight, ByteVector32(ByteVector.view(buffer)))
+    } toSet
+
+    assert(dummies.size >= 1000 - 10)
   }
 
   test("get transaction") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
@@ -230,11 +230,10 @@ class ElectrumWatcherSpec extends TestKit(ActorSystem("test")) with FunSuiteLike
   }
 
   test("compute dummy height/txindex for 0-conf channels") {
-    val currentHeight = 500000
     val buffer = new Array[Byte](32)
     val dummies = (0 to 1000).map { _ =>
-      val txid = Random.nextBytes(buffer)
-      ElectrumWatcher.makeDummyShortChannelId(currentHeight, ByteVector32(ByteVector.view(buffer)))
+      Random.nextBytes(buffer)
+      ElectrumWatcher.makeDummyShortChannelId(ByteVector32(ByteVector.view(buffer)))
     } toSet
 
     assert(dummies.size >= 1000 - 10)


### PR DESCRIPTION
Watcher now handles WatchConfirmed watches where min depth is set to 0: the watch event will sent when the tx enters the mempool