### PR TITLE
More aggressive channel exclusion

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -278,8 +278,8 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
       // channel flags to indicate that it's disabled
       data.c.assistedRoutes.flatMap(r => RouteCalculation.toChannelDescs(r, data.c.targetNodeId))
         .find(_.shortChannelId == failure.update.shortChannelId)
-        .foreach(desc => router ! ExcludeChannel(desc))
-      data.c.assistedRoutes.map(_.filter(extraHop => extraHop.shortChannelId != failure.update.shortChannelId))
+        .foreach(desc => router ! ExcludeChannel(desc)) // we want the exclusion to be router-wide so that sister payments in the case of MPP are aware the channel is faulty
+      data.c.assistedRoutes
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -240,6 +240,11 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
     goto(WAITING_FOR_ROUTE) using WaitingForRoute(data.sender, data.c, data.failures :+ failure, ignore1)
   }
 
+  /**
+   * Apply the channel update to our routing table.
+   *
+   * @return updated routing hints if applicable.
+   */
   private def handleUpdate(nodeId: PublicKey, failure: Update, data: WaitingForComplete): Seq[Seq[ExtraHop]] = {
     data.route.getChannelUpdateForNode(nodeId) match {
       case Some(u) if u.shortChannelId != failure.update.shortChannelId =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -116,6 +116,11 @@ object RouteCalculation {
     }._2
   }
 
+  def toChannelDescs(extraRoute: Seq[ExtraHop], targetNodeId: PublicKey): Seq[ChannelDesc] = {
+    val nextNodeIds = extraRoute.map(_.nodeId).drop(1) :+ targetNodeId
+    extraRoute.zip(nextNodeIds).map { case (hop, nextNodeId) => ChannelDesc(hop.shortChannelId, hop.nodeId, nextNodeId) }
+  }
+
   /** Bolt 11 routing hints don't include the channel's capacity, so we round up the maximum htlc amount. */
   private def htlcMaxToCapacity(htlcMaximum: MilliSatoshi): Satoshi = htlcMaximum.truncateToSatoshi + 1.sat
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -357,6 +357,29 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
   }
 
+  test("payment failed (Update in last attempt)") { routerFixture =>
+    val payFixture = createPaymentLifecycle()
+    import payFixture._
+
+    val request = SendPayment(d, FinalLegacyPayload(defaultAmountMsat, defaultExpiry), 1)
+    sender.send(paymentFSM, request)
+    routerForwarder.expectMsg(defaultRouteRequest(nodeParams.nodeId, d))
+    routerForwarder.forward(routerFixture.router)
+    awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
+    val WaitingForComplete(_, _, cmd1, Nil, sharedSecrets1, _, _) = paymentFSM.stateData
+    register.expectMsg(ForwardShortId(channelId_ab, cmd1))
+
+    // the node replies with a temporary failure containing the same update as the one we already have (likely a balance issue)
+    val failure = TemporaryChannelFailure(update_bc)
+    sender.send(paymentFSM, UpdateFailHtlc(ByteVector32.Zeroes, 0, Sphinx.FailurePacket.create(sharedSecrets1.head._1, failure)))
+    // we should temporarily exclude that channel
+    routerForwarder.expectMsg(ExcludeChannel(ChannelDesc(update_bc.shortChannelId, b, c)))
+    routerForwarder.expectMsg(update_bc)
+
+    // this was a single attempt payment
+    sender.expectMsgType[PaymentFailed]
+  }
+
   test("payment failed (Update in assisted route)") { routerFixture =>
     val payFixture = createPaymentLifecycle()
     import payFixture._
@@ -399,6 +422,32 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val WaitingForComplete(_, _, cmd2, _, _, _, _) = paymentFSM.stateData
     register.expectMsg(ForwardShortId(channelId_ab, cmd2))
     assert(cmd2.cltvExpiry > cmd1.cltvExpiry)
+  }
+
+  test("payment failed (Update disabled in assisted route)") { routerFixture =>
+    val payFixture = createPaymentLifecycle()
+    import payFixture._
+
+    // we build an assisted route for channel cd
+    val assistedRoutes = Seq(Seq(ExtraHop(c, channelId_cd, update_cd.feeBaseMsat, update_cd.feeProportionalMillionths, update_cd.cltvExpiryDelta)))
+    val request = SendPayment(d, FinalLegacyPayload(defaultAmountMsat, defaultExpiry), 1, assistedRoutes = assistedRoutes)
+    sender.send(paymentFSM, request)
+    awaitCond(paymentFSM.stateName == WAITING_FOR_ROUTE && nodeParams.db.payments.getOutgoingPayment(id).exists(_.status === OutgoingPaymentStatus.Pending))
+
+    routerForwarder.expectMsg(defaultRouteRequest(nodeParams.nodeId, d).copy(assistedRoutes = assistedRoutes))
+    routerForwarder.forward(routerFixture.router)
+    awaitCond(paymentFSM.stateName == WAITING_FOR_PAYMENT_COMPLETE)
+    val WaitingForComplete(_, _, cmd1, Nil, sharedSecrets1, _, _) = paymentFSM.stateData
+    register.expectMsg(ForwardShortId(channelId_ab, cmd1))
+
+    // we disable the channel
+    val channelUpdate_cd_disabled = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv_c, d, channelId_cd, CltvExpiryDelta(42), update_cd.htlcMinimumMsat, update_cd.feeBaseMsat, update_cd.feeProportionalMillionths, update_cd.htlcMaximumMsat.get, enable = false)
+    val failure = ChannelDisabled(channelUpdate_cd_disabled.messageFlags, channelUpdate_cd_disabled.channelFlags, channelUpdate_cd_disabled)
+    val failureOnion = Sphinx.FailurePacket.wrap(Sphinx.FailurePacket.create(sharedSecrets1(1)._1, failure), sharedSecrets1.head._1)
+    sender.send(paymentFSM, UpdateFailHtlc(ByteVector32.Zeroes, 0, failureOnion))
+
+    routerForwarder.expectMsg(channelUpdate_cd_disabled)
+    routerForwarder.expectMsg(ExcludeChannel(ChannelDesc(update_cd.shortChannelId, c, d)))
   }
 
   def testPermanentFailure(router: ActorRef, failure: FailureMessage): Unit = {


### PR DESCRIPTION
We were missing some cases where we should exclude temporarily unavailable channels.

The first missing case was when this was the last attempt (which impacts a lot the MPP scenario, since in MPP child payments do a single attempt).

The second missing case was when a channel from the routing hint is unavailable. Since we send the channel update to the router, the router was correctly removing it from the graph, but then we were re-adding it via the routing hints.