### PR TITLE
Avoid illegal reflective operation during startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,8 @@ docker exec <container_name> eclair-cli -p foobar getinfo
 
 For advanced usage, Eclair supports plugins written in Scala, Java, or any JVM-compatible language.
 
-A valid plugin is a jar that contains an implementation of the [Plugin](eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala) interface.
+A valid plugin is a jar that contains an implementation of the [Plugin](eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala) interface, and 
+a manifest entry for `Main-Class` with the FQDN of the implementation.
 
 Here is how to run Eclair with plugins:
 

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -91,12 +91,6 @@
             <artifactId>eclair-core_${scala.version.short}</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <!-- for plugins -->
-            <groupId>org.clapper</groupId>
-            <artifactId>classutil_${scala.version.short}</artifactId>
-            <version>1.4.0</version>
-        </dependency>
         <!-- logging -->
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
@@ -40,24 +40,21 @@ object Plugin extends Logging {
     * @return
     */
   def loadPlugins(jars: Seq[File]): Seq[Plugin] = {
-    val urls = jars.flatMap(f =>
-      getOrNone(new URL(s"jar:file:${f.getCanonicalPath}!/").openConnection().asInstanceOf[JarURLConnection], s"unable to load plugin file:${f.getAbsolutePath} ")
-    )
+    val urls = jars.flatMap(openJar)
     val loader = new URLClassLoader(urls.map(_.getJarFileURL).toArray, ClassLoader.getSystemClassLoader)
     val pluginClasses = urls
-        .map(_.getMainAttributes.getValue("Main-Class"))
-        .flatMap(classFQDN => getOrNone[Class[_]](loader.loadClass(classFQDN), s"error loading $classFQDN "))
-        .flatMap(c => getOrNone[Plugin](c.getDeclaredConstructor().newInstance().asInstanceOf[Plugin], s"${c.getCanonicalName} does not implement $Plugin "))
+        .flatMap(j => Option(j.getMainAttributes.getValue("Main-Class")))
+        .flatMap(classFQDN => Try[Class[_]](loader.loadClass(classFQDN)).toOption)
+        .flatMap(c => Try(c.getDeclaredConstructor().newInstance().asInstanceOf[Plugin]).toOption)
 
     logger.info(s"loading ${pluginClasses.size} plugins")
     pluginClasses
   }
 
-  def getOrNone[T](f: => T, errMsg: String): Option[T] = Try(f) match {
-    case Failure(exception) =>
-      logger.error(errMsg, exception)
-      None
-    case Success(value) => Some(value)
-  }
+  def openJar(jar: File): Option[JarURLConnection] =
+    Try(new URL(s"jar:file:${jar.getCanonicalPath}!/").openConnection().asInstanceOf[JarURLConnection]) match {
+      case Success(url) => Some(url)
+      case Failure(t) => logger.error(s"unable to load plugin file:${jar.getAbsolutePath} ", t); None
+    }
 
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
@@ -17,9 +17,11 @@
 package fr.acinq.eclair
 
 import java.io.File
-import java.net.{URL, URLClassLoader}
+import java.net.{JarURLConnection, URL, URLClassLoader}
 
-import org.clapper.classutil.ClassFinder
+import grizzled.slf4j.Logging
+
+import scala.util.{Failure, Success, Try}
 
 trait Plugin {
 
@@ -29,17 +31,33 @@ trait Plugin {
 
 }
 
-object Plugin {
+object Plugin extends Logging {
 
+  /**
+    * The files passed to this function must be jars containing a manifest entry for "Main-Class" with the
+    * FQDN of the entry point of the plugin. The entry point is the implementation of the interface "fr.acinq.eclair.Plugin"
+    * @param jars
+    * @return
+    */
   def loadPlugins(jars: Seq[File]): Seq[Plugin] = {
-      val finder = ClassFinder(jars)
-      val classes = finder.getClasses
-      val urls = jars.map(f => new URL(s"file:${f.getCanonicalPath}"))
-      val loader = new URLClassLoader(urls.toArray, ClassLoader.getSystemClassLoader)
-      classes
-        .filter(_.isConcrete)
-        .filter(_.implements(classOf[Plugin].getName))
-        .map(c => Class.forName(c.name, true, loader).getDeclaredConstructor().newInstance().asInstanceOf[Plugin])
-        .toList
-    }
+    val urls = jars.flatMap(f =>
+      getOrNone(new URL(s"jar:file:${f.getCanonicalPath}!/").openConnection().asInstanceOf[JarURLConnection], s"unable to load plugin file:${f.getAbsolutePath} ")
+    )
+    val loader = new URLClassLoader(urls.map(_.getJarFileURL).toArray, ClassLoader.getSystemClassLoader)
+    val pluginClasses = urls
+        .map(_.getMainAttributes.getValue("Main-Class"))
+        .flatMap(classFQDN => getOrNone[Class[_]](loader.loadClass(classFQDN), s"error loading $classFQDN "))
+        .flatMap(c => getOrNone[Plugin](c.getDeclaredConstructor().newInstance().asInstanceOf[Plugin], s"${c.getCanonicalName} does not implement $Plugin "))
+
+    logger.info(s"loading ${pluginClasses.size} plugins")
+    pluginClasses
+  }
+
+  def getOrNone[T](f: => T, errMsg: String): Option[T] = Try(f) match {
+    case Failure(exception) =>
+      logger.error(errMsg, exception)
+      None
+    case Success(value) => Some(value)
+  }
+
 }


### PR DESCRIPTION
~~This PR rewords the way we load plugins providing a stricter and safer way to load them. We now require plugins to exhibit a MANIFEST file with some well defined entries:~~
~~- `Main-Class` to identify the plugin entry point ( class implementing `Plugin`)~~
~~- `X-Eclair-Supported-Versions` contains a list of all supported eclair version~~

~~The `Main-Class` is mainly used to load the plugin without scanning using `org.clapper.classutils`, this allows us to avoid an illegal reflective call during startup. The list of supported version allows us to check if the plugin we're loading supports the current version of eclair, this prevents from running outdated (and incompatible) plugins.~~

This PR slightly reworks the way we load plugins to avoid doing an illegal reflective call. Instead of using org.clapper.classutils to scan for classes (and perform the illegal reflective call) we now require the plugin to tell us which class is implementing the Plugin interface via MANIFEST file.