### PR TITLE
Centralize metrics per package

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/PimpKamon.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/PimpKamon.scala
@@ -17,23 +17,12 @@
 package fr.acinq.eclair
 
 import fr.acinq.eclair.payment.{LocalFailure, PaymentFailure, RemoteFailure, UnreadableRemoteFailure}
-import kamon.Kamon
 import kamon.metric.Timer
-import kamon.tag.TagSet
 import kamon.trace.Span
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object KamonExt {
-
-  def time[T](name: String, tags: TagSet = TagSet.Empty)(f: => T): T = {
-    val started = Kamon.timer(name).withTags(tags).start()
-    try {
-      f
-    } finally {
-      started.stop()
-    }
-  }
 
   def time[T](timer: Timer)(f: => T): T = {
     val started = timer.start()
@@ -44,8 +33,8 @@ object KamonExt {
     }
   }
 
-  def timeFuture[T](name: String, tags: TagSet = TagSet.Empty)(f: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
-    val started = Kamon.timer(name).withTags(tags).start()
+  def timeFuture[T](timer: Timer)(f: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+    val started = timer.start()
     val res = f
     res onComplete (_ => started.stop)
     res

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/Monitoring.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.blockchain
+
+import kamon.Kamon
+
+object Monitoring {
+
+  object Metrics {
+    val NewBlockCheckConfirmedDuration = Kamon.timer("bitcoin.watcher.newblock.checkconfirmed")
+    val RpcBasicDuration = Kamon.timer("bitcoin.rpc.basic.invoke")
+    val RpcBatchDuration = Kamon.timer("bitcoin.rpc.batch.invoke")
+  }
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BasicBitcoinJsonRPCClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BasicBitcoinJsonRPCClient.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.blockchain.bitcoind.rpc
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.json4s._
 import fr.acinq.eclair.KamonExt
+import fr.acinq.eclair.blockchain.Monitoring.Metrics
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST.JValue
 import org.json4s.jackson.Serialization
@@ -40,15 +41,15 @@ class BasicBitcoinJsonRPCClient(user: String, password: String, host: String = "
   }
 
   def invoke(requests: Seq[JsonRPCRequest])(implicit ec: ExecutionContext): Future[Seq[JsonRPCResponse]] = {
-    KamonExt.timeFuture("bitcoin.rpc.basic.invoke.time") {
-    for {
-      res <- sttp
-        .post(uri"$scheme://$host:$port/wallet/") // wallet/ specifies to use the default bitcoind wallet, named ""
-        .body(requests)
-        .auth.basic(user, password)
-        .response(asJson[Seq[JsonRPCResponse]])
-        .send()
-    } yield res.unsafeBody
+    KamonExt.timeFuture(Metrics.RpcBasicDuration.withoutTags()) {
+      for {
+        res <- sttp
+          .post(uri"$scheme://$host:$port/wallet/") // wallet/ specifies to use the default bitcoind wallet, named ""
+          .body(requests)
+          .auth.basic(user, password)
+          .response(asJson[Seq[JsonRPCResponse]])
+          .send()
+      } yield res.unsafeBody
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BatchingBitcoinJsonRPCClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BatchingBitcoinJsonRPCClient.scala
@@ -20,6 +20,7 @@ import akka.actor.{ActorSystem, Props}
 import akka.pattern.ask
 import akka.util.Timeout
 import fr.acinq.eclair.KamonExt
+import fr.acinq.eclair.blockchain.Monitoring.Metrics
 import org.json4s.JsonAST
 
 import scala.concurrent.duration._
@@ -32,7 +33,7 @@ class BatchingBitcoinJsonRPCClient(rpcClient: BasicBitcoinJsonRPCClient)(implici
   val batchingClient = system.actorOf(Props(new BatchingClient(rpcClient)), name = "batching-client")
 
   override def invoke(method: String, params: Any*)(implicit ec: ExecutionContext): Future[JsonAST.JValue] = {
-    KamonExt.timeFuture("bitcoin.rpc.batch.invoke.time") {
+    KamonExt.timeFuture(Metrics.RpcBatchDuration.withoutTags()) {
       (batchingClient ? JsonRPCRequest(method = method, params = params)).mapTo[JsonAST.JValue]
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Monitoring.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.channel
+
+import kamon.Kamon
+
+object Monitoring {
+
+  object Metrics {
+    val ChannelErrors = Kamon.counter("channels.errors")
+    val ChannelLifecycleEvents = Kamon.counter("channels.lifecycle")
+  }
+
+  object Tags {
+    val Event = "event"
+    val Fatal = "fatal"
+    val Origin = "origin"
+
+    object Events {
+      val Created = "created"
+      val Closing = "closing"
+      val Closed = "closed"
+    }
+
+    object Origins {
+      val Local = "local"
+      val Remote = "remote"
+    }
+
+  }
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.io
+
+import kamon.Kamon
+
+object Monitoring {
+
+  object Metrics {
+    val PeerConnections = Kamon.counter("peers.connecting.count")
+    val ConnectedPeers = Kamon.gauge("peers.connected").withoutTags()
+  }
+
+  object Tags {
+    val ConnectionState = "state"
+
+    object ConnectionStates {
+      val Connected = "connected"
+      val Authenticating = "authenticating"
+      val Authenticated = "authenticated"
+    }
+
+  }
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Server.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Server.scala
@@ -19,19 +19,19 @@ package fr.acinq.eclair.io
 import java.net.InetSocketAddress
 
 import akka.Done
-import akka.actor.{Actor, ActorLogging, ActorRef, DiagnosticActorLogging, Props}
+import akka.actor.{Actor, ActorRef, DiagnosticActorLogging, Props}
 import akka.event.Logging.MDC
 import akka.io.Tcp.SO.KeepAlive
 import akka.io.{IO, Tcp}
 import fr.acinq.eclair.Logs.LogCategory
+import fr.acinq.eclair.io.Monitoring.{Metrics, Tags}
 import fr.acinq.eclair.{Logs, NodeParams}
-import kamon.Kamon
 
 import scala.concurrent.Promise
 
 /**
-  * Created by PM on 27/10/2015.
-  */
+ * Created by PM on 27/10/2015.
+ */
 class Server(nodeParams: NodeParams, authenticator: ActorRef, address: InetSocketAddress, bound: Option[Promise[Done]] = None) extends Actor with DiagnosticActorLogging {
 
   import Tcp._
@@ -55,7 +55,7 @@ class Server(nodeParams: NodeParams, authenticator: ActorRef, address: InetSocke
   def listening(listener: ActorRef): Receive = {
     case Connected(remote, _) =>
       log.info(s"connected to $remote")
-      Kamon.counter("peers.connecting.count").withTag("state", "connected").increment()
+      Metrics.PeerConnections.withTag(Tags.ConnectionState, Tags.ConnectionStates.Connected).increment()
       val connection = sender
       authenticator ! Authenticator.PendingAuth(connection, remoteNodeId_opt = None, address = remote, origin_opt = None)
       listener ! ResumeAccepting(batchSize = 1)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Auditor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Auditor.scala
@@ -19,10 +19,10 @@ package fr.acinq.eclair.payment
 import akka.actor.{Actor, ActorLogging, Props}
 import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.channel.Helpers.Closing._
+import fr.acinq.eclair.channel.Monitoring.{Metrics => ChannelMetrics, Tags => ChannelTags}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.ChannelLifecycleEvent
-import fr.acinq.eclair.payment.Monitoring.{Metrics, Tags}
-import kamon.Kamon
+import fr.acinq.eclair.payment.Monitoring.{Metrics => PaymentMetrics, Tags => PaymentTags}
 
 class Auditor(nodeParams: NodeParams) extends Actor with ActorLogging {
 
@@ -37,32 +37,32 @@ class Auditor(nodeParams: NodeParams) extends Actor with ActorLogging {
   override def receive: Receive = {
 
     case e: PaymentSent =>
-      Metrics.PaymentAmount.withTag(Tags.Direction, Tags.Directions.Sent).record(e.recipientAmount.truncateToSatoshi.toLong)
-      Metrics.PaymentFees.withTag(Tags.Direction, Tags.Directions.Sent).record(e.feesPaid.truncateToSatoshi.toLong)
-      Metrics.PaymentParts.withTag(Tags.Direction, Tags.Directions.Sent).record(e.parts.length)
+      PaymentMetrics.PaymentAmount.withTag(PaymentTags.Direction, PaymentTags.Directions.Sent).record(e.recipientAmount.truncateToSatoshi.toLong)
+      PaymentMetrics.PaymentFees.withTag(PaymentTags.Direction, PaymentTags.Directions.Sent).record(e.feesPaid.truncateToSatoshi.toLong)
+      PaymentMetrics.PaymentParts.withTag(PaymentTags.Direction, PaymentTags.Directions.Sent).record(e.parts.length)
       db.add(e)
 
     case _: PaymentFailed =>
-      Metrics.PaymentFailed.withTag(Tags.Direction, Tags.Directions.Sent).increment()
+      PaymentMetrics.PaymentFailed.withTag(PaymentTags.Direction, PaymentTags.Directions.Sent).increment()
 
     case e: PaymentReceived =>
-      Metrics.PaymentAmount.withTag(Tags.Direction, Tags.Directions.Received).record(e.amount.truncateToSatoshi.toLong)
-      Metrics.PaymentParts.withTag(Tags.Direction, Tags.Directions.Received).record(e.parts.length)
+      PaymentMetrics.PaymentAmount.withTag(PaymentTags.Direction, PaymentTags.Directions.Received).record(e.amount.truncateToSatoshi.toLong)
+      PaymentMetrics.PaymentParts.withTag(PaymentTags.Direction, PaymentTags.Directions.Received).record(e.parts.length)
       db.add(e)
 
     case e: PaymentRelayed =>
-      Metrics.PaymentAmount
-        .withTag(Tags.Direction, Tags.Directions.Relayed)
-        .withTag(Tags.Relay, Tags.RelayType(e))
+      PaymentMetrics.PaymentAmount
+        .withTag(PaymentTags.Direction, PaymentTags.Directions.Relayed)
+        .withTag(PaymentTags.Relay, PaymentTags.RelayType(e))
         .record(e.amountIn.truncateToSatoshi.toLong)
-      Metrics.PaymentFees
-        .withTag(Tags.Direction, Tags.Directions.Relayed)
-        .withTag(Tags.Relay, Tags.RelayType(e))
+      PaymentMetrics.PaymentFees
+        .withTag(PaymentTags.Direction, PaymentTags.Directions.Relayed)
+        .withTag(PaymentTags.Relay, PaymentTags.RelayType(e))
         .record((e.amountIn - e.amountOut).truncateToSatoshi.toLong)
       e match {
         case TrampolinePaymentRelayed(_, incoming, outgoing, _) =>
-          Metrics.PaymentParts.withTag(Tags.Direction, Tags.Directions.Received).record(incoming.length)
-          Metrics.PaymentParts.withTag(Tags.Direction, Tags.Directions.Sent).record(outgoing.length)
+          PaymentMetrics.PaymentParts.withTag(PaymentTags.Direction, PaymentTags.Directions.Received).record(incoming.length)
+          PaymentMetrics.PaymentParts.withTag(PaymentTags.Direction, PaymentTags.Directions.Sent).record(outgoing.length)
         case _: ChannelPaymentRelayed =>
       }
       db.add(e)
@@ -70,29 +70,27 @@ class Auditor(nodeParams: NodeParams) extends Actor with ActorLogging {
     case e: NetworkFeePaid => db.add(e)
 
     case e: ChannelErrorOccurred =>
-      val metric = Kamon.counter("channels.errors")
       e.error match {
-        case LocalError(_) if e.isFatal => metric.withTag("origin", "local").withTag("fatal", "yes").increment()
-        case LocalError(_) if !e.isFatal => metric.withTag("origin", "local").withTag("fatal", "no").increment()
-        case RemoteError(_) => metric.withTag("origin", "remote").increment()
+        case LocalError(_) if e.isFatal => ChannelMetrics.ChannelErrors.withTag(ChannelTags.Origin, ChannelTags.Origins.Local).withTag(ChannelTags.Fatal, value = true).increment()
+        case LocalError(_) if !e.isFatal => ChannelMetrics.ChannelErrors.withTag(ChannelTags.Origin, ChannelTags.Origins.Local).withTag(ChannelTags.Fatal, value = false).increment()
+        case RemoteError(_) => ChannelMetrics.ChannelErrors.withTag(ChannelTags.Origin, ChannelTags.Origins.Remote).increment()
       }
       db.add(e)
 
     case e: ChannelStateChanged =>
-      val metric = Kamon.counter("channels.lifecycle")
       // NB: order matters!
       e match {
         case ChannelStateChanged(_, _, remoteNodeId, WAIT_FOR_FUNDING_LOCKED, NORMAL, d: DATA_NORMAL) =>
-          metric.withTag("event", "created").increment()
+          ChannelMetrics.ChannelLifecycleEvents.withTag(ChannelTags.Event, ChannelTags.Events.Created).increment()
           db.add(ChannelLifecycleEvent(d.channelId, remoteNodeId, d.commitments.commitInput.txOut.amount, d.commitments.localParams.isFunder, !d.commitments.announceChannel, "created"))
         case ChannelStateChanged(_, _, _, WAIT_FOR_INIT_INTERNAL, _, _) =>
         case ChannelStateChanged(_, _, _, _, CLOSING, _) =>
-          metric.withTag("event", "closing").increment()
+          ChannelMetrics.ChannelLifecycleEvents.withTag(ChannelTags.Event, ChannelTags.Events.Closing).increment()
         case _ => ()
       }
 
     case e: ChannelClosed =>
-      Kamon.counter("channels.lifecycle").withTag("event", "closed").increment()
+      ChannelMetrics.ChannelLifecycleEvents.withTag(ChannelTags.Event, ChannelTags.Events.Closed).increment()
       val event = e.closingType match {
         case MutualClose => "mutual"
         case LocalClose => "local"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/Monitoring.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.wire
+
+import kamon.Kamon
+
+object Monitoring {
+
+  object Metrics {
+    val DecodeDuration = Kamon.timer("scodec.decode.time")
+    val EncodeDuration = Kamon.timer("scodec.encode.time")
+  }
+
+  object Tags {
+    val MessageType = "type"
+  }
+
+}


### PR DESCRIPTION
Centralize metrics to avoid bloating the business logic (some metrics were unused, like `peers.count`).
This is a first step before adding new metrics and extend existing ones to provide more alerting capabilities (in follow-up PRs).