### PR TITLE
Use 'getzmqnotifications' to get ZMQ addresses from bitcoind

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,6 @@ name                         | description                                      
  eclair.api.password         | API password (BASIC)                                                                  | "" (must be set if the API is enabled)
  eclair.bitcoind.rpcuser     | Bitcoin Core RPC user                                                                 | foo
  eclair.bitcoind.rpcpassword | Bitcoin Core RPC password                                                             | bar
- eclair.bitcoind.zmqblock    | Bitcoin Core ZMQ block address                                                        | "tcp://127.0.0.1:29000"
- eclair.bitcoind.zmqtx       | Bitcoin Core ZMQ tx address                                                           | "tcp://127.0.0.1:29000"
  eclair.gui.unit             | Unit in which amounts are displayed (possible values: msat, sat, bits, mbtc, btc)     | btc
 
 Quotes are not required unless the value contains special characters. Full syntax guide [here](https://github.com/lightbend/config/blob/master/HOCON.md).

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -25,8 +25,6 @@ eclair {
     rpcport = 8332
     rpcuser = "foo"
     rpcpassword = "bar"
-    zmqblock = "tcp://127.0.0.1:29000"
-    zmqtx = "tcp://127.0.0.1:29000"
   }
 
   min-feerate = 3 // minimum feerate in satoshis per byte

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -52,7 +52,7 @@ import fr.acinq.eclair.tor.TorProtocolHandler.OnionServiceVersion
 import fr.acinq.eclair.tor.{Controller, TorProtocolHandler}
 import fr.acinq.eclair.wire.NodeAddress
 import grizzled.slf4j.Logging
-import org.json4s.JsonAST.JArray
+import org.json4s.JsonAST.{JArray, JString}
 import scodec.bits.ByteVector
 
 import scala.concurrent._
@@ -247,11 +247,21 @@ class Setup(datadir: File,
           feeratesRetrieved.trySuccess(Done)
       })
       _ <- feeratesRetrieved.future
+      (zmqBlocks_opt, zmqTxs_opt) <- bitcoin match {
+        case Bitcoind(client) => client.invoke("getzmqnotifications").map {
+          case JArray(zmqInfos) =>
+            val blocksAddress = zmqInfos.find(_ \ "type" == JString("pubrawblock")).map(_.\("address").extract[String])
+            val txsAddress = zmqInfos.find(_ \ "type" == JString("pubrawtx")).map(_.\("address").extract[String])
+            (blocksAddress, txsAddress)
+          case _ => (None, None)
+        }
+        case _ => Future.successful((None, None))
+      }
 
       watcher = bitcoin match {
         case Bitcoind(bitcoinClient) =>
-          system.actorOf(SimpleSupervisor.props(Props(new ZMQActor(config.getString("bitcoind.zmqblock"), Some(zmqBlockConnected))), "zmqblock", SupervisorStrategy.Restart))
-          system.actorOf(SimpleSupervisor.props(Props(new ZMQActor(config.getString("bitcoind.zmqtx"), Some(zmqTxConnected))), "zmqtx", SupervisorStrategy.Restart))
+          system.actorOf(SimpleSupervisor.props(Props(new ZMQActor(zmqBlocks_opt.get, Some(zmqBlockConnected))), "zmqblock", SupervisorStrategy.Restart))
+          system.actorOf(SimpleSupervisor.props(Props(new ZMQActor(zmqTxs_opt.get, Some(zmqTxConnected))), "zmqtx", SupervisorStrategy.Restart))
           system.actorOf(SimpleSupervisor.props(ZmqWatcher.props(blockCount, new ExtendedBitcoinClient(new BatchingBitcoinJsonRPCClient(bitcoinClient))), "watcher", SupervisorStrategy.Resume))
         case Electrum(electrumClient) =>
           zmqBlockConnected.success(Done)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -252,8 +252,11 @@ class Setup(datadir: File,
           case JArray(zmqInfos) =>
             val blocksAddress = zmqInfos.find(_ \ "type" == JString("pubrawblock")).map(_.\("address").extract[String])
             val txsAddress = zmqInfos.find(_ \ "type" == JString("pubrawtx")).map(_.\("address").extract[String])
+            if(blocksAddress.isEmpty || txsAddress.isEmpty){
+              throw new IllegalArgumentException("Unable to get zmq addresses, please make sure ZMQ is enabled in bitcoin.conf")
+            }
             (blocksAddress, txsAddress)
-          case _ => (None, None)
+          case _ => throw new IllegalArgumentException("Unable to get zmq addresses, please make sure ZMQ is enabled in bitcoin.conf")
         }
         case _ => Future.successful((None, None))
       }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -89,8 +89,6 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     "eclair.server.public-ips.1" -> "127.0.0.1",
     "eclair.bitcoind.port" -> bitcoindPort,
     "eclair.bitcoind.rpcport" -> bitcoindRpcPort,
-    "eclair.bitcoind.zmqblock" -> s"tcp://127.0.0.1:$bitcoindZmqBlockPort",
-    "eclair.bitcoind.zmqtx" -> s"tcp://127.0.0.1:$bitcoindZmqTxPort",
     "eclair.mindepth-blocks" -> 2,
     "eclair.max-htlc-value-in-flight-msat" -> 100000000000L,
     "eclair.router.broadcast-interval" -> "2 second",


### PR DESCRIPTION
Replaces the configuration keys for the ZMQ with an RPC call to obtain the addresses from bitcoind, see #1314 