### PR TITLE
Router channel balance

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -190,8 +190,8 @@ class EclairImpl(appKit: Kit) extends Eclair {
     case None => (appKit.router ? 'updates).mapTo[Iterable[ChannelUpdate]]
     case Some(pk) => (appKit.router ? 'channelsMap).mapTo[Map[ShortChannelId, PublicChannel]].map { channels =>
       channels.values.flatMap {
-        case PublicChannel(ann, _, _, _, Some(u1), _, _) if ann.nodeId1 == pk && u1.isNode1 => List(u1)
-        case PublicChannel(ann, _, _, _, _, _, Some(u2)) if ann.nodeId2 == pk && !u2.isNode1 => List(u2)
+        case PublicChannel(ann, _, _, Some(u1), _, _) if ann.nodeId1 == pk && u1.isNode1 => List(u1)
+        case PublicChannel(ann, _, _, _, Some(u2), _) if ann.nodeId2 == pk && !u2.isNode1 => List(u2)
         case _: PublicChannel => List.empty
       }
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -190,9 +190,9 @@ class EclairImpl(appKit: Kit) extends Eclair {
     case None => (appKit.router ? 'updates).mapTo[Iterable[ChannelUpdate]]
     case Some(pk) => (appKit.router ? 'channelsMap).mapTo[Map[ShortChannelId, PublicChannel]].map { channels =>
       channels.values.flatMap {
-        case PublicChannel(ann, _, _, Some(u1), _) if ann.nodeId1 == pk && u1.isNode1 => List(u1)
-        case PublicChannel(ann, _, _, _, Some(u2)) if ann.nodeId2 == pk && !u2.isNode1 => List(u2)
-        case PublicChannel(_, _, _, _, _) => List.empty
+        case PublicChannel(ann, _, _, _, Some(u1), _, _) if ann.nodeId1 == pk && u1.isNode1 => List(u1)
+        case PublicChannel(ann, _, _, _, _, _, Some(u2)) if ann.nodeId2 == pk && !u2.isNode1 => List(u2)
+        case _: PublicChannel => List.empty
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -124,7 +124,7 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb with Logging {
         val capacity = rs.getLong("capacity_sat")
         val channel_update_1_opt = rs.getBitVectorOpt("channel_update_1").map(channelUpdateCodec.decode(_).require.value)
         val channel_update_2_opt = rs.getBitVectorOpt("channel_update_2").map(channelUpdateCodec.decode(_).require.value)
-        m = m + (ann.shortChannelId -> PublicChannel(ann, txId, Satoshi(capacity), None, channel_update_1_opt, None, channel_update_2_opt))
+        m = m + (ann.shortChannelId -> PublicChannel(ann, txId, Satoshi(capacity), channel_update_1_opt, channel_update_2_opt, None))
       }
       m
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -124,7 +124,7 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb with Logging {
         val capacity = rs.getLong("capacity_sat")
         val channel_update_1_opt = rs.getBitVectorOpt("channel_update_1").map(channelUpdateCodec.decode(_).require.value)
         val channel_update_2_opt = rs.getBitVectorOpt("channel_update_2").map(channelUpdateCodec.decode(_).require.value)
-        m = m + (ann.shortChannelId -> PublicChannel(ann, txId, Satoshi(capacity), channel_update_1_opt, channel_update_2_opt))
+        m = m + (ann.shortChannelId -> PublicChannel(ann, txId, Satoshi(capacity), None, channel_update_1_opt, None, channel_update_2_opt))
       }
       m
     }
@@ -132,12 +132,12 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb with Logging {
 
   override def removeChannels(shortChannelIds: Iterable[ShortChannelId]): Unit = {
     using(sqlite.createStatement) { statement =>
-    shortChannelIds
-      .grouped(1000) // remove channels by batch of 1000
-      .foreach {group =>
-        val ids = shortChannelIds.map(_.toLong).mkString(",")
-        statement.executeUpdate(s"DELETE FROM channels WHERE short_channel_id IN ($ids)")
-      }
+      shortChannelIds
+        .grouped(1000) // remove channels by batch of 1000
+        .foreach { _ =>
+          val ids = shortChannelIds.map(_.toLong).mkString(",")
+          statement.executeUpdate(s"DELETE FROM channels WHERE short_channel_id IN ($ids)")
+        }
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
@@ -91,7 +91,7 @@ object Autoprobe {
     // we only pick direct peers with enabled public channels
     val peers = routingData.channels
       .collect {
-        case (shortChannelId, c@PublicChannel(ann, _, _, _, Some(u1), _, _))
+        case (shortChannelId, c@PublicChannel(ann, _, _, Some(u1), _, _))
           if c.getNodeIdSameSideAs(u1) == nodeId && Announcements.isEnabled(u1.channelFlags) && routingData.channels.exists(_._1 == shortChannelId) => ann.nodeId2 // we only consider outgoing channels that are enabled and announced
       }
     if (peers.isEmpty) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
@@ -91,7 +91,7 @@ object Autoprobe {
     // we only pick direct peers with enabled public channels
     val peers = routingData.channels
       .collect {
-        case (shortChannelId, c@PublicChannel(ann, _, _, Some(u1), _))
+        case (shortChannelId, c@PublicChannel(ann, _, _, _, Some(u1), _, _))
           if c.getNodeIdSameSideAs(u1) == nodeId && Announcements.isEnabled(u1.channelFlags) && routingData.channels.exists(_._1 == shortChannelId) => ann.nodeId2 // we only consider outgoing channels that are enabled and announced
       }
     if (peers.isEmpty) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -78,7 +78,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
       span.tag(Tags.Expiry, c.finalPayload.expiry.toLong)
       log.debug("sending {} to route {}", c.finalPayload.amount, c.hops.mkString("->"))
       val send = SendPayment(c.hops.last, c.finalPayload, maxAttempts = 1)
-      router ! FinalizeRoute(c.hops, c.assistedRoutes)
+      router ! FinalizeRoute(c.finalPayload.amount, c.hops, c.assistedRoutes)
       if (cfg.storeInDb) {
         paymentsDb.addOutgoingPayment(OutgoingPayment(id, cfg.parentId, cfg.externalId, paymentHash, PaymentType.Standard, c.finalPayload.amount, cfg.recipientAmount, cfg.recipientNodeId, Platform.currentTime, cfg.paymentRequest, OutgoingPaymentStatus.Pending))
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -519,7 +519,7 @@ object Graph {
       // @formatter:off
       def apply(): DirectedGraph = new DirectedGraph(Map())
       def apply(key: PublicKey): DirectedGraph = new DirectedGraph(Map(key -> List.empty))
-      def apply(edge: GraphEdge): DirectedGraph = new DirectedGraph(Map()).addEdge(edge)
+      def apply(edge: GraphEdge): DirectedGraph = DirectedGraph().addEdge(edge)
       def apply(edges: Seq[GraphEdge]): DirectedGraph = DirectedGraph().addEdges(edges)
       // @formatter:on
 
@@ -542,11 +542,11 @@ object Graph {
         channels.values.foreach { channel =>
           channel.update_1_opt.foreach { u1 =>
             val desc1 = Router.getDesc(u1, channel.ann)
-            addDescToMap(desc1, u1, channel.capacity, channel.balance_1_opt)
+            addDescToMap(desc1, u1, channel.capacity, channel.meta_opt.map(_.balance1))
           }
           channel.update_2_opt.foreach { u2 =>
             val desc2 = Router.getDesc(u2, channel.ann)
-            addDescToMap(desc2, u2, channel.capacity, channel.balance_2_opt)
+            addDescToMap(desc2, u2, channel.capacity, channel.meta_opt.map(_.balance2))
           }
         }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -292,6 +292,10 @@ object Router {
     } else {
       copy(meta_opt = Some(ChannelMeta(commitments.availableBalanceForReceive, commitments.availableBalanceForSend)))
     }
+    def applyChannelUpdate(update: Either[LocalChannelUpdate, RemoteChannelUpdate]): PublicChannel = update match {
+      case Left(lcu) => updateChannelUpdateSameSideAs(lcu.channelUpdate).updateBalances(lcu.commitments)
+      case Right(rcu) => updateChannelUpdateSameSideAs(rcu.channelUpdate)
+    }
   }
   case class PrivateChannel(localNodeId: PublicKey, remoteNodeId: PublicKey, update_1_opt: Option[ChannelUpdate], update_2_opt: Option[ChannelUpdate], meta: ChannelMeta) {
     val (nodeId1, nodeId2) = if (Announcements.isNode1(localNodeId, remoteNodeId)) (localNodeId, remoteNodeId) else (remoteNodeId, localNodeId)
@@ -305,6 +309,10 @@ object Router {
       copy(meta = ChannelMeta(commitments.availableBalanceForSend, commitments.availableBalanceForReceive))
     } else {
       copy(meta = ChannelMeta(commitments.availableBalanceForReceive, commitments.availableBalanceForSend))
+    }
+    def applyChannelUpdate(update: Either[LocalChannelUpdate, RemoteChannelUpdate]): PrivateChannel = update match {
+      case Left(lcu) => updateChannelUpdateSameSideAs(lcu.channelUpdate).updateBalances(lcu.commitments)
+      case Right(rcu) => updateChannelUpdateSameSideAs(rcu.channelUpdate)
     }
   }
   // @formatter:on

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -57,6 +57,7 @@ class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[
 
   context.system.eventStream.subscribe(self, classOf[LocalChannelUpdate])
   context.system.eventStream.subscribe(self, classOf[LocalChannelDown])
+  context.system.eventStream.subscribe(self, classOf[AvailableBalanceChanged])
 
   setTimer(TickBroadcast.toString, TickBroadcast, nodeParams.routerConf.routerBroadcastInterval, repeat = true)
   setTimer(TickPruneStaleChannels.toString, TickPruneStaleChannels, 1 hour, repeat = true)
@@ -155,6 +156,11 @@ class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[
     case Event(LiftChannelExclusion(desc@ChannelDesc(shortChannelId, nodeId, _)), d) =>
       log.info("reinstating shortChannelId={} from nodeId={}", shortChannelId, nodeId)
       stay using d.copy(excludedChannels = d.excludedChannels - desc)
+
+    case Event(AvailableBalanceChanged(_, _, shortChannelId, commitments), d: Data) =>
+      val channels1 = d.channels.get(shortChannelId).map(c => d.channels + (shortChannelId -> c.updateBalances(commitments))).getOrElse(d.channels)
+      val privateChannels1 = d.privateChannels.get(shortChannelId).map(c => d.privateChannels + (shortChannelId -> c.updateBalances(commitments))).getOrElse(d.privateChannels)
+      stay using d.copy(channels = channels1, privateChannels = privateChannels1)
 
     case Event('nodes, d) =>
       sender ! d.nodes.values
@@ -274,24 +280,31 @@ object Router {
 
   // @formatter:off
   case class ChannelDesc(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey)
-  case class PublicChannel(ann: ChannelAnnouncement, fundingTxid: ByteVector32, capacity: Satoshi, update_1_opt: Option[ChannelUpdate], update_2_opt: Option[ChannelUpdate]) {
+  case class PublicChannel(ann: ChannelAnnouncement, fundingTxid: ByteVector32, capacity: Satoshi, balance_1_opt: Option[MilliSatoshi], update_1_opt: Option[ChannelUpdate], balance_2_opt: Option[MilliSatoshi], update_2_opt: Option[ChannelUpdate]) {
     update_1_opt.foreach(u => assert(Announcements.isNode1(u.channelFlags)))
     update_2_opt.foreach(u => assert(!Announcements.isNode1(u.channelFlags)))
 
     def getNodeIdSameSideAs(u: ChannelUpdate): PublicKey = if (Announcements.isNode1(u.channelFlags)) ann.nodeId1 else ann.nodeId2
-
     def getChannelUpdateSameSideAs(u: ChannelUpdate): Option[ChannelUpdate] = if (Announcements.isNode1(u.channelFlags)) update_1_opt else update_2_opt
-
     def updateChannelUpdateSameSideAs(u: ChannelUpdate): PublicChannel = if (Announcements.isNode1(u.channelFlags)) copy(update_1_opt = Some(u)) else copy(update_2_opt = Some(u))
+    def updateBalances(commitments: Commitments): PublicChannel = if (commitments.localParams.nodeId == ann.nodeId1) {
+      copy(balance_1_opt = Some(commitments.availableBalanceForSend), balance_2_opt = Some(commitments.availableBalanceForReceive))
+    } else {
+      copy(balance_1_opt = Some(commitments.availableBalanceForReceive), balance_2_opt = Some(commitments.availableBalanceForSend))
+    }
   }
-  case class PrivateChannel(localNodeId: PublicKey, remoteNodeId: PublicKey, update_1_opt: Option[ChannelUpdate], update_2_opt: Option[ChannelUpdate]) {
+  case class PrivateChannel(localNodeId: PublicKey, remoteNodeId: PublicKey, balance_1: MilliSatoshi, update_1_opt: Option[ChannelUpdate], balance_2: MilliSatoshi, update_2_opt: Option[ChannelUpdate]) {
     val (nodeId1, nodeId2) = if (Announcements.isNode1(localNodeId, remoteNodeId)) (localNodeId, remoteNodeId) else (remoteNodeId, localNodeId)
+    val capacity: Satoshi = (balance_1 + balance_2).truncateToSatoshi
 
     def getNodeIdSameSideAs(u: ChannelUpdate): PublicKey = if (Announcements.isNode1(u.channelFlags)) nodeId1 else nodeId2
-
     def getChannelUpdateSameSideAs(u: ChannelUpdate): Option[ChannelUpdate] = if (Announcements.isNode1(u.channelFlags)) update_1_opt else update_2_opt
-
     def updateChannelUpdateSameSideAs(u: ChannelUpdate): PrivateChannel = if (Announcements.isNode1(u.channelFlags)) copy(update_1_opt = Some(u)) else copy(update_2_opt = Some(u))
+    def updateBalances(commitments: Commitments): PrivateChannel = if (commitments.localParams.nodeId == nodeId1) {
+      copy(balance_1 = commitments.availableBalanceForSend, balance_2 = commitments.availableBalanceForReceive)
+    } else {
+      copy(balance_1 = commitments.availableBalanceForReceive, balance_2 = commitments.availableBalanceForSend)
+    }
   }
   // @formatter:on
 
@@ -430,6 +443,11 @@ object Router {
   def getDesc(u: ChannelUpdate, channel: ChannelAnnouncement): ChannelDesc = {
     // the least significant bit tells us if it is node1 or node2
     if (Announcements.isNode1(u.channelFlags)) ChannelDesc(u.shortChannelId, channel.nodeId1, channel.nodeId2) else ChannelDesc(u.shortChannelId, channel.nodeId2, channel.nodeId1)
+  }
+
+  def getDesc(u: ChannelUpdate, pc: PrivateChannel): ChannelDesc = {
+    // the least significant bit tells us if it is node1 or node2
+    if (Announcements.isNode1(u.channelFlags)) ChannelDesc(u.shortChannelId, pc.nodeId1, pc.nodeId2) else ChannelDesc(u.shortChannelId, pc.nodeId2, pc.nodeId1)
   }
 
   def isRelatedTo(c: ChannelAnnouncement, nodeId: PublicKey) = nodeId == c.nodeId1 || nodeId == c.nodeId2

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -211,10 +211,10 @@ class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[
       stay using Validation.handleNodeAnnouncement(d, nodeParams.db.network, Set(RemoteGossip(sender, remoteNodeId)), n)
 
     case Event(u: ChannelUpdate, d: Data) =>
-      stay using Validation.handleChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, Set(LocalGossip), u)
+      stay using Validation.handleChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, Set(LocalGossip), Right(u))
 
     case Event(PeerRoutingMessage(remoteNodeId, u: ChannelUpdate), d) =>
-      stay using Validation.handleChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, Set(RemoteGossip(sender, remoteNodeId)), u)
+      stay using Validation.handleChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, Set(RemoteGossip(sender, remoteNodeId)), Right(u))
 
     case Event(lcu: LocalChannelUpdate, d: Data) =>
       stay using Validation.handleLocalChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, nodeParams.nodeId, watcher, lcu)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -206,10 +206,10 @@ class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[
       stay using Validation.handleNodeAnnouncement(d, nodeParams.db.network, Set(RemoteGossip(sender, remoteNodeId)), n)
 
     case Event(u: ChannelUpdate, d: Data) =>
-      stay using Validation.handleChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, Set(LocalGossip), Right(u))
+      stay using Validation.handleChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, Right(RemoteChannelUpdate(u, Set(LocalGossip))))
 
     case Event(PeerRoutingMessage(remoteNodeId, u: ChannelUpdate), d) =>
-      stay using Validation.handleChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, Set(RemoteGossip(sender, remoteNodeId)), Right(u))
+      stay using Validation.handleChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, Right(RemoteChannelUpdate(u, Set(RemoteGossip(sender, remoteNodeId)))))
 
     case Event(lcu: LocalChannelUpdate, d: Data) =>
       stay using Validation.handleLocalChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, nodeParams.nodeId, watcher, lcu)
@@ -412,6 +412,7 @@ object Router {
     case class RelatedChannelPruned(ann: ChannelUpdate) extends Rejected
   }
 
+  case class RemoteChannelUpdate(channelUpdate: ChannelUpdate, origins: Set[GossipOrigin])
   case class Stash(updates: Map[ChannelUpdate, Set[GossipOrigin]], nodes: Map[NodeAnnouncement, Set[GossipOrigin]])
   case class Rebroadcast(channels: Map[ChannelAnnouncement, Set[GossipOrigin]], updates: Map[ChannelUpdate, Set[GossipOrigin]], nodes: Map[NodeAnnouncement, Set[GossipOrigin]])
   // @formatter:on

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -121,7 +121,7 @@ object Validation {
                     val nodeAnn = Announcements.makeNodeAnnouncement(nodeParams.privateKey, nodeParams.alias, nodeParams.color, nodeParams.publicAddresses, nodeParams.features)
                     ctx.self ! nodeAnn
                   }
-                  Some(PublicChannel(c, tx.txid, capacity, None, None, None, None))
+                  Some(PublicChannel(c, tx.txid, capacity, None, None, None))
                 }
               case ValidateResult(c, Right((tx, fundingTxStatus: UtxoStatus.Spent))) =>
                 if (fundingTxStatus.spendingTxConfirmed) {
@@ -433,7 +433,7 @@ object Validation {
             // channel isn't announced and we never heard of it (maybe it is a private channel or maybe it is a public channel that doesn't yet have 6 confirmations)
             // let's create a corresponding private channel and process the channel_update
             log.debug("adding unannounced local channel to remote={} shortChannelId={}", lcu.remoteNodeId, lcu.shortChannelId)
-            val pc = PrivateChannel(localNodeId, lcu.remoteNodeId, 0 msat, None, 0 msat, None).updateBalances(lcu.commitments)
+            val pc = PrivateChannel(localNodeId, lcu.remoteNodeId, None, None, ChannelMeta(0 msat, 0 msat)).updateBalances(lcu.commitments)
             val d1 = d.copy(privateChannels = d.privateChannels + (lcu.shortChannelId -> pc))
             handleChannelUpdate(d1, db, routerConf, Set(LocalGossip), Left(lcu))
         }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -181,7 +181,7 @@ class EclairImplSpec extends TestKit(ActorSystem("test")) with fixture.FunSuiteL
       (ann_cd, makeUpdate(3L, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(500))),
       (ann_ec, makeUpdate(7L, e, c, feeBase = 2 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)))
     ).foreach { case (ann, (desc, update)) =>
-      channels = channels + (desc.shortChannelId -> PublicChannel(ann, ByteVector32.Zeroes, 100 sat, Some(update.copy(channelFlags = 0)), None))
+      channels = channels + (desc.shortChannelId -> PublicChannel(ann, ByteVector32.Zeroes, 100 sat, None, Some(update.copy(channelFlags = 0)), None, None))
     }
 
     val mockNetworkDb = mock[NetworkDb]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -181,7 +181,7 @@ class EclairImplSpec extends TestKit(ActorSystem("test")) with fixture.FunSuiteL
       (ann_cd, makeUpdateShort(ShortChannelId(3L), c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(500))),
       (ann_ec, makeUpdateShort(ShortChannelId(7L), e, c, feeBase = 2 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)))
     ).foreach { case (ann, update) =>
-      channels = channels + (update.shortChannelId -> PublicChannel(ann, ByteVector32.Zeroes, 100 sat, None, Some(update.copy(channelFlags = 0)), None, None))
+      channels = channels + (update.shortChannelId -> PublicChannel(ann, ByteVector32.Zeroes, 100 sat, Some(update.copy(channelFlags = 0)), None, None))
     }
 
     val mockNetworkDb = mock[NetworkDb]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -33,7 +33,7 @@ import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceivePayment
 import fr.acinq.eclair.payment.receive.PaymentHandler
 import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentRequest, SendPaymentToRouteRequest}
-import fr.acinq.eclair.router.RouteCalculationSpec.makeUpdate
+import fr.acinq.eclair.router.RouteCalculationSpec.makeUpdateShort
 import fr.acinq.eclair.router.Router.{GetNetworkStats, GetNetworkStatsResponse, PublicChannel}
 import fr.acinq.eclair.router.{Announcements, NetworkStats, Router, Stats}
 import org.mockito.Mockito
@@ -175,13 +175,13 @@ class EclairImplSpec extends TestKit(ActorSystem("test")) with fixture.FunSuiteL
     var channels = scala.collection.immutable.SortedMap.empty[ShortChannelId, PublicChannel]
 
     List(
-      (ann_ab, makeUpdate(1L, a, b, feeBase = 0 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(13))),
-      (ann_ae, makeUpdate(4L, a, e, feeBase = 0 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12))),
-      (ann_bc, makeUpdate(2L, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(500))),
-      (ann_cd, makeUpdate(3L, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(500))),
-      (ann_ec, makeUpdate(7L, e, c, feeBase = 2 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)))
-    ).foreach { case (ann, (desc, update)) =>
-      channels = channels + (desc.shortChannelId -> PublicChannel(ann, ByteVector32.Zeroes, 100 sat, None, Some(update.copy(channelFlags = 0)), None, None))
+      (ann_ab, makeUpdateShort(ShortChannelId(1L), a, b, feeBase = 0 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(13))),
+      (ann_ae, makeUpdateShort(ShortChannelId(4L), a, e, feeBase = 0 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12))),
+      (ann_bc, makeUpdateShort(ShortChannelId(2L), b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(500))),
+      (ann_cd, makeUpdateShort(ShortChannelId(3L), c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(500))),
+      (ann_ec, makeUpdateShort(ShortChannelId(7L), e, c, feeBase = 2 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)))
+    ).foreach { case (ann, update) =>
+      channels = channels + (update.shortChannelId -> PublicChannel(ann, ByteVector32.Zeroes, 100 sat, None, Some(update.copy(channelFlags = 0)), None, None))
     }
 
     val mockNetworkDb = mock[NetworkDb]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -18,6 +18,7 @@ package fr.acinq.eclair.channel
 
 import java.util.UUID
 
+import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{DeterministicWallet, Satoshi, Transaction}
 import fr.acinq.eclair.channel.Commitments._
 import fr.acinq.eclair.channel.Helpers.Funding
@@ -498,6 +499,28 @@ object CommitmentsSpec {
       channelFlags = if (announceChannel) ChannelFlags.AnnounceChannel else ChannelFlags.Empty,
       LocalCommit(0, CommitmentSpec(Set.empty, feeRatePerKw, toLocal, toRemote), PublishableTxs(CommitTx(commitmentInput, Transaction(2, Nil, Nil, 0)), Nil)),
       RemoteCommit(0, CommitmentSpec(Set.empty, feeRatePerKw, toRemote, toLocal), randomBytes32, randomKey.publicKey),
+      LocalChanges(Nil, Nil, Nil),
+      RemoteChanges(Nil, Nil, Nil),
+      localNextHtlcId = 1,
+      remoteNextHtlcId = 1,
+      originChannels = Map.empty,
+      remoteNextCommitInfo = Right(randomKey.publicKey),
+      commitInput = commitmentInput,
+      remotePerCommitmentSecrets = ShaChain.init,
+      channelId = randomBytes32)
+  }
+
+  def makeCommitments(toLocal: MilliSatoshi, toRemote: MilliSatoshi, localNodeId: PublicKey, remoteNodeId: PublicKey, announceChannel: Boolean): Commitments = {
+    val localParams = LocalParams(localNodeId, DeterministicWallet.KeyPath(Seq(42L)), 0 sat, UInt64.MaxValue, 0 sat, 1 msat, CltvExpiryDelta(144), 50, isFunder = true, ByteVector.empty, ByteVector.empty)
+    val remoteParams = RemoteParams(remoteNodeId, 0 sat, UInt64.MaxValue, 0 sat, 1 msat, CltvExpiryDelta(144), 50, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, ByteVector.empty)
+    val commitmentInput = Funding.makeFundingInputInfo(randomBytes32, 0, (toLocal + toRemote).truncateToSatoshi, randomKey.publicKey, remoteParams.fundingPubKey)
+    Commitments(
+      ChannelVersion.STANDARD,
+      localParams,
+      remoteParams,
+      channelFlags = if (announceChannel) ChannelFlags.AnnounceChannel else ChannelFlags.Empty,
+      LocalCommit(0, CommitmentSpec(Set.empty, 0, toLocal, toRemote), PublishableTxs(CommitTx(commitmentInput, Transaction(2, Nil, Nil, 0)), Nil)),
+      RemoteCommit(0, CommitmentSpec(Set.empty, 0, toRemote, toLocal), randomBytes32, randomKey.publicKey),
       LocalChanges(Nil, Nil, Nil),
       RemoteChanges(Nil, Nil, Nil),
       localNextHtlcId = 1,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteNetworkDbSpec.scala
@@ -110,7 +110,7 @@ class SqliteNetworkDbSpec extends FunSuite {
     val c = Announcements.makeChannelAnnouncement(Block.RegtestGenesisBlock.hash, ShortChannelId(42), randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, sig, sig, sig, sig)
     val txid = ByteVector32.fromValidHex("0001" * 16)
     db.addChannel(c, txid, Satoshi(42))
-    assert(db.listChannels() === SortedMap(c.shortChannelId -> PublicChannel(c, txid, Satoshi(42), None, None, None, None)))
+    assert(db.listChannels() === SortedMap(c.shortChannelId -> PublicChannel(c, txid, Satoshi(42), None, None, None)))
   }
 
   def simpleTest(sqlite: Connection) = {
@@ -145,13 +145,13 @@ class SqliteNetworkDbSpec extends FunSuite {
     db.addChannel(channel_2, txid_2, capacity)
     db.addChannel(channel_3, txid_3, capacity)
     assert(db.listChannels() === SortedMap(
-      channel_1.shortChannelId -> PublicChannel(channel_1, txid_1, capacity, None, None, None, None),
-      channel_2.shortChannelId -> PublicChannel(channel_2, txid_2, capacity, None, None, None, None),
-      channel_3.shortChannelId -> PublicChannel(channel_3, txid_3, capacity, None, None, None, None)))
+      channel_1.shortChannelId -> PublicChannel(channel_1, txid_1, capacity, None, None, None),
+      channel_2.shortChannelId -> PublicChannel(channel_2, txid_2, capacity, None, None, None),
+      channel_3.shortChannelId -> PublicChannel(channel_3, txid_3, capacity, None, None, None)))
     db.removeChannel(channel_2.shortChannelId)
     assert(db.listChannels() === SortedMap(
-      channel_1.shortChannelId -> PublicChannel(channel_1, txid_1, capacity, None, None, None, None),
-      channel_3.shortChannelId -> PublicChannel(channel_3, txid_3, capacity, None, None, None, None)))
+      channel_1.shortChannelId -> PublicChannel(channel_1, txid_1, capacity, None, None, None),
+      channel_3.shortChannelId -> PublicChannel(channel_3, txid_3, capacity, None, None, None)))
 
     val channel_update_1 = Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, a, b.publicKey, ShortChannelId(42), CltvExpiryDelta(5), 7000000 msat, 50000 msat, 100, 500000000L msat, true)
     val channel_update_2 = Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, b, a.publicKey, ShortChannelId(42), CltvExpiryDelta(5), 7000000 msat, 50000 msat, 100, 500000000L msat, true)
@@ -162,11 +162,11 @@ class SqliteNetworkDbSpec extends FunSuite {
     db.updateChannel(channel_update_2)
     db.updateChannel(channel_update_3)
     assert(db.listChannels() === SortedMap(
-      channel_1.shortChannelId -> PublicChannel(channel_1, txid_1, capacity, None, Some(channel_update_1), None, Some(channel_update_2)),
-      channel_3.shortChannelId -> PublicChannel(channel_3, txid_3, capacity, None, Some(channel_update_3), None, None)))
+      channel_1.shortChannelId -> PublicChannel(channel_1, txid_1, capacity, Some(channel_update_1), Some(channel_update_2), None),
+      channel_3.shortChannelId -> PublicChannel(channel_3, txid_3, capacity, Some(channel_update_3), None, None)))
     db.removeChannel(channel_3.shortChannelId)
     assert(db.listChannels() === SortedMap(
-      channel_1.shortChannelId -> PublicChannel(channel_1, txid_1, capacity, None, Some(channel_update_1), None, Some(channel_update_2))))
+      channel_1.shortChannelId -> PublicChannel(channel_1, txid_1, capacity, Some(channel_update_1), Some(channel_update_2), None)))
   }
 
   test("add/remove/list channels and channel_updates") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -91,7 +91,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val request = SendPaymentToRoute(Seq(a, b, c, d), FinalLegacyPayload(defaultAmountMsat, defaultExpiry))
 
     sender.send(paymentFSM, request)
-    routerForwarder.expectMsg(FinalizeRoute(Seq(a, b, c, d)))
+    routerForwarder.expectMsg(FinalizeRoute(defaultAmountMsat, Seq(a, b, c, d)))
     val Transition(_, WAITING_FOR_REQUEST, WAITING_FOR_ROUTE) = monitor.expectMsgClass(classOf[Transition[_]])
 
     routerForwarder.forward(routerFixture.router)
@@ -128,7 +128,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val request = SendPaymentToRoute(Seq(a, b, c, recipient), FinalLegacyPayload(defaultAmountMsat, defaultExpiry), routingHint)
 
     sender.send(paymentFSM, request)
-    routerForwarder.expectMsg(FinalizeRoute(Seq(a, b, c, recipient), routingHint))
+    routerForwarder.expectMsg(FinalizeRoute(defaultAmountMsat, Seq(a, b, c, recipient), routingHint))
     val Transition(_, WAITING_FOR_REQUEST, WAITING_FOR_ROUTE) = monitor.expectMsgClass(classOf[Transition[_]])
 
     routerForwarder.forward(routerFixture.router)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -23,10 +23,11 @@ import fr.acinq.bitcoin.Script.{pay2wsh, write}
 import fr.acinq.bitcoin.{Block, ByteVector32, Transaction, TxOut}
 import fr.acinq.eclair.TestConstants.Alice
 import fr.acinq.eclair.blockchain.{UtxoStatus, ValidateRequest, ValidateResult, WatchSpentBasic}
+import fr.acinq.eclair.channel.{CommitmentsSpec, LocalChannelUpdate}
 import fr.acinq.eclair.crypto.LocalKeyManager
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.router.Announcements._
-import fr.acinq.eclair.router.Router.ChannelDesc
+import fr.acinq.eclair.router.Router.{ChannelDesc, PrivateChannel}
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestkitBaseClass, randomKey, _}
@@ -50,11 +51,11 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
   val seed = ByteVector32(ByteVector.fill(32)(2))
   val testKeyManager = new LocalKeyManager(seed, Block.RegtestGenesisBlock.hash)
 
-  val (priv_a, priv_b, priv_c, priv_d, priv_e, priv_f) = (testKeyManager.nodeKey.privateKey, randomKey, randomKey, randomKey, randomKey, randomKey)
-  val (a, b, c, d, e, f) = (testKeyManager.nodeId, priv_b.publicKey, priv_c.publicKey, priv_d.publicKey, priv_e.publicKey, priv_f.publicKey)
+  val (priv_a, priv_b, priv_c, priv_d, priv_e, priv_f, priv_g, priv_h) = (testKeyManager.nodeKey.privateKey, randomKey, randomKey, randomKey, randomKey, randomKey, randomKey, randomKey)
+  val (a, b, c, d, e, f, g, h) = (testKeyManager.nodeId, priv_b.publicKey, priv_c.publicKey, priv_d.publicKey, priv_e.publicKey, priv_f.publicKey, priv_g.publicKey, priv_h.publicKey)
 
-  val (priv_funding_a, priv_funding_b, priv_funding_c, priv_funding_d, priv_funding_e, priv_funding_f) = (randomKey, randomKey, randomKey, randomKey, randomKey, randomKey)
-  val (funding_a, funding_b, funding_c, funding_d, funding_e, funding_f) = (priv_funding_a.publicKey, priv_funding_b.publicKey, priv_funding_c.publicKey, priv_funding_d.publicKey, priv_funding_e.publicKey, priv_funding_f.publicKey)
+  val (priv_funding_a, priv_funding_b, priv_funding_c, priv_funding_d, priv_funding_e, priv_funding_f, priv_funding_g, priv_funding_h) = (randomKey, randomKey, randomKey, randomKey, randomKey, randomKey, randomKey, randomKey)
+  val (funding_a, funding_b, funding_c, funding_d, funding_e, funding_f, funding_g, funding_h) = (priv_funding_a.publicKey, priv_funding_b.publicKey, priv_funding_c.publicKey, priv_funding_d.publicKey, priv_funding_e.publicKey, priv_funding_f.publicKey, priv_funding_g.publicKey, priv_funding_h.publicKey)
 
   val node_a = makeNodeAnnouncement(priv_a, "node-A", Color(15, 10, -70), Nil, hex"0200")
   val node_b = makeNodeAnnouncement(priv_b, "node-B", Color(50, 99, -80), Nil, hex"")
@@ -62,11 +63,15 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
   val node_d = makeNodeAnnouncement(priv_d, "node-D", Color(-120, -20, 60), Nil, hex"00")
   val node_e = makeNodeAnnouncement(priv_e, "node-E", Color(-50, 0, 10), Nil, hex"00")
   val node_f = makeNodeAnnouncement(priv_f, "node-F", Color(30, 10, -50), Nil, hex"00")
+  val node_g = makeNodeAnnouncement(priv_g, "node-G", Color(30, 10, -50), Nil, hex"00")
+  val node_h = makeNodeAnnouncement(priv_h, "node-H", Color(30, 10, -50), Nil, hex"00")
 
   val channelId_ab = ShortChannelId(420000, 1, 0)
   val channelId_bc = ShortChannelId(420000, 2, 0)
   val channelId_cd = ShortChannelId(420000, 3, 0)
   val channelId_ef = ShortChannelId(420000, 4, 0)
+  val channelId_ag = ShortChannelId(420000, 5, 0)
+  val channelId_gh = ShortChannelId(420000, 6, 0)
 
   def channelAnnouncement(shortChannelId: ShortChannelId, node1_priv: PrivateKey, node2_priv: PrivateKey, funding1_priv: PrivateKey, funding2_priv: PrivateKey) = {
     val (node1_sig, funding1_sig) = signChannelAnnouncement(Block.RegtestGenesisBlock.hash, shortChannelId, node1_priv, node2_priv.publicKey, funding1_priv, funding2_priv.publicKey, ByteVector.empty)
@@ -78,6 +83,7 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
   val chan_bc = channelAnnouncement(channelId_bc, priv_b, priv_c, priv_funding_b, priv_funding_c)
   val chan_cd = channelAnnouncement(channelId_cd, priv_c, priv_d, priv_funding_c, priv_funding_d)
   val chan_ef = channelAnnouncement(channelId_ef, priv_e, priv_f, priv_funding_e, priv_funding_f)
+  val chan_gh = channelAnnouncement(channelId_gh, priv_g, priv_h, priv_funding_g, priv_funding_h)
 
   val update_ab = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, b, channelId_ab, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
   val update_ba = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, a, channelId_ab, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
@@ -87,29 +93,38 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
   val update_dc = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_d, c, channelId_cd, CltvExpiryDelta(3), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 4, htlcMaximumMsat = 500000000 msat)
   val update_ef = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_e, f, channelId_ef, CltvExpiryDelta(9), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 8, htlcMaximumMsat = 500000000 msat)
   val update_fe = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_f, e, channelId_ef, CltvExpiryDelta(9), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 8, htlcMaximumMsat = 500000000 msat)
+  val update_ag = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, g, channelId_ag, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
+  val update_ga = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_g, a, channelId_ag, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
+  val update_gh = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_g, h, channelId_gh, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
+  val update_hg = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_h, g, channelId_gh, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
 
   override def withFixture(test: OneArgTest): Outcome = {
-    // the network will be a --(1)--> b ---(2)--> c --(3)--> d and e --(4)--> f (we are a)
-
+    // the network will be a --(1)--> b ---(2)--> c --(3)--> d
+    //                     |
+    //                     +---(5)--> g ---(6)--> h
+    // and e --(4)--> f (we are a)
     within(30 seconds) {
-
       // first we make sure that we correctly resolve channelId+direction to nodeId
-      assert(Router.getDesc(update_ab, chan_ab) === ChannelDesc(chan_ab.shortChannelId, priv_a.publicKey, priv_b.publicKey))
-      assert(Router.getDesc(update_bc, chan_bc) === ChannelDesc(chan_bc.shortChannelId, priv_b.publicKey, priv_c.publicKey))
-      assert(Router.getDesc(update_cd, chan_cd) === ChannelDesc(chan_cd.shortChannelId, priv_c.publicKey, priv_d.publicKey))
-      assert(Router.getDesc(update_ef, chan_ef) === ChannelDesc(chan_ef.shortChannelId, priv_e.publicKey, priv_f.publicKey))
-
+      assert(Router.getDesc(update_ab, chan_ab) === ChannelDesc(chan_ab.shortChannelId, a, b))
+      assert(Router.getDesc(update_bc, chan_bc) === ChannelDesc(chan_bc.shortChannelId, b, c))
+      assert(Router.getDesc(update_cd, chan_cd) === ChannelDesc(chan_cd.shortChannelId, c, d))
+      assert(Router.getDesc(update_ef, chan_ef) === ChannelDesc(chan_ef.shortChannelId, e, f))
+      assert(Router.getDesc(update_ag, PrivateChannel(a, g, 1000 msat, None, 2000 msat, None)) === ChannelDesc(channelId_ag, a, g))
+      assert(Router.getDesc(update_ag, PrivateChannel(g, a, 2000 msat, None, 1000 msat, None)) === ChannelDesc(channelId_ag, a, g))
+      assert(Router.getDesc(update_gh, chan_gh) === ChannelDesc(chan_gh.shortChannelId, g, h))
 
       // let's set up the router
+      val sender = TestProbe()
       val peerConnection = TestProbe()
       val watcher = TestProbe()
-      val nodeParams = Alice.nodeParams
+      val nodeParams = Alice.nodeParams.copy(keyManager = testKeyManager)
       val router = system.actorOf(Router.props(nodeParams, watcher.ref))
       // we announce channels
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, chan_ab))
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, chan_bc))
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, chan_cd))
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, chan_ef))
+      peerConnection.send(router, PeerRoutingMessage(remoteNodeId, chan_gh))
       // then nodes
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, node_a))
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, node_b))
@@ -117,6 +132,8 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, node_d))
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, node_e))
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, node_f))
+      peerConnection.send(router, PeerRoutingMessage(remoteNodeId, node_g))
+      peerConnection.send(router, PeerRoutingMessage(remoteNodeId, node_h))
       // then channel updates
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, update_ab))
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, update_ba))
@@ -126,23 +143,28 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, update_dc))
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, update_ef))
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, update_fe))
+      peerConnection.send(router, PeerRoutingMessage(remoteNodeId, update_gh))
+      peerConnection.send(router, PeerRoutingMessage(remoteNodeId, update_hg))
+      // then private channels
+      sender.send(router, LocalChannelUpdate(sender.ref, randomBytes32, channelId_ag, g, None, update_ag, CommitmentsSpec.makeCommitments(300000000 msat, 100000000 msat, a, g, announceChannel = false)))
       // watcher receives the get tx requests
       watcher.expectMsg(ValidateRequest(chan_ab))
       watcher.expectMsg(ValidateRequest(chan_bc))
       watcher.expectMsg(ValidateRequest(chan_cd))
       watcher.expectMsg(ValidateRequest(chan_ef))
+      watcher.expectMsg(ValidateRequest(chan_gh))
       // and answers with valid scripts
       watcher.send(router, ValidateResult(chan_ab, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(1000000 sat, write(pay2wsh(Scripts.multiSig2of2(funding_a, funding_b)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
       watcher.send(router, ValidateResult(chan_bc, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(1000000 sat, write(pay2wsh(Scripts.multiSig2of2(funding_b, funding_c)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
       watcher.send(router, ValidateResult(chan_cd, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(1000000 sat, write(pay2wsh(Scripts.multiSig2of2(funding_c, funding_d)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
       watcher.send(router, ValidateResult(chan_ef, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(1000000 sat, write(pay2wsh(Scripts.multiSig2of2(funding_e, funding_f)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
+      watcher.send(router, ValidateResult(chan_gh, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(1000000 sat, write(pay2wsh(Scripts.multiSig2of2(funding_g, funding_h)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
       // watcher receives watch-spent request
       watcher.expectMsgType[WatchSpentBasic]
       watcher.expectMsgType[WatchSpentBasic]
       watcher.expectMsgType[WatchSpentBasic]
       watcher.expectMsgType[WatchSpentBasic]
-
-      val sender = TestProbe()
+      watcher.expectMsgType[WatchSpentBasic]
 
       awaitCond({
         sender.send(router, 'nodes)
@@ -151,7 +173,7 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
         val channels = sender.expectMsgType[Iterable[ChannelAnnouncement]]
         sender.send(router, 'updates)
         val updates = sender.expectMsgType[Iterable[ChannelUpdate]]
-        nodes.size === 6 && channels.size === 4 && updates.size === 8
+        nodes.size === 8 && channels.size === 5 && updates.size === 11
       }, max = 10 seconds, interval = 1 second)
 
       withFixture(test.toNoArgTest(FixtureParam(nodeParams, router, watcher)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -47,6 +47,8 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
   case class FixtureParam(nodeParams: NodeParams, router: ActorRef, watcher: TestProbe)
 
   val remoteNodeId = PrivateKey(ByteVector32(ByteVector.fill(32)(1))).publicKey
+  val publicChannelCapacity = 1000000 sat
+  val htlcMaximum = 500000000 msat
 
   val seed = ByteVector32(ByteVector.fill(32)(2))
   val testKeyManager = new LocalKeyManager(seed, Block.RegtestGenesisBlock.hash)
@@ -85,18 +87,18 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
   val chan_ef = channelAnnouncement(channelId_ef, priv_e, priv_f, priv_funding_e, priv_funding_f)
   val chan_gh = channelAnnouncement(channelId_gh, priv_g, priv_h, priv_funding_g, priv_funding_h)
 
-  val update_ab = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, b, channelId_ab, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
-  val update_ba = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, a, channelId_ab, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
-  val update_bc = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, c, channelId_bc, CltvExpiryDelta(5), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 1, htlcMaximumMsat = 500000000 msat)
-  val update_cb = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_c, b, channelId_bc, CltvExpiryDelta(5), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 1, htlcMaximumMsat = 500000000 msat)
-  val update_cd = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_c, d, channelId_cd, CltvExpiryDelta(3), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 4, htlcMaximumMsat = 500000000 msat)
-  val update_dc = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_d, c, channelId_cd, CltvExpiryDelta(3), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 4, htlcMaximumMsat = 500000000 msat)
-  val update_ef = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_e, f, channelId_ef, CltvExpiryDelta(9), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 8, htlcMaximumMsat = 500000000 msat)
-  val update_fe = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_f, e, channelId_ef, CltvExpiryDelta(9), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 8, htlcMaximumMsat = 500000000 msat)
-  val update_ag = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, g, channelId_ag, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
-  val update_ga = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_g, a, channelId_ag, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
-  val update_gh = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_g, h, channelId_gh, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
-  val update_hg = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_h, g, channelId_gh, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = 500000000 msat)
+  val update_ab = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, b, channelId_ab, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = htlcMaximum)
+  val update_ba = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, a, channelId_ab, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = htlcMaximum)
+  val update_bc = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_b, c, channelId_bc, CltvExpiryDelta(5), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 1, htlcMaximumMsat = htlcMaximum)
+  val update_cb = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_c, b, channelId_bc, CltvExpiryDelta(5), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 1, htlcMaximumMsat = htlcMaximum)
+  val update_cd = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_c, d, channelId_cd, CltvExpiryDelta(3), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 4, htlcMaximumMsat = htlcMaximum)
+  val update_dc = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_d, c, channelId_cd, CltvExpiryDelta(3), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 4, htlcMaximumMsat = htlcMaximum)
+  val update_ef = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_e, f, channelId_ef, CltvExpiryDelta(9), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 8, htlcMaximumMsat = htlcMaximum)
+  val update_fe = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_f, e, channelId_ef, CltvExpiryDelta(9), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 8, htlcMaximumMsat = htlcMaximum)
+  val update_ag = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, g, channelId_ag, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = htlcMaximum)
+  val update_ga = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_g, a, channelId_ag, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = htlcMaximum)
+  val update_gh = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_g, h, channelId_gh, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = htlcMaximum)
+  val update_hg = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_h, g, channelId_gh, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = htlcMaximum)
 
   override def withFixture(test: OneArgTest): Outcome = {
     // the network will be a --(1)--> b ---(2)--> c --(3)--> d
@@ -154,11 +156,11 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
       watcher.expectMsg(ValidateRequest(chan_ef))
       watcher.expectMsg(ValidateRequest(chan_gh))
       // and answers with valid scripts
-      watcher.send(router, ValidateResult(chan_ab, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(1000000 sat, write(pay2wsh(Scripts.multiSig2of2(funding_a, funding_b)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
-      watcher.send(router, ValidateResult(chan_bc, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(1000000 sat, write(pay2wsh(Scripts.multiSig2of2(funding_b, funding_c)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
-      watcher.send(router, ValidateResult(chan_cd, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(1000000 sat, write(pay2wsh(Scripts.multiSig2of2(funding_c, funding_d)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
-      watcher.send(router, ValidateResult(chan_ef, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(1000000 sat, write(pay2wsh(Scripts.multiSig2of2(funding_e, funding_f)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
-      watcher.send(router, ValidateResult(chan_gh, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(1000000 sat, write(pay2wsh(Scripts.multiSig2of2(funding_g, funding_h)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
+      watcher.send(router, ValidateResult(chan_ab, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(publicChannelCapacity, write(pay2wsh(Scripts.multiSig2of2(funding_a, funding_b)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
+      watcher.send(router, ValidateResult(chan_bc, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(publicChannelCapacity, write(pay2wsh(Scripts.multiSig2of2(funding_b, funding_c)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
+      watcher.send(router, ValidateResult(chan_cd, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(publicChannelCapacity, write(pay2wsh(Scripts.multiSig2of2(funding_c, funding_d)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
+      watcher.send(router, ValidateResult(chan_ef, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(publicChannelCapacity, write(pay2wsh(Scripts.multiSig2of2(funding_e, funding_f)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
+      watcher.send(router, ValidateResult(chan_gh, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(publicChannelCapacity, write(pay2wsh(Scripts.multiSig2of2(funding_g, funding_h)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
       // watcher receives watch-spent request
       watcher.expectMsgType[WatchSpentBasic]
       watcher.expectMsgType[WatchSpentBasic]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.channel.{CommitmentsSpec, LocalChannelUpdate}
 import fr.acinq.eclair.crypto.LocalKeyManager
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.router.Announcements._
-import fr.acinq.eclair.router.Router.{ChannelDesc, PrivateChannel}
+import fr.acinq.eclair.router.Router.{ChannelDesc, ChannelMeta, PrivateChannel}
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestkitBaseClass, randomKey, _}
@@ -109,8 +109,8 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
       assert(Router.getDesc(update_bc, chan_bc) === ChannelDesc(chan_bc.shortChannelId, b, c))
       assert(Router.getDesc(update_cd, chan_cd) === ChannelDesc(chan_cd.shortChannelId, c, d))
       assert(Router.getDesc(update_ef, chan_ef) === ChannelDesc(chan_ef.shortChannelId, e, f))
-      assert(Router.getDesc(update_ag, PrivateChannel(a, g, 1000 msat, None, 2000 msat, None)) === ChannelDesc(channelId_ag, a, g))
-      assert(Router.getDesc(update_ag, PrivateChannel(g, a, 2000 msat, None, 1000 msat, None)) === ChannelDesc(channelId_ag, a, g))
+      assert(Router.getDesc(update_ag, PrivateChannel(a, g, None, None, ChannelMeta(1000 msat, 2000 msat))) === ChannelDesc(channelId_ag, a, g))
+      assert(Router.getDesc(update_ag, PrivateChannel(g, a, None, None, ChannelMeta(2000 msat, 1000 msat))) === ChannelDesc(channelId_ag, a, g))
       assert(Router.getDesc(update_gh, chan_gh) === ChannelDesc(chan_gh.shortChannelId, g, h))
 
       // let's set up the router

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -105,8 +105,8 @@ class ChannelRangeQueriesSpec extends FunSuite {
     val ef = RouteCalculationSpec.makeChannel(167514L, e, f)
 
     val channels = SortedMap(
-      ab.shortChannelId -> PublicChannel(ab, ByteVector32.Zeroes, 0 sat, Some(uab1), Some(uab2)),
-      cd.shortChannelId -> PublicChannel(cd, ByteVector32.Zeroes, 0 sat, Some(ucd1), None)
+      ab.shortChannelId -> PublicChannel(ab, ByteVector32.Zeroes, 0 sat, Some(1000 msat), Some(uab1), Some(400 msat), Some(uab2)),
+      cd.shortChannelId -> PublicChannel(cd, ByteVector32.Zeroes, 0 sat, None, Some(ucd1), None, None)
     )
 
     import fr.acinq.eclair.wire.QueryShortChannelIdsTlv.QueryFlagType._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.router
 
 import fr.acinq.bitcoin.{Block, ByteVector32}
-import fr.acinq.eclair.router.Router.PublicChannel
+import fr.acinq.eclair.router.Router.{ChannelMeta, PublicChannel}
 import fr.acinq.eclair.router.Sync._
 import fr.acinq.eclair.wire.QueryChannelRangeTlv.QueryFlags
 import fr.acinq.eclair.wire.ReplyChannelRangeTlv._
@@ -105,8 +105,8 @@ class ChannelRangeQueriesSpec extends FunSuite {
     val ef = RouteCalculationSpec.makeChannel(167514L, e, f)
 
     val channels = SortedMap(
-      ab.shortChannelId -> PublicChannel(ab, ByteVector32.Zeroes, 0 sat, Some(1000 msat), Some(uab1), Some(400 msat), Some(uab2)),
-      cd.shortChannelId -> PublicChannel(cd, ByteVector32.Zeroes, 0 sat, None, Some(ucd1), None, None)
+      ab.shortChannelId -> PublicChannel(ab, ByteVector32.Zeroes, 0 sat, Some(uab1), Some(uab2), Some(ChannelMeta(1000 msat, 400 msat))),
+      cd.shortChannelId -> PublicChannel(cd, ByteVector32.Zeroes, 0 sat, Some(ucd1), None, None)
     )
 
     import fr.acinq.eclair.wire.QueryShortChannelIdsTlv.QueryFlagType._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRangeQueriesSpec.scala
@@ -91,14 +91,14 @@ class ChannelRangeQueriesSpec extends FunSuite {
     val a = randomKey.publicKey
     val b = randomKey.publicKey
     val ab = RouteCalculationSpec.makeChannel(123466L, a, b)
-    val (ab1, uab1) = RouteCalculationSpec.makeUpdateShort(ab.shortChannelId, ab.nodeId1, ab.nodeId2, 0 msat, 0, timestamp = now)
-    val (ab2, uab2) = RouteCalculationSpec.makeUpdateShort(ab.shortChannelId, ab.nodeId2, ab.nodeId1, 0 msat, 0, timestamp = now)
+    val uab1 = RouteCalculationSpec.makeUpdateShort(ab.shortChannelId, ab.nodeId1, ab.nodeId2, 0 msat, 0, timestamp = now)
+    val uab2 = RouteCalculationSpec.makeUpdateShort(ab.shortChannelId, ab.nodeId2, ab.nodeId1, 0 msat, 0, timestamp = now)
 
     val c = randomKey.publicKey
     val d = randomKey.publicKey
     val cd = RouteCalculationSpec.makeChannel(451312L, c, d)
-    val (cd1, ucd1) = RouteCalculationSpec.makeUpdateShort(cd.shortChannelId, cd.nodeId1, cd.nodeId2, 0 msat, 0, timestamp = now)
-    val (_, ucd2) = RouteCalculationSpec.makeUpdateShort(cd.shortChannelId, cd.nodeId2, cd.nodeId1, 0 msat, 0, timestamp = now)
+    val ucd1 = RouteCalculationSpec.makeUpdateShort(cd.shortChannelId, cd.nodeId1, cd.nodeId2, 0 msat, 0, timestamp = now)
+    val ucd2 = RouteCalculationSpec.makeUpdateShort(cd.shortChannelId, cd.nodeId2, cd.nodeId1, 0 msat, 0, timestamp = now)
 
     val e = randomKey.publicKey
     val f = randomKey.publicKey

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/NetworkStatsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/NetworkStatsSpec.scala
@@ -36,19 +36,19 @@ class NetworkStatsSpec extends FunSuite {
   test("network data missing") {
     assert(NetworkStats.computeStats(Nil) === None)
     assert(NetworkStats.computeStats(Seq(
-      PublicChannel(fakeChannelAnnouncement(randomKey.publicKey, randomKey.publicKey), randomBytes32, 10 sat, None, None),
-      PublicChannel(fakeChannelAnnouncement(randomKey.publicKey, randomKey.publicKey), randomBytes32, 15 sat, None, None)
+      PublicChannel(fakeChannelAnnouncement(randomKey.publicKey, randomKey.publicKey), randomBytes32, 10 sat, None, None, None, None),
+      PublicChannel(fakeChannelAnnouncement(randomKey.publicKey, randomKey.publicKey), randomBytes32, 15 sat, Some(10000 msat), None, Some(3000 msat), None)
     )) === None)
   }
 
   test("small network") {
     val nodes = Seq.fill(6)(randomKey.publicKey)
     val channels = Seq(
-      PublicChannel(fakeChannelAnnouncement(nodes(0), nodes(1)), randomBytes32, 10 sat, Some(fakeChannelUpdate1(CltvExpiryDelta(10), 10 msat, 10)), Some(fakeChannelUpdate2(CltvExpiryDelta(15), 15 msat, 15))),
-      PublicChannel(fakeChannelAnnouncement(nodes(1), nodes(2)), randomBytes32, 20 sat, None, Some(fakeChannelUpdate2(CltvExpiryDelta(25), 25 msat, 25))),
-      PublicChannel(fakeChannelAnnouncement(nodes(2), nodes(3)), randomBytes32, 30 sat, Some(fakeChannelUpdate1(CltvExpiryDelta(30), 30 msat, 30)), Some(fakeChannelUpdate2(CltvExpiryDelta(35), 35 msat, 35))),
-      PublicChannel(fakeChannelAnnouncement(nodes(3), nodes(4)), randomBytes32, 40 sat, Some(fakeChannelUpdate1(CltvExpiryDelta(40), 40 msat, 40)), None),
-      PublicChannel(fakeChannelAnnouncement(nodes(4), nodes(5)), randomBytes32, 50 sat, Some(fakeChannelUpdate1(CltvExpiryDelta(50), 50 msat, 50)), Some(fakeChannelUpdate2(CltvExpiryDelta(55), 55 msat, 55)))
+      PublicChannel(fakeChannelAnnouncement(nodes(0), nodes(1)), randomBytes32, 10 sat, None, Some(fakeChannelUpdate1(CltvExpiryDelta(10), 10 msat, 10)), None, Some(fakeChannelUpdate2(CltvExpiryDelta(15), 15 msat, 15))),
+      PublicChannel(fakeChannelAnnouncement(nodes(1), nodes(2)), randomBytes32, 20 sat, None, None, None, Some(fakeChannelUpdate2(CltvExpiryDelta(25), 25 msat, 25))),
+      PublicChannel(fakeChannelAnnouncement(nodes(2), nodes(3)), randomBytes32, 30 sat, Some(18000 msat), Some(fakeChannelUpdate1(CltvExpiryDelta(30), 30 msat, 30)), Some(12000 msat), Some(fakeChannelUpdate2(CltvExpiryDelta(35), 35 msat, 35))),
+      PublicChannel(fakeChannelAnnouncement(nodes(3), nodes(4)), randomBytes32, 40 sat, None, Some(fakeChannelUpdate1(CltvExpiryDelta(40), 40 msat, 40)), None, None),
+      PublicChannel(fakeChannelAnnouncement(nodes(4), nodes(5)), randomBytes32, 50 sat, None, Some(fakeChannelUpdate1(CltvExpiryDelta(50), 50 msat, 50)), None, Some(fakeChannelUpdate2(CltvExpiryDelta(55), 55 msat, 55)))
     )
     val Some(stats) = NetworkStats.computeStats(channels)
     assert(stats.channels === 5)
@@ -66,7 +66,9 @@ class NetworkStatsSpec extends FunSuite {
       fakeChannelAnnouncement(nodes(rand.nextInt(nodes.size)), nodes(rand.nextInt(nodes.size))),
       randomBytes32,
       Satoshi(1000 + rand.nextInt(10000)),
+      None,
       Some(fakeChannelUpdate1(CltvExpiryDelta(12 + rand.nextInt(144)), MilliSatoshi(21000 + rand.nextInt(79000)), rand.nextInt(1000))),
+      None,
       Some(fakeChannelUpdate2(CltvExpiryDelta(12 + rand.nextInt(144)), MilliSatoshi(21000 + rand.nextInt(79000)), rand.nextInt(1000)))
     ))
     val Some(stats) = NetworkStats.computeStats(channels)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/NetworkStatsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/NetworkStatsSpec.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.router
 
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.Satoshi
-import fr.acinq.eclair.router.Router.PublicChannel
+import fr.acinq.eclair.router.Router.{ChannelMeta, PublicChannel}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate}
 import fr.acinq.eclair.{CltvExpiryDelta, LongToBtcAmount, MilliSatoshi, ShortChannelId, randomBytes32, randomBytes64, randomKey}
 import org.scalatest.FunSuite
@@ -36,19 +36,19 @@ class NetworkStatsSpec extends FunSuite {
   test("network data missing") {
     assert(NetworkStats.computeStats(Nil) === None)
     assert(NetworkStats.computeStats(Seq(
-      PublicChannel(fakeChannelAnnouncement(randomKey.publicKey, randomKey.publicKey), randomBytes32, 10 sat, None, None, None, None),
-      PublicChannel(fakeChannelAnnouncement(randomKey.publicKey, randomKey.publicKey), randomBytes32, 15 sat, Some(10000 msat), None, Some(3000 msat), None)
+      PublicChannel(fakeChannelAnnouncement(randomKey.publicKey, randomKey.publicKey), randomBytes32, 10 sat, None, None, None),
+      PublicChannel(fakeChannelAnnouncement(randomKey.publicKey, randomKey.publicKey), randomBytes32, 15 sat, None, None, Some(ChannelMeta(10000 msat, 3000 msat)))
     )) === None)
   }
 
   test("small network") {
     val nodes = Seq.fill(6)(randomKey.publicKey)
     val channels = Seq(
-      PublicChannel(fakeChannelAnnouncement(nodes(0), nodes(1)), randomBytes32, 10 sat, None, Some(fakeChannelUpdate1(CltvExpiryDelta(10), 10 msat, 10)), None, Some(fakeChannelUpdate2(CltvExpiryDelta(15), 15 msat, 15))),
-      PublicChannel(fakeChannelAnnouncement(nodes(1), nodes(2)), randomBytes32, 20 sat, None, None, None, Some(fakeChannelUpdate2(CltvExpiryDelta(25), 25 msat, 25))),
-      PublicChannel(fakeChannelAnnouncement(nodes(2), nodes(3)), randomBytes32, 30 sat, Some(18000 msat), Some(fakeChannelUpdate1(CltvExpiryDelta(30), 30 msat, 30)), Some(12000 msat), Some(fakeChannelUpdate2(CltvExpiryDelta(35), 35 msat, 35))),
-      PublicChannel(fakeChannelAnnouncement(nodes(3), nodes(4)), randomBytes32, 40 sat, None, Some(fakeChannelUpdate1(CltvExpiryDelta(40), 40 msat, 40)), None, None),
-      PublicChannel(fakeChannelAnnouncement(nodes(4), nodes(5)), randomBytes32, 50 sat, None, Some(fakeChannelUpdate1(CltvExpiryDelta(50), 50 msat, 50)), None, Some(fakeChannelUpdate2(CltvExpiryDelta(55), 55 msat, 55)))
+      PublicChannel(fakeChannelAnnouncement(nodes(0), nodes(1)), randomBytes32, 10 sat, Some(fakeChannelUpdate1(CltvExpiryDelta(10), 10 msat, 10)), Some(fakeChannelUpdate2(CltvExpiryDelta(15), 15 msat, 15)), None),
+      PublicChannel(fakeChannelAnnouncement(nodes(1), nodes(2)), randomBytes32, 20 sat, None, Some(fakeChannelUpdate2(CltvExpiryDelta(25), 25 msat, 25)), None),
+      PublicChannel(fakeChannelAnnouncement(nodes(2), nodes(3)), randomBytes32, 30 sat, Some(fakeChannelUpdate1(CltvExpiryDelta(30), 30 msat, 30)), Some(fakeChannelUpdate2(CltvExpiryDelta(35), 35 msat, 35)), Some(ChannelMeta(18000 msat, 12000 msat))),
+      PublicChannel(fakeChannelAnnouncement(nodes(3), nodes(4)), randomBytes32, 40 sat, Some(fakeChannelUpdate1(CltvExpiryDelta(40), 40 msat, 40)), None, None),
+      PublicChannel(fakeChannelAnnouncement(nodes(4), nodes(5)), randomBytes32, 50 sat, Some(fakeChannelUpdate1(CltvExpiryDelta(50), 50 msat, 50)), Some(fakeChannelUpdate2(CltvExpiryDelta(55), 55 msat, 55)), None)
     )
     val Some(stats) = NetworkStats.computeStats(channels)
     assert(stats.channels === 5)
@@ -66,10 +66,9 @@ class NetworkStatsSpec extends FunSuite {
       fakeChannelAnnouncement(nodes(rand.nextInt(nodes.size)), nodes(rand.nextInt(nodes.size))),
       randomBytes32,
       Satoshi(1000 + rand.nextInt(10000)),
-      None,
       Some(fakeChannelUpdate1(CltvExpiryDelta(12 + rand.nextInt(144)), MilliSatoshi(21000 + rand.nextInt(79000)), rand.nextInt(1000))),
-      None,
-      Some(fakeChannelUpdate2(CltvExpiryDelta(12 + rand.nextInt(144)), MilliSatoshi(21000 + rand.nextInt(79000)), rand.nextInt(1000)))
+      Some(fakeChannelUpdate2(CltvExpiryDelta(12 + rand.nextInt(144)), MilliSatoshi(21000 + rand.nextInt(79000)), rand.nextInt(1000))),
+      None
     ))
     val Some(stats) = NetworkStats.computeStats(channels)
     assert(stats.channels === 500)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -540,7 +540,7 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
     val publicChannels = channels.map { case (shortChannelId, announcement) =>
       val (_, update) = updates.find { case (d, _) => d.shortChannelId == shortChannelId }.get
       val (update_1_opt, update_2_opt) = if (Announcements.isNode1(update.channelFlags)) (Some(update), None) else (None, Some(update))
-      val pc = PublicChannel(announcement, ByteVector32.Zeroes, Satoshi(1000), update_1_opt, update_2_opt)
+      val pc = PublicChannel(announcement, ByteVector32.Zeroes, Satoshi(1000), None, update_1_opt, None, update_2_opt)
       (shortChannelId, pc)
     }
 
@@ -892,21 +892,27 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
         ann = makeChannel(ShortChannelId("565643x1216x0").toLong, PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"), PublicKey(hex"024655b768ef40951b20053a5c4b951606d4d86085d51238f2c67c7dec29c792ca")),
         fundingTxid = ByteVector32.Zeroes,
         capacity = 0 sat,
+        balance_1_opt = None,
         update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565643x1216x0"), 0, 1.toByte, 0.toByte, CltvExpiryDelta(14), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 10, Some(4294967295L msat))),
+        balance_2_opt = None,
         update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565643x1216x0"), 0, 1.toByte, 1.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 0 msat, feeBaseMsat = 1000 msat, 100, Some(15000000000L msat)))
       ),
       ShortChannelId("542280x2156x0") -> PublicChannel(
         ann = makeChannel(ShortChannelId("542280x2156x0").toLong, PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"), PublicKey(hex"03cb7983dc247f9f81a0fa2dfa3ce1c255365f7279c8dd143e086ca333df10e278")),
         fundingTxid = ByteVector32.Zeroes,
         capacity = 0 sat,
+        balance_1_opt = None,
         update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("542280x2156x0"), 0, 1.toByte, 0.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 1000 msat, feeBaseMsat = 1000 msat, 100, Some(16777000000L msat))),
+        balance_2_opt = None,
         update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("542280x2156x0"), 0, 1.toByte, 1.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 667 msat, 1, Some(16777000000L msat)))
       ),
       ShortChannelId("565779x2711x0") -> PublicChannel(
         ann = makeChannel(ShortChannelId("565779x2711x0").toLong, PublicKey(hex"036d65409c41ab7380a43448f257809e7496b52bf92057c09c4f300cbd61c50d96"), PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f")),
         fundingTxid = ByteVector32.Zeroes,
         capacity = 0 sat,
+        balance_1_opt = None,
         update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565779x2711x0"), 0, 1.toByte, 0.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 100, Some(230000000L msat))),
+        balance_2_opt = None,
         update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565779x2711x0"), 0, 1.toByte, 3.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 100, Some(230000000L msat)))
       )
     )

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -493,7 +493,7 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
     val publicChannels = channels.map { case (shortChannelId, announcement) =>
       val update = edges.find(_.desc.shortChannelId == shortChannelId).get.update
       val (update_1_opt, update_2_opt) = if (Announcements.isNode1(update.channelFlags)) (Some(update), None) else (None, Some(update))
-      val pc = PublicChannel(announcement, ByteVector32.Zeroes, Satoshi(1000), None, update_1_opt, None, update_2_opt)
+      val pc = PublicChannel(announcement, ByteVector32.Zeroes, Satoshi(1000), update_1_opt, update_2_opt, None)
       (shortChannelId, pc)
     }
 
@@ -828,28 +828,25 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
         ann = makeChannel(ShortChannelId("565643x1216x0").toLong, PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"), PublicKey(hex"024655b768ef40951b20053a5c4b951606d4d86085d51238f2c67c7dec29c792ca")),
         fundingTxid = ByteVector32.Zeroes,
         capacity = 0 sat,
-        balance_1_opt = None,
         update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565643x1216x0"), 0, 1.toByte, 0.toByte, CltvExpiryDelta(14), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 10, Some(4294967295L msat))),
-        balance_2_opt = None,
-        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565643x1216x0"), 0, 1.toByte, 1.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 0 msat, feeBaseMsat = 1000 msat, 100, Some(15000000000L msat)))
+        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565643x1216x0"), 0, 1.toByte, 1.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 0 msat, feeBaseMsat = 1000 msat, 100, Some(15000000000L msat))),
+        meta_opt = None
       ),
       ShortChannelId("542280x2156x0") -> PublicChannel(
         ann = makeChannel(ShortChannelId("542280x2156x0").toLong, PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"), PublicKey(hex"03cb7983dc247f9f81a0fa2dfa3ce1c255365f7279c8dd143e086ca333df10e278")),
         fundingTxid = ByteVector32.Zeroes,
         capacity = 0 sat,
-        balance_1_opt = None,
         update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("542280x2156x0"), 0, 1.toByte, 0.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 1000 msat, feeBaseMsat = 1000 msat, 100, Some(16777000000L msat))),
-        balance_2_opt = None,
-        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("542280x2156x0"), 0, 1.toByte, 1.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 667 msat, 1, Some(16777000000L msat)))
+        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("542280x2156x0"), 0, 1.toByte, 1.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 667 msat, 1, Some(16777000000L msat))),
+        meta_opt = None
       ),
       ShortChannelId("565779x2711x0") -> PublicChannel(
         ann = makeChannel(ShortChannelId("565779x2711x0").toLong, PublicKey(hex"036d65409c41ab7380a43448f257809e7496b52bf92057c09c4f300cbd61c50d96"), PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f")),
         fundingTxid = ByteVector32.Zeroes,
         capacity = 0 sat,
-        balance_1_opt = None,
         update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565779x2711x0"), 0, 1.toByte, 0.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 100, Some(230000000L msat))),
-        balance_2_opt = None,
-        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565779x2711x0"), 0, 1.toByte, 3.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 100, Some(230000000L msat)))
+        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565779x2711x0"), 0, 1.toByte, 3.toByte, CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 100, Some(230000000L msat))),
+        meta_opt = None
       )
     )
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -44,14 +44,12 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
   val (a, b, c, d, e, f) = (randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey, randomKey.publicKey)
 
   test("calculate simple route") {
-    val updates = List(
-      makeUpdate(1L, a, b, 1 msat, 10, cltvDelta = CltvExpiryDelta(1)),
-      makeUpdate(2L, b, c, 1 msat, 10, cltvDelta = CltvExpiryDelta(1)),
-      makeUpdate(3L, c, d, 1 msat, 10, cltvDelta = CltvExpiryDelta(1)),
-      makeUpdate(4L, d, e, 1 msat, 10, cltvDelta = CltvExpiryDelta(1))
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 1 msat, 10, cltvDelta = CltvExpiryDelta(1)),
+      makeEdge(2L, b, c, 1 msat, 10, cltvDelta = CltvExpiryDelta(1)),
+      makeEdge(3L, c, d, 1 msat, 10, cltvDelta = CltvExpiryDelta(1)),
+      makeEdge(4L, d, e, 1 msat, 10, cltvDelta = CltvExpiryDelta(1))
+    ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
 
@@ -67,14 +65,12 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
     // so our fee will always be above the base fee, and we will always check that it is below our maximum percentage
     // of the amount being paid
 
-    val updates = List(
-      makeUpdate(1L, a, b, 10 msat, 10, cltvDelta = CltvExpiryDelta(1)),
-      makeUpdate(2L, b, c, 10 msat, 10, cltvDelta = CltvExpiryDelta(1)),
-      makeUpdate(3L, c, d, 10 msat, 10, cltvDelta = CltvExpiryDelta(1)),
-      makeUpdate(4L, d, e, 10 msat, 10, cltvDelta = CltvExpiryDelta(1))
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 10 msat, 10, cltvDelta = CltvExpiryDelta(1)),
+      makeEdge(2L, b, c, 10 msat, 10, cltvDelta = CltvExpiryDelta(1)),
+      makeEdge(3L, c, d, 10 msat, 10, cltvDelta = CltvExpiryDelta(1)),
+      makeEdge(4L, d, e, 10 msat, 10, cltvDelta = CltvExpiryDelta(1))
+    ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(maxFeeBase = 1 msat), currentBlockHeight = 400000)
 
@@ -102,16 +98,14 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
     val amount = 10000 msat
     val expectedCost = 10007 msat
 
-    val updates = List(
-      makeUpdate(1L, a, b, feeBase = 1 msat, feeProportionalMillionth = 200, minHtlc = 0 msat),
-      makeUpdate(4L, a, e, feeBase = 1 msat, feeProportionalMillionth = 200, minHtlc = 0 msat),
-      makeUpdate(2L, b, c, feeBase = 1 msat, feeProportionalMillionth = 300, minHtlc = 0 msat),
-      makeUpdate(3L, c, d, feeBase = 1 msat, feeProportionalMillionth = 400, minHtlc = 0 msat),
-      makeUpdate(5L, e, f, feeBase = 1 msat, feeProportionalMillionth = 400, minHtlc = 0 msat),
-      makeUpdate(6L, f, d, feeBase = 1 msat, feeProportionalMillionth = 100, minHtlc = 0 msat)
-    ).toMap
-
-    val graph = makeGraph(updates)
+    val graph = DirectedGraph(List(
+      makeEdge(1L, a, b, feeBase = 1 msat, feeProportionalMillionth = 200, minHtlc = 0 msat),
+      makeEdge(4L, a, e, feeBase = 1 msat, feeProportionalMillionth = 200, minHtlc = 0 msat),
+      makeEdge(2L, b, c, feeBase = 1 msat, feeProportionalMillionth = 300, minHtlc = 0 msat),
+      makeEdge(3L, c, d, feeBase = 1 msat, feeProportionalMillionth = 400, minHtlc = 0 msat),
+      makeEdge(5L, e, f, feeBase = 1 msat, feeProportionalMillionth = 400, minHtlc = 0 msat),
+      makeEdge(6L, f, d, feeBase = 1 msat, feeProportionalMillionth = 100, minHtlc = 0 msat)
+    ))
 
     val Success(route) = findRoute(graph, a, d, amount, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
 
@@ -121,8 +115,7 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
     assert(totalCost === expectedCost)
 
     // now channel 5 could route the amount (10000) but not the amount + fees (10007)
-    val (desc, update) = makeUpdate(5L, e, f, feeBase = 1 msat, feeProportionalMillionth = 400, minHtlc = 0 msat, maxHtlc = Some(10005 msat))
-    val graph1 = graph.addEdge(desc, update)
+    val graph1 = graph.addEdge(makeEdge(5L, e, f, feeBase = 1 msat, feeProportionalMillionth = 400, minHtlc = 0 msat, maxHtlc = Some(10005 msat)))
 
     val Success(route1) = findRoute(graph1, a, d, amount, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
 
@@ -130,29 +123,25 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
   }
 
   test("calculate route considering the direct channel pays no fees") {
-    val updates = List(
-      makeUpdate(1L, a, b, 5 msat, 0), // a -> b
-      makeUpdate(2L, a, d, 15 msat, 0), // a -> d  this goes a bit closer to the target and asks for higher fees but is a direct channel
-      makeUpdate(3L, b, c, 5 msat, 0), // b -> c
-      makeUpdate(4L, c, d, 5 msat, 0), // c -> d
-      makeUpdate(5L, d, e, 5 msat, 0) // d -> e
-    ).toMap
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 5 msat, 0), // a -> b
+      makeEdge(2L, a, d, 15 msat, 0), // a -> d  this goes a bit closer to the target and asks for higher fees but is a direct channel
+      makeEdge(3L, b, c, 5 msat, 0), // b -> c
+      makeEdge(4L, c, d, 5 msat, 0), // c -> d
+      makeEdge(5L, d, e, 5 msat, 0) // d -> e
+    ))
 
-    val g = makeGraph(updates)
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-
     assert(route.map(hops2Ids) === Success(2 :: 5 :: Nil))
   }
 
   test("calculate simple route (add and remove edges") {
-    val updates = List(
-      makeUpdate(1L, a, b, 0 msat, 0),
-      makeUpdate(2L, b, c, 0 msat, 0),
-      makeUpdate(3L, c, d, 0 msat, 0),
-      makeUpdate(4L, d, e, 0 msat, 0)
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 0 msat, 0),
+      makeEdge(2L, b, c, 0 msat, 0),
+      makeEdge(3L, c, d, 0 msat, 0),
+      makeEdge(4L, d, e, 0 msat, 0)
+    ))
 
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route1.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
@@ -170,14 +159,12 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
       PublicKey(hex"029e059b6780f155f38e83601969919aae631ddf6faed58fe860c72225eb327d7c") // target
     )
 
-    val updates = List(
-      makeUpdate(1L, f, g, 0 msat, 0),
-      makeUpdate(2L, g, h, 0 msat, 0),
-      makeUpdate(3L, h, i, 0 msat, 0),
-      makeUpdate(4L, f, h, 50 msat, 0) // more expensive
-    ).toMap
-
-    val graph = makeGraph(updates)
+    val graph = DirectedGraph(List(
+      makeEdge(1L, f, g, 0 msat, 0),
+      makeEdge(2L, g, h, 0 msat, 0),
+      makeEdge(3L, h, i, 0 msat, 0),
+      makeEdge(4L, f, h, 50 msat, 0) // more expensive
+    ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Success(4 :: 3 :: Nil))
@@ -192,14 +179,12 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
       PublicKey(hex"029e059b6780f155f38e83601969919aae631ddf6faed58fe860c72225eb327d7c") // target
     )
 
-    val updates = List(
-      makeUpdate(1L, f, g, 0 msat, 0),
-      makeUpdate(4L, f, i, 50 msat, 0), // our starting node F has a direct channel with I
-      makeUpdate(2L, g, h, 0 msat, 0),
-      makeUpdate(3L, h, i, 0 msat, 0)
-    ).toMap
-
-    val graph = makeGraph(updates)
+    val graph = DirectedGraph(List(
+      makeEdge(1L, f, g, 0 msat, 0),
+      makeEdge(4L, f, i, 50 msat, 0), // our starting node F has a direct channel with I
+      makeEdge(2L, g, h, 0 msat, 0),
+      makeEdge(3L, h, i, 0 msat, 0)
+    ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 2, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Success(4 :: Nil))
@@ -213,14 +198,12 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
       PublicKey(hex"029e059b6780f155f38e83601969919aae631ddf6faed58fe860c72225eb327d7c") // I target
     )
 
-    val updates = List(
-      makeUpdate(1L, f, g, 1 msat, 0),
+    val graph = DirectedGraph(List(
+      makeEdge(1L, f, g, 1 msat, 0),
       // the maximum htlc allowed by this channel is only 50msat greater than what we're sending
-      makeUpdate(2L, g, h, 1 msat, 0, maxHtlc = Some(DEFAULT_AMOUNT_MSAT + 50.msat)),
-      makeUpdate(3L, h, i, 1 msat, 0)
-    ).toMap
-
-    val graph = makeGraph(updates)
+      makeEdge(2L, g, h, 1 msat, 0, maxHtlc = Some(DEFAULT_AMOUNT_MSAT + 50.msat)),
+      makeEdge(3L, h, i, 1 msat, 0)
+    ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) == Success(1 :: 2 :: 3 :: Nil))
@@ -234,14 +217,12 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
       PublicKey(hex"029e059b6780f155f38e83601969919aae631ddf6faed58fe860c72225eb327d7c") // I target
     )
 
-    val updates = List(
-      makeUpdate(1L, f, g, 1 msat, 0),
+    val graph = DirectedGraph(List(
+      makeEdge(1L, f, g, 1 msat, 0),
       // this channel requires a minimum amount that is larger than what we are sending
-      makeUpdate(2L, g, h, 1 msat, 0, minHtlc = DEFAULT_AMOUNT_MSAT + 50.msat),
-      makeUpdate(3L, h, i, 1 msat, 0)
-    ).toMap
-
-    val graph = makeGraph(updates)
+      makeEdge(2L, g, h, 1 msat, 0, minHtlc = DEFAULT_AMOUNT_MSAT + 50.msat),
+      makeEdge(3L, h, i, 1 msat, 0)
+    ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Failure(RouteNotFound))
@@ -255,66 +236,56 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
       PublicKey(hex"029e059b6780f155f38e83601969919aae631ddf6faed58fe860c72225eb327d7c") // I target
     )
 
-    val updates = List(
-      makeUpdate(1L, f, g, 0 msat, 0),
-      makeUpdate(2L, g, h, 5 msat, 5), // expensive  g -> h channel
-      makeUpdate(6L, g, h, 0 msat, 0), // cheap      g -> h channel
-      makeUpdate(3L, h, i, 0 msat, 0)
-    ).toMap
-
-    val graph = makeGraph(updates)
+    val graph = DirectedGraph(List(
+      makeEdge(1L, f, g, 0 msat, 0),
+      makeEdge(2L, g, h, 5 msat, 5), // expensive  g -> h channel
+      makeEdge(6L, g, h, 0 msat, 0), // cheap      g -> h channel
+      makeEdge(3L, h, i, 0 msat, 0)
+    ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Success(1 :: 6 :: 3 :: Nil))
   }
 
   test("calculate longer but cheaper route") {
-    val updates = List(
-      makeUpdate(1L, a, b, 0 msat, 0),
-      makeUpdate(2L, b, c, 0 msat, 0),
-      makeUpdate(3L, c, d, 0 msat, 0),
-      makeUpdate(4L, d, e, 0 msat, 0),
-      makeUpdate(5L, b, e, 10 msat, 10)
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 0 msat, 0),
+      makeEdge(2L, b, c, 0 msat, 0),
+      makeEdge(3L, c, d, 0 msat, 0),
+      makeEdge(4L, d, e, 0 msat, 0),
+      makeEdge(5L, b, e, 10 msat, 10)
+    ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
   }
 
   test("no local channels") {
-    val updates = List(
-      makeUpdate(2L, b, c, 0 msat, 0),
-      makeUpdate(4L, d, e, 0 msat, 0)
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(2L, b, c, 0 msat, 0),
+      makeEdge(4L, d, e, 0 msat, 0)
+    ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Failure(RouteNotFound))
   }
 
   test("route not found") {
-    val updates = List(
-      makeUpdate(1L, a, b, 0 msat, 0),
-      makeUpdate(2L, b, c, 0 msat, 0),
-      makeUpdate(4L, d, e, 0 msat, 0)
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 0 msat, 0),
+      makeEdge(2L, b, c, 0 msat, 0),
+      makeEdge(4L, d, e, 0 msat, 0)
+    ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Failure(RouteNotFound))
   }
 
   test("route not found (source OR target node not connected)") {
-    val updates = List(
-      makeUpdate(2L, b, c, 0 msat, 0),
-      makeUpdate(4L, c, d, 0 msat, 0)
-    ).toMap
-
-    val g = makeGraph(updates).addVertex(a).addVertex(e)
+    val g = DirectedGraph(List(
+      makeEdge(2L, b, c, 0 msat, 0),
+      makeEdge(4L, c, d, 0 msat, 0)
+    )).addVertex(a).addVertex(e)
 
     assert(findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000) === Failure(RouteNotFound))
     assert(findRoute(g, b, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000) === Failure(RouteNotFound))
@@ -324,63 +295,56 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
     val highAmount = DEFAULT_AMOUNT_MSAT * 10
     val lowAmount = DEFAULT_AMOUNT_MSAT / 10
 
-    val updatesHi = List(
-      makeUpdate(1L, a, b, 0 msat, 0),
-      makeUpdate(2L, b, c, 0 msat, 0, maxHtlc = Some(DEFAULT_AMOUNT_MSAT)),
-      makeUpdate(3L, c, d, 0 msat, 0)
-    ).toMap
+    val edgesHi = List(
+      makeEdge(1L, a, b, 0 msat, 0),
+      makeEdge(2L, b, c, 0 msat, 0, maxHtlc = Some(DEFAULT_AMOUNT_MSAT)),
+      makeEdge(3L, c, d, 0 msat, 0)
+    )
 
-    val updatesLo = List(
-      makeUpdate(1L, a, b, 0 msat, 0),
-      makeUpdate(2L, b, c, 0 msat, 0, minHtlc = DEFAULT_AMOUNT_MSAT),
-      makeUpdate(3L, c, d, 0 msat, 0)
-    ).toMap
+    val edgesLo = List(
+      makeEdge(1L, a, b, 0 msat, 0),
+      makeEdge(2L, b, c, 0 msat, 0, minHtlc = DEFAULT_AMOUNT_MSAT),
+      makeEdge(3L, c, d, 0 msat, 0)
+    )
 
-    val g = makeGraph(updatesHi)
-    val g1 = makeGraph(updatesLo)
+    val g = DirectedGraph(edgesHi)
+    val g1 = DirectedGraph(edgesLo)
 
     assert(findRoute(g, a, d, highAmount, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000) === Failure(RouteNotFound))
     assert(findRoute(g1, a, d, lowAmount, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000) === Failure(RouteNotFound))
   }
 
   test("route to self") {
-    val updates = List(
-      makeUpdate(1L, a, b, 0 msat, 0),
-      makeUpdate(2L, b, c, 0 msat, 0),
-      makeUpdate(3L, c, d, 0 msat, 0)
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 0 msat, 0),
+      makeEdge(2L, b, c, 0 msat, 0),
+      makeEdge(3L, c, d, 0 msat, 0)
+    ))
 
     val route = findRoute(g, a, a, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Failure(CannotRouteToSelf))
   }
 
   test("route to immediate neighbor") {
-    val updates = List(
-      makeUpdate(1L, a, b, 0 msat, 0),
-      makeUpdate(2L, b, c, 0 msat, 0),
-      makeUpdate(3L, c, d, 0 msat, 0),
-      makeUpdate(4L, d, e, 0 msat, 0)
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 0 msat, 0),
+      makeEdge(2L, b, c, 0 msat, 0),
+      makeEdge(3L, c, d, 0 msat, 0),
+      makeEdge(4L, d, e, 0 msat, 0)
+    ))
 
     val route = findRoute(g, a, b, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Success(1 :: Nil))
   }
 
   test("directed graph") {
-    val updates = List(
-      makeUpdate(1L, a, b, 0 msat, 0),
-      makeUpdate(2L, b, c, 0 msat, 0),
-      makeUpdate(3L, c, d, 0 msat, 0),
-      makeUpdate(4L, d, e, 0 msat, 0)
-    ).toMap
-
     // a->e works, e->a fails
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 0 msat, 0),
+      makeEdge(2L, b, c, 0 msat, 0),
+      makeEdge(3L, c, d, 0 msat, 0),
+      makeEdge(4L, d, e, 0 msat, 0)
+    ))
 
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route1.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
@@ -401,18 +365,18 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
     val ude = ChannelUpdate(DUMMY_SIG, Block.RegtestGenesisBlock.hash, ShortChannelId(4L), 1L, 0, 0, CltvExpiryDelta(1), 48 msat, 2506 msat, 146, None)
     val ued = ChannelUpdate(DUMMY_SIG, Block.RegtestGenesisBlock.hash, ShortChannelId(4L), 1L, 0, 1, CltvExpiryDelta(1), 49 msat, 2507 msat, 147, None)
 
-    val updates = Map(
-      ChannelDesc(ShortChannelId(1L), a, b) -> uab,
-      ChannelDesc(ShortChannelId(1L), b, a) -> uba,
-      ChannelDesc(ShortChannelId(2L), b, c) -> ubc,
-      ChannelDesc(ShortChannelId(2L), c, b) -> ucb,
-      ChannelDesc(ShortChannelId(3L), c, d) -> ucd,
-      ChannelDesc(ShortChannelId(3L), d, c) -> udc,
-      ChannelDesc(ShortChannelId(4L), d, e) -> ude,
-      ChannelDesc(ShortChannelId(4L), e, d) -> ued
+    val edges = Seq(
+      GraphEdge(ChannelDesc(ShortChannelId(1L), a, b), uab, 0 sat, None),
+      GraphEdge(ChannelDesc(ShortChannelId(1L), b, a), uba, 0 sat, None),
+      GraphEdge(ChannelDesc(ShortChannelId(2L), b, c), ubc, 0 sat, None),
+      GraphEdge(ChannelDesc(ShortChannelId(2L), c, b), ucb, 0 sat, None),
+      GraphEdge(ChannelDesc(ShortChannelId(3L), c, d), ucd, 0 sat, None),
+      GraphEdge(ChannelDesc(ShortChannelId(3L), d, c), udc, 0 sat, None),
+      GraphEdge(ChannelDesc(ShortChannelId(4L), d, e), ude, 0 sat, None),
+      GraphEdge(ChannelDesc(ShortChannelId(4L), e, d), ued, 0 sat, None)
     )
 
-    val g = makeGraph(updates)
+    val g = DirectedGraph(edges)
 
     val hops = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).get
 
@@ -442,20 +406,18 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
   }
 
   test("blacklist routes") {
-    val updates = List(
-      makeUpdate(1L, a, b, 0 msat, 0),
-      makeUpdate(2L, b, c, 0 msat, 0),
-      makeUpdate(3L, c, d, 0 msat, 0),
-      makeUpdate(4L, d, e, 0 msat, 0)
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 0 msat, 0),
+      makeEdge(2L, b, c, 0 msat, 0),
+      makeEdge(3L, c, d, 0 msat, 0),
+      makeEdge(4L, d, e, 0 msat, 0)
+    ))
 
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, ignoredEdges = Set(ChannelDesc(ShortChannelId(3L), c, d)), routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route1.map(hops2Ids) === Failure(RouteNotFound))
 
     // verify that we left the graph untouched
-    assert(g.containsEdge(makeUpdate(3L, c, d, 0 msat, 0)._1)) // c -> d
+    assert(g.containsEdge(ChannelDesc(ShortChannelId(3), c, d)))
     assert(g.containsVertex(c))
     assert(g.containsVertex(d))
 
@@ -465,43 +427,34 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
   }
 
   test("route to a destination that is not in the graph (with assisted routes)") {
-    val updates = List(
-      makeUpdate(1L, a, b, 10 msat, 10),
-      makeUpdate(2L, b, c, 10 msat, 10),
-      makeUpdate(3L, c, d, 10 msat, 10)
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 10 msat, 10),
+      makeEdge(2L, b, c, 10 msat, 10),
+      makeEdge(3L, c, d, 10 msat, 10)
+    ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Failure(RouteNotFound))
 
     // now we add the missing edge to reach the destination
-    val (extraDesc, extraUpdate) = makeUpdate(4L, d, e, 5 msat, 5)
-    val extraGraphEdges = Set(GraphEdge(extraDesc, extraUpdate))
-
+    val extraGraphEdges = Set(makeEdge(4L, d, e, 5 msat, 5))
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, extraEdges = extraGraphEdges, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route1.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
   }
 
   test("verify that extra hops takes precedence over known channels") {
-    val updates = List(
-      makeUpdate(1L, a, b, 10 msat, 10),
-      makeUpdate(2L, b, c, 10 msat, 10),
-      makeUpdate(3L, c, d, 10 msat, 10),
-      makeUpdate(4L, d, e, 10 msat, 10)
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 10 msat, 10),
+      makeEdge(2L, b, c, 10 msat, 10),
+      makeEdge(3L, c, d, 10 msat, 10),
+      makeEdge(4L, d, e, 10 msat, 10)
+    ))
 
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route1.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
     assert(route1.get(1).lastUpdate.feeBaseMsat === 10.msat)
 
-    val (extraDesc, extraUpdate) = makeUpdate(2L, b, c, 5 msat, 5)
-
-    val extraGraphEdges = Set(GraphEdge(extraDesc, extraUpdate))
-
+    val extraGraphEdges = Set(makeEdge(2L, b, c, 5 msat, 5))
     val route2 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, extraEdges = extraGraphEdges, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route2.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
     assert(route2.get(1).lastUpdate.feeBaseMsat === 5.msat)
@@ -525,27 +478,26 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
       ShortChannelId(8L) -> makeChannel(8L, i, j)
     )
 
-    val updates = List(
-      makeUpdate(1L, a, b, 10 msat, 10),
-      makeUpdate(2L, b, c, 10 msat, 10),
-      makeUpdate(2L, c, b, 10 msat, 10),
-      makeUpdate(3L, c, d, 10 msat, 10),
-      makeUpdate(4L, d, e, 10 msat, 10),
-      makeUpdate(5L, f, g, 10 msat, 10),
-      makeUpdate(6L, f, h, 10 msat, 10),
-      makeUpdate(7L, h, i, 10 msat, 10),
-      makeUpdate(8L, i, j, 10 msat, 10)
-    ).toMap
+    val edges = List(
+      makeEdge(1L, a, b, 10 msat, 10),
+      makeEdge(2L, b, c, 10 msat, 10),
+      makeEdge(2L, c, b, 10 msat, 10),
+      makeEdge(3L, c, d, 10 msat, 10),
+      makeEdge(4L, d, e, 10 msat, 10),
+      makeEdge(5L, f, g, 10 msat, 10),
+      makeEdge(6L, f, h, 10 msat, 10),
+      makeEdge(7L, h, i, 10 msat, 10),
+      makeEdge(8L, i, j, 10 msat, 10)
+    )
 
     val publicChannels = channels.map { case (shortChannelId, announcement) =>
-      val (_, update) = updates.find { case (d, _) => d.shortChannelId == shortChannelId }.get
+      val update = edges.find(_.desc.shortChannelId == shortChannelId).get.update
       val (update_1_opt, update_2_opt) = if (Announcements.isNode1(update.channelFlags)) (Some(update), None) else (None, Some(update))
       val pc = PublicChannel(announcement, ByteVector32.Zeroes, Satoshi(1000), None, update_1_opt, None, update_2_opt)
       (shortChannelId, pc)
     }
 
     val ignored = getIgnoredChannelDesc(publicChannels, ignoreNodes = Set(c, j, randomKey.publicKey))
-
     assert(ignored.toSet.contains(ChannelDesc(ShortChannelId(2L), b, c)))
     assert(ignored.toSet.contains(ChannelDesc(ShortChannelId(2L), c, b)))
     assert(ignored.toSet.contains(ChannelDesc(ShortChannelId(3L), c, d)))
@@ -554,13 +506,12 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
 
   test("limit routes to 20 hops") {
     val nodes = (for (_ <- 0 until 22) yield randomKey.publicKey).toList
-    val updates = nodes
+    val edges = nodes
       .zip(nodes.drop(1)) // (0, 1) :: (1, 2) :: ...
       .zipWithIndex // ((0, 1), 0) :: ((1, 2), 1) :: ...
-      .map { case ((na, nb), index) => makeUpdate(index, na, nb, 5 msat, 0) }
-      .toMap
+      .map { case ((na, nb), index) => makeEdge(index, na, nb, 5 msat, 0) }
 
-    val g = makeGraph(updates)
+    val g = DirectedGraph(edges)
 
     assert(findRoute(g, nodes(0), nodes(18), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).map(hops2Ids) === Success(0 until 18))
     assert(findRoute(g, nodes(0), nodes(19), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).map(hops2Ids) === Success(0 until 19))
@@ -571,15 +522,14 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
   test("ignore cheaper route when it has more than 20 hops") {
     val nodes = (for (_ <- 0 until 50) yield randomKey.publicKey).toList
 
-    val updates = nodes
+    val edges = nodes
       .zip(nodes.drop(1)) // (0, 1) :: (1, 2) :: ...
       .zipWithIndex // ((0, 1), 0) :: ((1, 2), 1) :: ...
-      .map { case ((na, nb), index) => makeUpdate(index, na, nb, 1 msat, 0) }
-      .toMap
+      .map { case ((na, nb), index) => makeEdge(index, na, nb, 1 msat, 0) }
 
-    val updates2 = updates + makeUpdate(99, nodes(2), nodes(48), 1000 msat, 0) // expensive shorter route
+    val expensiveShortEdge = makeEdge(99, nodes(2), nodes(48), 1000 msat, 0) // expensive shorter route
 
-    val g = makeGraph(updates2)
+    val g = DirectedGraph(expensiveShortEdge :: edges)
 
     val route = findRoute(g, nodes(0), nodes(49), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Success(0 :: 1 :: 99 :: 48 :: Nil))
@@ -587,15 +537,14 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
 
   test("ignore cheaper route when it has more than the requested CLTV") {
     val f = randomKey.publicKey
-
-    val g = makeGraph(List(
-      makeUpdate(1, a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(50)),
-      makeUpdate(2, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(50)),
-      makeUpdate(3, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(50)),
-      makeUpdate(4, a, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
-      makeUpdate(5, e, f, feeBase = 5 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
-      makeUpdate(6, f, d, feeBase = 5 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9))
-    ).toMap)
+    val g = DirectedGraph(List(
+      makeEdge(1, a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(50)),
+      makeEdge(2, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(50)),
+      makeEdge(3, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(50)),
+      makeEdge(4, a, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
+      makeEdge(5, e, f, feeBase = 5 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
+      makeEdge(6, f, d, feeBase = 5 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9))
+    ))
 
     val route = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(routeMaxCltv = CltvExpiryDelta(28)), currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Success(4 :: 5 :: 6 :: Nil))
@@ -603,30 +552,27 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
 
   test("ignore cheaper route when it grows longer than the requested size") {
     val f = randomKey.publicKey
-
-    val g = makeGraph(List(
-      makeUpdate(1, a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
-      makeUpdate(2, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
-      makeUpdate(3, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
-      makeUpdate(4, d, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
-      makeUpdate(5, e, f, feeBase = 5 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
-      makeUpdate(6, b, f, feeBase = 5 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9))
-    ).toMap)
+    val g = DirectedGraph(List(
+      makeEdge(1, a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
+      makeEdge(2, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
+      makeEdge(3, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
+      makeEdge(4, d, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
+      makeEdge(5, e, f, feeBase = 5 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
+      makeEdge(6, b, f, feeBase = 5 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9))
+    ))
 
     val route = findRoute(g, a, f, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(routeMaxLength = 3), currentBlockHeight = 400000)
     assert(route.map(hops2Ids) === Success(1 :: 6 :: Nil))
   }
 
   test("ignore loops") {
-    val updates = List(
-      makeUpdate(1L, a, b, 10 msat, 10),
-      makeUpdate(2L, b, c, 10 msat, 10),
-      makeUpdate(3L, c, a, 10 msat, 10),
-      makeUpdate(4L, c, d, 10 msat, 10),
-      makeUpdate(5L, d, e, 10 msat, 10)
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 10 msat, 10),
+      makeEdge(2L, b, c, 10 msat, 10),
+      makeEdge(3L, c, a, 10 msat, 10),
+      makeEdge(4L, c, d, 10 msat, 10),
+      makeEdge(5L, d, e, 10 msat, 10)
+    ))
 
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route1.map(hops2Ids) === Success(1 :: 2 :: 4 :: 5 :: Nil))
@@ -634,17 +580,15 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
 
   test("ensure the route calculation terminates correctly when selecting 0-fees edges") {
     // the graph contains a possible 0-cost path that goes back on its steps ( e -> f, f -> e )
-    val updates = List(
-      makeUpdate(1L, a, b, 10 msat, 10), // a -> b
-      makeUpdate(2L, b, c, 10 msat, 10),
-      makeUpdate(4L, c, d, 10 msat, 10),
-      makeUpdate(3L, b, e, 0 msat, 0), // b -> e
-      makeUpdate(6L, e, f, 0 msat, 0), // e -> f
-      makeUpdate(6L, f, e, 0 msat, 0), // e <- f
-      makeUpdate(5L, e, d, 0 msat, 0) // e -> d
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 10 msat, 10), // a -> b
+      makeEdge(2L, b, c, 10 msat, 10),
+      makeEdge(4L, c, d, 10 msat, 10),
+      makeEdge(3L, b, e, 0 msat, 0), // b -> e
+      makeEdge(6L, e, f, 0 msat, 0), // e -> f
+      makeEdge(6L, f, e, 0 msat, 0), // e <- f
+      makeEdge(5L, e, d, 0 msat, 0) // e -> d
+    ))
 
     val route1 = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(route1.map(hops2Ids) === Success(1 :: 3 :: 5 :: Nil))
@@ -673,17 +617,15 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
       PublicKey(hex"03fc5b91ce2d857f146fd9b986363374ffe04dc143d8bcd6d7664c8873c463cdfc") //f
     )
 
-    val edges = Seq(
-      makeUpdate(1L, d, a, 1 msat, 0),
-      makeUpdate(2L, d, e, 1 msat, 0),
-      makeUpdate(3L, a, e, 1 msat, 0),
-      makeUpdate(4L, e, b, 1 msat, 0),
-      makeUpdate(5L, e, f, 1 msat, 0),
-      makeUpdate(6L, b, c, 1 msat, 0),
-      makeUpdate(7L, c, f, 1 msat, 0)
-    )
-
-    val graph = DirectedGraph().addEdges(edges)
+    val graph = DirectedGraph(Seq(
+      makeEdge(1L, d, a, 1 msat, 0),
+      makeEdge(2L, d, e, 1 msat, 0),
+      makeEdge(3L, a, e, 1 msat, 0),
+      makeEdge(4L, e, b, 1 msat, 0),
+      makeEdge(5L, e, f, 1 msat, 0),
+      makeEdge(6L, b, c, 1 msat, 0),
+      makeEdge(7L, c, f, 1 msat, 0)
+    ))
 
     val fourShortestPaths = Graph.yenKshortestPaths(graph, d, f, DEFAULT_AMOUNT_MSAT, Set.empty, Set.empty, Set.empty, pathsToFind = 4, None, 0, noopBoundaries)
 
@@ -704,19 +646,17 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
       PublicKey(hex"03fc5b91ce2d857f146fd9b986363374ffe04dc143d8bcd6d7664c8873c463cdfc") //h
     )
 
-    val edges = Seq(
-      makeUpdate(10L, c, e, 2 msat, 0),
-      makeUpdate(20L, c, d, 3 msat, 0),
-      makeUpdate(30L, d, f, 4 msat, 5), // D- > F has a higher cost to distinguish it from the 2nd cheapest route
-      makeUpdate(40L, e, d, 1 msat, 0),
-      makeUpdate(50L, e, f, 2 msat, 0),
-      makeUpdate(60L, e, g, 3 msat, 0),
-      makeUpdate(70L, f, g, 2 msat, 0),
-      makeUpdate(80L, f, h, 1 msat, 0),
-      makeUpdate(90L, g, h, 2 msat, 0)
-    )
-
-    val graph = DirectedGraph().addEdges(edges)
+    val graph = DirectedGraph(Seq(
+      makeEdge(10L, c, e, 2 msat, 0),
+      makeEdge(20L, c, d, 3 msat, 0),
+      makeEdge(30L, d, f, 4 msat, 5), // D- > F has a higher cost to distinguish it from the 2nd cheapest route
+      makeEdge(40L, e, d, 1 msat, 0),
+      makeEdge(50L, e, f, 2 msat, 0),
+      makeEdge(60L, e, g, 3 msat, 0),
+      makeEdge(70L, f, g, 2 msat, 0),
+      makeEdge(80L, f, h, 1 msat, 0),
+      makeEdge(90L, g, h, 2 msat, 0)
+    ))
 
     val twoShortestPaths = Graph.yenKshortestPaths(graph, c, h, DEFAULT_AMOUNT_MSAT, Set.empty, Set.empty, Set.empty, pathsToFind = 2, None, 0, noopBoundaries)
 
@@ -732,23 +672,21 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
     val f = randomKey.publicKey
 
     // simple graph with only 2 possible paths from A to F
-    val edges = Seq(
-      makeUpdate(1L, a, b, 1 msat, 0),
-      makeUpdate(1L, b, a, 1 msat, 0),
-      makeUpdate(2L, b, c, 1 msat, 0),
-      makeUpdate(2L, c, b, 1 msat, 0),
-      makeUpdate(3L, c, f, 1 msat, 0),
-      makeUpdate(3L, f, c, 1 msat, 0),
-      makeUpdate(4L, c, d, 1 msat, 0),
-      makeUpdate(4L, d, c, 1 msat, 0),
-      makeUpdate(41L, d, c, 1 msat, 0), // there is more than one D -> C channel
-      makeUpdate(5L, d, e, 1 msat, 0),
-      makeUpdate(5L, e, d, 1 msat, 0),
-      makeUpdate(6L, e, f, 1 msat, 0),
-      makeUpdate(6L, f, e, 1 msat, 0)
-    )
-
-    val graph = DirectedGraph().addEdges(edges)
+    val graph = DirectedGraph(Seq(
+      makeEdge(1L, a, b, 1 msat, 0),
+      makeEdge(1L, b, a, 1 msat, 0),
+      makeEdge(2L, b, c, 1 msat, 0),
+      makeEdge(2L, c, b, 1 msat, 0),
+      makeEdge(3L, c, f, 1 msat, 0),
+      makeEdge(3L, f, c, 1 msat, 0),
+      makeEdge(4L, c, d, 1 msat, 0),
+      makeEdge(4L, d, c, 1 msat, 0),
+      makeEdge(41L, d, c, 1 msat, 0), // there is more than one D -> C channel
+      makeEdge(5L, d, e, 1 msat, 0),
+      makeEdge(5L, e, d, 1 msat, 0),
+      makeEdge(6L, e, f, 1 msat, 0),
+      makeEdge(6L, f, e, 1 msat, 0)
+    ))
 
     //we ask for 3 shortest paths but only 2 can be found
     val foundPaths = Graph.yenKshortestPaths(graph, a, f, DEFAULT_AMOUNT_MSAT, Set.empty, Set.empty, Set.empty, pathsToFind = 3, None, 0, noopBoundaries)
@@ -764,15 +702,15 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
     // A -> B -> C -> D has total cost of 10000005
     // A -> E -> C -> D has total cost of 11080003 !!
     // A -> E -> F -> D has total cost of 10000006
-    val g = makeGraph(List(
-      makeUpdate(1L, a, b, feeBase = 1 msat, 0),
-      makeUpdate(4L, a, e, feeBase = 1 msat, 0),
-      makeUpdate(2L, b, c, feeBase = 2 msat, 0),
-      makeUpdate(3L, c, d, feeBase = 3 msat, 0),
-      makeUpdate(5L, e, f, feeBase = 3 msat, 0),
-      makeUpdate(6L, f, d, feeBase = 3 msat, 0),
-      makeUpdate(7L, e, c, feeBase = 9 msat, 0)
-    ).toMap)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, feeBase = 1 msat, 0),
+      makeEdge(4L, a, e, feeBase = 1 msat, 0),
+      makeEdge(2L, b, c, feeBase = 2 msat, 0),
+      makeEdge(3L, c, d, feeBase = 3 msat, 0),
+      makeEdge(5L, e, f, feeBase = 3 msat, 0),
+      makeEdge(6L, f, d, feeBase = 3 msat, 0),
+      makeEdge(7L, e, c, feeBase = 9 msat, 0)
+    ))
 
     (for {_ <- 0 to 10} yield findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 3, routeParams = strictFeeParams, currentBlockHeight = 400000)).map {
       case Failure(thr) => fail(thr)
@@ -791,17 +729,15 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
     // A -> B -> C -> D is 'fee optimized', lower fees route (totFees = 2, totCltv = 4000)
     // A -> E -> F -> D is 'timeout optimized', lower CLTV route (totFees = 3, totCltv = 18)
     // A -> E -> C -> D is 'capacity optimized', more recent channel/larger capacity route
-    val updates = List(
-      makeUpdate(1L, a, b, feeBase = 0 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(13)),
-      makeUpdate(4L, a, e, feeBase = 0 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(12)),
-      makeUpdate(2L, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(500)),
-      makeUpdate(3L, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(500)),
-      makeUpdate(5L, e, f, feeBase = 2 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
-      makeUpdate(6L, f, d, feeBase = 2 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
-      makeUpdate(7L, e, c, feeBase = 2 msat, 0, minHtlc = 0 msat, maxHtlc = Some(largeCapacity), CltvExpiryDelta(12))
-    ).toMap
-
-    val g = makeGraph(updates)
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, feeBase = 0 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(13)),
+      makeEdge(4L, a, e, feeBase = 0 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(12)),
+      makeEdge(2L, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(500)),
+      makeEdge(3L, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(500)),
+      makeEdge(5L, e, f, feeBase = 2 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
+      makeEdge(6L, f, d, feeBase = 2 msat, 0, minHtlc = 0 msat, maxHtlc = None, CltvExpiryDelta(9)),
+      makeEdge(7L, e, c, feeBase = 2 msat, 0, minHtlc = 0 msat, maxHtlc = Some(largeCapacity), CltvExpiryDelta(12))
+    ))
 
     val Success(routeFeeOptimized) = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 0, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
     assert(hops2Nodes(routeFeeOptimized) === (a, b) :: (b, c) :: (c, d) :: Nil)
@@ -826,14 +762,14 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
   test("prefer going through an older channel if fees and CLTV are the same") {
     val currentBlockHeight = 554000
 
-    val g = makeGraph(List(
-      makeUpdateShort(ShortChannelId(s"${currentBlockHeight}x0x1"), a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeUpdateShort(ShortChannelId(s"${currentBlockHeight}x0x4"), a, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeUpdateShort(ShortChannelId(s"${currentBlockHeight - 3000}x0x2"), b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)), // younger channel
-      makeUpdateShort(ShortChannelId(s"${currentBlockHeight - 3000}x0x3"), c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeUpdateShort(ShortChannelId(s"${currentBlockHeight}x0x5"), e, f, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeUpdateShort(ShortChannelId(s"${currentBlockHeight}x0x6"), f, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144))
-    ).toMap)
+    val g = DirectedGraph(List(
+      makeEdge(ShortChannelId(s"${currentBlockHeight}x0x1").toLong, a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(ShortChannelId(s"${currentBlockHeight}x0x4").toLong, a, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(ShortChannelId(s"${currentBlockHeight - 3000}x0x2").toLong, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)), // younger channel
+      makeEdge(ShortChannelId(s"${currentBlockHeight - 3000}x0x3").toLong, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(ShortChannelId(s"${currentBlockHeight}x0x5").toLong, e, f, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(ShortChannelId(s"${currentBlockHeight}x0x6").toLong, f, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144))
+    ))
 
     val Success(routeScoreOptimized) = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT / 2, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(ratios = Some(WeightRatios(
       ageFactor = 0.33,
@@ -845,14 +781,14 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
   }
 
   test("prefer a route with a smaller total CLTV if fees and score are the same") {
-    val g = makeGraph(List(
-      makeUpdateShort(ShortChannelId(s"0x0x1"), a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)),
-      makeUpdateShort(ShortChannelId(s"0x0x4"), a, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)),
-      makeUpdateShort(ShortChannelId(s"0x0x2"), b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(10)), // smaller CLTV
-      makeUpdateShort(ShortChannelId(s"0x0x3"), c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)),
-      makeUpdateShort(ShortChannelId(s"0x0x5"), e, f, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)),
-      makeUpdateShort(ShortChannelId(s"0x0x6"), f, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12))
-    ).toMap)
+    val g = DirectedGraph(List(
+      makeEdge(1, a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)),
+      makeEdge(4, a, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)),
+      makeEdge(2, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(10)), // smaller CLTV
+      makeEdge(3, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)),
+      makeEdge(5, e, f, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12)),
+      makeEdge(6, f, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(12))
+    ))
 
     val Success(routeScoreOptimized) = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(ratios = Some(WeightRatios(
       ageFactor = 0.33,
@@ -866,14 +802,14 @@ class RouteCalculationSpec extends FunSuite with ParallelTestExecution {
   test("avoid a route that breaks off the max CLTV") {
     // A -> B -> C -> D is cheaper but has a total CLTV > 2016!
     // A -> E -> F -> D is more expensive but has a total CLTV < 2016
-    val g = makeGraph(List(
-      makeUpdateShort(ShortChannelId(s"0x0x1"), a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeUpdateShort(ShortChannelId(s"0x0x4"), a, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeUpdateShort(ShortChannelId(s"0x0x2"), b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(1000)),
-      makeUpdateShort(ShortChannelId(s"0x0x3"), c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(900)),
-      makeUpdateShort(ShortChannelId(s"0x0x5"), e, f, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeUpdateShort(ShortChannelId(s"0x0x6"), f, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144))
-    ).toMap)
+    val g = DirectedGraph(List(
+      makeEdge(1, a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(4, a, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(2, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(1000)),
+      makeEdge(3, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(900)),
+      makeEdge(5, e, f, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(6, f, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144))
+    ))
 
     val Success(routeScoreOptimized) = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT / 2, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(ratios = Some(WeightRatios(
       ageFactor = 0.33,
@@ -938,22 +874,33 @@ object RouteCalculationSpec {
   val noopBoundaries = { _: RichWeight => true }
 
   val DEFAULT_AMOUNT_MSAT = 10000000 msat
+  val DEFAULT_CAPACITY = 100000 sat
 
   val DEFAULT_ROUTE_PARAMS = RouteParams(randomize = false, maxFeeBase = 21000 msat, maxFeePct = 0.03, routeMaxCltv = CltvExpiryDelta(2016), routeMaxLength = 6, ratios = None)
 
   val DUMMY_SIG = Transactions.PlaceHolderSig
 
-  def makeChannel(shortChannelId: Long, nodeIdA: PublicKey, nodeIdB: PublicKey) = {
+  def makeChannel(shortChannelId: Long, nodeIdA: PublicKey, nodeIdB: PublicKey): ChannelAnnouncement = {
     val (nodeId1, nodeId2) = if (Announcements.isNode1(nodeIdA, nodeIdB)) (nodeIdA, nodeIdB) else (nodeIdB, nodeIdA)
     ChannelAnnouncement(DUMMY_SIG, DUMMY_SIG, DUMMY_SIG, DUMMY_SIG, ByteVector.empty, Block.RegtestGenesisBlock.hash, ShortChannelId(shortChannelId), nodeId1, nodeId2, randomKey.publicKey, randomKey.publicKey)
   }
 
-  def makeUpdate(shortChannelId: Long, nodeId1: PublicKey, nodeId2: PublicKey, feeBase: MilliSatoshi, feeProportionalMillionth: Int, minHtlc: MilliSatoshi = DEFAULT_AMOUNT_MSAT, maxHtlc: Option[MilliSatoshi] = None, cltvDelta: CltvExpiryDelta = CltvExpiryDelta(0)): (ChannelDesc, ChannelUpdate) = {
-    makeUpdateShort(ShortChannelId(shortChannelId), nodeId1, nodeId2, feeBase, feeProportionalMillionth, minHtlc, maxHtlc, cltvDelta)
+  def makeEdge(shortChannelId: Long,
+               nodeId1: PublicKey,
+               nodeId2: PublicKey,
+               feeBase: MilliSatoshi,
+               feeProportionalMillionth: Int,
+               minHtlc: MilliSatoshi = DEFAULT_AMOUNT_MSAT,
+               maxHtlc: Option[MilliSatoshi] = None,
+               cltvDelta: CltvExpiryDelta = CltvExpiryDelta(0),
+               capacity: Satoshi = DEFAULT_CAPACITY,
+               balance_opt: Option[MilliSatoshi] = None): GraphEdge = {
+    val update = makeUpdateShort(ShortChannelId(shortChannelId), nodeId1, nodeId2, feeBase, feeProportionalMillionth, minHtlc, maxHtlc, cltvDelta)
+    GraphEdge(ChannelDesc(ShortChannelId(shortChannelId), nodeId1, nodeId2), update, capacity, balance_opt)
   }
 
-  def makeUpdateShort(shortChannelId: ShortChannelId, nodeId1: PublicKey, nodeId2: PublicKey, feeBase: MilliSatoshi, feeProportionalMillionth: Int, minHtlc: MilliSatoshi = DEFAULT_AMOUNT_MSAT, maxHtlc: Option[MilliSatoshi] = None, cltvDelta: CltvExpiryDelta = CltvExpiryDelta(0), timestamp: Long = 0): (ChannelDesc, ChannelUpdate) =
-    ChannelDesc(shortChannelId, nodeId1, nodeId2) -> ChannelUpdate(
+  def makeUpdateShort(shortChannelId: ShortChannelId, nodeId1: PublicKey, nodeId2: PublicKey, feeBase: MilliSatoshi, feeProportionalMillionth: Int, minHtlc: MilliSatoshi = DEFAULT_AMOUNT_MSAT, maxHtlc: Option[MilliSatoshi] = None, cltvDelta: CltvExpiryDelta = CltvExpiryDelta(0), timestamp: Long = 0): ChannelUpdate =
+    ChannelUpdate(
       signature = DUMMY_SIG,
       chainHash = Block.RegtestGenesisBlock.hash,
       shortChannelId = shortChannelId,
@@ -970,13 +917,9 @@ object RouteCalculationSpec {
       htlcMaximumMsat = maxHtlc
     )
 
-  def makeGraph(updates: Map[ChannelDesc, ChannelUpdate]) = DirectedGraph().addEdges(updates.toSeq)
-
   def hops2Ids(route: Seq[ChannelHop]) = route.map(hop => hop.lastUpdate.shortChannelId.toLong)
 
-  def hops2Edges(route: Seq[ChannelHop]) = route.map(hop => GraphEdge(ChannelDesc(hop.lastUpdate.shortChannelId, hop.nodeId, hop.nextNodeId), hop.lastUpdate))
-
-  def hops2ShortChannelIds(route: Seq[ChannelHop]) = route.map(hop => hop.lastUpdate.shortChannelId.toString).toList
+  def hops2Edges(route: Seq[ChannelHop]) = route.map(hop => GraphEdge(ChannelDesc(hop.lastUpdate.shortChannelId, hop.nodeId, hop.nextNodeId), hop.lastUpdate, 0 sat, None))
 
   def hops2Nodes(route: Seq[ChannelHop]) = route.map(hop => (hop.nodeId, hop.nextNodeId))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -22,7 +22,7 @@ import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.Script.{pay2wsh, write}
 import fr.acinq.bitcoin.{Block, Transaction, TxOut}
 import fr.acinq.eclair.blockchain._
-import fr.acinq.eclair.channel.BITCOIN_FUNDING_EXTERNAL_CHANNEL_SPENT
+import fr.acinq.eclair.channel.{AvailableBalanceChanged, BITCOIN_FUNDING_EXTERNAL_CHANNEL_SPENT, CommitmentsSpec, LocalChannelUpdate}
 import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
@@ -84,7 +84,7 @@ class RouterSpec extends BaseRouterSpec {
       // valid channel announcement, stashing while validating channel announcement
       val priv_u = randomKey
       val priv_funding_u = randomKey
-      val chan_uc = channelAnnouncement(ShortChannelId(420000, 6, 0), priv_u, priv_c, priv_funding_u, priv_funding_c)
+      val chan_uc = channelAnnouncement(ShortChannelId(420000, 100, 0), priv_u, priv_c, priv_funding_u, priv_funding_c)
       val update_uc = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_u, c, chan_uc.shortChannelId, CltvExpiryDelta(7), 0 msat, 766000 msat, 10, 500000000L msat)
       val node_u = makeNodeAnnouncement(priv_u, "node-U", Color(-120, -20, 60), Nil, hex"00")
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, chan_uc))
@@ -129,7 +129,7 @@ class RouterSpec extends BaseRouterSpec {
     {
       // invalid signatures
       val invalid_node_a = node_a.copy(timestamp = node_a.timestamp + 10)
-      val invalid_chan_a = channelAnnouncement(ShortChannelId(420000, 5, 1), priv_a, priv_c, priv_funding_a, priv_funding_c).copy(nodeId1 = randomKey.publicKey)
+      val invalid_chan_a = channelAnnouncement(ShortChannelId(420000, 101, 1), priv_a, priv_c, priv_funding_a, priv_funding_c).copy(nodeId1 = randomKey.publicKey)
       val invalid_update_ab = update_ab.copy(cltvExpiryDelta = CltvExpiryDelta(21), timestamp = update_ab.timestamp + 1)
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, invalid_node_a))
       peerConnection.expectMsg(TransportHandler.ReadAck(invalid_node_a))
@@ -149,7 +149,7 @@ class RouterSpec extends BaseRouterSpec {
       // pruned channel
       val priv_v = randomKey
       val priv_funding_v = randomKey
-      val chan_vc = channelAnnouncement(ShortChannelId(420000, 7, 0), priv_v, priv_c, priv_funding_v, priv_funding_c)
+      val chan_vc = channelAnnouncement(ShortChannelId(420000, 102, 0), priv_v, priv_c, priv_funding_v, priv_funding_c)
       nodeParams.db.network.addToPruned(chan_vc.shortChannelId :: Nil)
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, chan_vc))
       peerConnection.expectMsg(TransportHandler.ReadAck(chan_vc))
@@ -285,7 +285,7 @@ class RouterSpec extends BaseRouterSpec {
   test("handle bad signature for ChannelAnnouncement") { fixture =>
     import fixture._
     val peerConnection = TestProbe()
-    val channelId_ac = ShortChannelId(420000, 5, 0)
+    val channelId_ac = ShortChannelId(420000, 105, 0)
     val chan_ac = channelAnnouncement(channelId_ac, priv_a, priv_c, priv_funding_a, priv_funding_c)
     val buggy_chan_ac = chan_ac.copy(nodeSignature1 = chan_ac.nodeSignature2)
     peerConnection.send(router, PeerRoutingMessage(remoteNodeId, buggy_chan_ac))
@@ -296,10 +296,10 @@ class RouterSpec extends BaseRouterSpec {
   test("handle bad signature for NodeAnnouncement") { fixture =>
     import fixture._
     val peerConnection = TestProbe()
-    val buggy_ann_a = node_a.copy(signature = node_b.signature, timestamp = node_a.timestamp + 1)
-    peerConnection.send(router, PeerRoutingMessage(remoteNodeId, buggy_ann_a))
-    peerConnection.expectMsg(TransportHandler.ReadAck(buggy_ann_a))
-    peerConnection.expectMsg(GossipDecision.InvalidSignature(buggy_ann_a))
+    val buggy_ann_b = node_b.copy(signature = node_c.signature, timestamp = node_b.timestamp + 1)
+    peerConnection.send(router, PeerRoutingMessage(remoteNodeId, buggy_ann_b))
+    peerConnection.expectMsg(TransportHandler.ReadAck(buggy_ann_b))
+    peerConnection.expectMsg(GossipDecision.InvalidSignature(buggy_ann_b))
   }
 
   test("handle bad signature for ChannelUpdate") { fixture =>
@@ -375,6 +375,20 @@ class RouterSpec extends BaseRouterSpec {
     sender.expectMsg(Failure(RouteNotFound))
   }
 
+  test("route not found (private channel disabled)") { fixture =>
+    import fixture._
+    val sender = TestProbe()
+    sender.send(router, RouteRequest(a, h, DEFAULT_AMOUNT_MSAT))
+    val res = sender.expectMsgType[RouteResponse]
+    assert(res.hops.map(_.nodeId).toList === a :: g :: Nil)
+    assert(res.hops.last.nextNodeId === h)
+
+    val channelUpdate_ag1 = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, g, channelId_ag, CltvExpiryDelta(7), 0 msat, 10 msat, 10, 500000000 msat, enable = false)
+    sender.send(router, LocalChannelUpdate(sender.ref, null, channelId_ag, g, None, channelUpdate_ag1, CommitmentsSpec.makeCommitments(10000 msat, 15000 msat, a, g, announceChannel = false)))
+    sender.send(router, RouteRequest(a, h, DEFAULT_AMOUNT_MSAT))
+    sender.expectMsg(Failure(RouteNotFound))
+  }
+
   test("temporary channel exclusion") { fixture =>
     import fixture._
     val sender = TestProbe()
@@ -399,9 +413,9 @@ class RouterSpec extends BaseRouterSpec {
     val sender = TestProbe()
     sender.send(router, GetRoutingState)
     val state = sender.expectMsgType[RoutingState]
-    assert(state.channels.size == 4)
-    assert(state.nodes.size == 6)
-    assert(state.channels.flatMap(c => c.update_1_opt.toSeq ++ c.update_2_opt.toSeq).size == 8)
+    assert(state.channels.size == 5)
+    assert(state.nodes.size == 8)
+    assert(state.channels.flatMap(c => c.update_1_opt.toSeq ++ c.update_2_opt.toSeq).size == 10)
   }
 
   test("send network statistics") { fixture =>
@@ -421,10 +435,10 @@ class RouterSpec extends BaseRouterSpec {
     val GetNetworkStatsResponse(Some(stats)) = sender.expectMsgType[GetNetworkStatsResponse]
     // if you change this test update test "router returns Network Stats" in EclairImpSpec that mocks this call.
     // else will break the networkstats API call
-    assert(stats.channels === 4)
-    assert(stats.nodes === 6)
+    assert(stats.channels === 5)
+    assert(stats.nodes === 8)
     assert(stats.capacity.median === 1000000.sat)
-    assert(stats.cltvExpiryDelta.median === CltvExpiryDelta(6))
+    assert(stats.cltvExpiryDelta.median === CltvExpiryDelta(7))
   }
 
   test("given a pre-computed route add the proper channel updates") { fixture =>
@@ -470,6 +484,30 @@ class RouterSpec extends BaseRouterSpec {
     peerConnection.expectMsg(GossipDecision.RelatedChannelPruned(recentUpdate))
     val query = peerConnection.expectMsgType[QueryShortChannelIds]
     assert(query.shortChannelIds.array == List(channelId))
+  }
+
+  test("update local channels balances") { fixture =>
+    import fixture._
+
+    val sender = TestProbe()
+    sender.send(router, GetRoutingState)
+    val channel_ab = sender.expectMsgType[RoutingState].channels.find(_.ann == chan_ab).get
+    assert(channel_ab.balance_1_opt === None)
+    assert(channel_ab.balance_2_opt === None)
+
+    // When the local channel comes back online, it will send a LocalChannelUpdate to the router.
+    val commitments1 = CommitmentsSpec.makeCommitments(10000 msat, 15000 msat, a, b, announceChannel = true)
+    sender.send(router, LocalChannelUpdate(sender.ref, null, channelId_ab, b, Some(chan_ab), update_ab, commitments1))
+    sender.send(router, GetRoutingState)
+    val channel_ab1 = sender.expectMsgType[RoutingState].channels.find(_.ann == chan_ab).get
+    assert(Set(channel_ab1.balance_1_opt, channel_ab1.balance_2_opt) === Set(Some(10000 msat), Some(15000 msat)))
+
+    // When HTLCs are relayed through the channel, balance changes are sent to the router.
+    val commitments2 = CommitmentsSpec.makeCommitments(12000 msat, 13000 msat, a, b, announceChannel = true)
+    sender.send(router, AvailableBalanceChanged(sender.ref, null, channelId_ab, commitments2))
+    sender.send(router, GetRoutingState)
+    val channel_ab2 = sender.expectMsgType[RoutingState].channels.find(_.ann == chan_ab).get
+    assert(Set(channel_ab2.balance_1_opt, channel_ab2.balance_2_opt) === Set(Some(12000 msat), Some(13000 msat)))
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -492,8 +492,7 @@ class RouterSpec extends BaseRouterSpec {
     val sender = TestProbe()
     sender.send(router, GetRoutingState)
     val channel_ab = sender.expectMsgType[RoutingState].channels.find(_.ann == chan_ab).get
-    assert(channel_ab.balance_1_opt === None)
-    assert(channel_ab.balance_2_opt === None)
+    assert(channel_ab.meta_opt === None)
 
     // When the local channel comes back online, it will send a LocalChannelUpdate to the router.
     val balances1 = Set[Option[MilliSatoshi]](Some(10000 msat), Some(15000 msat))
@@ -501,7 +500,7 @@ class RouterSpec extends BaseRouterSpec {
     sender.send(router, LocalChannelUpdate(sender.ref, null, channelId_ab, b, Some(chan_ab), update_ab, commitments1))
     sender.send(router, GetRoutingState)
     val channel_ab1 = sender.expectMsgType[RoutingState].channels.find(_.ann == chan_ab).get
-    assert(Set(channel_ab1.balance_1_opt, channel_ab1.balance_2_opt) === balances1)
+    assert(Set(channel_ab1.meta_opt.map(_.balance1), channel_ab1.meta_opt.map(_.balance2)) === balances1)
     // And the graph should be updated too.
     sender.send(router, 'data)
     val g1 = sender.expectMsgType[Data].graph
@@ -517,7 +516,7 @@ class RouterSpec extends BaseRouterSpec {
     sender.send(router, AvailableBalanceChanged(sender.ref, null, channelId_ab, commitments2))
     sender.send(router, GetRoutingState)
     val channel_ab2 = sender.expectMsgType[RoutingState].channels.find(_.ann == chan_ab).get
-    assert(Set(channel_ab2.balance_1_opt, channel_ab2.balance_2_opt) === balances2)
+    assert(Set(channel_ab2.meta_opt.map(_.balance1), channel_ab2.meta_opt.map(_.balance2)) === balances2)
     // And the graph should be updated too.
     sender.send(router, 'data)
     val g2 = sender.expectMsgType[Data].graph

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
@@ -228,7 +228,7 @@ class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
 
     // bump random channel_updates
     def touchUpdate(shortChannelId: Int, side: Boolean) = {
-      val PublicChannel(c, _, _, _, Some(u1), _, Some(u2)) = fakeRoutingInfo.values.toList(shortChannelId)._1
+      val PublicChannel(c, _, _, Some(u1), Some(u2), _) = fakeRoutingInfo.values.toList(shortChannelId)._1
       makeNewerChannelUpdate(pub2priv)(c, if (side) u1 else u2)
     }
 
@@ -325,7 +325,7 @@ object RoutingSyncSpec {
     val channelUpdate_21 = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv2, priv1.publicKey, shortChannelId, cltvExpiryDelta = CltvExpiryDelta(7), 0 msat, feeBaseMsat = 766000 msat, feeProportionalMillionths = 10, 500000000L msat, timestamp = timestamp)
     val nodeAnnouncement_1 = makeNodeAnnouncement(priv1, "a", Color(0, 0, 0), List(), hex"0200")
     val nodeAnnouncement_2 = makeNodeAnnouncement(priv2, "b", Color(0, 0, 0), List(), hex"00")
-    val publicChannel = PublicChannel(channelAnn_12, ByteVector32.Zeroes, Satoshi(0), None, Some(channelUpdate_12), None, Some(channelUpdate_21))
+    val publicChannel = PublicChannel(channelAnn_12, ByteVector32.Zeroes, Satoshi(0), Some(channelUpdate_12), Some(channelUpdate_21), None)
     (publicChannel, nodeAnnouncement_1, nodeAnnouncement_2)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
@@ -222,17 +222,17 @@ class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
         sender.send(bob, PeerRoutingMessage(charlieId, na1))
         sender.send(bob, PeerRoutingMessage(charlieId, na2))
     }
-    awaitCond(bob.stateData.channels.size === fakeRoutingInfo.size && countUpdates(bob.stateData.channels) === 2 * fakeRoutingInfo.size,  max = 60 seconds)
+    awaitCond(bob.stateData.channels.size === fakeRoutingInfo.size && countUpdates(bob.stateData.channels) === 2 * fakeRoutingInfo.size, max = 60 seconds)
     assert(BasicSyncResult(ranges = 3, queries = 11, channels = fakeRoutingInfo.size - 10, updates = 2 * (fakeRoutingInfo.size - 10), nodes = if (requestNodeAnnouncements) 2 * (fakeRoutingInfo.size - 10) else 0) === sync(alice, bob, extendedQueryFlags_opt).counts)
     awaitCond(alice.stateData.channels === bob.stateData.channels, max = 60 seconds)
 
     // bump random channel_updates
     def touchUpdate(shortChannelId: Int, side: Boolean) = {
-      val PublicChannel(c, _, _, Some(u1), Some(u2)) = fakeRoutingInfo.values.toList(shortChannelId)._1
+      val PublicChannel(c, _, _, _, Some(u1), _, Some(u2)) = fakeRoutingInfo.values.toList(shortChannelId)._1
       makeNewerChannelUpdate(pub2priv)(c, if (side) u1 else u2)
     }
 
-    val bumpedUpdates = (List(0, 3, 7).map(touchUpdate(_, true)) ++ List(1, 3, 9).map(touchUpdate(_, false))).toSet
+    val bumpedUpdates = (List(0, 3, 7).map(touchUpdate(_, side = true)) ++ List(1, 3, 9).map(touchUpdate(_, side = false))).toSet
     bumpedUpdates.foreach(c => sender.send(bob, PeerRoutingMessage(charlieId, c)))
     assert(BasicSyncResult(ranges = 3, queries = 1, channels = 0, updates = bumpedUpdates.size, nodes = if (requestNodeAnnouncements) 5 * 2 else 0) === sync(alice, bob, extendedQueryFlags_opt).counts)
     awaitCond(alice.stateData.channels === bob.stateData.channels, max = 60 seconds)
@@ -276,7 +276,7 @@ class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
     sender.send(router, SendChannelQuery(params.chainHash, remoteNodeId, None))
     sender.expectMsgType[QueryChannelRange]
     sender.expectMsgType[GossipTimestampFilter]
-    assert(router.stateData.sync.get(remoteNodeId).isEmpty)
+    assert(!router.stateData.sync.contains(remoteNodeId))
   }
 
   test("sync progress") {
@@ -325,7 +325,7 @@ object RoutingSyncSpec {
     val channelUpdate_21 = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv2, priv1.publicKey, shortChannelId, cltvExpiryDelta = CltvExpiryDelta(7), 0 msat, feeBaseMsat = 766000 msat, feeProportionalMillionths = 10, 500000000L msat, timestamp = timestamp)
     val nodeAnnouncement_1 = makeNodeAnnouncement(priv1, "a", Color(0, 0, 0), List(), hex"0200")
     val nodeAnnouncement_2 = makeNodeAnnouncement(priv2, "b", Color(0, 0, 0), List(), hex"00")
-    val publicChannel = PublicChannel(channelAnn_12, ByteVector32.Zeroes, Satoshi(0), Some(channelUpdate_12), Some(channelUpdate_21))
+    val publicChannel = PublicChannel(channelAnn_12, ByteVector32.Zeroes, Satoshi(0), None, Some(channelUpdate_12), None, Some(channelUpdate_21))
     (publicChannel, nodeAnnouncement_1, nodeAnnouncement_2)
   }
 


### PR DESCRIPTION
This is a first step towards more changes to the router/path-finding.
It makes sense for the router to know about channel balances when looking for routes, especially for MPP.

This PR only adds a listener on `AvailableBalanceChanged` and tracks local channel balance in the router's internal maps. The next step will be to add this information to the graph edges. It will also be a good occasion to use the channel `capacity` instead of `htlcMaximumMsat` inside edges; we'll be able to provide more information to the path-finding algorithm.
