### PR TITLE
Feerate provider improvements

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -32,7 +32,7 @@ eclair {
 
   min-feerate = 3 // minimum feerate in satoshis per byte
   smooth-feerate-window = 6 // 1 = no smoothing
-  feerate-provider-timeout = 5 seconds // max time we'll wait for answers from a fee provider before we fallback to the next one
+  feerate-provider-timeout = 15 seconds // max time we'll wait for answers from a fee provider before we fallback to the next one
 
   node-alias = "eclair"
   node-color = "49daaa"

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -32,7 +32,7 @@ eclair {
 
   min-feerate = 3 // minimum feerate in satoshis per byte
   smooth-feerate-window = 6 // 1 = no smoothing
-  feerate-provider-timeout = 15 seconds // max time we'll wait for answers from a fee provider before we fallback to the next one
+  feerate-provider-timeout = 5 seconds // max time we'll wait for answers from a fee provider before we fallback to the next one
 
   node-alias = "eclair"
   node-color = "49daaa"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -234,11 +234,12 @@ class Setup(datadir: File,
       smoothFeerateWindow = config.getInt("smooth-feerate-window")
       readTimeout = FiniteDuration(config.getDuration("feerate-provider-timeout", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
       feeProvider = (nodeParams.chainHash, bitcoin) match {
-        case (Block.RegtestGenesisBlock.hash, _) => new FallbackFeeProvider(new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte)
+        case (Block.RegtestGenesisBlock.hash, _) =>
+          new FallbackFeeProvider(new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte)
         case (_, Bitcoind(bitcoinClient)) =>
-          new FallbackFeeProvider(new SmoothFeeProvider(new BitcoinCoreFeeProvider(bitcoinClient, defaultFeerates), smoothFeerateWindow) :: new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash, readTimeout), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(readTimeout), smoothFeerateWindow) :: new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte) // order matters!
+          new FallbackFeeProvider(new SmoothFeeProvider(new BitcoinCoreFeeProvider(bitcoinClient, defaultFeerates), smoothFeerateWindow) :: new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash, readTimeout), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(readTimeout), smoothFeerateWindow) :: Nil, minFeeratePerByte) // order matters!
         case _ =>
-          new FallbackFeeProvider(new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash, readTimeout), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(readTimeout), smoothFeerateWindow) :: new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte) // order matters!
+          new FallbackFeeProvider(new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash, readTimeout), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(readTimeout), smoothFeerateWindow) :: Nil, minFeeratePerByte) // order matters!
       }
       _ = system.scheduler.schedule(0 seconds, 10 minutes)(feeProvider.getFeerates.map {
         case feerates: FeeratesPerKB =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -57,6 +57,7 @@ import scodec.bits.ByteVector
 
 import scala.concurrent._
 import scala.concurrent.duration._
+import scala.util.{Failure, Success}
 
 /**
  * Setup eclair from a data directory.
@@ -241,13 +242,16 @@ class Setup(datadir: File,
         case _ =>
           new FallbackFeeProvider(new SmoothFeeProvider(new BitgoFeeProvider(nodeParams.chainHash, readTimeout), smoothFeerateWindow) :: new SmoothFeeProvider(new EarnDotComFeeProvider(readTimeout), smoothFeerateWindow) :: Nil, minFeeratePerByte) // order matters!
       }
-      _ = system.scheduler.schedule(0 seconds, 10 minutes)(feeProvider.getFeerates.map {
-        case feerates: FeeratesPerKB =>
+      _ = system.scheduler.schedule(0 seconds, 10 minutes)(feeProvider.getFeerates.onComplete {
+        case Success(feerates) =>
           feeratesPerKB.set(feerates)
           feeratesPerKw.set(FeeratesPerKw(feerates))
           system.eventStream.publish(CurrentFeerates(feeratesPerKw.get))
           logger.info(s"current feeratesPerKB=${feeratesPerKB.get()} feeratesPerKw=${feeratesPerKw.get()}")
           feeratesRetrieved.trySuccess(Done)
+        case Failure(exception) =>
+          logger.warn(s"cannot retrieve feerates: ${exception.getMessage}")
+          feeratesRetrieved.tryFailure(CannotRetrieveFeerates)
       })
       _ <- feeratesRetrieved.future
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProvider.scala
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class FallbackFeeProvider(providers: Seq[FeeProvider], minFeeratePerByte: Long)(implicit ec: ExecutionContext) extends FeeProvider with Logging {
 
-  require(providers.size >= 1, "need at least one fee provider")
+  require(providers.nonEmpty, "need at least one fee provider")
   require(minFeeratePerByte > 0, "minimum fee rate must be strictly greater than 0")
 
   def getFeerates(fallbacks: Seq[FeeProvider]): Future[FeeratesPerKB] =

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
@@ -21,19 +21,19 @@ import fr.acinq.eclair._
 import scala.concurrent.Future
 
 /**
-  * Created by PM on 09/07/2017.
-  */
+ * Created by PM on 09/07/2017.
+ */
 trait FeeProvider {
-
   def getFeerates: Future[FeeratesPerKB]
-
 }
+
+case object CannotRetrieveFeerates extends RuntimeException("cannot retrieve feerates: channels may be at risk")
 
 // stores fee rate in satoshi/kb (1 kb = 1000 bytes)
 case class FeeratesPerKB(block_1: Long, blocks_2: Long, blocks_6: Long, blocks_12: Long, blocks_36: Long, blocks_72: Long, blocks_144: Long) {
   require(block_1 > 0 && blocks_2 > 0 && blocks_6 > 0 && blocks_12 > 0 && blocks_36 > 0 && blocks_72 > 0 && blocks_144 > 0, "all feerates must be strictly greater than 0")
 
-  def feePerBlock(target: Int) = target match {
+  def feePerBlock(target: Int): Long = target match {
     case 1 => block_1
     case 2 => blocks_2
     case t if t <= 6 => blocks_6
@@ -48,7 +48,7 @@ case class FeeratesPerKB(block_1: Long, blocks_2: Long, blocks_6: Long, blocks_1
 case class FeeratesPerKw(block_1: Long, blocks_2: Long, blocks_6: Long, blocks_12: Long, blocks_36: Long, blocks_72: Long, blocks_144: Long) {
   require(block_1 > 0 && blocks_2 > 0 && blocks_6 > 0 && blocks_12 > 0 && blocks_36 > 0 && blocks_72 > 0 && blocks_144 > 0, "all feerates must be strictly greater than 0")
 
-  def feePerBlock(target: Int) = target match {
+  def feePerBlock(target: Int): Long = target match {
     case 1 => block_1
     case 2 => blocks_2
     case t if t <= 6 => blocks_6
@@ -69,12 +69,7 @@ object FeeratesPerKw {
     blocks_72 = feerateKB2Kw(feerates.blocks_72),
     blocks_144 = feerateKB2Kw(feerates.blocks_144))
 
-  /**
-    * Used in tests
-    *
-    * @param feeratePerKw
-    * @return
-    */
+  /** Used in tests */
   def single(feeratePerKw: Long): FeeratesPerKw = FeeratesPerKw(
     block_1 = feeratePerKw,
     blocks_2 = feeratePerKw,


### PR DESCRIPTION
- Use ConstantFeeProvider only on regtest: it doesn't make sense to fallback to hardcoded feerates on testnet/mainnet, better to stick with the one we previously used
- Fail bootstrap if we cannot retrieve feerates: this will prevent some unnecessary channel closing when starting eclair-mobile with a crappy connection
- Increase feerate providers timeout: 5 seconds was a bit aggressive for mobile connections