### PR TITLE
Refactor MultiPartPaymentFSM

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentFSMSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentFSMSpec.scala
@@ -20,9 +20,8 @@ import akka.actor.ActorSystem
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.eclair.payment.PaymentReceived.PartialPayment
 import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM
-import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM.PendingPayment
+import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM._
 import fr.acinq.eclair.wire.{IncorrectOrUnknownPaymentDetails, UpdateAddHtlc}
 import fr.acinq.eclair.{CltvExpiry, LongToBtcAmount, MilliSatoshi, NodeParams, TestConstants, randomBytes32, wire}
 import org.scalatest.FunSuiteLike
@@ -37,7 +36,6 @@ import scala.concurrent.duration._
 
 class MultiPartPaymentFSMSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
 
-  import MultiPartPaymentFSM._
   import MultiPartPaymentFSMSpec._
 
   case class FixtureParam(nodeParams: NodeParams, handler: TestActorRef[MultiPartPaymentFSM], parent: TestProbe, eventListener: TestProbe) {
@@ -61,23 +59,23 @@ class MultiPartPaymentFSMSpec extends TestKit(ActorSystem("test")) with FunSuite
     val CurrentState(_, WAITING_FOR_HTLC) = monitor.expectMsgClass(classOf[CurrentState[_]])
     val Transition(_, WAITING_FOR_HTLC, PAYMENT_FAILED) = monitor.expectMsgClass(classOf[Transition[_]])
 
-    f.parent.expectMsg(MultiPartHtlcFailed(paymentHash, wire.PaymentTimeout, Queue.empty))
+    f.parent.expectMsg(MultiPartPaymentFailed(paymentHash, wire.PaymentTimeout, Queue.empty))
     f.parent.expectNoMsg(50 millis)
     f.eventListener.expectNoMsg(50 millis)
   }
 
   test("timeout waiting for more htlcs") {
     val f = createFixture(250 millis, 1000 msat)
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 150 msat, 1))
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 100 msat, 2))
+    val parts = Seq(
+      createMultiPartHtlc(1000 msat, 150 msat, 1),
+      createMultiPartHtlc(1000 msat, 100 msat, 2)
+    )
+    parts.foreach(p => f.parent.send(f.handler, p))
 
-    val fail = f.parent.expectMsgType[MultiPartHtlcFailed]
+    val fail = f.parent.expectMsgType[MultiPartPaymentFailed]
     assert(fail.paymentHash === paymentHash)
     assert(fail.failure === wire.PaymentTimeout)
-    assert(setTimestamp(fail.parts, 0).toSet === Set(
-      PendingPayment(1, PartialPayment(150 msat, htlcIdToChannelId(1), 0)),
-      PendingPayment(2, PartialPayment(100 msat, htlcIdToChannelId(2), 0))
-    ))
+    assert(fail.parts.toSet === parts.toSet)
 
     f.parent.expectNoMsg(50 millis)
     f.eventListener.expectNoMsg(50 millis)
@@ -87,13 +85,14 @@ class MultiPartPaymentFSMSpec extends TestKit(ActorSystem("test")) with FunSuite
     val f = createFixture(250 millis, 1000 msat)
     f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 150 msat, 1))
     f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 100 msat, 2))
-    assert(f.parent.expectMsgType[MultiPartHtlcFailed].parts.length === 2)
+    assert(f.parent.expectMsgType[MultiPartPaymentFailed].parts.length === 2)
 
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 300 msat, 3))
-    val fail = f.parent.expectMsgType[ExtraHtlcReceived]
+    val extraPart = createMultiPartHtlc(1000 msat, 300 msat, 3)
+    f.parent.send(f.handler, extraPart)
+    val fail = f.parent.expectMsgType[ExtraPaymentReceived]
     assert(fail.paymentHash === paymentHash)
     assert(fail.failure === Some(wire.PaymentTimeout))
-    assert(setTimestamp(fail.payment :: Nil, 0) === Seq(PendingPayment(3, PartialPayment(300 msat, htlcIdToChannelId(3), 0))))
+    assert(fail.payment === extraPart)
 
     f.parent.expectNoMsg(50 millis)
     f.eventListener.expectNoMsg(50 millis)
@@ -103,7 +102,7 @@ class MultiPartPaymentFSMSpec extends TestKit(ActorSystem("test")) with FunSuite
     val f = createFixture(250 millis, 1000 msat)
     f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 600 msat, 1))
     f.parent.send(f.handler, createMultiPartHtlc(1100 msat, 650 msat, 2))
-    val fail = f.parent.expectMsgType[MultiPartHtlcFailed]
+    val fail = f.parent.expectMsgType[MultiPartPaymentFailed]
     assert(fail.paymentHash === paymentHash)
     assert(fail.failure === IncorrectOrUnknownPaymentDetails(1100 msat, f.currentBlockHeight))
     assert(fail.parts.length === 2)
@@ -114,34 +113,32 @@ class MultiPartPaymentFSMSpec extends TestKit(ActorSystem("test")) with FunSuite
 
   test("fulfill all when total amount reached") {
     val f = createFixture(10 seconds, 1000 msat)
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 300 msat, 1))
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 340 msat, 2))
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 360 msat, 3))
+    val parts = Seq(
+      createMultiPartHtlc(1000 msat, 300 msat, 1),
+      createMultiPartHtlc(1000 msat, 340 msat, 2),
+      createMultiPartHtlc(1000 msat, 360 msat, 3)
+    )
+    parts.foreach(p => f.parent.send(f.handler, p))
 
-    val paymentResult = f.parent.expectMsgType[MultiPartHtlcSucceeded]
+    val paymentResult = f.parent.expectMsgType[MultiPartPaymentSucceeded]
     assert(paymentResult.paymentHash === paymentHash)
-    assert(setTimestamp(paymentResult.parts, 0).toSet === Set(
-      PendingPayment(1, PartialPayment(300 msat, htlcIdToChannelId(1), 0)),
-      PendingPayment(2, PartialPayment(340 msat, htlcIdToChannelId(2), 0)),
-      PendingPayment(3, PartialPayment(360 msat, htlcIdToChannelId(3), 0))
-    ))
+    assert(paymentResult.parts.toSet === parts.toSet)
     f.parent.expectNoMsg(50 millis)
     f.eventListener.expectNoMsg(50 millis)
   }
 
   test("fulfill all with amount higher than total amount") {
     val f = createFixture(10 seconds, 1000 msat)
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 300 msat, 1))
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 340 msat, 2))
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 400 msat, 3))
+    val parts = Seq(
+      createMultiPartHtlc(1000 msat, 300 msat, 1),
+      createMultiPartHtlc(1000 msat, 340 msat, 2),
+      createMultiPartHtlc(1000 msat, 400 msat, 3)
+    )
+    parts.foreach(p => f.parent.send(f.handler, p))
 
-    val paymentResult = f.parent.expectMsgType[MultiPartHtlcSucceeded]
+    val paymentResult = f.parent.expectMsgType[MultiPartPaymentSucceeded]
     assert(paymentResult.paymentHash === paymentHash)
-    assert(setTimestamp(paymentResult.parts, 0).toSet === Set(
-      PendingPayment(1, PartialPayment(300 msat, htlcIdToChannelId(1), 0)),
-      PendingPayment(2, PartialPayment(340 msat, htlcIdToChannelId(2), 0)),
-      PendingPayment(3, PartialPayment(400 msat, htlcIdToChannelId(3), 0))
-    ))
+    assert(paymentResult.parts.toSet === parts.toSet)
 
     f.parent.expectNoMsg(50 millis)
     f.eventListener.expectNoMsg(50 millis)
@@ -149,18 +146,24 @@ class MultiPartPaymentFSMSpec extends TestKit(ActorSystem("test")) with FunSuite
 
   test("fulfill all with single htlc") {
     val f = createFixture(10 seconds, 1000 msat)
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 1000 msat, 1))
-    val paymentResult = f.parent.expectMsgType[MultiPartHtlcSucceeded]
-    assert(setTimestamp(paymentResult.parts, 0) === Seq(PendingPayment(1, PartialPayment(1000 msat, htlcIdToChannelId(1), 0))))
+    val part = createMultiPartHtlc(1000 msat, 1000 msat, 1)
+    f.parent.send(f.handler, part)
+
+    val paymentResult = f.parent.expectMsgType[MultiPartPaymentSucceeded]
+    assert(paymentResult.parts === Seq(part))
+
     f.parent.expectNoMsg(50 millis)
     f.eventListener.expectNoMsg(50 millis)
   }
 
   test("fulfill all with single htlc and amount higher than total amount") {
     val f = createFixture(10 seconds, 1000 msat)
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 1100 msat, 1))
-    val paymentResult = f.parent.expectMsgType[MultiPartHtlcSucceeded]
-    assert(setTimestamp(paymentResult.parts, 0) === Seq(PendingPayment(1, PartialPayment(1100 msat, htlcIdToChannelId(1), 0))))
+    val part = createMultiPartHtlc(1000 msat, 1100 msat, 1)
+    f.parent.send(f.handler, part)
+
+    val paymentResult = f.parent.expectMsgType[MultiPartPaymentSucceeded]
+    assert(paymentResult.parts === Seq(part))
+
     f.parent.expectNoMsg(50 millis)
     f.eventListener.expectNoMsg(50 millis)
   }
@@ -168,51 +171,55 @@ class MultiPartPaymentFSMSpec extends TestKit(ActorSystem("test")) with FunSuite
   test("receive additional htlcs after total amount reached") {
     val f = createFixture(10 seconds, 1000 msat)
 
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 600 msat, 1))
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 400 msat, 2))
-    val paymentResult = f.parent.expectMsgType[MultiPartHtlcSucceeded]
-    assert(setTimestamp(paymentResult.parts, 0).toSet === Set(
-      PendingPayment(1, PartialPayment(600 msat, htlcIdToChannelId(1), 0)),
-      PendingPayment(2, PartialPayment(400 msat, htlcIdToChannelId(2), 0))
-    ))
+    val parts = Seq(
+      createMultiPartHtlc(1000 msat, 600 msat, 1),
+      createMultiPartHtlc(1000 msat, 400 msat, 2)
+    )
+    parts.foreach(p => f.parent.send(f.handler, p))
+    val paymentResult = f.parent.expectMsgType[MultiPartPaymentSucceeded]
+    assert(paymentResult.parts.toSet === parts.toSet)
     f.parent.expectNoMsg(50 millis)
 
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 300 msat, 3))
-    val extraneousPayment = f.parent.expectMsgType[ExtraHtlcReceived]
+    val extra = createMultiPartHtlc(1000 msat, 300 msat, 3)
+    f.parent.send(f.handler, extra)
+    val extraneousPayment = f.parent.expectMsgType[ExtraPaymentReceived]
     assert(extraneousPayment.paymentHash === paymentHash)
-    assert(setTimestamp(extraneousPayment.payment :: Nil, 0) === Seq(PendingPayment(3, PartialPayment(300 msat, htlcIdToChannelId(3), 0))))
+    assert(extraneousPayment.payment === extra)
+
     f.parent.expectNoMsg(50 millis)
     f.eventListener.expectNoMsg(50 millis)
   }
 
   test("actor restart") {
     val f = createFixture(10 seconds, 1000 msat)
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 600 msat, 1))
+    val parts = Seq(
+      createMultiPartHtlc(1000 msat, 600 msat, 1),
+      createMultiPartHtlc(1000 msat, 400 msat, 2)
+    )
+    f.parent.send(f.handler, parts.head)
 
     f.handler.suspend()
     f.handler.resume(new IllegalArgumentException("something went wrong"))
 
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 400 msat, 2))
-    val paymentResult = f.parent.expectMsgType[MultiPartHtlcSucceeded]
+    f.parent.send(f.handler, parts(1))
+    val paymentResult = f.parent.expectMsgType[MultiPartPaymentSucceeded]
     assert(paymentResult.paymentHash === paymentHash)
-    assert(setTimestamp(paymentResult.parts, 0).toSet === Set(
-      PendingPayment(1, PartialPayment(600 msat, htlcIdToChannelId(1), 0)),
-      PendingPayment(2, PartialPayment(400 msat, htlcIdToChannelId(2), 0))
-    ))
+    assert(paymentResult.parts.toSet === parts.toSet)
     f.parent.expectNoMsg(50 millis)
   }
 
   test("unknown message") {
     val f = createFixture(10 seconds, 1000 msat)
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 600 msat, 1))
+    val parts = Seq(
+      createMultiPartHtlc(1000 msat, 600 msat, 1),
+      createMultiPartHtlc(1000 msat, 400 msat, 2)
+    )
+    f.parent.send(f.handler, parts.head)
     f.parent.send(f.handler, "hello")
-    f.parent.send(f.handler, createMultiPartHtlc(1000 msat, 400 msat, 2))
+    f.parent.send(f.handler, parts(1))
 
-    val paymentResult = f.parent.expectMsgType[MultiPartHtlcSucceeded]
-    assert(setTimestamp(paymentResult.parts, 0).toSet === Set(
-      PendingPayment(1, PartialPayment(600 msat, htlcIdToChannelId(1), 0)),
-      PendingPayment(2, PartialPayment(400 msat, htlcIdToChannelId(2), 0))
-    ))
+    val paymentResult = f.parent.expectMsgType[MultiPartPaymentSucceeded]
+    assert(paymentResult.parts.toSet === parts.toSet)
     f.parent.expectNoMsg(50 millis)
   }
 
@@ -220,15 +227,13 @@ class MultiPartPaymentFSMSpec extends TestKit(ActorSystem("test")) with FunSuite
 
 object MultiPartPaymentFSMSpec {
 
-  import MultiPartPaymentFSM.MultiPartHtlc
-
   val paymentHash = randomBytes32
 
   def htlcIdToChannelId(htlcId: Long) = ByteVector32(ByteVector.fromLong(htlcId).padLeft(32))
 
-  def createMultiPartHtlc(totalAmount: MilliSatoshi, htlcAmount: MilliSatoshi, htlcId: Long) =
-    MultiPartHtlc(totalAmount, UpdateAddHtlc(htlcIdToChannelId(htlcId), htlcId, htlcAmount, paymentHash, CltvExpiry(42), TestConstants.emptyOnionPacket))
+  def createMultiPartHtlc(totalAmount: MilliSatoshi, htlcAmount: MilliSatoshi, htlcId: Long): HtlcPart = {
+    val htlc = UpdateAddHtlc(htlcIdToChannelId(htlcId), htlcId, htlcAmount, paymentHash, CltvExpiry(42), TestConstants.emptyOnionPacket)
+    HtlcPart(totalAmount, htlc)
+  }
 
-  /** Sets all inner timestamps to the given value (useful to test equality when timestamp is set to current automatically) */
-  def setTimestamp(parts: Seq[PendingPayment], timestamp: Long): Seq[PendingPayment] = parts.map(p => p.copy(payment = p.payment.copy(timestamp = timestamp)))
 }


### PR DESCRIPTION
Add an abstraction of a PaymentPart.
Remove unnecessary intermediary case classes.
This allows extending how payment parts can be received.
It's not limited to HTLCs (could be swaps, pay-to-opens, etc).

@araspitzu you also mentioned a missing abstraction necessary for hodl invoice, can you detail? Maybe this is the right PR to also add something like this.