### PR TITLE
Send `update_fee` on reconnection

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -22,7 +22,7 @@ import akka.actor.Status
 import akka.testkit.{TestActorRef, TestProbe}
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{ByteVector32, ScriptFlags, Transaction}
-import fr.acinq.eclair.TestConstants.Alice
+import fr.acinq.eclair.TestConstants.{Alice, TestFeeEstimator}
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
 import fr.acinq.eclair.channel._
@@ -94,7 +94,6 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     val aliceCurrentPerCommitmentPoint = TestConstants.Alice.keyManager.commitmentPoint(
       TestConstants.Alice.keyManager.channelKeyPath(aliceCommitments.localParams, aliceCommitments.channelVersion),
       aliceCommitments.localCommit.index)
-
 
     // a didn't receive any update or sig
     val ab_reestablish = alice2bob.expectMsg(ChannelReestablish(ab_add_0.channelId, 1, 0, PrivateKey(ByteVector32.Zeroes), aliceCurrentPerCommitmentPoint))
@@ -208,7 +207,6 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
 
     awaitCond(alice.stateName == NORMAL)
     awaitCond(bob.stateName == NORMAL)
-
   }
 
   test("discover that we have a revoked commitment") { f =>
@@ -262,7 +260,6 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     // alice is able to claim its main output
     val claimMainOutput = alice2blockchain.expectMsgType[PublishAsap].tx
     Transaction.correctlySpends(claimMainOutput, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-
   }
 
   test("discover that they have a more recent commit than the one we know") { f =>
@@ -314,7 +311,6 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     // alice is able to claim its main output
     val claimMainOutput = alice2blockchain.expectMsgType[PublishAsap].tx
     Transaction.correctlySpends(claimMainOutput, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-
   }
 
   test("counterparty lies about having a more recent commitment") { f =>
@@ -492,7 +488,7 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     alice2blockchain.expectMsg(PublishAsap(aliceCommitTx))
   }
 
-  test("handle feerate changes while offline (don't close on mismatch)", Tag("disable-offline-mismatch")) { f =>
+  test("handle feerate changes while offline (don't close on mismatch, update on reconnect)", Tag("disable-offline-mismatch")) { f =>
     import f._
     val sender = TestProbe()
 
@@ -508,9 +504,23 @@ class OfflineStateSpec extends TestkitBaseClass with StateTestsHelperMethods {
     val highFeerate = FeeratesPerKw.single(tooHighFeeratePerKw)
 
     // this time Alice will ignore feerate changes for the offline channel
+    alice.underlyingActor.nodeParams.onChainFeeConf.feeEstimator.asInstanceOf[TestFeeEstimator].setFeerate(highFeerate)
     sender.send(alice, CurrentFeerates(highFeerate))
     alice2blockchain.expectNoMsg()
     alice2bob.expectNoMsg()
+
+    // then we reconnect them; Alice should send the feerate changes to Bob
+    sender.send(alice, INPUT_RECONNECTED(alice2bob.ref, aliceInit, bobInit))
+    sender.send(bob, INPUT_RECONNECTED(bob2alice.ref, bobInit, aliceInit))
+
+    // peers exchange channel_reestablish messages
+    alice2bob.expectMsgType[ChannelReestablish]
+    bob2alice.expectMsgType[ChannelReestablish]
+    // note that we don't forward the channel_reestablish so that only alice reaches NORMAL state, it facilitates the test below
+    bob2alice.forward(alice)
+
+    alice2bob.expectMsgType[FundingLocked] // since the channel's commitment hasn't been updated, we re-send funding_locked
+    alice2bob.expectMsg(UpdateFee(channelId(alice), tooHighFeeratePerKw))
   }
 
   test("handle feerate changes while offline (fundee scenario)") { f =>


### PR DESCRIPTION
We update transaction fees at every block (ie every 10 minutes). While this works well when the remote peer is a node that's online for more than 10 minutes, it's an issue for mobile wallets that usually come online for a few minutes and then disconnect.

We want to make sure we send these wallet peers an update_fee when one is needed, so we now check for feerate updates on reconnection.

Fixes #1381.