### PR TITLE
Add on-chain APIs

### DIFF
--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -26,19 +26,58 @@ where OPTIONS can be:
   -h                    Show this help
   -s                    Some commands can print a trimmed JSON
 
-and COMMAND is one of:
-  getinfo, connect, disconnect, open, close, forceclose, updaterelayfee,
-  peers, channels, channel, allnodes, allchannels, allupdates
-  findroute, findroutetonode, parseinvoice, payinvoice, sendtonode,
-  sendtoroute, getsentinfo, createinvoice, getinvoice, listinvoices,
-  listpendinginvoices, getreceivedinfo, audit, networkfees,
-  channelstats, usablebalances
+and COMMAND is one of the available commands:
+
+  === Node ===
+    - getinfo
+    - connect
+    - disconnect
+    - peers
+    - allnodes
+    - audit
+
+  === Channel ===
+    - open
+    - close
+    - forceclose
+    - channel
+    - channels
+    - allchannels
+    - allupdates
+    - channelstats
+    - networkfees
+    - updaterelayfee
+
+  === Path-finding ===
+    - findroute
+    - findroutetonode
+    - networkstats
+
+  === Invoice ===
+    - createinvoice
+    - getinvoice
+    - listinvoices
+    - listpendinginvoices
+    - parseinvoice
+
+  === Payment ===
+    - getnewaddress
+    - usablebalances
+    - onchainbalances
+    - payinvoice
+    - sendtonode
+    - sendtoroute
+    - sendonchain
+    - getsentinfo
+    - getreceivedinfo
+    - listtransactions
 
 Examples
 --------
-  eclair-cli -a localhost:1234 peers        list the peers of a node hosted on localhost:1234
-  eclair-cli close --channelId=006fb...     closes the channel with id 006fb...
-
+  eclair-cli -a localhost:1234 peers                  list the peers of a node hosted on localhost:1234
+  eclair-cli connect --nodeId=03864e...               connect to node with id 03864e...
+  eclair-cli open --nodeId=... --fundingSatoshis=...  open a channel to a given node
+  eclair-cli close --channelId=006fb...               closes the channel with id 006fb...
 
 Full documentation here: <https://acinq.github.io/eclair>" 1>&2;
 exit 1;

--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -63,14 +63,14 @@ and COMMAND is one of the available commands:
   === Payment ===
     - getnewaddress
     - usablebalances
-    - onchainbalances
+    - onchainbalance
     - payinvoice
     - sendtonode
     - sendtoroute
     - sendonchain
     - getsentinfo
     - getreceivedinfo
-    - listtransactions
+    - onchaintransactions
 
 Examples
 --------

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -26,6 +26,7 @@ import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.TimestampQueryFilters._
 import fr.acinq.eclair.blockchain.OnChainBalance
 import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet
+import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.WalletTransaction
 import fr.acinq.eclair.channel.Register.{Forward, ForwardShortId}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.{IncomingPayment, NetworkFee, OutgoingPayment, Stats}
@@ -127,6 +128,8 @@ trait Eclair {
 
   def onChainBalance()(implicit timeout: Timeout): Future[OnChainBalance]
 
+  def listTransactions(count: Int, skip: Int)(implicit timeout: Timeout): Future[Iterable[WalletTransaction]]
+
 }
 
 class EclairImpl(appKit: Kit) extends Eclair {
@@ -221,6 +224,13 @@ class EclairImpl(appKit: Kit) extends Eclair {
   override def onChainBalance()(implicit timeout: Timeout): Future[OnChainBalance] = {
     appKit.wallet match {
       case w: BitcoinCoreWallet => w.getBalance
+      case _ => Future.failed(new IllegalArgumentException("this call is only available with a bitcoin core backend"))
+    }
+  }
+
+  override def listTransactions(count: Int, skip: Int)(implicit timeout: Timeout): Future[Iterable[WalletTransaction]] = {
+    appKit.wallet match {
+      case w: BitcoinCoreWallet => w.listTransactions(count, skip)
       case _ => Future.failed(new IllegalArgumentException("this call is only available with a bitcoin core backend"))
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -124,7 +124,7 @@ trait Eclair {
 
   def allUpdates(nodeId_opt: Option[PublicKey])(implicit timeout: Timeout): Future[Iterable[ChannelUpdate]]
 
-  def getInfoResponse()(implicit timeout: Timeout): Future[GetInfoResponse]
+  def getInfo()(implicit timeout: Timeout): Future[GetInfoResponse]
 
   def usableBalances()(implicit timeout: Timeout): Future[Iterable[UsableBalance]]
 
@@ -355,7 +355,7 @@ class EclairImpl(appKit: Kit) extends Eclair {
     Future.foldLeft(commands)(Map.empty[ApiTypes.ChannelIdentifier, Either[Throwable, T]])(_ + _)
   }
 
-  override def getInfoResponse()(implicit timeout: Timeout): Future[GetInfoResponse] = Future.successful(
+  override def getInfo()(implicit timeout: Timeout): Future[GetInfoResponse] = Future.successful(
     GetInfoResponse(
       version = Kit.getVersionLong,
       color = appKit.nodeParams.color.toString,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/EclairWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/EclairWallet.scala
@@ -16,18 +16,18 @@
 
 package fr.acinq.eclair.blockchain
 
-import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
+import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{Satoshi, Transaction}
 import scodec.bits.ByteVector
 
 import scala.concurrent.Future
 
 /**
-  * Created by PM on 06/07/2017.
-  */
+ * Created by PM on 06/07/2017.
+ */
 trait EclairWallet {
 
-  def getBalance: Future[Satoshi]
+  def getBalance: Future[OnChainBalance]
 
   def getReceiveAddress: Future[String]
 
@@ -36,37 +36,31 @@ trait EclairWallet {
   def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: Long): Future[MakeFundingTxResponse]
 
   /**
-    * Committing *must* include publishing the transaction on the network.
-    *
-    * We need to be very careful here, we don't want to consider a commit 'failed' if we are not absolutely sure that the
-    * funding tx won't end up on the blockchain: if that happens and we have cancelled the channel, then we would lose our
-    * funds!
-    *
-    * @param tx
-    * @return true if success
-    *         false IF AND ONLY IF *HAS NOT BEEN PUBLISHED* otherwise funds are at risk!!!
-    */
+   * Committing *must* include publishing the transaction on the network.
+   *
+   * We need to be very careful here, we don't want to consider a commit 'failed' if we are not absolutely sure that the
+   * funding tx won't end up on the blockchain: if that happens and we have cancelled the channel, then we would lose our
+   * funds!
+   *
+   * @return true if success
+   *         false IF AND ONLY IF *HAS NOT BEEN PUBLISHED* otherwise funds are at risk!!!
+   */
   def commit(tx: Transaction): Future[Boolean]
 
   /**
-    * Cancels this transaction: this probably translates to "release locks on utxos".
-    *
-    * @param tx
-    * @return
-    */
+   * Cancels this transaction: this probably translates to "release locks on utxos".
+   */
   def rollback(tx: Transaction): Future[Boolean]
 
-
   /**
-    * Tests whether the inputs of the provided transaction have been spent by another transaction.
-    *
-    * Implementations may always return false if they don't want to implement it
-    *
-    * @param tx
-    * @return
-    */
+   * Tests whether the inputs of the provided transaction have been spent by another transaction.
+   *
+   * Implementations may always return false if they don't want to implement it
+   */
   def doubleSpent(tx: Transaction): Future[Boolean]
 
 }
+
+final case class OnChainBalance(confirmed: Satoshi, unconfirmed: Satoshi)
 
 final case class MakeFundingTxResponse(fundingTx: Transaction, fundingTxOutputIndex: Int, fee: Satoshi)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/TestWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/TestWallet.scala
@@ -16,10 +16,9 @@
 
 package fr.acinq.eclair.blockchain
 
-import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
-import fr.acinq.bitcoin.{Base58, ByteVector32, Crypto, OutPoint, Satoshi, Transaction, TxIn, TxOut}
+import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.bitcoin.{ByteVector32, Crypto, OutPoint, Satoshi, Transaction, TxIn, TxOut}
 import fr.acinq.eclair.LongToBtcAmount
-import scodec.bits.ByteVector
 import scodec.bits._
 
 import scala.concurrent.Future
@@ -31,14 +30,14 @@ class TestWallet extends EclairWallet {
 
   var rolledback = Set.empty[Transaction]
 
-  override def getBalance: Future[Satoshi] = ???
+  override def getBalance: Future[OnChainBalance] = Future.successful(OnChainBalance(1105 sat, 561 sat))
 
   override def getReceiveAddress: Future[String] = Future.successful("bcrt1qwcv8naajwn8fjhu8z59q9e6ucrqr068rlcenux")
 
   override def getReceivePubkey(receiveAddress: Option[String] = None): Future[Crypto.PublicKey] = Future.successful(PublicKey(hex"028feba10d0eafd0fad8fe20e6d9206e6bd30242826de05c63f459a00aced24b12"))
 
   override def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: Long): Future[MakeFundingTxResponse] =
-    Future.successful(TestWallet.makeDummyFundingTx(pubkeyScript, amount, feeRatePerKw))
+    Future.successful(TestWallet.makeDummyFundingTx(pubkeyScript, amount))
 
   override def commit(tx: Transaction): Future[Boolean] = Future.successful(true)
 
@@ -52,11 +51,12 @@ class TestWallet extends EclairWallet {
 
 object TestWallet {
 
-  def makeDummyFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: Long): MakeFundingTxResponse = {
+  def makeDummyFundingTx(pubkeyScript: ByteVector, amount: Satoshi): MakeFundingTxResponse = {
     val fundingTx = Transaction(version = 2,
       txIn = TxIn(OutPoint(ByteVector32(ByteVector.fill(32)(1)), 42), signatureScript = Nil, sequence = TxIn.SEQUENCE_FINAL) :: Nil,
       txOut = TxOut(amount, pubkeyScript) :: Nil,
       lockTime = 0)
     MakeFundingTxResponse(fundingTx, 0, 420 sat)
   }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -21,7 +21,7 @@ import akka.pattern.pipe
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{Block, Btc, ByteVector32, Crypto, MilliBtc, OP_CHECKSIG, OP_DUP, OP_EQUALVERIFY, OP_HASH160, OP_PUSHDATA, OutPoint, Satoshi, Script, Transaction, TxIn, TxOut}
+import fr.acinq.bitcoin.{Block, Btc, ByteVector32, MilliBtc, OutPoint, Satoshi, Script, Transaction, TxIn, TxOut}
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.{FundTransactionResponse, SignTransactionResponse}
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
@@ -69,7 +69,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
     waitForBitcoindReady()
   }
 
-  def getLocks(sender: TestProbe = TestProbe()) : Set[OutPoint] = {
+  def getLocks(sender: TestProbe = TestProbe()): Set[OutPoint] = {
     implicit val formats = DefaultFormats
     sender.send(bitcoincli, BitcoinReq("listlockunspent"))
     val JArray(locks) = sender.expectMsgType[JValue]
@@ -88,7 +88,6 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       host = config.getString("bitcoind.host"),
       port = config.getInt("bitcoind.rpcport"))
     val wallet = new BitcoinCoreWallet(bitcoinClient)
-
     val sender = TestProbe()
     val pubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(randomKey.publicKey, randomKey.publicKey)))
 
@@ -132,9 +131,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       password = config.getString("bitcoind.rpcpassword"),
       host = config.getString("bitcoind.host"),
       port = config.getInt("bitcoind.rpcport"))
-
     val wallet = new BitcoinCoreWallet(bitcoinClient)
-
     val sender = TestProbe()
     val pubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(randomKey.publicKey, randomKey.publicKey)))
 
@@ -142,7 +139,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       // test #1: unlock outpoints that are actually locked
       // create a huge tx so we make sure it has > 1 inputs
       wallet.makeFundingTx(pubkeyScript, Btc(250), 1000).pipeTo(sender.ref)
-      val MakeFundingTxResponse(fundingTx, outputIndex, _) = sender.expectMsgType[MakeFundingTxResponse]
+      val MakeFundingTxResponse(fundingTx, _, _) = sender.expectMsgType[MakeFundingTxResponse]
       assert(fundingTx.txIn.size > 2)
       assert(getLocks(sender) == fundingTx.txIn.map(_.outPoint).toSet)
       wallet.rollback(fundingTx).pipeTo(sender.ref)
@@ -151,7 +148,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
     {
       // test #2: some outpoints are locked, some are unlocked
       wallet.makeFundingTx(pubkeyScript, Btc(250), 1000).pipeTo(sender.ref)
-      val MakeFundingTxResponse(fundingTx, outputIndex, _) = sender.expectMsgType[MakeFundingTxResponse]
+      val MakeFundingTxResponse(fundingTx, _, _) = sender.expectMsgType[MakeFundingTxResponse]
       assert(fundingTx.txIn.size > 2)
       assert(getLocks(sender) == fundingTx.txIn.map(_.outPoint).toSet)
 
@@ -173,30 +170,25 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
     val hexOut = "02000000013361e994f6bd5cbe9dc9e8cb3acdc12bc1510a3596469d9fc03cfddd71b223720000000000feffffff02c821354a00000000160014b6aa25d6f2a692517f2cf1ad55f243a5ba672cac404b4c0000000000220020822eb4234126c5fc84910e51a161a9b7af94eb67a2344f7031db247e0ecc2f9200000000"
 
     0 to 9 foreach { satoshi =>
-
       val apiAmount = JDecimal(BigDecimal(s"0.0000000$satoshi"))
-
       val bitcoinClient = new BasicBitcoinJsonRPCClient(
         user = config.getString("bitcoind.rpcuser"),
         password = config.getString("bitcoind.rpcpassword"),
         host = config.getString("bitcoind.host"),
         port = config.getInt("bitcoind.rpcport")) {
-
         override def invoke(method: String, params: Any*)(implicit ec: ExecutionContext): Future[JValue] = method match {
-          case "getbalance" => Future(apiAmount)(ec)
+          case "getbalances" => Future(JObject("mine" -> JObject("trusted" -> apiAmount, "untrusted_pending" -> apiAmount)))(ec)
           case "fundrawtransaction" => Future(JObject(List("hex" -> JString(hexOut), "changepos" -> JInt(1), "fee" -> apiAmount)))(ec)
           case _ => Future.failed(new RuntimeException(s"Test BasicBitcoinJsonRPCClient: method $method is not supported"))
         }
       }
 
-      val wallet = new BitcoinCoreWallet(bitcoinClient)
-
       val sender = TestProbe()
-
+      val wallet = new BitcoinCoreWallet(bitcoinClient)
       wallet.getBalance.pipeTo(sender.ref)
-      assert(sender.expectMsgType[Satoshi] == Satoshi(satoshi))
+      assert(sender.expectMsgType[OnChainBalance] === OnChainBalance(Satoshi(satoshi), Satoshi(satoshi)))
 
-      wallet.fundTransaction(hexIn, false, 250).pipeTo(sender.ref)
+      wallet.fundTransaction(hexIn, lockUnspents = false, 250).pipeTo(sender.ref)
       val FundTransactionResponse(_, _, fee) = sender.expectMsgType[FundTransactionResponse]
       assert(fee == Satoshi(satoshi))
     }
@@ -209,7 +201,6 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       host = config.getString("bitcoind.host"),
       port = config.getInt("bitcoind.rpcport"))
     val wallet = new BitcoinCoreWallet(bitcoinClient)
-
     val sender = TestProbe()
 
     // create a transaction that spends UTXOs that don't exist
@@ -242,11 +233,10 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       host = config.getString("bitcoind.host"),
       port = config.getInt("bitcoind.rpcport"))
     val wallet = new BitcoinCoreWallet(bitcoinClient)
-
     val sender = TestProbe()
 
     wallet.getBalance.pipeTo(sender.ref)
-    assert(sender.expectMsgType[Satoshi] > 0.sat)
+    assert(sender.expectMsgType[OnChainBalance].confirmed > 0.sat)
 
     wallet.getReceiveAddress.pipeTo(sender.ref)
     val address = sender.expectMsgType[String]
@@ -307,11 +297,10 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       host = config.getString("bitcoind.host"),
       port = config.getInt("bitcoind.rpcport"))
     val wallet = new BitcoinCoreWallet(bitcoinClient)
-
     val sender = TestProbe()
 
     wallet.getBalance.pipeTo(sender.ref)
-    assert(sender.expectMsgType[Satoshi] > 0.sat)
+    assert(sender.expectMsgType[OnChainBalance].confirmed > 0.sat)
 
     wallet.getReceiveAddress.pipeTo(sender.ref)
     val address = sender.expectMsgType[String]
@@ -338,7 +327,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
     assert(sender.expectMsgType[Boolean])
 
     wallet.getBalance.pipeTo(sender.ref)
-    assert(sender.expectMsgType[Satoshi] > 0.sat)
+    assert(sender.expectMsgType[OnChainBalance].confirmed > 0.sat)
   }
 
   test("detect if tx has been doublespent") {
@@ -348,7 +337,6 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       host = config.getString("bitcoind.host"),
       port = config.getInt("bitcoind.rpcport"))
     val wallet = new BitcoinCoreWallet(bitcoinClient)
-
     val sender = TestProbe()
 
     // first let's create a tx
@@ -394,7 +382,6 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       host = config.getString("bitcoind.host"),
       port = config.getInt("bitcoind.rpcport"))
     val wallet = new BitcoinCoreWallet(bitcoinClient)
-
     val sender = TestProbe()
 
     wallet.getReceiveAddress.pipeTo(sender.ref)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -233,6 +233,11 @@ trait Service extends ExtraDirectives with Logging {
                               complete(eclairApi.sendToRoute(amountMsat, recipientAmountMsat_opt, externalId_opt, parentId_opt, invoice, CltvExpiryDelta(finalCltvExpiry), route, trampolineSecret_opt, trampolineFeesMsat_opt, trampolineCltvExpiry_opt.map(CltvExpiryDelta), trampolineNodes_opt.getOrElse(Nil)))
                           }
                         } ~
+                        path("sendonchain") {
+                          formFields("address".as[String], "amountSatoshis".as[Satoshi], "confirmationTarget".as[Long]) { (address, amount, confirmationTarget) =>
+                            complete(eclairApi.sendOnChain(address, amount, confirmationTarget))
+                          }
+                        } ~
                         path("getsentinfo") {
                           formFields("id".as[UUID]) { id =>
                             complete(eclairApi.sentInfo(Left(id)))

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -288,15 +288,15 @@ trait Service extends ExtraDirectives with Logging {
                         path("usablebalances") {
                           complete(eclairApi.usableBalances())
                         } ~
-                        path("onchainbalances") {
+                        path("onchainbalance") {
                           complete(eclairApi.onChainBalance())
                         } ~
                         path("getnewaddress") {
                           complete(eclairApi.newAddress())
                         } ~
-                        path("listtransactions") {
+                        path("onchaintransactions") {
                           formFields("count".as[Int].?, "skip".as[Int].?) { (count_opt, skip_opt) =>
-                            complete(eclairApi.listTransactions(count_opt.getOrElse(10), skip_opt.getOrElse(0)))
+                            complete(eclairApi.onChainTransactions(count_opt.getOrElse(10), skip_opt.getOrElse(0)))
                           }
                         }
                     } ~ get {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -288,6 +288,11 @@ trait Service extends ExtraDirectives with Logging {
                         } ~
                         path("getnewaddress") {
                           complete(eclairApi.newAddress())
+                        } ~
+                        path("listtransactions") {
+                          formFields("count".as[Int].?, "skip".as[Int].?) { (count_opt, skip_opt) =>
+                            complete(eclairApi.listTransactions(count_opt.getOrElse(10), skip_opt.getOrElse(0)))
+                          }
                         }
                     } ~ get {
                       path("ws") {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -283,6 +283,9 @@ trait Service extends ExtraDirectives with Logging {
                         path("usablebalances") {
                           complete(eclairApi.usableBalances())
                         } ~
+                        path("onchainbalances") {
+                          complete(eclairApi.onChainBalance())
+                        } ~
                         path("getnewaddress") {
                           complete(eclairApi.newAddress())
                         }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -127,7 +127,7 @@ trait Service extends ExtraDirectives with Logging {
                   authenticateBasicAsync(realm = "Access restricted", userPassAuthenticator) { _ =>
                     post {
                       path("getinfo") {
-                        complete(eclairApi.getInfoResponse())
+                        complete(eclairApi.getInfo())
                       } ~
                         path("connect") {
                           formFields("uri".as[NodeURI]) { uri =>

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -171,7 +171,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
   test("'getinfo' response should include this node ID") {
     val eclair = mock[Eclair]
     val mockService = new MockService(eclair)
-    eclair.getInfoResponse()(any[Timeout]) returns Future.successful(GetInfoResponse(
+    eclair.getInfo()(any[Timeout]) returns Future.successful(GetInfoResponse(
       version = "1.0.0-SNAPSHOT-e3f1ec0",
       color = Color(0.toByte, 1.toByte, 2.toByte).toString,
       features = Features(Set(ActivatedFeature(OptionDataLossProtect, Mandatory), ActivatedFeature(ChannelRangeQueriesExtended, Optional))),
@@ -190,7 +190,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(status == OK)
         val resp = entityAs[String]
         assert(resp.contains(aliceNodeId.toString))
-        eclair.getInfoResponse()(any[Timeout]).wasCalled(once)
+        eclair.getInfo()(any[Timeout]).wasCalled(once)
         matchTestJson("getinfo", resp)
       }
   }


### PR DESCRIPTION
This is a collection of independent commits.
The goal is to add some basic on-chain APIs (that simply forward to Bitcoin Core) to provide a good integration into [RTL](https://github.com/Ride-The-Lightning/RTL).

We clearly don't want eclair to become a wallet for bitcoin core, but adding basic pass-through APIs can be useful for end-users.

Fixes #1457, #1458 and #1459.
