### PR TITLE
make Commitments method return Try[]

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -252,20 +252,20 @@ object Commitments {
     commitments1
   }
 
-  def getHtlcCrossSigned(commitments: Commitments, directionRelativeToLocal: Direction, htlcId: Long): Option[UpdateAddHtlc] = for {
+  def getHtlcCrossSigned(commitments: Commitments, directionRelativeToLocal: Direction, htlcId: Long): Option[(UpdateAddHtlc, Option[Origin])] = for {
     localSigned <- commitments.remoteNextCommitInfo.left.toOption.map(_.nextRemoteCommit).getOrElse(commitments.remoteCommit).spec.findHtlcById(htlcId, directionRelativeToLocal.opposite)
     remoteSigned <- commitments.localCommit.spec.findHtlcById(htlcId, directionRelativeToLocal)
   } yield {
     require(localSigned.add == remoteSigned.add)
-    localSigned.add
+    (localSigned.add, commitments.originChannels.get(htlcId))
   }
 
   def sendFulfill(commitments: Commitments, cmd: CMD_FULFILL_HTLC): Try[(Commitments, UpdateFulfillHtlc)] =
     getHtlcCrossSigned(commitments, IN, cmd.id) match {
-      case Some(htlc) if alreadyProposed(commitments.localChanges.proposed, htlc.id) =>
+      case Some((htlc, _)) if alreadyProposed(commitments.localChanges.proposed, htlc.id) =>
         // we have already sent a fail/fulfill for this htlc
         Failure(UnknownHtlcId(commitments.channelId, cmd.id))
-      case Some(htlc) if htlc.paymentHash == sha256(cmd.r) =>
+      case Some((htlc, _)) if htlc.paymentHash == sha256(cmd.r) =>
         val fulfill = UpdateFulfillHtlc(commitments.channelId, cmd.id, cmd.r)
         val commitments1 = addLocalProposal(commitments, fulfill)
         Success((commitments1, fulfill))
@@ -275,17 +275,17 @@ object Commitments {
 
   def receiveFulfill(commitments: Commitments, fulfill: UpdateFulfillHtlc): Try[(Commitments, Origin, UpdateAddHtlc)] =
     getHtlcCrossSigned(commitments, OUT, fulfill.id) match {
-      case Some(htlc) if htlc.paymentHash == sha256(fulfill.paymentPreimage) => Success((addRemoteProposal(commitments, fulfill), commitments.originChannels(fulfill.id), htlc))
+      case Some((htlc, Some(origin))) if htlc.paymentHash == sha256(fulfill.paymentPreimage) => Success((addRemoteProposal(commitments, fulfill), origin, htlc))
       case Some(_) => Failure(InvalidHtlcPreimage(commitments.channelId, fulfill.id))
       case None => Failure(UnknownHtlcId(commitments.channelId, fulfill.id))
     }
 
   def sendFail(commitments: Commitments, cmd: CMD_FAIL_HTLC, nodeSecret: PrivateKey): Try[(Commitments, UpdateFailHtlc)] =
     getHtlcCrossSigned(commitments, IN, cmd.id) match {
-      case Some(htlc) if alreadyProposed(commitments.localChanges.proposed, htlc.id) =>
+      case Some((htlc, _)) if alreadyProposed(commitments.localChanges.proposed, htlc.id) =>
         // we have already sent a fail/fulfill for this htlc
         Failure(UnknownHtlcId(commitments.channelId, cmd.id))
-      case Some(htlc) =>
+      case Some((htlc, _)) =>
         // we need the shared secret to build the error packet
         Sphinx.PaymentPacket.peel(nodeSecret, htlc.paymentHash, htlc.onionRoutingPacket) match {
           case Right(Sphinx.DecryptedPacket(_, _, sharedSecret)) =>
@@ -307,7 +307,7 @@ object Commitments {
       Failure(InvalidFailureCode(commitments.channelId))
     } else {
       getHtlcCrossSigned(commitments, IN, cmd.id) match {
-        case Some(htlc) if alreadyProposed(commitments.localChanges.proposed, htlc.id) =>
+        case Some((htlc, _)) if alreadyProposed(commitments.localChanges.proposed, htlc.id) =>
           // we have already sent a fail/fulfill for this htlc
           Failure(UnknownHtlcId(commitments.channelId, cmd.id))
         case Some(_) =>
@@ -321,8 +321,8 @@ object Commitments {
 
   def receiveFail(commitments: Commitments, fail: UpdateFailHtlc): Try[(Commitments, Origin, UpdateAddHtlc)] =
     getHtlcCrossSigned(commitments, OUT, fail.id) match {
-      case Some(htlc) => Success((addRemoteProposal(commitments, fail), commitments.originChannels(fail.id), htlc))
-      case None => Failure(UnknownHtlcId(commitments.channelId, fail.id))
+      case Some((htlc, Some(origin))) => Success((addRemoteProposal(commitments, fail), origin, htlc))
+      case _ => Failure(UnknownHtlcId(commitments.channelId, fail.id))
     }
 
   def receiveFailMalformed(commitments: Commitments, fail: UpdateFailMalformedHtlc): Try[(Commitments, Origin, UpdateAddHtlc)] = {
@@ -331,8 +331,8 @@ object Commitments {
       Failure(InvalidFailureCode(commitments.channelId))
     } else {
       getHtlcCrossSigned(commitments, OUT, fail.id) match {
-        case Some(htlc) => Success((addRemoteProposal(commitments, fail), commitments.originChannels(fail.id), htlc))
-        case None => Failure(UnknownHtlcId(commitments.channelId, fail.id))
+        case Some((htlc, Some(origin))) => Success((addRemoteProposal(commitments, fail), origin, htlc))
+        case _ => Failure(UnknownHtlcId(commitments.channelId, fail.id))
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -27,6 +27,8 @@ import fr.acinq.eclair.transactions._
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{MilliSatoshi, _}
 
+import scala.util.{Failure, Success, Try}
+
 // @formatter:off
 case class LocalChanges(proposed: List[UpdateMessage], signed: List[UpdateMessage], acked: List[UpdateMessage]) {
   def all: List[UpdateMessage] = proposed ++ signed ++ acked
@@ -155,20 +157,20 @@ object Commitments {
    * @param cmd         add HTLC command
    * @return either Left(failure, error message) where failure is a failure message (see BOLT #4 and the Failure Message class) or Right((new commitments, updateAddHtlc)
    */
-  def sendAdd(commitments: Commitments, cmd: CMD_ADD_HTLC, origin: Origin, blockHeight: Long): Either[ChannelException, (Commitments, UpdateAddHtlc)] = {
+  def sendAdd(commitments: Commitments, cmd: CMD_ADD_HTLC, origin: Origin, blockHeight: Long): Try[(Commitments, UpdateAddHtlc)] = {
     // our counterparty needs a reasonable amount of time to pull the funds from downstream before we can get refunded (see BOLT 2 and BOLT 11 for a calculation and rationale)
     val minExpiry = Channel.MIN_CLTV_EXPIRY_DELTA.toCltvExpiry(blockHeight)
     if (cmd.cltvExpiry < minExpiry) {
-      return Left(ExpiryTooSmall(commitments.channelId, minimum = minExpiry, actual = cmd.cltvExpiry, blockCount = blockHeight))
+      return Failure(ExpiryTooSmall(commitments.channelId, minimum = minExpiry, actual = cmd.cltvExpiry, blockCount = blockHeight))
     }
     val maxExpiry = Channel.MAX_CLTV_EXPIRY_DELTA.toCltvExpiry(blockHeight)
     // we don't want to use too high a refund timeout, because our funds will be locked during that time if the payment is never fulfilled
     if (cmd.cltvExpiry >= maxExpiry) {
-      return Left(ExpiryTooBig(commitments.channelId, maximum = maxExpiry, actual = cmd.cltvExpiry, blockCount = blockHeight))
+      return Failure(ExpiryTooBig(commitments.channelId, maximum = maxExpiry, actual = cmd.cltvExpiry, blockCount = blockHeight))
     }
 
     if (cmd.amount < commitments.remoteParams.htlcMinimum) {
-      return Left(HtlcValueTooSmall(commitments.channelId, minimum = commitments.remoteParams.htlcMinimum, actual = cmd.amount))
+      return Failure(HtlcValueTooSmall(commitments.channelId, minimum = commitments.remoteParams.htlcMinimum, actual = cmd.amount))
     }
 
     // let's compute the current commitment *as seen by them* with this change taken into account
@@ -186,12 +188,12 @@ object Commitments {
     val missingForSender = reduced.toRemote - commitments1.remoteParams.channelReserve - (if (commitments1.localParams.isFunder) fees else 0.sat)
     val missingForReceiver = reduced.toLocal - commitments1.localParams.channelReserve - (if (commitments1.localParams.isFunder) 0.sat else fees)
     if (missingForSender < 0.msat) {
-      return Left(InsufficientFunds(commitments.channelId, amount = cmd.amount, missing = -missingForSender.truncateToSatoshi, reserve = commitments1.remoteParams.channelReserve, fees = if (commitments1.localParams.isFunder) fees else 0.sat))
+      return Failure(InsufficientFunds(commitments.channelId, amount = cmd.amount, missing = -missingForSender.truncateToSatoshi, reserve = commitments1.remoteParams.channelReserve, fees = if (commitments1.localParams.isFunder) fees else 0.sat))
     } else if (missingForReceiver < 0.msat) {
       if (commitments.localParams.isFunder) {
         // receiver is fundee; it is ok if it can't maintain its channel_reserve for now, as long as its balance is increasing, which is the case if it is receiving a payment
       } else {
-        return Left(RemoteCannotAffordFeesForNewHtlc(commitments.channelId, amount = cmd.amount, missing = -missingForReceiver.truncateToSatoshi, reserve = commitments1.remoteParams.channelReserve, fees = fees))
+        return Failure(RemoteCannotAffordFeesForNewHtlc(commitments.channelId, amount = cmd.amount, missing = -missingForReceiver.truncateToSatoshi, reserve = commitments1.remoteParams.channelReserve, fees = fees))
       }
     }
 
@@ -199,17 +201,17 @@ object Commitments {
     val htlcValueInFlight = outgoingHtlcs.toSeq.map(_.add.amountMsat).sum
     if (commitments1.remoteParams.maxHtlcValueInFlightMsat < htlcValueInFlight) {
       // TODO: this should be a specific UPDATE error
-      return Left(HtlcValueTooHighInFlight(commitments.channelId, maximum = commitments1.remoteParams.maxHtlcValueInFlightMsat, actual = htlcValueInFlight))
+      return Failure(HtlcValueTooHighInFlight(commitments.channelId, maximum = commitments1.remoteParams.maxHtlcValueInFlightMsat, actual = htlcValueInFlight))
     }
 
     if (outgoingHtlcs.size > commitments1.remoteParams.maxAcceptedHtlcs) {
-      return Left(TooManyAcceptedHtlcs(commitments.channelId, maximum = commitments1.remoteParams.maxAcceptedHtlcs))
+      return Failure(TooManyAcceptedHtlcs(commitments.channelId, maximum = commitments1.remoteParams.maxAcceptedHtlcs))
     }
 
-    Right(commitments1, add)
+    Success(commitments1, add)
   }
 
-  def receiveAdd(commitments: Commitments, add: UpdateAddHtlc): Commitments = {
+  def receiveAdd(commitments: Commitments, add: UpdateAddHtlc): Try[Commitments] = Try {
     if (add.id != commitments.remoteNextHtlcId) {
       throw UnexpectedHtlcId(commitments.channelId, expected = commitments.remoteNextHtlcId, actual = add.id)
     }
@@ -258,31 +260,31 @@ object Commitments {
     localSigned.add
   }
 
-  def sendFulfill(commitments: Commitments, cmd: CMD_FULFILL_HTLC): (Commitments, UpdateFulfillHtlc) =
+  def sendFulfill(commitments: Commitments, cmd: CMD_FULFILL_HTLC): Try[(Commitments, UpdateFulfillHtlc)] =
     getHtlcCrossSigned(commitments, IN, cmd.id) match {
       case Some(htlc) if alreadyProposed(commitments.localChanges.proposed, htlc.id) =>
         // we have already sent a fail/fulfill for this htlc
-        throw UnknownHtlcId(commitments.channelId, cmd.id)
+        Failure(UnknownHtlcId(commitments.channelId, cmd.id))
       case Some(htlc) if htlc.paymentHash == sha256(cmd.r) =>
         val fulfill = UpdateFulfillHtlc(commitments.channelId, cmd.id, cmd.r)
         val commitments1 = addLocalProposal(commitments, fulfill)
-        (commitments1, fulfill)
-      case Some(_) => throw InvalidHtlcPreimage(commitments.channelId, cmd.id)
-      case None => throw UnknownHtlcId(commitments.channelId, cmd.id)
+        Success((commitments1, fulfill))
+      case Some(_) => Failure(InvalidHtlcPreimage(commitments.channelId, cmd.id))
+      case None => Failure(UnknownHtlcId(commitments.channelId, cmd.id))
     }
 
-  def receiveFulfill(commitments: Commitments, fulfill: UpdateFulfillHtlc): Either[Commitments, (Commitments, Origin, UpdateAddHtlc)] =
+  def receiveFulfill(commitments: Commitments, fulfill: UpdateFulfillHtlc): Try[(Commitments, Origin, UpdateAddHtlc)] =
     getHtlcCrossSigned(commitments, OUT, fulfill.id) match {
-      case Some(htlc) if htlc.paymentHash == sha256(fulfill.paymentPreimage) => Right((addRemoteProposal(commitments, fulfill), commitments.originChannels(fulfill.id), htlc))
-      case Some(_) => throw InvalidHtlcPreimage(commitments.channelId, fulfill.id)
-      case None => throw UnknownHtlcId(commitments.channelId, fulfill.id)
+      case Some(htlc) if htlc.paymentHash == sha256(fulfill.paymentPreimage) => Success((addRemoteProposal(commitments, fulfill), commitments.originChannels(fulfill.id), htlc))
+      case Some(_) => Failure(InvalidHtlcPreimage(commitments.channelId, fulfill.id))
+      case None => Failure(UnknownHtlcId(commitments.channelId, fulfill.id))
     }
 
-  def sendFail(commitments: Commitments, cmd: CMD_FAIL_HTLC, nodeSecret: PrivateKey): (Commitments, UpdateFailHtlc) =
+  def sendFail(commitments: Commitments, cmd: CMD_FAIL_HTLC, nodeSecret: PrivateKey): Try[(Commitments, UpdateFailHtlc)] =
     getHtlcCrossSigned(commitments, IN, cmd.id) match {
       case Some(htlc) if alreadyProposed(commitments.localChanges.proposed, htlc.id) =>
         // we have already sent a fail/fulfill for this htlc
-        throw UnknownHtlcId(commitments.channelId, cmd.id)
+        Failure(UnknownHtlcId(commitments.channelId, cmd.id))
       case Some(htlc) =>
         // we need the shared secret to build the error packet
         Sphinx.PaymentPacket.peel(nodeSecret, htlc.paymentHash, htlc.onionRoutingPacket) match {
@@ -293,100 +295,100 @@ object Commitments {
             }
             val fail = UpdateFailHtlc(commitments.channelId, cmd.id, reason)
             val commitments1 = addLocalProposal(commitments, fail)
-            (commitments1, fail)
-          case Left(_) => throw CannotExtractSharedSecret(commitments.channelId, htlc)
+            Success((commitments1, fail))
+          case Left(_) => Failure(CannotExtractSharedSecret(commitments.channelId, htlc))
         }
-      case None => throw UnknownHtlcId(commitments.channelId, cmd.id)
+      case None => Failure(UnknownHtlcId(commitments.channelId, cmd.id))
     }
 
-  def sendFailMalformed(commitments: Commitments, cmd: CMD_FAIL_MALFORMED_HTLC): (Commitments, UpdateFailMalformedHtlc) = {
+  def sendFailMalformed(commitments: Commitments, cmd: CMD_FAIL_MALFORMED_HTLC): Try[(Commitments, UpdateFailMalformedHtlc)] = {
     // BADONION bit must be set in failure_code
     if ((cmd.failureCode & FailureMessageCodecs.BADONION) == 0) {
-      throw InvalidFailureCode(commitments.channelId)
-    }
-    getHtlcCrossSigned(commitments, IN, cmd.id) match {
-      case Some(htlc) if alreadyProposed(commitments.localChanges.proposed, htlc.id) =>
-        // we have already sent a fail/fulfill for this htlc
-        throw UnknownHtlcId(commitments.channelId, cmd.id)
-      case Some(_) =>
-        val fail = UpdateFailMalformedHtlc(commitments.channelId, cmd.id, cmd.onionHash, cmd.failureCode)
-        val commitments1 = addLocalProposal(commitments, fail)
-        (commitments1, fail)
-      case None => throw UnknownHtlcId(commitments.channelId, cmd.id)
+      Failure(InvalidFailureCode(commitments.channelId))
+    } else {
+      getHtlcCrossSigned(commitments, IN, cmd.id) match {
+        case Some(htlc) if alreadyProposed(commitments.localChanges.proposed, htlc.id) =>
+          // we have already sent a fail/fulfill for this htlc
+          Failure(UnknownHtlcId(commitments.channelId, cmd.id))
+        case Some(_) =>
+          val fail = UpdateFailMalformedHtlc(commitments.channelId, cmd.id, cmd.onionHash, cmd.failureCode)
+          val commitments1 = addLocalProposal(commitments, fail)
+          Success((commitments1, fail))
+        case None => Failure(UnknownHtlcId(commitments.channelId, cmd.id))
+      }
     }
   }
 
-  def receiveFail(commitments: Commitments, fail: UpdateFailHtlc): Either[Commitments, (Commitments, Origin, UpdateAddHtlc)] =
+  def receiveFail(commitments: Commitments, fail: UpdateFailHtlc): Try[(Commitments, Origin, UpdateAddHtlc)] =
     getHtlcCrossSigned(commitments, OUT, fail.id) match {
-      case Some(htlc) => Right((addRemoteProposal(commitments, fail), commitments.originChannels(fail.id), htlc))
-      case None => throw UnknownHtlcId(commitments.channelId, fail.id)
+      case Some(htlc) => Success((addRemoteProposal(commitments, fail), commitments.originChannels(fail.id), htlc))
+      case None => Failure(UnknownHtlcId(commitments.channelId, fail.id))
     }
 
-  def receiveFailMalformed(commitments: Commitments, fail: UpdateFailMalformedHtlc): Either[Commitments, (Commitments, Origin, UpdateAddHtlc)] = {
+  def receiveFailMalformed(commitments: Commitments, fail: UpdateFailMalformedHtlc): Try[(Commitments, Origin, UpdateAddHtlc)] = {
     // A receiving node MUST fail the channel if the BADONION bit in failure_code is not set for update_fail_malformed_htlc.
     if ((fail.failureCode & FailureMessageCodecs.BADONION) == 0) {
-      throw InvalidFailureCode(commitments.channelId)
-    }
-
-    getHtlcCrossSigned(commitments, OUT, fail.id) match {
-      case Some(htlc) => Right((addRemoteProposal(commitments, fail), commitments.originChannels(fail.id), htlc))
-      case None => throw UnknownHtlcId(commitments.channelId, fail.id)
+      Failure(InvalidFailureCode(commitments.channelId))
+    } else {
+      getHtlcCrossSigned(commitments, OUT, fail.id) match {
+        case Some(htlc) => Success((addRemoteProposal(commitments, fail), commitments.originChannels(fail.id), htlc))
+        case None => Failure(UnknownHtlcId(commitments.channelId, fail.id))
+      }
     }
   }
 
-  def sendFee(commitments: Commitments, cmd: CMD_UPDATE_FEE): (Commitments, UpdateFee) = {
+  def sendFee(commitments: Commitments, cmd: CMD_UPDATE_FEE): Try[(Commitments, UpdateFee)] = {
     if (!commitments.localParams.isFunder) {
-      throw FundeeCannotSendUpdateFee(commitments.channelId)
-    }
-    // let's compute the current commitment *as seen by them* with this change taken into account
-    val fee = UpdateFee(commitments.channelId, cmd.feeratePerKw)
-    // update_fee replace each other, so we can remove previous ones
-    val commitments1 = commitments.copy(localChanges = commitments.localChanges.copy(proposed = commitments.localChanges.proposed.filterNot(_.isInstanceOf[UpdateFee]) :+ fee))
-    val reduced = CommitmentSpec.reduce(commitments1.remoteCommit.spec, commitments1.remoteChanges.acked, commitments1.localChanges.proposed)
+      Failure(FundeeCannotSendUpdateFee(commitments.channelId))
+    } else {
+      // let's compute the current commitment *as seen by them* with this change taken into account
+      val fee = UpdateFee(commitments.channelId, cmd.feeratePerKw)
+      // update_fee replace each other, so we can remove previous ones
+      val commitments1 = commitments.copy(localChanges = commitments.localChanges.copy(proposed = commitments.localChanges.proposed.filterNot(_.isInstanceOf[UpdateFee]) :+ fee))
+      val reduced = CommitmentSpec.reduce(commitments1.remoteCommit.spec, commitments1.remoteChanges.acked, commitments1.localChanges.proposed)
 
-    // a node cannot spend pending incoming htlcs, and need to keep funds above the reserve required by the counterparty, after paying the fee
-    // we look from remote's point of view, so if local is funder remote doesn't pay the fees
-    val fees = commitTxFee(commitments1.remoteParams.dustLimit, reduced)
-    val missing = reduced.toRemote.truncateToSatoshi - commitments1.remoteParams.channelReserve - fees
-    if (missing < 0.sat) {
-      throw CannotAffordFees(commitments.channelId, missing = -missing, reserve = commitments1.localParams.channelReserve, fees = fees)
+      // a node cannot spend pending incoming htlcs, and need to keep funds above the reserve required by the counterparty, after paying the fee
+      // we look from remote's point of view, so if local is funder remote doesn't pay the fees
+      val fees = commitTxFee(commitments1.remoteParams.dustLimit, reduced)
+      val missing = reduced.toRemote.truncateToSatoshi - commitments1.remoteParams.channelReserve - fees
+      if (missing < 0.sat) {
+        Failure(CannotAffordFees(commitments.channelId, missing = -missing, reserve = commitments1.localParams.channelReserve, fees = fees))
+      } else {
+        Success((commitments1, fee))
+      }
     }
-
-    (commitments1, fee)
   }
 
-  def receiveFee(commitments: Commitments, feeEstimator: FeeEstimator, feeTargets: FeeTargets, fee: UpdateFee, maxFeerateMismatch: Double): Commitments = {
+  def receiveFee(commitments: Commitments, feeEstimator: FeeEstimator, feeTargets: FeeTargets, fee: UpdateFee, maxFeerateMismatch: Double): Try[Commitments] = {
     if (commitments.localParams.isFunder) {
-      throw FundeeCannotSendUpdateFee(commitments.channelId)
+      Failure(FundeeCannotSendUpdateFee(commitments.channelId))
+    } else if (fee.feeratePerKw < fr.acinq.eclair.MinimumFeeratePerKw) {
+      Failure(FeerateTooSmall(commitments.channelId, remoteFeeratePerKw = fee.feeratePerKw))
+    } else {
+      val localFeeratePerKw = feeEstimator.getFeeratePerKw(target = feeTargets.commitmentBlockTarget)
+      if (Helpers.isFeeDiffTooHigh(fee.feeratePerKw, localFeeratePerKw, maxFeerateMismatch)) {
+        Failure(FeerateTooDifferent(commitments.channelId, localFeeratePerKw = localFeeratePerKw, remoteFeeratePerKw = fee.feeratePerKw))
+      } else {
+        // NB: we check that the funder can afford this new fee even if spec allows to do it at next signature
+        // It is easier to do it here because under certain (race) conditions spec allows a lower-than-normal fee to be paid,
+        // and it would be tricky to check if the conditions are met at signing
+        // (it also means that we need to check the fee of the initial commitment tx somewhere)
+
+        // let's compute the current commitment *as seen by us* including this change
+        // update_fee replace each other, so we can remove previous ones
+        val commitments1 = commitments.copy(remoteChanges = commitments.remoteChanges.copy(proposed = commitments.remoteChanges.proposed.filterNot(_.isInstanceOf[UpdateFee]) :+ fee))
+        val reduced = CommitmentSpec.reduce(commitments1.localCommit.spec, commitments1.localChanges.acked, commitments1.remoteChanges.proposed)
+
+        // a node cannot spend pending incoming htlcs, and need to keep funds above the reserve required by the counterparty, after paying the fee
+        val fees = commitTxFee(commitments1.remoteParams.dustLimit, reduced)
+        val missing = reduced.toRemote.truncateToSatoshi - commitments1.localParams.channelReserve - fees
+        if (missing < 0.sat) {
+          Failure(CannotAffordFees(commitments.channelId, missing = -missing, reserve = commitments1.localParams.channelReserve, fees = fees))
+        } else {
+       Success(commitments1)
+        }
+      }
     }
-
-    if (fee.feeratePerKw < fr.acinq.eclair.MinimumFeeratePerKw) {
-      throw FeerateTooSmall(commitments.channelId, remoteFeeratePerKw = fee.feeratePerKw)
-    }
-
-    val localFeeratePerKw = feeEstimator.getFeeratePerKw(target = feeTargets.commitmentBlockTarget)
-    if (Helpers.isFeeDiffTooHigh(fee.feeratePerKw, localFeeratePerKw, maxFeerateMismatch)) {
-      throw FeerateTooDifferent(commitments.channelId, localFeeratePerKw = localFeeratePerKw, remoteFeeratePerKw = fee.feeratePerKw)
-    }
-
-    // NB: we check that the funder can afford this new fee even if spec allows to do it at next signature
-    // It is easier to do it here because under certain (race) conditions spec allows a lower-than-normal fee to be paid,
-    // and it would be tricky to check if the conditions are met at signing
-    // (it also means that we need to check the fee of the initial commitment tx somewhere)
-
-    // let's compute the current commitment *as seen by us* including this change
-    // update_fee replace each other, so we can remove previous ones
-    val commitments1 = commitments.copy(remoteChanges = commitments.remoteChanges.copy(proposed = commitments.remoteChanges.proposed.filterNot(_.isInstanceOf[UpdateFee]) :+ fee))
-    val reduced = CommitmentSpec.reduce(commitments1.localCommit.spec, commitments1.localChanges.acked, commitments1.remoteChanges.proposed)
-
-    // a node cannot spend pending incoming htlcs, and need to keep funds above the reserve required by the counterparty, after paying the fee
-    val fees = commitTxFee(commitments1.remoteParams.dustLimit, reduced)
-    val missing = reduced.toRemote.truncateToSatoshi - commitments1.localParams.channelReserve - fees
-    if (missing < 0.sat) {
-      throw CannotAffordFees(commitments.channelId, missing = -missing, reserve = commitments1.localParams.channelReserve, fees = fees)
-    }
-
-    commitments1
   }
 
   def localHasUnsignedOutgoingHtlcs(commitments: Commitments): Boolean = commitments.localChanges.proposed.collectFirst { case u: UpdateAddHtlc => u }.isDefined
@@ -401,12 +403,12 @@ object Commitments {
 
   def revocationHash(seed: ByteVector32, index: Long): ByteVector32 = Crypto.sha256(revocationPreimage(seed, index))
 
-  def sendCommit(commitments: Commitments, keyManager: KeyManager)(implicit log: LoggingAdapter): (Commitments, CommitSig) = {
+  def sendCommit(commitments: Commitments, keyManager: KeyManager)(implicit log: LoggingAdapter): Try[(Commitments, CommitSig)] = {
     import commitments._
     commitments.remoteNextCommitInfo match {
       case Right(_) if !localHasChanges(commitments) =>
-        throw CannotSignWithoutChanges(commitments.channelId)
-      case Right(remoteNextPerCommitmentPoint) =>
+        Failure(CannotSignWithoutChanges(commitments.channelId))
+      case Right(remoteNextPerCommitmentPoint) => Try {
         // remote commitment will includes all local changes + remote acked changes
         val spec = CommitmentSpec.reduce(remoteCommit.spec, remoteChanges.acked, localChanges.proposed)
         val (remoteCommitTx, htlcTimeoutTxs, htlcSuccessTxs) = makeRemoteTxs(keyManager, channelVersion, remoteCommit.index + 1, localParams, remoteParams, commitInput, remoteNextPerCommitmentPoint, spec)
@@ -431,12 +433,13 @@ object Commitments {
           localChanges = localChanges.copy(proposed = Nil, signed = localChanges.proposed),
           remoteChanges = remoteChanges.copy(acked = Nil, signed = remoteChanges.acked))
         (commitments1, commitSig)
+      }
       case Left(_) =>
-        throw CannotSignBeforeRevocation(commitments.channelId)
+        Failure(CannotSignBeforeRevocation(commitments.channelId))
     }
   }
 
-  def receiveCommit(commitments: Commitments, commit: CommitSig, keyManager: KeyManager)(implicit log: LoggingAdapter): (Commitments, RevokeAndAck) = {
+  def receiveCommit(commitments: Commitments, commit: CommitSig, keyManager: KeyManager)(implicit log: LoggingAdapter): Try[(Commitments, RevokeAndAck)] = Try {
     import commitments._
     // they sent us a signature for *their* view of *our* next commit tx
     // so in terms of rev.hashes and indexes we have:
@@ -515,13 +518,13 @@ object Commitments {
     (commitments1, revocation)
   }
 
-  def receiveRevocation(commitments: Commitments, revocation: RevokeAndAck): (Commitments, Seq[Relayer.ForwardMessage]) = {
+  def receiveRevocation(commitments: Commitments, revocation: RevokeAndAck): Try[(Commitments, Seq[Relayer.ForwardMessage])] = {
     import commitments._
     // we receive a revocation because we just sent them a sig for their next commit tx
     remoteNextCommitInfo match {
       case Left(_) if revocation.perCommitmentSecret.publicKey != remoteCommit.remotePerCommitmentPoint =>
-        throw InvalidRevocation(commitments.channelId)
-      case Left(WaitingForRevocation(theirNextCommit, _, _, _)) =>
+        Failure(InvalidRevocation(commitments.channelId))
+      case Left(WaitingForRevocation(theirNextCommit, _, _, _)) => Try {
         val forwards = commitments.remoteChanges.signed collect {
           // we forward adds downstream only when they have been committed by both sides
           // it always happen when we receive a revocation, because they send the add, then they sign it, then we sign it
@@ -551,8 +554,9 @@ object Commitments {
           remotePerCommitmentSecrets = commitments.remotePerCommitmentSecrets.addHash(revocation.perCommitmentSecret.value, 0xFFFFFFFFFFFFL - commitments.remoteCommit.index),
           originChannels = originChannels1)
         (commitments1, forwards)
+      }
       case Right(_) =>
-        throw UnexpectedRevocation(commitments.channelId)
+        Failure(UnexpectedRevocation(commitments.channelId))
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -275,7 +275,7 @@ object Commitments {
 
   def receiveFulfill(commitments: Commitments, fulfill: UpdateFulfillHtlc): Try[(Commitments, Origin, UpdateAddHtlc)] =
     getHtlcCrossSigned(commitments, OUT, fulfill.id) match {
-      case Some(htlc) if htlc.paymentHash == sha256(fulfill.paymentPreimage) => Success((addRemoteProposal(commitments, fulfill), commitments.originChannels(fulfill.id), htlc))
+      case Some(htlc) if htlc.paymentHash == sha256(fulfill.paymentPreimage) => Try((addRemoteProposal(commitments, fulfill), commitments.originChannels(fulfill.id), htlc))
       case Some(_) => Failure(InvalidHtlcPreimage(commitments.channelId, fulfill.id))
       case None => Failure(UnknownHtlcId(commitments.channelId, fulfill.id))
     }
@@ -321,7 +321,7 @@ object Commitments {
 
   def receiveFail(commitments: Commitments, fail: UpdateFailHtlc): Try[(Commitments, Origin, UpdateAddHtlc)] =
     getHtlcCrossSigned(commitments, OUT, fail.id) match {
-      case Some(htlc) => Success((addRemoteProposal(commitments, fail), commitments.originChannels(fail.id), htlc))
+      case Some(htlc) => Try((addRemoteProposal(commitments, fail), commitments.originChannels(fail.id), htlc))
       case None => Failure(UnknownHtlcId(commitments.channelId, fail.id))
     }
 
@@ -331,7 +331,7 @@ object Commitments {
       Failure(InvalidFailureCode(commitments.channelId))
     } else {
       getHtlcCrossSigned(commitments, OUT, fail.id) match {
-        case Some(htlc) => Success((addRemoteProposal(commitments, fail), commitments.originChannels(fail.id), htlc))
+        case Some(htlc) => Try((addRemoteProposal(commitments, fail), commitments.originChannels(fail.id), htlc))
         case None => Failure(UnknownHtlcId(commitments.channelId, fail.id))
       }
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -32,7 +32,7 @@ import org.scalatest.{Outcome, Tag}
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
-import scala.util.{Failure, Random, Success, Try}
+import scala.util.{Failure, Random, Success}
 
 class CommitmentsSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
@@ -62,10 +62,10 @@ class CommitmentsSpec extends TestkitBaseClass with StateTestsHelperMethods {
     assert(bc0.availableBalanceForReceive == a - htlcOutputFee)
 
     val (_, cmdAdd) = makeCmdAdd(a - htlcOutputFee - 1000.msat, bob.underlyingActor.nodeParams.nodeId, currentBlockHeight)
-    val Right((ac1, add)) = sendAdd(ac0, cmdAdd, Local(UUID.randomUUID, None), currentBlockHeight)
-    val bc1 = receiveAdd(bc0, add)
-    val (_, commit1) = sendCommit(ac1, alice.underlyingActor.nodeParams.keyManager)
-    val (bc2, _) = receiveCommit(bc1, commit1, bob.underlyingActor.nodeParams.keyManager)
+    val Success((ac1, add)) = sendAdd(ac0, cmdAdd, Local(UUID.randomUUID, None), currentBlockHeight)
+    val Success(bc1) = receiveAdd(bc0, add)
+    val Success((_, commit1)) = sendCommit(ac1, alice.underlyingActor.nodeParams.keyManager)
+    val Success((bc2, _)) = receiveCommit(bc1, commit1, bob.underlyingActor.nodeParams.keyManager)
     // we don't take into account the additional HTLC fee since Alice's balance is below the trim threshold.
     assert(ac1.availableBalanceForSend == 1000.msat)
     assert(bc2.availableBalanceForReceive == 1000.msat)
@@ -89,68 +89,68 @@ class CommitmentsSpec extends TestkitBaseClass with StateTestsHelperMethods {
     assert(bc0.availableBalanceForReceive == a)
 
     val (payment_preimage, cmdAdd) = makeCmdAdd(p, bob.underlyingActor.nodeParams.nodeId, currentBlockHeight)
-    val Right((ac1, add)) = sendAdd(ac0, cmdAdd, Local(UUID.randomUUID, None), currentBlockHeight)
+    val Success((ac1, add)) = sendAdd(ac0, cmdAdd, Local(UUID.randomUUID, None), currentBlockHeight)
     assert(ac1.availableBalanceForSend == a - p - fee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
     assert(ac1.availableBalanceForReceive == b)
 
-    val bc1 = receiveAdd(bc0, add)
+    val Success(bc1) = receiveAdd(bc0, add)
     assert(bc1.availableBalanceForSend == b)
     assert(bc1.availableBalanceForReceive == a - p - fee)
 
-    val (ac2, commit1) = sendCommit(ac1, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac2, commit1)) = sendCommit(ac1, alice.underlyingActor.nodeParams.keyManager)
     assert(ac2.availableBalanceForSend == a - p - fee)
     assert(ac2.availableBalanceForReceive == b)
 
-    val (bc2, revocation1) = receiveCommit(bc1, commit1, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc2, revocation1)) = receiveCommit(bc1, commit1, bob.underlyingActor.nodeParams.keyManager)
     assert(bc2.availableBalanceForSend == b)
     assert(bc2.availableBalanceForReceive == a - p - fee)
 
-    val (ac3, _) = receiveRevocation(ac2, revocation1)
+    val Success((ac3, _)) = receiveRevocation(ac2, revocation1)
     assert(ac3.availableBalanceForSend == a - p - fee)
     assert(ac3.availableBalanceForReceive == b)
 
-    val (bc3, commit2) = sendCommit(bc2, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc3, commit2)) = sendCommit(bc2, bob.underlyingActor.nodeParams.keyManager)
     assert(bc3.availableBalanceForSend == b)
     assert(bc3.availableBalanceForReceive == a - p - fee)
 
-    val (ac4, revocation2) = receiveCommit(ac3, commit2, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac4, revocation2)) = receiveCommit(ac3, commit2, alice.underlyingActor.nodeParams.keyManager)
     assert(ac4.availableBalanceForSend == a - p - fee)
     assert(ac4.availableBalanceForReceive == b)
 
-    val (bc4, _) = receiveRevocation(bc3, revocation2)
+    val Success((bc4, _)) = receiveRevocation(bc3, revocation2)
     assert(bc4.availableBalanceForSend == b)
     assert(bc4.availableBalanceForReceive == a - p - fee)
 
     val cmdFulfill = CMD_FULFILL_HTLC(0, payment_preimage)
-    val (bc5, fulfill) = sendFulfill(bc4, cmdFulfill)
+    val Success((bc5, fulfill)) = sendFulfill(bc4, cmdFulfill)
     assert(bc5.availableBalanceForSend == b + p) // as soon as we have the fulfill, the balance increases
     assert(bc5.availableBalanceForReceive == a - p - fee)
 
-    val Right((ac5, _, _)) = receiveFulfill(ac4, fulfill)
+    val Success((ac5, _, _)) = receiveFulfill(ac4, fulfill)
     assert(ac5.availableBalanceForSend == a - p - fee)
     assert(ac5.availableBalanceForReceive == b + p)
 
-    val (bc6, commit3) = sendCommit(bc5, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc6, commit3)) = sendCommit(bc5, bob.underlyingActor.nodeParams.keyManager)
     assert(bc6.availableBalanceForSend == b + p)
     assert(bc6.availableBalanceForReceive == a - p - fee)
 
-    val (ac6, revocation3) = receiveCommit(ac5, commit3, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac6, revocation3)) = receiveCommit(ac5, commit3, alice.underlyingActor.nodeParams.keyManager)
     assert(ac6.availableBalanceForSend == a - p)
     assert(ac6.availableBalanceForReceive == b + p)
 
-    val (bc7, _) = receiveRevocation(bc6, revocation3)
+    val Success((bc7, _)) = receiveRevocation(bc6, revocation3)
     assert(bc7.availableBalanceForSend == b + p)
     assert(bc7.availableBalanceForReceive == a - p)
 
-    val (ac7, commit4) = sendCommit(ac6, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac7, commit4)) = sendCommit(ac6, alice.underlyingActor.nodeParams.keyManager)
     assert(ac7.availableBalanceForSend == a - p)
     assert(ac7.availableBalanceForReceive == b + p)
 
-    val (bc8, revocation4) = receiveCommit(bc7, commit4, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc8, revocation4)) = receiveCommit(bc7, commit4, bob.underlyingActor.nodeParams.keyManager)
     assert(bc8.availableBalanceForSend == b + p)
     assert(bc8.availableBalanceForReceive == a - p)
 
-    val (ac8, _) = receiveRevocation(ac7, revocation4)
+    val Success((ac8, _)) = receiveRevocation(ac7, revocation4)
     assert(ac8.availableBalanceForSend == a - p)
     assert(ac8.availableBalanceForReceive == b + p)
   }
@@ -173,68 +173,68 @@ class CommitmentsSpec extends TestkitBaseClass with StateTestsHelperMethods {
     assert(bc0.availableBalanceForReceive == a)
 
     val (_, cmdAdd) = makeCmdAdd(p, bob.underlyingActor.nodeParams.nodeId, currentBlockHeight)
-    val Right((ac1, add)) = sendAdd(ac0, cmdAdd, Local(UUID.randomUUID, None), currentBlockHeight)
+    val Success((ac1, add)) = sendAdd(ac0, cmdAdd, Local(UUID.randomUUID, None), currentBlockHeight)
     assert(ac1.availableBalanceForSend == a - p - fee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
     assert(ac1.availableBalanceForReceive == b)
 
-    val bc1 = receiveAdd(bc0, add)
+    val Success(bc1) = receiveAdd(bc0, add)
     assert(bc1.availableBalanceForSend == b)
     assert(bc1.availableBalanceForReceive == a - p - fee)
 
-    val (ac2, commit1) = sendCommit(ac1, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac2, commit1)) = sendCommit(ac1, alice.underlyingActor.nodeParams.keyManager)
     assert(ac2.availableBalanceForSend == a - p - fee)
     assert(ac2.availableBalanceForReceive == b)
 
-    val (bc2, revocation1) = receiveCommit(bc1, commit1, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc2, revocation1)) = receiveCommit(bc1, commit1, bob.underlyingActor.nodeParams.keyManager)
     assert(bc2.availableBalanceForSend == b)
     assert(bc2.availableBalanceForReceive == a - p - fee)
 
-    val (ac3, _) = receiveRevocation(ac2, revocation1)
+    val Success((ac3, _)) = receiveRevocation(ac2, revocation1)
     assert(ac3.availableBalanceForSend == a - p - fee)
     assert(ac3.availableBalanceForReceive == b)
 
-    val (bc3, commit2) = sendCommit(bc2, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc3, commit2)) = sendCommit(bc2, bob.underlyingActor.nodeParams.keyManager)
     assert(bc3.availableBalanceForSend == b)
     assert(bc3.availableBalanceForReceive == a - p - fee)
 
-    val (ac4, revocation2) = receiveCommit(ac3, commit2, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac4, revocation2)) = receiveCommit(ac3, commit2, alice.underlyingActor.nodeParams.keyManager)
     assert(ac4.availableBalanceForSend == a - p - fee)
     assert(ac4.availableBalanceForReceive == b)
 
-    val (bc4, _) = receiveRevocation(bc3, revocation2)
+    val Success((bc4, _)) = receiveRevocation(bc3, revocation2)
     assert(bc4.availableBalanceForSend == b)
     assert(bc4.availableBalanceForReceive == a - p - fee)
 
     val cmdFail = CMD_FAIL_HTLC(0, Right(IncorrectOrUnknownPaymentDetails(p, 42)))
-    val (bc5, fail) = sendFail(bc4, cmdFail, bob.underlyingActor.nodeParams.privateKey)
+    val Success((bc5, fail)) = sendFail(bc4, cmdFail, bob.underlyingActor.nodeParams.privateKey)
     assert(bc5.availableBalanceForSend == b)
     assert(bc5.availableBalanceForReceive == a - p - fee) // a's balance won't return to previous before she acknowledges the fail
 
-    val Right((ac5, _, _)) = receiveFail(ac4, fail)
+    val Success((ac5, _, _)) = receiveFail(ac4, fail)
     assert(ac5.availableBalanceForSend == a - p - fee)
     assert(ac5.availableBalanceForReceive == b)
 
-    val (bc6, commit3) = sendCommit(bc5, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc6, commit3)) = sendCommit(bc5, bob.underlyingActor.nodeParams.keyManager)
     assert(bc6.availableBalanceForSend == b)
     assert(bc6.availableBalanceForReceive == a - p - fee)
 
-    val (ac6, revocation3) = receiveCommit(ac5, commit3, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac6, revocation3)) = receiveCommit(ac5, commit3, alice.underlyingActor.nodeParams.keyManager)
     assert(ac6.availableBalanceForSend == a)
     assert(ac6.availableBalanceForReceive == b)
 
-    val (bc7, _) = receiveRevocation(bc6, revocation3)
+    val Success((bc7, _)) = receiveRevocation(bc6, revocation3)
     assert(bc7.availableBalanceForSend == b)
     assert(bc7.availableBalanceForReceive == a)
 
-    val (ac7, commit4) = sendCommit(ac6, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac7, commit4)) = sendCommit(ac6, alice.underlyingActor.nodeParams.keyManager)
     assert(ac7.availableBalanceForSend == a)
     assert(ac7.availableBalanceForReceive == b)
 
-    val (bc8, revocation4) = receiveCommit(bc7, commit4, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc8, revocation4)) = receiveCommit(bc7, commit4, bob.underlyingActor.nodeParams.keyManager)
     assert(bc8.availableBalanceForSend == b)
     assert(bc8.availableBalanceForReceive == a)
 
-    val (ac8, _) = receiveRevocation(ac7, revocation4)
+    val Success((ac8, _)) = receiveRevocation(ac7, revocation4)
     assert(ac8.availableBalanceForSend == a)
     assert(ac8.availableBalanceForReceive == b)
   }
@@ -260,128 +260,128 @@ class CommitmentsSpec extends TestkitBaseClass with StateTestsHelperMethods {
     assert(bc0.availableBalanceForReceive == a)
 
     val (payment_preimage1, cmdAdd1) = makeCmdAdd(p1, bob.underlyingActor.nodeParams.nodeId, currentBlockHeight)
-    val Right((ac1, add1)) = sendAdd(ac0, cmdAdd1, Local(UUID.randomUUID, None), currentBlockHeight)
+    val Success((ac1, add1)) = sendAdd(ac0, cmdAdd1, Local(UUID.randomUUID, None), currentBlockHeight)
     assert(ac1.availableBalanceForSend == a - p1 - fee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
     assert(ac1.availableBalanceForReceive == b)
 
     val (_, cmdAdd2) = makeCmdAdd(p2, bob.underlyingActor.nodeParams.nodeId, currentBlockHeight)
-    val Right((ac2, add2)) = sendAdd(ac1, cmdAdd2, Local(UUID.randomUUID, None), currentBlockHeight)
+    val Success((ac2, add2)) = sendAdd(ac1, cmdAdd2, Local(UUID.randomUUID, None), currentBlockHeight)
     assert(ac2.availableBalanceForSend == a - p1 - fee - p2 - fee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
     assert(ac2.availableBalanceForReceive == b)
 
     val (payment_preimage3, cmdAdd3) = makeCmdAdd(p3, alice.underlyingActor.nodeParams.nodeId, currentBlockHeight)
-    val Right((bc1, add3)) = sendAdd(bc0, cmdAdd3, Local(UUID.randomUUID, None), currentBlockHeight)
+    val Success((bc1, add3)) = sendAdd(bc0, cmdAdd3, Local(UUID.randomUUID, None), currentBlockHeight)
     assert(bc1.availableBalanceForSend == b - p3) // bob doesn't pay the fee
     assert(bc1.availableBalanceForReceive == a)
 
-    val bc2 = receiveAdd(bc1, add1)
+    val Success(bc2) = receiveAdd(bc1, add1)
     assert(bc2.availableBalanceForSend == b - p3)
     assert(bc2.availableBalanceForReceive == a - p1 - fee)
 
-    val bc3 = receiveAdd(bc2, add2)
+    val Success(bc3) = receiveAdd(bc2, add2)
     assert(bc3.availableBalanceForSend == b - p3)
     assert(bc3.availableBalanceForReceive == a - p1 - fee - p2 - fee)
 
-    val ac3 = receiveAdd(ac2, add3)
+    val Success(ac3) = receiveAdd(ac2, add3)
     assert(ac3.availableBalanceForSend == a - p1 - fee - p2 - fee)
     assert(ac3.availableBalanceForReceive == b - p3)
 
-    val (ac4, commit1) = sendCommit(ac3, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac4, commit1)) = sendCommit(ac3, alice.underlyingActor.nodeParams.keyManager)
     assert(ac4.availableBalanceForSend == a - p1 - fee - p2 - fee)
     assert(ac4.availableBalanceForReceive == b - p3)
 
-    val (bc4, revocation1) = receiveCommit(bc3, commit1, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc4, revocation1)) = receiveCommit(bc3, commit1, bob.underlyingActor.nodeParams.keyManager)
     assert(bc4.availableBalanceForSend == b - p3)
     assert(bc4.availableBalanceForReceive == a - p1 - fee - p2 - fee)
 
-    val (ac5, _) = receiveRevocation(ac4, revocation1)
+    val Success((ac5, _)) = receiveRevocation(ac4, revocation1)
     assert(ac5.availableBalanceForSend == a - p1 - fee - p2 - fee)
     assert(ac5.availableBalanceForReceive == b - p3)
 
-    val (bc5, commit2) = sendCommit(bc4, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc5, commit2)) = sendCommit(bc4, bob.underlyingActor.nodeParams.keyManager)
     assert(bc5.availableBalanceForSend == b - p3)
     assert(bc5.availableBalanceForReceive == a - p1 - fee - p2 - fee)
 
-    val (ac6, revocation2) = receiveCommit(ac5, commit2, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac6, revocation2)) = receiveCommit(ac5, commit2, alice.underlyingActor.nodeParams.keyManager)
     assert(ac6.availableBalanceForSend == a - p1 - fee - p2 - fee - fee) // alice has acknowledged b's hltc so it needs to pay the fee for it
     assert(ac6.availableBalanceForReceive == b - p3)
 
-    val (bc6, _) = receiveRevocation(bc5, revocation2)
+    val Success((bc6, _)) = receiveRevocation(bc5, revocation2)
     assert(bc6.availableBalanceForSend == b - p3)
     assert(bc6.availableBalanceForReceive == a - p1 - fee - p2 - fee - fee)
 
-    val (ac7, commit3) = sendCommit(ac6, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac7, commit3)) = sendCommit(ac6, alice.underlyingActor.nodeParams.keyManager)
     assert(ac7.availableBalanceForSend == a - p1 - fee - p2 - fee - fee)
     assert(ac7.availableBalanceForReceive == b - p3)
 
-    val (bc7, revocation3) = receiveCommit(bc6, commit3, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc7, revocation3)) = receiveCommit(bc6, commit3, bob.underlyingActor.nodeParams.keyManager)
     assert(bc7.availableBalanceForSend == b - p3)
     assert(bc7.availableBalanceForReceive == a - p1 - fee - p2 - fee - fee)
 
-    val (ac8, _) = receiveRevocation(ac7, revocation3)
+    val Success((ac8, _)) = receiveRevocation(ac7, revocation3)
     assert(ac8.availableBalanceForSend == a - p1 - fee - p2 - fee - fee)
     assert(ac8.availableBalanceForReceive == b - p3)
 
     val cmdFulfill1 = CMD_FULFILL_HTLC(0, payment_preimage1)
-    val (bc8, fulfill1) = sendFulfill(bc7, cmdFulfill1)
+    val Success((bc8, fulfill1)) = sendFulfill(bc7, cmdFulfill1)
     assert(bc8.availableBalanceForSend == b + p1 - p3) // as soon as we have the fulfill, the balance increases
     assert(bc8.availableBalanceForReceive == a - p1 - fee - p2 - fee - fee)
 
     val cmdFail2 = CMD_FAIL_HTLC(1, Right(IncorrectOrUnknownPaymentDetails(p2, 42)))
-    val (bc9, fail2) = sendFail(bc8, cmdFail2, bob.underlyingActor.nodeParams.privateKey)
+    val Success((bc9, fail2)) = sendFail(bc8, cmdFail2, bob.underlyingActor.nodeParams.privateKey)
     assert(bc9.availableBalanceForSend == b + p1 - p3)
     assert(bc9.availableBalanceForReceive == a - p1 - fee - p2 - fee - fee) // a's balance won't return to previous before she acknowledges the fail
 
     val cmdFulfill3 = CMD_FULFILL_HTLC(0, payment_preimage3)
-    val (ac9, fulfill3) = sendFulfill(ac8, cmdFulfill3)
+    val Success((ac9, fulfill3)) = sendFulfill(ac8, cmdFulfill3)
     assert(ac9.availableBalanceForSend == a - p1 - fee - p2 - fee + p3) // as soon as we have the fulfill, the balance increases
     assert(ac9.availableBalanceForReceive == b - p3)
 
-    val Right((ac10, _, _)) = receiveFulfill(ac9, fulfill1)
+    val Success((ac10, _, _)) = receiveFulfill(ac9, fulfill1)
     assert(ac10.availableBalanceForSend == a - p1 - fee - p2 - fee + p3)
     assert(ac10.availableBalanceForReceive == b + p1 - p3)
 
-    val Right((ac11, _, _)) = receiveFail(ac10, fail2)
+    val Success((ac11, _, _)) = receiveFail(ac10, fail2)
     assert(ac11.availableBalanceForSend == a - p1 - fee - p2 - fee + p3)
     assert(ac11.availableBalanceForReceive == b + p1 - p3)
 
-    val Right((bc10, _, _)) = receiveFulfill(bc9, fulfill3)
+    val Success((bc10, _, _)) = receiveFulfill(bc9, fulfill3)
     assert(bc10.availableBalanceForSend == b + p1 - p3)
     assert(bc10.availableBalanceForReceive == a - p1 - fee - p2 - fee + p3) // the fee for p3 disappears
 
-    val (ac12, commit4) = sendCommit(ac11, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac12, commit4)) = sendCommit(ac11, alice.underlyingActor.nodeParams.keyManager)
     assert(ac12.availableBalanceForSend == a - p1 - fee - p2 - fee + p3)
     assert(ac12.availableBalanceForReceive == b + p1 - p3)
 
-    val (bc11, revocation4) = receiveCommit(bc10, commit4, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc11, revocation4)) = receiveCommit(bc10, commit4, bob.underlyingActor.nodeParams.keyManager)
     assert(bc11.availableBalanceForSend == b + p1 - p3)
     assert(bc11.availableBalanceForReceive == a - p1 - fee - p2 - fee + p3)
 
-    val (ac13, _) = receiveRevocation(ac12, revocation4)
+    val Success((ac13, _)) = receiveRevocation(ac12, revocation4)
     assert(ac13.availableBalanceForSend == a - p1 - fee - p2 - fee + p3)
     assert(ac13.availableBalanceForReceive == b + p1 - p3)
 
-    val (bc12, commit5) = sendCommit(bc11, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc12, commit5)) = sendCommit(bc11, bob.underlyingActor.nodeParams.keyManager)
     assert(bc12.availableBalanceForSend == b + p1 - p3)
     assert(bc12.availableBalanceForReceive == a - p1 - fee - p2 - fee + p3)
 
-    val (ac14, revocation5) = receiveCommit(ac13, commit5, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac14, revocation5)) = receiveCommit(ac13, commit5, alice.underlyingActor.nodeParams.keyManager)
     assert(ac14.availableBalanceForSend == a - p1 + p3)
     assert(ac14.availableBalanceForReceive == b + p1 - p3)
 
-    val (bc13, _) = receiveRevocation(bc12, revocation5)
+    val Success((bc13, _)) = receiveRevocation(bc12, revocation5)
     assert(bc13.availableBalanceForSend == b + p1 - p3)
     assert(bc13.availableBalanceForReceive == a - p1 + p3)
 
-    val (ac15, commit6) = sendCommit(ac14, alice.underlyingActor.nodeParams.keyManager)
+    val Success((ac15, commit6)) = sendCommit(ac14, alice.underlyingActor.nodeParams.keyManager)
     assert(ac15.availableBalanceForSend == a - p1 + p3)
     assert(ac15.availableBalanceForReceive == b + p1 - p3)
 
-    val (bc14, revocation6) = receiveCommit(bc13, commit6, bob.underlyingActor.nodeParams.keyManager)
+    val Success((bc14, revocation6)) = receiveCommit(bc13, commit6, bob.underlyingActor.nodeParams.keyManager)
     assert(bc14.availableBalanceForSend == b + p1 - p3)
     assert(bc14.availableBalanceForReceive == a - p1 + p3)
 
-    val (ac16, _) = receiveRevocation(ac15, revocation6)
+    val Success((ac16, _)) = receiveRevocation(ac15, revocation6)
     assert(ac16.availableBalanceForSend == a - p1 + p3)
     assert(ac16.availableBalanceForReceive == b + p1 - p3)
   }
@@ -391,7 +391,7 @@ class CommitmentsSpec extends TestkitBaseClass with StateTestsHelperMethods {
       val c = CommitmentsSpec.makeCommitments(702000000 msat, 52000000 msat, 2679, 546 sat, isFunder)
       val (_, cmdAdd) = makeCmdAdd(c.availableBalanceForSend, randomKey.publicKey, f.currentBlockHeight)
       val result = sendAdd(c, cmdAdd, Local(UUID.randomUUID, None), f.currentBlockHeight)
-      assert(result.isRight, result)
+      assert(result.isSuccess, result)
     }
   }
 
@@ -421,13 +421,13 @@ class CommitmentsSpec extends TestkitBaseClass with StateTestsHelperMethods {
         val amount = Random.nextInt(maxPendingHtlcAmount.toLong.toInt).msat
         val (_, cmdAdd) = makeCmdAdd(amount, randomKey.publicKey, f.currentBlockHeight)
         sendAdd(c, cmdAdd, Local(UUID.randomUUID, None), f.currentBlockHeight) match {
-          case Right((cc, _)) => c = cc
-          case Left(e) => fail(s"$t -> could not setup initial htlcs: $e")
+          case Success((cc, _)) => c = cc
+          case Failure(e) => fail(s"$t -> could not setup initial htlcs: $e")
         }
       }
       val (_, cmdAdd) = makeCmdAdd(c.availableBalanceForSend, randomKey.publicKey, f.currentBlockHeight)
       val result = sendAdd(c, cmdAdd, Local(UUID.randomUUID, None), f.currentBlockHeight)
-      assert(result.isRight, s"$t -> $result")
+      assert(result.isSuccess, s"$t -> $result")
     }
   }
 
@@ -448,13 +448,13 @@ class CommitmentsSpec extends TestkitBaseClass with StateTestsHelperMethods {
       for (_ <- 0 to t.pendingHtlcs) {
         val amount = Random.nextInt(maxPendingHtlcAmount.toLong.toInt).msat
         val add = UpdateAddHtlc(randomBytes32, c.remoteNextHtlcId, amount, randomBytes32, CltvExpiry(f.currentBlockHeight), TestConstants.emptyOnionPacket)
-        Try(receiveAdd(c, add)) match {
+        receiveAdd(c, add) match {
           case Success(cc) => c = cc
           case Failure(e) => fail(s"$t -> could not setup initial htlcs: $e")
         }
       }
       val add = UpdateAddHtlc(randomBytes32, c.remoteNextHtlcId, c.availableBalanceForReceive, randomBytes32, CltvExpiry(f.currentBlockHeight), TestConstants.emptyOnionPacket)
-      Try(receiveAdd(c, add)) match {
+      receiveAdd(c, add) match {
         case Success(_) => ()
         case Failure(e) => fail(s"$t -> $e")
       }


### PR DESCRIPTION
Currently, those methods throw exceptions, and we rely on `Channel` to
call them within a `Try(...)`. It puts more burden on `Channel` and
isn't very functional.

Some methods were returning an `Either[]`, which seem to play the role
of a `Try` but isn't used. It seems the idea was to not fail the channel
upon receiving a `fulfill`/`fail` for an unknown htlc, but it is not
fully wired, and isn't compliant (BOLT 2):

> A receiving node:
> if the id does not correspond to an HTLC in its current commitment
transaction:
>    MUST fail the channel.

For signature-related methods, I went with the minimal change of
encapsulating portions of the code inside a `Try {...}` to minimize risk
of regression. We could also make `CommitmentSpec` methods return
`Try[]` but I suspect that would be more complicated with little
benefit.

Note that if some part isn't covered by the `Try` and ends up throwing
an exception, that will be covered by the `handleException` handler of
`Channel`.

Fixes #1305. 