### PR TITLE
Payment lifecycle refactor

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/PimpKamon.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/PimpKamon.scala
@@ -45,7 +45,7 @@ object KamonExt {
    */
   def failSpan(span: Span, failure: PaymentFailure) = {
     failure match {
-      case LocalFailure(t) => span.fail("local failure", t)
+      case LocalFailure(_, t) => span.fail("local failure", t)
       case RemoteFailure(_, e) => span.fail(s"remote failure: origin=${e.originNode} error=${e.failureMessage}")
       case UnreadableRemoteFailure(_) => span.fail("unreadable remote failure")
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/PimpKamon.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/PimpKamon.scala
@@ -45,7 +45,7 @@ object KamonExt {
    */
   def failSpan(span: Span, failure: PaymentFailure) = {
     failure match {
-      case LocalFailure(_, t) => span.fail("local failure", t)
+      case f: LocalFailure => span.fail("local failure", f.t)
       case RemoteFailure(_, e) => span.fail(s"remote failure: origin=${e.originNode} error=${e.failureMessage}")
       case UnreadableRemoteFailure(_) => span.fail("unreadable remote failure")
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/PimpKamon.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/PimpKamon.scala
@@ -45,7 +45,7 @@ object KamonExt {
    */
   def failSpan(span: Span, failure: PaymentFailure) = {
     failure match {
-      case f: LocalFailure => span.fail("local failure", f.t)
+      case LocalFailure(_, t) => span.fail("local failure", t)
       case RemoteFailure(_, e) => span.fail(s"remote failure: origin=${e.originNode} error=${e.failureMessage}")
       case UnreadableRemoteFailure(_) => span.fail("unreadable remote failure")
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -207,7 +207,7 @@ object FailureType extends Enumeration {
 
 object FailureSummary {
   def apply(f: PaymentFailure): FailureSummary = f match {
-    case f: LocalFailure => FailureSummary(FailureType.LOCAL, f.t.getMessage, f.route.map(h => HopSummary(h)).toList)
+    case LocalFailure(route, t) => FailureSummary(FailureType.LOCAL, t.getMessage, route.map(h => HopSummary(h)).toList)
     case RemoteFailure(route, e) => FailureSummary(FailureType.REMOTE, e.failureMessage.message, route.map(h => HopSummary(h)).toList)
     case UnreadableRemoteFailure(route) => FailureSummary(FailureType.UNREADABLE_REMOTE, "could not decrypt failure onion", route.map(h => HopSummary(h)).toList)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -207,7 +207,7 @@ object FailureType extends Enumeration {
 
 object FailureSummary {
   def apply(f: PaymentFailure): FailureSummary = f match {
-    case LocalFailure(route, t) => FailureSummary(FailureType.LOCAL, t.getMessage, route.map(h => HopSummary(h)).toList)
+    case f: LocalFailure => FailureSummary(FailureType.LOCAL, f.t.getMessage, f.route.map(h => HopSummary(h)).toList)
     case RemoteFailure(route, e) => FailureSummary(FailureType.REMOTE, e.failureMessage.message, route.map(h => HopSummary(h)).toList)
     case UnreadableRemoteFailure(route) => FailureSummary(FailureType.UNREADABLE_REMOTE, "could not decrypt failure onion", route.map(h => HopSummary(h)).toList)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -25,8 +25,6 @@ import fr.acinq.eclair.payment._
 import fr.acinq.eclair.router.Router.{ChannelHop, Hop, NodeHop}
 import fr.acinq.eclair.{MilliSatoshi, ShortChannelId}
 
-import scala.compat.Platform
-
 trait PaymentsDb extends IncomingPaymentsDb with OutgoingPaymentsDb with PaymentsOverviewDb with Closeable
 
 trait IncomingPaymentsDb {
@@ -209,7 +207,7 @@ object FailureType extends Enumeration {
 
 object FailureSummary {
   def apply(f: PaymentFailure): FailureSummary = f match {
-    case LocalFailure(t) => FailureSummary(FailureType.LOCAL, t.getMessage, Nil)
+    case LocalFailure(route, t) => FailureSummary(FailureType.LOCAL, t.getMessage, route.map(h => HopSummary(h)).toList)
     case RemoteFailure(route, e) => FailureSummary(FailureType.REMOTE, e.failureMessage.message, route.map(h => HopSummary(h)).toList)
     case UnreadableRemoteFailure(route) => FailureSummary(FailureType.UNREADABLE_REMOTE, "could not decrypt failure onion", route.map(h => HopSummary(h)).toList)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Monitoring.scala
@@ -92,7 +92,7 @@ object Monitoring {
       }
 
       def apply(pf: PaymentFailure): String = pf match {
-        case f: LocalFailure => f.t.getClass.getSimpleName
+        case LocalFailure(_, t) => t.getClass.getSimpleName
         case RemoteFailure(_, e) => e.failureMessage.getClass.getSimpleName
         case UnreadableRemoteFailure(_) => "UnreadableRemoteFailure"
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Monitoring.scala
@@ -92,7 +92,7 @@ object Monitoring {
       }
 
       def apply(pf: PaymentFailure): String = pf match {
-        case LocalFailure(_, t) => t.getClass.getSimpleName
+        case f: LocalFailure => f.t.getClass.getSimpleName
         case RemoteFailure(_, e) => e.failureMessage.getClass.getSimpleName
         case UnreadableRemoteFailure(_) => "UnreadableRemoteFailure"
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Monitoring.scala
@@ -92,7 +92,7 @@ object Monitoring {
       }
 
       def apply(pf: PaymentFailure): String = pf match {
-        case LocalFailure(t) => t.getClass.getSimpleName
+        case LocalFailure(_, t) => t.getClass.getSimpleName
         case RemoteFailure(_, e) => e.failureMessage.getClass.getSimpleName
         case UnreadableRemoteFailure(_) => "UnreadableRemoteFailure"
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -116,15 +116,8 @@ sealed trait PaymentFailure {
   def route: Seq[Hop]
 }
 
-sealed trait LocalFailure {
-  def t: Throwable
-}
-
-/** A retriable local failure (e.g. local channel unavailable or doesn't have enough outgoing capacity). */
-case class RetriableLocalFailure(route: Seq[Hop], t: Throwable) extends PaymentFailure with LocalFailure
-
-/** A non-retriable local failure (e.g. no route found). */
-case class NonRetriableLocalFailure(route: Seq[Hop], t: Throwable) extends PaymentFailure with LocalFailure
+/** A failure happened locally, preventing the payment from being sent (e.g. no route found). */
+case class LocalFailure(route: Seq[Hop], t: Throwable) extends PaymentFailure
 
 /** A remote node failed the payment and we were able to decrypt the onion failure packet. */
 case class RemoteFailure(route: Seq[Hop], e: Sphinx.DecryptedFailurePacket) extends PaymentFailure
@@ -151,12 +144,10 @@ object PaymentFailure {
    */
   def transformForUser(failures: Seq[PaymentFailure]): Seq[PaymentFailure] = {
     failures.map {
-      // we're interested in the error which caused the add-htlc to fail
-      case RetriableLocalFailure(hops, AddHtlcFailed(_, _, t, _, _, _)) => RetriableLocalFailure(hops, t)
-      case NonRetriableLocalFailure(hops, AddHtlcFailed(_, _, t, _, _, _)) => NonRetriableLocalFailure(hops, t)
+      case LocalFailure(hops, AddHtlcFailed(_, _, t, _, _, _)) => LocalFailure(hops, t) // we're interested in the error which caused the add-htlc to fail
       case other => other
     } match {
-      case previousFailures :+ NonRetriableLocalFailure(_, RouteNotFound) if previousFailures.nonEmpty => previousFailures
+      case previousFailures :+ LocalFailure(_, RouteNotFound) if previousFailures.nonEmpty => previousFailures
       case other => other
     }
   }
@@ -197,7 +188,7 @@ object PaymentFailure {
       // We don't know which node is sending garbage, let's blacklist all nodes except the one we are directly connected to and the final recipient.
       val blacklist = hops.map(_.nextNodeId).drop(1).dropRight(1)
       (ignoreNodes ++ blacklist, ignoreChannels)
-    case f: LocalFailure => f.route.headOption match {
+    case LocalFailure(hops, _) => hops.headOption match {
       case Some(hop: ChannelHop) =>
         val faultyChannel = ChannelDesc(hop.lastUpdate.shortChannelId, hop.nodeId, hop.nextNodeId)
         (ignoreNodes, ignoreChannels + faultyChannel)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -22,9 +22,9 @@ import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.MilliSatoshi
 import fr.acinq.eclair.crypto.Sphinx
-import fr.acinq.eclair.router.Router.Hop
-
-import scala.compat.Platform
+import fr.acinq.eclair.router.Announcements
+import fr.acinq.eclair.router.Router.{ChannelDesc, ChannelHop, Hop}
+import fr.acinq.eclair.wire.Node
 
 /**
  * Created by PM on 01/02/2017.
@@ -112,10 +112,12 @@ object PaymentReceived {
 
 case class PaymentSettlingOnChain(id: UUID, amount: MilliSatoshi, paymentHash: ByteVector32, timestamp: Long = System.currentTimeMillis) extends PaymentEvent
 
-sealed trait PaymentFailure
+sealed trait PaymentFailure {
+  def route: Seq[Hop]
+}
 
 /** A failure happened locally, preventing the payment from being sent (e.g. no route found). */
-case class LocalFailure(t: Throwable) extends PaymentFailure
+case class LocalFailure(route: Seq[Hop], t: Throwable) extends PaymentFailure
 
 /** A remote node failed the payment and we were able to decrypt the onion failure packet. */
 case class RemoteFailure(route: Seq[Hop], e: Sphinx.DecryptedFailurePacket) extends PaymentFailure
@@ -142,10 +144,10 @@ object PaymentFailure {
    */
   def transformForUser(failures: Seq[PaymentFailure]): Seq[PaymentFailure] = {
     failures.map {
-      case LocalFailure(AddHtlcFailed(_, _, t, _, _, _)) => LocalFailure(t) // we're interested in the error which caused the add-htlc to fail
+      case LocalFailure(hops, AddHtlcFailed(_, _, t, _, _, _)) => LocalFailure(hops, t) // we're interested in the error which caused the add-htlc to fail
       case other => other
     } match {
-      case previousFailures :+ LocalFailure(RouteNotFound) if previousFailures.nonEmpty => previousFailures
+      case previousFailures :+ LocalFailure(_, RouteNotFound) if previousFailures.nonEmpty => previousFailures
       case other => other
     }
   }
@@ -158,5 +160,45 @@ object PaymentFailure {
     failures
       .collectFirst { case RemoteFailure(_, Sphinx.DecryptedFailurePacket(origin, u: Update)) if origin == nodeId => u.update }
       .isDefined
+
+  /** Update the set of nodes and channels to ignore in retries depending on the failure we received. */
+  def updateIgnored(failure: PaymentFailure, ignoreNodes: Set[PublicKey], ignoreChannels: Set[ChannelDesc]): (Set[PublicKey], Set[ChannelDesc]) = failure match {
+    case RemoteFailure(hops, Sphinx.DecryptedFailurePacket(nodeId, _)) if nodeId == hops.last.nextNodeId =>
+      // The failure came from the final recipient: the payment should be aborted without penalizing anyone in the route.
+      (ignoreNodes, ignoreChannels)
+    case RemoteFailure(_, Sphinx.DecryptedFailurePacket(nodeId, _: Node)) =>
+      (ignoreNodes + nodeId, ignoreChannels)
+    case RemoteFailure(_, Sphinx.DecryptedFailurePacket(nodeId, failureMessage: Update)) =>
+      if (Announcements.checkSig(failureMessage.update, nodeId)) {
+        // We were using an outdated channel update, we should retry with the new one and nobody should be penalized.
+        (ignoreNodes, ignoreChannels)
+      } else {
+        // This node is fishy, it gave us a bad signature, so let's filter it out.
+        (ignoreNodes + nodeId, ignoreChannels)
+      }
+    case RemoteFailure(hops, Sphinx.DecryptedFailurePacket(nodeId, _)) =>
+      // Let's ignore the channel outgoing from nodeId.
+      hops.collectFirst {
+        case hop: ChannelHop if hop.nodeId == nodeId => ChannelDesc(hop.lastUpdate.shortChannelId, hop.nodeId, hop.nextNodeId)
+      } match {
+        case Some(faultyChannel) => (ignoreNodes, ignoreChannels + faultyChannel)
+        case None => (ignoreNodes, ignoreChannels)
+      }
+    case UnreadableRemoteFailure(hops) =>
+      // We don't know which node is sending garbage, let's blacklist all nodes except the one we are directly connected to and the final recipient.
+      val blacklist = hops.map(_.nextNodeId).drop(1).dropRight(1)
+      (ignoreNodes ++ blacklist, ignoreChannels)
+    case LocalFailure(hops, _) => hops.headOption match {
+      case Some(hop: ChannelHop) =>
+        val faultyChannel = ChannelDesc(hop.lastUpdate.shortChannelId, hop.nodeId, hop.nextNodeId)
+        (ignoreNodes, ignoreChannels + faultyChannel)
+      case _ => (ignoreNodes, ignoreChannels)
+    }
+  }
+
+  /** Update the set of nodes and channels to ignore in retries depending on the failures we received. */
+  def updateIgnored(failures: Seq[PaymentFailure], ignoreNodes: Set[PublicKey], ignoreChannels: Set[ChannelDesc]): (Set[PublicKey], Set[ChannelDesc]) = {
+    failures.foldLeft((ignoreNodes, ignoreChannels)) { case ((nodes, channels), failure) => updateIgnored(failure, nodes, channels) }
+  }
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
@@ -260,13 +260,13 @@ object NodeRelayer {
    */
   private def translateError(failures: Seq[PaymentFailure], outgoingNodeId: PublicKey): Option[FailureMessage] = {
     def tooManyRouteNotFound(failures: Seq[PaymentFailure]): Boolean = {
-      val routeNotFoundCount = failures.collect { case f@LocalFailure(_, RouteNotFound) => f }.length
+      val routeNotFoundCount = failures.collect { case f: LocalFailure if f.t == RouteNotFound => f }.length
       routeNotFoundCount > failures.length / 2
     }
 
     failures match {
       case Nil => None
-      case LocalFailure(_, PaymentError.BalanceTooLow) :: Nil => Some(TemporaryNodeFailure) // we don't have enough outgoing liquidity at the moment
+      case NonRetriableLocalFailure(_, PaymentError.BalanceTooLow) :: Nil => Some(TemporaryNodeFailure) // we don't have enough outgoing liquidity at the moment
       case _ if tooManyRouteNotFound(failures) => Some(TrampolineFeeInsufficient) // if we couldn't find routes, it's likely that the fee/cltv was insufficient
       case _ =>
         // Otherwise, we try to find a downstream error that we could decrypt.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
@@ -260,7 +260,7 @@ object NodeRelayer {
    */
   private def translateError(failures: Seq[PaymentFailure], outgoingNodeId: PublicKey): Option[FailureMessage] = {
     def tooManyRouteNotFound(failures: Seq[PaymentFailure]): Boolean = {
-      val routeNotFoundCount = failures.count(_ == LocalFailure(Nil, RouteNotFound))
+      val routeNotFoundCount = failures.collect { case f@LocalFailure(_, RouteNotFound) => f }.length
       routeNotFoundCount > failures.length / 2
     }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -95,8 +95,8 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
       val (remaining, payments) = splitPayment(nodeParams, d.request.totalAmount, channels, d.networkStats, d.request, randomize = false)
       if (remaining > 0.msat) {
         log.warning(s"cannot send ${d.request.totalAmount} with our current balance")
-        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(Nil, PaymentError.BalanceTooLow)))
-        goto(PAYMENT_ABORTED) using PaymentAborted(d.sender, d.request, LocalFailure(Nil, PaymentError.BalanceTooLow) :: Nil, Set.empty)
+        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(NonRetriableLocalFailure(Nil, PaymentError.BalanceTooLow)))
+        goto(PAYMENT_ABORTED) using PaymentAborted(d.sender, d.request, NonRetriableLocalFailure(Nil, PaymentError.BalanceTooLow) :: Nil, Set.empty)
       } else {
         val pending = setFees(d.request.routeParams, payments, payments.size)
         Kamon.runWithContextEntry(parentPaymentIdKey, cfg.parentId) {
@@ -154,8 +154,8 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
       val (remaining, payments) = splitPayment(nodeParams, d.toSend, filteredChannels, d.networkStats, d.request, randomize = true) // we randomize channel selection when we retry
       if (remaining > 0.msat) {
         log.warning(s"cannot send ${d.toSend} with our current balance")
-        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(Nil, PaymentError.BalanceTooLow)))
-        goto(PAYMENT_ABORTED) using PaymentAborted(d.sender, d.request, d.failures :+ LocalFailure(Nil, PaymentError.BalanceTooLow), d.pending.keySet)
+        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(NonRetriableLocalFailure(Nil, PaymentError.BalanceTooLow)))
+        goto(PAYMENT_ABORTED) using PaymentAborted(d.sender, d.request, d.failures :+ NonRetriableLocalFailure(Nil, PaymentError.BalanceTooLow), d.pending.keySet)
       } else {
         val pending = setFees(d.request.routeParams, payments, payments.size + d.pending.size)
         pending.foreach { case (childId, payment) => spawnChildPaymentFsm(childId) ! payment }
@@ -269,7 +269,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
     if (isFromFinalRecipient) {
       Some(PaymentAborted(d.sender, d.request, d.failures ++ pf.failures, d.pending.keySet - pf.id))
     } else if (d.remainingAttempts == 0) {
-      val failure = LocalFailure(Nil, PaymentError.RetryExhausted)
+      val failure = NonRetriableLocalFailure(Nil, PaymentError.RetryExhausted)
       Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(failure))
       Some(PaymentAborted(d.sender, d.request, d.failures ++ pf.failures :+ failure, d.pending.keySet - pf.id))
     } else {
@@ -389,7 +389,7 @@ object MultiPartPaymentLifecycle {
 
   /** If the payment failed immediately with a RouteNotFound, the channel we selected should be ignored in retries. */
   private def shouldBlacklistChannel(pf: PaymentFailed): Boolean = pf.failures match {
-    case LocalFailure(_, RouteNotFound) :: Nil => true
+    case NonRetriableLocalFailure(_, RouteNotFound) :: Nil => true
     case _ => false
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -32,7 +32,7 @@ import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.relay.Relayer.{GetOutgoingChannels, OutgoingChannel, OutgoingChannels}
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentConfig
 import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPayment
-import fr.acinq.eclair.router.Router.{ChannelHop, GetNetworkStats, GetNetworkStatsResponse, RouteParams, TickComputeNetworkStats}
+import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.router._
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{CltvExpiry, FSMDiagnosticActorLogging, Logs, LongToBtcAmount, MilliSatoshi, NodeParams, ShortChannelId, ToMilliSatoshiConversion}
@@ -41,7 +41,6 @@ import kamon.context.Context
 import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
-import scala.compat.Platform
 import scala.util.Random
 
 /**
@@ -96,8 +95,8 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
       val (remaining, payments) = splitPayment(nodeParams, d.request.totalAmount, channels, d.networkStats, d.request, randomize = false)
       if (remaining > 0.msat) {
         log.warning(s"cannot send ${d.request.totalAmount} with our current balance")
-        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(PaymentError.BalanceTooLow)))
-        goto(PAYMENT_ABORTED) using PaymentAborted(d.sender, d.request, LocalFailure(PaymentError.BalanceTooLow) :: Nil, Set.empty)
+        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(Nil, PaymentError.BalanceTooLow)))
+        goto(PAYMENT_ABORTED) using PaymentAborted(d.sender, d.request, LocalFailure(Nil, PaymentError.BalanceTooLow) :: Nil, Set.empty)
       } else {
         val pending = setFees(d.request.routeParams, payments, payments.size)
         Kamon.runWithContextEntry(parentPaymentIdKey, cfg.parentId) {
@@ -155,8 +154,8 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
       val (remaining, payments) = splitPayment(nodeParams, d.toSend, filteredChannels, d.networkStats, d.request, randomize = true) // we randomize channel selection when we retry
       if (remaining > 0.msat) {
         log.warning(s"cannot send ${d.toSend} with our current balance")
-        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(PaymentError.BalanceTooLow)))
-        goto(PAYMENT_ABORTED) using PaymentAborted(d.sender, d.request, d.failures :+ LocalFailure(PaymentError.BalanceTooLow), d.pending.keySet)
+        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(Nil, PaymentError.BalanceTooLow)))
+        goto(PAYMENT_ABORTED) using PaymentAborted(d.sender, d.request, d.failures :+ LocalFailure(Nil, PaymentError.BalanceTooLow), d.pending.keySet)
       } else {
         val pending = setFees(d.request.routeParams, payments, payments.size + d.pending.size)
         pending.foreach { case (childId, payment) => spawnChildPaymentFsm(childId) ! payment }
@@ -270,7 +269,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
     if (isFromFinalRecipient) {
       Some(PaymentAborted(d.sender, d.request, d.failures ++ pf.failures, d.pending.keySet - pf.id))
     } else if (d.remainingAttempts == 0) {
-      val failure = LocalFailure(PaymentError.RetryExhausted)
+      val failure = LocalFailure(Nil, PaymentError.RetryExhausted)
       Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(failure))
       Some(PaymentAborted(d.sender, d.request, d.failures ++ pf.failures :+ failure, d.pending.keySet - pf.id))
     } else {
@@ -390,7 +389,7 @@ object MultiPartPaymentLifecycle {
 
   /** If the payment failed immediately with a RouteNotFound, the channel we selected should be ignored in retries. */
   private def shouldBlacklistChannel(pf: PaymentFailed): Boolean = pf.failures match {
-    case LocalFailure(RouteNotFound) :: Nil => true
+    case LocalFailure(_, RouteNotFound) :: Nil => true
     case _ => false
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -50,13 +50,13 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, relayer: ActorR
       val finalExpiry = r.finalExpiry(nodeParams.currentBlockHeight)
       r.paymentRequest match {
         case Some(invoice) if !invoice.features.supported =>
-          sender ! PaymentFailed(paymentId, r.paymentHash, NonRetriableLocalFailure(Nil, UnsupportedFeatures(invoice.features.bitmask)) :: Nil)
+          sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, UnsupportedFeatures(invoice.features.bitmask)) :: Nil)
         case Some(invoice) if invoice.features.allowMultiPart && Features.hasFeature(nodeParams.features, Features.BasicMultiPartPayment) =>
           invoice.paymentSecret match {
             case Some(paymentSecret) =>
               spawnMultiPartPaymentFsm(paymentCfg) forward SendMultiPartPayment(paymentSecret, r.recipientNodeId, r.recipientAmount, finalExpiry, r.maxAttempts, r.assistedRoutes, r.routeParams, userCustomTlvs = r.userCustomTlvs)
             case None =>
-              sender ! PaymentFailed(paymentId, r.paymentHash, NonRetriableLocalFailure(Nil, PaymentSecretMissing) :: Nil)
+              sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, PaymentSecretMissing) :: Nil)
           }
         case _ =>
           val paymentSecret = r.paymentRequest.flatMap(_.paymentSecret)
@@ -69,9 +69,9 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, relayer: ActorR
       sender ! paymentId
       r.trampolineAttempts match {
         case Nil =>
-          sender ! PaymentFailed(paymentId, r.paymentHash, NonRetriableLocalFailure(Nil, TrampolineFeesMissing) :: Nil)
+          sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, TrampolineFeesMissing) :: Nil)
         case _ if !r.paymentRequest.features.allowTrampoline && r.paymentRequest.amount.isEmpty =>
-          sender ! PaymentFailed(paymentId, r.paymentHash, NonRetriableLocalFailure(Nil, TrampolineLegacyAmountLessInvoice) :: Nil)
+          sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, TrampolineLegacyAmountLessInvoice) :: Nil)
         case (trampolineFees, trampolineExpiryDelta) :: remainingAttempts =>
           log.info(s"sending trampoline payment with trampoline fees=$trampolineFees and expiry delta=$trampolineExpiryDelta")
           sendTrampolinePayment(paymentId, r, trampolineFees, trampolineExpiryDelta)
@@ -121,7 +121,7 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, relayer: ActorR
             case None => payFsm forward SendPaymentToRoute(r.route, FinalLegacyPayload(r.recipientAmount, finalExpiry), r.paymentRequest.routingInfo)
           }
         case _ =>
-          sender ! PaymentFailed(paymentId, r.paymentHash, NonRetriableLocalFailure(Nil, TrampolineMultiNodeNotSupported) :: Nil)
+          sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, TrampolineMultiNodeNotSupported) :: Nil)
       }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -50,13 +50,13 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, relayer: ActorR
       val finalExpiry = r.finalExpiry(nodeParams.currentBlockHeight)
       r.paymentRequest match {
         case Some(invoice) if !invoice.features.supported =>
-          sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, UnsupportedFeatures(invoice.features.bitmask)) :: Nil)
+          sender ! PaymentFailed(paymentId, r.paymentHash, NonRetriableLocalFailure(Nil, UnsupportedFeatures(invoice.features.bitmask)) :: Nil)
         case Some(invoice) if invoice.features.allowMultiPart && Features.hasFeature(nodeParams.features, Features.BasicMultiPartPayment) =>
           invoice.paymentSecret match {
             case Some(paymentSecret) =>
               spawnMultiPartPaymentFsm(paymentCfg) forward SendMultiPartPayment(paymentSecret, r.recipientNodeId, r.recipientAmount, finalExpiry, r.maxAttempts, r.assistedRoutes, r.routeParams, userCustomTlvs = r.userCustomTlvs)
             case None =>
-              sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, PaymentSecretMissing) :: Nil)
+              sender ! PaymentFailed(paymentId, r.paymentHash, NonRetriableLocalFailure(Nil, PaymentSecretMissing) :: Nil)
           }
         case _ =>
           val paymentSecret = r.paymentRequest.flatMap(_.paymentSecret)
@@ -69,9 +69,9 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, relayer: ActorR
       sender ! paymentId
       r.trampolineAttempts match {
         case Nil =>
-          sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, TrampolineFeesMissing) :: Nil)
+          sender ! PaymentFailed(paymentId, r.paymentHash, NonRetriableLocalFailure(Nil, TrampolineFeesMissing) :: Nil)
         case _ if !r.paymentRequest.features.allowTrampoline && r.paymentRequest.amount.isEmpty =>
-          sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, TrampolineLegacyAmountLessInvoice) :: Nil)
+          sender ! PaymentFailed(paymentId, r.paymentHash, NonRetriableLocalFailure(Nil, TrampolineLegacyAmountLessInvoice) :: Nil)
         case (trampolineFees, trampolineExpiryDelta) :: remainingAttempts =>
           log.info(s"sending trampoline payment with trampoline fees=$trampolineFees and expiry delta=$trampolineExpiryDelta")
           sendTrampolinePayment(paymentId, r, trampolineFees, trampolineExpiryDelta)
@@ -121,7 +121,7 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, relayer: ActorR
             case None => payFsm forward SendPaymentToRoute(r.route, FinalLegacyPayload(r.recipientAmount, finalExpiry), r.paymentRequest.routingInfo)
           }
         case _ =>
-          sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, TrampolineMultiNodeNotSupported) :: Nil)
+          sender ! PaymentFailed(paymentId, r.paymentHash, NonRetriableLocalFailure(Nil, TrampolineMultiNodeNotSupported) :: Nil)
       }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.SendMultiPartPayment
 import fr.acinq.eclair.payment.send.PaymentError._
 import fr.acinq.eclair.payment.send.PaymentLifecycle.{SendPayment, SendPaymentToRoute}
-import fr.acinq.eclair.router.Router.{ChannelHop, Hop, NodeHop, RouteParams}
+import fr.acinq.eclair.router.Router.{Hop, NodeHop, Route, RouteParams}
 import fr.acinq.eclair.wire.Onion.FinalLegacyPayload
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, LongToBtcAmount, MilliSatoshi, NodeParams, randomBytes32}
@@ -310,7 +310,7 @@ object PaymentInitiator {
                                storeInDb: Boolean, // e.g. for trampoline we don't want to store in the DB when we're relaying payments
                                publishEvent: Boolean,
                                additionalHops: Seq[NodeHop]) {
-    def fullRoute(hops: Seq[ChannelHop]): Seq[Hop] = hops ++ additionalHops
+    def fullRoute(route: Route): Seq[Hop] = route.hops ++ additionalHops
 
     def createPaymentSent(preimage: ByteVector32, parts: Seq[PaymentSent.PartialPayment]) = PaymentSent(parentId, paymentHash, preimage, recipientAmount, recipientNodeId, parts)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -81,7 +81,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
       if (cfg.storeInDb) {
         paymentsDb.addOutgoingPayment(OutgoingPayment(id, cfg.parentId, cfg.externalId, paymentHash, PaymentType.Standard, c.finalPayload.amount, cfg.recipientAmount, cfg.recipientNodeId, System.currentTimeMillis, cfg.paymentRequest, OutgoingPaymentStatus.Pending))
       }
-      goto(WAITING_FOR_ROUTE) using WaitingForRoute(sender, send, failures = Nil)
+      goto(WAITING_FOR_ROUTE) using WaitingForRoute(sender, send, Nil, Set.empty, Set.empty)
 
     case Event(c: SendPayment, WaitingForRequest) =>
       span.tag(Tags.TargetNodeId, c.targetNodeId.toString())
@@ -93,26 +93,26 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
       val ignoredNodes = c.routePrefix.map(_.nodeId).toSet
       if (c.routePrefix.lastOption.exists(_.nextNodeId == c.targetNodeId)) {
         // If the sender already provided a route to the target, no need to involve the router.
-        self ! RouteResponse(Nil, ignoredNodes, Set.empty, allowEmpty = true)
+        self ! RouteResponse(Seq(Route(c.finalPayload.amount, Nil, allowEmpty = true)))
       } else {
         router ! RouteRequest(c.getRouteRequestStart(nodeParams), c.targetNodeId, c.finalPayload.amount, c.assistedRoutes, routeParams = c.routeParams, ignoreNodes = ignoredNodes)
       }
       if (cfg.storeInDb) {
         paymentsDb.addOutgoingPayment(OutgoingPayment(id, cfg.parentId, cfg.externalId, paymentHash, PaymentType.Standard, c.finalPayload.amount, cfg.recipientAmount, cfg.recipientNodeId, System.currentTimeMillis, cfg.paymentRequest, OutgoingPaymentStatus.Pending))
       }
-      goto(WAITING_FOR_ROUTE) using WaitingForRoute(sender, c, failures = Nil)
+      goto(WAITING_FOR_ROUTE) using WaitingForRoute(sender, c, Nil, ignoredNodes, Set.empty)
   }
 
   when(WAITING_FOR_ROUTE) {
-    case Event(RouteResponse(routeHops, ignoreNodes, ignoreChannels, _), WaitingForRoute(s, c, failures)) =>
-      val hops = c.routePrefix ++ routeHops
+    case Event(RouteResponse(routes), WaitingForRoute(s, c, failures, ignoreNodes, ignoreChannels)) =>
+      val hops = c.routePrefix ++ routes.head.hops
       log.info(s"route found: attempt=${failures.size + 1}/${c.maxAttempts} route=${hops.map(_.nextNodeId).mkString("->")} channels=${hops.map(_.lastUpdate.shortChannelId).mkString("->")}")
       val firstHop = hops.head
       val (cmd, sharedSecrets) = OutgoingPacket.buildCommand(cfg.upstream, paymentHash, hops, c.finalPayload)
       register ! Register.ForwardShortId(firstHop.lastUpdate.shortChannelId, cmd)
-      goto(WAITING_FOR_PAYMENT_COMPLETE) using WaitingForComplete(s, c, cmd, failures, sharedSecrets, ignoreNodes, ignoreChannels, hops)
+      goto(WAITING_FOR_PAYMENT_COMPLETE) using WaitingForComplete(s, c, cmd, failures, sharedSecrets, ignoreNodes, ignoreChannels, Route(c.finalPayload.amount, hops))
 
-    case Event(Status.Failure(t), WaitingForRoute(s, _, failures)) =>
+    case Event(Status.Failure(t), WaitingForRoute(s, _, failures, _, _)) =>
       Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(Nil, t))).increment()
       onFailure(s, PaymentFailed(id, paymentHash, failures :+ LocalFailure(Nil, t)))
       myStop()
@@ -134,7 +134,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
       }
       stay
 
-    case Event(fail: UpdateFailHtlc, data@WaitingForComplete(s, c, _, failures, sharedSecrets, ignoreNodes, ignoreChannels, hops)) =>
+    case Event(fail: UpdateFailHtlc, data@WaitingForComplete(s, c, _, failures, sharedSecrets, ignoreNodes, ignoreChannels, route)) =>
       (Sphinx.FailurePacket.decrypt(fail.reason, sharedSecrets) match {
         case success@Success(e) =>
           Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(RemoteFailure(Nil, e))).increment()
@@ -146,33 +146,33 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
         case Success(e@Sphinx.DecryptedFailurePacket(nodeId, failureMessage)) if nodeId == c.targetNodeId =>
           // if destination node returns an error, we fail the payment immediately
           log.warning(s"received an error message from target nodeId=$nodeId, failing the payment (failure=$failureMessage)")
-          onFailure(s, PaymentFailed(id, paymentHash, failures :+ RemoteFailure(cfg.fullRoute(hops), e)))
+          onFailure(s, PaymentFailed(id, paymentHash, failures :+ RemoteFailure(cfg.fullRoute(route), e)))
           myStop()
         case res if failures.size + 1 >= c.maxAttempts =>
           // otherwise we never try more than maxAttempts, no matter the kind of error returned
           val failure = res match {
             case Success(e@Sphinx.DecryptedFailurePacket(nodeId, failureMessage)) =>
               log.info(s"received an error message from nodeId=$nodeId (failure=$failureMessage)")
-              RemoteFailure(cfg.fullRoute(hops), e)
+              RemoteFailure(cfg.fullRoute(route), e)
             case Failure(t) =>
               log.warning(s"cannot parse returned error: ${t.getMessage}")
-              UnreadableRemoteFailure(cfg.fullRoute(hops))
+              UnreadableRemoteFailure(cfg.fullRoute(route))
           }
           log.warning(s"too many failed attempts, failing the payment")
           onFailure(s, PaymentFailed(id, paymentHash, failures :+ failure))
           myStop()
         case Failure(t) =>
-          log.warning(s"cannot parse returned error: ${t.getMessage}, route=${hops.map(_.nextNodeId)}")
-          val failure = UnreadableRemoteFailure(cfg.fullRoute(hops))
+          log.warning(s"cannot parse returned error: ${t.getMessage}, route=${route.hops.map(_.nextNodeId)}")
+          val failure = UnreadableRemoteFailure(cfg.fullRoute(route))
           retry(failure, data)
         case Success(e@Sphinx.DecryptedFailurePacket(nodeId, failureMessage: Node)) =>
           log.info(s"received 'Node' type error message from nodeId=$nodeId, trying to route around it (failure=$failureMessage)")
-          val failure = RemoteFailure(cfg.fullRoute(hops), e)
+          val failure = RemoteFailure(cfg.fullRoute(route), e)
           retry(failure, data)
         case Success(e@Sphinx.DecryptedFailurePacket(nodeId, failureMessage: Update)) =>
           log.info(s"received 'Update' type error message from nodeId=$nodeId, retrying payment (failure=$failureMessage)")
-          if (Announcements.checkSig(failureMessage.update, nodeId)) {
-            getChannelUpdateForNode(nodeId, hops) match {
+          val ignoreNodes1 = if (Announcements.checkSig(failureMessage.update, nodeId)) {
+            route.getChannelUpdateForNode(nodeId) match {
               case Some(u) if u.shortChannelId != failureMessage.update.shortChannelId =>
                 // it is possible that nodes in the route prefer using a different channel (to the same N+1 node) than the one we requested, that's fine
                 log.info(s"received an update for a different channel than the one we asked: requested=${u.shortChannelId} actual=${failureMessage.update.shortChannelId} update=${failureMessage.update}")
@@ -180,12 +180,12 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
                 // node returned the exact same update we used, this can happen e.g. if the channel is imbalanced
                 // in that case, let's temporarily exclude the channel from future routes, giving it time to recover
                 log.info(s"received exact same update from nodeId=$nodeId, excluding the channel from futures routes")
-                val nextNodeId = hops.find(_.nodeId == nodeId).get.nextNodeId
+                val nextNodeId = route.hops.find(_.nodeId == nodeId).get.nextNodeId
                 router ! ExcludeChannel(ChannelDesc(u.shortChannelId, nodeId, nextNodeId))
               case Some(u) if PaymentFailure.hasAlreadyFailedOnce(nodeId, failures) =>
                 // this node had already given us a new channel update and is still unhappy, it is probably messing with us, let's exclude it
                 log.warning(s"it is the second time nodeId=$nodeId answers with a new update, excluding it: old=$u new=${failureMessage.update}")
-                val nextNodeId = hops.find(_.nodeId == nodeId).get.nextNodeId
+                val nextNodeId = route.hops.find(_.nodeId == nodeId).get.nextNodeId
                 router ! ExcludeChannel(ChannelDesc(u.shortChannelId, nodeId, nextNodeId))
               case Some(u) =>
                 log.info(s"got a new update for shortChannelId=${u.shortChannelId}: old=$u new=${failureMessage.update}")
@@ -205,15 +205,17 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
             })
             // let's try again, router will have updated its state
             router ! RouteRequest(c.getRouteRequestStart(nodeParams), c.targetNodeId, c.finalPayload.amount, assistedRoutes1, ignoreNodes, ignoreChannels, c.routeParams)
+            ignoreNodes
           } else {
             // this node is fishy, it gave us a bad sig!! let's filter it out
             log.warning(s"got bad signature from node=$nodeId update=${failureMessage.update}")
             router ! RouteRequest(c.getRouteRequestStart(nodeParams), c.targetNodeId, c.finalPayload.amount, c.assistedRoutes, ignoreNodes + nodeId, ignoreChannels, c.routeParams)
+            ignoreNodes + nodeId
           }
-          goto(WAITING_FOR_ROUTE) using WaitingForRoute(s, c, failures :+ RemoteFailure(cfg.fullRoute(hops), e))
+          goto(WAITING_FOR_ROUTE) using WaitingForRoute(s, c, failures :+ RemoteFailure(cfg.fullRoute(route), e), ignoreNodes1, ignoreChannels)
         case Success(e@Sphinx.DecryptedFailurePacket(nodeId, failureMessage)) =>
           log.info(s"received an error message from nodeId=$nodeId, trying to use a different channel (failure=$failureMessage)")
-          val failure = RemoteFailure(cfg.fullRoute(hops), e)
+          val failure = RemoteFailure(cfg.fullRoute(route), e)
           retry(failure, data)
       }
 
@@ -252,7 +254,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
           // this means that previous state was WAITING_FOR_COMPLETE
           d.failures.lastOption.foreach(failure => stateSpan.foreach(span => KamonExt.failSpan(span, failure)))
         case d: WaitingForComplete =>
-          stateSpanBuilder.tag("route", s"${cfg.fullRoute(d.hops).map(_.nextNodeId).mkString("->")}")
+          stateSpanBuilder.tag("route", s"${cfg.fullRoute(d.route).map(_.nextNodeId).mkString("->")}")
         case _ => ()
       }
       stateSpan.foreach(_.finish())
@@ -266,7 +268,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
   private def retry(failure: PaymentFailure, data: WaitingForComplete): FSM.State[PaymentLifecycle.State, PaymentLifecycle.Data] = {
     val (ignoreNodes1, ignoreChannels1) = PaymentFailure.updateIgnored(failure, data.ignoreNodes, data.ignoreChannels)
     router ! RouteRequest(data.c.getRouteRequestStart(nodeParams), data.c.targetNodeId, data.c.finalPayload.amount, data.c.assistedRoutes, ignoreNodes1, ignoreChannels1, data.c.routeParams)
-    goto(WAITING_FOR_ROUTE) using WaitingForRoute(data.sender, data.c, data.failures :+ failure)
+    goto(WAITING_FOR_ROUTE) using WaitingForRoute(data.sender, data.c, data.failures :+ failure, ignoreNodes1, ignoreChannels1)
   }
 
   private def myStop(): State = {
@@ -348,21 +350,13 @@ object PaymentLifecycle {
   // @formatter:off
   sealed trait Data
   case object WaitingForRequest extends Data
-  case class WaitingForRoute(sender: ActorRef, c: SendPayment, failures: Seq[PaymentFailure]) extends Data
-  case class WaitingForComplete(sender: ActorRef, c: SendPayment, cmd: CMD_ADD_HTLC, failures: Seq[PaymentFailure], sharedSecrets: Seq[(ByteVector32, PublicKey)], ignoreNodes: Set[PublicKey], ignoreChannels: Set[ChannelDesc], hops: Seq[ChannelHop]) extends Data
+  case class WaitingForRoute(sender: ActorRef, c: SendPayment, failures: Seq[PaymentFailure], ignoreNodes: Set[PublicKey], ignoreChannels: Set[ChannelDesc]) extends Data
+  case class WaitingForComplete(sender: ActorRef, c: SendPayment, cmd: CMD_ADD_HTLC, failures: Seq[PaymentFailure], sharedSecrets: Seq[(ByteVector32, PublicKey)], ignoreNodes: Set[PublicKey], ignoreChannels: Set[ChannelDesc], route: Route) extends Data
 
   sealed trait State
   case object WAITING_FOR_REQUEST extends State
   case object WAITING_FOR_ROUTE extends State
   case object WAITING_FOR_PAYMENT_COMPLETE extends State
   // @formatter:on
-
-  /**
-   * This method retrieves the channel update that we used when we built a route.
-   * It just iterates over the hops, but there are at most 20 of them.
-   *
-   * @return the channel update if found
-   */
-  def getChannelUpdateForNode(nodeId: PublicKey, hops: Seq[ChannelHop]): Option[ChannelUpdate] = hops.find(_.nodeId == nodeId).map(_.lastUpdate)
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -113,8 +113,8 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
       goto(WAITING_FOR_PAYMENT_COMPLETE) using WaitingForComplete(s, c, cmd, failures, sharedSecrets, ignoreNodes, ignoreChannels, Route(c.finalPayload.amount, hops))
 
     case Event(Status.Failure(t), WaitingForRoute(s, _, failures, _, _)) =>
-      Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(NonRetriableLocalFailure(Nil, t))).increment()
-      onFailure(s, PaymentFailed(id, paymentHash, failures :+ NonRetriableLocalFailure(Nil, t)))
+      Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(Nil, t))).increment()
+      onFailure(s, PaymentFailed(id, paymentHash, failures :+ LocalFailure(Nil, t)))
       myStop()
   }
 
@@ -229,16 +229,16 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
       stay
 
     case Event(Status.Failure(t), data@WaitingForComplete(s, c, _, failures, _, _, _, hops)) =>
-      Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(RetriableLocalFailure(cfg.fullRoute(hops), t))).increment()
+      Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(cfg.fullRoute(hops), t))).increment()
       val isFatal = failures.size + 1 >= c.maxAttempts || // retries exhausted
         c.routePrefix.nonEmpty || // first hop was selected by the sender and failed, it doesn't make sense to retry
         t.isInstanceOf[HtlcsTimedoutDownstream] // htlc timed out so retrying won't help, we need to re-compute cltvs
       if (isFatal) {
-        onFailure(s, PaymentFailed(id, paymentHash, failures :+ NonRetriableLocalFailure(cfg.fullRoute(hops), t)))
+        onFailure(s, PaymentFailed(id, paymentHash, failures :+ LocalFailure(cfg.fullRoute(hops), t)))
         myStop()
       } else {
         log.info(s"received an error message from local, trying to use a different channel (failure=${t.getMessage})")
-        val failure = RetriableLocalFailure(cfg.fullRoute(hops), t)
+        val failure = LocalFailure(cfg.fullRoute(hops), t)
         retry(failure, data)
       }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -375,8 +375,16 @@ object Router {
 
   case class FinalizeRoute(amount: MilliSatoshi, hops: Seq[PublicKey], assistedRoutes: Seq[Seq[ExtraHop]] = Nil)
 
-  case class RouteResponse(hops: Seq[ChannelHop], ignoreNodes: Set[PublicKey], ignoreChannels: Set[ChannelDesc], allowEmpty: Boolean = false) {
+  case class Route(amount: MilliSatoshi, hops: Seq[ChannelHop], allowEmpty: Boolean = false) {
     require(allowEmpty || hops.nonEmpty, "route cannot be empty")
+    val length = hops.length
+
+    /** This method retrieves the channel update that we used when we built the route. */
+    def getChannelUpdateForNode(nodeId: PublicKey): Option[ChannelUpdate] = hops.find(_.nodeId == nodeId).map(_.lastUpdate)
+  }
+
+  case class RouteResponse(routes: Seq[Route]) {
+    require(routes.nonEmpty, "routes cannot be empty")
   }
 
   // @formatter:off

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
@@ -393,7 +393,7 @@ class SqlitePaymentsDbSpec extends AnyFunSuite {
     db.updateOutgoingPayment(PaymentFailed(s3.id, s3.paymentHash, Nil, 310))
     val ss3 = s3.copy(status = OutgoingPaymentStatus.Failed(Nil, 310))
     assert(db.getOutgoingPayment(s3.id) === Some(ss3))
-    db.updateOutgoingPayment(PaymentFailed(s4.id, s4.paymentHash, Seq(RetriableLocalFailure(Seq(hop_ab), new RuntimeException("woops")), RemoteFailure(Seq(hop_ab, hop_bc), Sphinx.DecryptedFailurePacket(carol, UnknownNextPeer))), 320))
+    db.updateOutgoingPayment(PaymentFailed(s4.id, s4.paymentHash, Seq(LocalFailure(Seq(hop_ab), new RuntimeException("woops")), RemoteFailure(Seq(hop_ab, hop_bc), Sphinx.DecryptedFailurePacket(carol, UnknownNextPeer))), 320))
     val ss4 = s4.copy(status = OutgoingPaymentStatus.Failed(Seq(FailureSummary(FailureType.LOCAL, "woops", List(HopSummary(alice, bob, Some(ShortChannelId(42))))), FailureSummary(FailureType.REMOTE, "processing node does not know the next peer in the route", List(HopSummary(alice, bob, Some(ShortChannelId(42))), HopSummary(bob, carol, None)))), 320))
     assert(db.getOutgoingPayment(s4.id) === Some(ss4))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
@@ -393,7 +393,7 @@ class SqlitePaymentsDbSpec extends AnyFunSuite {
     db.updateOutgoingPayment(PaymentFailed(s3.id, s3.paymentHash, Nil, 310))
     val ss3 = s3.copy(status = OutgoingPaymentStatus.Failed(Nil, 310))
     assert(db.getOutgoingPayment(s3.id) === Some(ss3))
-    db.updateOutgoingPayment(PaymentFailed(s4.id, s4.paymentHash, Seq(LocalFailure(Seq(hop_ab), new RuntimeException("woops")), RemoteFailure(Seq(hop_ab, hop_bc), Sphinx.DecryptedFailurePacket(carol, UnknownNextPeer))), 320))
+    db.updateOutgoingPayment(PaymentFailed(s4.id, s4.paymentHash, Seq(RetriableLocalFailure(Seq(hop_ab), new RuntimeException("woops")), RemoteFailure(Seq(hop_ab, hop_bc), Sphinx.DecryptedFailurePacket(carol, UnknownNextPeer))), 320))
     val ss4 = s4.copy(status = OutgoingPaymentStatus.Failed(Seq(FailureSummary(FailureType.LOCAL, "woops", List(HopSummary(alice, bob, Some(ShortChannelId(42))))), FailureSummary(FailureType.REMOTE, "processing node does not know the next peer in the route", List(HopSummary(alice, bob, Some(ShortChannelId(42))), HopSummary(bob, carol, None)))), 320))
     assert(db.getOutgoingPayment(s4.id) === Some(ss4))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqlitePaymentsDbSpec.scala
@@ -29,7 +29,6 @@ import fr.acinq.eclair.wire.{ChannelUpdate, UnknownNextPeer}
 import fr.acinq.eclair.{CltvExpiryDelta, LongToBtcAmount, ShortChannelId, TestConstants, randomBytes32, randomBytes64, randomKey}
 import org.scalatest.funsuite.AnyFunSuite
 
-import scala.compat.Platform
 import scala.concurrent.duration._
 
 class SqlitePaymentsDbSpec extends AnyFunSuite {
@@ -245,7 +244,7 @@ class SqlitePaymentsDbSpec extends AnyFunSuite {
     using(connection.prepareStatement("INSERT INTO sent_payments (id, parent_id, external_id, payment_hash, amount_msat, target_node_id, created_at, completed_at, failures) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")) { statement =>
       statement.setString(1, ps1.id.toString)
       statement.setString(2, ps1.parentId.toString)
-      statement.setString(3, ps1.externalId.get.toString)
+      statement.setString(3, ps1.externalId.get)
       statement.setBytes(4, ps1.paymentHash.toArray)
       statement.setLong(5, ps1.amount.toLong)
       statement.setBytes(6, ps1.recipientNodeId.value.toArray)
@@ -258,7 +257,7 @@ class SqlitePaymentsDbSpec extends AnyFunSuite {
     using(connection.prepareStatement("INSERT INTO sent_payments (id, parent_id, external_id, payment_hash, amount_msat, target_node_id, created_at, payment_request) VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) { statement =>
       statement.setString(1, ps2.id.toString)
       statement.setString(2, ps2.parentId.toString)
-      statement.setString(3, ps2.externalId.get.toString)
+      statement.setString(3, ps2.externalId.get)
       statement.setBytes(4, ps2.paymentHash.toArray)
       statement.setLong(5, ps2.amount.toLong)
       statement.setBytes(6, ps2.recipientNodeId.value.toArray)
@@ -394,8 +393,8 @@ class SqlitePaymentsDbSpec extends AnyFunSuite {
     db.updateOutgoingPayment(PaymentFailed(s3.id, s3.paymentHash, Nil, 310))
     val ss3 = s3.copy(status = OutgoingPaymentStatus.Failed(Nil, 310))
     assert(db.getOutgoingPayment(s3.id) === Some(ss3))
-    db.updateOutgoingPayment(PaymentFailed(s4.id, s4.paymentHash, Seq(LocalFailure(new RuntimeException("woops")), RemoteFailure(Seq(hop_ab, hop_bc), Sphinx.DecryptedFailurePacket(carol, UnknownNextPeer))), 320))
-    val ss4 = s4.copy(status = OutgoingPaymentStatus.Failed(Seq(FailureSummary(FailureType.LOCAL, "woops", Nil), FailureSummary(FailureType.REMOTE, "processing node does not know the next peer in the route", List(HopSummary(alice, bob, Some(ShortChannelId(42))), HopSummary(bob, carol, None)))), 320))
+    db.updateOutgoingPayment(PaymentFailed(s4.id, s4.paymentHash, Seq(LocalFailure(Seq(hop_ab), new RuntimeException("woops")), RemoteFailure(Seq(hop_ab, hop_bc), Sphinx.DecryptedFailurePacket(carol, UnknownNextPeer))), 320))
+    val ss4 = s4.copy(status = OutgoingPaymentStatus.Failed(Seq(FailureSummary(FailureType.LOCAL, "woops", List(HopSummary(alice, bob, Some(ShortChannelId(42))))), FailureSummary(FailureType.REMOTE, "processing node does not know the next peer in the route", List(HopSummary(alice, bob, Some(ShortChannelId(42))), HopSummary(bob, carol, None)))), 320))
     assert(db.getOutgoingPayment(s4.id) === Some(ss4))
 
     // can't update again once it's in a final state

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -331,7 +331,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     val faultyLocalPayments = pending.filter { case (_, p) => getFirstHopShortChannelId(p) == faultyLocalChannelId }
     val faultyRemotePayment = pending.filter { case (_, p) => getFirstHopShortChannelId(p) != faultyLocalChannelId }.head
     faultyLocalPayments.keys.foreach(id => {
-      childPayFsm.send(payFsm, PaymentFailed(id, paymentHash, LocalFailure(Nil, RouteNotFound) :: Nil))
+      childPayFsm.send(payFsm, PaymentFailed(id, paymentHash, NonRetriableLocalFailure(Nil, RouteNotFound) :: Nil))
     })
     childPayFsm.send(payFsm, PaymentFailed(faultyRemotePayment._1, paymentHash, UnreadableRemoteFailure(Nil) :: Nil))
 
@@ -345,7 +345,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     // New payments should be sent that match the failed amount.
     waitUntilAmountSent(f, faultyRemotePayment._2.finalPayload.amount + faultyLocalPayments.values.map(_.finalPayload.amount).sum)
     val stateData = payFsm.stateData.asInstanceOf[PaymentProgress]
-    assert(stateData.failures.toSet === Set(LocalFailure(Nil, RouteNotFound), UnreadableRemoteFailure(Nil)))
+    assert(stateData.failures.toSet === Set(NonRetriableLocalFailure(Nil, RouteNotFound), UnreadableRemoteFailure(Nil)))
     assert(stateData.pending.values.forall(p => getFirstHopShortChannelId(p) != faultyLocalChannelId))
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -18,8 +18,8 @@ package fr.acinq.eclair.payment
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.testkit.{TestFSMRef, TestKit, TestProbe}
+import akka.actor.ActorRef
+import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.{Block, Crypto, Satoshi}
 import fr.acinq.eclair.TestConstants.TestFeeEstimator
 import fr.acinq.eclair._
@@ -331,7 +331,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     val faultyLocalPayments = pending.filter { case (_, p) => getFirstHopShortChannelId(p) == faultyLocalChannelId }
     val faultyRemotePayment = pending.filter { case (_, p) => getFirstHopShortChannelId(p) != faultyLocalChannelId }.head
     faultyLocalPayments.keys.foreach(id => {
-      childPayFsm.send(payFsm, PaymentFailed(id, paymentHash, LocalFailure(RouteNotFound) :: Nil))
+      childPayFsm.send(payFsm, PaymentFailed(id, paymentHash, LocalFailure(Nil, RouteNotFound) :: Nil))
     })
     childPayFsm.send(payFsm, PaymentFailed(faultyRemotePayment._1, paymentHash, UnreadableRemoteFailure(Nil) :: Nil))
 
@@ -345,7 +345,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     // New payments should be sent that match the failed amount.
     waitUntilAmountSent(f, faultyRemotePayment._2.finalPayload.amount + faultyLocalPayments.values.map(_.finalPayload.amount).sum)
     val stateData = payFsm.stateData.asInstanceOf[PaymentProgress]
-    assert(stateData.failures.toSet === Set(LocalFailure(RouteNotFound), UnreadableRemoteFailure(Nil)))
+    assert(stateData.failures.toSet === Set(LocalFailure(Nil, RouteNotFound), UnreadableRemoteFailure(Nil)))
     assert(stateData.pending.values.forall(p => getFirstHopShortChannelId(p) != faultyLocalChannelId))
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -331,7 +331,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     val faultyLocalPayments = pending.filter { case (_, p) => getFirstHopShortChannelId(p) == faultyLocalChannelId }
     val faultyRemotePayment = pending.filter { case (_, p) => getFirstHopShortChannelId(p) != faultyLocalChannelId }.head
     faultyLocalPayments.keys.foreach(id => {
-      childPayFsm.send(payFsm, PaymentFailed(id, paymentHash, NonRetriableLocalFailure(Nil, RouteNotFound) :: Nil))
+      childPayFsm.send(payFsm, PaymentFailed(id, paymentHash, LocalFailure(Nil, RouteNotFound) :: Nil))
     })
     childPayFsm.send(payFsm, PaymentFailed(faultyRemotePayment._1, paymentHash, UnreadableRemoteFailure(Nil) :: Nil))
 
@@ -345,7 +345,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     // New payments should be sent that match the failed amount.
     waitUntilAmountSent(f, faultyRemotePayment._2.finalPayload.amount + faultyLocalPayments.values.map(_.finalPayload.amount).sum)
     val stateData = payFsm.stateData.asInstanceOf[PaymentProgress]
-    assert(stateData.failures.toSet === Set(NonRetriableLocalFailure(Nil, RouteNotFound), UnreadableRemoteFailure(Nil)))
+    assert(stateData.failures.toSet === Set(LocalFailure(Nil, RouteNotFound), UnreadableRemoteFailure(Nil)))
     assert(stateData.pending.values.forall(p => getFirstHopShortChannelId(p) != faultyLocalChannelId))
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
@@ -219,7 +219,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val outgoingPaymentId = outgoingPayFSM.expectMsgType[SendPaymentConfig].id
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
-    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, NonRetriableLocalFailure(Nil, PaymentError.BalanceTooLow) :: Nil))
+    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, LocalFailure(Nil, PaymentError.BalanceTooLow) :: Nil))
     incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TemporaryNodeFailure), commit = true))))
     commandBuffer.expectNoMsg(100 millis)
     eventListener.expectNoMsg(100 millis)
@@ -234,7 +234,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
     // If we're having a hard time finding routes, raising the fee/cltv will likely help.
-    val failures = NonRetriableLocalFailure(Nil, RouteNotFound) :: RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, PermanentNodeFailure)) :: NonRetriableLocalFailure(Nil, RouteNotFound) :: Nil
+    val failures = LocalFailure(Nil, RouteNotFound) :: RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, PermanentNodeFailure)) :: LocalFailure(Nil, RouteNotFound) :: Nil
     outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, failures))
     incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true))))
     commandBuffer.expectNoMsg(100 millis)
@@ -249,7 +249,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val outgoingPaymentId = outgoingPayFSM.expectMsgType[SendPaymentConfig].id
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
-    val failures = RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, FinalIncorrectHtlcAmount(42 msat))) :: UnreadableRemoteFailure(Nil) :: NonRetriableLocalFailure(Nil, RouteNotFound) :: Nil
+    val failures = RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, FinalIncorrectHtlcAmount(42 msat))) :: UnreadableRemoteFailure(Nil) :: LocalFailure(Nil, RouteNotFound) :: Nil
     outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, failures))
     incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(FinalIncorrectHtlcAmount(42 msat)), commit = true))))
     commandBuffer.expectNoMsg(100 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
@@ -219,7 +219,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val outgoingPaymentId = outgoingPayFSM.expectMsgType[SendPaymentConfig].id
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
-    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, LocalFailure(PaymentError.BalanceTooLow) :: Nil))
+    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, LocalFailure(Nil, PaymentError.BalanceTooLow) :: Nil))
     incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TemporaryNodeFailure), commit = true))))
     commandBuffer.expectNoMsg(100 millis)
     eventListener.expectNoMsg(100 millis)
@@ -234,7 +234,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
     // If we're having a hard time finding routes, raising the fee/cltv will likely help.
-    val failures = LocalFailure(RouteNotFound) :: RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, PermanentNodeFailure)) :: LocalFailure(RouteNotFound) :: Nil
+    val failures = LocalFailure(Nil, RouteNotFound) :: RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, PermanentNodeFailure)) :: LocalFailure(Nil, RouteNotFound) :: Nil
     outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, failures))
     incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true))))
     commandBuffer.expectNoMsg(100 millis)
@@ -249,7 +249,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val outgoingPaymentId = outgoingPayFSM.expectMsgType[SendPaymentConfig].id
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
-    val failures = RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, FinalIncorrectHtlcAmount(42 msat))) :: UnreadableRemoteFailure(Nil) :: LocalFailure(RouteNotFound) :: Nil
+    val failures = RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, FinalIncorrectHtlcAmount(42 msat))) :: UnreadableRemoteFailure(Nil) :: LocalFailure(Nil, RouteNotFound) :: Nil
     outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, failures))
     incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(FinalIncorrectHtlcAmount(42 msat)), commit = true))))
     commandBuffer.expectNoMsg(100 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
@@ -219,7 +219,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val outgoingPaymentId = outgoingPayFSM.expectMsgType[SendPaymentConfig].id
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
-    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, LocalFailure(Nil, PaymentError.BalanceTooLow) :: Nil))
+    outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, NonRetriableLocalFailure(Nil, PaymentError.BalanceTooLow) :: Nil))
     incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TemporaryNodeFailure), commit = true))))
     commandBuffer.expectNoMsg(100 millis)
     eventListener.expectNoMsg(100 millis)
@@ -234,7 +234,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
     // If we're having a hard time finding routes, raising the fee/cltv will likely help.
-    val failures = LocalFailure(Nil, RouteNotFound) :: RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, PermanentNodeFailure)) :: LocalFailure(Nil, RouteNotFound) :: Nil
+    val failures = NonRetriableLocalFailure(Nil, RouteNotFound) :: RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, PermanentNodeFailure)) :: NonRetriableLocalFailure(Nil, RouteNotFound) :: Nil
     outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, failures))
     incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true))))
     commandBuffer.expectNoMsg(100 millis)
@@ -249,7 +249,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val outgoingPaymentId = outgoingPayFSM.expectMsgType[SendPaymentConfig].id
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
-    val failures = RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, FinalIncorrectHtlcAmount(42 msat))) :: UnreadableRemoteFailure(Nil) :: LocalFailure(Nil, RouteNotFound) :: Nil
+    val failures = RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, FinalIncorrectHtlcAmount(42 msat))) :: UnreadableRemoteFailure(Nil) :: NonRetriableLocalFailure(Nil, RouteNotFound) :: Nil
     outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, failures))
     incomingMultiPart.foreach(p => commandBuffer.expectMsg(CommandBuffer.CommandSend(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(FinalIncorrectHtlcAmount(42 msat)), commit = true))))
     commandBuffer.expectNoMsg(100 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -237,7 +237,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
     assert(fail.id === id)
-    assert(fail.failures === LocalFailure(Nil, PaymentError.TrampolineLegacyAmountLessInvoice) :: Nil)
+    assert(fail.failures === NonRetriableLocalFailure(Nil, PaymentError.TrampolineLegacyAmountLessInvoice) :: Nil)
 
     multiPartPayFsm.expectNoMsg(50 millis)
     payFsm.expectNoMsg(50 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -18,8 +18,8 @@ package fr.acinq.eclair.payment
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.testkit.{TestActorRef, TestKit, TestProbe}
+import akka.actor.ActorRef
+import akka.testkit.{TestActorRef, TestProbe}
 import fr.acinq.bitcoin.Block
 import fr.acinq.eclair.Features._
 import fr.acinq.eclair.UInt64.Conversions._
@@ -237,7 +237,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
     assert(fail.id === id)
-    assert(fail.failures === LocalFailure(PaymentError.TrampolineLegacyAmountLessInvoice) :: Nil)
+    assert(fail.failures === LocalFailure(Nil, PaymentError.TrampolineLegacyAmountLessInvoice) :: Nil)
 
     multiPartPayFsm.expectNoMsg(50 millis)
     payFsm.expectNoMsg(50 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -237,7 +237,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
     assert(fail.id === id)
-    assert(fail.failures === NonRetriableLocalFailure(Nil, PaymentError.TrampolineLegacyAmountLessInvoice) :: Nil)
+    assert(fail.failures === LocalFailure(Nil, PaymentError.TrampolineLegacyAmountLessInvoice) :: Nil)
 
     multiPartPayFsm.expectNoMsg(50 millis)
     payFsm.expectNoMsg(50 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -152,7 +152,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val Transition(_, WAITING_FOR_REQUEST, WAITING_FOR_ROUTE) = monitor.expectMsgClass(classOf[Transition[_]])
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status == OutgoingPaymentStatus.Pending))
 
-    routerForwarder.send(paymentFSM, RouteResponse(Seq(ChannelHop(c, d, update_cd)), Set.empty, Set.empty))
+    routerForwarder.send(paymentFSM, RouteResponse(Route(defaultAmountMsat, Seq(ChannelHop(c, d, update_cd))) :: Nil))
     val Transition(_, WAITING_FOR_ROUTE, WAITING_FOR_PAYMENT_COMPLETE) = monitor.expectMsgClass(classOf[Transition[_]])
   }
 
@@ -178,7 +178,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val Transition(_, WAITING_FOR_REQUEST, WAITING_FOR_ROUTE) = monitor.expectMsgClass(classOf[Transition[_]])
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status == OutgoingPaymentStatus.Pending))
 
-    routerForwarder.send(paymentFSM, RouteResponse(Seq(ChannelHop(c, d, update_cd)), Set(a, b), Set.empty))
+    routerForwarder.send(paymentFSM, RouteResponse(Route(defaultAmountMsat, Seq(ChannelHop(c, d, update_cd))) :: Nil))
     val Transition(_, WAITING_FOR_ROUTE, WAITING_FOR_PAYMENT_COMPLETE) = monitor.expectMsgClass(classOf[Transition[_]])
 
     sender.send(paymentFSM, UpdateFailHtlc(randomBytes32, 0, randomBytes(Sphinx.FailurePacket.PacketLength)))
@@ -225,10 +225,11 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.expectMsg(RouteRequest(a, d, defaultAmountMsat, ignoreNodes = Set.empty, ignoreChannels = Set.empty))
     awaitCond(paymentFSM.stateName == WAITING_FOR_ROUTE && nodeParams.db.payments.getOutgoingPayment(id).exists(_.status === OutgoingPaymentStatus.Pending))
 
-    val WaitingForRoute(_, _, Nil) = paymentFSM.stateData
+    val WaitingForRoute(_, _, Nil, _, _) = paymentFSM.stateData
     routerForwarder.forward(routerFixture.router)
     awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
-    val WaitingForComplete(_, _, cmd1, Nil, _, _, _, hops) = paymentFSM.stateData
+    val WaitingForComplete(_, _, cmd1, Nil, _, ignoreNodes1, _, route) = paymentFSM.stateData
+    assert(ignoreNodes1.isEmpty)
 
     register.expectMsg(ForwardShortId(channelId_ab, cmd1))
     sender.send(paymentFSM, Relayer.ForwardRemoteFail(UpdateFailHtlc(ByteVector32.Zeroes, 0, randomBytes32), defaultOrigin, UpdateAddHtlc(ByteVector32.Zeroes, 0, defaultAmountMsat, defaultPaymentHash, defaultExpiry, TestConstants.emptyOnionPacket))) // unparsable message
@@ -237,15 +238,16 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.expectMsg(RouteRequest(nodeParams.nodeId, d, defaultAmountMsat, ignoreNodes = Set(c), ignoreChannels = Set.empty))
 
     // let's simulate a response by the router with another route
-    sender.send(paymentFSM, RouteResponse(hops, Set(c), Set.empty))
+    sender.send(paymentFSM, RouteResponse(route :: Nil))
     awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
-    val WaitingForComplete(_, _, cmd2, _, _, _, _, _) = paymentFSM.stateData
+    val WaitingForComplete(_, _, cmd2, _, _, ignoreNodes2, _, _) = paymentFSM.stateData
+    assert(ignoreNodes2 === Set(c))
     // and reply a 2nd time with an unparsable failure
     register.expectMsg(ForwardShortId(channelId_ab, cmd2))
     sender.send(paymentFSM, UpdateFailHtlc(ByteVector32.Zeroes, 0, defaultPaymentHash)) // unparsable message
 
     // we allow 2 tries, so we send a 2nd request to the router
-    assert(sender.expectMsgType[PaymentFailed].failures === UnreadableRemoteFailure(hops) :: UnreadableRemoteFailure(hops) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === UnreadableRemoteFailure(route.hops) :: UnreadableRemoteFailure(route.hops) :: Nil)
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed])) // after last attempt the payment is failed
   }
 
@@ -257,7 +259,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.send(paymentFSM, request)
     awaitCond(paymentFSM.stateName == WAITING_FOR_ROUTE && nodeParams.db.payments.getOutgoingPayment(id).exists(_.status === OutgoingPaymentStatus.Pending))
 
-    val WaitingForRoute(_, _, Nil) = paymentFSM.stateData
+    val WaitingForRoute(_, _, Nil, _, _) = paymentFSM.stateData
     routerForwarder.expectMsg(RouteRequest(nodeParams.nodeId, d, defaultAmountMsat, assistedRoutes = Nil, ignoreNodes = Set.empty, ignoreChannels = Set.empty))
     routerForwarder.forward(routerFixture.router)
     awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
@@ -279,7 +281,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.send(paymentFSM, request)
     awaitCond(paymentFSM.stateName == WAITING_FOR_ROUTE && nodeParams.db.payments.getOutgoingPayment(id).exists(_.status === OutgoingPaymentStatus.Pending))
 
-    val WaitingForRoute(_, _, Nil) = paymentFSM.stateData
+    val WaitingForRoute(_, _, Nil, _, _) = paymentFSM.stateData
     routerForwarder.expectMsg(RouteRequest(nodeParams.nodeId, d, defaultAmountMsat, assistedRoutes = Nil, ignoreNodes = Set.empty, ignoreChannels = Set.empty))
     routerForwarder.forward(routerFixture.router)
     awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
@@ -300,11 +302,11 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val request = SendPayment(d, FinalLegacyPayload(defaultAmountMsat, defaultExpiry), 2)
     sender.send(paymentFSM, request)
     awaitCond(paymentFSM.stateName == WAITING_FOR_ROUTE)
-    val WaitingForRoute(_, _, Nil) = paymentFSM.stateData
+    val WaitingForRoute(_, _, Nil, _, _) = paymentFSM.stateData
     routerForwarder.expectMsg(RouteRequest(nodeParams.nodeId, d, defaultAmountMsat, assistedRoutes = Nil, ignoreNodes = Set.empty, ignoreChannels = Set.empty))
     routerForwarder.forward(routerFixture.router)
     awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
-    val WaitingForComplete(_, _, cmd1, Nil, sharedSecrets1, _, _, hops) = paymentFSM.stateData
+    val WaitingForComplete(_, _, cmd1, Nil, sharedSecrets1, _, _, route) = paymentFSM.stateData
 
     register.expectMsg(ForwardShortId(channelId_ab, cmd1))
     val failure = TemporaryChannelFailure(update_bc)
@@ -319,7 +321,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.expectMsg(RouteRequest(a, d, defaultAmountMsat, assistedRoutes = Nil, ignoreNodes = Set.empty, ignoreChannels = Set.empty))
     routerForwarder.forward(routerFixture.router)
     // we allow 2 tries, so we send a 2nd request to the router
-    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(hops, Sphinx.DecryptedFailurePacket(b, failure)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
   }
 
   test("payment failed (Update)") { routerFixture =>
@@ -330,11 +332,11 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.send(paymentFSM, request)
     awaitCond(paymentFSM.stateName == WAITING_FOR_ROUTE && nodeParams.db.payments.getOutgoingPayment(id).exists(_.status === OutgoingPaymentStatus.Pending))
 
-    val WaitingForRoute(_, _, Nil) = paymentFSM.stateData
+    val WaitingForRoute(_, _, Nil, _, _) = paymentFSM.stateData
     routerForwarder.expectMsg(RouteRequest(nodeParams.nodeId, d, defaultAmountMsat, assistedRoutes = Nil, ignoreNodes = Set.empty, ignoreChannels = Set.empty))
     routerForwarder.forward(routerFixture.router)
     awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
-    val WaitingForComplete(_, _, cmd1, Nil, sharedSecrets1, _, _, hops) = paymentFSM.stateData
+    val WaitingForComplete(_, _, cmd1, Nil, sharedSecrets1, _, _, route1) = paymentFSM.stateData
     register.expectMsg(ForwardShortId(channelId_ab, cmd1))
 
     // we change the cltv expiry
@@ -351,7 +353,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
 
     // router answers with a new route, taking into account the new update
     awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
-    val WaitingForComplete(_, _, cmd2, _, sharedSecrets2, _, _, hops2) = paymentFSM.stateData
+    val WaitingForComplete(_, _, cmd2, _, sharedSecrets2, _, _, route2) = paymentFSM.stateData
     register.expectMsg(ForwardShortId(channelId_ab, cmd2))
 
     // we change the cltv expiry one more time
@@ -370,7 +372,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.forward(routerFixture.router)
 
     // this time the router can't find a route: game over
-    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(hops, Sphinx.DecryptedFailurePacket(b, failure)) :: RemoteFailure(hops2, Sphinx.DecryptedFailurePacket(b, failure2)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route1.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: RemoteFailure(route2.hops, Sphinx.DecryptedFailurePacket(b, failure2)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
   }
 
@@ -388,7 +390,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.send(paymentFSM, request)
     awaitCond(paymentFSM.stateName == WAITING_FOR_ROUTE && nodeParams.db.payments.getOutgoingPayment(id).exists(_.status === OutgoingPaymentStatus.Pending))
 
-    val WaitingForRoute(_, _, Nil) = paymentFSM.stateData
+    val WaitingForRoute(_, _, Nil, _, _) = paymentFSM.stateData
     routerForwarder.expectMsg(RouteRequest(nodeParams.nodeId, d, defaultAmountMsat, assistedRoutes = assistedRoutes, ignoreNodes = Set.empty, ignoreChannels = Set.empty))
     routerForwarder.forward(routerFixture.router)
     awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
@@ -426,11 +428,11 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.send(paymentFSM, request)
     awaitCond(paymentFSM.stateName == WAITING_FOR_ROUTE && nodeParams.db.payments.getOutgoingPayment(id).exists(_.status === OutgoingPaymentStatus.Pending))
 
-    val WaitingForRoute(_, _, Nil) = paymentFSM.stateData
+    val WaitingForRoute(_, _, Nil, _, _) = paymentFSM.stateData
     routerForwarder.expectMsg(RouteRequest(nodeParams.nodeId, d, defaultAmountMsat, assistedRoutes = Nil, ignoreNodes = Set.empty, ignoreChannels = Set.empty))
     routerForwarder.forward(router)
     awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
-    val WaitingForComplete(_, _, cmd1, Nil, sharedSecrets1, _, _, hops) = paymentFSM.stateData
+    val WaitingForComplete(_, _, cmd1, Nil, sharedSecrets1, _, _, route1) = paymentFSM.stateData
 
     register.expectMsg(ForwardShortId(channelId_ab, cmd1))
     sender.send(paymentFSM, UpdateFailHtlc(ByteVector32.Zeroes, 0, Sphinx.FailurePacket.create(sharedSecrets1.head._1, failure)))
@@ -441,7 +443,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.forward(router)
     // we allow 2 tries, so we send a 2nd request to the router, which won't find another route
 
-    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(hops, Sphinx.DecryptedFailurePacket(b, failure)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route1.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -198,7 +198,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status === OutgoingPaymentStatus.Pending))
 
     routerForwarder.forward(routerFixture.router, routeRequest)
-    assert(sender.expectMsgType[PaymentFailed].failures === NonRetriableLocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === LocalFailure(Nil, RouteNotFound) :: Nil)
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
   }
 
@@ -212,7 +212,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val Transition(_, WAITING_FOR_REQUEST, WAITING_FOR_ROUTE) = monitor.expectMsgClass(classOf[Transition[_]])
 
     routerForwarder.forward(routerFixture.router, routeRequest)
-    val Seq(NonRetriableLocalFailure(Nil, RouteNotFound)) = sender.expectMsgType[PaymentFailed].failures
+    val Seq(LocalFailure(Nil, RouteNotFound)) = sender.expectMsgType[PaymentFailed].failures
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
   }
 
@@ -321,7 +321,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.expectMsg(RouteRequest(a, d, defaultAmountMsat, assistedRoutes = Nil, ignoreNodes = Set.empty, ignoreChannels = Set.empty))
     routerForwarder.forward(routerFixture.router)
     // we allow 2 tries, so we send a 2nd request to the router
-    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: NonRetriableLocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
   }
 
   test("payment failed (Update)") { routerFixture =>
@@ -372,7 +372,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.forward(routerFixture.router)
 
     // this time the router can't find a route: game over
-    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route1.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: RemoteFailure(route2.hops, Sphinx.DecryptedFailurePacket(b, failure2)) :: NonRetriableLocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route1.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: RemoteFailure(route2.hops, Sphinx.DecryptedFailurePacket(b, failure2)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
   }
 
@@ -443,7 +443,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.forward(router)
     // we allow 2 tries, so we send a 2nd request to the router, which won't find another route
 
-    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route1.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: NonRetriableLocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route1.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
   }
 
@@ -533,16 +533,16 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
 
   test("filter errors properly") { _ =>
     val failures = Seq(
-      NonRetriableLocalFailure(Nil, RouteNotFound),
+      LocalFailure(Nil, RouteNotFound),
       RemoteFailure(ChannelHop(a, b, update_ab) :: Nil, Sphinx.DecryptedFailurePacket(a, TemporaryNodeFailure)),
-      RetriableLocalFailure(ChannelHop(a, b, update_ab) :: Nil, AddHtlcFailed(ByteVector32.Zeroes, ByteVector32.Zeroes, ChannelUnavailable(ByteVector32.Zeroes), Local(UUID.randomUUID(), None), None, None)),
-      NonRetriableLocalFailure(Nil, RouteNotFound)
+      LocalFailure(ChannelHop(a, b, update_ab) :: Nil, AddHtlcFailed(ByteVector32.Zeroes, ByteVector32.Zeroes, ChannelUnavailable(ByteVector32.Zeroes), Local(UUID.randomUUID(), None), None, None)),
+      LocalFailure(Nil, RouteNotFound)
     )
     val filtered = PaymentFailure.transformForUser(failures)
     val expected = Seq(
-      NonRetriableLocalFailure(Nil, RouteNotFound),
+      LocalFailure(Nil, RouteNotFound),
       RemoteFailure(ChannelHop(a, b, update_ab) :: Nil, Sphinx.DecryptedFailurePacket(a, TemporaryNodeFailure)),
-      RetriableLocalFailure(ChannelHop(a, b, update_ab) :: Nil, ChannelUnavailable(ByteVector32.Zeroes))
+      LocalFailure(ChannelHop(a, b, update_ab) :: Nil, ChannelUnavailable(ByteVector32.Zeroes))
     )
     assert(filtered === expected)
   }
@@ -551,9 +551,9 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val route_abcd = ChannelHop(a, b, update_ab) :: ChannelHop(b, c, update_bc) :: ChannelHop(c, d, update_cd) :: Nil
     val testCases = Seq(
       // local failures -> ignore first channel if there is one
-      (NonRetriableLocalFailure(Nil, RouteNotFound), Set.empty, Set.empty),
-      (NonRetriableLocalFailure(NodeHop(a, b, CltvExpiryDelta(144), 0 msat) :: NodeHop(b, c, CltvExpiryDelta(144), 0 msat) :: Nil, RouteNotFound), Set.empty, Set.empty),
-      (RetriableLocalFailure(route_abcd, new RuntimeException("fatal")), Set.empty, Set(ChannelDesc(channelId_ab, a, b))),
+      (LocalFailure(Nil, RouteNotFound), Set.empty, Set.empty),
+      (LocalFailure(NodeHop(a, b, CltvExpiryDelta(144), 0 msat) :: NodeHop(b, c, CltvExpiryDelta(144), 0 msat) :: Nil, RouteNotFound), Set.empty, Set.empty),
+      (LocalFailure(route_abcd, new RuntimeException("fatal")), Set.empty, Set(ChannelDesc(channelId_ab, a, b))),
       // remote failure from final recipient -> all intermediate nodes behaved correctly
       (RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(d, IncorrectOrUnknownPaymentDetails(100 msat, 42))), Set.empty, Set.empty),
       // remote failures from intermediate nodes -> depending on the failure, ignore either the failing node or its outgoing channel
@@ -576,7 +576,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val failures = Seq(
       RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(c, TemporaryNodeFailure)),
       RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(b, UnknownNextPeer)),
-      RetriableLocalFailure(route_abcd, new RuntimeException("fatal"))
+      LocalFailure(route_abcd, new RuntimeException("fatal"))
     )
     val (ignoreNodes, ignoreChannels) = PaymentFailure.updateIgnored(failures, Set.empty, Set.empty)
     assert(ignoreNodes === Set(c))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -53,7 +53,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
+    assert(route.map(route2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
   }
 
   test("check fee against max pct properly") {
@@ -74,7 +74,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(maxFeeBase = 1 msat), currentBlockHeight = 400000)
 
-    assert(route.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
+    assert(route.map(route2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
   }
 
   test("calculate the shortest path (correct fees)") {
@@ -117,8 +117,8 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val Success(route) = findRoute(graph, a, d, amount, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    val weightedPath = Graph.pathWeight(a, hops2Edges(route), amount, 0, None)
-    assert(hops2Ids(route) === 4 :: 5 :: 6 :: Nil)
+    val weightedPath = Graph.pathWeight(a, route2Edges(route), amount, 0, None)
+    assert(route2Ids(route) === 4 :: 5 :: 6 :: Nil)
     assert(weightedPath.length === 3)
     assert(weightedPath.cost === expectedCost)
 
@@ -128,7 +128,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     val graph3 = graph.addEdge(makeEdge(5L, e, f, feeBase = 1 msat, feeProportionalMillionth = 400, minHtlc = 0 msat, balance_opt = Some(10001 msat)))
     for (g <- Seq(graph1, graph2, graph3)) {
       val Success(route1) = findRoute(g, a, d, amount, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-      assert(hops2Ids(route1) === 1 :: 2 :: 3 :: Nil)
+      assert(route2Ids(route1) === 1 :: 2 :: 3 :: Nil)
     }
   }
 
@@ -142,7 +142,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(2 :: 5 :: Nil))
+    assert(route.map(route2Ids) === Success(2 :: 5 :: Nil))
   }
 
   test("calculate simple route (add and remove edges") {
@@ -154,11 +154,11 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route1.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
+    assert(route1.map(route2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
 
     val graphWithRemovedEdge = g.removeEdge(ChannelDesc(ShortChannelId(3L), c, d))
     val route2 = findRoute(graphWithRemovedEdge, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route2.map(hops2Ids) === Failure(RouteNotFound))
+    assert(route2.map(route2Ids) === Failure(RouteNotFound))
   }
 
   test("calculate the shortest path (hardcoded nodes)") {
@@ -177,7 +177,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(4 :: 3 :: Nil))
+    assert(route.map(route2Ids) === Success(4 :: 3 :: Nil))
   }
 
   test("calculate the shortest path (select direct channel)") {
@@ -196,7 +196,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 2, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(4 :: Nil))
+    assert(route.map(route2Ids) === Success(4 :: Nil))
   }
 
   test("find a route using channels with htlMaximumMsat close to the payment amount") {
@@ -215,7 +215,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) == Success(1 :: 2 :: 3 :: Nil))
+    assert(route.map(route2Ids) == Success(1 :: 2 :: 3 :: Nil))
   }
 
   test("find a route using channels with htlMinimumMsat close to the payment amount") {
@@ -234,7 +234,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Failure(RouteNotFound))
+    assert(route.map(route2Ids) === Failure(RouteNotFound))
   }
 
   test("if there are multiple channels between the same node, select the cheapest") {
@@ -253,7 +253,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(1 :: 6 :: 3 :: Nil))
+    assert(route.map(route2Ids) === Success(1 :: 6 :: 3 :: Nil))
   }
 
   test("if there are multiple channels between the same node, select one that has enough balance") {
@@ -272,7 +272,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(graph, f, i, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(1 :: 2 :: 3 :: Nil))
+    assert(route.map(route2Ids) === Success(1 :: 2 :: 3 :: Nil))
   }
 
   test("calculate longer but cheaper route") {
@@ -285,7 +285,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
+    assert(route.map(route2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
   }
 
   test("no local channels") {
@@ -295,7 +295,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Failure(RouteNotFound))
+    assert(route.map(route2Ids) === Failure(RouteNotFound))
   }
 
   test("route not found") {
@@ -306,7 +306,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Failure(RouteNotFound))
+    assert(route.map(route2Ids) === Failure(RouteNotFound))
   }
 
   test("route not found (source OR target node not connected)") {
@@ -379,7 +379,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, a, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Failure(CannotRouteToSelf))
+    assert(route.map(route2Ids) === Failure(CannotRouteToSelf))
   }
 
   test("route to immediate neighbor") {
@@ -391,7 +391,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, b, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(1 :: Nil))
+    assert(route.map(route2Ids) === Success(1 :: Nil))
   }
 
   test("directed graph") {
@@ -404,10 +404,10 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route1.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
+    assert(route1.map(route2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
 
     val route2 = findRoute(g, e, a, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route2.map(hops2Ids) === Failure(RouteNotFound))
+    assert(route2.map(route2Ids) === Failure(RouteNotFound))
   }
 
   test("calculate route and return metadata") {
@@ -434,7 +434,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     )
 
     val g = DirectedGraph(edges)
-    val Success(hops) = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
+    val hops = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).get.hops
     assert(hops === ChannelHop(a, b, uab) :: ChannelHop(b, c, ubc) :: ChannelHop(c, d, ucd) :: ChannelHop(d, e, ude) :: Nil)
   }
 
@@ -469,7 +469,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, ignoredEdges = Set(ChannelDesc(ShortChannelId(3L), c, d)), routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route1.map(hops2Ids) === Failure(RouteNotFound))
+    assert(route1.map(route2Ids) === Failure(RouteNotFound))
 
     // verify that we left the graph untouched
     assert(g.containsEdge(ChannelDesc(ShortChannelId(3), c, d)))
@@ -478,7 +478,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
 
     // make sure we can find a route if without the blacklist
     val route2 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route2.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
+    assert(route2.map(route2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
   }
 
   test("route to a destination that is not in the graph (with assisted routes)") {
@@ -489,12 +489,12 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Failure(RouteNotFound))
+    assert(route.map(route2Ids) === Failure(RouteNotFound))
 
     // now we add the missing edge to reach the destination
     val extraGraphEdges = Set(makeEdge(4L, d, e, 5 msat, 5))
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, extraEdges = extraGraphEdges, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route1.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
+    assert(route1.map(route2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
   }
 
   test("route from a source that is not in the graph (with assisted routes)") {
@@ -504,12 +504,12 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Failure(RouteNotFound))
+    assert(route.map(route2Ids) === Failure(RouteNotFound))
 
     // now we add the missing starting edge
     val extraGraphEdges = Set(makeEdge(1L, a, b, 5 msat, 5))
     val route1 = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, extraEdges = extraGraphEdges, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route1.map(hops2Ids) === Success(1 :: 2 :: 3 :: Nil))
+    assert(route1.map(route2Ids) === Success(1 :: 2 :: 3 :: Nil))
   }
 
   test("verify that extra hops takes precedence over known channels") {
@@ -521,13 +521,13 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route1.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
-    assert(route1.get(1).lastUpdate.feeBaseMsat === 10.msat)
+    assert(route1.map(route2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
+    assert(route1.get.hops(1).lastUpdate.feeBaseMsat === 10.msat)
 
     val extraGraphEdges = Set(makeEdge(2L, b, c, 5 msat, 5))
     val route2 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, extraEdges = extraGraphEdges, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route2.map(hops2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
-    assert(route2.get(1).lastUpdate.feeBaseMsat === 5.msat)
+    assert(route2.map(route2Ids) === Success(1 :: 2 :: 3 :: 4 :: Nil))
+    assert(route2.get.hops(1).lastUpdate.feeBaseMsat === 5.msat)
   }
 
   test("compute ignored channels") {
@@ -583,10 +583,10 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
 
     val g = DirectedGraph(edges)
 
-    assert(findRoute(g, nodes(0), nodes(18), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).map(hops2Ids) === Success(0 until 18))
-    assert(findRoute(g, nodes(0), nodes(19), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).map(hops2Ids) === Success(0 until 19))
-    assert(findRoute(g, nodes(0), nodes(20), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).map(hops2Ids) === Success(0 until 20))
-    assert(findRoute(g, nodes(0), nodes(21), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).map(hops2Ids) === Failure(RouteNotFound))
+    assert(findRoute(g, nodes(0), nodes(18), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).map(route2Ids) === Success(0 until 18))
+    assert(findRoute(g, nodes(0), nodes(19), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).map(route2Ids) === Success(0 until 19))
+    assert(findRoute(g, nodes(0), nodes(20), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).map(route2Ids) === Success(0 until 20))
+    assert(findRoute(g, nodes(0), nodes(21), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000).map(route2Ids) === Failure(RouteNotFound))
   }
 
   test("ignore cheaper route when it has more than 20 hops") {
@@ -602,7 +602,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     val g = DirectedGraph(expensiveShortEdge :: edges)
 
     val route = findRoute(g, nodes(0), nodes(49), DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(0 :: 1 :: 99 :: 48 :: Nil))
+    assert(route.map(route2Ids) === Success(0 :: 1 :: 99 :: 48 :: Nil))
   }
 
   test("ignore cheaper route when it has more than the requested CLTV") {
@@ -617,7 +617,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(routeMaxCltv = CltvExpiryDelta(28)), currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(4 :: 5 :: 6 :: Nil))
+    assert(route.map(route2Ids) === Success(4 :: 5 :: 6 :: Nil))
   }
 
   test("ignore cheaper route when it grows longer than the requested size") {
@@ -632,7 +632,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route = findRoute(g, a, f, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(routeMaxLength = 3), currentBlockHeight = 400000)
-    assert(route.map(hops2Ids) === Success(1 :: 6 :: Nil))
+    assert(route.map(route2Ids) === Success(1 :: 6 :: Nil))
   }
 
   test("ignore loops") {
@@ -645,7 +645,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route1 = findRoute(g, a, e, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route1.map(hops2Ids) === Success(1 :: 2 :: 4 :: 5 :: Nil))
+    assert(route1.map(route2Ids) === Success(1 :: 2 :: 4 :: 5 :: Nil))
   }
 
   test("ensure the route calculation terminates correctly when selecting 0-fees edges") {
@@ -661,7 +661,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val route1 = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(route1.map(hops2Ids) === Success(1 :: 3 :: 5 :: Nil))
+    assert(route1.map(route2Ids) === Success(1 :: 3 :: 5 :: Nil))
   }
 
   // +---+                       +---+    +---+
@@ -787,7 +787,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     (for {_ <- 0 to 10} yield findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 3, routeParams = strictFeeParams, currentBlockHeight = 400000)).map {
       case Failure(thr) => fail(thr)
       case Success(someRoute) =>
-        val weightedPath = Graph.pathWeight(a, hops2Edges(someRoute), DEFAULT_AMOUNT_MSAT, 0, None)
+        val weightedPath = Graph.pathWeight(a, route2Edges(someRoute), DEFAULT_AMOUNT_MSAT, 0, None)
         val totalFees = weightedPath.cost - DEFAULT_AMOUNT_MSAT
         // over the three routes we could only get the 2 cheapest because the third is too expensive (over 7 msat of fees)
         assert(totalFees === 5.msat || totalFees === 6.msat)
@@ -813,21 +813,21 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     ))
 
     val Success(routeFeeOptimized) = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000)
-    assert(hops2Nodes(routeFeeOptimized) === (a, b) :: (b, c) :: (c, d) :: Nil)
+    assert(route2Nodes(routeFeeOptimized) === (a, b) :: (b, c) :: (c, d) :: Nil)
 
     val Success(routeCltvOptimized) = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(ratios = Some(WeightRatios(
       cltvDeltaFactor = 1,
       ageFactor = 0,
       capacityFactor = 0
     ))), currentBlockHeight = 400000)
-    assert(hops2Nodes(routeCltvOptimized) === (a, e) :: (e, f) :: (f, d) :: Nil)
+    assert(route2Nodes(routeCltvOptimized) === (a, e) :: (e, f) :: (f, d) :: Nil)
 
     val Success(routeCapacityOptimized) = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(ratios = Some(WeightRatios(
       cltvDeltaFactor = 0,
       ageFactor = 0,
       capacityFactor = 1
     ))), currentBlockHeight = 400000)
-    assert(hops2Nodes(routeCapacityOptimized) === (a, e) :: (e, c) :: (c, d) :: Nil)
+    assert(route2Nodes(routeCapacityOptimized) === (a, e) :: (e, c) :: (c, d) :: Nil)
   }
 
   test("prefer going through an older channel if fees and CLTV are the same") {
@@ -848,7 +848,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       capacityFactor = 0.33
     ))), currentBlockHeight = currentBlockHeight)
 
-    assert(hops2Nodes(routeScoreOptimized) === (a, b) :: (b, c) :: (c, d) :: Nil)
+    assert(route2Nodes(routeScoreOptimized) === (a, b) :: (b, c) :: (c, d) :: Nil)
   }
 
   test("prefer a route with a smaller total CLTV if fees and score are the same") {
@@ -867,7 +867,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       capacityFactor = 0.33
     ))), currentBlockHeight = 400000)
 
-    assert(hops2Nodes(routeScoreOptimized) === (a, b) :: (b, c) :: (c, d) :: Nil)
+    assert(route2Nodes(routeScoreOptimized) === (a, b) :: (b, c) :: (c, d) :: Nil)
   }
 
   test("avoid a route that breaks off the max CLTV") {
@@ -888,7 +888,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       capacityFactor = 0.33
     ))), currentBlockHeight = 400000)
 
-    assert(hops2Nodes(routeScoreOptimized) === (a, e) :: (e, f) :: (f, d) :: Nil)
+    assert(route2Nodes(routeScoreOptimized) === (a, e) :: (e, f) :: (f, d) :: Nil)
   }
 
   test("cost function is monotonic") {
@@ -930,8 +930,8 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     val amount = 351000 msat
 
     val Success(route) = findRoute(g, thisNode, targetNode, amount, 1, Set.empty, Set.empty, Set.empty, params, currentBlockHeight = 567634) // simulate mainnet block for heuristic
-    assert(route.size == 2)
-    assert(route.last.nextNodeId == targetNode)
+    assert(route.length == 2)
+    assert(route.hops.last.nextNodeId == targetNode)
   }
 
   test("validate path fees") {
@@ -1004,10 +1004,12 @@ object RouteCalculationSpec {
       htlcMaximumMsat = maxHtlc
     )
 
-  def hops2Ids(route: Seq[ChannelHop]) = route.map(hop => hop.lastUpdate.shortChannelId.toLong)
+  def hops2Ids(hops: Seq[ChannelHop]) = hops.map(hop => hop.lastUpdate.shortChannelId.toLong)
 
-  def hops2Edges(route: Seq[ChannelHop]) = route.map(hop => GraphEdge(ChannelDesc(hop.lastUpdate.shortChannelId, hop.nodeId, hop.nextNodeId), hop.lastUpdate, 0 sat, None))
+  def route2Ids(route: Route) = hops2Ids(route.hops)
 
-  def hops2Nodes(route: Seq[ChannelHop]) = route.map(hop => (hop.nodeId, hop.nextNodeId))
+  def route2Edges(route: Route) = route.hops.map(hop => GraphEdge(ChannelDesc(hop.lastUpdate.shortChannelId, hop.nodeId, hop.nextNodeId), hop.lastUpdate, 0 sat, None))
+
+  def route2Nodes(route: Route) = route.hops.map(hop => (hop.nodeId, hop.nextNodeId))
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -340,13 +340,13 @@ class RouterSpec extends BaseRouterSpec {
     val sender = TestProbe()
     sender.send(router, RouteRequest(a, d, DEFAULT_AMOUNT_MSAT, routeParams = relaxedRouteParams))
     val res = sender.expectMsgType[RouteResponse]
-    assert(res.hops.map(_.nodeId).toList === a :: b :: c :: Nil)
-    assert(res.hops.last.nextNodeId === d)
+    assert(res.routes.head.hops.map(_.nodeId).toList === a :: b :: c :: Nil)
+    assert(res.routes.head.hops.last.nextNodeId === d)
 
     sender.send(router, RouteRequest(a, h, DEFAULT_AMOUNT_MSAT))
     val res1 = sender.expectMsgType[RouteResponse]
-    assert(res1.hops.map(_.nodeId).toList === a :: g :: Nil)
-    assert(res1.hops.last.nextNodeId === h)
+    assert(res1.routes.head.hops.map(_.nodeId).toList === a :: g :: Nil)
+    assert(res1.routes.head.hops.last.nextNodeId === h)
   }
 
   test("route found (with extra routing info)") { fixture =>
@@ -360,8 +360,8 @@ class RouterSpec extends BaseRouterSpec {
     val extraHop_yz = ExtraHop(y, ShortChannelId(3), 20 msat, 21, CltvExpiryDelta(22))
     sender.send(router, RouteRequest(a, z, DEFAULT_AMOUNT_MSAT, assistedRoutes = Seq(extraHop_cx :: extraHop_xy :: extraHop_yz :: Nil)))
     val res = sender.expectMsgType[RouteResponse]
-    assert(res.hops.map(_.nodeId).toList === a :: b :: c :: x :: y :: Nil)
-    assert(res.hops.last.nextNodeId === z)
+    assert(res.routes.head.hops.map(_.nodeId).toList === a :: b :: c :: x :: y :: Nil)
+    assert(res.routes.head.hops.last.nextNodeId === z)
   }
 
   test("route not found (channel disabled)") { fixture =>
@@ -370,8 +370,8 @@ class RouterSpec extends BaseRouterSpec {
     val peerConnection = TestProbe()
     sender.send(router, RouteRequest(a, d, DEFAULT_AMOUNT_MSAT, routeParams = relaxedRouteParams))
     val res = sender.expectMsgType[RouteResponse]
-    assert(res.hops.map(_.nodeId).toList === a :: b :: c :: Nil)
-    assert(res.hops.last.nextNodeId === d)
+    assert(res.routes.head.hops.map(_.nodeId).toList === a :: b :: c :: Nil)
+    assert(res.routes.head.hops.last.nextNodeId === d)
 
     val channelUpdate_cd1 = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_c, d, channelId_cd, CltvExpiryDelta(3), 0 msat, 153000 msat, 4, htlcMaximum, enable = false)
     peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, channelUpdate_cd1))
@@ -385,8 +385,8 @@ class RouterSpec extends BaseRouterSpec {
     val sender = TestProbe()
     sender.send(router, RouteRequest(a, h, DEFAULT_AMOUNT_MSAT))
     val res = sender.expectMsgType[RouteResponse]
-    assert(res.hops.map(_.nodeId).toList === a :: g :: Nil)
-    assert(res.hops.last.nextNodeId === h)
+    assert(res.routes.head.hops.map(_.nodeId).toList === a :: g :: Nil)
+    assert(res.routes.head.hops.last.nextNodeId === h)
 
     val channelUpdate_ag1 = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_a, g, channelId_ag, CltvExpiryDelta(7), 0 msat, 10 msat, 10, htlcMaximum, enable = false)
     sender.send(router, LocalChannelUpdate(sender.ref, null, channelId_ag, g, None, channelUpdate_ag1, CommitmentsSpec.makeCommitments(10000 msat, 15000 msat, a, g, announceChannel = false)))
@@ -477,9 +477,9 @@ class RouterSpec extends BaseRouterSpec {
 
     val response = sender.expectMsgType[RouteResponse]
     // the route hasn't changed (nodes are the same)
-    assert(response.hops.map(_.nodeId).toList == preComputedRoute.dropRight(1).toList)
-    assert(response.hops.last.nextNodeId == preComputedRoute.last)
-    assert(response.hops.map(_.lastUpdate).toList == List(update_ab, update_bc, update_cd))
+    assert(response.routes.head.hops.map(_.nodeId).toList == preComputedRoute.dropRight(1).toList)
+    assert(response.routes.head.hops.last.nextNodeId == preComputedRoute.last)
+    assert(response.routes.head.hops.map(_.lastUpdate).toList == List(update_ab, update_bc, update_cd))
   }
 
   test("ask for channels that we marked as stale for which we receive a new update") { fixture =>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -201,7 +201,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
       val distilledFailures = PaymentFailure.transformForUser(p.failures)
       val message = s"${distilledFailures.size} attempts:\n${
         distilledFailures.map {
-          case LocalFailure(t) => s"- (local) ${t.getMessage}"
+          case LocalFailure(_, t) => s"- (local) ${t.getMessage}"
           case RemoteFailure(_, e) => s"- (remote) ${e.failureMessage.message}"
           case _ => "- Unknown error"
         }.mkString("\n")

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -182,7 +182,7 @@ class RouteResponseSerializer extends CustomSerializer[RouteResponse](_ => ( {
   null
 }, {
   case route: RouteResponse =>
-    val nodeIds = route.hops match {
+    val nodeIds = route.routes.head.hops match {
       case rest :+ last => rest.map(_.nodeId) :+ last.nodeId :+ last.nextNodeId
       case Nil => Nil
     }


### PR DESCRIPTION
This is a necessary refactoring prior to MPP v2.
The two commits can be reviewed separately.

## Extract faulty channels selection from PaymentLifecycle

This commit extracts the logic of deciding which nodes/channels to ignore in a payment retry.
We enrich the `LocalFailure` so that this can be completely decided by only looking at the generated failures.
The next version of the MultiPartPaymentLifecycle will use these new helpers to ignore faulty nodes/channels from potentially multiple failed partial payments.

## Refactor RouteResponse

It was useless to return `ignoreNodes` and `ignoreChannels` in `RouteResponse`, it's rather the responsibility of the caller (`PaymentLifecycle` and later `MultiPartPaymentLifecycle`) to store and update these sets.

Preparing for the MPP move inside the router, we introduce a `Route` class and let `RouteResponse` return a collection of those.

Some of these changes create/highlight some ugliness in `PaymentLifecycle` because of the `routePrefix` and `allowEmpty`, but this is just temporary: the goal (in a few more PRs) is to completely get rid of these two somewhat hackish fields that were added to make the first version of MPP-split possible.
