### PR TITLE
Router property-based testing

### DIFF
--- a/.semaphore/fuzzing.yml
+++ b/.semaphore/fuzzing.yml
@@ -1,0 +1,25 @@
+version: v1.0
+name: Fuzz Tests
+agent:
+  machine:
+    type: e1-standard-4
+    os_image: ubuntu1804
+execution_time_limit:
+  minutes: 15
+
+blocks:
+  - name: Fuzz Tests
+    task:
+      env_vars:
+        # Set maven to use a local directory. This is required for
+        # the cache util. It must be set in all blocks.
+        - name: MAVEN_OPTS
+          value: "-Dmaven.repo.local=.m2"
+      jobs:
+        - name: Fuzz Tests
+          commands:
+            - sem-version java 11
+            - checkout
+            - cache restore maven
+            - mvn -DtagsToInclude=fuzzy -DfuzzFactor=250 test
+            - cache store maven .m2

--- a/.semaphore/fuzzing.yml
+++ b/.semaphore/fuzzing.yml
@@ -21,5 +21,5 @@ blocks:
             - sem-version java 11
             - checkout
             - cache restore maven
-            - mvn -DtagsToInclude=fuzzy -DfuzzFactor=250 test
+            - mvn -DtagsToInclude=fr.acinq.eclair.tags.Fuzzy -DfuzzFactor=250 test
             - cache store maven .m2

--- a/BUILD.md
+++ b/BUILD.md
@@ -44,6 +44,12 @@ To run tests for a specific class, run:
 mvn test -Dsuites=*<TestClassName>
 ```
 
+To skip fuzz tests, run:
+
+```shell
+mvn test -DtagsToExclude=fuzzy
+```
+
 ## Build the API documentation
 
 ### Slate

--- a/BUILD.md
+++ b/BUILD.md
@@ -47,7 +47,7 @@ mvn test -Dsuites=*<TestClassName>
 To skip fuzz tests, run:
 
 ```shell
-mvn test -DtagsToExclude=fuzzy
+mvn test -DtagsToExclude=fr.acinq.eclair.tags.Fuzzy
 ```
 
 ## Build the API documentation

--- a/eclair-core/src/test/java/fr/acinq/eclair/tags/Fuzzy.java
+++ b/eclair-core/src/test/java/fr/acinq/eclair/tags/Fuzzy.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.tags;
+
+import java.lang.annotation.*;
+
+import org.scalatest.TagAnnotation;
+
+@TagAnnotation
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface Fuzzy {}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FuzzingBaseClass.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FuzzingBaseClass.scala
@@ -16,8 +16,11 @@
 
 package fr.acinq.eclair
 
+import org.scalactic.anyvals.PosInt
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FunSuite, ParallelTestExecution, Tag}
+
+import scala.util.Try
 
 /**
  * Created by t-bast on 10/03/2020.
@@ -25,7 +28,9 @@ import org.scalatest.{FunSuite, ParallelTestExecution, Tag}
 
 abstract class FuzzingBaseClass extends FunSuite with GeneratorDrivenPropertyChecks with ParallelTestExecution {
 
-  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 10)
+  lazy val fuzzCount = sys.props.get("fuzzFactor").flatMap(f => Try(f.toInt).toOption).flatMap(PosInt.from).getOrElse(PosInt(10))
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = fuzzCount)
 
 }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FuzzingBaseClass.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FuzzingBaseClass.scala
@@ -16,6 +16,7 @@
 
 package fr.acinq.eclair
 
+import fr.acinq.eclair.tags.Fuzzy
 import org.scalactic.anyvals.PosInt
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{FunSuite, ParallelTestExecution, Tag}
@@ -26,6 +27,7 @@ import scala.util.Try
  * Created by t-bast on 10/03/2020.
  */
 
+@Fuzzy
 abstract class FuzzingBaseClass extends FunSuite with GeneratorDrivenPropertyChecks with ParallelTestExecution {
 
   lazy val fuzzCount = sys.props.get("fuzzFactor").flatMap(f => Try(f.toInt).toOption).flatMap(PosInt.from).getOrElse(PosInt(10))
@@ -39,7 +41,7 @@ object FuzzingBaseClass {
   object Tags {
 
     // Use this tag for fuzz tests to ensure they run in nightly builds with a high degree of fuzzing.
-    object Fuzzy extends Tag("fuzzy")
+    object Fuzzy extends Tag("fr.acinq.eclair.tags.Fuzzy")
 
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FuzzingBaseClass.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FuzzingBaseClass.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair
+
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FunSuite, ParallelTestExecution, Tag}
+
+/**
+ * Created by t-bast on 10/03/2020.
+ */
+
+abstract class FuzzingBaseClass extends FunSuite with GeneratorDrivenPropertyChecks with ParallelTestExecution {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 10)
+
+}
+
+object FuzzingBaseClass {
+
+  object Tags {
+
+    // Use this tag for fuzz tests to ensure they run in nightly builds with a high degree of fuzzing.
+    object Fuzzy extends Tag("fuzzy")
+
+  }
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -20,7 +20,7 @@ import java.sql.{Connection, DriverManager}
 import java.util.concurrent.atomic.AtomicLong
 
 import fr.acinq.bitcoin.Crypto.PrivateKey
-import fr.acinq.bitcoin.{Block, Btc, ByteVector32, Script}
+import fr.acinq.bitcoin.{Block, ByteVector32, Script}
 import fr.acinq.eclair.NodeParams.BITCOIND
 import fr.acinq.eclair.blockchain.fee.{FeeEstimator, FeeTargets, FeeratesPerKw, OnChainFeeConf}
 import fr.acinq.eclair.crypto.LocalKeyManager

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -23,16 +23,20 @@ import fr.acinq.eclair.channel.Commitments._
 import fr.acinq.eclair.channel.Helpers.Funding
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.crypto.ShaChain
+import fr.acinq.eclair.payment.OutgoingPacket
 import fr.acinq.eclair.payment.relay.Origin.Local
+import fr.acinq.eclair.router.ChannelHop
 import fr.acinq.eclair.transactions.CommitmentSpec
 import fr.acinq.eclair.transactions.Transactions.CommitTx
+import fr.acinq.eclair.wire.Onion.FinalLegacyPayload
 import fr.acinq.eclair.wire.{IncorrectOrUnknownPaymentDetails, UpdateAddHtlc}
 import fr.acinq.eclair.{TestkitBaseClass, _}
-import org.scalatest.{Outcome, Tag}
+import org.scalacheck.Gen
+import org.scalatest.Outcome
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
-import scala.util.{Failure, Random, Success}
+import scala.util.{Failure, Success}
 
 class CommitmentsSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
@@ -403,60 +407,71 @@ class CommitmentsSpec extends TestkitBaseClass with StateTestsHelperMethods {
     }
   }
 
-  test("should always be able to send availableForSend", Tag("fuzzy")) { f =>
-    val maxPendingHtlcAmount = 1000000.msat
-    case class FuzzTest(isFunder: Boolean, pendingHtlcs: Int, feeRatePerKw: Long, dustLimit: Satoshi, toLocal: MilliSatoshi, toRemote: MilliSatoshi)
-    for (_ <- 1 to 100) {
-      val t = FuzzTest(
-        isFunder = Random.nextInt(2) == 0,
-        pendingHtlcs = Random.nextInt(10),
-        feeRatePerKw = Random.nextInt(10000),
-        dustLimit = Random.nextInt(1000).sat,
-        // We make sure both sides have enough to send/receive at least the initial pending HTLCs.
-        toLocal = maxPendingHtlcAmount * 2 * 10 + Random.nextInt(1000000000).msat,
-        toRemote = maxPendingHtlcAmount * 2 * 10 + Random.nextInt(1000000000).msat)
-      var c = CommitmentsSpec.makeCommitments(t.toLocal, t.toRemote, t.feeRatePerKw, t.dustLimit, t.isFunder)
+}
+
+class CommitmentsFuzzSpec extends FuzzingBaseClass {
+
+  val maxPendingHtlcAmount = 1000000.msat
+
+  def makeCmdAdd(amount: MilliSatoshi): CMD_ADD_HTLC = {
+    val expiry = CltvExpiryDelta(144).toCltvExpiry(TestConstants.defaultBlockHeight)
+    OutgoingPacket.buildCommand(Upstream.Local(UUID.randomUUID), randomBytes32, ChannelHop(null, randomKey.publicKey, null) :: Nil, FinalLegacyPayload(amount, expiry))._1
+  }
+
+  case class Params(isFunder: Boolean, pendingHtlcs: Seq[MilliSatoshi], feeRatePerKw: Long, dustLimit: Satoshi, toLocal: MilliSatoshi, toRemote: MilliSatoshi)
+
+  val paramsGen = for {
+    isFunder <- Gen.oneOf(true :: false :: Nil)
+    pendingHtlcsCount <- Gen.choose(0, 10)
+    pendingHtlcs <- Gen.listOfN(pendingHtlcsCount, Gen.choose(1, maxPendingHtlcAmount.toLong).map(MilliSatoshi(_)))
+    feeRatePerKw <- Gen.choose(1, 10000)
+    dustLimit <- Gen.choose(1, 1000).map(Satoshi(_))
+    toLocal <- Gen.choose(1, 1000000000).map(MilliSatoshi(_))
+    toRemote <- Gen.choose(1, 1000000000).map(MilliSatoshi(_))
+  } yield Params(isFunder, pendingHtlcs, feeRatePerKw, dustLimit, toLocal, toRemote)
+
+  test("should always be able to send availableForSend", FuzzingBaseClass.Tags.Fuzzy) {
+    forAll(paramsGen) { p =>
+      var c = CommitmentsSpec.makeCommitments(p.toLocal, p.toRemote, p.feeRatePerKw, p.dustLimit, p.isFunder)
       // Add some initial HTLCs to the pending list (bigger commit tx).
-      for (_ <- 0 to t.pendingHtlcs) {
-        val amount = Random.nextInt(maxPendingHtlcAmount.toLong.toInt).msat
-        val (_, cmdAdd) = makeCmdAdd(amount, randomKey.publicKey, f.currentBlockHeight)
-        sendAdd(c, cmdAdd, Local(UUID.randomUUID, None), f.currentBlockHeight) match {
-          case Success((cc, _)) => c = cc
-          case Failure(e) => fail(s"$t -> could not setup initial htlcs: $e")
+      p.pendingHtlcs.foreach(amount => sendAdd(c, makeCmdAdd(amount), Local(UUID.randomUUID, None), TestConstants.defaultBlockHeight) match {
+        case Success((cc, _)) => c = cc
+        case Failure(_: InsufficientFunds) => // this is ok, we don't add the HTLC
+        case Failure(_: CannotAffordFees) => // this is ok, we don't add the HTLC
+        case Failure(_: RemoteCannotAffordFeesForNewHtlc) => // this is ok, we don't add the HTLC
+        case Failure(e) => fail(s"could not setup initial htlcs: $e")
+      })
+      whenever(c.availableBalanceForSend > 0.msat) {
+        sendAdd(c, makeCmdAdd(c.availableBalanceForSend), Local(UUID.randomUUID, None), TestConstants.defaultBlockHeight) match {
+          case Success(_) => // great!
+          case Failure(_: RemoteCannotAffordFeesForNewHtlc) if !p.isFunder => // this is ok too, we don't take that into account in availableBalanceForSend for now
+          case Failure(e) => fail(s"could not send ${c.availableBalanceForSend}: $e")
         }
       }
-      val (_, cmdAdd) = makeCmdAdd(c.availableBalanceForSend, randomKey.publicKey, f.currentBlockHeight)
-      val result = sendAdd(c, cmdAdd, Local(UUID.randomUUID, None), f.currentBlockHeight)
-      assert(result.isSuccess, s"$t -> $result")
     }
   }
 
-  test("should always be able to receive availableForReceive", Tag("fuzzy")) { f =>
-    val maxPendingHtlcAmount = 1000000.msat
-    case class FuzzTest(isFunder: Boolean, pendingHtlcs: Int, feeRatePerKw: Long, dustLimit: Satoshi, toLocal: MilliSatoshi, toRemote: MilliSatoshi)
-    for (_ <- 1 to 100) {
-      val t = FuzzTest(
-        isFunder = Random.nextInt(2) == 0,
-        pendingHtlcs = Random.nextInt(10),
-        feeRatePerKw = Random.nextInt(10000),
-        dustLimit = Random.nextInt(1000).sat,
-        // We make sure both sides have enough to send/receive at least the initial pending HTLCs.
-        toLocal = maxPendingHtlcAmount * 2 * 10 + Random.nextInt(1000000000).msat,
-        toRemote = maxPendingHtlcAmount * 2 * 10 + Random.nextInt(1000000000).msat)
-      var c = CommitmentsSpec.makeCommitments(t.toLocal, t.toRemote, t.feeRatePerKw, t.dustLimit, t.isFunder)
+  test("should always be able to receive availableForReceive", FuzzingBaseClass.Tags.Fuzzy) {
+    forAll(paramsGen) { p =>
+      var c = CommitmentsSpec.makeCommitments(p.toLocal, p.toRemote, p.feeRatePerKw, p.dustLimit, p.isFunder)
       // Add some initial HTLCs to the pending list (bigger commit tx).
-      for (_ <- 0 to t.pendingHtlcs) {
-        val amount = Random.nextInt(maxPendingHtlcAmount.toLong.toInt).msat
-        val add = UpdateAddHtlc(randomBytes32, c.remoteNextHtlcId, amount, randomBytes32, CltvExpiry(f.currentBlockHeight), TestConstants.emptyOnionPacket)
+      p.pendingHtlcs.foreach(amount => {
+        val add = UpdateAddHtlc(randomBytes32, c.remoteNextHtlcId, amount, randomBytes32, CltvExpiry(TestConstants.defaultBlockHeight), TestConstants.emptyOnionPacket)
         receiveAdd(c, add) match {
           case Success(cc) => c = cc
-          case Failure(e) => fail(s"$t -> could not setup initial htlcs: $e")
+          case Failure(_: InsufficientFunds) => // this is ok, we don't add the HTLC
+          case Failure(_: CannotAffordFees) => // this is ok, we don't add the HTLC
+          case Failure(_: RemoteCannotAffordFeesForNewHtlc) => // this is ok, we don't add the HTLC
+          case Failure(e) => fail(s"could not setup initial htlcs: $e")
         }
-      }
-      val add = UpdateAddHtlc(randomBytes32, c.remoteNextHtlcId, c.availableBalanceForReceive, randomBytes32, CltvExpiry(f.currentBlockHeight), TestConstants.emptyOnionPacket)
-      receiveAdd(c, add) match {
-        case Success(_) => ()
-        case Failure(e) => fail(s"$t -> $e")
+      })
+      whenever(c.availableBalanceForReceive > 0.msat) {
+        val add = UpdateAddHtlc(randomBytes32, c.remoteNextHtlcId, c.availableBalanceForReceive, randomBytes32, CltvExpiry(TestConstants.defaultBlockHeight), TestConstants.emptyOnionPacket)
+        receiveAdd(c, add) match {
+          case Success(_) => // great!
+          case Failure(_: CannotAffordFees) if p.isFunder => // this is ok too, we don't take that into account in availableBalanceForReceive for now
+          case Failure(e) => fail(s"could not receive ${c.availableBalanceForReceive}: $e")
+        }
       }
     }
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -430,7 +430,7 @@ class CommitmentsFuzzSpec extends FuzzingBaseClass {
     toRemote <- Gen.choose(1, 1000000000).map(MilliSatoshi(_))
   } yield Params(isFunder, pendingHtlcs, feeRatePerKw, dustLimit, toLocal, toRemote)
 
-  test("should always be able to send availableForSend", FuzzingBaseClass.Tags.Fuzzy) {
+  test("should always be able to send availableForSend") {
     forAll(paramsGen) { p =>
       var c = CommitmentsSpec.makeCommitments(p.toLocal, p.toRemote, p.feeRatePerKw, p.dustLimit, p.isFunder)
       // Add some initial HTLCs to the pending list (bigger commit tx).
@@ -451,7 +451,7 @@ class CommitmentsFuzzSpec extends FuzzingBaseClass {
     }
   }
 
-  test("should always be able to receive availableForReceive", FuzzingBaseClass.Tags.Fuzzy) {
+  test("should always be able to receive availableForReceive") {
     forAll(paramsGen) { p =>
       var c = CommitmentsSpec.makeCommitments(p.toLocal, p.toRemote, p.feeRatePerKw, p.dustLimit, p.isFunder)
       // Add some initial HTLCs to the pending list (bigger commit tx).

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -35,7 +35,7 @@ import fr.acinq.eclair.router.ChannelHop
 import fr.acinq.eclair.wire.Onion.FinalLegacyPayload
 import fr.acinq.eclair.wire._
 import grizzled.slf4j.Logging
-import org.scalatest.{Outcome, Tag}
+import org.scalatest.Outcome
 
 import scala.collection.immutable.Nil
 import scala.concurrent.duration._
@@ -153,7 +153,7 @@ class FuzzySpec extends TestkitBaseClass with StateTestsHelperMethods with Loggi
 
   }
 
-  test("fuzzy test with only one party sending HTLCs", Tag("fuzzy")) { f =>
+  test("fuzzy test with only one party sending HTLCs", FuzzingBaseClass.Tags.Fuzzy) { f =>
     import f._
     val senders = 2
     val totalMessages = 100
@@ -164,7 +164,7 @@ class FuzzySpec extends TestkitBaseClass with StateTestsHelperMethods with Loggi
     assert(List(NORMAL, OFFLINE, SYNCING).contains(bob.stateName))
   }
 
-  test("fuzzy test with both parties sending HTLCs", Tag("fuzzy")) { f =>
+  test("fuzzy test with both parties sending HTLCs", FuzzingBaseClass.Tags.Fuzzy) { f =>
     import f._
     val senders = 2
     val totalMessages = 100

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -34,7 +34,7 @@ import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPayment
 import fr.acinq.eclair.payment.send.{MultiPartPaymentLifecycle, PaymentError}
 import fr.acinq.eclair.router._
 import fr.acinq.eclair.wire._
-import org.scalatest.{Outcome, Tag, fixture}
+import org.scalatest.{Outcome, fixture}
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
@@ -485,7 +485,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     assert(result.nonTrampolineFees === 5.msat)
   }
 
-  test("split payment", Tag("fuzzy")) { f =>
+  test("split payment", FuzzingBaseClass.Tags.Fuzzy) { f =>
     // The fees for a single HTLC will be 100 * 172 / 1000 = 17 satoshis.
     val testChannels = localChannels(100)
     for (_ <- 1 to 100) {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -1009,7 +1009,7 @@ class RouteCalculationFuzzSpec extends FuzzingBaseClass {
     amount <- Gen.choose(1, 1000).map(Satoshi(_).toMilliSatoshi)
   } yield (g, source, target, amount)
 
-  test("route tiny amounts", FuzzingBaseClass.Tags.Fuzzy) {
+  test("route tiny amounts") {
     forAll(paymentGen) { case (g, source, target, _) =>
       val amount = 100 msat
       val route = Router.findRoute(g, source, target, amount, 3, Set.empty, Set.empty, Set.empty, DEFAULT_ROUTE_PARAMS, TestConstants.defaultBlockHeight)
@@ -1019,7 +1019,7 @@ class RouteCalculationFuzzSpec extends FuzzingBaseClass {
     }
   }
 
-  test("route contains no cycles", FuzzingBaseClass.Tags.Fuzzy) {
+  test("route contains no cycles") {
     forAll(paymentGen) { case (g, source, target, amount) =>
       val route = Router.findRoute(g, source, target, amount, 3, Set.empty, Set.empty, Set.empty, DEFAULT_ROUTE_PARAMS, TestConstants.defaultBlockHeight)
       whenever(route.isSuccess) {
@@ -1030,7 +1030,7 @@ class RouteCalculationFuzzSpec extends FuzzingBaseClass {
     }
   }
 
-  test("route can work in both directions", FuzzingBaseClass.Tags.Fuzzy) {
+  test("route can work in both directions") {
     forAll(paymentGen) { case (g, source, target, amount) =>
       // Very lenient parameters that make sure we can take a route in the reverse direction without hitting fee or cltv limits.
       val routeParams = RouteParams(randomize = false, 1000000 msat, 10, 20, CltvExpiryDelta(2016), None)
@@ -1042,7 +1042,7 @@ class RouteCalculationFuzzSpec extends FuzzingBaseClass {
     }
   }
 
-  test("route can be extended", FuzzingBaseClass.Tags.Fuzzy) {
+  test("route can be extended") {
     forAll(paymentGen) { case (g, source, target, amount) =>
       // Very lenient parameters that make sure we can extend routes without hitting fee, cltv or length limits.
       val routeParams = RouteParams(randomize = false, 1000000 msat, 10, 20, CltvExpiryDelta(2016), None)

--- a/pom.xml
+++ b/pom.xml
@@ -275,5 +275,11 @@
             <version>3.0.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.scalacheck</groupId>
+            <artifactId>scalacheck_2.11</artifactId>
+            <version>1.14.3</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,7 @@
                     <parallel>true</parallel>
                     <systemProperties>
                         <buildDirectory>${project.build.directory}</buildDirectory>
+                        <fuzzFactor>${fuzzFactor}</fuzzFactor>
                     </systemProperties>
                     <argLine>-Xmx1024m -Dfile.encoding=UTF-8</argLine>
                 </configuration>


### PR DESCRIPTION
Add property-based testing and start migrating some of our old-school fuzz tests.

By default our property-based tests run with a very small factor (10) so that they're fast (but they won't find many issues). This way `mvn test` is still fast, but still runs those tests (which is important to ensure they're not completely broken).

I defined a new pipeline for the CI, that runs only the fuzz tests over a lot more samples.
This pipeline is configured to run every night at 1am UTC (this is configured directly on the semaphore UI). Here is one example run of the nightly build: https://acinq.semaphoreci.com/workflows/b9eb193d-2f1b-43b3-af58-99eaa7a6daac

This allowed me to add some tests on the router that generate graphs with certain properties. This is an important first step before we start experimenting with changes to the path-finding algorithm.
