### PR TITLE
Node relayer faster fulfill

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
@@ -20,8 +20,8 @@ import java.util.UUID
 
 import akka.actor.{Actor, ActorRef, DiagnosticActorLogging, PoisonPill, Props}
 import akka.event.Logging.MDC
-import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.bitcoin.{ByteVector32, Crypto}
 import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FULFILL_HTLC, Upstream}
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM
@@ -50,31 +50,36 @@ class NodeRelayer(nodeParams: NodeParams, relayer: ActorRef, router: ActorRef, c
 
   override def receive: Receive = main(Map.empty, Map.empty)
 
-  def main(pendingIncoming: Map[ByteVector32, PendingRelay], pendingOutgoing: Map[UUID, PendingResult]): Receive = {
+  def main(pendingIncoming: Map[ByteVector32, PendingRelay], pendingOutgoing: Map[ByteVector32, PendingResult]): Receive = {
     // We make sure we receive all payment parts before forwarding to the next trampoline node.
     case IncomingPacket.NodeRelayPacket(add, outer, inner, next) => outer.paymentSecret match {
       case None =>
         log.warning(s"rejecting htlcId=${add.id} channelId=${add.channelId}: missing payment secret")
         rejectHtlc(add.id, add.channelId, add.amountMsat)
-      case Some(secret) => pendingIncoming.get(add.paymentHash) match {
-        case Some(relay) =>
-          if (relay.secret != secret) {
-            log.warning(s"rejecting htlcId=${add.id} channelId=${add.channelId}: payment secret doesn't match other HTLCs in the set")
+      case Some(secret) =>
+        pendingOutgoing.get(add.paymentHash) match {
+          case Some(outgoing) =>
+            log.warning(s"rejecting htlcId=${add.id} channelId=${add.channelId}: already relayed out with id=${outgoing.paymentId}")
             rejectHtlc(add.id, add.channelId, add.amountMsat)
-          } else {
-            relay.handler ! MultiPartPaymentFSM.MultiPartHtlc(outer.totalAmount, add)
-            context become main(pendingIncoming + (add.paymentHash -> relay.copy(htlcs = relay.htlcs :+ add)), pendingOutgoing)
+          case None => pendingIncoming.get(add.paymentHash) match {
+            case Some(relay) =>
+              if (relay.secret != secret) {
+                log.warning(s"rejecting htlcId=${add.id} channelId=${add.channelId}: payment secret doesn't match other HTLCs in the set")
+                rejectHtlc(add.id, add.channelId, add.amountMsat)
+              } else {
+                relay.handler ! MultiPartPaymentFSM.MultiPartHtlc(outer.totalAmount, add)
+                context become main(pendingIncoming + (add.paymentHash -> relay.copy(htlcs = relay.htlcs :+ add)), pendingOutgoing)
+              }
+            case None =>
+              val handler = context.actorOf(MultiPartPaymentFSM.props(nodeParams, add.paymentHash, outer.totalAmount, self))
+              handler ! MultiPartPaymentFSM.MultiPartHtlc(outer.totalAmount, add)
+              context become main(pendingIncoming + (add.paymentHash -> PendingRelay(Queue(add), secret, inner, next, handler)), pendingOutgoing)
           }
-        case None =>
-          val handler = context.actorOf(MultiPartPaymentFSM.props(nodeParams, add.paymentHash, outer.totalAmount, self))
-          handler ! MultiPartPaymentFSM.MultiPartHtlc(outer.totalAmount, add)
-          context become main(pendingIncoming + (add.paymentHash -> PendingRelay(Queue(add), secret, inner, next, handler)), pendingOutgoing)
-      }
+        }
     }
 
     // We always fail extraneous HTLCs. They are a spec violation from the sender, but harmless in the relay case.
-    // By failing them fast (before the payment has reached the final recipient) there's a good chance the sender
-    // won't lose any money.
+    // By failing them fast (before the payment has reached the final recipient) there's a good chance the sender won't lose any money.
     case MultiPartPaymentFSM.ExtraHtlcReceived(_, p, failure) => rejectHtlc(p.htlcId, p.payment.fromChannelId, p.payment.amount, failure)
 
     case MultiPartPaymentFSM.MultiPartHtlcFailed(paymentHash, failure, parts) =>
@@ -95,26 +100,40 @@ class NodeRelayer(nodeParams: NodeParams, relayer: ActorRef, router: ActorRef, c
           case None =>
             log.info(s"relaying trampoline payment (amountIn=${upstream.amountIn} expiryIn=${upstream.expiryIn} amountOut=${nextPayload.amountToForward} expiryOut=${nextPayload.outgoingCltv} htlcCount=${parts.length})")
             val paymentId = relay(paymentHash, upstream, nextPayload, nextPacket)
-            context become main(pendingIncoming - paymentHash, pendingOutgoing + (paymentId -> PendingResult(upstream, nextPayload)))
+            context become main(pendingIncoming - paymentHash, pendingOutgoing + (paymentHash -> PendingResult(upstream, nextPayload, paymentId, settled = false)))
         }
-      case None => throw new RuntimeException(s"could not find pending incoming payment (paymentHash=$paymentHash)")
+      case None => log.error("could not find pending incoming payment: payment will not be relayed: please investigate")
     }
 
-    case PaymentSent(id, paymentHash, paymentPreimage, _, _, parts) =>
-      log.debug("trampoline payment successfully relayed")
-      pendingOutgoing.get(id).foreach {
-        case PendingResult(upstream, _) =>
-          fulfillPayment(upstream, paymentPreimage)
-          val incoming = upstream.adds.map(add => PaymentRelayed.Part(add.amountMsat, add.channelId))
-          val outgoing = parts.map(part => PaymentRelayed.Part(part.amountWithFees, part.toChannelId))
-          context.system.eventStream.publish(TrampolinePaymentRelayed(paymentHash, incoming, outgoing))
-      }
-      context become main(pendingIncoming, pendingOutgoing - id)
+    case Relayer.ForwardFulfill(fulfill, Origin.TrampolineRelayed(_, Some(paymentSender)), _) =>
+      paymentSender ! fulfill
+      val paymentHash = Crypto.sha256(fulfill.paymentPreimage)
+      pendingOutgoing.get(paymentHash).foreach(p => if (!p.settled) {
+        // We want to fulfill upstream as soon as we receive the preimage (even if not all HTLCs have fulfilled downstream).
+        log.debug("trampoline payment successfully relayed")
+        fulfillPayment(p.upstream, fulfill.paymentPreimage)
+        context become main(pendingIncoming, pendingOutgoing + (paymentHash -> p.copy(settled = true)))
+      })
 
-    case PaymentFailed(id, _, failures, _) =>
-      log.debug("trampoline payment failed")
-      pendingOutgoing.get(id).foreach { case PendingResult(upstream, nextPayload) => rejectPayment(upstream, translateError(failures, nextPayload.outgoingNodeId)) }
-      context become main(pendingIncoming, pendingOutgoing - id)
+    case PaymentSent(id, paymentHash, paymentPreimage, _, _, parts) =>
+      // We may have already fulfilled upstream, but we can now emit an accurate relayed event and clean-up resources.
+      log.debug(s"trampoline payment fully resolved downstream (id=$id)")
+      pendingOutgoing.get(paymentHash).foreach(p => {
+        if (!p.settled) {
+          fulfillPayment(p.upstream, paymentPreimage)
+        }
+        val incoming = p.upstream.adds.map(add => PaymentRelayed.Part(add.amountMsat, add.channelId))
+        val outgoing = parts.map(part => PaymentRelayed.Part(part.amountWithFees, part.toChannelId))
+        context.system.eventStream.publish(TrampolinePaymentRelayed(paymentHash, incoming, outgoing))
+      })
+      context become main(pendingIncoming, pendingOutgoing - paymentHash)
+
+    case PaymentFailed(id, paymentHash, failures, _) =>
+      log.debug(s"trampoline payment failed downstream (id=$id)")
+      pendingOutgoing.get(paymentHash).foreach(p => if (!p.settled) {
+        rejectPayment(p.upstream, translateError(failures, p.nextPayload.outgoingNodeId))
+      })
+      context become main(pendingIncoming, pendingOutgoing - paymentHash)
 
     case ack: CommandBuffer.CommandAck => commandBuffer forward ack
 
@@ -200,8 +219,10 @@ object NodeRelayer {
    *
    * @param upstream    complete HTLC set received.
    * @param nextPayload relay instructions.
+   * @param paymentId   id of the outgoing payment.
+   * @param settled     true if we already settled the payment upstream.
    */
-  case class PendingResult(upstream: Upstream.TrampolineRelayed, nextPayload: Onion.NodeRelayPayload)
+  case class PendingResult(upstream: Upstream.TrampolineRelayed, nextPayload: Onion.NodeRelayPayload, paymentId: UUID, settled: Boolean)
 
   private def validateRelay(nodeParams: NodeParams, upstream: Upstream.TrampolineRelayed, payloadOut: Onion.NodeRelayPayload): Option[FailureMessage] = {
     val fee = nodeFee(nodeParams.feeBase, nodeParams.feeProportionalMillionth, payloadOut.amountToForward)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.SendMultiPartPayment
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentConfig
 import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPayment
-import fr.acinq.eclair.payment.send.{MultiPartPaymentLifecycle, PaymentLifecycle}
+import fr.acinq.eclair.payment.send.{MultiPartPaymentLifecycle, PaymentError, PaymentLifecycle}
 import fr.acinq.eclair.router.{RouteNotFound, RouteParams, Router}
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{CltvExpiry, Logs, MilliSatoshi, NodeParams, nodeFee, randomBytes32}
@@ -237,7 +237,7 @@ object NodeRelayer {
 
     failures match {
       case Nil => None
-      case LocalFailure(MultiPartPaymentLifecycle.BalanceTooLow) :: Nil => Some(TemporaryNodeFailure) // we don't have enough outgoing liquidity at the moment
+      case LocalFailure(PaymentError.BalanceTooLow) :: Nil => Some(TemporaryNodeFailure) // we don't have enough outgoing liquidity at the moment
       case _ if tooManyRouteNotFound(failures) => Some(TrampolineFeeInsufficient) // if we couldn't find routes, it's likely that the fee/cltv was insufficient
       case _ =>
         // Otherwise, we try to find a downstream error that we could decrypt.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -164,7 +164,7 @@ class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, comm
           commandBuffer ! CommandBuffer.CommandSend(originChannelId, cmd)
           context.system.eventStream.publish(ChannelPaymentRelayed(amountIn, amountOut, add.paymentHash, originChannelId, fulfill.channelId))
         case Origin.TrampolineRelayed(_, None) => postRestartCleaner forward ff
-        case Origin.TrampolineRelayed(_, Some(paymentSender)) => paymentSender ! fulfill
+        case Origin.TrampolineRelayed(_, Some(_)) => nodeRelayer forward ff
       }
 
     case ff@ForwardFail(fail, to, _) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentError.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentError.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.payment.send
+
+import scodec.bits.BitVector
+
+sealed trait PaymentError extends Throwable
+
+object PaymentError {
+
+  // @formatter:off
+  sealed trait InvalidInvoice extends PaymentError
+  /** The invoice contains a feature we don't support. */
+  case class UnsupportedFeatures(features: BitVector) extends InvalidInvoice
+  /** The invoice is missing a payment secret. */
+  case object PaymentSecretMissing extends InvalidInvoice
+  // @formatter:on
+
+  // @formatter:off
+  sealed trait InvalidTrampolineArguments extends PaymentError
+  /** Trampoline fees or cltv expiry delta is missing. */
+  case object TrampolineFeesMissing extends InvalidTrampolineArguments
+  /** 0-value invoice should not be paid via trampoline-to-legacy (trampoline may steal funds). */
+  case object TrampolineLegacyAmountLessInvoice extends InvalidTrampolineArguments
+  /** Only a single trampoline node is currently supported. */
+  case object TrampolineMultiNodeNotSupported extends InvalidTrampolineArguments
+  // @formatter:on
+
+  // @formatter:off
+  /** Outbound capacity is too low. */
+  case object BalanceTooLow extends PaymentError
+  /** Payment attempts exhausted without success. */
+  case object RetryExhausted extends PaymentError
+  // @formatter:on
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 
 import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{TestFSMRef, TestKit, TestProbe}
-import fr.acinq.bitcoin.{Block, Crypto, DeterministicWallet, Satoshi, Transaction}
+import fr.acinq.bitcoin.{Block, Crypto, Satoshi}
 import fr.acinq.eclair.TestConstants.TestFeeEstimator
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
@@ -28,10 +28,10 @@ import fr.acinq.eclair.channel.{ChannelFlags, Commitments, CommitmentsSpec, Upst
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.PaymentSent.PartialPayment
 import fr.acinq.eclair.payment.relay.Relayer.{GetOutgoingChannels, OutgoingChannel, OutgoingChannels}
-import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle._
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentConfig
 import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPayment
+import fr.acinq.eclair.payment.send.{MultiPartPaymentLifecycle, PaymentError}
 import fr.acinq.eclair.router._
 import fr.acinq.eclair.wire._
 import org.scalatest.{Outcome, Tag, fixture}
@@ -359,7 +359,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(result.id === paymentId)
     assert(result.paymentHash === paymentHash)
     assert(result.failures.length === 1)
-    assert(result.failures.head.asInstanceOf[LocalFailure].t === BalanceTooLow)
+    assert(result.failures.head.asInstanceOf[LocalFailure].t === PaymentError.BalanceTooLow)
   }
 
   test("cannot send (fee rate too high)") { f =>
@@ -374,7 +374,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(result.id === paymentId)
     assert(result.paymentHash === paymentHash)
     assert(result.failures.length === 1)
-    assert(result.failures.head.asInstanceOf[LocalFailure].t === BalanceTooLow)
+    assert(result.failures.head.asInstanceOf[LocalFailure].t === PaymentError.BalanceTooLow)
   }
 
   test("payment timeout") { f =>
@@ -430,7 +430,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(result.paymentHash === paymentHash)
     assert(result.failures.length === 3)
     assert(result.failures.slice(0, 2) === failures)
-    assert(result.failures.last.asInstanceOf[LocalFailure].t === RetryExhausted)
+    assert(result.failures.last.asInstanceOf[LocalFailure].t === PaymentError.RetryExhausted)
   }
 
   test("receive partial failure after success (recipient spec violation)") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
@@ -27,7 +27,8 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.PaymentRequest.{ExtraHop, Features}
 import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM
 import fr.acinq.eclair.payment.relay.{CommandBuffer, NodeRelayer}
-import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.{BalanceTooLow, SendMultiPartPayment}
+import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.SendMultiPartPayment
+import fr.acinq.eclair.payment.send.PaymentError
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentConfig
 import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPayment
 import fr.acinq.eclair.router.RouteNotFound
@@ -186,7 +187,7 @@ class NodeRelayerSpec extends TestkitBaseClass {
     val outgoingPaymentId = outgoingPayFSM.expectMsgType[SendPaymentConfig].id
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
-    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, LocalFailure(BalanceTooLow) :: Nil))
+    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, LocalFailure(PaymentError.BalanceTooLow) :: Nil))
     incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TemporaryNodeFailure), commit = true))))
     commandBuffer.expectNoMsg(100 millis)
     eventListener.expectNoMsg(100 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -27,9 +27,9 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.PaymentPacketSpec._
 import fr.acinq.eclair.payment.PaymentRequest.{ExtraHop, Features}
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.SendMultiPartPayment
-import fr.acinq.eclair.payment.send.PaymentInitiator
 import fr.acinq.eclair.payment.send.PaymentInitiator._
 import fr.acinq.eclair.payment.send.PaymentLifecycle.{SendPayment, SendPaymentToRoute}
+import fr.acinq.eclair.payment.send.{PaymentError, PaymentInitiator}
 import fr.acinq.eclair.router.{NodeHop, RouteParams}
 import fr.acinq.eclair.wire.Onion.FinalLegacyPayload
 import fr.acinq.eclair.wire.{Onion, OnionCodecs, OnionTlv, TrampolineFeeInsufficient}
@@ -221,7 +221,7 @@ class PaymentInitiatorSpec extends TestKit(ActorSystem("test")) with fixture.Fun
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
     assert(fail.id === id)
-    assert(fail.failures === LocalFailure(TrampolineLegacyAmountLessInvoice) :: Nil)
+    assert(fail.failures === LocalFailure(PaymentError.TrampolineLegacyAmountLessInvoice) :: Nil)
 
     multiPartPayFsm.expectNoMsg(50 millis)
     payFsm.expectNoMsg(50 millis)


### PR DESCRIPTION
These two commits are best reviewed individually.

`06faa52` is a small refactoring of payment errors to make it simpler for Phoenix/Eclair-Mobile to classify errors.

`2e48792` is an improvement for trampoline HTLC fulfills.
We were previously waiting for the whole downstream payment to be settled (all individual HTLCs).
We can do better and fulfill upstream as soon as we get the preimage (which only needs one downstream fulfill).
