### PR TITLE
Minor: catch harmless unhandled events

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
@@ -121,6 +121,10 @@ class ReconnectionTask(nodeParams: NodeParams, remoteNodeId: PublicKey) extends 
   }
 
   whenUnhandled {
+    case Event("connected", _) => stay
+
+    case Event(Status.Failure(_: Client.ConnectionFailed), _) => stay
+
     case Event(TickReconnect, _) => stay
 
     case Event(Peer.Connect(_, hostAndPort_opt), _) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
@@ -33,7 +33,7 @@ import scala.concurrent.duration._
 
 class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with StateTestsHelperMethods {
 
-  val fakeIPAddress = NodeAddress.fromParts("localhost", 42000).get
+  val fakeIPAddress = NodeAddress.fromParts("1.2.3.4", 42000).get
   val channels = Map(Peer.FinalChannelId(randomBytes32) -> system.deadLetters)
 
   val PeerNothingData = Peer.Nothing
@@ -134,13 +134,13 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     probe.send(reconnectionTask, ReconnectionTask.TickReconnect) // we send it manually in order to not have to actually wait (duplicates don't matter since we look at transitions sequentially)
     val TransitionWithData(ReconnectionTask.WAITING, ReconnectionTask.CONNECTING, _, _) = monitor.expectMsgType[TransitionWithData]
 
-    val TransitionWithData(ReconnectionTask.CONNECTING, ReconnectionTask.WAITING, _, waitingData1: WaitingData) = monitor.expectMsgType[TransitionWithData]
+    val TransitionWithData(ReconnectionTask.CONNECTING, ReconnectionTask.WAITING, _, waitingData1: WaitingData) = monitor.expectMsgType[TransitionWithData](60 seconds)
     assert(waitingData1.nextReconnectionDelay === (waitingData0.nextReconnectionDelay * 2))
 
     probe.send(reconnectionTask, ReconnectionTask.TickReconnect)
     val TransitionWithData(ReconnectionTask.WAITING, ReconnectionTask.CONNECTING, _, _) = monitor.expectMsgType[TransitionWithData]
 
-    val TransitionWithData(ReconnectionTask.CONNECTING, ReconnectionTask.WAITING, _, waitingData2: WaitingData) = monitor.expectMsgType[TransitionWithData]
+    val TransitionWithData(ReconnectionTask.CONNECTING, ReconnectionTask.WAITING, _, waitingData2: WaitingData) = monitor.expectMsgType[TransitionWithData](60 seconds)
     assert(waitingData2.nextReconnectionDelay === (waitingData0.nextReconnectionDelay * 4))
 
     probe.send(reconnectionTask, ReconnectionTask.TickReconnect)


### PR DESCRIPTION
This prevents unnecessary warnings to clog up the logs.