### PR TITLE
Load plugins from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,16 @@ For advanced usage, Eclair supports plugins written in Scala, Java, or any JVM-c
 A valid plugin is a jar that contains an implementation of the [Plugin](eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala) interface, and 
 a manifest entry for `Main-Class` with the FQDN of the implementation.
 
-Here is how to run Eclair with plugins:
+To run eclair with plugins you can either specify the plugin files via command line or configuration.
 
+Using command line:
 ```shell
 eclair-node-<version>-<commit_id>/bin/eclair-node.sh <plugin1.jar> <plugin2.jar> <...>
+```
+
+Using configuration:
+```
+eclair.plugin-paths = [ "/my/plugin/full/path.jar", "/my/plugin/full/path1.jar" ]
 ```
 
 ## Testnet usage

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -163,6 +163,8 @@ eclair {
     port = 9051
     private-key-file = "tor.dat"
   }
+
+  plugin-paths = [] // list of absolute paths to plugin files
 }
 
 // do not edit or move this section


### PR DESCRIPTION
~~This PR changes the way plugins are passed to the eclair application, instead of specifying the plugin filename as a command line parameter we now require all the plugins to be placed in a `plugin/` folder inside the eclair `<datadir>`.  I've updated the README but i think we might need a separate file for plugins instruction.~~

This PR improves plugin loading by allowing the user to specify the full path for a plugin file via configuration, this is handy for users who cannot/don't want to deal with command line options. The new configuration key is an array of strings containing the full path for the plugin file(s).