### PR TITLE
Routing hints balance

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -109,7 +109,7 @@ object RouteCalculation {
     // should be able to route the payment, so we'll compute an htlcMaximumMsat accordingly.
     // We could also get the channel capacity from the blockchain (since we have the shortChannelId) but that's more expensive.
     // We also need to make sure the channel isn't excluded by our heuristics.
-    val lastChannelCapacity = amount.max(RoutingHeuristics.CAPACITY_CHANNEL_LOW)
+    val lastChannelCapacity = (amount * 2).max(RoutingHeuristics.CAPACITY_CHANNEL_LOW)
     val nextNodeIds = extraRoute.map(_.nodeId).drop(1) :+ targetNodeId
     extraRoute.zip(nextNodeIds).reverse.foldLeft((lastChannelCapacity, Map.empty[ShortChannelId, AssistedChannel])) {
       case ((amount, acs), (extraHop: ExtraHop, nextNodeId)) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -109,7 +109,7 @@ object RouteCalculation {
     // should be able to route the payment, so we'll compute an htlcMaximumMsat accordingly.
     // We could also get the channel capacity from the blockchain (since we have the shortChannelId) but that's more expensive.
     // We also need to make sure the channel isn't excluded by our heuristics.
-    val lastChannelCapacity = (amount * 2).max(RoutingHeuristics.CAPACITY_CHANNEL_LOW)
+    val lastChannelCapacity = amount.max(RoutingHeuristics.CAPACITY_CHANNEL_LOW)
     val nextNodeIds = extraRoute.map(_.nodeId).drop(1) :+ targetNodeId
     extraRoute.zip(nextNodeIds).reverse.foldLeft((lastChannelCapacity, Map.empty[ShortChannelId, AssistedChannel])) {
       case ((amount, acs), (extraHop: ExtraHop, nextNodeId)) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -63,7 +63,9 @@ object RouteCalculation {
 
     // we convert extra routing info provided in the payment request to fake channel_update
     // it takes precedence over all other channel_updates we know
-    val assistedChannels: Map[ShortChannelId, AssistedChannel] = r.assistedRoutes.flatMap(toAssistedChannels(_, r.target, r.amount)).toMap
+    val assistedChannels: Map[ShortChannelId, AssistedChannel] = r.assistedRoutes.flatMap(toAssistedChannels(_, r.target, r.amount))
+      .filterNot { case (_, ac) => ac.extraHop.nodeId == r.source } // we ignore routing hints for our own channels, we have more accurate information
+      .toMap
     val extraEdges = assistedChannels.values.map(ac =>
       GraphEdge(ChannelDesc(ac.extraHop.shortChannelId, ac.extraHop.nodeId, ac.nextNodeId), toFakeUpdate(ac.extraHop, ac.htlcMaximum), htlcMaxToCapacity(ac.htlcMaximum), Some(ac.htlcMaximum))
     ).toSet

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -471,25 +471,29 @@ object Validation {
     }
   }
 
-  def handleAvailableBalanceChanged(d: Data, e: AvailableBalanceChanged): Data = {
-    val (channels1, graph1) = d.channels.get(e.shortChannelId) match {
+  def handleAvailableBalanceChanged(d: Data, e: AvailableBalanceChanged)(implicit log: LoggingAdapter): Data = {
+    val desc = ChannelDesc(e.shortChannelId, e.commitments.localParams.nodeId, e.commitments.remoteParams.nodeId)
+    val (publicChannels1, graph1) = d.channels.get(e.shortChannelId) match {
       case Some(pc) =>
         val pc1 = pc.updateBalances(e.commitments)
-        val desc = ChannelDesc(e.shortChannelId, e.commitments.localParams.nodeId, e.commitments.remoteParams.nodeId)
+        log.debug("public channel balance updated: {}", pc1)
         val update_opt = if (e.commitments.localParams.nodeId == pc1.ann.nodeId1) pc1.update_1_opt else pc1.update_2_opt
         val graph1 = update_opt.map(u => d.graph.addEdge(desc, u, pc1.capacity, pc1.getBalanceSameSideAs(u))).getOrElse(d.graph)
         (d.channels + (e.shortChannelId -> pc1), graph1)
       case None =>
         (d.channels, d.graph)
     }
-    val privateChannels1 = d.privateChannels.get(e.shortChannelId) match {
+    val (privateChannels1, graph2) = d.privateChannels.get(e.shortChannelId) match {
       case Some(pc) =>
         val pc1 = pc.updateBalances(e.commitments)
-        d.privateChannels + (e.shortChannelId -> pc1)
+        log.debug("private channel balance updated: {}", pc1)
+        val update_opt = if (e.commitments.localParams.nodeId == pc1.nodeId1) pc1.update_1_opt else pc1.update_2_opt
+        val graph2 = update_opt.map(u => graph1.addEdge(desc, u, pc1.capacity, pc1.getBalanceSameSideAs(u))).getOrElse(graph1)
+        (d.privateChannels + (e.shortChannelId -> pc1), graph2)
       case None =>
-        d.privateChannels
+        (d.privateChannels, graph1)
     }
-    d.copy(channels = channels1, privateChannels = privateChannels1, graph = graph1)
+    d.copy(channels = publicChannels1, privateChannels = privateChannels1, graph = graph2)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -455,10 +455,10 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     val amount = 90000 sat // below RoutingHeuristics.CAPACITY_CHANNEL_LOW
     val assistedChannels = toAssistedChannels(extraHops, e, amount.toMilliSatoshi)
 
-    assert(assistedChannels(extraHop4.shortChannelId) === AssistedChannel(extraHop4, e, 100050.sat.toMilliSatoshi))
-    assert(assistedChannels(extraHop3.shortChannelId) === AssistedChannel(extraHop3, d, 100200.sat.toMilliSatoshi))
-    assert(assistedChannels(extraHop2.shortChannelId) === AssistedChannel(extraHop2, c, 100400.sat.toMilliSatoshi))
-    assert(assistedChannels(extraHop1.shortChannelId) === AssistedChannel(extraHop1, b, 101416.sat.toMilliSatoshi))
+    assert(assistedChannels(extraHop4.shortChannelId) === AssistedChannel(extraHop4, e, 180050.sat.toMilliSatoshi))
+    assert(assistedChannels(extraHop3.shortChannelId) === AssistedChannel(extraHop3, d, 180200.sat.toMilliSatoshi))
+    assert(assistedChannels(extraHop2.shortChannelId) === AssistedChannel(extraHop2, c, 180400.sat.toMilliSatoshi))
+    assert(assistedChannels(extraHop1.shortChannelId) === AssistedChannel(extraHop1, b, 182216.sat.toMilliSatoshi))
   }
 
   test("blacklist routes") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -455,10 +455,10 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     val amount = 90000 sat // below RoutingHeuristics.CAPACITY_CHANNEL_LOW
     val assistedChannels = toAssistedChannels(extraHops, e, amount.toMilliSatoshi)
 
-    assert(assistedChannels(extraHop4.shortChannelId) === AssistedChannel(extraHop4, e, 180050.sat.toMilliSatoshi))
-    assert(assistedChannels(extraHop3.shortChannelId) === AssistedChannel(extraHop3, d, 180200.sat.toMilliSatoshi))
-    assert(assistedChannels(extraHop2.shortChannelId) === AssistedChannel(extraHop2, c, 180400.sat.toMilliSatoshi))
-    assert(assistedChannels(extraHop1.shortChannelId) === AssistedChannel(extraHop1, b, 182216.sat.toMilliSatoshi))
+    assert(assistedChannels(extraHop4.shortChannelId) === AssistedChannel(extraHop4, e, 100050.sat.toMilliSatoshi))
+    assert(assistedChannels(extraHop3.shortChannelId) === AssistedChannel(extraHop3, d, 100200.sat.toMilliSatoshi))
+    assert(assistedChannels(extraHop2.shortChannelId) === AssistedChannel(extraHop2, c, 100400.sat.toMilliSatoshi))
+    assert(assistedChannels(extraHop1.shortChannelId) === AssistedChannel(extraHop1, b, 101416.sat.toMilliSatoshi))
   }
 
   test("blacklist routes") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -582,6 +582,21 @@ class RouterSpec extends BaseRouterSpec {
       assert(balances.contains(edge_ab.balance_opt))
       assert(edge_ba.balance_opt === None)
     }
+
+    {
+      // Private channels should also update the graph when HTLCs are relayed through them.
+      val balances = Set(33000000 msat, 5000000 msat)
+      val commitments = CommitmentsSpec.makeCommitments(33000000 msat, 5000000 msat, a, g, announceChannel = false)
+      sender.send(router, AvailableBalanceChanged(sender.ref, null, channelId_ag, commitments))
+      sender.send(router, Symbol("data"))
+      val data = sender.expectMsgType[Data]
+      val channel_ag = data.privateChannels(channelId_ag)
+      assert(Set(channel_ag.meta.balance1, channel_ag.meta.balance2) === balances)
+      // And the graph should be updated too.
+      val edge_ag = data.graph.getEdge(ChannelDesc(channelId_ag, a, g)).get
+      assert(edge_ag.capacity == channel_ag.capacity)
+      assert(edge_ag.balance_opt === Some(33000000 msat))
+    }
   }
 
 }


### PR DESCRIPTION
This is a collection of several small fixes/improvements:

- Ignore routing hints for our own channels
- Assume a bigger capacity than just the HTLC amount in routing hints
- Correctly handle balance change events for private channels
