### PR TITLE
Scale fulfill safety window based on amount at risk

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -67,11 +67,22 @@ eclair {
   max-to-local-delay-blocks = 2016 // maximum number of blocks that we are ready to accept for our own delayed outputs (2016 ~ 2 weeks)
   mindepth-blocks = 3
   expiry-delta-blocks = 144
-  // When we receive the pre-image for an HTLC and want to fulfill it but the upstream peer stops responding, we want to
+
+  // When we receive the preimage for an HTLC and want to fulfill it but the upstream peer stops responding, we want to
   // avoid letting its HTLC-timeout transaction become enforceable on-chain (otherwise there is a race condition between
   // our HTLC-success and their HTLC-timeout).
-  // We will close the channel when the HTLC-timeout will happen in less than this number.
-  fulfill-safety-before-timeout-blocks = 6
+  // We will close the channel when the HTLC-timeout will happen in less than N blocks, where we scale N linearly depending
+  // on the total amount at risk (there may be multiple HTLCs in that state).
+  fulfill-safety-before-timeout {
+    // If incoming HTLCs expire in less than `min-blocks`, we close the channel regardless of the amount at risk.
+    min-blocks = 6
+    // We ignore incoming HTLCs that expire in more than `max-blocks`.
+    max-blocks = 18
+    // Linear scaling factor for the safety window. Assuming a value of 25 mBTC and min-blocks = 6, if for example we
+    // have 80 mBTC at risk expiring in 9 blocks, we will close the channel immediately. If we only had 70 mBTC at risk,
+    // we would close the channel when they expire in 8 blocks.
+    delta-per-block-mbtc = 25
+  }
 
   fee-base-msat = 1000
   fee-proportional-millionths = 100 // fee charged per transferred satoshi in millionths of a satoshi (100 = 0.01%)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -44,6 +44,37 @@ import scala.util.{Failure, Success, Try}
 object Helpers {
 
   /**
+   * When we receive the preimage for an HTLC and want to fulfill it but the upstream peer stops responding, we want to
+   * avoid letting its HTLC-timeout transaction become enforceable on-chain (otherwise there is a race condition between
+   * our HTLC-success and their HTLC-timeout).
+   * We will close the channel when the HTLC-timeout will happen in less than N blocks, where we scale N linearly depending
+   * on the total amount at risk (there may be multiple HTLCs in that state).
+   *
+   * @param min           if incoming HTLCs expire in less than `min`, we close the channel regardless of the amount at risk.
+   * @param max           incoming HTLCs that expire in more than `max` are ignored.
+   * @param deltaPerBlock linear scaling factor for the safety window.
+   */
+  case class FulfillSafetyBeforeTimeout(min: CltvExpiryDelta, max: CltvExpiryDelta, deltaPerBlock: MilliSatoshi) {
+    require(min >= CltvExpiryDelta(3), "at least 3 blocks are necessary to enforce a fulfill safety window")
+    require(min <= max, "fulfill safety minimum must be lower than maximum")
+
+    /**
+     * @param htlcsAtRisk all htlcs in a given channel that expire soon, for which we know the preimage but couldn't
+     *                    remove from the commitment (most likely because our remote is malicious or unresponsive).
+     * @return true if the funds at risk are too great and we should close the channel to safely redeem HTLCs on-chain.
+     */
+    def shouldClose(blockHeight: Long, htlcsAtRisk: Set[UpdateAddHtlc]): Boolean = {
+      htlcsAtRisk.toSeq.filter(_.cltvExpiry.toLong <= blockHeight + max.toInt).sortBy(_.cltvExpiry).foldLeft((0 msat, false)) {
+        case ((amountAtRisk, true), _) => (amountAtRisk, true)
+        case ((amountAtRisk, false), htlc) =>
+          val amount2 = amountAtRisk + htlc.amountMsat
+          val shouldClose = deltaPerBlock * (htlc.cltvExpiry.toLong - blockHeight - min.toInt).max(0) < amount2
+          (amount2, shouldClose)
+      }._2
+    }
+  }
+
+  /**
    * Depending on the state, returns the current temporaryChannelId or channelId
    *
    * @return the long identifier of the channel
@@ -341,7 +372,6 @@ object Helpers {
         false
     }
   }
-
 
   object Closing {
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -22,9 +22,10 @@ import java.util.concurrent.atomic.AtomicLong
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{Block, ByteVector32, Script}
 import fr.acinq.eclair.FeatureSupport.Optional
-import fr.acinq.eclair.Features.{ChannelRangeQueries, ChannelRangeQueriesExtended, InitialRoutingSync, OptionDataLossProtect, VariableLengthOnion}
+import fr.acinq.eclair.Features._
 import fr.acinq.eclair.NodeParams.BITCOIND
 import fr.acinq.eclair.blockchain.fee.{FeeEstimator, FeeTargets, FeeratesPerKw, OnChainFeeConf}
+import fr.acinq.eclair.channel.Helpers.FulfillSafetyBeforeTimeout
 import fr.acinq.eclair.crypto.LocalKeyManager
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.io.Peer
@@ -91,7 +92,7 @@ object TestConstants {
       maxHtlcValueInFlightMsat = UInt64(150000000),
       maxAcceptedHtlcs = 100,
       expiryDeltaBlocks = CltvExpiryDelta(144),
-      fulfillSafetyBeforeTimeoutBlocks = CltvExpiryDelta(6),
+      fulfillSafetyBeforeTimeout = FulfillSafetyBeforeTimeout(CltvExpiryDelta(6), CltvExpiryDelta(12), 10000000 msat),
       htlcMinimum = 0 msat,
       minDepthBlocks = 3,
       toRemoteDelayBlocks = CltvExpiryDelta(144),
@@ -173,7 +174,7 @@ object TestConstants {
       maxHtlcValueInFlightMsat = UInt64.MaxValue, // Bob has no limit on the combined max value of in-flight htlcs
       maxAcceptedHtlcs = 30,
       expiryDeltaBlocks = CltvExpiryDelta(144),
-      fulfillSafetyBeforeTimeoutBlocks = CltvExpiryDelta(6),
+      fulfillSafetyBeforeTimeout = FulfillSafetyBeforeTimeout(CltvExpiryDelta(6), CltvExpiryDelta(12), 10000000 msat),
       htlcMinimum = 1000 msat,
       minDepthBlocks = 3,
       toRemoteDelayBlocks = CltvExpiryDelta(144),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.wire.{AcceptChannel, ChannelTlv, Error, Init, OpenChannel
 import fr.acinq.eclair.{ActivatedFeature, CltvExpiryDelta, Features, LongToBtcAmount, TestConstants, TestKitBaseClass, ToMilliSatoshiConversion}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.{Outcome, Tag}
-import scodec.bits.{ByteVector, HexStringSyntax}
+import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -426,8 +426,9 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
 
     // We simulate a pending fulfill on that HTLC but not relayed.
     // When it is close to expiring upstream, we should close the channel.
+    assert(bob.underlyingActor.nodeParams.fulfillSafetyBeforeTimeout.min.toInt < 9 && 9 < bob.underlyingActor.nodeParams.fulfillSafetyBeforeTimeout.max.toInt)
     sender.send(commandBuffer, CommandBuffer.CommandSend(htlc.channelId, CMD_FULFILL_HTLC(htlc.id, r, commit = true)))
-    sender.send(bob, CurrentBlockCount((htlc.cltvExpiry - bob.underlyingActor.nodeParams.fulfillSafetyBeforeTimeoutBlocks).toLong))
+    sender.send(bob, CurrentBlockCount(htlc.cltvExpiry.toLong - 9))
 
     val ChannelErrorOccurred(_, _, _, _, LocalError(err), isFatal) = listener.expectMsgType[ChannelErrorOccurred]
     assert(isFatal)
@@ -461,7 +462,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     // We simulate a pending failure on that HTLC.
     // Even if we get close to expiring upstream we shouldn't close the channel, because we have nothing to lose.
     sender.send(commandBuffer, CommandBuffer.CommandSend(htlc.channelId, CMD_FAIL_HTLC(htlc.id, Right(IncorrectOrUnknownPaymentDetails(0 msat, 0)))))
-    sender.send(bob, CurrentBlockCount((htlc.cltvExpiry - bob.underlyingActor.nodeParams.fulfillSafetyBeforeTimeoutBlocks).toLong))
+    sender.send(bob, CurrentBlockCount((htlc.cltvExpiry - bob.underlyingActor.nodeParams.fulfillSafetyBeforeTimeout.min).toLong))
 
     bob2blockchain.expectNoMsg(250 millis)
     alice2blockchain.expectNoMsg(250 millis)


### PR DESCRIPTION
When an upstream peer is not responsive to htlc fulfills, there is a risk that they will try to cheat us by force-closing the channel and redeeming the htlc-timeout on-chain.

To avoid that, we previously used a constant security window of 6 blocks to force-close the channel ourselves (which gives us time to redeem the htlc-success on-chain).

Instead of using a constant window, it may make sense to scale it based on the amount at risk. Coupled with the `max-htlc-value-in-flight-msat` restriction, it provides a good adaptive defence against those attacks.

Let me know if you think this is worth the added complexity: an easier solution since we use a high `cltv_expiry_delta` is to simply always use a much higher `fulfill-safety-before-timeout-blocks`. With a `cltv_expiry_delta` of 144, we can safely set `fulfill-safety-before-timeout-blocks` to 24 or even 48.