### PR TITLE
Kanela-agent 1.0.1->1.0.5

### DIFF
--- a/eclair-node-gui/src/main/resources/eclair-node-gui.sh
+++ b/eclair-node-gui/src/main/resources/eclair-node-gui.sh
@@ -164,7 +164,7 @@ addDebugger () {
 }
 
 addKanelaAgent () {
-  addJava "-javaagent:$lib_dir/kanela-agent-1.0.1.jar"
+  addJava "-javaagent:$lib_dir/kanela-agent-1.0.5.jar"
 }
 
 require_arg () {

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>io.kamon</groupId>
             <artifactId>kanela-agent</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.5</version>
         </dependency>
     </dependencies>
 </project>

--- a/eclair-node/src/main/resources/eclair-node.sh
+++ b/eclair-node/src/main/resources/eclair-node.sh
@@ -164,7 +164,7 @@ addDebugger () {
 }
 
 addKanelaAgent () {
-  addJava "-javaagent:$lib_dir/kanela-agent-1.0.1.jar"
+  addJava "-javaagent:$lib_dir/kanela-agent-1.0.5.jar"
 }
 
 require_arg () {


### PR DESCRIPTION
NB: using `addJava "-javaagent:$lib_dir/kanela-agent-*.jar"` in scripts
to make them update proof doesn't work unfortunately.