### PR TITLE
Update to scala 2.13 and akka 2.6 (incremental)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 dist: trusty
 language: scala
 scala:
- - 2.11.12
+ - 2.13.1
 env:
  - export LD_LIBRARY_PATH=/usr/local/lib
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
 dist: trusty
 language: scala
 scala:
- - 2.13.1
+ - 2.13.2
 env:
  - export LD_LIBRARY_PATH=/usr/local/lib
 before_install:

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -20,11 +20,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.acinq.eclair</groupId>
-        <artifactId>eclair_2.11</artifactId>
+        <artifactId>eclair_2.13</artifactId>
         <version>0.3.5-SNAPSHOT</version>
     </parent>
 
-    <artifactId>eclair-core_2.11</artifactId>
+    <artifactId>eclair-core_2.13</artifactId>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -115,6 +115,11 @@
     </profiles>
 
     <dependencies>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-collection-contrib_${scala.version.short}</artifactId>
+            <version>0.2.1</version>
+        </dependency>
         <!-- AKKA -->
         <dependency>
             <groupId>com.typesafe.akka</groupId>
@@ -170,7 +175,7 @@
         <dependency>
             <groupId>org.scodec</groupId>
             <artifactId>scodec-core_${scala.version.short}</artifactId>
-            <version>1.11.2</version>
+            <version>1.11.7</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -36,7 +36,7 @@ import fr.acinq.eclair.wire.{Color, EncodingType, NodeAddress}
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration.FiniteDuration
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Created by PM on 26/02/2017.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -174,6 +174,7 @@ package object eclair {
     override def toFloat(x: MilliSatoshi): Float = x.toLong
     override def toDouble(x: MilliSatoshi): Double = x.toLong
     override def compare(x: MilliSatoshi, y: MilliSatoshi): Int = x.compare(y)
+    override def parseString(str: String): Option[MilliSatoshi] = ???
     // @formatter:on
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelayer.scala
@@ -150,7 +150,7 @@ object ChannelRelayer {
       case Some(nextNodeId) =>
         log.debug(s"next hop for htlc #{} is nodeId={}", add.id, nextNodeId)
         // then we retrieve all known channels to this node
-        val allChannels = node2channels.getOrElse(nextNodeId, Set.empty[ShortChannelId])
+        val allChannels = node2channels.get(nextNodeId)
         // we then filter out channels that we have already tried
         val candidateChannels = allChannels -- alreadyTried
         // and we filter keep the ones that are compatible with this payment (mainly fees, expiry delta)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -95,7 +95,7 @@ object Graph {
     var allSpurPathsFound = false
 
     // stores the shortest paths
-    val shortestPaths = new mutable.MutableList[WeightedPath]
+    val shortestPaths = new mutable.ArrayDeque[WeightedPath]
     // stores the candidates for k(K +1) shortest paths, sorted by path cost
     val candidates = new mutable.PriorityQueue[WeightedPath]
 
@@ -167,7 +167,7 @@ object Graph {
       }
     }
 
-    shortestPaths
+    shortestPaths.toSeq
   }
 
   /**
@@ -284,7 +284,7 @@ object Graph {
           current = prev.get(current.desc.b)
         }
 
-        edgePath
+        edgePath.toSeq
     }
   }
 
@@ -534,9 +534,7 @@ object Graph {
        */
       def makeGraph(channels: SortedMap[ShortChannelId, PublicChannel]): DirectedGraph = {
         // initialize the map with the appropriate size to avoid resizing during the graph initialization
-        val mutableMap = new {} with mutable.HashMap[PublicKey, List[GraphEdge]] {
-          override def initialSize: Int = channels.size + 1
-        }
+        val mutableMap = new mutable.HashMap[PublicKey, List[GraphEdge]](initialCapacity = channels.size + 1, mutable.HashMap.defaultLoadFactor)
 
         // add all the vertices and edges in one go
         channels.values.foreach { channel =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -23,7 +23,7 @@ import fr.acinq.bitcoin.Block
 import fr.acinq.eclair.crypto.LocalKeyManager
 import org.scalatest.funsuite.AnyFunSuite
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 class StartupSpec extends AnyFunSuite {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -33,10 +33,10 @@ import org.json4s.JsonAST.{JString, _}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuiteLike
 
-import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
 import scala.util.{Random, Try}
 
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
@@ -29,8 +29,8 @@ import org.json4s.JsonAST.{JString, _}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuiteLike
 
-import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.jdk.CollectionConverters._
 
 
 class ExtendedBitcoinClientSpec extends TestKit(ActorSystem("test")) with BitcoindService with AnyFunSuiteLike with BeforeAndAfterAll with Logging {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProviderSpec.scala
@@ -32,7 +32,7 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProviderSpec.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.blockchain.fee
 
 import akka.actor.ActorSystem
 import akka.util.Timeout
-import com.softwaremill.sttp.okhttp.{OkHttpBackend, OkHttpFutureBackend}
+import com.softwaremill.sttp.okhttp.OkHttpFutureBackend
 import fr.acinq.bitcoin.Block
 import org.json4s.DefaultFormats
 import org.scalatest.funsuite.AnyFunSuite

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -60,11 +60,11 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuiteLike
 import scodec.bits.ByteVector
 
-import scala.collection.JavaConverters._
 import scala.compat.Platform
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 /**
  * Created by PM on 15/03/2017.

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -44,7 +44,7 @@ class PeerConnectionSpec extends TestkitBaseClass with StateTestsHelperMethods {
   // this map will store private keys so that we can sign new announcements at will
   val pub2priv: mutable.Map[PublicKey, PrivateKey] = mutable.HashMap.empty
   val shortChannelIds = RoutingSyncSpec.shortChannelIds.take(100)
-  val fakeRoutingInfo = shortChannelIds.map(RoutingSyncSpec.makeFakeRoutingInfo(pub2priv))
+  val fakeRoutingInfo = shortChannelIds.unsorted.map(RoutingSyncSpec.makeFakeRoutingInfo(pub2priv))
   val channels = fakeRoutingInfo.map(_._1.ann).toList
   val updates = (fakeRoutingInfo.flatMap(_._1.update_1_opt) ++ fakeRoutingInfo.flatMap(_._1.update_2_opt)).toList
   val nodes = (fakeRoutingInfo.map(_._1.ann.nodeId1) ++ fakeRoutingInfo.map(_._1.ann.nodeId2)).map(RoutingSyncSpec.makeFakeNodeAnnouncement(pub2priv)).toList

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/ChannelSelectionSpec.scala
@@ -90,9 +90,13 @@ class ChannelSelectionSpec extends AnyFunSuite {
       ShortChannelId(44444) -> OutgoingChannel(b, channelUpdate, makeCommitments(ByteVector32.Zeroes, 1000000 msat))
     )
 
-    val node2channels = new mutable.HashMap[PublicKey, mutable.Set[ShortChannelId]] with mutable.MultiMap[PublicKey, ShortChannelId]
-    node2channels.put(a, mutable.Set(ShortChannelId(12345), ShortChannelId(11111), ShortChannelId(22222), ShortChannelId(33333)))
-    node2channels.put(b, mutable.Set(ShortChannelId(44444)))
+    val node2channels = mutable.MultiDict.empty[PublicKey, ShortChannelId]
+    node2channels.addAll(
+      (a, ShortChannelId(12345)) ::
+        (a, ShortChannelId(11111)) ::
+        (a, ShortChannelId(22222)) ::
+        (a, ShortChannelId(33333)) ::
+        (b, ShortChannelId(44444)) :: Nil)
 
     // select the channel to the same node, with the lowest balance but still high enough to handle the payment
     assert(selectPreferredChannel(relayPayload, channelUpdates, node2channels, Seq.empty) === Some(ShortChannelId(22222)))

--- a/eclair-node-gui/pom.xml
+++ b/eclair-node-gui/pom.xml
@@ -20,11 +20,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.acinq.eclair</groupId>
-        <artifactId>eclair_2.11</artifactId>
+        <artifactId>eclair_2.13</artifactId>
         <version>0.3.5-SNAPSHOT</version>
     </parent>
 
-    <artifactId>eclair-node-gui_2.11</artifactId>
+    <artifactId>eclair-node-gui_2.13</artifactId>
     <packaging>jar</packaging>
 
     <name>eclair-node-gui</name>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -27,8 +27,8 @@ import fr.acinq.eclair.blockchain.electrum.ElectrumClient.{ElectrumDisconnected,
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.gui.controllers._
 import fr.acinq.eclair.payment._
-import fr.acinq.eclair.router.{Announcements, ChannelLost, ChannelUpdatesReceived, ChannelsDiscovered, NodeLost, NodeUpdated, NodesDiscovered, SingleChannelDiscovered}
-import fr.acinq.eclair.router.Router.{NORMAL => _, _}
+import fr.acinq.eclair.router.Router.{NORMAL => _}
+import fr.acinq.eclair.router._
 import javafx.application.Platform
 import javafx.fxml.FXMLLoader
 import javafx.scene.layout.VBox

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/IndexedObservableList.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/IndexedObservableList.scala
@@ -53,7 +53,7 @@ class IndexedObservableList[K, V] {
       map2index.remove(key)
       list.remove(index)
       // now we need to decrement all higher indices by 1
-      import scala.collection.JavaConverters._
+      import scala.jdk.CollectionConverters._
       for (entry <- map2index.entrySet().asScala) {
         if (entry.getValue > index) {
           map2index.put(entry.getKey, entry.getValue - 1)

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/QRCodeUtils.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/utils/QRCodeUtils.scala
@@ -28,7 +28,7 @@ import javafx.scene.paint.Color
 case object QRCodeUtils {
 
   def createQRCode(data: String, width: Int = 250, height: Int = 250, margin: Int = 5): WritableImage = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val hintMap = collection.mutable.Map[EncodeHintType, Object]()
     hintMap.put(EncodeHintType.CHARACTER_SET, "UTF-8")
     hintMap.put(EncodeHintType.ERROR_CORRECTION, ErrorCorrectionLevel.L)

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -20,11 +20,11 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>fr.acinq.eclair</groupId>
-        <artifactId>eclair_2.11</artifactId>
+        <artifactId>eclair_2.13</artifactId>
         <version>0.3.5-SNAPSHOT</version>
     </parent>
 
-    <artifactId>eclair-node_2.11</artifactId>
+    <artifactId>eclair-node_2.13</artifactId>
     <packaging>jar</packaging>
 
     <name>eclair-node</name>
@@ -112,7 +112,7 @@
         <dependency>
             <groupId>de.heikoseeberger</groupId>
             <artifactId>akka-http-json4s_${scala.version.short}</artifactId>
-            <version>1.19.0</version>
+            <version>1.32.0</version>
         </dependency>
         <!-- metrics -->
         <dependency>
@@ -135,6 +135,12 @@
             <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-http-testkit_${scala.version.short}</artifactId>
             <version>${akka.http.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-stream-testkit_${scala.version.short}</artifactId>
+            <version>${akka.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <scala.version>2.13.1</scala.version>
+        <scala.version>2.13.2</scala.version>
         <scala.version.short>2.13</scala.version.short>
         <akka.version>2.6.4</akka.version>
         <akka.http.version>10.1.11</akka.http.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>fr.acinq.eclair</groupId>
-    <artifactId>eclair_2.11</artifactId>
+    <artifactId>eclair_2.13</artifactId>
     <version>0.3.5-SNAPSHOT</version>
     <packaging>pom</packaging>
 
@@ -64,12 +64,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <scala.version>2.11.12</scala.version>
-        <scala.version.short>2.11</scala.version.short>
-        <akka.version>2.4.20</akka.version>
-        <akka.http.version>10.0.11</akka.http.version>
+        <scala.version>2.13.1</scala.version>
+        <scala.version.short>2.13</scala.version.short>
+        <akka.version>2.6.4</akka.version>
+        <akka.http.version>10.1.11</akka.http.version>
         <sttp.version>1.7.2</sttp.version>
-        <bitcoinlib.version>0.17</bitcoinlib.version>
+        <bitcoinlib.version>0.18-SNAPSHOT</bitcoinlib.version>
         <guava.version>24.0-android</guava.version>
         <kamon.version>2.0.0</kamon.version>
     </properties>
@@ -132,16 +132,12 @@
                 <version>3.4.2</version>
                 <configuration>
                     <args combine.children="append">
-                        <arg>-deprecation</arg>
+                        <!--arg>-Xlint:deprecation</arg-->
                         <arg>-feature</arg>
                         <arg>-language:postfixOps</arg>
                         <arg>-language:implicitConversions</arg>
-                        <arg>-Xfatal-warnings</arg>
+                        <!--arg>-Werror</arg-->
                         <arg>-unchecked</arg>
-                        <arg>-Xmax-classfile-name</arg>
-                        <arg>140</arg>
-                        <!-- needed to compile Scala code on JDK9+ -->
-                        <arg>-nobootcp</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xmx1024m</jvmArg>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <akka.version>2.6.4</akka.version>
         <akka.http.version>10.1.11</akka.http.version>
         <sttp.version>1.7.2</sttp.version>
-        <bitcoinlib.version>0.18-SNAPSHOT</bitcoinlib.version>
+        <bitcoinlib.version>0.18</bitcoinlib.version>
         <guava.version>24.0-android</guava.version>
         <kamon.version>2.0.0</kamon.version>
     </properties>


### PR DESCRIPTION
This builds on #1389, so the changeset is minimal (disregard the first commit).

Main changes:
- relaxed compiler parameters to minimize impact (e.g. allow
deprecated features)
- `scala.collection.JavaConverters` -> `scala.jdk.CollectionConverters`
- `MultiMap` -> `MultiDict`

Compilation is 25% faster on my machine, compiler is a bit more strict
(it found an "invalid comparison" bug).