### PR TITLE
Add a rejection for update when channel is pruned

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -361,6 +361,7 @@ class PeerConnection(nodeParams: NodeParams, switchboard: ActorRef, router: Acto
           case _: GossipDecision.ChannelClosing => d.behavior
           case _: GossipDecision.Stale => d.behavior
           case _: GossipDecision.NoRelatedChannel => d.behavior
+          case _: GossipDecision.RelatedChannelPruned => d.behavior
         }
         stay using d.copy(behavior = behavior1)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -387,6 +387,7 @@ object Router {
     case class ChannelClosed(ann: ChannelAnnouncement) extends Rejected
     case class Stale(ann: ChannelUpdate) extends Rejected
     case class NoRelatedChannel(ann: ChannelUpdate) extends Rejected
+    case class RelatedChannelPruned(ann: ChannelUpdate) extends Rejected
   }
 
   case class Stash(updates: Map[ChannelUpdate, Set[GossipOrigin]], nodes: Map[NodeAnnouncement, Set[GossipOrigin]])

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -362,7 +362,7 @@ object Validation {
       // let's remove the channel from the zombie list and ask the sender to re-send announcements (channel_announcement + updates)
       // about that channel. We can ignore this update since we will receive it again
       log.info(s"channel shortChannelId=${u.shortChannelId} is back from the dead! requesting announcements about this channel")
-      remoteOrigins.foreach(sendDecision(_, GossipDecision.Duplicate(u)))
+      remoteOrigins.foreach(sendDecision(_, GossipDecision.RelatedChannelPruned(u)))
       db.removeFromPruned(u.shortChannelId)
 
       // peerConnection_opt will contain a valid peerConnection only when we're handling an update that we received from a peer, not

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -464,9 +464,9 @@ class RouterSpec extends BaseRouterSpec {
 
     // we want to make sure that transport receives the query
     val peerConnection = TestProbe()
-    peerConnection.ignoreMsg { case _: GossipDecision.Duplicate => true }
     probe.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, update1))
     peerConnection.expectMsg(TransportHandler.ReadAck(update1))
+    peerConnection.expectMsg(GossipDecision.RelatedChannelPruned(update1))
     val query = peerConnection.expectMsgType[QueryShortChannelIds]
     assert(query.shortChannelIds.array == List(channelId))
   }


### PR DESCRIPTION
In case a channel has been pruned, and we receive a recent update, we
"unprune" it and immediately request the channel announcement again
(which will cause us to revalidate it). We also discard the update,
assuming that we will receive it again with the channel announcement.

We were using a `GossipDecision.Duplicate` rejection for the channel
update, which is inaccurate. This PR introduces a new
`GossipDecision.RelatedChannelPruned`.