### PR TITLE
Split the peer in two

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Logs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Logs.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.blockchain.ValidateResult
 import fr.acinq.eclair.channel.{LocalChannelDown, LocalChannelUpdate}
 import fr.acinq.eclair.crypto.TransportHandler.HandshakeCompleted
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
-import fr.acinq.eclair.io.{Authenticator, Peer}
+import fr.acinq.eclair.io.{Authenticator, Peer, PeerConnection}
 import fr.acinq.eclair.router.{ExcludeChannel, GetRoutingState, LiftChannelExclusion, Rebroadcast, RouteRequest, SyncProgress, TickBroadcast, TickPruneStaleChannels}
 import fr.acinq.eclair.wire.{ChannelReestablish, Ping, Pong, RoutingMessage, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFulfillHtlc}
 
@@ -103,12 +103,12 @@ object Logs {
         case TickBroadcast => Some(LogCategory.ROUTING_SYNC)
         case TickPruneStaleChannels => Some(LogCategory.ROUTING_SYNC)
 
-        case _: Authenticator.Authenticated => Some(LogCategory.CONNECTION)
         case _: Authenticator.PendingAuth => Some(LogCategory.CONNECTION)
         case _: HandshakeCompleted => Some(LogCategory.CONNECTION)
         case _: Peer.Connect => Some(LogCategory.CONNECTION)
         case _: Peer.Disconnect => Some(LogCategory.CONNECTION)
-        case _: Peer.DelayedRebroadcast => Some(LogCategory.ROUTING_SYNC)
+        case _: PeerConnection.InitializeConnection => Some(LogCategory.CONNECTION)
+        case _: PeerConnection.DelayedRebroadcast => Some(LogCategory.ROUTING_SYNC)
         case Peer.Reconnect => Some(LogCategory.CONNECTION)
         case _: Ping => Some(LogCategory.CONNECTION)
         case _: Pong => Some(LogCategory.CONNECTION)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -45,7 +45,7 @@ import scala.util.{Failure, Success, Try}
  */
 
 object Channel {
-  def props(nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: PublicKey, blockchain: ActorRef, router: ActorRef, relayer: ActorRef, origin_opt: Option[ActorRef]) = Props(new Channel(nodeParams, wallet, remoteNodeId, blockchain, router, relayer, origin_opt))
+  def props(nodeParams: NodeParams, wallet: EclairWallet, remoteNodeId: PublicKey, blockchain: ActorRef, relayer: ActorRef, origin_opt: Option[ActorRef]) = Props(new Channel(nodeParams, wallet, remoteNodeId, blockchain, relayer, origin_opt))
 
   // see https://github.com/lightningnetwork/lightning-rfc/blob/master/07-routing-gossip.md#requirements
   val ANNOUNCEMENTS_MINCONF = 6
@@ -94,7 +94,7 @@ object Channel {
   }
 }
 
-class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId: PublicKey, blockchain: ActorRef, router: ActorRef, relayer: ActorRef, origin_opt: Option[ActorRef] = None)(implicit ec: ExecutionContext = ExecutionContext.Implicits.global) extends FSM[State, Data] with FSMDiagnosticActorLogging[State, Data] {
+class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId: PublicKey, blockchain: ActorRef, relayer: ActorRef, origin_opt: Option[ActorRef] = None)(implicit ec: ExecutionContext = ExecutionContext.Implicits.global) extends FSM[State, Data] with FSMDiagnosticActorLogging[State, Data] {
 
   import Channel._
   import nodeParams.keyManager

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -29,21 +29,18 @@ import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair.blockchain.EclairWallet
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.TransportHandler
-import fr.acinq.eclair.router._
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{wire, _}
 import kamon.Kamon
-import scodec.Attempt
-import scodec.bits.{BitVector, ByteVector}
+import scodec.bits.ByteVector
 
-import scala.compat.Platform
 import scala.concurrent.duration._
 import scala.util.Random
 
 /**
  * Created by PM on 26/08/2016.
  */
-class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: ActorRef, watcher: ActorRef, router: ActorRef, relayer: ActorRef, paymentHandler: ActorRef, wallet: EclairWallet) extends FSMDiagnosticActorLogging[Peer.State, Peer.Data] {
+class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: ActorRef, watcher: ActorRef, relayer: ActorRef, paymentHandler: ActorRef, wallet: EclairWallet) extends FSMDiagnosticActorLogging[Peer.State, Peer.Data] {
 
   import Peer._
 
@@ -96,32 +93,11 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
           stay using d.copy(nextReconnectionDelay = nextReconnectionDelay(d.nextReconnectionDelay, nodeParams.maxReconnectInterval))
       }
 
-    case Event(Authenticator.Authenticated(_, transport, remoteNodeId1, address, outgoing, origin_opt), d: DisconnectedData) =>
+    case Event(PeerConnection.ConnectionReady(peerConnection, remoteNodeId1, address, outgoing, localInit, remoteInit), d: DisconnectedData) =>
       require(remoteNodeId == remoteNodeId1, s"invalid nodeid: $remoteNodeId != $remoteNodeId1")
       log.debug(s"got authenticated connection to $remoteNodeId@${address.getHostString}:${address.getPort}")
-      transport ! TransportHandler.Listener(self)
-      context watch transport
-      val localFeatures = nodeParams.overrideFeatures.get(remoteNodeId) match {
-        case Some(f) => f
-        case None =>
-          // Eclair-mobile thinks feature bit 15 (payment_secret) is gossip_queries_ex which creates issues, so we mask
-          // off basic_mpp and payment_secret. As long as they're provided in the invoice it's not an issue.
-          // We use a long enough mask to account for future features.
-          // TODO: remove that once eclair-mobile is patched.
-          val tweakedFeatures = BitVector.bits(nodeParams.features.bits.reverse.toIndexedSeq.zipWithIndex.map {
-            // we disable those bits if they are set...
-            case (true, 14) => false
-            case (true, 15) => false
-            case (true, 16) => false
-            case (true, 17) => false
-            // ... and leave the others untouched
-            case (value, _) => value
-          }).reverse.bytes.dropWhile(_ == 0)
-          tweakedFeatures
-      }
-      log.info(s"using features=${localFeatures.toBin}")
-      val localInit = wire.Init(localFeatures, TlvStream(InitTlv.Networks(nodeParams.chainHash :: Nil)))
-      transport ! localInit
+
+      context watch peerConnection
 
       val address_opt = if (outgoing) {
         // we store the node address upon successful outgoing connection, so we can reconnect later
@@ -130,7 +106,10 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
         Some(address)
       } else None
 
-      goto(INITIALIZING) using InitializingData(address_opt, transport, d.channels, origin_opt, localInit)
+      // let's bring existing/requested channels online
+      d.channels.values.toSet[ActorRef].foreach(_ ! INPUT_RECONNECTED(peerConnection, localInit, remoteInit)) // we deduplicate with toSet because there might be two entries per channel (tmp id and final id)
+
+      goto(CONNECTED) using ConnectedData(address_opt, peerConnection, localInit, remoteInit, d.channels.map { case (k: ChannelId, v) => (k, v) })
 
     case Event(Terminated(actor), d: DisconnectedData) if d.channels.exists(_._2 == actor) =>
       val h = d.channels.filter(_._2 == actor).keys
@@ -146,155 +125,19 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
     case Event(_: wire.LightningMessage, _) => stay // we probably just got disconnected and that's the last messages we received
   }
 
-  when(INITIALIZING) {
-    case Event(remoteInit: wire.Init, d: InitializingData) =>
-      d.transport ! TransportHandler.ReadAck(remoteInit)
-
-      log.info(s"peer is using features=${remoteInit.features.toBin}, networks=${remoteInit.networks.mkString(",")}")
-
-      if (remoteInit.networks.nonEmpty && !remoteInit.networks.contains(nodeParams.chainHash)) {
-        log.warning(s"incompatible networks (${remoteInit.networks}), disconnecting")
-        d.origin_opt.foreach(origin => origin ! Status.Failure(new RuntimeException("incompatible networks")))
-        d.transport ! PoisonPill
-        stay
-      } else if (!Features.areSupported(remoteInit.features)) {
-        log.warning("incompatible features, disconnecting")
-        d.origin_opt.foreach(origin => origin ! Status.Failure(new RuntimeException("incompatible features")))
-        d.transport ! PoisonPill
-        stay
-      } else {
-        d.origin_opt.foreach(origin => origin ! "connected")
-
-        def localHasFeature(f: Feature): Boolean = Features.hasFeature(d.localInit.features, f)
-
-        def remoteHasFeature(f: Feature): Boolean = Features.hasFeature(remoteInit.features, f)
-
-        val canUseChannelRangeQueries = localHasFeature(Features.ChannelRangeQueries) && remoteHasFeature(Features.ChannelRangeQueries)
-        val canUseChannelRangeQueriesEx = localHasFeature(Features.ChannelRangeQueriesExtended) && remoteHasFeature(Features.ChannelRangeQueriesExtended)
-        if (canUseChannelRangeQueries || canUseChannelRangeQueriesEx) {
-          // if they support channel queries we don't send routing info yet, if they want it they will query us
-          // we will query them, using extended queries if supported
-          val flags_opt = if (canUseChannelRangeQueriesEx) Some(QueryChannelRangeTlv.QueryFlags(QueryChannelRangeTlv.QueryFlags.WANT_ALL)) else None
-          if (nodeParams.syncWhitelist.isEmpty || nodeParams.syncWhitelist.contains(remoteNodeId)) {
-            log.info(s"sending sync channel range query with flags_opt=$flags_opt")
-            router ! SendChannelQuery(remoteNodeId, d.transport, flags_opt = flags_opt)
-          } else {
-            log.info("not syncing with this peer")
-          }
-        } else if (remoteHasFeature(Features.InitialRoutingSync)) {
-          // "old" nodes, do as before
-          log.info("peer requested a full routing table dump")
-          router ! GetRoutingState
-        }
-
-        // let's bring existing/requested channels online
-        d.channels.values.toSet[ActorRef].foreach(_ ! INPUT_RECONNECTED(d.transport, d.localInit, remoteInit)) // we deduplicate with toSet because there might be two entries per channel (tmp id and final id)
-        // we will delay all rebroadcasts with this value in order to prevent herd effects (each peer has a different delay)
-        val rebroadcastDelay = Random.nextInt(nodeParams.routerConf.routerBroadcastInterval.toSeconds.toInt).seconds
-        log.info(s"rebroadcast will be delayed by $rebroadcastDelay")
-        goto(CONNECTED) using ConnectedData(d.address_opt, d.transport, d.localInit, remoteInit, d.channels.map { case (k: ChannelId, v) => (k, v) }, rebroadcastDelay)
-      }
-
-    case Event(Authenticator.Authenticated(connection, _, _, _, _, origin_opt), _) =>
-      // two connections in parallel
-      origin_opt.foreach(origin => origin ! Status.Failure(new RuntimeException("there is another connection attempt in progress")))
-      // we kill this one
-      log.warning(s"killing parallel connection $connection")
-      connection ! PoisonPill
-      stay
-
-    case Event(Terminated(actor), d: InitializingData) if actor == d.transport =>
-      Logs.withMdc(diagLog)(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
-        log.warning(s"lost connection to $remoteNodeId")
-      }
-      goto(DISCONNECTED) using DisconnectedData(d.address_opt, d.channels)
-
-    case Event(Terminated(actor), d: InitializingData) if d.channels.exists(_._2 == actor) =>
-      val h = d.channels.filter(_._2 == actor).keys
-      log.info(s"channel closed: channelId=${h.mkString("/")}")
-      val channels1 = d.channels -- h
-      if (channels1.isEmpty) {
-        // we have no existing channels, we can forget about this peer
-        stopPeer()
-      } else {
-        stay using d.copy(channels = channels1)
-      }
-
-    case Event(Disconnect(nodeId), d: InitializingData) if nodeId == remoteNodeId =>
-      log.info("disconnecting")
-      sender ! "disconnecting"
-      d.transport ! PoisonPill
-      stay
-
-    case Event(unhandledMsg: LightningMessage, d: InitializingData) =>
-      // we ack unhandled messages because we don't want to block further reads on the connection
-      d.transport ! TransportHandler.ReadAck(unhandledMsg)
-      log.warning(s"acking unhandled message $unhandledMsg")
-      stay
-  }
-
   when(CONNECTED) {
-    heartbeat {
-      case Event(SendPing, d: ConnectedData) =>
-        if (d.expectedPong_opt.isEmpty) {
-          // no need to use secure random here
-          val pingSize = Random.nextInt(1000)
-          val pongSize = Random.nextInt(1000)
-          val ping = wire.Ping(pongSize, ByteVector.fill(pingSize)(0))
-          setTimer(PingTimeout.toString, PingTimeout(ping), nodeParams.pingTimeout, repeat = false)
-          d.transport ! ping
-          stay using d.copy(expectedPong_opt = Some(ExpectedPong(ping)))
-        } else {
-          log.warning(s"can't send ping, already have one in flight")
-          stay
-        }
-
-      case Event(PingTimeout(ping), d: ConnectedData) =>
-        if (nodeParams.pingDisconnect) {
-          log.warning(s"no response to ping=$ping, closing connection")
-          d.transport ! PoisonPill
-        } else {
-          log.warning(s"no response to ping=$ping (ignored)")
-        }
-        stay
-
-      case Event(ping@wire.Ping(pongLength, _), d: ConnectedData) =>
-        d.transport ! TransportHandler.ReadAck(ping)
-        if (pongLength <= 65532) {
-          // see BOLT 1: we reply only if requested pong length is acceptable
-          d.transport ! wire.Pong(ByteVector.fill(pongLength)(0.toByte))
-        } else {
-          log.warning(s"ignoring invalid ping with pongLength=${ping.pongLength}")
-        }
-        stay
-
-      case Event(pong@wire.Pong(data), d: ConnectedData) =>
-        d.transport ! TransportHandler.ReadAck(pong)
-        d.expectedPong_opt match {
-          case Some(ExpectedPong(ping, timestamp)) if ping.pongLength == data.length =>
-            // we use the pong size to correlate between pings and pongs
-            val latency = Platform.currentTime - timestamp
-            log.debug(s"received pong with latency=$latency")
-            cancelTimer(PingTimeout.toString())
-            // we don't need to call scheduleNextPing here, the next ping was already scheduled when we received that pong
-          case None =>
-            log.debug(s"received unexpected pong with size=${data.length}")
-        }
-        stay using d.copy(expectedPong_opt = None)
 
       case Event(err@wire.Error(channelId, reason), d: ConnectedData) if channelId == CHANNELID_ZERO =>
-        d.transport ! TransportHandler.ReadAck(err)
         log.error(s"connection-level error, failing all channels! reason=${new String(reason.toArray)}")
         d.channels.values.toSet[ActorRef].foreach(_ forward err) // we deduplicate with toSet because there might be two entries per channel (tmp id and final id)
-        d.transport ! PoisonPill
+        d.peerConnection ! PoisonPill
         stay
 
       case Event(err: wire.Error, d: ConnectedData) =>
-        d.transport ! TransportHandler.ReadAck(err)
         // error messages are a bit special because they can contain either temporaryChannelId or channelId (see BOLT 1)
         d.channels.get(FinalChannelId(err.channelId)).orElse(d.channels.get(TemporaryChannelId(err.channelId))) match {
           case Some(channel) => channel forward err
-          case None => d.transport ! wire.Error(err.channelId, UNKNOWN_CHANNEL_MESSAGE)
+          case None => d.peerConnection ! wire.Error(err.channelId, UNKNOWN_CHANNEL_MESSAGE)
         }
         stay
 
@@ -315,18 +158,17 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
           val channelFeeratePerKw = nodeParams.onChainFeeConf.feeEstimator.getFeeratePerKw(target = nodeParams.onChainFeeConf.feeTargets.commitmentBlockTarget)
           val fundingTxFeeratePerKw = c.fundingTxFeeratePerKw_opt.getOrElse(nodeParams.onChainFeeConf.feeEstimator.getFeeratePerKw(target = nodeParams.onChainFeeConf.feeTargets.fundingBlockTarget))
           log.info(s"requesting a new channel with fundingSatoshis=${c.fundingSatoshis}, pushMsat=${c.pushMsat} and fundingFeeratePerByte=${c.fundingTxFeeratePerKw_opt} temporaryChannelId=$temporaryChannelId localParams=$localParams")
-          channel ! INPUT_INIT_FUNDER(temporaryChannelId, c.fundingSatoshis, c.pushMsat, channelFeeratePerKw, fundingTxFeeratePerKw, localParams, d.transport, d.remoteInit, c.channelFlags.getOrElse(nodeParams.channelFlags), ChannelVersion.STANDARD)
+          channel ! INPUT_INIT_FUNDER(temporaryChannelId, c.fundingSatoshis, c.pushMsat, channelFeeratePerKw, fundingTxFeeratePerKw, localParams, d.peerConnection, d.remoteInit, c.channelFlags.getOrElse(nodeParams.channelFlags), ChannelVersion.STANDARD)
           stay using d.copy(channels = d.channels + (TemporaryChannelId(temporaryChannelId) -> channel))
         }
 
       case Event(msg: wire.OpenChannel, d: ConnectedData) =>
-        d.transport ! TransportHandler.ReadAck(msg)
         d.channels.get(TemporaryChannelId(msg.temporaryChannelId)) match {
           case None =>
             val (channel, localParams) = createNewChannel(nodeParams, funder = false, fundingAmount = msg.fundingSatoshis, origin_opt = None)
             val temporaryChannelId = msg.temporaryChannelId
             log.info(s"accepting a new channel to $remoteNodeId temporaryChannelId=$temporaryChannelId localParams=$localParams")
-            channel ! INPUT_INIT_FUNDEE(temporaryChannelId, localParams, d.transport, d.remoteInit)
+            channel ! INPUT_INIT_FUNDEE(temporaryChannelId, localParams, d.peerConnection, d.remoteInit)
             channel ! msg
             stay using d.copy(channels = d.channels + (TemporaryChannelId(temporaryChannelId) -> channel))
           case Some(_) =>
@@ -335,18 +177,16 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
         }
 
       case Event(msg: wire.HasChannelId, d: ConnectedData) =>
-        d.transport ! TransportHandler.ReadAck(msg)
         d.channels.get(FinalChannelId(msg.channelId)) match {
           case Some(channel) => channel forward msg
-          case None => d.transport ! wire.Error(msg.channelId, UNKNOWN_CHANNEL_MESSAGE)
+          case None => d.peerConnection ! wire.Error(msg.channelId, UNKNOWN_CHANNEL_MESSAGE)
         }
         stay
 
       case Event(msg: wire.HasTemporaryChannelId, d: ConnectedData) =>
-        d.transport ! TransportHandler.ReadAck(msg)
         d.channels.get(TemporaryChannelId(msg.temporaryChannelId)) match {
           case Some(channel) => channel forward msg
-          case None => d.transport ! wire.Error(msg.temporaryChannelId, UNKNOWN_CHANNEL_MESSAGE)
+          case None => d.peerConnection ! wire.Error(msg.temporaryChannelId, UNKNOWN_CHANNEL_MESSAGE)
         }
         stay
 
@@ -356,123 +196,13 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
         // we won't clean it up, but we won't remember the temporary id on channel termination
         stay using d.copy(channels = d.channels + (FinalChannelId(channelId) -> channel))
 
-      case Event(RoutingState(channels, nodes), d: ConnectedData) =>
-        // let's send the messages
-        def send(announcements: Iterable[_ <: LightningMessage]) = announcements.foldLeft(0) {
-          case (c, ann) =>
-            d.transport ! ann
-            c + 1
-        }
-
-        log.info(s"sending all announcements to {}", remoteNodeId)
-        val channelsSent = send(channels.map(_.ann))
-        val nodesSent = send(nodes)
-        val updatesSent = send(channels.flatMap(c => c.update_1_opt.toSeq ++ c.update_2_opt.toSeq))
-        log.info(s"sent all announcements to {}: channels={} updates={} nodes={}", remoteNodeId, channelsSent, updatesSent, nodesSent)
-        stay
-
-      case Event(rebroadcast: Rebroadcast, d: ConnectedData) =>
-        context.system.scheduler.scheduleOnce(d.rebroadcastDelay, self, DelayedRebroadcast(rebroadcast))(context.dispatcher)
-        stay
-
-      case Event(DelayedRebroadcast(rebroadcast), d: ConnectedData) =>
-
-        /**
-         * Send and count in a single iteration
-         */
-        def sendAndCount(msgs: Map[_ <: RoutingMessage, Set[GossipOrigin]]): Int = msgs.foldLeft(0) {
-          case (count, (_, origins)) if origins.contains(RemoteGossip(self)) =>
-            // the announcement came from this peer, we don't send it back
-            count
-          case (count, (msg, origins)) if !timestampInRange(msg, origins, d.gossipTimestampFilter) =>
-            // the peer has set up a filter on timestamp and this message is out of range
-            count
-          case (count, (msg, _)) =>
-            d.transport ! msg
-            count + 1
-        }
-
-        val channelsSent = sendAndCount(rebroadcast.channels)
-        val updatesSent = sendAndCount(rebroadcast.updates)
-        val nodesSent = sendAndCount(rebroadcast.nodes)
-
-        if (channelsSent > 0 || updatesSent > 0 || nodesSent > 0) {
-          log.info(s"sent announcements to {}: channels={} updates={} nodes={}", remoteNodeId, channelsSent, updatesSent, nodesSent)
-        }
-        stay
-
-      case Event(msg: GossipTimestampFilter, d: ConnectedData) =>
-        // special case: time range filters are peer specific and must not be sent to the router
-        sender ! TransportHandler.ReadAck(msg)
-        if (msg.chainHash != nodeParams.chainHash) {
-          log.warning("received gossip_timestamp_range message for chain {}, we're on {}", msg.chainHash, nodeParams.chainHash)
-          stay
-        } else {
-          log.info(s"setting up gossipTimestampFilter=$msg")
-          // update their timestamp filter
-          stay using d.copy(gossipTimestampFilter = Some(msg))
-        }
-
-      case Event(msg: wire.RoutingMessage, d: ConnectedData) =>
-        msg match {
-          case _: ChannelAnnouncement | _: ChannelUpdate | _: NodeAnnouncement if d.behavior.ignoreNetworkAnnouncement =>
-            // this peer is currently under embargo!
-            sender ! TransportHandler.ReadAck(msg)
-          case _ =>
-            // Note: we don't ack messages here because we don't want them to be stacked in the router's mailbox
-            router ! PeerRoutingMessage(d.transport, remoteNodeId, msg)
-        }
-        stay
-
-      case Event(readAck: TransportHandler.ReadAck, d: ConnectedData) =>
-        // we just forward acks from router to transport
-        d.transport forward readAck
-        stay
-
-      case Event(badMessage: BadMessage, d: ConnectedData) =>
-        val behavior1 = badMessage match {
-          case InvalidSignature(r) =>
-            val bin: String = LightningMessageCodecs.meteredLightningMessageCodec.encode(r) match {
-              case Attempt.Successful(b) => b.toHex
-              case _ => "unknown"
-            }
-            log.error(s"peer sent us a routing message with invalid sig: r=$r bin=$bin")
-            // for now we just return an error, maybe ban the peer in the future?
-            // TODO: this doesn't actually disconnect the peer, once we introduce peer banning we should actively disconnect
-            d.transport ! Error(CHANNELID_ZERO, ByteVector.view(s"bad announcement sig! bin=$bin".getBytes()))
-            d.behavior
-          case InvalidAnnouncement(c) =>
-            // they seem to be sending us fake announcements?
-            log.error(s"couldn't find funding tx with valid scripts for shortChannelId=${c.shortChannelId}")
-            // for now we just return an error, maybe ban the peer in the future?
-            // TODO: this doesn't actually disconnect the peer, once we introduce peer banning we should actively disconnect
-            d.transport ! Error(CHANNELID_ZERO, ByteVector.view(s"couldn't verify channel! shortChannelId=${c.shortChannelId}".getBytes()))
-            d.behavior
-          case ChannelClosed(_) =>
-            if (d.behavior.ignoreNetworkAnnouncement) {
-              // we already are ignoring announcements, we may have additional notifications for announcements that were received right before our ban
-              d.behavior.copy(fundingTxAlreadySpentCount = d.behavior.fundingTxAlreadySpentCount + 1)
-            } else if (d.behavior.fundingTxAlreadySpentCount < MAX_FUNDING_TX_ALREADY_SPENT) {
-              d.behavior.copy(fundingTxAlreadySpentCount = d.behavior.fundingTxAlreadySpentCount + 1)
-            } else {
-              log.warning(s"peer sent us too many channel announcements with funding tx already spent (count=${d.behavior.fundingTxAlreadySpentCount + 1}), ignoring network announcements for $IGNORE_NETWORK_ANNOUNCEMENTS_PERIOD")
-              setTimer(ResumeAnnouncements.toString, ResumeAnnouncements, IGNORE_NETWORK_ANNOUNCEMENTS_PERIOD, repeat = false)
-              d.behavior.copy(fundingTxAlreadySpentCount = d.behavior.fundingTxAlreadySpentCount + 1, ignoreNetworkAnnouncement = true)
-            }
-        }
-        stay using d.copy(behavior = behavior1)
-
-      case Event(ResumeAnnouncements, d: ConnectedData) =>
-        log.info(s"resuming processing of network announcements for peer")
-        stay using d.copy(behavior = d.behavior.copy(fundingTxAlreadySpentCount = 0, ignoreNetworkAnnouncement = false))
-
       case Event(Disconnect(nodeId), d: ConnectedData) if nodeId == remoteNodeId =>
         log.info(s"disconnecting")
         sender ! "disconnecting"
-        d.transport ! PoisonPill
+        d.peerConnection ! PoisonPill
         stay
 
-      case Event(Terminated(actor), d: ConnectedData) if actor == d.transport =>
+      case Event(Terminated(actor), d: ConnectedData) if actor == d.peerConnection =>
         Logs.withMdc(diagLog)(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
           log.info(s"lost connection to $remoteNodeId")
         }
@@ -490,24 +220,21 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
         log.info(s"channel closed: channelId=${channelIds.mkString("/")}")
         if (d.channels.values.toSet - actor == Set.empty) {
           log.info(s"that was the last open channel, closing the connection")
-          d.transport ! PoisonPill
+          d.peerConnection ! PoisonPill
         }
         stay using d.copy(channels = d.channels -- channelIds)
 
-      case Event(h: Authenticator.Authenticated, d: ConnectedData) =>
-        log.info(s"got new transport while already connected, switching to new transport")
-        context unwatch d.transport
-        d.transport ! PoisonPill
+      case Event(connectionReady: PeerConnection.ConnectionReady, d: ConnectedData) =>
+        log.info(s"got new connection, killing current one and switching")
+        context unwatch d.peerConnection
+        d.peerConnection ! PoisonPill
         d.channels.values.toSet[ActorRef].foreach(_ ! INPUT_DISCONNECTED) // we deduplicate with toSet because there might be two entries per channel (tmp id and final id)
-        self ! h
+        self ! connectionReady
         goto(DISCONNECTED) using DisconnectedData(d.address_opt, d.channels.collect { case (k: FinalChannelId, v) => (k, v) })
 
-      case Event(unhandledMsg: LightningMessage, d: ConnectedData) =>
-        // we ack unhandled messages because we don't want to block further reads on the connection
-        d.transport ! TransportHandler.ReadAck(unhandledMsg)
-        log.warning(s"acking unhandled message $unhandledMsg")
+      case Event(unhandledMsg: LightningMessage, _) =>
+        log.warning("ignoring message {}", unhandledMsg)
         stay
-    }
   }
 
   whenUnhandled {
@@ -523,23 +250,14 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
       sender ! PeerInfo(remoteNodeId, stateName.toString, d.address_opt, d.channels.values.toSet.size) // we use toSet to dedup because a channel can have a TemporaryChannelId + a ChannelId
       stay
 
-    case Event(_: Rebroadcast, _) => stay // ignored
-
-    case Event(_: DelayedRebroadcast, _) => stay // ignored
-
-    case Event(_: RoutingState, _) => stay // ignored
-
     case Event(_: TransportHandler.ReadAck, _) => stay // ignored
 
     case Event(Peer.Reconnect, _) => stay // we got connected in the meantime
 
-    case Event(SendPing, _) => stay // we got disconnected in the meantime
+    case Event(msg, _) =>
+      log.warning("unhandled msg {} in state {}", msg, stateName)
+      stay
 
-    case Event(_: Pong, _) => stay // we got disconnected before receiving the pong
-
-    case Event(_: PingTimeout, _) => stay // we got disconnected after sending a ping
-
-    case Event(_: BadMessage, _) => stay // we got disconnected while syncing
   }
 
   /**
@@ -560,7 +278,6 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
     case _ -> CONNECTED =>
       Metrics.connectedPeers.increment()
       context.system.eventStream.publish(PeerConnected(self, remoteNodeId))
-      scheduleNextPing()
     case CONNECTED -> DISCONNECTED =>
       Metrics.connectedPeers.decrement()
       context.system.eventStream.publish(PeerDisconnected(self, remoteNodeId))
@@ -573,29 +290,6 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
       context.system.eventStream.publish(PeerDisconnected(self, remoteNodeId))
   }
 
-  /**
-   * As long as we receive messages from our peer, we consider it is online and don't send ping requests. If we don't
-   * hear from the peer, we send pings and expect timely answers, otherwise we'll close the connection.
-   *
-   * This is implemented by scheduling a ping request every 30 seconds, and pushing it back every time we receive a
-   * message from the peer.
-   *
-   */
-  def heartbeat(s: StateFunction): StateFunction = {
-    case event if s.isDefinedAt(event) =>
-      event match {
-        case Event(_: LightningMessage, c: ConnectedData) if sender == c.transport =>
-          // this is a message from the peer, he's alive, we can delay the next ping
-          scheduleNextPing()
-        case _ => ()
-      }
-      s(event)
-  }
-
-  def scheduleNextPing() = {
-    setTimer(SEND_PING_TIMER, SendPing, 30 seconds)
-  }
-
   def createNewChannel(nodeParams: NodeParams, funder: Boolean, fundingAmount: Satoshi, origin_opt: Option[ActorRef]): (ActorRef, LocalParams) = {
     val defaultFinalScriptPubKey = Helpers.getFinalScriptPubKey(wallet, nodeParams.chainHash)
     val localParams = makeChannelParams(nodeParams, defaultFinalScriptPubKey, funder, fundingAmount)
@@ -604,7 +298,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
   }
 
   def spawnChannel(nodeParams: NodeParams, origin_opt: Option[ActorRef]): ActorRef = {
-    val channel = context.actorOf(Channel.props(nodeParams, wallet, remoteNodeId, watcher, router, relayer, origin_opt))
+    val channel = context.actorOf(Channel.props(nodeParams, wallet, remoteNodeId, watcher, relayer, origin_opt))
     context watch channel
     channel
   }
@@ -618,31 +312,6 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: A
   // TODO gets the first of the list, improve selection?
   def getPeerAddressFromNodeAnnouncement: Option[InetSocketAddress] = {
     nodeParams.db.network.getNode(remoteNodeId).flatMap(_.addresses.headOption.map(_.socketAddress))
-  }
-
-  /**
-   * Peer may want to filter announcements based on timestamp.
-   *
-   * @param gossipTimestampFilter_opt optional gossip timestamp range
-   * @return
-   *         - true if this is our own gossip
-   *         - true if there is a filter and msg has no timestamp, or has one that matches the filter
-   *         - false otherwise
-   */
-  def timestampInRange(msg: RoutingMessage, origins: Set[GossipOrigin], gossipTimestampFilter_opt: Option[GossipTimestampFilter]): Boolean = {
-    // For our own gossip, we should ignore the peer's timestamp filter.
-    val isOurGossip = msg match {
-      case n: NodeAnnouncement if n.nodeId == nodeParams.nodeId => true
-      case _ if origins.contains(LocalGossip) => true
-      case _ => false
-    }
-    // Otherwise we check if this message has a timestamp that matches the timestamp filter.
-    val matchesFilter = (msg, gossipTimestampFilter_opt) match {
-      case (_, None) => false // BOLT 7: A node which wants any gossip messages would have to send this, otherwise [...] no gossip messages would be received.
-      case (hasTs: HasTimestamp, Some(GossipTimestampFilter(_, firstTimestamp, timestampRange))) => hasTs.timestamp >= firstTimestamp && hasTs.timestamp <= firstTimestamp + timestampRange
-      case _ => true // if there is a filter and message doesn't have a timestamp (e.g. channel_announcement), then we send it
-    }
-    isOurGossip || matchesFilter
   }
 
   // a failing channel won't be restarted, it should handle its states
@@ -671,7 +340,7 @@ object Peer {
 
   val IGNORE_NETWORK_ANNOUNCEMENTS_PERIOD = 5 minutes
 
-  def props(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: ActorRef, watcher: ActorRef, router: ActorRef, relayer: ActorRef, paymentHandler: ActorRef, wallet: EclairWallet) = Props(new Peer(nodeParams, remoteNodeId, authenticator, watcher, router, relayer, paymentHandler, wallet))
+  def props(nodeParams: NodeParams, remoteNodeId: PublicKey, authenticator: ActorRef, watcher: ActorRef, relayer: ActorRef, paymentHandler: ActorRef, wallet: EclairWallet) = Props(new Peer(nodeParams, remoteNodeId, authenticator, watcher, relayer, paymentHandler, wallet))
 
   // @formatter:off
 
@@ -685,15 +354,11 @@ object Peer {
   }
   case class Nothing() extends Data { override def address_opt = None; override def channels = Map.empty }
   case class DisconnectedData(address_opt: Option[InetSocketAddress], channels: Map[FinalChannelId, ActorRef], nextReconnectionDelay: FiniteDuration = randomizeDelay(10 seconds)) extends Data
-  case class InitializingData(address_opt: Option[InetSocketAddress], transport: ActorRef, channels: Map[FinalChannelId, ActorRef], origin_opt: Option[ActorRef], localInit: wire.Init) extends Data
-  case class ConnectedData(address_opt: Option[InetSocketAddress], transport: ActorRef, localInit: wire.Init, remoteInit: wire.Init, channels: Map[ChannelId, ActorRef], rebroadcastDelay: FiniteDuration, gossipTimestampFilter: Option[GossipTimestampFilter] = None, behavior: Behavior = Behavior(), expectedPong_opt: Option[ExpectedPong] = None) extends Data
-  case class ExpectedPong(ping: Ping, timestamp: Long = Platform.currentTime)
-  case class PingTimeout(ping: Ping)
+  case class ConnectedData(address_opt: Option[InetSocketAddress], peerConnection: ActorRef, localInit: wire.Init, remoteInit: wire.Init, channels: Map[ChannelId, ActorRef]) extends Data
 
   sealed trait State
   case object INSTANTIATING extends State
   case object DISCONNECTED extends State
-  case object INITIALIZING extends State
   case object CONNECTED extends State
 
   case class Init(previousKnownAddress: Option[InetSocketAddress], storedChannels: Set[HasCommitments])
@@ -705,7 +370,6 @@ object Peer {
   }
   case object Reconnect
   case class Disconnect(nodeId: PublicKey)
-  case object ResumeAnnouncements
   case class OpenChannel(remoteNodeId: PublicKey, fundingSatoshis: Satoshi, pushMsat: MilliSatoshi, fundingTxFeeratePerKw_opt: Option[Long], channelFlags: Option[Byte], timeout_opt: Option[Timeout]) {
     require(pushMsat <= fundingSatoshis, s"pushMsat must be less or equal to fundingSatoshis")
     require(fundingSatoshis >= 0.sat, s"fundingSatoshis must be positive")
@@ -713,19 +377,9 @@ object Peer {
     fundingTxFeeratePerKw_opt.foreach(feeratePerKw => require(feeratePerKw >= MinimumFeeratePerKw, s"fee rate $feeratePerKw is below minimum $MinimumFeeratePerKw rate/kw"))
   }
   case object GetPeerInfo
-  case object SendPing
   case class PeerInfo(nodeId: PublicKey, state: String, address: Option[InetSocketAddress], channels: Int)
 
-  case class PeerRoutingMessage(transport: ActorRef, remoteNodeId: PublicKey, message: RoutingMessage)
-
-  case class DelayedRebroadcast(rebroadcast: Rebroadcast)
-
-  sealed trait BadMessage
-  case class InvalidSignature(r: RoutingMessage) extends BadMessage
-  case class InvalidAnnouncement(c: ChannelAnnouncement) extends BadMessage
-  case class ChannelClosed(c: ChannelAnnouncement) extends BadMessage
-
-  case class Behavior(fundingTxAlreadySpentCount: Int = 0, fundingTxNotFoundCount: Int = 0, ignoreNetworkAnnouncement: Boolean = false)
+  case class PeerRoutingMessage(peerConnection: ActorRef, remoteNodeId: PublicKey, message: LightningMessage)
 
   // @formatter:on
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -24,13 +24,12 @@ import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.blockchain.EclairWallet
 import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel._
-import fr.acinq.eclair.router.Rebroadcast
 
 /**
  * Ties network connections to peers.
  * Created by PM on 14/02/2017.
  */
-class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: ActorRef, router: ActorRef, relayer: ActorRef, paymentHandler: ActorRef, wallet: EclairWallet) extends Actor with ActorLogging {
+class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: ActorRef, relayer: ActorRef, paymentHandler: ActorRef, wallet: EclairWallet) extends Actor with ActorLogging {
 
   import Switchboard._
 
@@ -85,12 +84,10 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
         case None => sender ! Status.Failure(new RuntimeException("no connection to peer"))
       }
 
-    case auth@Authenticator.Authenticated(_, _, remoteNodeId, _, _, _) =>
+    case authenticated: Authenticator.Authenticated =>
       // if this is an incoming connection, we might not yet have created the peer
-      val peer = createOrGetPeer(remoteNodeId, previousKnownAddress = None, offlineChannels = Set.empty)
-      peer forward auth
-
-    case r: Rebroadcast => context.children.foreach(_ forward r)
+      val peer = createOrGetPeer(authenticated.remoteNodeId, previousKnownAddress = None, offlineChannels = Set.empty)
+      authenticated.peerConnection ! PeerConnection.InitializeConnection(peer)
 
     case 'peers => sender ! context.children
 
@@ -107,7 +104,7 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
   def getPeer(remoteNodeId: PublicKey): Option[ActorRef] = context.child(peerActorName(remoteNodeId))
 
   def createPeer(remoteNodeId: PublicKey): ActorRef = context.actorOf(
-    Peer.props(nodeParams, remoteNodeId, authenticator, watcher, router, relayer, paymentHandler, wallet),
+    Peer.props(nodeParams, remoteNodeId, authenticator, watcher, relayer, paymentHandler, wallet),
     name = peerActorName(remoteNodeId))
 
   /**
@@ -132,7 +129,7 @@ class Switchboard(nodeParams: NodeParams, authenticator: ActorRef, watcher: Acto
 
 object Switchboard {
 
-  def props(nodeParams: NodeParams, authenticator: ActorRef, watcher: ActorRef, router: ActorRef, relayer: ActorRef, paymentHandler: ActorRef, wallet: EclairWallet) = Props(new Switchboard(nodeParams, authenticator, watcher, router, relayer, paymentHandler, wallet))
+  def props(nodeParams: NodeParams, authenticator: ActorRef, watcher: ActorRef, relayer: ActorRef, paymentHandler: ActorRef, wallet: EclairWallet) = Props(new Switchboard(nodeParams, authenticator, watcher, relayer, paymentHandler, wallet))
 
   def peerActorName(remoteNodeId: PublicKey): String = s"peer-$remoteNodeId"
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/NetworkEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/NetworkEvents.scala
@@ -32,7 +32,7 @@ case class NodeUpdated(ann: NodeAnnouncement) extends NetworkEvent
 
 case class NodeLost(nodeId: PublicKey) extends NetworkEvent
 
-case class SingleChannelDiscovered(ann: ChannelAnnouncement, capacity: Satoshi)
+case class SingleChannelDiscovered(ann: ChannelAnnouncement, capacity: Satoshi, u1_opt: Option[ChannelUpdate], u2_opt: Option[ChannelUpdate])
 
 case class ChannelsDiscovered(c: Iterable[SingleChannelDiscovered]) extends NetworkEvent
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -62,10 +62,9 @@ class FuzzySpec extends TestkitBaseClass with StateTestsHelperMethods with Loggi
     val paymentHandlerB = system.actorOf(Props(new PaymentHandler(Bob.nodeParams, commandBufferB)))
     val relayerA = system.actorOf(Relayer.props(Alice.nodeParams, TestProbe().ref, registerA, commandBufferA, paymentHandlerA))
     val relayerB = system.actorOf(Relayer.props(Bob.nodeParams, TestProbe().ref, registerB, commandBufferB, paymentHandlerB))
-    val router = TestProbe()
     val wallet = new TestWallet
-    val alice: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(Alice.nodeParams, wallet, Bob.nodeParams.nodeId, alice2blockchain.ref, router.ref, relayerA))
-    val bob: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(Bob.nodeParams, wallet, Alice.nodeParams.nodeId, bob2blockchain.ref, router.ref, relayerB))
+    val alice: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(Alice.nodeParams, wallet, Bob.nodeParams.nodeId, alice2blockchain.ref, relayerA))
+    val bob: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(Bob.nodeParams, wallet, Alice.nodeParams.nodeId, bob2blockchain.ref, relayerB))
     within(30 seconds) {
       val aliceInit = Init(Alice.channelParams.features)
       val bobInit = Init(Bob.channelParams.features)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/ThroughputSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/ThroughputSpec.scala
@@ -69,8 +69,8 @@ class ThroughputSpec extends FunSuite {
     val relayerA = system.actorOf(Relayer.props(Alice.nodeParams, TestProbe().ref, registerA.ref, commandBufferA, paymentHandler))
     val relayerB = system.actorOf(Relayer.props(Bob.nodeParams, TestProbe().ref, registerB.ref, commandBufferB, paymentHandler))
     val wallet = new TestWallet
-    val alice = system.actorOf(Channel.props(Alice.nodeParams, wallet, Bob.nodeParams.nodeId, blockchain, ???, relayerA, None), "a")
-    val bob = system.actorOf(Channel.props(Bob.nodeParams, wallet, Alice.nodeParams.nodeId, blockchain, ???, relayerB, None), "b")
+    val alice = system.actorOf(Channel.props(Alice.nodeParams, wallet, Bob.nodeParams.nodeId, blockchain, relayerA, None), "a")
+    val bob = system.actorOf(Channel.props(Bob.nodeParams, wallet, Alice.nodeParams.nodeId, blockchain, relayerB, None), "b")
     val aliceInit = Init(Alice.channelParams.features)
     val bobInit = Init(Bob.channelParams.features)
     alice ! INPUT_INIT_FUNDER(ByteVector32.Zeroes, TestConstants.fundingSatoshis, TestConstants.pushMsat, TestConstants.feeratePerKw, TestConstants.feeratePerKw, Alice.channelParams, pipe, bobInit, ChannelFlags.Empty, ChannelVersion.STANDARD)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
@@ -62,8 +62,8 @@ trait StateTestsHelperMethods extends TestKitBase with fixture.TestSuite with Pa
     system.eventStream.subscribe(channelUpdateListener.ref, classOf[LocalChannelUpdate])
     system.eventStream.subscribe(channelUpdateListener.ref, classOf[LocalChannelDown])
     val router = TestProbe()
-    val alice: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(nodeParamsA, wallet, Bob.nodeParams.nodeId, alice2blockchain.ref, router.ref, relayerA.ref))
-    val bob: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(nodeParamsB, wallet, Alice.nodeParams.nodeId, bob2blockchain.ref, router.ref, relayerB.ref))
+    val alice: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(nodeParamsA, wallet, Bob.nodeParams.nodeId, alice2blockchain.ref, relayerA.ref))
+    val bob: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(nodeParamsB, wallet, Alice.nodeParams.nodeId, bob2blockchain.ref, relayerB.ref))
     SetupFixture(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, router, relayerA, relayerB, channelUpdateListener)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
@@ -53,11 +53,10 @@ class RustyTestsSpec extends TestKit(ActorSystem("test")) with Matchers with fix
     paymentHandler ! new ForwardHandler(TestProbe().ref)
     // we just bypass the relayer for this test
     val relayer = paymentHandler
-    val router = TestProbe()
     val wallet = new TestWallet
     val feeEstimator = new TestFeeEstimator
-    val alice: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(Alice.nodeParams.copy(blockCount = blockCount, onChainFeeConf = Alice.nodeParams.onChainFeeConf.copy(feeEstimator = feeEstimator)), wallet, Bob.nodeParams.nodeId, alice2blockchain.ref, router.ref, relayer))
-    val bob: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(Bob.nodeParams.copy(blockCount = blockCount, onChainFeeConf = Bob.nodeParams.onChainFeeConf.copy(feeEstimator = feeEstimator)), wallet, Alice.nodeParams.nodeId, bob2blockchain.ref, router.ref, relayer))
+    val alice: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(Alice.nodeParams.copy(blockCount = blockCount, onChainFeeConf = Alice.nodeParams.onChainFeeConf.copy(feeEstimator = feeEstimator)), wallet, Bob.nodeParams.nodeId, alice2blockchain.ref, relayer))
+    val bob: TestFSMRef[State, Data, Channel] = TestFSMRef(new Channel(Bob.nodeParams.copy(blockCount = blockCount, onChainFeeConf = Bob.nodeParams.onChainFeeConf.copy(feeEstimator = feeEstimator)), wallet, Alice.nodeParams.nodeId, bob2blockchain.ref, relayer))
     val aliceInit = Init(Alice.channelParams.features)
     val bobInit = Init(Bob.channelParams.features)
     // alice and bob will both have 1 000 000 sat

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.io
+
+import java.net.{Inet4Address, InetSocketAddress}
+
+import akka.actor.ActorRef
+import akka.testkit.{TestFSMRef, TestProbe}
+import fr.acinq.bitcoin.Block
+import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.eclair.TestConstants._
+import fr.acinq.eclair._
+import fr.acinq.eclair.channel.states.StateTestsHelperMethods
+import fr.acinq.eclair.crypto.TransportHandler
+import fr.acinq.eclair.router.RoutingSyncSpec.makeFakeRoutingInfo
+import fr.acinq.eclair.router._
+import fr.acinq.eclair.wire._
+import org.scalatest.{Outcome, Tag}
+import scodec.bits._
+
+import scala.concurrent.duration._
+
+class PeerConnectionSpec extends TestkitBaseClass with StateTestsHelperMethods {
+
+  def ipv4FromInet4(address: InetSocketAddress) = IPv4.apply(address.getAddress.asInstanceOf[Inet4Address], address.getPort)
+
+  val fakeIPAddress = NodeAddress.fromParts("1.2.3.4", 42000).get
+  val shortChannelIds = RoutingSyncSpec.shortChannelIds.take(100)
+  val fakeRoutingInfo = shortChannelIds.map(makeFakeRoutingInfo)
+  val channels = fakeRoutingInfo.map(_._1.ann).toList
+  val updates = (fakeRoutingInfo.flatMap(_._1.update_1_opt) ++ fakeRoutingInfo.flatMap(_._1.update_2_opt)).toList
+  val nodes = (fakeRoutingInfo.map(_._1.ann.nodeId1) ++ fakeRoutingInfo.map(_._1.ann.nodeId2)).map(RoutingSyncSpec.makeFakeNodeAnnouncement).toList
+
+  case class FixtureParam(remoteNodeId: PublicKey, authenticator: TestProbe, router: TestProbe, connection: TestProbe, transport: TestProbe, peerConnection: TestFSMRef[PeerConnection.State, PeerConnection.Data, PeerConnection], peer: TestProbe)
+
+  override protected def withFixture(test: OneArgTest): Outcome = {
+    val authenticator = TestProbe()
+    val router = TestProbe()
+    val connection = TestProbe()
+    val transport = TestProbe()
+    val peer = TestProbe()
+    val remoteNodeId = Bob.nodeParams.nodeId
+    val address = new InetSocketAddress("localhost", 42000)
+
+    import com.softwaremill.quicklens._
+    val aliceParams = TestConstants.Alice.nodeParams
+      .modify(_.syncWhitelist).setToIf(test.tags.contains("sync-whitelist-bob"))(Set(remoteNodeId))
+      .modify(_.syncWhitelist).setToIf(test.tags.contains("sync-whitelist-random"))(Set(randomKey.publicKey))
+
+    val peerConnection: TestFSMRef[PeerConnection.State, PeerConnection.Data, PeerConnection] = TestFSMRef(new PeerConnection(aliceParams, remoteNodeId, address, outgoing = false, origin_opt = None, transport.ref,  authenticator.ref, router.ref))
+    withFixture(test.toNoArgTest(FixtureParam(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)))
+  }
+
+  def connect(remoteNodeId: PublicKey, authenticator: TestProbe, router: TestProbe, connection: TestProbe, transport: TestProbe, peerConnection: TestFSMRef[PeerConnection.State, PeerConnection.Data, PeerConnection], peer: TestProbe, remoteInit: wire.Init = wire.Init(Bob.nodeParams.features), expectSync: Boolean = false): Unit = {
+    // let's simulate a connection
+    val probe = TestProbe()
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
+    transport.expectMsgType[TransportHandler.Listener]
+    val localInit = transport.expectMsgType[wire.Init]
+    assert(localInit.networks === List(Block.RegtestGenesisBlock.hash))
+    transport.send(peerConnection, remoteInit)
+    transport.expectMsgType[TransportHandler.ReadAck]
+    if (expectSync) {
+      router.expectMsgType[SendChannelQuery]
+    } else {
+      router.expectNoMsg(1 second)
+    }
+    peer.expectMsg(PeerConnection.ConnectionReady(peerConnection, remoteNodeId, peerConnection.underlyingActor.address, peerConnection.underlyingActor.outgoing, localInit, remoteInit))
+    assert(peerConnection.stateName === PeerConnection.CONNECTED)
+  }
+
+  test("establish connection") { f =>
+    import f._
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)
+  }
+
+  test("disconnect if incompatible local features") { f =>
+    import f._
+    val probe = TestProbe()
+    probe.watch(transport.ref)
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
+    transport.expectMsgType[TransportHandler.Listener]
+    transport.expectMsgType[wire.Init]
+    transport.send(peerConnection, LightningMessageCodecs.initCodec.decode(hex"0000 00050100000000".bits).require.value)
+    transport.expectMsgType[TransportHandler.ReadAck]
+    probe.expectTerminated(transport.ref)
+  }
+
+  test("disconnect if incompatible global features") { f =>
+    import f._
+    val probe = TestProbe()
+    probe.watch(transport.ref)
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
+    transport.expectMsgType[TransportHandler.Listener]
+    transport.expectMsgType[wire.Init]
+    transport.send(peerConnection, LightningMessageCodecs.initCodec.decode(hex"00050100000000 0000".bits).require.value)
+    transport.expectMsgType[TransportHandler.ReadAck]
+    probe.expectTerminated(transport.ref)
+  }
+
+  test("masks off MPP and PaymentSecret features") { f =>
+    import f._
+    val probe = TestProbe()
+
+    val testCases = Seq(
+      (bin"                00000010", bin"                00000010"), // option_data_loss_protect
+      (bin"        0000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex
+      (bin"        1000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret
+      (bin"        0100101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret
+      (bin"000000101000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret, basic_mpp
+      (bin"000010101000101010001010", bin"000010000000101010001010") // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret, basic_mpp and large_channel_support (optional)
+    )
+
+    for ((configuredFeatures, sentFeatures) <- testCases) {
+      val nodeParams = TestConstants.Alice.nodeParams.copy(features = configuredFeatures.bytes)
+      val peerConnection = TestFSMRef(new PeerConnection(nodeParams, remoteNodeId, new InetSocketAddress("localhost", 42000), outgoing = false, origin_opt = None, transport.ref,  authenticator.ref, router.ref))
+      probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
+      transport.expectMsgType[TransportHandler.Listener]
+      val init = transport.expectMsgType[wire.Init]
+      assert(init.features === sentFeatures.bytes)
+    }
+  }
+
+  test("disconnect if incompatible networks") { f =>
+    import f._
+    val probe = TestProbe()
+    probe.watch(transport.ref)
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
+    transport.expectMsgType[TransportHandler.Listener]
+    transport.expectMsgType[wire.Init]
+    transport.send(peerConnection, wire.Init(Bob.nodeParams.features, TlvStream(InitTlv.Networks(Block.LivenetGenesisBlock.hash :: Block.SegnetGenesisBlock.hash :: Nil))))
+    transport.expectMsgType[TransportHandler.ReadAck]
+    probe.expectTerminated(transport.ref)
+  }
+
+  test("sync if no whitelist is defined") { f =>
+    import f._
+    val remoteInit = wire.Init(bin"10000000".bytes) // bob supports channel range queries
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer, remoteInit, expectSync = true)
+  }
+
+  test("sync if whitelist contains peer", Tag("sync-whitelist-bob")) { f =>
+    import f._
+    val remoteInit = wire.Init(bin"0000001010000000".bytes) // bob supports channel range queries and variable length onion
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer, remoteInit, expectSync = true)
+  }
+
+  test("don't sync if whitelist doesn't contain peer", Tag("sync-whitelist-random")) { f =>
+    import f._
+    val remoteInit = wire.Init(bin"0000001010000000".bytes) // bob supports channel range queries
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer, remoteInit, expectSync = false)
+  }
+
+  test("reply to ping") { f =>
+    import f._
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)
+    val ping = Ping(42, randomBytes(127))
+    transport.send(peerConnection, ping)
+    transport.expectMsg(TransportHandler.ReadAck(ping))
+    assert(transport.expectMsgType[Pong].data.size === ping.pongLength)
+  }
+
+  test("send a ping if no message received for 30s") { f =>
+    import f._
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)
+    // we make the transport send a message, this will delay the sending of a ping
+    val dummy = updates.head
+    for (_ <- 1 to 5) { // the goal of this loop is to make sure that we don't send pings when we receive messages
+      // we make the transport send a message, this will delay the sending of a ping --again
+      transport.expectNoMsg(10 / transport.testKitSettings.TestTimeFactor seconds) // we don't want dilated time here
+      transport.send(peerConnection, dummy)
+    }
+    // ~30s without an incoming message: peer should send a ping
+    transport.expectMsgType[Ping](35 seconds)
+    transport.expectNoMsg()
+  }
+
+  test("ignore malicious ping") { f =>
+    import f._
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)
+    // huge requested pong length
+    val ping = Ping(Int.MaxValue, randomBytes(127))
+    transport.send(peerConnection, ping)
+    transport.expectMsg(TransportHandler.ReadAck(ping))
+    transport.expectNoMsg()
+  }
+
+  test("disconnect if no reply to ping") { f =>
+    import f._
+    val sender = TestProbe()
+    val deathWatcher = TestProbe()
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)
+    // we manually trigger a ping because we don't want to wait too long in tests
+    sender.send(peerConnection, PeerConnection.SendPing)
+    transport.expectMsgType[Ping]
+    deathWatcher.watch(transport.ref)
+    deathWatcher.expectTerminated(transport.ref, max = 11 seconds)
+  }
+
+  test("filter gossip message (no filtering)") { f =>
+    import f._
+    val probe = TestProbe()
+    val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref))
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)
+    val rebroadcast = Rebroadcast(channels.map(_ -> gossipOrigin).toMap, updates.map(_ -> gossipOrigin).toMap, nodes.map(_ -> gossipOrigin).toMap)
+    probe.send(peerConnection, rebroadcast)
+    transport.expectNoMsg(10 / transport.testKitSettings.TestTimeFactor seconds) // we don't want dilated time here
+  }
+
+  test("filter gossip message (filtered by origin)") { f =>
+    import f._
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)
+    val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref))
+    val pcActor: ActorRef = peerConnection
+    val rebroadcast = Rebroadcast(
+      channels.map(_ -> gossipOrigin).toMap + (channels(5) -> Set(RemoteGossip(pcActor))),
+      updates.map(_ -> gossipOrigin).toMap + (updates(6) -> (gossipOrigin + RemoteGossip(pcActor))) + (updates(10) -> Set(RemoteGossip(pcActor))),
+      nodes.map(_ -> gossipOrigin).toMap + (nodes(4) -> Set(RemoteGossip(pcActor))))
+    val filter = wire.GossipTimestampFilter(Alice.nodeParams.chainHash, 0, Long.MaxValue) // no filtering on timestamps
+    transport.send(peerConnection, filter)
+    transport.expectMsg(TransportHandler.ReadAck(filter))
+    transport.send(peerConnection, rebroadcast)
+    // peer won't send out announcements that came from itself
+    (channels.toSet - channels(5)).foreach(transport.expectMsg(_))
+    (updates.toSet - updates(6) - updates(10)).foreach(transport.expectMsg(_))
+    (nodes.toSet - nodes(4)).foreach(transport.expectMsg(_))
+  }
+
+  test("filter gossip message (filtered by timestamp)") { f =>
+    import f._
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)
+    val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref))
+    val rebroadcast = Rebroadcast(channels.map(_ -> gossipOrigin).toMap, updates.map(_ -> gossipOrigin).toMap, nodes.map(_ -> gossipOrigin).toMap)
+    val timestamps = updates.map(_.timestamp).sorted.slice(10, 30)
+    val filter = wire.GossipTimestampFilter(Alice.nodeParams.chainHash, timestamps.head, timestamps.last - timestamps.head)
+    transport.send(peerConnection, filter)
+    transport.expectMsg(TransportHandler.ReadAck(filter))
+    transport.send(peerConnection, rebroadcast)
+    // peer doesn't filter channel announcements
+    channels.foreach(transport.expectMsg(10 seconds, _))
+    // but it will only send updates and node announcements matching the filter
+    updates.filter(u => timestamps.contains(u.timestamp)).foreach(transport.expectMsg(_))
+    nodes.filter(u => timestamps.contains(u.timestamp)).foreach(transport.expectMsg(_))
+  }
+
+  test("does not filter our own gossip message") { f =>
+    import f._
+    val probe = TestProbe()
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)
+    val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref))
+    val rebroadcast = Rebroadcast(
+      channels.map(_ -> gossipOrigin).toMap + (channels(5) -> Set(LocalGossip)),
+      updates.map(_ -> gossipOrigin).toMap + (updates(6) -> (gossipOrigin + LocalGossip)) + (updates(10) -> Set(LocalGossip)),
+      nodes.map(_ -> gossipOrigin).toMap + (nodes(4) -> Set(LocalGossip)))
+    // No timestamp filter set -> the only gossip we should broadcast is our own.
+    probe.send(peerConnection, rebroadcast)
+    transport.expectMsg(channels(5))
+    transport.expectMsg(updates(6))
+    transport.expectMsg(updates(10))
+    transport.expectMsg(nodes(4))
+    transport.expectNoMsg(10 / transport.testKitSettings.TestTimeFactor seconds) // we don't want dilated time here
+  }
+
+  test("react to peer's bad behavior") { f =>
+    import f._
+    val probe = TestProbe()
+    connect(remoteNodeId, authenticator, router, connection, transport, peerConnection, peer)
+
+    val query = QueryShortChannelIds(
+      Alice.nodeParams.chainHash,
+      EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List(ShortChannelId(42000))),
+      TlvStream.empty)
+
+    // make sure that routing messages go through
+    for (ann <- channels ++ updates) {
+      transport.send(peerConnection, ann)
+      router.expectMsg(Peer.PeerRoutingMessage(peerConnection, remoteNodeId, ann))
+    }
+    transport.expectNoMsg(1 second) // peer hasn't acknowledged the messages
+
+    // let's assume that the router isn't happy with those channels because the funding tx is already spent
+    for (c <- channels) {
+      router.send(peerConnection, PeerConnection.ChannelClosed(c))
+    }
+    // peer will temporary ignore announcements coming from bob
+    for (ann <- channels ++ updates) {
+      transport.send(peerConnection, ann)
+      transport.expectMsg(TransportHandler.ReadAck(ann))
+    }
+    router.expectNoMsg(1 second)
+    // other routing messages go through
+    transport.send(peerConnection, query)
+    router.expectMsg(Peer.PeerRoutingMessage(peerConnection, remoteNodeId, query))
+
+    // after a while the ban is lifted
+    probe.send(peerConnection, PeerConnection.ResumeAnnouncements)
+
+    // and announcements are processed again
+    for (ann <- channels ++ updates) {
+      transport.send(peerConnection, ann)
+      router.expectMsg(Peer.PeerRoutingMessage(peerConnection, remoteNodeId, ann))
+    }
+    transport.expectNoMsg(1 second) // peer hasn't acknowledged the messages
+
+    // now let's assume that the router isn't happy with those channels because the announcement is invalid
+    router.send(peerConnection, PeerConnection.InvalidAnnouncement(channels(0)))
+    // peer will return a connection-wide error, including the hex-encoded representation of the bad message
+    val error1 = transport.expectMsgType[Error]
+    assert(error1.channelId === Peer.CHANNELID_ZERO)
+    assert(new String(error1.data.toArray).startsWith("couldn't verify channel! shortChannelId="))
+
+    // let's assume that one of the sigs were invalid
+    router.send(peerConnection, PeerConnection.InvalidSignature(channels(0)))
+    // peer will return a connection-wide error, including the hex-encoded representation of the bad message
+    val error2 = transport.expectMsgType[Error]
+    assert(error2.channelId === Peer.CHANNELID_ZERO)
+    assert(new String(error2.data.toArray).startsWith("bad announcement sig! bin=0100"))
+  }
+
+}
+

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -16,24 +16,21 @@
 
 package fr.acinq.eclair.io
 
-import java.net.{Inet4Address, InetAddress, InetSocketAddress, ServerSocket}
+import java.net.{InetAddress, InetSocketAddress, ServerSocket}
 
 import akka.actor.FSM.{CurrentState, SubscribeTransitionCallBack, Transition}
+import akka.actor.PoisonPill
 import akka.actor.Status.Failure
-import akka.actor.{ActorRef, PoisonPill}
 import akka.testkit.{TestFSMRef, TestProbe}
+import fr.acinq.bitcoin.Btc
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{Block, Btc}
 import fr.acinq.eclair.TestConstants._
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.{EclairWallet, TestWallet}
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.channel.{Channel, ChannelCreated, HasCommitments}
-import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.io.Peer._
-import fr.acinq.eclair.router.RoutingSyncSpec.makeFakeRoutingInfo
-import fr.acinq.eclair.router._
-import fr.acinq.eclair.wire.{ChannelCodecsSpec, Color, EncodedShortChannelIds, EncodingType, Error, IPv4, InitTlv, LightningMessageCodecs, NodeAddress, NodeAnnouncement, Ping, Pong, QueryShortChannelIds, TlvStream}
+import fr.acinq.eclair.wire.{ChannelCodecsSpec, Color, NodeAddress, NodeAnnouncement}
 import org.scalatest.{Outcome, Tag}
 import scodec.bits.{ByteVector, _}
 
@@ -41,32 +38,21 @@ import scala.concurrent.duration._
 
 class PeerSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
-  def ipv4FromInet4(address: InetSocketAddress) = IPv4.apply(address.getAddress.asInstanceOf[Inet4Address], address.getPort)
-
   val fakeIPAddress = NodeAddress.fromParts("1.2.3.4", 42000).get
-  val shortChannelIds = RoutingSyncSpec.shortChannelIds.take(100)
-  val fakeRoutingInfo = shortChannelIds.map(makeFakeRoutingInfo)
-  val channels = fakeRoutingInfo.map(_._1.ann).toList
-  val updates = (fakeRoutingInfo.flatMap(_._1.update_1_opt) ++ fakeRoutingInfo.flatMap(_._1.update_2_opt)).toList
-  val nodes = (fakeRoutingInfo.map(_._1.ann.nodeId1) ++ fakeRoutingInfo.map(_._1.ann.nodeId2)).map(RoutingSyncSpec.makeFakeNodeAnnouncement).toList
 
-  case class FixtureParam(remoteNodeId: PublicKey, authenticator: TestProbe, watcher: TestProbe, router: TestProbe, relayer: TestProbe, connection: TestProbe, transport: TestProbe, peer: TestFSMRef[Peer.State, Peer.Data, Peer])
+  case class FixtureParam(remoteNodeId: PublicKey, authenticator: TestProbe, watcher: TestProbe, relayer: TestProbe, peer: TestFSMRef[Peer.State, Peer.Data, Peer], peerConnection: TestProbe)
 
   override protected def withFixture(test: OneArgTest): Outcome = {
     val authenticator = TestProbe()
     val watcher = TestProbe()
-    val router = TestProbe()
     val relayer = TestProbe()
-    val connection = TestProbe()
-    val transport = TestProbe()
     val paymentHandler = TestProbe()
     val wallet: EclairWallet = new TestWallet()
     val remoteNodeId = Bob.nodeParams.nodeId
+    val peerConnection = TestProbe()
 
     import com.softwaremill.quicklens._
     val aliceParams = TestConstants.Alice.nodeParams
-      .modify(_.syncWhitelist).setToIf(test.tags.contains("sync-whitelist-bob"))(Set(remoteNodeId))
-      .modify(_.syncWhitelist).setToIf(test.tags.contains("sync-whitelist-random"))(Set(randomKey.publicKey))
       .modify(_.features).setToIf(test.tags.contains("wumbo"))(hex"80000")
       .modify(_.maxFundingSatoshis).setToIf(test.tags.contains("high-max-funding-satoshis"))(Btc(0.9))
 
@@ -75,25 +61,16 @@ class PeerSpec extends TestkitBaseClass with StateTestsHelperMethods {
       aliceParams.db.network.addNode(bobAnnouncement)
     }
 
-    val peer: TestFSMRef[Peer.State, Peer.Data, Peer] = TestFSMRef(new Peer(aliceParams, remoteNodeId, authenticator.ref, watcher.ref, router.ref, relayer.ref, paymentHandler.ref, wallet))
-    withFixture(test.toNoArgTest(FixtureParam(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)))
+    val peer: TestFSMRef[Peer.State, Peer.Data, Peer] = TestFSMRef(new Peer(aliceParams, remoteNodeId, authenticator.ref, watcher.ref, relayer.ref, paymentHandler.ref, wallet))
+    withFixture(test.toNoArgTest(FixtureParam(remoteNodeId, authenticator, watcher, relayer, peer, peerConnection)))
   }
 
-  def connect(remoteNodeId: PublicKey, authenticator: TestProbe, watcher: TestProbe, router: TestProbe, relayer: TestProbe, connection: TestProbe, transport: TestProbe, peer: ActorRef, channels: Set[HasCommitments] = Set.empty, remoteInit: wire.Init = wire.Init(Bob.nodeParams.features), expectSync: Boolean = false): Unit = {
+  def connect(remoteNodeId: PublicKey, authenticator: TestProbe, watcher: TestProbe, relayer: TestProbe, peer: TestFSMRef[Peer.State, Peer.Data, Peer], peerConnection: TestProbe, channels: Set[HasCommitments] = Set.empty, remoteInit: wire.Init = wire.Init(Bob.nodeParams.features)): Unit = {
     // let's simulate a connection
     val probe = TestProbe()
     probe.send(peer, Peer.Init(None, channels))
-    authenticator.send(peer, Authenticator.Authenticated(connection.ref, transport.ref, remoteNodeId, fakeIPAddress.socketAddress, outgoing = true, None))
-    transport.expectMsgType[TransportHandler.Listener]
-    val localInit = transport.expectMsgType[wire.Init]
-    assert(localInit.networks === List(Block.RegtestGenesisBlock.hash))
-    transport.send(peer, remoteInit)
-    transport.expectMsgType[TransportHandler.ReadAck]
-    if (expectSync) {
-      router.expectMsgType[SendChannelQuery]
-    } else {
-      router.expectNoMsg(1 second)
-    }
+    val localInit = wire.Init(peer.underlyingActor.nodeParams.features)
+    probe.send(peer, PeerConnection.ConnectionReady(peerConnection.ref, remoteNodeId, fakeIPAddress.socketAddress, outgoing = true, localInit, remoteInit))
     probe.send(peer, Peer.GetPeerInfo)
     assert(probe.expectMsgType[Peer.PeerInfo].state == "CONNECTED")
   }
@@ -101,7 +78,7 @@ class PeerSpec extends TestkitBaseClass with StateTestsHelperMethods {
   test("restore existing channels") { f =>
     import f._
     val probe = TestProbe()
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer, channels = Set(ChannelCodecsSpec.normal))
+    connect(remoteNodeId, authenticator, watcher, relayer, peer, peerConnection, channels = Set(ChannelCodecsSpec.normal))
     probe.send(peer, Peer.GetPeerInfo)
     probe.expectMsg(PeerInfo(remoteNodeId, "CONNECTED", Some(fakeIPAddress.socketAddress), 1))
   }
@@ -199,8 +176,8 @@ class PeerSpec extends TestkitBaseClass with StateTestsHelperMethods {
   test("reconnect with increasing delays") { f =>
     import f._
     val probe = TestProbe()
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer, channels = Set(ChannelCodecsSpec.normal))
-    probe.send(transport.ref, PoisonPill)
+    connect(remoteNodeId, authenticator, watcher, relayer, peer, peerConnection, channels = Set(ChannelCodecsSpec.normal))
+    probe.send(peerConnection.ref, PoisonPill)
     awaitCond(peer.stateName === DISCONNECTED)
     val initialReconnectDelay = peer.stateData.asInstanceOf[DisconnectedData].nextReconnectionDelay
     assert(initialReconnectDelay >= (200 milliseconds))
@@ -211,89 +188,11 @@ class PeerSpec extends TestkitBaseClass with StateTestsHelperMethods {
     assert(peer.stateData.asInstanceOf[DisconnectedData].nextReconnectionDelay === (initialReconnectDelay * 4))
   }
 
-  test("disconnect if incompatible local features") { f =>
-    import f._
-    val probe = TestProbe()
-    probe.watch(transport.ref)
-    probe.send(peer, Peer.Init(None, Set.empty))
-    authenticator.send(peer, Authenticator.Authenticated(connection.ref, transport.ref, remoteNodeId, new InetSocketAddress("1.2.3.4", 42000), outgoing = true, None))
-    transport.expectMsgType[TransportHandler.Listener]
-    transport.expectMsgType[wire.Init]
-    transport.send(peer, LightningMessageCodecs.initCodec.decode(hex"0000 00050100000000".bits).require.value)
-    transport.expectMsgType[TransportHandler.ReadAck]
-    probe.expectTerminated(transport.ref)
-  }
-
-  test("disconnect if incompatible global features") { f =>
-    import f._
-    val probe = TestProbe()
-    probe.watch(transport.ref)
-    probe.send(peer, Peer.Init(None, Set.empty))
-    authenticator.send(peer, Authenticator.Authenticated(connection.ref, transport.ref, remoteNodeId, new InetSocketAddress("1.2.3.4", 42000), outgoing = true, None))
-    transport.expectMsgType[TransportHandler.Listener]
-    transport.expectMsgType[wire.Init]
-    transport.send(peer, LightningMessageCodecs.initCodec.decode(hex"00050100000000 0000".bits).require.value)
-    transport.expectMsgType[TransportHandler.ReadAck]
-    probe.expectTerminated(transport.ref)
-  }
-
-  test("masks off MPP and PaymentSecret features") { f =>
-    import f._
-    val wallet = new TestWallet
-    val probe = TestProbe()
-
-    val testCases = Seq(
-      (bin"                00000010", bin"                00000010"), // option_data_loss_protect
-      (bin"        0000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex
-      (bin"        1000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret
-      (bin"        0100101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret
-      (bin"000000101000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret, basic_mpp
-      (bin"000010101000101010001010", bin"000010000000101010001010") // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret, basic_mpp and large_channel_support (optional)
-    )
-
-    for ((configuredFeatures, sentFeatures) <- testCases) {
-      val nodeParams = TestConstants.Alice.nodeParams.copy(features = configuredFeatures.bytes)
-      val peer = TestFSMRef(new Peer(nodeParams, remoteNodeId, authenticator.ref, watcher.ref, router.ref, relayer.ref, TestProbe().ref, wallet))
-      probe.send(peer, Peer.Init(None, Set.empty))
-      authenticator.send(peer, Authenticator.Authenticated(connection.ref, transport.ref, remoteNodeId, new InetSocketAddress("1.2.3.4", 42000), outgoing = true, None))
-      transport.expectMsgType[TransportHandler.Listener]
-      val init = transport.expectMsgType[wire.Init]
-      assert(init.features === sentFeatures.bytes)
-    }
-  }
-
-  test("disconnect if incompatible networks") { f =>
-    import f._
-    val probe = TestProbe()
-    probe.watch(transport.ref)
-    probe.send(peer, Peer.Init(None, Set.empty))
-    authenticator.send(peer, Authenticator.Authenticated(connection.ref, transport.ref, remoteNodeId, new InetSocketAddress("1.2.3.4", 42000), outgoing = true, None))
-    transport.expectMsgType[TransportHandler.Listener]
-    transport.expectMsgType[wire.Init]
-    transport.send(peer, wire.Init(Bob.nodeParams.features, TlvStream(InitTlv.Networks(Block.LivenetGenesisBlock.hash :: Block.SegnetGenesisBlock.hash :: Nil))))
-    transport.expectMsgType[TransportHandler.ReadAck]
-    probe.expectTerminated(transport.ref)
-  }
-
-  test("handle disconnect in status INITIALIZING") { f =>
-    import f._
-
-    val probe = TestProbe()
-    probe.send(peer, Peer.Init(None, Set(ChannelCodecsSpec.normal)))
-    authenticator.send(peer, Authenticator.Authenticated(connection.ref, transport.ref, remoteNodeId, fakeIPAddress.socketAddress, outgoing = true, None))
-
-    probe.send(peer, Peer.GetPeerInfo)
-    assert(probe.expectMsgType[Peer.PeerInfo].state == "INITIALIZING")
-
-    probe.send(peer, Peer.Disconnect(f.remoteNodeId))
-    probe.expectMsg("disconnecting")
-  }
-
   test("handle disconnect in status CONNECTED") { f =>
     import f._
 
     val probe = TestProbe()
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer, channels = Set(ChannelCodecsSpec.normal))
+    connect(remoteNodeId, authenticator, watcher, relayer, peer, peerConnection, channels = Set(ChannelCodecsSpec.normal))
 
     probe.send(peer, Peer.GetPeerInfo)
     assert(probe.expectMsgType[Peer.PeerInfo].state == "CONNECTED")
@@ -308,7 +207,7 @@ class PeerSpec extends TestkitBaseClass with StateTestsHelperMethods {
     val probe = TestProbe()
     val fundingAmountBig = Channel.MAX_FUNDING + 10000.sat
     system.eventStream.subscribe(probe.ref, classOf[ChannelCreated])
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
+    connect(remoteNodeId, authenticator, watcher, relayer, peer, peerConnection)
 
     assert(peer.stateData.channels.isEmpty)
     probe.send(peer, Peer.OpenChannel(remoteNodeId, fundingAmountBig, 0 msat, None, None, None))
@@ -322,7 +221,7 @@ class PeerSpec extends TestkitBaseClass with StateTestsHelperMethods {
     val probe = TestProbe()
     val fundingAmountBig = Channel.MAX_FUNDING + 10000.sat
     system.eventStream.subscribe(probe.ref, classOf[ChannelCreated])
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer) // Bob doesn't support wumbo, Alice does
+    connect(remoteNodeId, authenticator, watcher, relayer, peer, peerConnection) // Bob doesn't support wumbo, Alice does
 
     assert(peer.stateData.channels.isEmpty)
     probe.send(peer, Peer.OpenChannel(remoteNodeId, fundingAmountBig, 0 msat, None, None, None))
@@ -336,7 +235,7 @@ class PeerSpec extends TestkitBaseClass with StateTestsHelperMethods {
     val probe = TestProbe()
     val fundingAmountBig = Btc(1).toSatoshi
     system.eventStream.subscribe(probe.ref, classOf[ChannelCreated])
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer, remoteInit = wire.Init(hex"80000")) // Bob supports wumbo
+    connect(remoteNodeId, authenticator, watcher, relayer, peer, peerConnection, remoteInit = wire.Init(hex"80000")) // Bob supports wumbo
 
     assert(peer.stateData.channels.isEmpty)
     probe.send(peer, Peer.OpenChannel(remoteNodeId, fundingAmountBig, 0 msat, None, None, None))
@@ -344,13 +243,12 @@ class PeerSpec extends TestkitBaseClass with StateTestsHelperMethods {
     assert(probe.expectMsgType[Failure].cause.getMessage == s"fundingSatoshis=$fundingAmountBig is too big for the current settings, increase 'eclair.max-funding-satoshis' (see eclair.conf)")
   }
 
-
   test("use correct fee rates when spawning a channel") { f =>
     import f._
 
     val probe = TestProbe()
     system.eventStream.subscribe(probe.ref, classOf[ChannelCreated])
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
+    connect(remoteNodeId, authenticator, watcher, relayer, peer, peerConnection)
 
     assert(peer.stateData.channels.isEmpty)
     probe.send(peer, Peer.OpenChannel(remoteNodeId, 12300 sat, 0 msat, None, None, None))
@@ -360,191 +258,4 @@ class PeerSpec extends TestkitBaseClass with StateTestsHelperMethods {
     assert(channelCreated.initialFeeratePerKw == peer.feeEstimator.getFeeratePerKw(peer.feeTargets.commitmentBlockTarget))
     assert(channelCreated.fundingTxFeeratePerKw.get == peer.feeEstimator.getFeeratePerKw(peer.feeTargets.fundingBlockTarget))
   }
-
-  test("sync if no whitelist is defined") { f =>
-    import f._
-    val remoteInit = wire.Init(bin"10000000".bytes) // bob supports channel range queries
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer, Set.empty, remoteInit, expectSync = true)
-  }
-
-  test("sync if whitelist contains peer", Tag("sync-whitelist-bob")) { f =>
-    import f._
-    val remoteInit = wire.Init(bin"0000001010000000".bytes) // bob supports channel range queries and variable length onion
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer, Set.empty, remoteInit, expectSync = true)
-  }
-
-  test("don't sync if whitelist doesn't contain peer", Tag("sync-whitelist-random")) { f =>
-    import f._
-    val remoteInit = wire.Init(bin"0000001010000000".bytes) // bob supports channel range queries
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer, Set.empty, remoteInit, expectSync = false)
-  }
-
-  test("reply to ping") { f =>
-    import f._
-    val probe = TestProbe()
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
-    val ping = Ping(42, randomBytes(127))
-    probe.send(peer, ping)
-    transport.expectMsg(TransportHandler.ReadAck(ping))
-    assert(transport.expectMsgType[Pong].data.size === ping.pongLength)
-  }
-
-  test("send a ping if no message received for 30s") { f =>
-    import f._
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
-    // we make the transport send a message, this will delay the sending of a ping
-    val dummy = updates.head
-    for (_ <- 1 to 5) { // the goal of this loop is to make sure that we don't send pings when we receive messages
-      // we make the transport send a message, this will delay the sending of a ping --again
-      transport.expectNoMsg(10 / transport.testKitSettings.TestTimeFactor seconds) // we don't want dilated time here
-      transport.send(peer, dummy)
-    }
-    // ~30s without an incoming message: peer should send a ping
-    transport.expectMsgType[Ping](35 seconds)
-    transport.expectNoMsg()
-  }
-
-  test("ignore malicious ping") { f =>
-    import f._
-    val probe = TestProbe()
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
-    // huge requested pong length
-    val ping = Ping(Int.MaxValue, randomBytes(127))
-    probe.send(peer, ping)
-    transport.expectMsg(TransportHandler.ReadAck(ping))
-    transport.expectNoMsg()
-  }
-
-  test("disconnect if no reply to ping") { f =>
-    import f._
-    val sender = TestProbe()
-    val deathWatcher = TestProbe()
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
-    // we manually trigger a ping because we don't want to wait too long in tests
-    sender.send(peer, SendPing)
-    transport.expectMsgType[Ping]
-    deathWatcher.watch(transport.ref)
-    deathWatcher.expectTerminated(transport.ref, max = 11 seconds)
-  }
-
-  test("filter gossip message (no filtering)") { f =>
-    import f._
-    val probe = TestProbe()
-    val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref))
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
-    val rebroadcast = Rebroadcast(channels.map(_ -> gossipOrigin).toMap, updates.map(_ -> gossipOrigin).toMap, nodes.map(_ -> gossipOrigin).toMap)
-    probe.send(peer, rebroadcast)
-    transport.expectNoMsg(10 / transport.testKitSettings.TestTimeFactor seconds) // we don't want dilated time here
-  }
-
-  test("filter gossip message (filtered by origin)") { f =>
-    import f._
-    val probe = TestProbe()
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
-    val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref))
-    val peerActor: ActorRef = peer
-    val rebroadcast = Rebroadcast(
-      channels.map(_ -> gossipOrigin).toMap + (channels(5) -> Set(RemoteGossip(peerActor))),
-      updates.map(_ -> gossipOrigin).toMap + (updates(6) -> (gossipOrigin + RemoteGossip(peerActor))) + (updates(10) -> Set(RemoteGossip(peerActor))),
-      nodes.map(_ -> gossipOrigin).toMap + (nodes(4) -> Set(RemoteGossip(peerActor))))
-    val filter = wire.GossipTimestampFilter(Alice.nodeParams.chainHash, 0, Long.MaxValue) // no filtering on timestamps
-    probe.send(peer, filter)
-    probe.send(peer, rebroadcast)
-    // peer won't send out announcements that came from itself
-    (channels.toSet - channels(5)).foreach(transport.expectMsg(_))
-    (updates.toSet - updates(6) - updates(10)).foreach(transport.expectMsg(_))
-    (nodes.toSet - nodes(4)).foreach(transport.expectMsg(_))
-  }
-
-  test("filter gossip message (filtered by timestamp)") { f =>
-    import f._
-    val probe = TestProbe()
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
-    val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref))
-    val rebroadcast = Rebroadcast(channels.map(_ -> gossipOrigin).toMap, updates.map(_ -> gossipOrigin).toMap, nodes.map(_ -> gossipOrigin).toMap)
-    val timestamps = updates.map(_.timestamp).sorted.slice(10, 30)
-    val filter = wire.GossipTimestampFilter(Alice.nodeParams.chainHash, timestamps.head, timestamps.last - timestamps.head)
-    probe.send(peer, filter)
-    probe.send(peer, rebroadcast)
-    // peer doesn't filter channel announcements
-    channels.foreach(transport.expectMsg(10 seconds, _))
-    // but it will only send updates and node announcements matching the filter
-    updates.filter(u => timestamps.contains(u.timestamp)).foreach(transport.expectMsg(_))
-    nodes.filter(u => timestamps.contains(u.timestamp)).foreach(transport.expectMsg(_))
-  }
-
-  test("does not filter our own gossip message") { f =>
-    import f._
-    val probe = TestProbe()
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
-    val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref))
-    val rebroadcast = Rebroadcast(
-      channels.map(_ -> gossipOrigin).toMap + (channels(5) -> Set(LocalGossip)),
-      updates.map(_ -> gossipOrigin).toMap + (updates(6) -> (gossipOrigin + LocalGossip)) + (updates(10) -> Set(LocalGossip)),
-      nodes.map(_ -> gossipOrigin).toMap + (nodes(4) -> Set(LocalGossip)))
-    // No timestamp filter set -> the only gossip we should broadcast is our own.
-    probe.send(peer, rebroadcast)
-    transport.expectMsg(channels(5))
-    transport.expectMsg(updates(6))
-    transport.expectMsg(updates(10))
-    transport.expectMsg(nodes(4))
-    transport.expectNoMsg(10 / transport.testKitSettings.TestTimeFactor seconds) // we don't want dilated time here
-  }
-
-  test("react to peer's bad behavior") { f =>
-    import f._
-    val probe = TestProbe()
-    connect(remoteNodeId, authenticator, watcher, router, relayer, connection, transport, peer)
-
-    val query = QueryShortChannelIds(
-      Alice.nodeParams.chainHash,
-      EncodedShortChannelIds(EncodingType.UNCOMPRESSED, List(ShortChannelId(42000))),
-      TlvStream.empty)
-
-    // make sure that routing messages go through
-    for (ann <- channels ++ updates) {
-      transport.send(peer, ann)
-      router.expectMsg(Peer.PeerRoutingMessage(transport.ref, remoteNodeId, ann))
-    }
-    transport.expectNoMsg(1 second) // peer hasn't acknowledged the messages
-
-    // let's assume that the router isn't happy with those channels because the funding tx is already spent
-    for (c <- channels) {
-      router.send(peer, Peer.ChannelClosed(c))
-    }
-    // peer will temporary ignore announcements coming from bob
-    for (ann <- channels ++ updates) {
-      transport.send(peer, ann)
-      transport.expectMsg(TransportHandler.ReadAck(ann))
-    }
-    router.expectNoMsg(1 second)
-    // other routing messages go through
-    transport.send(peer, query)
-    router.expectMsg(Peer.PeerRoutingMessage(transport.ref, remoteNodeId, query))
-
-    // after a while the ban is lifted
-    probe.send(peer, ResumeAnnouncements)
-
-    // and announcements are processed again
-    for (ann <- channels ++ updates) {
-      transport.send(peer, ann)
-      router.expectMsg(Peer.PeerRoutingMessage(transport.ref, remoteNodeId, ann))
-    }
-    transport.expectNoMsg(1 second) // peer hasn't acknowledged the messages
-
-    // now let's assume that the router isn't happy with those channels because the announcement is invalid
-    router.send(peer, Peer.InvalidAnnouncement(channels(0)))
-    // peer will return a connection-wide error, including the hex-encoded representation of the bad message
-    val error1 = transport.expectMsgType[Error]
-    assert(error1.channelId === CHANNELID_ZERO)
-    assert(new String(error1.data.toArray).startsWith("couldn't verify channel! shortChannelId="))
-
-    // let's assume that one of the sigs were invalid
-    router.send(peer, Peer.InvalidSignature(channels(0)))
-    // peer will return a connection-wide error, including the hex-encoded representation of the bad message
-    val error2 = transport.expectMsgType[Error]
-    assert(error2.channelId === CHANNELID_ZERO)
-    assert(new String(error2.data.toArray).startsWith("bad announcement sig! bin=0100"))
-  }
-
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
@@ -13,7 +13,7 @@ import scodec.bits._
 
 class SwitchboardSpec extends TestKit(ActorSystem("test")) with FunSuiteLike {
 
-  class TestSwitchboard(nodeParams: NodeParams, remoteNodeId: PublicKey, remotePeer: TestProbe) extends Switchboard(nodeParams, TestProbe().ref, TestProbe().ref, TestProbe().ref, TestProbe().ref, TestProbe().ref, new TestWallet()) {
+  class TestSwitchboard(nodeParams: NodeParams, remoteNodeId: PublicKey, remotePeer: TestProbe) extends Switchboard(nodeParams, TestProbe().ref, TestProbe().ref, TestProbe().ref, TestProbe().ref, new TestWallet()) {
     override def createPeer(remoteNodeId2: PublicKey): ActorRef = {
       assert(remoteNodeId === remoteNodeId2)
       remotePeer.ref

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -24,7 +24,8 @@ import fr.acinq.bitcoin.{Block, Transaction, TxOut}
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel.BITCOIN_FUNDING_EXTERNAL_CHANNEL_SPENT
 import fr.acinq.eclair.crypto.TransportHandler
-import fr.acinq.eclair.io.Peer.{InvalidSignature, PeerRoutingMessage}
+import fr.acinq.eclair.io.Peer.PeerRoutingMessage
+import fr.acinq.eclair.io.PeerConnection.InvalidSignature
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.router.Announcements.makeChannelUpdate
 import fr.acinq.eclair.router.RouteCalculationSpec.DEFAULT_AMOUNT_MSAT
@@ -87,7 +88,7 @@ class RouterSpec extends BaseRouterSpec {
     watcher.expectMsgType[WatchSpentBasic]
     watcher.expectNoMsg(1 second)
 
-    eventListener.expectMsg(ChannelsDiscovered(SingleChannelDiscovered(chan_ac, 1000000 sat) :: Nil))
+    eventListener.expectMsg(ChannelsDiscovered(SingleChannelDiscovered(chan_ac, 1000000 sat, None, None) :: Nil))
   }
 
   test("properly announce lost channels and nodes") { fixture =>

--- a/eclair-front/src/main/scala/fr/acinq/eclair/router/FrontRouter.scala
+++ b/eclair-front/src/main/scala/fr/acinq/eclair/router/FrontRouter.scala
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.router
+
+import akka.Done
+import akka.actor.{ActorRef, Props}
+import akka.event.Logging.MDC
+import akka.event.LoggingAdapter
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.eclair.Logs.LogCategory
+import fr.acinq.eclair.crypto.TransportHandler
+import fr.acinq.eclair.io.Peer.PeerRoutingMessage
+import fr.acinq.eclair.router.Router.{RegisterToChanges, keep, remoteNodeIdKey, split}
+import fr.acinq.eclair.wire.{NodeAnnouncement, QueryChannelRange, QueryShortChannelIds, ReplyShortChannelIdsEnd}
+import fr.acinq.eclair.{FSMDiagnosticActorLogging, Logs, ShortChannelId}
+import kamon.Kamon
+
+import scala.collection.SortedSet
+import scala.collection.immutable.SortedMap
+import scala.concurrent.Promise
+
+class FrontRouter(routerConf: RouterConf, remoteRouter: ActorRef, initialized: Option[Promise[Done]] = None) extends FSMDiagnosticActorLogging[FrontRouter.State, FrontRouter.Data] {
+
+  import FrontRouter._
+
+  // we pass these to helpers classes so that they have the logging context
+  implicit def implicitLog: LoggingAdapter = log
+
+  remoteRouter ! RegisterToChanges(self)
+
+  startWith(SYNCING, Data(Map.empty, SortedMap.empty))
+
+  when(SYNCING) {
+    updateTable {
+      case Event("done", d) =>
+        log.info("sync done nodes={} channels={}", d.nodes.size, d.channels.size)
+        initialized.map(_.success(Done))
+        goto(NORMAL) using d
+    }
+  }
+
+  when(NORMAL) {
+    updateTable {
+      case Event(s: SendChannelQuery, _) =>
+        remoteRouter forward s
+        stay
+
+      case Event(PeerRoutingMessage(peerConnection, remoteNodeId, routingMessage@QueryChannelRange(chainHash, firstBlockNum, numberOfBlocks, extendedQueryFlags_opt)), d) =>
+        sender ! TransportHandler.ReadAck(routingMessage)
+        Kamon.runWithContextEntry(remoteNodeIdKey, remoteNodeId.toString) {
+          Kamon.runWithSpan(Kamon.spanBuilder("query-channel-range").start(), finishSpan = true) {
+            log.info("received query_channel_range with firstBlockNum={} numberOfBlocks={} extendedQueryFlags_opt={}", firstBlockNum, numberOfBlocks, extendedQueryFlags_opt)
+            // keep channel ids that are in [firstBlockNum, firstBlockNum + numberOfBlocks]
+            val shortChannelIds: SortedSet[ShortChannelId] = d.channels.keySet.filter(keep(firstBlockNum, numberOfBlocks, _))
+            log.info("replying with {} items for range=({}, {})", shortChannelIds.size, firstBlockNum, numberOfBlocks)
+            val chunks = Kamon.runWithSpan(Kamon.spanBuilder("split-channel-ids").start(), finishSpan = true) {
+              split(shortChannelIds, firstBlockNum, numberOfBlocks, routerConf.channelRangeChunkSize)
+            }
+
+            Kamon.runWithSpan(Kamon.spanBuilder("compute-timestamps-checksums").start(), finishSpan = true) {
+              chunks.foreach { chunk =>
+                val reply = Router.buildReplyChannelRange(chunk, chainHash, routerConf.encodingType, routingMessage.queryFlags_opt, d.channels)
+                peerConnection ! reply
+              }
+            }
+            stay
+          }
+        }
+
+      case Event(PeerRoutingMessage(peerConnection, remoteNodeId, routingMessage@QueryShortChannelIds(chainHash, shortChannelIds, _)), d) =>
+        sender ! TransportHandler.ReadAck(routingMessage)
+
+        Kamon.runWithContextEntry(remoteNodeIdKey, remoteNodeId.toString) {
+          Kamon.runWithSpan(Kamon.spanBuilder("query-short-channel-ids").start(), finishSpan = true) {
+
+            val flags = routingMessage.queryFlags_opt.map(_.array).getOrElse(List.empty[Long])
+
+            var channelCount = 0
+            var updateCount = 0
+            var nodeCount = 0
+
+            Router.processChannelQuery(d.nodes, d.channels)(
+              shortChannelIds.array,
+              flags,
+              ca => {
+                channelCount = channelCount + 1
+                peerConnection ! ca
+              },
+              cu => {
+                updateCount = updateCount + 1
+                peerConnection ! cu
+              },
+              na => {
+                nodeCount = nodeCount + 1
+                peerConnection ! na
+              }
+            )
+            log.info("received query_short_channel_ids with {} items, sent back {} channels and {} updates and {} nodes", shortChannelIds.array.size, channelCount, updateCount, nodeCount)
+            peerConnection ! ReplyShortChannelIdsEnd(chainHash, 1)
+            stay
+          }
+        }
+
+      case Event(msg: PeerRoutingMessage, _) =>
+        log.info("forwarding peer routing message class={}", msg.message.getClass.getSimpleName)
+        remoteRouter forward msg
+        stay
+    }
+  }
+
+  def updateTable(s: StateFunction): StateFunction = {
+    case Event(NodesDiscovered(nodes), d) =>
+      log.debug("adding {} nodes", nodes.size)
+      val nodes1 = nodes.map(n => n.nodeId -> n).toMap
+      stay using d.copy(nodes = d.nodes ++ nodes1)
+
+    case Event(NodeUpdated(n), d) =>
+      log.debug("updating {} nodes", 1)
+      stay using d.copy(nodes = d.nodes + (n.nodeId -> n))
+
+    case Event(NodeLost(nodeId), d) =>
+      log.debug("removing {} nodes", 1)
+      stay using d.copy(nodes = d.nodes - nodeId)
+
+    case Event(ChannelsDiscovered(channels), d) =>
+      log.debug("adding {} channels", channels.size)
+      val channels1 = channels.foldLeft(SortedMap.empty[ShortChannelId, PublicChannel]) {
+        case (channels, sc) => channels + (sc.ann.shortChannelId -> PublicChannel(sc.ann, ByteVector32.Zeroes, sc.capacity, sc.u1_opt, sc.u2_opt))
+      }
+      stay using d.copy(channels = d.channels ++ channels1)
+
+    case Event(ChannelLost(channelId), d) =>
+      log.debug("removing {} channels", 1)
+      stay using d.copy(channels = d.channels - channelId)
+
+    case Event(ChannelUpdatesReceived(updates), d) =>
+      log.debug("adding/updating {} channel_updates", updates.size)
+      val channels1 = updates.foldLeft(d.channels) {
+        case (channels, u) => channels.get(u.shortChannelId) match {
+          case Some(c) => channels + (c.ann.shortChannelId -> c.updateChannelUpdateSameSideAs(u))
+          case None => channels
+        }
+      }
+      stay using d.copy(channels = channels1)
+
+    case Event(_: SyncProgress, _) =>
+      // we receive this as part of network events but it's useless
+      stay
+
+    case event if s.isDefinedAt(event) => s(event)
+  }
+
+  override def mdc(currentMessage: Any): MDC = {
+    val category_opt = LogCategory(currentMessage)
+    currentMessage match {
+      case PeerRoutingMessage(_, remoteNodeId, _) => Logs.mdc(category_opt, remoteNodeId_opt = Some(remoteNodeId))
+      case _ => Logs.mdc(category_opt)
+    }
+  }
+}
+
+object FrontRouter {
+
+  def props(routerConf: RouterConf, remoteRouter: ActorRef, initialized: Option[Promise[Done]] = None) = Props(new FrontRouter(routerConf: RouterConf, remoteRouter: ActorRef, initialized))
+
+  // @formatter:off
+  sealed trait State
+  case object SYNCING extends State
+  case object NORMAL extends State
+  // @formatter:on
+
+  case class Data(nodes: Map[PublicKey, NodeAnnouncement],
+                  channels: SortedMap[ShortChannelId, PublicChannel])
+
+}

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -164,7 +164,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
 
     case ChannelsDiscovered(channelsDiscovered) =>
       runInGuiThread { () =>
-        channelsDiscovered.foreach { case SingleChannelDiscovered(channelAnnouncement, capacity) =>
+        channelsDiscovered.foreach { case SingleChannelDiscovered(channelAnnouncement, capacity, _, _) =>
           log.debug(s"peer channel discovered with channel id={}", channelAnnouncement.shortChannelId)
           if (!mainController.networkChannelsMap.containsKey(channelAnnouncement.shortChannelId)) {
             mainController.networkChannelsMap.put(channelAnnouncement.shortChannelId, ChannelInfo(channelAnnouncement, None, None, None, None, capacity, None, None))


### PR DESCRIPTION
Peer has been split in two and now handles only channel related stuff.

A new PeerConnection class is in charge of managing the BOLT 1 part
(init handshake, pings) and has the same lifetime as the underlying
connection.

Two possible next steps:
- have `TransportHandler` be a child of `PeerConnection`; this is easy
for outgoing connection, but not straightforward for incoming
connections because we don't know what the remote node id is before the
crypto hasndshake. We could work around that by either (1) making the
`remoteNodeId` an attribute of the state of `PeerConnection` instead of
a constructor argument or (2) read the first few bytes of the incoming
connection before the crypto handshake to know the node id before it is
authenticated.
- put the reconnection logic outside of the `Peer` to simplify it even
further.