### PR TITLE
Skip executing some plugins when skipping tests

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -26,7 +26,7 @@ NB: some of the tests use [Docker](https://www.docker.com/), so make sure your d
 To skip all tests, run:
 
 ```shell
-mvn package -DskipTests
+mvn package -Dmaven.test.skip=true
 ```
 
 To only build the `eclair-node` module, run:
@@ -45,6 +45,12 @@ To run tests for a specific class, run:
 
 ```shell
 mvn test -Dsuites=*<TestClassName>
+```
+
+To install eclair-core into your local maven repository, run:
+
+```shell
+mvn clean install -pl eclair-core -am -Dmaven.test.skip=true
 ```
 
 ## Build the API documentation

--- a/BUILD.md
+++ b/BUILD.md
@@ -8,7 +8,7 @@
 
 ## Build
 
-Eclair is packaged as a compressed archive with a launcher script, the archives are built deterministically
+Eclair is packaged as a compressed archive with a launcher script. The archives are built deterministically
 so it's possible to reproduce the build and verify its equality byte-by-byte. To build the exact same artifacts
 that we release, you must use the build environment (OS, JDK, maven...) that we specify in our release notes.
 
@@ -18,24 +18,29 @@ To build the project and run the tests, simply run:
 mvn package
 ```
 
-NB: if the build fails, you may need to clean previously built artifacts with the `mvn clean` command.
-NB: some of the tests use [Docker](https://www.docker.com/), so make sure your docker daemon is running.
+Notes:
+- This command will build all modules (core, node, gui).
+- If the build fails, you may need to clean previously built artifacts with the `mvn clean` command.
+- Some of the tests use [Docker](https://www.docker.com/), so make sure your docker daemon is running.
+- Archives can be found in the `target` folder for each module.
 
-### Other build options
+### Skip tests
 
-To skip all tests, run:
+Running tests takes time. If you want to skip them, use `-DskipTests`:
+
+```shell
+mvn package -DskipTests
+```
+
+You can even skip the tests compilation with `maven.test.skip`:
 
 ```shell
 mvn package -Dmaven.test.skip=true
 ```
 
-To only build the `eclair-node` module, run:
+### Run tests
 
-```shell
-mvn package -pl eclair-node -am -DskipTests
-```
-
-To run the tests, run:
+To only run the tests, run:
 
 ```shell
 mvn test
@@ -47,7 +52,15 @@ To run tests for a specific class, run:
 mvn test -Dsuites=*<TestClassName>
 ```
 
-To install eclair-core into your local maven repository, run:
+### Build specific module
+
+To only build the `eclair-node` module, run:
+
+```shell
+mvn package -pl eclair-node -am -Dmaven.test.skip=true
+```
+
+To install `eclair-core` into your local maven repository and use it in another project, run:
 
 ```shell
 mvn clean install -pl eclair-core -am -Dmaven.test.skip=true

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -43,6 +43,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
+                            <skip>${maven.test.skip}</skip>
                             <url>${bitcoind.url}</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.build.directory}</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
                             <goal>doc-jar</goal>
                         </goals>
                         <configuration>
+                            <skip>${maven.test.skip}</skip>
                             <args>
                                 <arg>-no-link-warnings</arg>
                             </args>
@@ -246,6 +247,7 @@
                 <artifactId>scoverage-maven-plugin</artifactId>
                 <version>1.4.0-RC1</version>
                 <configuration>
+                    <skip>${maven.test.skip}</skip>
                     <scalaVersion>${scala.version}</scalaVersion>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Some plugins are only used for tests, like the `download-bitcoind` plugin, tasked with downloading bitcoin-core. Skipping these plugins can save some time especially when we only want to build the library.

Note that this is only used when using the `-Dmaven.test.skip=true` option. `-DskipTests` only skip the test running phase, but still compiles the tests which also takes time.

Impact on my machine:

```shell
# before, with -DskipTests
[INFO] eclair-core_2.13 ................................... SUCCESS [02:25 min]

# after, with -Dmaven.test.skip=true
[INFO] eclair-core_2.13 ................................... SUCCESS [01:23 min]
```
