### PR TITLE
Add logback config for eclair-node tests

### DIFF
--- a/eclair-node/src/test/resources/logback-test.xml
+++ b/eclair-node/src/test/resources/logback-test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration scan="true" debug="false">
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <encoder>
+            <pattern>%date{HH:mm:ss.SSS} %highlight(%-5level) %logger{0}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <!--appender-ref ref="CONSOLE"/-->
+    </root>
+
+</configuration>


### PR DESCRIPTION
Otherwise we use the default logback.xml file which writes to a
rolling file in the user directory.

NB: when enabling console logging, there are a lot of WARN outputs. Maybe something to look into @araspitzu?
```shell
10:37:33.657 WARN  ActorSystemImpl - withRequestTimeout was used in route however no request-timeout is set!
10:37:33.657 WARN  ActorSystemImpl - withRequestTimeoutResponse was used in route however no request-timeout is set!
10:37:33.683 WARN  ActorSystemImpl - withRequestTimeout was used in route however no request-timeout is set!
10:37:33.683 WARN  ActorSystemImpl - withRequestTimeoutResponse was used in route however no request-timeout is set!         
```