### PR TITLE
Harden requirements on htlc-minimum-msat

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -162,7 +162,7 @@ object NodeParams {
     }
 
     val htlcMinimum = MilliSatoshi(config.getInt("htlc-minimum-msat"))
-    require(htlcMinimum > 0.msat, "htlc-minimum-msat must not be 0")
+    require(htlcMinimum > 0.msat, "htlc-minimum-msat must be strictly greater than 0")
 
     val maxAcceptedHtlcs = config.getInt("max-accepted-htlcs")
     require(maxAcceptedHtlcs <= Channel.MAX_ACCEPTED_HTLCS, s"max-accepted-htlcs must be lower than ${Channel.MAX_ACCEPTED_HTLCS}")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -161,6 +161,9 @@ object NodeParams {
       require(dustLimitSatoshis >= Channel.MIN_DUSTLIMIT, s"dust limit must be greater than ${Channel.MIN_DUSTLIMIT}")
     }
 
+    val htlcMinimum = MilliSatoshi(config.getInt("htlc-minimum-msat"))
+    require(htlcMinimum > 0.msat, "htlc-minimum-msat must not be 0")
+
     val maxAcceptedHtlcs = config.getInt("max-accepted-htlcs")
     require(maxAcceptedHtlcs <= Channel.MAX_ACCEPTED_HTLCS, s"max-accepted-htlcs must be lower than ${Channel.MAX_ACCEPTED_HTLCS}")
 
@@ -242,7 +245,7 @@ object NodeParams {
       maxAcceptedHtlcs = maxAcceptedHtlcs,
       expiryDeltaBlocks = expiryDeltaBlocks,
       fulfillSafetyBeforeTimeoutBlocks = fulfillSafetyBeforeTimeoutBlocks,
-      htlcMinimum = MilliSatoshi(config.getInt("htlc-minimum-msat")),
+      htlcMinimum = htlcMinimum,
       toRemoteDelayBlocks = CltvExpiryDelta(config.getInt("to-remote-delay-blocks")),
       maxToLocalDelayBlocks = CltvExpiryDelta(config.getInt("max-to-local-delay-blocks")),
       minDepthBlocks = config.getInt("mindepth-blocks"),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -169,8 +169,8 @@ object Commitments {
       return Failure(ExpiryTooBig(commitments.channelId, maximum = maxExpiry, actual = cmd.cltvExpiry, blockCount = blockHeight))
     }
 
-    if (cmd.amount < commitments.remoteParams.htlcMinimum) {
-      return Failure(HtlcValueTooSmall(commitments.channelId, minimum = commitments.remoteParams.htlcMinimum, actual = cmd.amount))
+    if (cmd.amount < commitments.remoteParams.htlcMinimum.max(1 msat)) {
+      return Failure(HtlcValueTooSmall(commitments.channelId, minimum = commitments.remoteParams.htlcMinimum.max(1 msat), actual = cmd.amount))
     }
 
     // let's compute the current commitment *as seen by them* with this change taken into account
@@ -216,8 +216,8 @@ object Commitments {
       throw UnexpectedHtlcId(commitments.channelId, expected = commitments.remoteNextHtlcId, actual = add.id)
     }
 
-    if (add.amountMsat < commitments.localParams.htlcMinimum) {
-      throw HtlcValueTooSmall(commitments.channelId, minimum = commitments.localParams.htlcMinimum, actual = add.amountMsat)
+    if (add.amountMsat < commitments.localParams.htlcMinimum.max(1 msat)) {
+      throw HtlcValueTooSmall(commitments.channelId, minimum = commitments.localParams.htlcMinimum.max(1 msat), actual = add.amountMsat)
     }
 
     // let's compute the current commitment *as seen by us* including this change

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -82,4 +82,9 @@ class StartupSpec extends FunSuite {
     assert(Try(makeNodeParamsWithDefaults(illegalFeaturesConf.withFallback(defaultConf))).isFailure)
   }
 
+  test("NodeParams should fail if htlc-minimum-msat is set to 0") {
+    val noHtlcMinimumConf = ConfigFactory.parseString("htlc-minimum-msat = 0")
+    assert(Try(makeNodeParamsWithDefaults(noHtlcMinimumConf.withFallback(defaultConf))).isFailure)
+  }
+
 }


### PR DESCRIPTION
We were allowing users to set htlc-minimum-msat to 0, which directly
contradicts the fact that we must never send an HTLC for 0 msat.
We now explicitly disallow that behavior: the minimum is 1 msat.

In case the remote side of a channel had set its htlc-minimum-msat to 0,
we would forward HTLC with a value of 0 msat if a sender crafted such a
payment. The spec disallows that, so we now explicitly check for that
lower bound.