### PR TITLE
Update to scala 2.13 and akka 2.6

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -20,11 +20,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.acinq.eclair</groupId>
-        <artifactId>eclair_2.11</artifactId>
+        <artifactId>eclair_2.13</artifactId>
         <version>0.3.5-SNAPSHOT</version>
     </parent>
 
-    <artifactId>eclair-core_2.11</artifactId>
+    <artifactId>eclair-core_2.13</artifactId>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -115,6 +115,11 @@
     </profiles>
 
     <dependencies>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-collection-contrib_${scala.version.short}</artifactId>
+            <version>0.2.1</version>
+        </dependency>
         <!-- AKKA -->
         <dependency>
             <groupId>com.typesafe.akka</groupId>
@@ -136,7 +141,7 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-jackson_${scala.version.short}</artifactId>
-            <version>3.6.0</version>
+            <version>3.6.7</version>
         </dependency>
         <dependency>
             <groupId>com.softwaremill.sttp</groupId>
@@ -170,7 +175,7 @@
         <dependency>
             <groupId>org.scodec</groupId>
             <artifactId>scodec-core_${scala.version.short}</artifactId>
-            <version>1.11.2</version>
+            <version>1.11.7</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -181,7 +186,7 @@
         <dependency>
             <groupId>org.clapper</groupId>
             <artifactId>grizzled-slf4j_${scala.version.short}</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.4</version>
         </dependency>
         <!-- OTHER -->
         <dependency>
@@ -220,19 +225,19 @@
         <dependency>
             <groupId>com.softwaremill.quicklens</groupId>
             <artifactId>quicklens_${scala.version.short}</artifactId>
-            <version>1.4.11</version>
+            <version>1.5.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.whisk</groupId>
             <artifactId>docker-testkit-scalatest_${scala.version.short}</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.whisk</groupId>
             <artifactId>docker-testkit-impl-spotify_${scala.version.short}</artifactId>
-            <version>0.9.8</version>
+            <version>0.9.9</version>
             <scope>test</scope>
         </dependency>
 	<!-- neeeded for our docker tests, see  https://github.com/spotify/dockerfile-maven/issues/90 -->
@@ -256,8 +261,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-scala-scalatest_2.11</artifactId>
-            <version>1.4.1</version>
+            <artifactId>mockito-scala-scalatest_${scala.version.short}</artifactId>
+            <version>1.5.9</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/CoinUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/CoinUtils.scala
@@ -144,11 +144,11 @@ object CoinUtils extends Logging {
     }
     // note: we can't use the fr.acinq.bitcoin._ conversion methods because they truncate the sub-satoshi part
     getUnitFromString(unit) match {
-      case MSatUnit => MilliSatoshi((amountDecimal * MSatUnit.factorToMsat).longValue())
-      case SatUnit => MilliSatoshi((amountDecimal * SatUnit.factorToMsat).longValue())
-      case BitUnit => MilliSatoshi((amountDecimal * BitUnit.factorToMsat).longValue())
-      case MBtcUnit => MilliSatoshi((amountDecimal * MBtcUnit.factorToMsat).longValue())
-      case BtcUnit => MilliSatoshi((amountDecimal * BtcUnit.factorToMsat).longValue())
+      case MSatUnit => MilliSatoshi((amountDecimal * MSatUnit.factorToMsat).longValue)
+      case SatUnit => MilliSatoshi((amountDecimal * SatUnit.factorToMsat).longValue)
+      case BitUnit => MilliSatoshi((amountDecimal * BitUnit.factorToMsat).longValue)
+      case MBtcUnit => MilliSatoshi((amountDecimal * MBtcUnit.factorToMsat).longValue)
+      case BtcUnit => MilliSatoshi((amountDecimal * BtcUnit.factorToMsat).longValue)
       case _ => throw new IllegalArgumentException("unhandled unit")
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -161,17 +161,17 @@ class EclairImpl(appKit: Kit) extends Eclair {
   }
 
   override def peersInfo()(implicit timeout: Timeout): Future[Iterable[PeerInfo]] = for {
-    peers <- (appKit.switchboard ? 'peers).mapTo[Iterable[ActorRef]]
+    peers <- (appKit.switchboard ? Symbol("peers")).mapTo[Iterable[ActorRef]]
     peerinfos <- Future.sequence(peers.map(peer => (peer ? GetPeerInfo).mapTo[PeerInfo]))
   } yield peerinfos
 
   override def channelsInfo(toRemoteNode_opt: Option[PublicKey])(implicit timeout: Timeout): Future[Iterable[RES_GETINFO]] = toRemoteNode_opt match {
     case Some(pk) => for {
-      channelIds <- (appKit.register ? 'channelsTo).mapTo[Map[ByteVector32, PublicKey]].map(_.filter(_._2 == pk).keys)
+      channelIds <- (appKit.register ? Symbol("channelsTo")).mapTo[Map[ByteVector32, PublicKey]].map(_.filter(_._2 == pk).keys)
       channels <- Future.sequence(channelIds.map(channelId => sendToChannel(Left(channelId), CMD_GETINFO).mapTo[RES_GETINFO]))
     } yield channels
     case None => for {
-      channelIds <- (appKit.register ? 'channels).mapTo[Map[ByteVector32, ActorRef]].map(_.keys)
+      channelIds <- (appKit.register ? Symbol("channels")).mapTo[Map[ByteVector32, ActorRef]].map(_.keys)
       channels <- Future.sequence(channelIds.map(channelId => sendToChannel(Left(channelId), CMD_GETINFO).mapTo[RES_GETINFO]))
     } yield channels
   }
@@ -180,15 +180,15 @@ class EclairImpl(appKit: Kit) extends Eclair {
     sendToChannel(channelIdentifier, CMD_GETINFO).mapTo[RES_GETINFO]
   }
 
-  override def allNodes()(implicit timeout: Timeout): Future[Iterable[NodeAnnouncement]] = (appKit.router ? 'nodes).mapTo[Iterable[NodeAnnouncement]]
+  override def allNodes()(implicit timeout: Timeout): Future[Iterable[NodeAnnouncement]] = (appKit.router ? Symbol("nodes")).mapTo[Iterable[NodeAnnouncement]]
 
   override def allChannels()(implicit timeout: Timeout): Future[Iterable[ChannelDesc]] = {
-    (appKit.router ? 'channels).mapTo[Iterable[ChannelAnnouncement]].map(_.map(c => ChannelDesc(c.shortChannelId, c.nodeId1, c.nodeId2)))
+    (appKit.router ? Symbol("channels")).mapTo[Iterable[ChannelAnnouncement]].map(_.map(c => ChannelDesc(c.shortChannelId, c.nodeId1, c.nodeId2)))
   }
 
   override def allUpdates(nodeId_opt: Option[PublicKey])(implicit timeout: Timeout): Future[Iterable[ChannelUpdate]] = nodeId_opt match {
-    case None => (appKit.router ? 'updates).mapTo[Iterable[ChannelUpdate]]
-    case Some(pk) => (appKit.router ? 'channelsMap).mapTo[Map[ShortChannelId, PublicChannel]].map { channels =>
+    case None => (appKit.router ? Symbol("updates")).mapTo[Iterable[ChannelUpdate]]
+    case Some(pk) => (appKit.router ? Symbol("channelsMap")).mapTo[Map[ShortChannelId, PublicChannel]].map { channels =>
       channels.values.flatMap {
         case PublicChannel(ann, _, _, Some(u1), _) if ann.nodeId1 == pk && u1.isNode1 => List(u1)
         case PublicChannel(ann, _, _, _, Some(u2)) if ann.nodeId2 == pk && !u2.isNode1 => List(u2)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -35,8 +35,8 @@ import fr.acinq.eclair.tor.Socks5ProxyParams
 import fr.acinq.eclair.wire.{Color, EncodingType, NodeAddress}
 import scodec.bits.ByteVector
 
-import scala.collection.JavaConversions._
 import scala.concurrent.duration.FiniteDuration
+import scala.jdk.CollectionConverters._
 
 /**
  * Created by PM on 26/02/2017.
@@ -184,13 +184,13 @@ object NodeParams {
     val featuresErr = Features.validateFeatureGraph(features)
     require(featuresErr.isEmpty, featuresErr.map(_.message))
 
-    val overrideFeatures: Map[PublicKey, ByteVector] = config.getConfigList("override-features").map { e =>
+    val overrideFeatures: Map[PublicKey, ByteVector] = config.getConfigList("override-features").asScala.map { e =>
       val p = PublicKey(ByteVector.fromValidHex(e.getString("nodeid")))
       val f = ByteVector.fromValidHex(e.getString("features"))
       p -> f
     }.toMap
 
-    val syncWhitelist: Set[PublicKey] = config.getStringList("sync-whitelist").map(s => PublicKey(ByteVector.fromValidHex(s))).toSet
+    val syncWhitelist: Set[PublicKey] = config.getStringList("sync-whitelist").asScala.map(s => PublicKey(ByteVector.fromValidHex(s))).toSet
 
     val socksProxy_opt = if (config.getBoolean("socks5.enabled")) {
       Some(Socks5ProxyParams(
@@ -206,6 +206,7 @@ object NodeParams {
     }
 
     val addresses = config.getStringList("server.public-ips")
+      .asScala
       .toList
       .map(ip => NodeAddress.fromParts(ip, config.getInt("server.port")).get) ++ torAddress_opt
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -190,7 +190,7 @@ class Setup(datadir: File,
           logger.info(s"override electrum default with server=$address ssl=$ssl")
           Set(ElectrumServerAddress(address, ssl))
         case false =>
-          val (addressesFile, sslEnabled) = nodeParams.chainHash match {
+          val (addressesFile, sslEnabled) = (nodeParams.chainHash: @unchecked) match {
             case Block.RegtestGenesisBlock.hash => ("/electrum/servers_regtest.json", false) // in regtest we connect in plaintext
             case Block.TestnetGenesisBlock.hash => ("/electrum/servers_testnet.json", true)
             case Block.LivenetGenesisBlock.hash => ("/electrum/servers_mainnet.json", true)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
@@ -42,7 +42,7 @@ class BitcoinCoreWallet(rpcClient: BitcoinJsonRPCClient)(implicit ec: ExecutionC
       val JString(hex) = json \ "hex"
       val JInt(changepos) = json \ "changepos"
       val JDecimal(fee) = json \ "fee"
-      FundTransactionResponse(Transaction.read(hex), changepos.intValue(), Satoshi(fee.bigDecimal.scaleByPowerOfTen(8).longValue()))
+      FundTransactionResponse(Transaction.read(hex), changepos.intValue, Satoshi(fee.bigDecimal.scaleByPowerOfTen(8).longValue))
     })
   }
 
@@ -65,7 +65,7 @@ class BitcoinCoreWallet(rpcClient: BitcoinJsonRPCClient)(implicit ec: ExecutionC
 
   def unlockOutpoints(outPoints: Seq[OutPoint])(implicit ec: ExecutionContext): Future[Boolean] = rpcClient.invoke("lockunspent", true, outPoints.toList.map(outPoint => Utxo(outPoint.txid, outPoint.index))) collect { case JBool(result) => result }
 
-  override def getBalance: Future[Satoshi] = rpcClient.invoke("getbalance") collect { case JDecimal(balance) => Satoshi(balance.bigDecimal.scaleByPowerOfTen(8).longValue()) }
+  override def getBalance: Future[Satoshi] = rpcClient.invoke("getbalance") collect { case JDecimal(balance) => Satoshi(balance.bigDecimal.scaleByPowerOfTen(8).longValue) }
 
   override def getFinalAddress: Future[String] = for {
     JString(address) <- rpcClient.invoke("getnewaddress")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
@@ -31,7 +31,7 @@ import fr.acinq.eclair.transactions.Scripts
 import org.json4s.JsonAST.JDecimal
 import scodec.bits.ByteVector
 
-import scala.collection.{Set, SortedMap}
+import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -88,7 +88,7 @@ class ZmqWatcher(blockCount: AtomicLong, client: ExtendedBitcoinClient)(implicit
       }
       client.rpcClient.invoke("getbalance").collect {
         // We track our balance in mBTC because a rounding issue in BTC would be too impactful.
-        case JDecimal(balance) => Metrics.BitcoinBalance.withoutTags().update(balance.doubleValue() * 1000)
+        case JDecimal(balance) => Metrics.BitcoinBalance.withoutTags().update(balance.doubleValue * 1000)
       }
       // TODO: beware of the herd effect
       KamonExt.timeFuture(Metrics.NewBlockCheckConfirmedDuration.withoutTags()) {
@@ -195,7 +195,7 @@ class ZmqWatcher(blockCount: AtomicLong, client: ExtendedBitcoinClient)(implicit
       val watchedUtxos1 = deprecatedWatches.foldLeft(watchedUtxos) { case (m, w) => removeWatchedUtxos(m, w) }
       context.become(watching(watches -- deprecatedWatches, watchedUtxos1, block2tx, None))
 
-    case 'watches => sender ! watches
+    case Symbol("watches") => sender ! watches
 
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
@@ -65,17 +65,17 @@ class ZMQActor(address: String, connected: Option[Promise[Done]] = None) extends
     case None => ()
   }
 
-  self ! 'checkEvent
-  self ! 'checkMsg
+  self ! Symbol("checkEvent")
+  self ! Symbol("checkMsg")
 
   override def receive: Receive = {
-    case 'checkEvent =>
+    case Symbol("checkEvent") =>
       checkEvent
-      context.system.scheduler.scheduleOnce(1 second, self ,'checkEvent)
+      context.system.scheduler.scheduleOnce(1 second, self ,Symbol("checkEvent"))
 
-    case 'checkMsg =>
+    case Symbol("checkMsg") =>
       checkMsg
-      context.system.scheduler.scheduleOnce(1 second, self, 'checkMsg)
+      context.system.scheduler.scheduleOnce(1 second, self, Symbol("checkMsg"))
 
     case event: Event => event.getEvent match {
       case ZMQ.EVENT_CONNECTED =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/Blockchain.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/Blockchain.scala
@@ -98,7 +98,7 @@ object Blockchain extends Logging {
 
     lazy val blockId = header.blockId
 
-    lazy val logwork = if (chainwork == 0) 0.0 else Math.log(chainwork.doubleValue()) / Math.log(2.0)
+    lazy val logwork = if (chainwork == 0) 0.0 else Math.log(chainwork.doubleValue) / Math.log(2.0)
 
     override def toString = s"BlockIndex($blockId, $height, ${parent.map(_.blockId)}, $logwork)"
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/CheckPoint.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/CheckPoint.scala
@@ -40,7 +40,7 @@ object CheckPoint {
     * we're on the right chain and to validate proof-of-work by checking the difficulty target
     * @return an ordered list of checkpoints, with one checkpoint every 2016 blocks
     */
-  def load(chainHash: ByteVector32): Vector[CheckPoint] = chainHash match {
+  def load(chainHash: ByteVector32): Vector[CheckPoint] = (chainHash: @unchecked) match {
     case Block.LivenetGenesisBlock.hash => load(classOf[CheckPoint].getResourceAsStream("/electrum/checkpoints_mainnet.json"))
     case Block.TestnetGenesisBlock.hash => load(classOf[CheckPoint].getResourceAsStream("/electrum/checkpoints_testnet.json"))
     case Block.RegtestGenesisBlock.hash => Vector.empty[CheckPoint] // no checkpoints on regtest

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumClient.scala
@@ -227,8 +227,8 @@ class ElectrumClient(serverAddress: InetSocketAddress, ssl: SSL, socksProxy_opt:
   override def unhandled(message: Any): Unit = {
     message match {
       case Terminated(deadActor) =>
-        addressSubscriptions = addressSubscriptions.mapValues(subscribers => subscribers - deadActor)
-        scriptHashSubscriptions = scriptHashSubscriptions.mapValues(subscribers => subscribers - deadActor)
+        addressSubscriptions = addressSubscriptions.mapValues(subscribers => subscribers - deadActor).toMap
+        scriptHashSubscriptions = scriptHashSubscriptions.mapValues(subscribers => subscribers - deadActor).toMap
         statusListeners -= deadActor
         headerSubscriptions -= deadActor
 
@@ -512,8 +512,8 @@ object ElectrumClient {
           case _ => ""
         }
         val code = other \ " code" match {
-          case JInt(value) => value.intValue()
-          case JLong(value) => value.intValue()
+          case JInt(value) => value.intValue
+          case JLong(value) => value.intValue
           case _ => 0
         }
         Some(Error(code, message))
@@ -528,13 +528,13 @@ object ElectrumClient {
   }
 
   def longField(jvalue: JValue, field: String): Long = (jvalue \ field: @unchecked) match {
-    case JLong(value) => value.longValue()
-    case JInt(value) => value.longValue()
+    case JLong(value) => value.longValue
+    case JInt(value) => value.longValue
   }
 
   def intField(jvalue: JValue, field: String): Int = (jvalue \ field: @unchecked) match {
-    case JLong(value) => value.intValue()
-    case JInt(value) => value.intValue()
+    case JLong(value) => value.intValue
+    case JInt(value) => value.intValue
   }
 
   def parseBlockHeader(json: JValue): (Int, BlockHeader) = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
@@ -26,8 +26,7 @@ import fr.acinq.eclair.channel.{BITCOIN_FUNDING_DEPTHOK, BITCOIN_PARENT_TX_CONFI
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.{LongToBtcAmount, ShortChannelId, TxCoordinates}
 
-import scala.collection.SortedMap
-import scala.collection.immutable.Queue
+import scala.collection.immutable.{Queue, SortedMap}
 
 
 class ElectrumWatcher(blockCount: AtomicLong, client: ActorRef) extends Actor with Stash with ActorLogging {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
@@ -55,7 +55,7 @@ object BitgoFeeProvider {
     val blockTargets = json \ "feeByBlockTarget"
     blockTargets.foldField(Seq.empty[BlockTarget]) {
       // BitGo returns estimates in Satoshi/KB, which is what we want
-      case (list, (strBlockTarget, JInt(feePerKB))) => list :+ BlockTarget(strBlockTarget.toInt, feePerKB.longValue())
+      case (list, (strBlockTarget, JInt(feePerKB))) => list :+ BlockTarget(strBlockTarget.toInt, feePerKB.longValue)
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -722,7 +722,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
         case Failure(cause) => handleLocalError(cause, d, Some(fee))
       }
 
-    case Event(c@CMD_SIGN, d: DATA_NORMAL) =>
+    case Event(c: Command, d: DATA_NORMAL) if c == CMD_SIGN =>
       d.commitments.remoteNextCommitInfo match {
         case _ if !Commitments.localHasChanges(d.commitments) =>
           log.debug("ignoring CMD_SIGN (nothing to sign)")
@@ -760,7 +760,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
 
     case Event(commit: CommitSig, d: DATA_NORMAL) =>
       Commitments.receiveCommit(d.commitments, commit, keyManager) match {
-        case Success((commitments1, revocation)) =>
+        case Success((commitments1: Commitments, revocation)) =>
           log.debug("received a new sig, spec:\n{}", Commitments.specs2String(commitments1))
           if (Commitments.localHasChanges(commitments1)) {
             // if we have newly acknowledged changes let's sign them
@@ -1063,7 +1063,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
         case Failure(cause) => handleLocalError(cause, d, Some(fee))
       }
 
-    case Event(c@CMD_SIGN, d: DATA_SHUTDOWN) =>
+    case Event(c: Command, d: DATA_SHUTDOWN) if c == CMD_SIGN =>
       d.commitments.remoteNextCommitInfo match {
         case _ if !Commitments.localHasChanges(d.commitments) =>
           log.debug("ignoring CMD_SIGN (nothing to sign)")
@@ -1086,7 +1086,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
 
     case Event(commit: CommitSig, d@DATA_SHUTDOWN(_, localShutdown, remoteShutdown)) =>
       Commitments.receiveCommit(d.commitments, commit, keyManager) match {
-        case Success((commitments1, revocation)) =>
+        case Success((commitments1: Commitments, revocation)) =>
           // we always reply with a revocation
           log.debug("received a new sig:\n{}", Commitments.specs2String(commitments1))
           context.system.eventStream.publish(ChannelSignatureReceived(self, commitments1))
@@ -1374,7 +1374,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
   })
 
   when(CLOSED)(handleExceptions {
-    case Event('shutdown, _) =>
+    case Event(Symbol("shutdown"), _) =>
       stateData match {
         case d: HasCommitments =>
           log.info(s"deleting database record for channelId=${d.channelId}")
@@ -1617,7 +1617,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
   })
 
   def errorStateHandler: StateFunction = {
-    case Event('nevermatches, _) => stay // we can't define a state with no event handler, so we put a dummy one here
+    case Event(Symbol("nevermatches"), _) => stay // we can't define a state with no event handler, so we put a dummy one here
   }
 
   when(ERR_INFORMATION_LEAK)(errorStateHandler)
@@ -1650,7 +1650,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
 
     case Event(c: CMD_CLOSE, d) => handleCommandError(CommandUnavailableInThisState(Helpers.getChannelId(d), "close", stateName), c)
 
-    case Event(c@CMD_FORCECLOSE, d) =>
+    case Event(c: Command, d) if c == CMD_FORCECLOSE =>
       d match {
         case data: HasCommitments => handleLocalError(ForcedLocalCommit(data.channelId), data, Some(c)) replying ChannelCommandResponse.Ok
         case _ => handleCommandError(CommandUnavailableInThisState(Helpers.getChannelId(d), "forceclose", stateName), c)
@@ -1698,7 +1698,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
       }
       if (nextState == CLOSED) {
         // channel is closed, scheduling this actor for self destruction
-        context.system.scheduler.scheduleOnce(10 seconds, self, 'shutdown)
+        context.system.scheduler.scheduleOnce(10 seconds, self, Symbol("shutdown"))
       }
       if (nextState == OFFLINE) {
         // we can cancel the timer, we are not expecting anything when disconnected
@@ -2287,7 +2287,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
 
   case class MyState(state: FSM.State[fr.acinq.eclair.channel.State, Data]) {
 
-    def storing(): FSM.State[fr.acinq.eclair.channel.State, Data] = {
+    def storing(unused: Unit = ()): FSM.State[fr.acinq.eclair.channel.State, Data] = {
       state.stateData match {
         case d: HasCommitments =>
           log.debug("updating database record for channelId={}", d.channelId)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -56,11 +56,11 @@ class Register extends Actor with ActorLogging {
       val shortChannelId = shortIds.find(_._2 == channelId).map(_._1).getOrElse(ShortChannelId(0L))
       context become main(channels - channelId, shortIds - shortChannelId, channelsTo - channelId)
 
-    case 'channels => sender ! channels
+    case Symbol("channels") => sender ! channels
 
-    case 'shortIds => sender ! shortIds
+    case Symbol("shortIds") => sender ! shortIds
 
-    case 'channelsTo => sender ! channelsTo
+    case Symbol("channelsTo") => sender ! channelsTo
 
     case fwd@Forward(channelId, msg) =>
       channels.get(channelId) match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.{ShortChannelId, secureRandom}
 import scodec.bits.ByteVector
 
 object LocalKeyManager {
-  def channelKeyBasePath(chainHash: ByteVector32) = chainHash match {
+  def channelKeyBasePath(chainHash: ByteVector32) = (chainHash: @unchecked) match {
     case Block.RegtestGenesisBlock.hash | Block.TestnetGenesisBlock.hash => DeterministicWallet.hardened(46) :: DeterministicWallet.hardened(1) :: Nil
     case Block.LivenetGenesisBlock.hash => DeterministicWallet.hardened(47) :: DeterministicWallet.hardened(1) :: Nil
   }
@@ -36,7 +36,7 @@ object LocalKeyManager {
   // WARNING: if you change this path, you will change your node id even if the seed remains the same!!!
   // Note that the node path and the above channel path are on different branches so even if the
   // node key is compromised there is no way to retrieve the wallet keys
-  def nodeKeyBasePath(chainHash: ByteVector32) = chainHash match {
+  def nodeKeyBasePath(chainHash: ByteVector32) = (chainHash: @unchecked) match {
     case Block.RegtestGenesisBlock.hash | Block.TestnetGenesisBlock.hash => DeterministicWallet.hardened(46) :: DeterministicWallet.hardened(0) :: Nil
     case Block.LivenetGenesisBlock.hash => DeterministicWallet.hardened(47) :: DeterministicWallet.hardened(0) :: Nil
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -25,17 +25,17 @@ import fr.acinq.eclair.payment.{PaymentReceived, PaymentRelayed, PaymentSent}
 
 trait AuditDb extends Closeable {
 
-  def add(channelLifecycle: ChannelLifecycleEvent)
+  def add(channelLifecycle: ChannelLifecycleEvent): Unit
 
-  def add(paymentSent: PaymentSent)
+  def add(paymentSent: PaymentSent): Unit
 
-  def add(paymentReceived: PaymentReceived)
+  def add(paymentReceived: PaymentReceived): Unit
 
-  def add(paymentRelayed: PaymentRelayed)
+  def add(paymentRelayed: PaymentRelayed): Unit
 
-  def add(networkFeePaid: NetworkFeePaid)
+  def add(networkFeePaid: NetworkFeePaid): Unit
 
-  def add(channelErrorOccurred: ChannelErrorOccurred)
+  def add(channelErrorOccurred: ChannelErrorOccurred): Unit
 
   def listSent(from: Long, to: Long): Seq[PaymentSent]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -24,13 +24,13 @@ import fr.acinq.eclair.channel.HasCommitments
 
 trait ChannelsDb extends Closeable {
 
-  def addOrUpdateChannel(state: HasCommitments)
+  def addOrUpdateChannel(state: HasCommitments): Unit
 
-  def removeChannel(channelId: ByteVector32)
+  def removeChannel(channelId: ByteVector32): Unit
 
   def listLocalChannels(): Seq[HasCommitments]
 
-  def addHtlcInfo(channelId: ByteVector32, commitmentNumber: Long, paymentHash: ByteVector32, cltvExpiry: CltvExpiry)
+  def addHtlcInfo(channelId: ByteVector32, commitmentNumber: Long, paymentHash: ByteVector32, cltvExpiry: CltvExpiry): Unit
 
   def listHtlcInfos(channelId: ByteVector32, commitmentNumber: Long): Seq[(ByteVector32, CltvExpiry)]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
@@ -28,29 +28,29 @@ import scala.collection.immutable.SortedMap
 
 trait NetworkDb extends Closeable {
 
-  def addNode(n: NodeAnnouncement)
+  def addNode(n: NodeAnnouncement): Unit
 
-  def updateNode(n: NodeAnnouncement)
+  def updateNode(n: NodeAnnouncement): Unit
 
   def getNode(nodeId: PublicKey): Option[NodeAnnouncement]
 
-  def removeNode(nodeId: PublicKey)
+  def removeNode(nodeId: PublicKey): Unit
 
   def listNodes(): Seq[NodeAnnouncement]
 
-  def addChannel(c: ChannelAnnouncement, txid: ByteVector32, capacity: Satoshi)
+  def addChannel(c: ChannelAnnouncement, txid: ByteVector32, capacity: Satoshi): Unit
 
-  def updateChannel(u: ChannelUpdate)
+  def updateChannel(u: ChannelUpdate): Unit
 
-  def removeChannel(shortChannelId: ShortChannelId) = removeChannels(Set(shortChannelId))
+  def removeChannel(shortChannelId: ShortChannelId) = removeChannels(Set(shortChannelId)): Unit
 
-  def removeChannels(shortChannelIds: Iterable[ShortChannelId])
+  def removeChannels(shortChannelIds: Iterable[ShortChannelId]): Unit
 
   def listChannels(): SortedMap[ShortChannelId, PublicChannel]
 
   def addToPruned(shortChannelIds: Iterable[ShortChannelId]): Unit
 
-  def removeFromPruned(shortChannelId: ShortChannelId)
+  def removeFromPruned(shortChannelId: ShortChannelId): Unit
 
   def isPruned(shortChannelId: ShortChannelId): Boolean
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
@@ -23,9 +23,9 @@ import fr.acinq.eclair.wire.NodeAddress
 
 trait PeersDb extends Closeable {
 
-  def addOrUpdatePeer(nodeId: PublicKey, address: NodeAddress)
+  def addOrUpdatePeer(nodeId: PublicKey, address: NodeAddress): Unit
 
-  def removePeer(nodeId: PublicKey)
+  def removePeer(nodeId: PublicKey): Unit
 
   def getPeer(nodeId: PublicKey): Option[NodeAddress]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
@@ -35,9 +35,9 @@ import fr.acinq.eclair.channel.{Command, HasHtlcId}
  */
 trait PendingRelayDb extends Closeable {
 
-  def addPendingRelay(channelId: ByteVector32, cmd: Command with HasHtlcId)
+  def addPendingRelay(channelId: ByteVector32, cmd: Command with HasHtlcId): Unit
 
-  def removePendingRelay(channelId: ByteVector32, htlcId: Long)
+  def removePendingRelay(channelId: ByteVector32, htlcId: Long): Unit
 
   def listPendingRelay(channelId: ByteVector32): Seq[Command with HasHtlcId]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Client.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Client.scala
@@ -40,10 +40,10 @@ class Client(nodeParams: NodeParams, switchboard: ActorRef, router: ActorRef, re
   import context.system
 
   // we could connect directly here but this allows to take advantage of the automated mdc configuration on message reception
-  self ! 'connect
+  self ! Symbol("connect")
 
   def receive: Receive = {
-    case 'connect =>
+    case Symbol("connect") =>
       val (peerOrProxyAddress, proxyParams_opt) = nodeParams.socksProxy_opt.map(proxyParams => (proxyParams, Socks5ProxyParams.proxyAddress(remoteAddress, proxyParams))) match {
         case Some((proxyParams, Some(proxyAddress))) =>
           log.info(s"connecting to SOCKS5 proxy ${str(proxyAddress)}")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -74,7 +74,7 @@ class Switchboard(nodeParams: NodeParams, router: ActorRef, watcher: ActorRef, r
       val peer = createOrGetPeer(authenticated.remoteNodeId, offlineChannels = Set.empty)
       sender.tell(PeerConnection.InitializeConnection, peer) // switchboard impersonates the peer, which will appear as the sender
 
-    case 'peers => sender ! context.children
+    case Symbol("peers") => sender ! context.children
 
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -174,6 +174,7 @@ package object eclair {
     override def toFloat(x: MilliSatoshi): Float = x.toLong
     override def toDouble(x: MilliSatoshi): Double = x.toLong
     override def compare(x: MilliSatoshi, y: MilliSatoshi): Int = x.compare(y)
+    override def parseString(str: String): Option[MilliSatoshi] = ???
     // @formatter:on
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
@@ -478,7 +478,7 @@ object PaymentRequest {
   }
 
   // char -> 5 bits value
-  val charToint5: Map[Char, BitVector] = Bech32.alphabet.zipWithIndex.toMap.mapValues(BitVector.fromInt(_, size = 5, ordering = ByteOrdering.BigEndian))
+  val charToint5: Map[Char, BitVector] = Bech32.alphabet.zipWithIndex.toMap.mapValues(BitVector.fromInt(_, size = 5, ordering = ByteOrdering.BigEndian)).toMap
 
   // TODO: could be optimized by preallocating the resulting buffer
   def string2Bits(data: String): BitVector = data.map(charToint5).foldLeft(BitVector.empty)(_ ++ _)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelayer.scala
@@ -150,7 +150,7 @@ object ChannelRelayer {
       case Some(nextNodeId) =>
         log.debug(s"next hop for htlc #{} is nodeId={}", add.id, nextNodeId)
         // then we retrieve all known channels to this node
-        val allChannels = node2channels.getOrElse(nextNodeId, Set.empty[ShortChannelId])
+        val allChannels = node2channels.get(nextNodeId)
         // we then filter out channels that we have already tried
         val candidateChannels = allChannels -- alreadyTried
         // and we filter keep the ones that are compatible with this payment (mainly fees, expiry delta)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
@@ -353,6 +353,7 @@ object PostRestartHtlcCleaner {
         case Origin.Relayed(channelId, htlcId, _, _) => isPendingUpstream(channelId, htlcId)
         case Origin.TrampolineRelayed(htlcs, _) => htlcs.exists { case (channelId, htlcId) => isPendingUpstream(channelId, htlcId) }
       }
+      .toMap
 
     val notRelayed = htlcsIn.filterNot(htlcIn => relayedOut.keys.exists(origin => matchesOrigin(htlcIn.add, origin)))
     log.info(s"htlcsIn=${htlcsIn.length} notRelayed=${notRelayed.length} relayedOut=${relayedOut.values.flatten.size}")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
@@ -38,7 +38,7 @@ class Autoprobe(nodeParams: NodeParams, router: ActorRef, paymentInitiator: Acto
   import scala.concurrent.ExecutionContext.Implicits.global
 
   // refresh our map of channel_updates regularly from the router
-  context.system.scheduler.schedule(0 seconds, ROUTING_TABLE_REFRESH_INTERVAL, router, 'data)
+  context.system.scheduler.schedule(0 seconds, ROUTING_TABLE_REFRESH_INTERVAL, router, Symbol("data"))
 
   override def receive: Receive = {
     case routingData: Data =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -95,7 +95,7 @@ object Graph {
     var allSpurPathsFound = false
 
     // stores the shortest paths
-    val shortestPaths = new mutable.MutableList[WeightedPath]
+    val shortestPaths = new mutable.ArrayDeque[WeightedPath]
     // stores the candidates for k(K +1) shortest paths, sorted by path cost
     val candidates = new mutable.PriorityQueue[WeightedPath]
 
@@ -167,7 +167,7 @@ object Graph {
       }
     }
 
-    shortestPaths
+    shortestPaths.toSeq
   }
 
   /**
@@ -284,7 +284,7 @@ object Graph {
           current = prev.get(current.desc.b)
         }
 
-        edgePath
+        edgePath.toSeq
     }
   }
 
@@ -386,7 +386,7 @@ object Graph {
 
       def addEdge(d: ChannelDesc, u: ChannelUpdate): DirectedGraph = addEdge(GraphEdge(d, u))
 
-      def addEdges(edges: Seq[(ChannelDesc, ChannelUpdate)]): DirectedGraph = {
+      def addEdges(edges: Iterable[(ChannelDesc, ChannelUpdate)]): DirectedGraph = {
         edges.foldLeft(this)((acc, edge) => acc.addEdge(edge._1, edge._2))
       }
 
@@ -423,7 +423,7 @@ object Graph {
         }
       }
 
-      def removeEdges(descList: Seq[ChannelDesc]): DirectedGraph = {
+      def removeEdges(descList: Iterable[ChannelDesc]): DirectedGraph = {
         descList.foldLeft(this)((acc, edge) => acc.removeEdge(edge))
       }
 
@@ -538,9 +538,7 @@ object Graph {
        */
       def makeGraph(channels: SortedMap[ShortChannelId, PublicChannel]): DirectedGraph = {
         // initialize the map with the appropriate size to avoid resizing during the graph initialization
-        val mutableMap = new {} with mutable.HashMap[PublicKey, List[GraphEdge]] {
-          override def initialSize: Int = channels.size + 1
-        }
+        val mutableMap = new mutable.HashMap[PublicKey, List[GraphEdge]](initialCapacity = channels.size + 1, mutable.HashMap.defaultLoadFactor)
 
         // add all the vertices and edges in one go
         channels.values.foreach { channel =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -156,24 +156,24 @@ class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[
       log.info("reinstating shortChannelId={} from nodeId={}", shortChannelId, nodeId)
       stay using d.copy(excludedChannels = d.excludedChannels - desc)
 
-    case Event('nodes, d) =>
+    case Event(Symbol("nodes"), d) =>
       sender ! d.nodes.values
       stay
 
-    case Event('channels, d) =>
+    case Event(Symbol("channels"), d) =>
       sender ! d.channels.values.map(_.ann)
       stay
 
-    case Event('channelsMap, d) =>
+    case Event(Symbol("channelsMap"), d) =>
       sender ! d.channels
       stay
 
-    case Event('updates, d) =>
+    case Event(Symbol("updates"), d) =>
       val updates: Iterable[ChannelUpdate] = d.channels.values.flatMap(d => d.update_1_opt ++ d.update_2_opt) ++ d.privateChannels.values.flatMap(d => d.update_1_opt ++ d.update_2_opt)
       sender ! updates
       stay
 
-    case Event('data, d) =>
+    case Event(Symbol("data"), d) =>
       sender ! d
       stay
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/StaleChannels.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/StaleChannels.scala
@@ -48,7 +48,7 @@ object StaleChannels {
       ctx.system.eventStream.publish(ChannelLost(shortChannelId))
     }
 
-    val staleChannelsToRemove = new mutable.MutableList[ChannelDesc]
+    val staleChannelsToRemove = new mutable.ArrayBuffer[ChannelDesc]
     staleChannels.foreach(ca => {
       staleChannelsToRemove += ChannelDesc(ca.ann.shortChannelId, ca.ann.nodeId1, ca.ann.nodeId2)
       staleChannelsToRemove += ChannelDesc(ca.ann.shortChannelId, ca.ann.nodeId2, ca.ann.nodeId1)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -269,7 +269,7 @@ object Transactions {
       outputs.append(CommitmentOutputLink(TxOut(htlc.add.amountMsat.truncateToSatoshi, pay2wsh(redeemScript)), redeemScript, InHtlc(htlc)))
     }
 
-    outputs.sortWith(CommitmentOutputLink.sort)
+    outputs.sortWith(CommitmentOutputLink.sort).toSeq
   }
 
   def makeCommitTx(commitTxInput: InputInfo,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -23,7 +23,7 @@ import fr.acinq.bitcoin.Block
 import fr.acinq.eclair.crypto.LocalKeyManager
 import org.scalatest.FunSuite
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 class StartupSpec extends FunSuite {
@@ -40,7 +40,7 @@ class StartupSpec extends FunSuite {
 
   test("check configuration") {
     assert(Try(makeNodeParamsWithDefaults(ConfigFactory.load().getConfig("eclair"))).isSuccess)
-    assert(Try(makeNodeParamsWithDefaults(ConfigFactory.load().getConfig("eclair").withFallback(ConfigFactory.parseMap(Map("max-feerate-mismatch" -> 42))))).isFailure)
+    assert(Try(makeNodeParamsWithDefaults(ConfigFactory.load().getConfig("eclair").withFallback(ConfigFactory.parseMap(Map("max-feerate-mismatch" -> 42).asJava)))).isFailure)
   }
 
   test("NodeParams should fail if the alias is illegal (over 32 bytes)") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -26,16 +26,16 @@ import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.FundTransactionResponse
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, JsonRPCError}
 import fr.acinq.eclair.transactions.Scripts
-import fr.acinq.eclair.{LongToBtcAmount, TestConstants, addressToPublicKeyScript, randomKey}
+import fr.acinq.eclair.{LongToBtcAmount, addressToPublicKeyScript, randomKey}
 import grizzled.slf4j.Logging
-import org.json4s.JsonAST.{JString, _}
 import org.json4s.DefaultFormats
+import org.json4s.JsonAST.{JString, _}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
-import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 import scala.util.{Random, Try}
 
 
@@ -48,7 +48,7 @@ class BitcoinCoreWalletSpec extends TestKit(ActorSystem("test")) with BitcoindSe
     "eclair.bitcoind.port" -> bitcoindPort,
     "eclair.bitcoind.rpcport" -> bitcoindRpcPort,
     "eclair.router-broadcast-interval" -> "2 second",
-    "eclair.auto-reconnect" -> false))
+    "eclair.auto-reconnect" -> false).asJava)
   val config = ConfigFactory.load(commonConfig).getConfig("eclair")
 
   val walletPassword = Random.alphanumeric.take(8).mkString
@@ -82,8 +82,8 @@ class BitcoinCoreWalletSpec extends TestKit(ActorSystem("test")) with BitcoindSe
         port = config.getInt("bitcoind.rpcport")) {
 
         override def invoke(method: String, params: Any*)(implicit ec: ExecutionContext): Future[JValue] = method match {
-          case "getbalance" => Future(apiAmount)
-          case "fundrawtransaction" => Future(JObject(List("hex" -> JString(hexOut), "changepos" -> JInt(1), "fee" -> apiAmount)))
+          case "getbalance" => Future(apiAmount)(ec)
+          case "fundrawtransaction" => Future(JObject(List("hex" -> JString(hexOut), "changepos" -> JInt(1), "fee" -> apiAmount)))(ec)
           case _ => Future.failed(new RuntimeException(s"Test BasicBitcoinJsonRPCClient: method $method is not supported"))
         }
       }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
@@ -24,12 +24,12 @@ import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.Transaction
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, ExtendedBitcoinClient}
 import grizzled.slf4j.Logging
+import org.json4s.DefaultFormats
 import org.json4s.JsonAST.{JString, _}
-import org.json4s.{DefaultFormats}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 
-import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters._
 
 
 class ExtendedBitcoinClientSpec extends TestKit(ActorSystem("test")) with BitcoindService with FunSuiteLike with BeforeAndAfterAll with Logging {
@@ -41,7 +41,7 @@ class ExtendedBitcoinClientSpec extends TestKit(ActorSystem("test")) with Bitcoi
     "eclair.bitcoind.port" -> bitcoindPort,
     "eclair.bitcoind.rpcport" -> bitcoindRpcPort,
     "eclair.router-broadcast-interval" -> "2 second",
-    "eclair.auto-reconnect" -> false))
+    "eclair.auto-reconnect" -> false).asJava)
   val config = ConfigFactory.load(commonConfig).getConfig("eclair")
 
   implicit val formats = DefaultFormats

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSimulatedClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSimulatedClientSpec.scala
@@ -391,7 +391,7 @@ object ElectrumWalletSimulatedClientSpec {
     val status1 = data.history.mapValues(items => {
       val status = items.map(i => s"${i.tx_hash}:${i.height}:").mkString("")
       Crypto.sha256(ByteVector.view(status.getBytes())).toString()
-    })
+    }).toMap
     data.copy(status = status1)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletSpec.scala
@@ -38,7 +38,6 @@ import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 import scodec.bits.ByteVector
 
 import scala.concurrent.Await
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class ElectrumWalletSpec extends TestKit(ActorSystem("test")) with FunSuiteLike with BitcoindService with ElectrumxService with BeforeAndAfterAll with Logging {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -45,11 +45,10 @@ import fr.acinq.eclair.payment.relay.Relayer
 import fr.acinq.eclair.payment.relay.Relayer.{GetOutgoingChannels, OutgoingChannels}
 import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentRequest, SendTrampolinePaymentRequest}
 import fr.acinq.eclair.payment.send.PaymentLifecycle.{State => _}
-import fr.acinq.eclair.router.{Announcements, AnnouncementsBatchValidationSpec}
 import fr.acinq.eclair.router.Graph.WeightRatios
 import fr.acinq.eclair.router.RouteCalculation.ROUTE_MAX_LENGTH
-import fr.acinq.eclair.router.Router.{GossipDecision, PublicChannel, RouteParams}
-import fr.acinq.eclair.router.Router.{NORMAL => _, State => _, _}
+import fr.acinq.eclair.router.Router.{GossipDecision, PublicChannel, RouteParams, NORMAL => _, State => _}
+import fr.acinq.eclair.router.{Announcements, AnnouncementsBatchValidationSpec}
 import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.transactions.Transactions.{HtlcSuccessTx, HtlcTimeoutTx}
 import fr.acinq.eclair.wire._
@@ -60,11 +59,11 @@ import org.json4s.JsonAST.{JString, JValue}
 import org.scalatest.{BeforeAndAfterAll, FunSuiteLike}
 import scodec.bits.ByteVector
 
-import scala.collection.JavaConversions._
 import scala.compat.Platform
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 /**
  * Created by PM on 15/03/2017.
@@ -100,7 +99,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     "eclair.router.broadcast-interval" -> "2 second",
     "eclair.auto-reconnect" -> false,
     "eclair.to-remote-delay-blocks" -> 144,
-    "eclair.multi-part-payment-expiry" -> "20 seconds"))
+    "eclair.multi-part-payment-expiry" -> "20 seconds").asJava)
 
   implicit val formats = DefaultFormats
 
@@ -150,18 +149,17 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
   }
 
   test("starting eclair nodes") {
-    import collection.JavaConversions._
-    instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.node-alias" -> "A", "eclair.expiry-delta-blocks" -> 130, "eclair.server.port" -> 29730, "eclair.api.port" -> 28080, "eclair.features" -> "028a8a", "eclair.channel-flags" -> 0)).withFallback(commonConfig)) // A's channels are private
-    instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.node-alias" -> "B", "eclair.expiry-delta-blocks" -> 131, "eclair.server.port" -> 29731, "eclair.api.port" -> 28081, "eclair.features" -> "028a8a", "eclair.trampoline-payments-enable" -> true)).withFallback(commonConfig))
-    instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.expiry-delta-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082, "eclair.features" -> "0a8a8a", "eclair.max-funding-satoshis" -> 500000000, "eclair.trampoline-payments-enable" -> true, "eclair.max-payment-attempts" -> 15)).withFallback(commonConfig))
-    instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.node-alias" -> "D", "eclair.expiry-delta-blocks" -> 133, "eclair.server.port" -> 29733, "eclair.api.port" -> 28083, "eclair.features" -> "028a8a", "eclair.trampoline-payments-enable" -> true)).withFallback(commonConfig))
-    instantiateEclairNode("E", ConfigFactory.parseMap(Map("eclair.node-alias" -> "E", "eclair.expiry-delta-blocks" -> 134, "eclair.server.port" -> 29734, "eclair.api.port" -> 28084)).withFallback(commonConfig))
-    instantiateEclairNode("F1", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F1", "eclair.expiry-delta-blocks" -> 135, "eclair.server.port" -> 29735, "eclair.api.port" -> 28085, "eclair.features" -> "0a8a8a", "eclair.max-funding-satoshis" -> 500000000)).withFallback(commonConfig))
-    instantiateEclairNode("F2", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F2", "eclair.expiry-delta-blocks" -> 136, "eclair.server.port" -> 29736, "eclair.api.port" -> 28086)).withFallback(commonConfig))
-    instantiateEclairNode("F3", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F3", "eclair.expiry-delta-blocks" -> 137, "eclair.server.port" -> 29737, "eclair.api.port" -> 28087, "eclair.features" -> "028a8a", "eclair.trampoline-payments-enable" -> true)).withFallback(commonConfig))
-    instantiateEclairNode("F4", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F4", "eclair.expiry-delta-blocks" -> 138, "eclair.server.port" -> 29738, "eclair.api.port" -> 28088)).withFallback(commonConfig))
-    instantiateEclairNode("F5", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F5", "eclair.expiry-delta-blocks" -> 139, "eclair.server.port" -> 29739, "eclair.api.port" -> 28089)).withFallback(commonConfig))
-    instantiateEclairNode("G", ConfigFactory.parseMap(Map("eclair.node-alias" -> "G", "eclair.expiry-delta-blocks" -> 140, "eclair.server.port" -> 29740, "eclair.api.port" -> 28090, "eclair.fee-base-msat" -> 1010, "eclair.fee-proportional-millionths" -> 102, "eclair.trampoline-payments-enable" -> true)).withFallback(commonConfig))
+    instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.node-alias" -> "A", "eclair.expiry-delta-blocks" -> 130, "eclair.server.port" -> 29730, "eclair.api.port" -> 28080, "eclair.features" -> "028a8a", "eclair.channel-flags" -> 0).asJava).withFallback(commonConfig)) // A's channels are private
+    instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.node-alias" -> "B", "eclair.expiry-delta-blocks" -> 131, "eclair.server.port" -> 29731, "eclair.api.port" -> 28081, "eclair.features" -> "028a8a", "eclair.trampoline-payments-enable" -> true).asJava).withFallback(commonConfig))
+    instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.expiry-delta-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082, "eclair.features" -> "0a8a8a", "eclair.max-funding-satoshis" -> 500000000, "eclair.trampoline-payments-enable" -> true, "eclair.max-payment-attempts" -> 15).asJava).withFallback(commonConfig))
+    instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.node-alias" -> "D", "eclair.expiry-delta-blocks" -> 133, "eclair.server.port" -> 29733, "eclair.api.port" -> 28083, "eclair.features" -> "028a8a", "eclair.trampoline-payments-enable" -> true).asJava).withFallback(commonConfig))
+    instantiateEclairNode("E", ConfigFactory.parseMap(Map("eclair.node-alias" -> "E", "eclair.expiry-delta-blocks" -> 134, "eclair.server.port" -> 29734, "eclair.api.port" -> 28084).asJava).withFallback(commonConfig))
+    instantiateEclairNode("F1", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F1", "eclair.expiry-delta-blocks" -> 135, "eclair.server.port" -> 29735, "eclair.api.port" -> 28085, "eclair.features" -> "0a8a8a", "eclair.max-funding-satoshis" -> 500000000).asJava).withFallback(commonConfig))
+    instantiateEclairNode("F2", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F2", "eclair.expiry-delta-blocks" -> 136, "eclair.server.port" -> 29736, "eclair.api.port" -> 28086).asJava).withFallback(commonConfig))
+    instantiateEclairNode("F3", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F3", "eclair.expiry-delta-blocks" -> 137, "eclair.server.port" -> 29737, "eclair.api.port" -> 28087, "eclair.features" -> "028a8a", "eclair.trampoline-payments-enable" -> true).asJava).withFallback(commonConfig))
+    instantiateEclairNode("F4", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F4", "eclair.expiry-delta-blocks" -> 138, "eclair.server.port" -> 29738, "eclair.api.port" -> 28088).asJava).withFallback(commonConfig))
+    instantiateEclairNode("F5", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F5", "eclair.expiry-delta-blocks" -> 139, "eclair.server.port" -> 29739, "eclair.api.port" -> 28089).asJava).withFallback(commonConfig))
+    instantiateEclairNode("G", ConfigFactory.parseMap(Map("eclair.node-alias" -> "G", "eclair.expiry-delta-blocks" -> 140, "eclair.server.port" -> 29740, "eclair.api.port" -> 28090, "eclair.fee-base-msat" -> 1010, "eclair.fee-proportional-millionths" -> 102, "eclair.trampoline-payments-enable" -> true).asJava).withFallback(commonConfig))
 
     // by default C has a normal payment handler, but this can be overriden in tests
     val paymentHandlerC = nodes("C").system.actorOf(PaymentHandler.props(nodes("C").nodeParams, nodes("C").commandBuffer))
@@ -260,8 +258,8 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     // A requires private channels, as a consequence:
     // - only A and B know about channel A-B (and there is no channel_announcement)
     // - A is not announced (no node_announcement)
-    awaitAnnouncements(nodes.filterKeys(key => List("A", "B").contains(key)), 10, 12, 26)
-    awaitAnnouncements(nodes.filterKeys(key => !List("A", "B").contains(key)), 10, 12, 24)
+    awaitAnnouncements(nodes.filterKeys(key => List("A", "B").contains(key)).toMap, 10, 12, 26)
+    awaitAnnouncements(nodes.filterKeys(key => !List("A", "B").contains(key)).toMap, 10, 12, 24)
   }
 
   test("open a wumbo channel and wait for longer than the default min_depth") {
@@ -341,7 +339,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
       fundeeState == NORMAL && funderState == NORMAL
     })
 
-    awaitAnnouncements(nodes.filterKeys(_ == "A"), 10, 13, 28)
+    awaitAnnouncements(nodes.filterKeys(_ == "A").toMap, 10, 13, 28)
   }
 
   test("send an HTLC A->D") {
@@ -680,7 +678,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     assert(relayed.amountIn - relayed.amountOut < 1000000.msat, relayed)
 
     val outgoingSuccess = nodes("B").nodeParams.db.payments.listOutgoingPayments(paymentId).filter(p => p.status.isInstanceOf[OutgoingPaymentStatus.Succeeded])
-    outgoingSuccess.foreach { case p@OutgoingPayment(_, _, _, _, _, _, _, recipientNodeId, _, _, OutgoingPaymentStatus.Succeeded(_, _, route, _)) =>
+    outgoingSuccess.collect { case p@OutgoingPayment(_, _, _, _, _, _, _, recipientNodeId, _, _, OutgoingPaymentStatus.Succeeded(_, _, route, _)) =>
       assert(recipientNodeId === nodes("F3").nodeParams.nodeId, p)
       assert(route.lastOption === Some(HopSummary(nodes("G").nodeParams.nodeId, nodes("F3").nodeParams.nodeId)), p)
     }
@@ -719,7 +717,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     assert(relayed.amountIn - relayed.amountOut < 300000.msat, relayed)
 
     val outgoingSuccess = nodes("D").nodeParams.db.payments.listOutgoingPayments(paymentId).filter(p => p.status.isInstanceOf[OutgoingPaymentStatus.Succeeded])
-    outgoingSuccess.foreach { case p@OutgoingPayment(_, _, _, _, _, _, _, recipientNodeId, _, _, OutgoingPaymentStatus.Succeeded(_, _, route, _)) =>
+    outgoingSuccess.collect { case p@OutgoingPayment(_, _, _, _, _, _, _, recipientNodeId, _, _, OutgoingPaymentStatus.Succeeded(_, _, route, _)) =>
       assert(recipientNodeId === nodes("B").nodeParams.nodeId, p)
       assert(route.lastOption === Some(HopSummary(nodes("C").nodeParams.nodeId, nodes("B").nodeParams.nodeId)), p)
     }
@@ -767,7 +765,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     assert(relayed.amountIn - relayed.amountOut < 1000000.msat, relayed)
 
     val outgoingSuccess = nodes("F3").nodeParams.db.payments.listOutgoingPayments(paymentId).filter(p => p.status.isInstanceOf[OutgoingPaymentStatus.Succeeded])
-    outgoingSuccess.foreach { case p@OutgoingPayment(_, _, _, _, _, _, _, recipientNodeId, _, _, OutgoingPaymentStatus.Succeeded(_, _, route, _)) =>
+    outgoingSuccess.collect { case p@OutgoingPayment(_, _, _, _, _, _, _, recipientNodeId, _, _, OutgoingPaymentStatus.Succeeded(_, _, route, _)) =>
       assert(recipientNodeId === nodes("A").nodeParams.nodeId, p)
       assert(route.lastOption === Some(HopSummary(nodes("C").nodeParams.nodeId, nodes("A").nodeParams.nodeId)), p)
     }
@@ -910,7 +908,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     generateBlocks(bitcoincli, 2)
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
-    awaitAnnouncements(nodes.filterKeys(_ == "A"), 10, 12, 26)
+    awaitAnnouncements(nodes.filterKeys(_ == "A").toMap, 10, 12, 26)
   }
 
   def getBlockCount: Long = {
@@ -991,7 +989,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     generateBlocks(bitcoincli, 2, Some(address))
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
-    awaitAnnouncements(nodes.filterKeys(_ == "A"), 9, 11, 24)
+    awaitAnnouncements(nodes.filterKeys(_ == "A").toMap, 9, 11, 24)
   }
 
   test("propagate a failure upstream when a downstream htlc times out (local commit)") {
@@ -1049,7 +1047,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     generateBlocks(bitcoincli, 2, Some(address))
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
-    awaitAnnouncements(nodes.filterKeys(_ == "A"), 8, 10, 22)
+    awaitAnnouncements(nodes.filterKeys(_ == "A").toMap, 8, 10, 22)
   }
 
   test("propagate a failure upstream when a downstream htlc times out (remote commit)") {
@@ -1111,7 +1109,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     generateBlocks(bitcoincli, 2, Some(address))
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
-    awaitAnnouncements(nodes.filterKeys(_ == "A"), 7, 9, 20)
+    awaitAnnouncements(nodes.filterKeys(_ == "A").toMap, 7, 9, 20)
   }
 
   test("punish a node that has published a revoked commit tx") {
@@ -1234,7 +1232,7 @@ class IntegrationSpec extends TestKit(ActorSystem("test")) with BitcoindService 
     // and we wait for C'channel to close
     awaitCond(stateListener.expectMsgType[ChannelStateChanged].currentState == CLOSED, max = 30 seconds)
     // this will remove the channel
-    awaitAnnouncements(nodes.filterKeys(_ == "A"), 6, 8, 18)
+    awaitAnnouncements(nodes.filterKeys(_ == "A").toMap, 6, 8, 18)
   }
 
   test("generate and validate lots of channels") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
@@ -90,9 +90,13 @@ class ChannelSelectionSpec extends FunSuite {
       ShortChannelId(44444) -> OutgoingChannel(b, channelUpdate, makeCommitments(ByteVector32.Zeroes, 1000000 msat))
     )
 
-    val node2channels = new mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId]
-    node2channels.put(a, mutable.Set(ShortChannelId(12345), ShortChannelId(11111), ShortChannelId(22222), ShortChannelId(33333)))
-    node2channels.put(b, mutable.Set(ShortChannelId(44444)))
+    val node2channels = mutable.MultiDict.empty[PublicKey, ShortChannelId]
+    node2channels.addAll(
+      (a, ShortChannelId(12345)) ::
+        (a, ShortChannelId(11111)) ::
+        (a, ShortChannelId(22222)) ::
+        (a, ShortChannelId(33333)) ::
+        (b, ShortChannelId(44444)) :: Nil)
 
     // select the channel to the same node, with the lowest balance but still high enough to handle the payment
     assert(selectPreferredChannel(relayPayload, channelUpdates, node2channels, Seq.empty) === Some(ShortChannelId(22222)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -166,7 +166,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     import f._
     val payment = SendMultiPartPayment(randomBytes32, b, 1000 * 1000 msat, expiry, 1)
     // Network statistics should be ignored when sending to peer (otherwise we should have split into multiple payments).
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(100), d => Satoshi(d.toLong))), localChannels(0))
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(100), d => Satoshi(d.toLong))), localChannels(0))
     childPayFsm.expectMsg(SendPayment(b, Onion.createMultiPartPayload(payment.totalAmount, payment.totalAmount, expiry, payment.paymentSecret), 1, routePrefix = Seq(ChannelHop(nodeParams.nodeId, b, channelUpdate_ab_1))))
     childPayFsm.expectNoMsg(50 millis)
   }
@@ -178,7 +178,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     val testChannels = localChannels()
     val balanceToTarget = testChannels.channels.filter(_.nextNodeId == d).map(_.commitments.availableBalanceForSend).sum
     assert(balanceToTarget < (1000 * 1000).msat) // the commit tx fee prevents us from completely emptying our channel
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(500), d => Satoshi(d.toLong))), testChannels)
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(500), d => Satoshi(d.toLong))), testChannels)
     waitUntilAmountSent(f, payment.totalAmount)
     val payments = payFsm.stateData.asInstanceOf[PaymentProgress].pending.values
     assert(payments.size > 1)
@@ -190,7 +190,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
   test("send to remote node without splitting") { f =>
     import f._
     val payment = SendMultiPartPayment(randomBytes32, e, 300 * 1000 msat, expiry, 1)
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1500), d => Satoshi(d.toLong))), localChannels())
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1500), d => Satoshi(d.toLong))), localChannels())
     waitUntilAmountSent(f, payment.totalAmount)
     payFsm.stateData.asInstanceOf[PaymentProgress].pending.foreach {
       case (id, payment) => childPayFsm.send(payFsm, PaymentSent(paymentId, paymentHash, paymentPreimage, finalAmount, e, Seq(PartialPayment(id, payment.finalPayload.amount, 5 msat, randomBytes32, None))))
@@ -206,7 +206,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     import f._
     val payment = SendMultiPartPayment(randomBytes32, e, 3200 * 1000 msat, expiry, 3)
     // A network capacity of 1000 sat should split the payment in at least 3 parts.
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), localChannels())
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1000), d => Satoshi(d.toLong))), localChannels())
 
     val payments = Iterator.iterate(0 msat)(sent => {
       val child = childPayFsm.expectMsgType[SendPayment]
@@ -218,7 +218,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
       assert(child.routePrefix.length === 1 && child.routePrefix.head.nodeId === nodeParams.nodeId)
       assert(sent + child.finalPayload.amount <= payment.totalAmount)
       sent + child.finalPayload.amount
-    }).toSeq.takeWhile(sent => sent != payment.totalAmount)
+    }).takeWhile(sent => sent != payment.totalAmount).toSeq
     assert(payments.length > 2)
     assert(payments.length < 10)
     childPayFsm.expectNoMsg(50 millis)
@@ -248,7 +248,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     // A network capacity of 1500 sat should split the payment in at least 2 parts.
     // We have a single big channel inside which we'll send multiple payments.
     val localChannel = OutgoingChannels(Seq(OutgoingChannel(b, channelUpdate_ab_1, makeCommitments(5000 * 1000 msat, feeRatePerKw))))
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1500), d => Satoshi(d.toLong))), localChannel)
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1500), d => Satoshi(d.toLong))), localChannel)
     waitUntilAmountSent(f, payment.totalAmount)
 
     val pending = payFsm.stateData.asInstanceOf[PaymentProgress].pending
@@ -271,7 +271,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     import f._
     val trampolineTlv = OnionTlv.TrampolineOnion(OnionRoutingPacket(0, ByteVector.fill(33)(0), ByteVector.fill(400)(0), randomBytes32))
     val payment = SendMultiPartPayment(randomBytes32, e, 3000 * 1000 msat, expiry, 3, additionalTlvs = Seq(trampolineTlv))
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), localChannels())
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1000), d => Satoshi(d.toLong))), localChannels())
     waitUntilAmountSent(f, payment.totalAmount)
 
     val pending = payFsm.stateData.asInstanceOf[PaymentProgress].pending
@@ -284,7 +284,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     import f._
     val routeParams = RouteParams(randomize = false, 100 msat, 0.05, 20, CltvExpiryDelta(144), None)
     val payment = SendMultiPartPayment(randomBytes32, e, 3000 * 1000 msat, expiry, 3, routeParams = Some(routeParams))
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), localChannels())
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1000), d => Satoshi(d.toLong))), localChannels())
     waitUntilAmountSent(f, 3000 * 1000 msat)
 
     val pending = payFsm.stateData.asInstanceOf[PaymentProgress].pending
@@ -304,7 +304,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
       OutgoingChannel(b, channelUpdate_ab_1.copy(shortChannelId = ShortChannelId(42)), makeCommitments(0 msat, 10)),
       OutgoingChannel(e, channelUpdate_ab_1.copy(shortChannelId = ShortChannelId(43)), makeCommitments(0 msat, 10)
       )))
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), testChannels1)
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1000), d => Satoshi(d.toLong))), testChannels1)
     waitUntilAmountSent(f, payment.totalAmount)
     payFsm.stateData.asInstanceOf[PaymentProgress].pending.foreach {
       case (id, p) => childPayFsm.send(payFsm, PaymentSent(paymentId, paymentHash, paymentPreimage, payment.totalAmount, e, Seq(PartialPayment(id, p.finalPayload.amount, 5 msat, randomBytes32, None))))
@@ -320,7 +320,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     val payment = SendMultiPartPayment(randomBytes32, e, 3000 * 1000 msat, expiry, 3)
     val testChannels = localChannels()
     // A network capacity of 1000 sat should split the payment in at least 3 parts.
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), testChannels)
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1000), d => Satoshi(d.toLong))), testChannels)
     waitUntilAmountSent(f, payment.totalAmount)
     val pending = payFsm.stateData.asInstanceOf[PaymentProgress].pending
     assert(pending.size > 2)
@@ -351,7 +351,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
   test("cannot send (not enough capacity on local channels)") { f =>
     import f._
     val payment = SendMultiPartPayment(randomBytes32, e, 3000 * 1000 msat, expiry, 3)
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), OutgoingChannels(Seq(
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1000), d => Satoshi(d.toLong))), OutgoingChannels(Seq(
       OutgoingChannel(b, channelUpdate_ab_1, makeCommitments(1000 * 1000 msat, 10)),
       OutgoingChannel(c, channelUpdate_ac_2, makeCommitments(1000 * 1000 msat, 10)),
       OutgoingChannel(d, channelUpdate_ad_1, makeCommitments(1000 * 1000 msat, 10))))
@@ -366,7 +366,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
   test("cannot send (fee rate too high)") { f =>
     import f._
     val payment = SendMultiPartPayment(randomBytes32, e, 2500 * 1000 msat, expiry, 3)
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), OutgoingChannels(Seq(
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1000), d => Satoshi(d.toLong))), OutgoingChannels(Seq(
       OutgoingChannel(b, channelUpdate_ab_1, makeCommitments(1500 * 1000 msat, 1000)),
       OutgoingChannel(c, channelUpdate_ac_2, makeCommitments(1500 * 1000 msat, 1000)),
       OutgoingChannel(d, channelUpdate_ad_1, makeCommitments(1500 * 1000 msat, 1000))))
@@ -381,7 +381,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
   test("payment timeout") { f =>
     import f._
     val payment = SendMultiPartPayment(randomBytes32, e, 3000 * 1000 msat, expiry, 5)
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), localChannels())
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1000), d => Satoshi(d.toLong))), localChannels())
     waitUntilAmountSent(f, payment.totalAmount)
     val (childId1, _) = payFsm.stateData.asInstanceOf[PaymentProgress].pending.head
 
@@ -394,7 +394,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
   test("failure received from final recipient") { f =>
     import f._
     val payment = SendMultiPartPayment(randomBytes32, e, 3000 * 1000 msat, expiry, 5)
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), localChannels())
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1000), d => Satoshi(d.toLong))), localChannels())
     waitUntilAmountSent(f, payment.totalAmount)
     val (childId1, _) = payFsm.stateData.asInstanceOf[PaymentProgress].pending.head
 
@@ -407,7 +407,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
   test("fail after too many attempts") { f =>
     import f._
     val payment = SendMultiPartPayment(randomBytes32, e, 3000 * 1000 msat, expiry, 2)
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1000), d => Satoshi(d.toLong))), localChannels())
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1000), d => Satoshi(d.toLong))), localChannels())
     waitUntilAmountSent(f, payment.totalAmount)
     val (childId1, childPayment1) = payFsm.stateData.asInstanceOf[PaymentProgress].pending.head
 
@@ -437,7 +437,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
   test("receive partial failure after success (recipient spec violation)") { f =>
     import f._
     val payment = SendMultiPartPayment(randomBytes32, e, 4000 * 1000 msat, expiry, 2)
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(1500), d => Satoshi(d.toLong))), localChannels())
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(1500), d => Satoshi(d.toLong))), localChannels())
     waitUntilAmountSent(f, payment.totalAmount)
     val pending = payFsm.stateData.asInstanceOf[PaymentProgress].pending
 
@@ -461,7 +461,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
   test("receive partial success after abort (recipient spec violation)") { f =>
     import f._
     val payment = SendMultiPartPayment(randomBytes32, e, 5000 * 1000 msat, expiry, 1)
-    initPayment(f, payment, emptyStats.copy(capacity = Stats(Seq(2000), d => Satoshi(d.toLong))), localChannels())
+    initPayment(f, payment, emptyStats.copy(capacity = Stats.generate(Seq(2000), d => Satoshi(d.toLong))), localChannels())
     waitUntilAmountSent(f, payment.totalAmount)
     val pending = payFsm.stateData.asInstanceOf[PaymentProgress].pending
 
@@ -492,7 +492,7 @@ class MultiPartPaymentLifecycleSpec extends TestKit(ActorSystem("test")) with fi
     for (_ <- 1 to 100) {
       // We have a total of 6500 satoshis across all channels. We try to send lower amounts to take fees into account.
       val toSend = ((1 + Random.nextInt(3500)) * 1000).msat
-      val networkStats = emptyStats.copy(capacity = Stats(Seq(400 + Random.nextInt(1600)), d => Satoshi(d.toLong)))
+      val networkStats = emptyStats.copy(capacity = Stats.generate(Seq(400 + Random.nextInt(1600)), d => Satoshi(d.toLong)))
       val routeParams = RouteParams(randomize = true, Random.nextInt(1000).msat, Random.nextInt(10).toDouble / 100, 20, CltvExpiryDelta(144), None)
       val request = SendMultiPartPayment(randomBytes32, e, toSend, CltvExpiry(561), 1, Nil, Some(routeParams))
       val fuzzParams = s"(sending $toSend with network capacity ${networkStats.capacity.percentile75.toMilliSatoshi}, fee base ${routeParams.maxFeeBase} and fee percentage ${routeParams.maxFeePct})"
@@ -551,7 +551,7 @@ object MultiPartPaymentLifecycleSpec {
   val hop_ab_2 = ChannelHop(a, b, channelUpdate_ab_2)
   val hop_ac_1 = ChannelHop(a, c, channelUpdate_ac_1)
 
-  val emptyStats = NetworkStats(0, 0, Stats(Seq(0), d => Satoshi(d.toLong)), Stats(Seq(0), d => CltvExpiryDelta(d.toInt)), Stats(Seq(0), d => MilliSatoshi(d.toLong)), Stats(Seq(0), d => d.toLong))
+  val emptyStats = NetworkStats(0, 0, Stats.generate(Seq(0), d => Satoshi(d.toLong)), Stats.generate(Seq(0), d => CltvExpiryDelta(d.toInt)), Stats.generate(Seq(0), d => MilliSatoshi(d.toLong)), Stats.generate(Seq(0), d => d.toLong))
 
   // We are only interested in availableBalanceForSend so we can put dummy values for the rest.
   def makeCommitments(canSend: MilliSatoshi, feeRatePerKw: Long, announceChannel: Boolean = true): Commitments =

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -103,7 +103,8 @@ abstract class BaseRouterSpec extends TestkitBaseClass {
       // let's set up the router
       val peerConnection = TestProbe()
       val watcher = TestProbe()
-      val nodeParams = Alice.nodeParams
+      import com.softwaremill.quicklens._
+      val nodeParams = Alice.nodeParams.modify(_.routerConf.routerBroadcastInterval).setTo(1 day) // "disable" auto rebroadcast
       val router = system.actorOf(Router.props(nodeParams, watcher.ref))
       // we announce channels
       peerConnection.send(router, PeerRoutingMessage(remoteNodeId, chan_ab))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -964,7 +964,7 @@ object RouteCalculationSpec {
       htlcMaximumMsat = maxHtlc
     )
 
-  def makeGraph(updates: Map[ChannelDesc, ChannelUpdate]) = DirectedGraph().addEdges(updates.toSeq)
+  def makeGraph(updates: Map[ChannelDesc, ChannelUpdate]) = DirectedGraph().addEdges(updates)
 
   def hops2Ids(route: Seq[ChannelHop]) = route.map(hop => hop.lastUpdate.shortChannelId.toLong)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RoutingSyncSpec.scala
@@ -302,7 +302,7 @@ class RoutingSyncSpec extends TestKit(ActorSystem("test")) with FunSuiteLike wit
 
 object RoutingSyncSpec {
 
-  lazy val shortChannelIds: immutable.SortedSet[ShortChannelId] = (for {
+  lazy val shortChannelIds: SortedSet[ShortChannelId] = (for {
     block <- 400000 to 420000
     txindex <- 0 to 5
     outputIndex <- 0 to 1

--- a/eclair-node-gui/pom.xml
+++ b/eclair-node-gui/pom.xml
@@ -20,11 +20,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.acinq.eclair</groupId>
-        <artifactId>eclair_2.11</artifactId>
+        <artifactId>eclair_2.13</artifactId>
         <version>0.3.5-SNAPSHOT</version>
     </parent>
 
-    <artifactId>eclair-node-gui_2.11</artifactId>
+    <artifactId>eclair-node-gui_2.13</artifactId>
     <packaging>jar</packaging>
 
     <name>eclair-node-gui</name>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -33,7 +33,7 @@ import javafx.application.Platform
 import javafx.fxml.FXMLLoader
 import javafx.scene.layout.VBox
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 
 /**
  * Created by PM on 16/08/2016.
@@ -41,8 +41,8 @@ import scala.collection.JavaConversions._
 
 class GUIUpdater(mainController: MainController) extends Actor with ActorLogging {
 
-  val STATE_MUTUAL_CLOSE = Set(WAIT_FOR_INIT_INTERNAL, WAIT_FOR_OPEN_CHANNEL, WAIT_FOR_ACCEPT_CHANNEL, WAIT_FOR_FUNDING_INTERNAL, WAIT_FOR_FUNDING_CREATED, WAIT_FOR_FUNDING_SIGNED, NORMAL)
-  val STATE_FORCE_CLOSE = Set(WAIT_FOR_FUNDING_CONFIRMED, WAIT_FOR_FUNDING_LOCKED, NORMAL, SHUTDOWN, NEGOTIATING, OFFLINE, SYNCING)
+  val STATE_MUTUAL_CLOSE: Set[fr.acinq.eclair.channel.State] = Set(WAIT_FOR_INIT_INTERNAL, WAIT_FOR_OPEN_CHANNEL, WAIT_FOR_ACCEPT_CHANNEL, WAIT_FOR_FUNDING_INTERNAL, WAIT_FOR_FUNDING_CREATED, WAIT_FOR_FUNDING_SIGNED, NORMAL)
+  val STATE_FORCE_CLOSE: Set[fr.acinq.eclair.channel.State] = Set(WAIT_FOR_FUNDING_CONFIRMED, WAIT_FOR_FUNDING_LOCKED, NORMAL, SHUTDOWN, NEGOTIATING, OFFLINE, SYNCING)
 
   /**
    * Needed to stop JavaFX complaining about updates from non GUI thread
@@ -214,15 +214,15 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
       log.debug(s"payment sent with h=${p.paymentHash}, amount=${p.recipientAmount}, fees=${p.feesPaid}")
       val message = CoinUtils.formatAmountInUnit(p.amountWithFees, FxApp.getUnit, withUnit = true)
       mainController.handlers.notification("Payment Sent", message, NOTIFICATION_SUCCESS)
-      runInGuiThread(() => mainController.paymentSentList.prepend(PaymentSentRecord(p, LocalDateTime.now())))
+      runInGuiThread(() => mainController.paymentSentList.asScala.prepend(PaymentSentRecord(p, LocalDateTime.now())))
 
     case p: PaymentReceived =>
       log.debug(s"payment received with h=${p.paymentHash}, amount=${p.amount}")
-      runInGuiThread(() => mainController.paymentReceivedList.prepend(PaymentReceivedRecord(p, LocalDateTime.now())))
+      runInGuiThread(() => mainController.paymentReceivedList.asScala.prepend(PaymentReceivedRecord(p, LocalDateTime.now())))
 
     case p: PaymentRelayed =>
       log.debug(s"payment relayed with h=${p.paymentHash}, amount=${p.amountIn}, feesEarned=${p.amountOut}")
-      runInGuiThread(() => mainController.paymentRelayedList.prepend(PaymentRelayedRecord(p, LocalDateTime.now())))
+      runInGuiThread(() => mainController.paymentRelayedList.asScala.prepend(PaymentRelayedRecord(p, LocalDateTime.now())))
 
     case ZMQConnected =>
       log.debug("ZMQ connection UP")

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/IndexedObservableList.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/IndexedObservableList.scala
@@ -53,8 +53,8 @@ class IndexedObservableList[K, V] {
       map2index.remove(key)
       list.remove(index)
       // now we need to decrement all higher indices by 1
-      import scala.collection.JavaConversions._
-      for (entry <- map2index.entrySet()) {
+      import scala.jdk.CollectionConverters._
+      for (entry <- map2index.entrySet().asScala) {
         if (entry.getValue > index) {
           map2index.put(entry.getKey, entry.getValue - 1)
         }

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/QRCodeUtils.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/QRCodeUtils.scala
@@ -28,13 +28,13 @@ import javafx.scene.paint.Color
 case object QRCodeUtils {
 
   def createQRCode(data: String, width: Int = 250, height: Int = 250, margin: Int = 5): WritableImage = {
-    import scala.collection.JavaConversions._
+    import scala.jdk.CollectionConverters._
     val hintMap = collection.mutable.Map[EncodeHintType, Object]()
     hintMap.put(EncodeHintType.CHARACTER_SET, "UTF-8")
     hintMap.put(EncodeHintType.ERROR_CORRECTION, ErrorCorrectionLevel.L)
     hintMap.put(EncodeHintType.MARGIN, margin.toString)
     val qrWriter = new QRCodeWriter
-    val byteMatrix = qrWriter.encode(data, BarcodeFormat.QR_CODE, width, height, hintMap)
+    val byteMatrix = qrWriter.encode(data, BarcodeFormat.QR_CODE, width, height, hintMap.asJava)
     val writableImage = new WritableImage(width, height)
     val pixelWriter = writableImage.getPixelWriter
     for (i <- 0 until byteMatrix.getWidth) {

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -20,11 +20,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.acinq.eclair</groupId>
-        <artifactId>eclair_2.11</artifactId>
+        <artifactId>eclair_2.13</artifactId>
         <version>0.3.5-SNAPSHOT</version>
     </parent>
 
-    <artifactId>eclair-node_2.11</artifactId>
+    <artifactId>eclair-node_2.13</artifactId>
     <packaging>jar</packaging>
 
     <name>eclair-node</name>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>de.heikoseeberger</groupId>
             <artifactId>akka-http-json4s_${scala.version.short}</artifactId>
-            <version>1.19.0</version>
+            <version>1.32.0</version>
         </dependency>
         <!-- metrics -->
         <dependency>
@@ -138,9 +138,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-stream-testkit_${scala.version.short}</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-scala-scalatest_2.11</artifactId>
-            <version>1.4.1</version>
+            <artifactId>mockito-scala-scalatest_${scala.version.short}</artifactId>
+            <version>1.5.9</version>
             <scope>test</scope>
         </dependency>
         <!-- agents -->

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -80,7 +80,7 @@ object Boot extends App with Logging {
         override val password = apiPassword
         override val eclairApi: Eclair = new EclairImpl(kit)
       }.route
-      Http().bindAndHandle(apiRoute, config.getString("api.binding-ip"), config.getInt("api.port")).onFailure {
+      Http().bindAndHandle(apiRoute, config.getString("api.binding-ip"), config.getInt("api.port")).recover {
         case _: BindFailedException => onError(TCPBindException(config.getInt("api.port")))
       }
     } else {

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>fr.acinq.eclair</groupId>
-    <artifactId>eclair_2.11</artifactId>
+    <artifactId>eclair_2.13</artifactId>
     <version>0.3.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
@@ -64,12 +64,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <scala.version>2.11.12</scala.version>
-        <scala.version.short>2.11</scala.version.short>
-        <akka.version>2.4.20</akka.version>
-        <akka.http.version>10.0.11</akka.http.version>
-        <sttp.version>1.3.9</sttp.version>
-        <bitcoinlib.version>0.17</bitcoinlib.version>
+        <scala.version>2.13.1</scala.version>
+        <scala.version.short>2.13</scala.version.short>
+        <akka.version>2.6.4</akka.version>
+        <akka.http.version>10.1.11</akka.http.version>
+        <sttp.version>1.7.2</sttp.version>
+        <bitcoinlib.version>0.18-SNAPSHOT</bitcoinlib.version>
         <guava.version>24.0-android</guava.version>
         <kamon.version>2.0.0</kamon.version>
     </properties>
@@ -132,16 +132,12 @@
                 <version>3.4.2</version>
                 <configuration>
                     <args combine.children="append">
-                        <arg>-deprecation</arg>
+                        <!--arg>-Xlint:deprecation</arg-->
                         <arg>-feature</arg>
                         <arg>-language:postfixOps</arg>
                         <arg>-language:implicitConversions</arg>
-                        <arg>-Xfatal-warnings</arg>
+                        <!--arg>-Werror</arg-->
                         <arg>-unchecked</arg>
-                        <arg>-Xmax-classfile-name</arg>
-                        <arg>140</arg>
-			<!-- needed to compile Scala code on JDK9+ -->
-                        <arg>-nobootcp</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xmx1024m</jvmArg>
@@ -272,7 +268,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.version.short}</artifactId>
-            <version>3.0.5</version>
+            <version>3.1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Main changes:
- some dependencies had to be updated
- relaxed compiler parameters to minimize impact (e.g. allow
deprecated features)
- `'something` -> `Symbol("something")`
- `BigDecimal.xValue()` -> `BigDecimal.xValue`
- `Map.filterKeys` -> `Map.filterKeys.toMap` (same for `Map.mapValues`)
- `def myMethod(...)` -> `def myMethod(...): Unit`

Compilation is 25% faster on my machine, compiler is a bit more strict
(it found an "invalid comparison" bug).