### PR TITLE
Do not merge user provided features with defaults

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -46,10 +46,12 @@ eclair {
     gossip_queries = optional
     gossip_queries_ex = optional
     var_onion_optin = optional
+    option_static_remotekey = disabled
     payment_secret = optional
     basic_mpp = optional
     option_support_large_channel = optional
     trampoline_payment = disabled
+    keysend = disabled
   }
   override-features = [ // optional per-node features
     #  {

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -49,6 +49,7 @@ eclair {
     payment_secret = optional
     basic_mpp = optional
     option_support_large_channel = optional
+    trampoline_payment = disabled
   }
   override-features = [ // optional per-node features
     #  {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -133,6 +133,7 @@ object Features {
       config.getString(s"features.$name") match {
         case support if support == Mandatory.toString => Some(Mandatory)
         case support if support == Optional.toString => Some(Optional)
+        case support if support == "disabled" => None
         case wrongSupport => throw new IllegalArgumentException(s"Wrong support specified ($wrongSupport)")
       }
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -94,6 +94,11 @@ case class Features(activated: Set[ActivatedFeature], unknown: Set[UnknownFeatur
     )
   }
 
+  override def toString: String = {
+    val a = activated.map(f => f.feature.rfcName + ":" + f.support).mkString(",")
+    val u = unknown.map(_.bitIndex).mkString(",")
+    s"features=$a" + (if (unknown.nonEmpty) s" (unknown=$u)" else "")
+  }
 }
 
 object Features {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
@@ -244,6 +244,26 @@ class FeaturesSpec extends AnyFunSuite {
 
       assertThrows[RuntimeException](fromConfiguration(confWithUnknownSupport))
     }
+
+    {
+      val confWithDisabledFeatures = ConfigFactory.parseString(
+        """
+          |features {
+          |  option_data_loss_protect = disabled
+          |  gossip_queries = optional
+          |  payment_secret = mandatory
+          |  option_support_large_channel = disabled
+          |  gossip_queries_ex = mandatory
+          |}
+        """.stripMargin)
+
+      val features = fromConfiguration(confWithDisabledFeatures)
+      assert(!features.hasFeature(OptionDataLossProtect))
+      assert(!features.hasFeature(Wumbo))
+      assert(features.hasFeature(ChannelRangeQueries))
+      assert(features.hasFeature(ChannelRangeQueriesExtended))
+      assert(features.hasFeature(PaymentSecret))
+    }
   }
 
   test("'knownFeatures' contains all our known features (reflection test)") {


### PR DESCRIPTION
~~Currently we always merge the features defined by the user in `eclair.conf` with our `reference.conf` file, this led to some unexpected behaviors as described in #1434.
The PR corrects this behavior by making sure we never merge our default features with the user defined features, if the user provides some value then we use only that and if it doesn't we fallback to our hard-coded default features. Note that this makes impossible for a user to completely disable all features (i.e setting `features { }`) but i think it's okay because it doesn't affect any actual use-case.~~

Because of #1434 we need a way to let the user disable the default features. This PR explicitly allows to disable any feature from the configuration by setting `disabled` near the feature definition, all features are defined in the reference conf even if not active by default.