### PR TITLE
Add more information to GetInfoResponse

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -41,7 +41,7 @@ import scodec.bits.ByteVector
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
-case class GetInfoResponse(nodeId: PublicKey, alias: String, chainHash: ByteVector32, blockHeight: Int, publicAddresses: Seq[NodeAddress])
+case class GetInfoResponse(version: String, nodeId: PublicKey, alias: String, color: String, features: String, chainHash: ByteVector32, blockHeight: Int, publicAddresses: Seq[NodeAddress])
 
 case class AuditResponse(sent: Seq[PaymentSent], received: Seq[PaymentReceived], relayed: Seq[PaymentRelayed])
 
@@ -313,7 +313,11 @@ class EclairImpl(appKit: Kit) extends Eclair {
   }
 
   override def getInfoResponse()(implicit timeout: Timeout): Future[GetInfoResponse] = Future.successful(
-    GetInfoResponse(nodeId = appKit.nodeParams.nodeId,
+    GetInfoResponse(
+      version = Kit.getVersionLong,
+      color = appKit.nodeParams.color.toString,
+      features = appKit.nodeParams.features.toHex,
+      nodeId = appKit.nodeParams.nodeId,
       alias = appKit.nodeParams.alias,
       chainHash = appKit.nodeParams.chainHash,
       blockHeight = appKit.nodeParams.currentBlockHeight.toInt,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -78,7 +78,7 @@ class Setup(datadir: File,
   implicit val sttpBackend = OkHttpFutureBackend()
 
   logger.info(s"hello!")
-  logger.info(s"version=${getClass.getPackage.getImplementationVersion} commit=${getClass.getPackage.getSpecificationVersion}")
+  logger.info(s"version=${Kit.getVersion} commit=${Kit.getCommit}")
   logger.info(s"datadir=${datadir.getCanonicalPath}")
   logger.info(s"initializing secure random generator")
   // this will force the secure random instance to initialize itself right now, making sure it doesn't hang later (see comment in package.scala)
@@ -375,6 +375,16 @@ case class Kit(nodeParams: NodeParams,
                paymentInitiator: ActorRef,
                server: ActorRef,
                wallet: EclairWallet)
+
+object Kit {
+
+  def getVersionLong: String = s"$getVersion-$getCommit"
+
+  def getVersion: String = getClass.getPackage.getImplementationVersion
+
+  def getCommit: String = Option(getClass.getPackage.getSpecificationVersion).map(_.take(7)).getOrElse("null")
+
+}
 
 case object BitcoinZMQConnectionTimeoutException extends RuntimeException("could not connect to bitcoind using zeromq")
 

--- a/eclair-node/src/test/resources/api/getinfo
+++ b/eclair-node/src/test/resources/api/getinfo
@@ -1,1 +1,1 @@
-{"nodeId":"03af0ed6052cf28d670665549bc86f4b721c9fdb309d40c58f5811f63966e005d0","alias":"alice","chainHash":"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f","blockHeight":9999,"publicAddresses":["localhost:9731"]}
+{"version":"1.0.0-SNAPSHOT-e3f1ec0","nodeId":"03af0ed6052cf28d670665549bc86f4b721c9fdb309d40c58f5811f63966e005d0","alias":"alice","color":"#000102","features":"","chainHash":"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f","blockHeight":9999,"publicAddresses":["localhost:9731"]}

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -38,7 +38,7 @@ import fr.acinq.eclair.payment.relay.Relayer.UsableBalance
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentToRouteResponse
 import fr.acinq.eclair.payment.{PaymentFailed, _}
 import fr.acinq.eclair.router.{NetworkStats, Stats}
-import fr.acinq.eclair.wire.NodeAddress
+import fr.acinq.eclair.wire.{Color, NodeAddress}
 import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.{FunSuite, Matchers}
 import scodec.bits._
@@ -168,6 +168,9 @@ class ApiServiceSpec extends FunSuite with ScalatestRouteTest with IdiomaticMock
     val eclair = mock[Eclair]
     val mockService = new MockService(eclair)
     eclair.getInfoResponse()(any[Timeout]) returns Future.successful(GetInfoResponse(
+      version = "1.0.0-SNAPSHOT-e3f1ec0",
+      color = Color(0.toByte, 1.toByte, 2.toByte).toString,
+      features = "",
       nodeId = aliceNodeId,
       alias = "alice",
       chainHash = ByteVector32(hex"06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f"),


### PR DESCRIPTION
This PR adds some extra information in the `/getinfo` API response such as version, color and features, the version string uses a truncated commit and is also used to _log_ the version during boot.

- [ ] update documentation