### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ COPY pom.xml pom.xml
 COPY eclair-core/pom.xml eclair-core/pom.xml
 COPY eclair-node/pom.xml eclair-node/pom.xml
 COPY eclair-node-gui/pom.xml eclair-node-gui/pom.xml
-COPY eclair-node/modules/eclair-node.xml eclair-node/modules/eclair-node.xml
-COPY eclair-node-gui/modules/eclair-node-gui.xml eclair-node-gui/modules/eclair-node-gui.xml
+COPY eclair-node/modules/assembly.xml eclair-node/modules/assembly.xml
+COPY eclair-node-gui/modules/assembly.xml eclair-node-gui/modules/assembly.xml
 RUN mkdir -p eclair-core/src/main/scala && touch eclair-core/src/main/scala/empty.scala
 # Blank build. We only care about eclair-node, and we use install because eclair-node depends on eclair-core
 RUN mvn install -pl eclair-node -am
@@ -63,4 +63,4 @@ ENV JAVA_OPTS=
 RUN mkdir -p "$ECLAIR_DATADIR"
 VOLUME [ "/data" ]
 
-ENTRYPOINT $JAVA_OPTS eclair-node/bin/eclair-node.sh -Declair.datadir=$ECLAIR_DATADIR
+ENTRYPOINT $JAVA_OPTS bash eclair-node/bin/eclair-node.sh -Declair.datadir=$ECLAIR_DATADIR


### PR DESCRIPTION
With #1307 the docker file was broken and failed to build, this PR fixes the wrong names in the assembly descriptors and uses bash explicitly to launch eclair-node.sh. Fixes #1336