### PR TITLE
Clarify trampoline route not found error

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -85,10 +85,10 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, register: Actor
       val shouldRetry = decryptedFailures.contains(TrampolineFeeInsufficient) || decryptedFailures.contains(TrampolineExpiryTooSoon)
       if (shouldRetry) {
         pp.remainingAttempts match {
-          case (trampolineFees, trampolineExpiryDelta) :: remainingAttempts =>
+          case (trampolineFees, trampolineExpiryDelta) :: remaining =>
             log.info(s"retrying trampoline payment with trampoline fees=$trampolineFees and expiry delta=$trampolineExpiryDelta")
             sendTrampolinePayment(pf.id, pp.r, trampolineFees, trampolineExpiryDelta)
-            context become main(pending + (pf.id -> pp.copy(remainingAttempts = remainingAttempts)))
+            context become main(pending + (pf.id -> pp.copy(remainingAttempts = remaining)))
           case Nil =>
             log.info("trampoline node couldn't find a route after all retries")
             val trampolineRoute = Seq(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -32,6 +32,7 @@ import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.SendMultiPartPayme
 import fr.acinq.eclair.payment.send.PaymentInitiator._
 import fr.acinq.eclair.payment.send.PaymentLifecycle.{SendPayment, SendPaymentToRoute}
 import fr.acinq.eclair.payment.send.{PaymentError, PaymentInitiator}
+import fr.acinq.eclair.router.RouteNotFound
 import fr.acinq.eclair.router.Router.{MultiPartParams, NodeHop, RouteParams}
 import fr.acinq.eclair.wire.Onion.{FinalLegacyPayload, FinalTlvPayload}
 import fr.acinq.eclair.wire.OnionTlv.{AmountToForward, OutgoingCltv}
@@ -302,16 +303,44 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(msg1.totalAmount === finalAmount + 21000.msat)
 
     // Simulate a failure which should trigger a retry.
-    val failed = PaymentFailed(cfg.parentId, pr.paymentHash, Seq(RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(b, TrampolineFeeInsufficient))))
-    multiPartPayFsm.send(initiator, failed)
+    multiPartPayFsm.send(initiator, PaymentFailed(cfg.parentId, pr.paymentHash, Seq(RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(b, TrampolineFeeInsufficient)))))
     multiPartPayFsm.expectMsgType[SendPaymentConfig]
     val msg2 = multiPartPayFsm.expectMsgType[SendMultiPartPayment]
     assert(msg2.totalAmount === finalAmount + 25000.msat)
 
     // Simulate a failure that exhausts payment attempts.
+    val failed = PaymentFailed(cfg.parentId, pr.paymentHash, Seq(RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(b, TemporaryNodeFailure))))
     multiPartPayFsm.send(initiator, failed)
     sender.expectMsg(failed)
     eventListener.expectMsg(failed)
+    sender.expectNoMsg(100 millis)
+    eventListener.expectNoMsg(100 millis)
+  }
+
+  test("retry trampoline payment and fail (route not found)") { f =>
+    import f._
+    val features = PaymentRequestFeatures(VariableLengthOnion.optional, PaymentSecret.optional, BasicMultiPartPayment.optional, TrampolinePayment.optional)
+    val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, "Some phoenix invoice", features = Some(features))
+    val trampolineAttempts = (21000 msat, CltvExpiryDelta(12)) :: (25000 msat, CltvExpiryDelta(24)) :: Nil
+    val req = SendTrampolinePaymentRequest(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9))
+    sender.send(initiator, req)
+    sender.expectMsgType[UUID]
+
+    val cfg = multiPartPayFsm.expectMsgType[SendPaymentConfig]
+    val msg1 = multiPartPayFsm.expectMsgType[SendMultiPartPayment]
+    assert(msg1.totalAmount === finalAmount + 21000.msat)
+    // Trampoline node couldn't find a route for the given fee.
+    val failed = PaymentFailed(cfg.parentId, pr.paymentHash, Seq(RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(b, TrampolineFeeInsufficient))))
+    multiPartPayFsm.send(initiator, failed)
+    multiPartPayFsm.expectMsgType[SendPaymentConfig]
+    val msg2 = multiPartPayFsm.expectMsgType[SendMultiPartPayment]
+    assert(msg2.totalAmount === finalAmount + 25000.msat)
+    // Trampoline node couldn't find a route even with the increased fee.
+    multiPartPayFsm.send(initiator, failed)
+
+    val failure = sender.expectMsgType[PaymentFailed]
+    assert(failure.failures === Seq(LocalFailure(Seq(NodeHop(nodeParams.nodeId, b, nodeParams.expiryDeltaBlocks, 0 msat), NodeHop(b, c, CltvExpiryDelta(24), 25000 msat)), RouteNotFound)))
+    eventListener.expectMsg(failure)
     sender.expectNoMsg(100 millis)
     eventListener.expectNoMsg(100 millis)
   }


### PR DESCRIPTION
The payment initiator retries trampoline payments by raising the fee/ctlv when the trampoline node couldn't find a route.
If we exhaust all attempts and the trampoline node keep returning a fee insufficient error, it actually means `RouteNotFound`, so we should translate the error for the end user (otherwise it's misleading, they think they should raise the fee but it's a red herring).