### PR TITLE
Unlock transaction inputs if tx cannot be published

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
@@ -133,7 +133,7 @@ class BitcoinCoreWallet(rpcClient: BitcoinJsonRPCClient)(implicit ec: ExecutionC
       logger.warn(s"txid=${tx.txid} error=$e")
       bitcoinClient.getTransaction(tx.txid).transformWith {
         case Success(_) => Future.successful(true) // tx is in the mempool, we consider that it was published
-        case Failure(_) => rollback(tx).transform { case _ => Success(false) } // we use transform here as unlocking utxos that are not locked will fail
+        case Failure(_) => rollback(tx).transform { case _ => Success(false) } // we use transform here because we want to return false in all cases even if rollback fails
       }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
@@ -26,6 +26,7 @@ import org.json4s.JsonAST._
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 /**
  * Created by PM on 06/07/2017.
@@ -63,7 +64,19 @@ class BitcoinCoreWallet(rpcClient: BitcoinJsonRPCClient)(implicit ec: ExecutionC
 
   def publishTransaction(tx: Transaction)(implicit ec: ExecutionContext): Future[String] = bitcoinClient.publishTransaction(tx)
 
-  def unlockOutpoints(outPoints: Seq[OutPoint])(implicit ec: ExecutionContext): Future[Boolean] = rpcClient.invoke("lockunspent", true, outPoints.toList.map(outPoint => Utxo(outPoint.txid, outPoint.index))) collect { case JBool(result) => result }
+  def unlockOutpoints(outPoints: Seq[OutPoint])(implicit ec: ExecutionContext): Future[Boolean] = {
+    // we unlock utxos one by one and not as a list as it would fail at the first utxo that is not actually lock and the rest would not be processed
+    val futures = outPoints.toList.map(outPoint => Utxo(outPoint.txid, outPoint.index)).map(utxo => {
+      val f = rpcClient.invoke("lockunspent", true, List(utxo))
+      f.recover { case t: Throwable =>
+        logger.warn(s"Cannot unlock utxo=$utxo", t)
+        false
+      }
+      f
+    })
+    val future = Future.sequence(futures).map(_ collect { case JBool(result) => result })
+    future.map(_.forall(b => b))
+  }
 
   override def getBalance: Future[Satoshi] = rpcClient.invoke("getbalance") collect { case JDecimal(balance) => Satoshi(balance.bigDecimal.scaleByPowerOfTen(8).longValue) }
 
@@ -103,13 +116,15 @@ class BitcoinCoreWallet(rpcClient: BitcoinJsonRPCClient)(implicit ec: ExecutionC
     } yield MakeFundingTxResponse(fundingTx, outputIndex, fee)
   }
 
-  override def commit(tx: Transaction): Future[Boolean] = publishTransaction(tx)
-    .map(_ => true) // if bitcoind says OK, then we consider the tx successfully published
-    .recoverWith { case JsonRPCError(e) =>
+  override def commit(tx: Transaction): Future[Boolean] = publishTransaction(tx).transformWith {
+    case Success(_) => Future.successful(true)
+    case Failure(e) =>
       logger.warn(s"txid=${tx.txid} error=$e")
-      bitcoinClient.getTransaction(tx.txid).map(_ => true).recover { case _ => false } // if we get a parseable error from bitcoind AND the tx is NOT in the mempool/blockchain, then we consider that the tx was not published
-    }
-    .recover { case _ => true } // in all other cases we consider that the tx has been published
+      bitcoinClient.getTransaction(tx.txid).transformWith {
+        case Success(_) => Future.successful(true) // tx is in the mempool, we consider that it was published
+        case Failure(_) => rollback(tx).transform { case _ => Success(false) } // we use transform here as unlocking utxos that are not locked will fail
+      }
+  }
 
   override def rollback(tx: Transaction): Future[Boolean] = unlockOutpoints(tx.txIn.map(_.outPoint)) // we unlock all utxos used by the tx
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
@@ -64,6 +64,11 @@ class BitcoinCoreWallet(rpcClient: BitcoinJsonRPCClient)(implicit ec: ExecutionC
 
   def publishTransaction(tx: Transaction)(implicit ec: ExecutionContext): Future[String] = bitcoinClient.publishTransaction(tx)
 
+  /**
+   *
+   * @param outPoints outpoints to unlock
+   * @return true if all outpoints were successfully unlocked, false otherwise
+   */
   def unlockOutpoints(outPoints: Seq[OutPoint])(implicit ec: ExecutionContext): Future[Boolean] = {
     // we unlock utxos one by one and not as a list as it would fail at the first utxo that is not actually lock and the rest would not be processed
     val futures = outPoints

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -163,6 +163,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       // and try to unlock all outpoints: it should work too
       wallet.rollback(fundingTx).pipeTo(sender.ref)
       assert(sender.expectMsgType[Boolean])
+      assert(getLocks(sender) isEmpty)
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -156,9 +156,8 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       // unlock the first 2 outpoints
       val tx1 = fundingTx.copy(txIn = fundingTx.txIn.take(2))
       wallet.rollback(tx1).pipeTo(sender.ref)
-      val check = sender.expectMsgType[Boolean]
+      assert(sender.expectMsgType[Boolean])
       assert(getLocks(sender) == fundingTx.txIn.drop(2).map(_.outPoint).toSet)
-      assert(check)
 
       // and try to unlock all outpoints: it should work too
       wallet.rollback(fundingTx).pipeTo(sender.ref)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -145,8 +145,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       assert(fundingTx.txIn.size > 2)
       assert(getLocks(sender) == fundingTx.txIn.map(_.outPoint).toSet)
       wallet.rollback(fundingTx).pipeTo(sender.ref)
-      val check = sender.expectMsgType[Boolean]
-      assert(check)
+      assert(sender.expectMsgType[Boolean])
     }
     {
       // test #2: some outpoints are locked, some are unlocked

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -162,8 +162,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
 
       // and try to unlock all outpoints: it should work too
       wallet.rollback(fundingTx).pipeTo(sender.ref)
-      val check1 = sender.expectMsgType[Boolean]
-      assert(check1)
+      assert(sender.expectMsgType[Boolean])
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -152,6 +152,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       // test #2: some outpoints are locked, some are unlocked
       wallet.makeFundingTx(pubkeyScript, Btc(250), 1000).pipeTo(sender.ref)
       val MakeFundingTxResponse(fundingTx, outputIndex, _) = sender.expectMsgType[MakeFundingTxResponse]
+      assert(fundingTx.txIn.size > 2)
       assert(getLocks(sender) == fundingTx.txIn.map(_.outPoint).toSet)
 
       // unlock the first 2 outpoints

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -121,7 +121,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
     // and all locked inputs should now be unlocked
     awaitCond({
       val locks = getLocks()
-      locks intersect expectedLocks isEmpty
+      locks isEmpty
     }, max = 10 seconds, interval = 1 second)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -142,6 +142,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       // create a huge tx so we make sure it has > 1 inputs
       wallet.makeFundingTx(pubkeyScript, Btc(250), 1000).pipeTo(sender.ref)
       val MakeFundingTxResponse(fundingTx, outputIndex, _) = sender.expectMsgType[MakeFundingTxResponse]
+      assert(fundingTx.txIn.size > 2)
       assert(getLocks(sender) == fundingTx.txIn.map(_.outPoint).toSet)
       wallet.rollback(fundingTx).pipeTo(sender.ref)
       val check = sender.expectMsgType[Boolean]


### PR DESCRIPTION
In some cases, funding a tx will work but publishing it may fail (because mempool fees are not met for example). In that case we need to make sure that the tx inputs, which were locked by `fundrawtransaction`, are unlocked.