### PR TITLE
Fixup funder fee buffer

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -101,6 +101,32 @@ case class Commitments(channelVersion: ChannelVersion,
 
   val announceChannel: Boolean = (channelFlags & 0x01) != 0
 
+  // NB: when computing availableBalanceForSend and availableBalanceForReceive, the funder keeps an extra buffer on top
+  // of its usual channel reserve to avoid getting channels stuck in case the on-chain feerate increases (see
+  // https://github.com/lightningnetwork/lightning-rfc/issues/728 for details).
+  //
+  // This extra buffer (which we call "funder fee buffer") is calculated as follows:
+  //  1) Simulate a x2 feerate increase and compute the corresponding commit tx fee (note that it may trim some HTLCs)
+  //  2) Add the cost of adding a new untrimmed HTLC at that increased feerate. This ensures that we'll be able to
+  //     actually use the channel to add new HTLCs if the feerate doubles.
+  //
+  // If for example the current feerate is 1000 sat/kw, the dust limit 546 sat, and we have 3 pending outgoing HTLCs for
+  // respectively 1250 sat, 2000 sat and 2500 sat.
+  // commit tx fee = commitWeight * feerate + 3 * htlcOutputWeight * feerate = 724 * 1000 + 3 * 172 * 1000 = 1240 sat
+  // To calculate the funder fee buffer, we first double the feerate and calculate the corresponding commit tx fee.
+  // By doubling the feerate, the first HTLC becomes trimmed so the result is: 724 * 2000 + 2 * 172 * 2000 = 2136 sat
+  // We then add the additional fee for a potential new untrimmed HTLC: 172 * 2000 = 344 sat
+  // The funder fee buffer is 2136 + 344 = 2480 sat
+  //
+  // If there are many pending HTLCs that are only slightly above the trim threshold, the funder fee buffer may be
+  // smaller than the current commit tx fee because those HTLCs will be trimmed and the commit tx weight will decrease.
+  // For example if we have 10 outgoing HTLCs of 1250 sat:
+  //  - commit tx fee = 724 * 1000 + 10 * 172 * 1000 = 2444 sat
+  //  - commit tx fee at twice the feerate = 724 * 2000 = 1448 sat (all HTLCs have been trimmed)
+  //  - cost of an additional untrimmed HTLC = 172 * 2000 = 344 sat
+  //  - funder fee buffer = 1448 + 344 = 1792 sat
+  // In that case the current commit tx fee is higher than the funder fee buffer and will dominate the balance restrictions.
+
   lazy val availableBalanceForSend: MilliSatoshi = {
     // we need to base the next current commitment on the last sig we sent, even if we didn't yet receive their revocation
     val remoteCommit1 = remoteNextCommitInfo.left.toOption.map(_.nextRemoteCommit).getOrElse(remoteCommit)
@@ -109,16 +135,19 @@ case class Commitments(channelVersion: ChannelVersion,
     if (localParams.isFunder) {
       // The funder always pays the on-chain fees, so we must subtract that from the amount we can send.
       val commitFees = commitTxFeeMsat(remoteParams.dustLimit, reduced, commitmentFormat)
-      // the funder needs to keep an extra reserve to be able to handle fee increase without getting the channel stuck
-      // (see https://github.com/lightningnetwork/lightning-rfc/issues/728)
-      val funderFeeReserve = htlcOutputFee(reduced.feeratePerKw * 2, commitmentFormat)
-      val htlcFees = htlcOutputFee(reduced.feeratePerKw, commitmentFormat)
-      if (balanceNoFees - commitFees < offeredHtlcTrimThreshold(remoteParams.dustLimit, reduced, commitmentFormat)) {
+      // the funder needs to keep a "funder fee buffer" (see explanation above)
+      val funderFeeBuffer = commitTxFeeMsat(remoteParams.dustLimit, reduced.copy(feeratePerKw = reduced.feeratePerKw * 2), commitmentFormat) + htlcOutputFee(reduced.feeratePerKw * 2, commitmentFormat)
+      val amountToReserve = commitFees.max(funderFeeBuffer)
+      if (balanceNoFees - amountToReserve < offeredHtlcTrimThreshold(remoteParams.dustLimit, reduced, commitmentFormat)) {
         // htlc will be trimmed
-        (balanceNoFees - commitFees - funderFeeReserve).max(0 msat)
+        (balanceNoFees - amountToReserve).max(0 msat)
       } else {
         // htlc will have an output in the commitment tx, so there will be additional fees.
-        (balanceNoFees - commitFees - funderFeeReserve - htlcFees).max(0 msat)
+        val commitFees1 = commitFees + htlcOutputFee(reduced.feeratePerKw, commitmentFormat)
+        // we take the additional fees for that htlc output into account in the fee buffer at a x2 feerate increase
+        val funderFeeBuffer1 = funderFeeBuffer + htlcOutputFee(reduced.feeratePerKw * 2, commitmentFormat)
+        val amountToReserve1 = commitFees1.max(funderFeeBuffer1)
+        (balanceNoFees - amountToReserve1).max(0 msat)
       }
     } else {
       // The fundee doesn't pay on-chain fees.
@@ -135,16 +164,19 @@ case class Commitments(channelVersion: ChannelVersion,
     } else {
       // The funder always pays the on-chain fees, so we must subtract that from the amount we can receive.
       val commitFees = commitTxFeeMsat(localParams.dustLimit, reduced, commitmentFormat)
-      // we expect the funder to keep an extra reserve to be able to handle fee increase without getting the channel stuck
-      // (see https://github.com/lightningnetwork/lightning-rfc/issues/728)
-      val funderFeeReserve = htlcOutputFee(reduced.feeratePerKw * 2, commitmentFormat)
-      val htlcFees = htlcOutputFee(reduced.feeratePerKw, commitmentFormat)
-      if (balanceNoFees - commitFees < receivedHtlcTrimThreshold(localParams.dustLimit, reduced, commitmentFormat)) {
+      // we expected the funder to keep a "funder fee buffer" (see explanation above)
+      val funderFeeBuffer = commitTxFeeMsat(localParams.dustLimit, reduced.copy(feeratePerKw = reduced.feeratePerKw * 2), commitmentFormat) + htlcOutputFee(reduced.feeratePerKw * 2, commitmentFormat)
+      val amountToReserve = commitFees.max(funderFeeBuffer)
+      if (balanceNoFees - amountToReserve < receivedHtlcTrimThreshold(localParams.dustLimit, reduced, commitmentFormat)) {
         // htlc will be trimmed
-        (balanceNoFees - commitFees - funderFeeReserve).max(0 msat)
+        (balanceNoFees - amountToReserve).max(0 msat)
       } else {
         // htlc will have an output in the commitment tx, so there will be additional fees.
-        (balanceNoFees - commitFees - funderFeeReserve - htlcFees).max(0 msat)
+        val commitFees1 = commitFees + htlcOutputFee(reduced.feeratePerKw, commitmentFormat)
+        // we take the additional fees for that htlc output into account in the fee buffer at a x2 feerate increase
+        val funderFeeBuffer1 = funderFeeBuffer + htlcOutputFee(reduced.feeratePerKw * 2, commitmentFormat)
+        val amountToReserve1 = commitFees1.max(funderFeeBuffer1)
+        (balanceNoFees - amountToReserve1).max(0 msat)
       }
     }
   }
@@ -176,7 +208,7 @@ object Commitments {
    *
    * @param commitments current commitments
    * @param cmd         add HTLC command
-   * @return either Left(failure, error message) where failure is a failure message (see BOLT #4 and the Failure Message class) or Right((new commitments, updateAddHtlc)
+   * @return either Left(failure, error message) where failure is a failure message (see BOLT #4 and the Failure Message class) or Right(new commitments, updateAddHtlc)
    */
   def sendAdd(commitments: Commitments, cmd: CMD_ADD_HTLC, blockHeight: Long, feeConf: OnChainFeeConf): Either[ChannelException, (Commitments, UpdateAddHtlc)] = {
     // we don't want to use too high a refund timeout, because our funds will be locked during that time if the payment is never fulfilled
@@ -210,10 +242,12 @@ object Commitments {
 
     // note that the funder pays the fee, so if sender != funder, both sides will have to afford this payment
     val fees = commitTxFee(commitments1.remoteParams.dustLimit, reduced, commitments.commitmentFormat)
-    // the funder needs to keep an extra reserve to be able to handle fee increase without getting the channel stuck
-    // (see https://github.com/lightningnetwork/lightning-rfc/issues/728)
-    val funderFeeReserve = htlcOutputFee(reduced.feeratePerKw * 2, commitments.commitmentFormat)
-    val missingForSender = reduced.toRemote - commitments1.remoteParams.channelReserve - (if (commitments1.localParams.isFunder) fees + funderFeeReserve else 0.msat)
+    // the funder needs to keep an extra buffer to be able to handle a x2 feerate increase and an additional htlc to avoid
+    // getting the channel stuck (see https://github.com/lightningnetwork/lightning-rfc/issues/728).
+    val funderFeeBuffer = commitTxFeeMsat(commitments1.remoteParams.dustLimit, reduced.copy(feeratePerKw = reduced.feeratePerKw * 2), commitments.commitmentFormat) + htlcOutputFee(reduced.feeratePerKw * 2, commitments.commitmentFormat)
+    // NB: increasing the feerate can actually remove htlcs from the commit tx (if they fall below the trim threshold)
+    // which may result in a lower commit tx fee; this is why we take the max of the two.
+    val missingForSender = reduced.toRemote - commitments1.remoteParams.channelReserve - (if (commitments1.localParams.isFunder) fees.max(funderFeeBuffer.truncateToSatoshi) else 0.sat)
     val missingForReceiver = reduced.toLocal - commitments1.localParams.channelReserve - (if (commitments1.localParams.isFunder) 0.sat else fees)
     if (missingForSender < 0.msat) {
       return Left(InsufficientFunds(commitments.channelId, amount = cmd.amount, missing = -missingForSender.truncateToSatoshi, reserve = commitments1.remoteParams.channelReserve, fees = if (commitments1.localParams.isFunder) fees else 0.sat))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -56,36 +56,13 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     }
   }
 
-  test("take additional HTLC fee into account") { f =>
-    import f._
-    // The fee for a single HTLC is 1720000 msat but the funder keeps an extra reserve to make sure we're able to handle
-    // an additional HTLC at twice the feerate (hence the multiplier).
-    val htlcOutputFee = 3 * 1720000 msat
-    val a = 772760000 msat // initial balance alice
-    val ac0 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments
-    val bc0 = bob.stateData.asInstanceOf[DATA_NORMAL].commitments
-    // we need to take the additional HTLC fee into account because balances are above the trim threshold.
-    assert(ac0.availableBalanceForSend == a - htlcOutputFee)
-    assert(bc0.availableBalanceForReceive == a - htlcOutputFee)
-
-    val (_, cmdAdd) = makeCmdAdd(a - htlcOutputFee - 1000.msat, bob.underlyingActor.nodeParams.nodeId, currentBlockHeight)
-    val Right((ac1, add)) = sendAdd(ac0, cmdAdd, currentBlockHeight, alice.underlyingActor.nodeParams.onChainFeeConf)
-    val Success(bc1) = receiveAdd(bc0, add, bob.underlyingActor.nodeParams.onChainFeeConf)
-    val Success((_, commit1)) = sendCommit(ac1, alice.underlyingActor.nodeParams.keyManager)
-    val Success((bc2, _)) = receiveCommit(bc1, commit1, bob.underlyingActor.nodeParams.keyManager)
-    // we don't take into account the additional HTLC fee since Alice's balance is below the trim threshold.
-    assert(ac1.availableBalanceForSend == 1000.msat)
-    assert(bc2.availableBalanceForReceive == 1000.msat)
-  }
-
   test("correct values for availableForSend/availableForReceive (success case)") { f =>
     import f._
 
-    val fee = 1720000 msat // fee due to the additional htlc output
-    val funderFeeReserve = fee * 2 // extra reserve to handle future fee increase
-    val a = (772760000 msat) - fee - funderFeeReserve // initial balance alice
+    val a = 758640000 msat // initial balance alice
     val b = 190000000 msat // initial balance bob
     val p = 42000000 msat // a->b payment
+    val htlcOutputFee = 2 * 1720000 msat // fee due to the additional htlc output; we count it twice because we keep a reserve for a x2 feerate increase
 
     val ac0 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments
     val bc0 = bob.stateData.asInstanceOf[DATA_NORMAL].commitments
@@ -98,49 +75,49 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
 
     val (payment_preimage, cmdAdd) = makeCmdAdd(p, bob.underlyingActor.nodeParams.nodeId, currentBlockHeight)
     val Right((ac1, add)) = sendAdd(ac0, cmdAdd, currentBlockHeight, alice.underlyingActor.nodeParams.onChainFeeConf)
-    assert(ac1.availableBalanceForSend == a - p - fee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
+    assert(ac1.availableBalanceForSend == a - p - htlcOutputFee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
     assert(ac1.availableBalanceForReceive == b)
 
     val Success(bc1) = receiveAdd(bc0, add, bob.underlyingActor.nodeParams.onChainFeeConf)
     assert(bc1.availableBalanceForSend == b)
-    assert(bc1.availableBalanceForReceive == a - p - fee)
+    assert(bc1.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val Success((ac2, commit1)) = sendCommit(ac1, alice.underlyingActor.nodeParams.keyManager)
-    assert(ac2.availableBalanceForSend == a - p - fee)
+    assert(ac2.availableBalanceForSend == a - p - htlcOutputFee)
     assert(ac2.availableBalanceForReceive == b)
 
     val Success((bc2, revocation1)) = receiveCommit(bc1, commit1, bob.underlyingActor.nodeParams.keyManager)
     assert(bc2.availableBalanceForSend == b)
-    assert(bc2.availableBalanceForReceive == a - p - fee)
+    assert(bc2.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val Success((ac3, _)) = receiveRevocation(ac2, revocation1)
-    assert(ac3.availableBalanceForSend == a - p - fee)
+    assert(ac3.availableBalanceForSend == a - p - htlcOutputFee)
     assert(ac3.availableBalanceForReceive == b)
 
     val Success((bc3, commit2)) = sendCommit(bc2, bob.underlyingActor.nodeParams.keyManager)
     assert(bc3.availableBalanceForSend == b)
-    assert(bc3.availableBalanceForReceive == a - p - fee)
+    assert(bc3.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val Success((ac4, revocation2)) = receiveCommit(ac3, commit2, alice.underlyingActor.nodeParams.keyManager)
-    assert(ac4.availableBalanceForSend == a - p - fee)
+    assert(ac4.availableBalanceForSend == a - p - htlcOutputFee)
     assert(ac4.availableBalanceForReceive == b)
 
     val Success((bc4, _)) = receiveRevocation(bc3, revocation2)
     assert(bc4.availableBalanceForSend == b)
-    assert(bc4.availableBalanceForReceive == a - p - fee)
+    assert(bc4.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val cmdFulfill = CMD_FULFILL_HTLC(0, payment_preimage)
     val Success((bc5, fulfill)) = sendFulfill(bc4, cmdFulfill)
     assert(bc5.availableBalanceForSend == b + p) // as soon as we have the fulfill, the balance increases
-    assert(bc5.availableBalanceForReceive == a - p - fee)
+    assert(bc5.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val Success((ac5, _, _)) = receiveFulfill(ac4, fulfill)
-    assert(ac5.availableBalanceForSend == a - p - fee)
+    assert(ac5.availableBalanceForSend == a - p - htlcOutputFee)
     assert(ac5.availableBalanceForReceive == b + p)
 
     val Success((bc6, commit3)) = sendCommit(bc5, bob.underlyingActor.nodeParams.keyManager)
     assert(bc6.availableBalanceForSend == b + p)
-    assert(bc6.availableBalanceForReceive == a - p - fee)
+    assert(bc6.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val Success((ac6, revocation3)) = receiveCommit(ac5, commit3, alice.underlyingActor.nodeParams.keyManager)
     assert(ac6.availableBalanceForSend == a - p)
@@ -166,11 +143,10 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("correct values for availableForSend/availableForReceive (failure case)") { f =>
     import f._
 
-    val fee = 1720000 msat // fee due to the additional htlc output
-    val funderFeeReserve = fee * 2 // extra reserve to handle future fee increase
-    val a = (772760000 msat) - fee - funderFeeReserve // initial balance alice
+    val a = 758640000 msat // initial balance alice
     val b = 190000000 msat // initial balance bob
     val p = 42000000 msat // a->b payment
+    val htlcOutputFee = 2 * 1720000 msat // fee due to the additional htlc output; we count it twice because we keep a reserve for a x2 feerate increase
 
     val ac0 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments
     val bc0 = bob.stateData.asInstanceOf[DATA_NORMAL].commitments
@@ -183,49 +159,49 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
 
     val (_, cmdAdd) = makeCmdAdd(p, bob.underlyingActor.nodeParams.nodeId, currentBlockHeight)
     val Right((ac1, add)) = sendAdd(ac0, cmdAdd, currentBlockHeight, alice.underlyingActor.nodeParams.onChainFeeConf)
-    assert(ac1.availableBalanceForSend == a - p - fee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
+    assert(ac1.availableBalanceForSend == a - p - htlcOutputFee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
     assert(ac1.availableBalanceForReceive == b)
 
     val Success(bc1) = receiveAdd(bc0, add, bob.underlyingActor.nodeParams.onChainFeeConf)
     assert(bc1.availableBalanceForSend == b)
-    assert(bc1.availableBalanceForReceive == a - p - fee)
+    assert(bc1.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val Success((ac2, commit1)) = sendCommit(ac1, alice.underlyingActor.nodeParams.keyManager)
-    assert(ac2.availableBalanceForSend == a - p - fee)
+    assert(ac2.availableBalanceForSend == a - p - htlcOutputFee)
     assert(ac2.availableBalanceForReceive == b)
 
     val Success((bc2, revocation1)) = receiveCommit(bc1, commit1, bob.underlyingActor.nodeParams.keyManager)
     assert(bc2.availableBalanceForSend == b)
-    assert(bc2.availableBalanceForReceive == a - p - fee)
+    assert(bc2.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val Success((ac3, _)) = receiveRevocation(ac2, revocation1)
-    assert(ac3.availableBalanceForSend == a - p - fee)
+    assert(ac3.availableBalanceForSend == a - p - htlcOutputFee)
     assert(ac3.availableBalanceForReceive == b)
 
     val Success((bc3, commit2)) = sendCommit(bc2, bob.underlyingActor.nodeParams.keyManager)
     assert(bc3.availableBalanceForSend == b)
-    assert(bc3.availableBalanceForReceive == a - p - fee)
+    assert(bc3.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val Success((ac4, revocation2)) = receiveCommit(ac3, commit2, alice.underlyingActor.nodeParams.keyManager)
-    assert(ac4.availableBalanceForSend == a - p - fee)
+    assert(ac4.availableBalanceForSend == a - p - htlcOutputFee)
     assert(ac4.availableBalanceForReceive == b)
 
     val Success((bc4, _)) = receiveRevocation(bc3, revocation2)
     assert(bc4.availableBalanceForSend == b)
-    assert(bc4.availableBalanceForReceive == a - p - fee)
+    assert(bc4.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val cmdFail = CMD_FAIL_HTLC(0, Right(IncorrectOrUnknownPaymentDetails(p, 42)))
     val Success((bc5, fail)) = sendFail(bc4, cmdFail, bob.underlyingActor.nodeParams.privateKey)
     assert(bc5.availableBalanceForSend == b)
-    assert(bc5.availableBalanceForReceive == a - p - fee) // a's balance won't return to previous before she acknowledges the fail
+    assert(bc5.availableBalanceForReceive == a - p - htlcOutputFee) // a's balance won't return to previous before she acknowledges the fail
 
     val Success((ac5, _, _)) = receiveFail(ac4, fail)
-    assert(ac5.availableBalanceForSend == a - p - fee)
+    assert(ac5.availableBalanceForSend == a - p - htlcOutputFee)
     assert(ac5.availableBalanceForReceive == b)
 
     val Success((bc6, commit3)) = sendCommit(bc5, bob.underlyingActor.nodeParams.keyManager)
     assert(bc6.availableBalanceForSend == b)
-    assert(bc6.availableBalanceForReceive == a - p - fee)
+    assert(bc6.availableBalanceForReceive == a - p - htlcOutputFee)
 
     val Success((ac6, revocation3)) = receiveCommit(ac5, commit3, alice.underlyingActor.nodeParams.keyManager)
     assert(ac6.availableBalanceForSend == a)
@@ -251,13 +227,12 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("correct values for availableForSend/availableForReceive (multiple htlcs)") { f =>
     import f._
 
-    val fee = 1720000 msat // fee due to the additional htlc output
-    val funderFeeReserve = fee * 2 // extra reserve to handle future fee increase
-    val a = (772760000 msat) - fee - funderFeeReserve // initial balance alice
+    val a = 758640000 msat // initial balance alice
     val b = 190000000 msat // initial balance bob
-    val p1 = 10000000 msat // a->b payment
+    val p1 = 18000000 msat // a->b payment
     val p2 = 20000000 msat // a->b payment
     val p3 = 40000000 msat // b->a payment
+    val htlcOutputFee = 2 * 1720000 msat // fee due to the additional htlc output; we count it twice because we keep a reserve for a x2 feerate increase
 
     val ac0 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments
     val bc0 = bob.stateData.asInstanceOf[DATA_NORMAL].commitments
@@ -271,12 +246,12 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
 
     val (payment_preimage1, cmdAdd1) = makeCmdAdd(p1, bob.underlyingActor.nodeParams.nodeId, currentBlockHeight)
     val Right((ac1, add1)) = sendAdd(ac0, cmdAdd1, currentBlockHeight, alice.underlyingActor.nodeParams.onChainFeeConf)
-    assert(ac1.availableBalanceForSend == a - p1 - fee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
+    assert(ac1.availableBalanceForSend == a - p1 - htlcOutputFee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
     assert(ac1.availableBalanceForReceive == b)
 
     val (_, cmdAdd2) = makeCmdAdd(p2, bob.underlyingActor.nodeParams.nodeId, currentBlockHeight)
     val Right((ac2, add2)) = sendAdd(ac1, cmdAdd2, currentBlockHeight, alice.underlyingActor.nodeParams.onChainFeeConf)
-    assert(ac2.availableBalanceForSend == a - p1 - fee - p2 - fee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
+    assert(ac2.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
     assert(ac2.availableBalanceForReceive == b)
 
     val (payment_preimage3, cmdAdd3) = makeCmdAdd(p3, alice.underlyingActor.nodeParams.nodeId, currentBlockHeight)
@@ -286,94 +261,94 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
 
     val Success(bc2) = receiveAdd(bc1, add1, bob.underlyingActor.nodeParams.onChainFeeConf)
     assert(bc2.availableBalanceForSend == b - p3)
-    assert(bc2.availableBalanceForReceive == a - p1 - fee)
+    assert(bc2.availableBalanceForReceive == a - p1 - htlcOutputFee)
 
     val Success(bc3) = receiveAdd(bc2, add2, bob.underlyingActor.nodeParams.onChainFeeConf)
     assert(bc3.availableBalanceForSend == b - p3)
-    assert(bc3.availableBalanceForReceive == a - p1 - fee - p2 - fee)
+    assert(bc3.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee)
 
     val Success(ac3) = receiveAdd(ac2, add3, alice.underlyingActor.nodeParams.onChainFeeConf)
-    assert(ac3.availableBalanceForSend == a - p1 - fee - p2 - fee)
+    assert(ac3.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee)
     assert(ac3.availableBalanceForReceive == b - p3)
 
     val Success((ac4, commit1)) = sendCommit(ac3, alice.underlyingActor.nodeParams.keyManager)
-    assert(ac4.availableBalanceForSend == a - p1 - fee - p2 - fee)
+    assert(ac4.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee)
     assert(ac4.availableBalanceForReceive == b - p3)
 
     val Success((bc4, revocation1)) = receiveCommit(bc3, commit1, bob.underlyingActor.nodeParams.keyManager)
     assert(bc4.availableBalanceForSend == b - p3)
-    assert(bc4.availableBalanceForReceive == a - p1 - fee - p2 - fee)
+    assert(bc4.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee)
 
     val Success((ac5, _)) = receiveRevocation(ac4, revocation1)
-    assert(ac5.availableBalanceForSend == a - p1 - fee - p2 - fee)
+    assert(ac5.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee)
     assert(ac5.availableBalanceForReceive == b - p3)
 
     val Success((bc5, commit2)) = sendCommit(bc4, bob.underlyingActor.nodeParams.keyManager)
     assert(bc5.availableBalanceForSend == b - p3)
-    assert(bc5.availableBalanceForReceive == a - p1 - fee - p2 - fee)
+    assert(bc5.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee)
 
     val Success((ac6, revocation2)) = receiveCommit(ac5, commit2, alice.underlyingActor.nodeParams.keyManager)
-    assert(ac6.availableBalanceForSend == a - p1 - fee - p2 - fee - fee) // alice has acknowledged b's hltc so it needs to pay the fee for it
+    assert(ac6.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee - htlcOutputFee) // alice has acknowledged b's hltc so it needs to pay the fee for it
     assert(ac6.availableBalanceForReceive == b - p3)
 
     val Success((bc6, _)) = receiveRevocation(bc5, revocation2)
     assert(bc6.availableBalanceForSend == b - p3)
-    assert(bc6.availableBalanceForReceive == a - p1 - fee - p2 - fee - fee)
+    assert(bc6.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee - htlcOutputFee)
 
     val Success((ac7, commit3)) = sendCommit(ac6, alice.underlyingActor.nodeParams.keyManager)
-    assert(ac7.availableBalanceForSend == a - p1 - fee - p2 - fee - fee)
+    assert(ac7.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee - htlcOutputFee)
     assert(ac7.availableBalanceForReceive == b - p3)
 
     val Success((bc7, revocation3)) = receiveCommit(bc6, commit3, bob.underlyingActor.nodeParams.keyManager)
     assert(bc7.availableBalanceForSend == b - p3)
-    assert(bc7.availableBalanceForReceive == a - p1 - fee - p2 - fee - fee)
+    assert(bc7.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee - htlcOutputFee)
 
     val Success((ac8, _)) = receiveRevocation(ac7, revocation3)
-    assert(ac8.availableBalanceForSend == a - p1 - fee - p2 - fee - fee)
+    assert(ac8.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee - htlcOutputFee)
     assert(ac8.availableBalanceForReceive == b - p3)
 
     val cmdFulfill1 = CMD_FULFILL_HTLC(0, payment_preimage1)
     val Success((bc8, fulfill1)) = sendFulfill(bc7, cmdFulfill1)
     assert(bc8.availableBalanceForSend == b + p1 - p3) // as soon as we have the fulfill, the balance increases
-    assert(bc8.availableBalanceForReceive == a - p1 - fee - p2 - fee - fee)
+    assert(bc8.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee - htlcOutputFee)
 
     val cmdFail2 = CMD_FAIL_HTLC(1, Right(IncorrectOrUnknownPaymentDetails(p2, 42)))
     val Success((bc9, fail2)) = sendFail(bc8, cmdFail2, bob.underlyingActor.nodeParams.privateKey)
     assert(bc9.availableBalanceForSend == b + p1 - p3)
-    assert(bc9.availableBalanceForReceive == a - p1 - fee - p2 - fee - fee) // a's balance won't return to previous before she acknowledges the fail
+    assert(bc9.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee - htlcOutputFee) // a's balance won't return to previous before she acknowledges the fail
 
     val cmdFulfill3 = CMD_FULFILL_HTLC(0, payment_preimage3)
     val Success((ac9, fulfill3)) = sendFulfill(ac8, cmdFulfill3)
-    assert(ac9.availableBalanceForSend == a - p1 - fee - p2 - fee + p3) // as soon as we have the fulfill, the balance increases
+    assert(ac9.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee + p3) // as soon as we have the fulfill, the balance increases
     assert(ac9.availableBalanceForReceive == b - p3)
 
     val Success((ac10, _, _)) = receiveFulfill(ac9, fulfill1)
-    assert(ac10.availableBalanceForSend == a - p1 - fee - p2 - fee + p3)
+    assert(ac10.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee + p3)
     assert(ac10.availableBalanceForReceive == b + p1 - p3)
 
     val Success((ac11, _, _)) = receiveFail(ac10, fail2)
-    assert(ac11.availableBalanceForSend == a - p1 - fee - p2 - fee + p3)
+    assert(ac11.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee + p3)
     assert(ac11.availableBalanceForReceive == b + p1 - p3)
 
     val Success((bc10, _, _)) = receiveFulfill(bc9, fulfill3)
     assert(bc10.availableBalanceForSend == b + p1 - p3)
-    assert(bc10.availableBalanceForReceive == a - p1 - fee - p2 - fee + p3) // the fee for p3 disappears
+    assert(bc10.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee + p3) // the fee for p3 disappears
 
     val Success((ac12, commit4)) = sendCommit(ac11, alice.underlyingActor.nodeParams.keyManager)
-    assert(ac12.availableBalanceForSend == a - p1 - fee - p2 - fee + p3)
+    assert(ac12.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee + p3)
     assert(ac12.availableBalanceForReceive == b + p1 - p3)
 
     val Success((bc11, revocation4)) = receiveCommit(bc10, commit4, bob.underlyingActor.nodeParams.keyManager)
     assert(bc11.availableBalanceForSend == b + p1 - p3)
-    assert(bc11.availableBalanceForReceive == a - p1 - fee - p2 - fee + p3)
+    assert(bc11.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee + p3)
 
     val Success((ac13, _)) = receiveRevocation(ac12, revocation4)
-    assert(ac13.availableBalanceForSend == a - p1 - fee - p2 - fee + p3)
+    assert(ac13.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee + p3)
     assert(ac13.availableBalanceForReceive == b + p1 - p3)
 
     val Success((bc12, commit5)) = sendCommit(bc11, bob.underlyingActor.nodeParams.keyManager)
     assert(bc12.availableBalanceForSend == b + p1 - p3)
-    assert(bc12.availableBalanceForReceive == a - p1 - fee - p2 - fee + p3)
+    assert(bc12.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee + p3)
 
     val Success((ac14, revocation5)) = receiveCommit(ac13, commit5, alice.underlyingActor.nodeParams.keyManager)
     assert(ac14.availableBalanceForSend == a - p1 + p3)


### PR DESCRIPTION
We were previously only counting the additional HTLC at twice
the current feerate.

An HTLC in isolation doesn't make much sense: the feerate
applies to the whole commit tx. Our fee buffer needs to account
for a x2 feerate increase on the commit tx + an additional htlc.

Note that this introduces another subtlety. The commit tx fee at twice the
current feerate may actually be lower than the commit tx fee at the current
feerate (if the commit tx contains many htlcs that are only slightly above
the trim threshold).

See https://github.com/lightningnetwork/lightning-rfc/pull/740#discussion_r399740407 for context.