### PR TITLE
Electrum: add support for socks5 proxies

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -200,7 +200,7 @@ class Setup(datadir: File,
           val stream = classOf[Setup].getResourceAsStream(addressesFile)
           ElectrumClientPool.readServerAddresses(stream, sslEnabled)
       }
-      val electrumClient = system.actorOf(SimpleSupervisor.props(Props(new ElectrumClientPool(blockCount, addresses)), "electrum-client", SupervisorStrategy.Resume))
+      val electrumClient = system.actorOf(SimpleSupervisor.props(Props(new ElectrumClientPool(blockCount, addresses, nodeParams.socksProxy_opt)), "electrum-client", SupervisorStrategy.Resume))
       Electrum(electrumClient)
   }
 


### PR DESCRIPTION
We use the same socks5 proxy that is optionally enabled in the configuration and is typically used to connect to LN nodes running as TOR hidden services.

This will allow eclair:
- to connect to .onion Electrum servers running behind TOR
- to connect to regular Electrum servers through TOR