### PR TITLE
Support additional TLV records in SendPayentRequest

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -304,6 +304,7 @@ object MultiPartPaymentLifecycle {
    * @param assistedRoutes routing hints (usually from a Bolt 11 invoice).
    * @param routeParams    parameters to fine-tune the routing algorithm.
    * @param additionalTlvs when provided, additional tlvs that will be added to the onion sent to the target node.
+   * @param userCustomTlvs when provided, additional user-defined custom tlvs that will be added to the onion sent to the target node.
    */
   case class SendMultiPartPayment(paymentSecret: ByteVector32,
                                   targetNodeId: PublicKey,
@@ -312,7 +313,8 @@ object MultiPartPaymentLifecycle {
                                   maxAttempts: Int,
                                   assistedRoutes: Seq[Seq[ExtraHop]] = Nil,
                                   routeParams: Option[RouteParams] = None,
-                                  additionalTlvs: Seq[OnionTlv] = Nil) {
+                                  additionalTlvs: Seq[OnionTlv] = Nil,
+                                  userCustomTlvs: Seq[GenericTlv] = Nil) {
     require(totalAmount > 0.msat, s"total amount must be > 0")
   }
 
@@ -416,7 +418,7 @@ object MultiPartPaymentLifecycle {
   private def createChildPayment(nodeParams: NodeParams, request: SendMultiPartPayment, childAmount: MilliSatoshi, channel: OutgoingChannel): SendPayment = {
     SendPayment(
       request.targetNodeId,
-      Onion.createMultiPartPayload(childAmount, request.totalAmount, request.targetExpiry, request.paymentSecret, request.additionalTlvs),
+      Onion.createMultiPartPayload(childAmount, request.totalAmount, request.targetExpiry, request.paymentSecret, request.additionalTlvs, request.userCustomTlvs),
       request.maxAttempts,
       request.assistedRoutes,
       request.routeParams,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
@@ -276,17 +276,14 @@ object Onion {
     NodeRelayPayload(TlvStream(tlvs2))
   }
 
-  def createSinglePartPayload(amount: MilliSatoshi, expiry: CltvExpiry, paymentSecret: Option[ByteVector32] = None): FinalPayload = paymentSecret match {
-    // We try to use the legacy format as much as possible for maximum compatibility, but when we have a payment secret we need to use TLV to include it.
-    case Some(paymentSecret) => FinalTlvPayload(TlvStream(AmountToForward(amount), OutgoingCltv(expiry), PaymentData(paymentSecret, amount)))
+  def createSinglePartPayload(amount: MilliSatoshi, expiry: CltvExpiry, paymentSecret: Option[ByteVector32] = None, userCustomTlvs: Seq[GenericTlv] = Nil): FinalPayload = paymentSecret match {
+    case Some(paymentSecret) => FinalTlvPayload(TlvStream(Seq(AmountToForward(amount), OutgoingCltv(expiry), PaymentData(paymentSecret, amount)), userCustomTlvs))
+    case None if userCustomTlvs.nonEmpty => FinalTlvPayload(TlvStream(Seq(AmountToForward(amount), OutgoingCltv(expiry)), userCustomTlvs))
     case None => FinalLegacyPayload(amount, expiry)
   }
 
-  def createMultiPartPayload(amount: MilliSatoshi, totalAmount: MilliSatoshi, expiry: CltvExpiry, paymentSecret: ByteVector32): FinalPayload =
-    FinalTlvPayload(TlvStream(AmountToForward(amount), OutgoingCltv(expiry), PaymentData(paymentSecret, totalAmount)))
-
-  def createMultiPartPayload(amount: MilliSatoshi, totalAmount: MilliSatoshi, expiry: CltvExpiry, paymentSecret: ByteVector32, additionalTlvs: Seq[OnionTlv]): FinalPayload =
-    FinalTlvPayload(TlvStream(AmountToForward(amount) +: OutgoingCltv(expiry) +: PaymentData(paymentSecret, totalAmount) +: additionalTlvs))
+  def createMultiPartPayload(amount: MilliSatoshi, totalAmount: MilliSatoshi, expiry: CltvExpiry, paymentSecret: ByteVector32, additionalTlvs: Seq[OnionTlv] = Nil, userCustomTlvs: Seq[GenericTlv] = Nil): FinalPayload =
+    FinalTlvPayload(TlvStream(AmountToForward(amount) +: OutgoingCltv(expiry) +: PaymentData(paymentSecret, totalAmount) +: additionalTlvs, userCustomTlvs))
 
   /** Create a trampoline outer payload. */
   def createTrampolinePayload(amount: MilliSatoshi, totalAmount: MilliSatoshi, expiry: CltvExpiry, paymentSecret: ByteVector32, trampolinePacket: OnionRoutingPacket): FinalPayload = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/TlvCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/TlvCodecs.scala
@@ -27,7 +27,7 @@ import scodec.{Attempt, Codec, Err}
  * Created by t-bast on 20/06/2019.
  */
 object TlvCodecs {
-
+  // high range types are greater than or equal 2^16, see https://github.com/lightningnetwork/lightning-rfc/blob/master/01-messaging.md#type-length-value-format
   private val TLV_TYPE_HIGH_RANGE = 65536
 
   /**
@@ -112,10 +112,7 @@ object TlvCodecs {
     }
   }
 
-  private val genericTlv: Codec[GenericTlv] = (("tag" | varint) :: variableSizeBytesLong(varintoverflow, bytes)).as[GenericTlv].exmap(
-    validateGenericTlv, // we must reject incoming even unknown tlv records
-    g => Attempt.Successful(g) // but we allow outgoing even unknown tlv records (so that users can provide experimental tlv records)
-  )
+  private val genericTlv: Codec[GenericTlv] = (("tag" | varint) :: variableSizeBytesLong(varintoverflow, bytes)).as[GenericTlv].exmap(validateGenericTlv, validateGenericTlv)
 
   private def tag[T <: Tlv](codec: DiscriminatorCodec[T, UInt64], record: Either[GenericTlv, T]): UInt64 = record match {
     case Left(generic) => generic.tag

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/TlvCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/TlvCodecs.scala
@@ -27,6 +27,9 @@ import scodec.{Attempt, Codec, Err}
  * Created by t-bast on 20/06/2019.
  */
 object TlvCodecs {
+
+  private val TLV_TYPE_HIGH_RANGE = 65536
+
   /**
    * Truncated uint64 (0 to 8 bytes unsigned integer).
    * The encoder minimally-encodes every value, and the decoder verifies that values are minimally-encoded.
@@ -102,7 +105,7 @@ object TlvCodecs {
   val ltu16: Codec[Int] = variableSizeBytes(uint8, tu16)
 
   private def validateGenericTlv(g: GenericTlv): Attempt[GenericTlv] = {
-    if (g.tag.toBigInt % 2 == 0) {
+    if (g.tag < TLV_TYPE_HIGH_RANGE && g.tag.toBigInt % 2 == 0) {
       Attempt.Failure(Err("unknown even tlv type"))
     } else {
       Attempt.Successful(g)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/TlvCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/TlvCodecs.scala
@@ -26,9 +26,7 @@ import scodec.{Attempt, Codec, Err}
 /**
  * Created by t-bast on 20/06/2019.
  */
-
 object TlvCodecs {
-
   /**
    * Truncated uint64 (0 to 8 bytes unsigned integer).
    * The encoder minimally-encodes every value, and the decoder verifies that values are minimally-encoded.
@@ -111,7 +109,10 @@ object TlvCodecs {
     }
   }
 
-  private val genericTlv: Codec[GenericTlv] = (("tag" | varint) :: variableSizeBytesLong(varintoverflow, bytes)).as[GenericTlv].exmap(validateGenericTlv, validateGenericTlv)
+  private val genericTlv: Codec[GenericTlv] = (("tag" | varint) :: variableSizeBytesLong(varintoverflow, bytes)).as[GenericTlv].exmap(
+    validateGenericTlv, // we must reject incoming even unknown tlv records
+    g => Attempt.Successful(g) // but we allow outgoing even unknown tlv records (so that users can provide experimental tlv records)
+  )
 
   private def tag[T <: Tlv](codec: DiscriminatorCodec[T, UInt64], record: Either[GenericTlv, T]): UInt64 = record match {
     case Left(generic) => generic.tag

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -31,9 +31,11 @@ import fr.acinq.eclair.payment.send.PaymentInitiator._
 import fr.acinq.eclair.payment.send.PaymentLifecycle.{SendPayment, SendPaymentToRoute}
 import fr.acinq.eclair.payment.send.{PaymentError, PaymentInitiator}
 import fr.acinq.eclair.router.{NodeHop, RouteParams}
-import fr.acinq.eclair.wire.Onion.FinalLegacyPayload
-import fr.acinq.eclair.wire.{Onion, OnionCodecs, OnionTlv, TrampolineFeeInsufficient}
+import fr.acinq.eclair.wire.Onion.{FinalLegacyPayload, FinalTlvPayload}
+import fr.acinq.eclair.wire.OnionTlv.{AmountToForward, OutgoingCltv}
+import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{CltvExpiryDelta, LongToBtcAmount, NodeParams, TestConstants, randomBytes32, randomKey}
+import fr.acinq.eclair.UInt64.Conversions._
 import org.scalatest.{Outcome, Tag, fixture}
 import scodec.bits.HexStringSyntax
 
@@ -67,6 +69,19 @@ class PaymentInitiatorSpec extends TestKit(ActorSystem("test")) with fixture.Fun
     }
     val initiator = TestActorRef(new TestPaymentInitiator().asInstanceOf[PaymentInitiator])
     withFixture(test.toNoArgTest(FixtureParam(nodeParams, initiator, payFsm, multiPartPayFsm, sender, eventListener)))
+  }
+
+  test("forward payment with user custom tlv records") { f =>
+    import f._
+    val keySendTlvRecords = Seq(GenericTlv(5482373484L, paymentPreimage))
+    val req = SendPaymentRequest(finalAmount, paymentHash, c, 1, CltvExpiryDelta(42), userCustomTlvs = keySendTlvRecords)
+    sender.send(initiator, req)
+    sender.expectMsgType[UUID]
+    payFsm.expectMsgType[SendPaymentConfig]
+    val FinalTlvPayload(tlvs) = payFsm.expectMsgType[SendPayment].finalPayload
+    assert(tlvs.get[AmountToForward].get.amount == finalAmount)
+    assert(tlvs.get[OutgoingCltv].get.cltv == req.finalExpiryDelta.toCltvExpiry(nodeParams.currentBlockHeight + 1))
+    assert(tlvs.unknown == keySendTlvRecords)
   }
 
   test("reject payment with unknown mandatory feature") { f =>
@@ -105,14 +120,14 @@ class PaymentInitiatorSpec extends TestKit(ActorSystem("test")) with fixture.Fun
     payFsm.expectMsg(SendPayment(e, FinalLegacyPayload(finalAmount, Channel.MIN_CLTV_EXPIRY_DELTA.toCltvExpiry(nodeParams.currentBlockHeight + 1)), 3))
   }
 
-  test("forward legacy payment when multi-part deactivated", Tag("mpp_disabled")) { f =>
+  test("forward single-part payment when multi-part deactivated", Tag("mpp_disabled")) { f =>
     import f._
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, randomKey, "Some MPP invoice", features = Some(Features(VariableLengthOnion.optional, PaymentSecret.optional, BasicMultiPartPayment.optional)))
     val req = SendPaymentRequest(finalAmount, paymentHash, c, 1, CltvExpiryDelta(42), Some(pr))
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     payFsm.expectMsg(SendPaymentConfig(id, id, None, paymentHash, finalAmount, c, Upstream.Local(id), Some(pr), storeInDb = true, publishEvent = true, Nil))
-    payFsm.expectMsg(SendPayment(c, FinalLegacyPayload(finalAmount, req.finalExpiry(nodeParams.currentBlockHeight)), 1))
+    payFsm.expectMsg(SendPayment(c, FinalTlvPayload(TlvStream(OnionTlv.AmountToForward(finalAmount), OnionTlv.OutgoingCltv(req.finalExpiry(nodeParams.currentBlockHeight)), OnionTlv.PaymentData(pr.paymentSecret.get, finalAmount))), 1))
   }
 
   test("forward multi-part payment") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/OnionCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/OnionCodecsSpec.scala
@@ -182,6 +182,15 @@ class OnionCodecsSpec extends FunSuite {
     }
   }
 
+  test("encode/decode variable-length (tlv) final per-hop payload with custom user records") {
+    val tlvs = TlvStream[OnionTlv](Seq(AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42))), Seq(GenericTlv(5482373484L, hex"16c7ec71663784ff100b6eface1e60a97b92ea9d18b8ece5e558586bc7453828")))
+    val bin = hex"31 02020231 04012a ff0000000146c6616c2016c7ec71663784ff100b6eface1e60a97b92ea9d18b8ece5e558586bc7453828"
+
+    val encoded = finalPerHopPayloadCodec.encode(FinalTlvPayload(tlvs)).require.bytes
+    assert(encoded === bin)
+    assert(finalPerHopPayloadCodec.decode(bin.bits).isFailure)
+  }
+
   test("decode multi-part final per-hop payload") {
     val notMultiPart = finalPerHopPayloadCodec.decode(hex"07 02020231 04012a".bits).require.value
     assert(notMultiPart.totalAmount === 561.msat)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/OnionCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/OnionCodecsSpec.scala
@@ -188,7 +188,7 @@ class OnionCodecsSpec extends FunSuite {
 
     val encoded = finalPerHopPayloadCodec.encode(FinalTlvPayload(tlvs)).require.bytes
     assert(encoded === bin)
-    assert(finalPerHopPayloadCodec.decode(bin.bits).isFailure)
+    assert(finalPerHopPayloadCodec.decode(bin.bits).require.value == FinalTlvPayload(tlvs))
   }
 
   test("decode multi-part final per-hop payload") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/TlvCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/TlvCodecsSpec.scala
@@ -302,17 +302,14 @@ class TlvCodecsSpec extends FunSuite {
     }
   }
 
-  test("encode unordered tlv stream (codec should sort appropriately)") {
-    val stream = TlvStream[TestTlv](Seq(TestType254(42), TestType1(42)), Seq(GenericTlv(13, hex"2a"), GenericTlv(11, hex"2b")))
-    assert(testTlvStreamCodec.encode(stream).require.toByteVector === hex"01012a 0b012b 0d012a fd00fe02002a")
-    assert(lengthPrefixedTestTlvStreamCodec.encode(stream).require.toByteVector === hex"0f 01012a 0b012b 0d012a fd00fe02002a")
+  test("encode unordered tlv stream (codec should sort appropriately and allow unknown even tlvs)") {
+    val stream = TlvStream[TestTlv](Seq(TestType254(42), TestType1(42)), Seq(GenericTlv(14, hex"2a"), GenericTlv(11, hex"2b")))
+    assert(testTlvStreamCodec.encode(stream).require.toByteVector === hex"01012a 0b012b 0e012a fd00fe02002a")
+    assert(lengthPrefixedTestTlvStreamCodec.encode(stream).require.toByteVector === hex"0f 01012a 0b012b 0e012a fd00fe02002a")
   }
 
   test("encode invalid tlv stream") {
     val testCases = Seq(
-      // Unknown even type.
-      TlvStream[TestTlv](Nil, Seq(GenericTlv(42, hex"2a"))),
-      TlvStream[TestTlv](Seq(TestType1(561), TestType2(ShortChannelId(1105))), Seq(GenericTlv(42, hex"2a"))),
       // Duplicate type.
       TlvStream[TestTlv](TestType1(561), TestType1(1105)),
       TlvStream[TestTlv](Seq(TestType1(561)), Seq(GenericTlv(1, hex"0451")))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/TlvCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/TlvCodecsSpec.scala
@@ -306,14 +306,14 @@ class TlvCodecsSpec extends FunSuite {
     assert(lengthPrefixedTestTlvStreamCodec.encode(stream).require.toByteVector === hex"0f 01012a 0b012b 0d012a fd00fe02002a")
   }
 
-  test("encode/decode even generic tlv types above high range") {
+  test("encode/decode custom even tlv records") {
     val lowRangeEven = TlvStream[TestTlv](records = Nil, unknown = Seq(GenericTlv(124, hex"2a")))
     val highRangeEven = TlvStream[TestTlv](records = Nil, unknown = Seq(GenericTlv(67876545678L, hex"2b")))
 
     assert(testTlvStreamCodec.encode(lowRangeEven).isFailure)
     assert(testTlvStreamCodec.encode(highRangeEven).isSuccessful)
     assert(testTlvStreamCodec.decode(hex"7c 01 2a".toBitVector).isFailure) // lowRangeEven
-    assert(testTlvStreamCodec.decode(testTlvStreamCodec.encode(highRangeEven).require.bytes.toBitVector).isSuccessful)
+    assert(testTlvStreamCodec.decode(testTlvStreamCodec.encode(highRangeEven).require).isSuccessful)
   }
 
   test("encode invalid tlv stream") {


### PR DESCRIPTION
This PR adds the possibility to attach extra TLV records when sending a payment, the feature is meant to be used by plugin developers and experimentally via API (although this PR is missing the API part). It will allow to support features like `keysend` (invoiceless payments) and/or custom messages attached as TLV record to final onion packet.
I've chosen to not support this feature in trampoline/mpp payments for the moment because i'm not aware of any custom protocol built on top them. 
Users willing to experiment with this feature must take care of properly sorting the extra TLV records. 
