### PR TITLE
Support bitcoin-0.19.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You will find detailed guides and frequently asked questions there.
 
 ### Configuring Bitcoin Core
 
-:warning: Eclair requires Bitcoin Core 0.17.1 or higher. If you are upgrading an existing wallet, you need to create a new address and send all your funds to that address.
+:warning: Eclair requires Bitcoin Core 0.18.1 or 0.19.1. If you are upgrading an existing wallet, you need to create a new address and send all your funds to that address.
 
 Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
 Eclair will use any BTC it finds in the default Bitcoin Core wallet to fund any channels you choose to open. Eclair will return BTC from closed channels to this wallet. You can have multiple Bitcoin Core wallets but make sure that the default one is always available.

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -79,10 +79,9 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoin.org/bin/bitcoin-core-0.18.1/bitcoin-0.18.1-x86_64-linux-gnu.tar.gz
-                </bitcoind.url>
-                <bitcoind.md5>d3159a28702ca0cba2e0459e83219dfb</bitcoind.md5>
-                <bitcoind.sha1>969020835c1f0c759032def0d7b99669db06d8f7</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.19.1/bitcoin-0.19.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
+                <bitcoind.md5>c2e41019caab82e6c5cb45f44964f44e</bitcoind.md5>
+                <bitcoind.sha1>efabbb93827fa35d16a8ba73360e5fbf6b86a91c</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -93,10 +92,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoin.org/bin/bitcoin-core-0.18.1/bitcoin-0.18.1-osx64.tar.gz
-                </bitcoind.url>
-                <bitcoind.md5>0334b1024f28e83341c89df14e622bb6</bitcoind.md5>
-                <bitcoind.sha1>80354b40b409f342f5d35acd6b2c0e71f689285b</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.19.1/bitcoin-0.19.1-osx64.tar.gz</bitcoind.url>
+                <bitcoind.md5>6687a2df8b8a167b3afb9e0107deeb7d</bitcoind.md5>
+                <bitcoind.sha1>a02469a77781cd1413df120133be131bd388a997</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -107,9 +105,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoin.org/bin/bitcoin-core-0.18.1/bitcoin-0.18.1-win64.zip</bitcoind.url>
-                <bitcoind.md5>637776ca50b4354ca2f523bdee576bdb</bitcoind.md5>
-                <bitcoind.sha1>44771cc2161853b5230a7a159278dc8f27e7d4c2</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.19.1/bitcoin-0.19.1-win64.zip</bitcoind.url>
+                <bitcoind.md5>0ef5729d71a8b996b7753f564259cef9</bitcoind.md5>
+                <bitcoind.sha1>13d056bfb26d6d18b656b57ab2ab36dd38fa4043</bitcoind.sha1>
             </properties>
         </profile>
     </profiles>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -151,13 +151,17 @@ class BitcoinCoreWalletSpec extends TestKit(ActorSystem("test")) with BitcoindSe
     val address = sender.expectMsgType[String]
     assert(Try(addressToPublicKeyScript(address, Block.RegtestGenesisBlock.hash)).isSuccess)
 
-    val fundingTxes = for (i <- 0 to 3) yield {
+    val fundingTxes = for (_ <- 0 to 3) yield {
       val pubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(randomKey.publicKey, randomKey.publicKey)))
-      wallet.makeFundingTx(pubkeyScript, MilliBtc(50), 249).pipeTo(sender.ref)
-      assert(sender.expectMsgType[Failure].cause.asInstanceOf[JsonRPCError].error.message.contains("Transaction too large for fee policy"))
+      wallet.makeFundingTx(pubkeyScript, MilliBtc(50), 249).pipeTo(sender.ref) // create a tx with an invalid feerate (too little)
+      val belowFeeFundingTx = sender.expectMsgType[MakeFundingTxResponse].fundingTx
+      wallet.publishTransaction(belowFeeFundingTx).pipeTo(sender.ref) // try publishing the tx
+      assert(sender.expectMsgType[Failure].cause.asInstanceOf[JsonRPCError].error.message.contains("min relay fee not met, 152 < 153 (code 66)"))
+      wallet.rollback(belowFeeFundingTx) // rollback the locked outputs
+
+      // now fund a tx with correct feerate
       wallet.makeFundingTx(pubkeyScript, MilliBtc(50), 250).pipeTo(sender.ref)
-      val MakeFundingTxResponse(fundingTx, _, _) = sender.expectMsgType[MakeFundingTxResponse]
-      fundingTx
+      sender.expectMsgType[MakeFundingTxResponse].fundingTx
     }
 
     sender.send(bitcoincli, BitcoinReq("listlockunspent"))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -53,7 +53,7 @@ trait BitcoindService extends Logging {
   val INTEGRATION_TMP_DIR = new File(TestUtils.BUILD_DIRECTORY, s"integration-${UUID.randomUUID()}")
   logger.info(s"using tmp dir: $INTEGRATION_TMP_DIR")
 
-  val PATH_BITCOIND = new File(TestUtils.BUILD_DIRECTORY, "bitcoin-0.18.1/bin/bitcoind")
+  val PATH_BITCOIND = new File(TestUtils.BUILD_DIRECTORY, "bitcoin-0.19.1/bin/bitcoind")
   val PATH_BITCOIND_DATADIR = new File(INTEGRATION_TMP_DIR, "datadir-bitcoin")
 
   var bitcoind: Process = null


### PR DESCRIPTION
Update our regtests to use bitcoin-0.19.1, the most notable changes in this release are about fees (especially the CPFP-carve out rule for the dual-anchor commitment format). There are also some RPC changes: the `fundrawtransaction` RPC does not fail when providing a too little feerate but instead bitcoin will fail when broadcasting the transaction with `sendrawtransaction`, the error message is also changed.

I replaced the URLs for our bitcoin-core test instance with bitcoincore.org which is quite faster than bitcoin.org