### PR TITLE
Revert Electrum Tor disable SSL

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -183,12 +183,10 @@ class Setup(datadir: File,
           val port = config.getInt("electrum.port")
           val address = InetSocketAddress.createUnresolved(host, port)
           val ssl = config.getString("electrum.ssl") match {
-              case _ if address.getHostName.endsWith(".onion") => SSL.OFF // Tor already adds end-to-end encryption, adding TLS on top doesn't add anything
-              case "off" => SSL.OFF
-              case "loose" => SSL.LOOSE
-              case _ => SSL.STRICT // strict mode is the default when we specify a custom electrum server, we don't want to be MITMed
+            case "off" => SSL.OFF
+            case "loose" => SSL.LOOSE
+            case _ => SSL.STRICT // strict mode is the default when we specify a custom electrum server, we don't want to be MITMed
           }
-
           logger.info(s"override electrum default with server=$address ssl=$ssl")
           Set(ElectrumServerAddress(address, ssl))
         case false =>


### PR DESCRIPTION
Revert #1278. The correct way to handle that is to add more ways for
users to choose their SSL behavior in phoenix/eclair-mobile.

In the long run it will be via more checkboxes / a better configuration
panel, but at first it can simply be moving #1278's logic directly in both
Phoenix and eclair-mobile (which is done in https://github.com/ACINQ/phoenix/pull/53 and https://github.com/ACINQ/eclair-mobile/pull/242).