### PR TITLE
Allow users to have multiple wallets in bitcoind

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ You will find detailed guides and frequently asked questions there.
 :warning: Eclair requires Bitcoin Core 0.17.1 or higher. If you are upgrading an existing wallet, you need to create a new address and send all your funds to that address.
 
 Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
-Eclair will use any BTC it finds in the Bitcoin Core wallet to fund any channels you choose to open. Eclair will return BTC from closed channels to this wallet. 
+Eclair will use the default unnamed wallet in Bitcoin Core, you can have more than one wallet but make sure there is always the default wallet available.
+Any BTC found in the wallet can be used to fund the channels you choose to open and the BTC from closed channels will return to this wallet. 
 You can configure your Bitcoin Node to use either `p2sh-segwit` addresses or `bech32` addresses, Eclair is compatible with both modes.
 If your Bitcoin Core wallet has "non-segwit UTXOs" (outputs that are neither `p2sh-segwit` or `bech32`), you must send them to a `p2sh-segwit` or `bech32` address.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You will find detailed guides and frequently asked questions there.
 :warning: Eclair requires Bitcoin Core 0.17.1 or higher. If you are upgrading an existing wallet, you need to create a new address and send all your funds to that address.
 
 Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
-Eclair will use the default unnamed wallet in Bitcoin Core, you can have more than one wallet but make sure there is always the default wallet available.
+Eclair will use any BTC it finds in the default Bitcoin Core wallet to fund any channels you choose to open. Eclair will return BTC from closed channels to this wallet. You can have multiple Bitcoin Core wallets but make sure that the default one is always available.
 Any BTC found in the wallet can be used to fund the channels you choose to open and the BTC from closed channels will return to this wallet. 
 You can configure your Bitcoin Node to use either `p2sh-segwit` addresses or `bech32` addresses, Eclair is compatible with both modes.
 If your Bitcoin Core wallet has "non-segwit UTXOs" (outputs that are neither `p2sh-segwit` or `bech32`), you must send them to a `p2sh-segwit` or `bech32` address.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BasicBitcoinJsonRPCClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BasicBitcoinJsonRPCClient.scala
@@ -43,7 +43,7 @@ class BasicBitcoinJsonRPCClient(user: String, password: String, host: String = "
     KamonExt.timeFuture("bitcoin.rpc.basic.invoke.time") {
     for {
       res <- sttp
-        .post(uri"$scheme://$host:$port")
+        .post(uri"$scheme://$host:$port/wallet/") // wallet/ specifies to use the default bitcoind wallet, named ""
         .body(requests)
         .auth.basic(user, password)
         .response(asJson[Seq[JsonRPCResponse]])


### PR DESCRIPTION
In this PR we force the usage of the default bitcoind wallet (named ""). This is necessary to allow the user to have multiple bitcoind wallets because when there are more than one we need to specify which wallet to use in the RPC calls. Fixes #1330.

Note for reviewers: the extra path in the bitcoin RPC URL identifies the wallet to be used and can be used in all the others RPC too. By default bitcoind has an unnamed wallet `""` and eclair always expect to have that, users can add new wallets but should never rename or remove the default wallet (maybe we can add a few lines in the README for this).