### PR TITLE
Onion payload and HTLC in-flight metrics

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -17,10 +17,10 @@
 package fr.acinq.eclair.channel
 
 import akka.event.LoggingAdapter
-import fr.acinq.eclair.channel.ChannelVersion._
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey, sha256}
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Crypto}
 import fr.acinq.eclair.blockchain.fee.{FeeEstimator, FeeTargets}
+import fr.acinq.eclair.channel.ChannelVersion._
 import fr.acinq.eclair.channel.Monitoring.Metrics
 import fr.acinq.eclair.crypto.{Generators, KeyManager, ShaChain, Sphinx}
 import fr.acinq.eclair.payment.relay.{Origin, Relayer}
@@ -453,6 +453,7 @@ object Commitments {
 
         // NB: IN/OUT htlcs are inverted because this is the remote commit
         log.info(s"built remote commit number=${remoteCommit.index + 1} toLocalMsat=${spec.toLocal.toLong} toRemoteMsat=${spec.toRemote.toLong} htlc_in={} htlc_out={} feeratePerKw=${spec.feeratePerKw} txid=${remoteCommitTx.tx.txid} tx={}", spec.htlcs.collect(outgoing).map(_.id).mkString(","), spec.htlcs.collect(incoming).map(_.id).mkString(","), remoteCommitTx.tx)
+        Metrics.recordHtlcsInFlight(spec, remoteCommit.spec)
 
         // don't sign if they don't get paid
         val commitSig = CommitSig(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Monitoring.scala
@@ -16,6 +16,7 @@
 
 package fr.acinq.eclair.channel
 
+import fr.acinq.eclair.transactions.{CommitmentSpec, DirectedHtlc}
 import kamon.Kamon
 
 object Monitoring {
@@ -24,11 +25,31 @@ object Monitoring {
     val ChannelsCount = Kamon.gauge("channels.count")
     val ChannelErrors = Kamon.counter("channels.errors")
     val ChannelLifecycleEvents = Kamon.counter("channels.lifecycle")
+    val HtlcsInFlight = Kamon.histogram("channels.htlc-in-flight", "Per-channel HTLCs in flight")
+    val HtlcsInFlightGlobal = Kamon.gauge("channels.htlc-in-flight-global", "Global HTLCs in flight across all channels")
+    val HtlcValueInFlight = Kamon.histogram("channels.htlc-value-in-flight", "Per-channel HTLC value in flight")
+    val HtlcValueInFlightGlobal = Kamon.gauge("channels.htlc-value-in-flight-global", "Global HTLC value in flight across all channels")
     val LocalFeeratePerKw = Kamon.gauge("channels.local-feerate-per-kw")
     val RemoteFeeratePerKw = Kamon.histogram("channels.remote-feerate-per-kw")
+
+    def recordHtlcsInFlight(remoteSpec: CommitmentSpec, previousRemoteSpec: CommitmentSpec): Unit = {
+      Seq(Tags.Directions.Incoming, Tags.Directions.Outgoing).foreach(direction => {
+        // NB: IN/OUT htlcs are inverted because this is the remote commit
+        val filter = if (direction == Tags.Directions.Incoming) DirectedHtlc.outgoing else DirectedHtlc.incoming
+        // NB: we need the `toSeq` because otherwise duplicate amounts would be removed (since htlcs are sets)
+        val htlcs = remoteSpec.htlcs.collect(filter).toSeq.map(_.amountMsat)
+        val previousHtlcs = previousRemoteSpec.htlcs.collect(filter).toSeq.map(_.amountMsat)
+        HtlcsInFlight.withTag(Tags.Direction, direction).record(htlcs.length)
+        HtlcsInFlightGlobal.withTag(Tags.Direction, direction).increment(htlcs.length - previousHtlcs.length)
+        val (value, previousValue) = (htlcs.sum.truncateToSatoshi.toLong, previousHtlcs.sum.truncateToSatoshi.toLong)
+        HtlcValueInFlight.withTag(Tags.Direction, direction).record(value)
+        HtlcValueInFlightGlobal.withTag(Tags.Direction, direction).increment(value - previousValue)
+      })
+    }
   }
 
   object Tags {
+    val Direction = "direction"
     val Event = "event"
     val Fatal = "fatal"
     val Origin = "origin"
@@ -43,6 +64,11 @@ object Monitoring {
     object Origins {
       val Local = "local"
       val Remote = "remote"
+    }
+
+    object Directions {
+      val Incoming = "incoming"
+      val Outgoing = "outgoing"
     }
 
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Monitoring.scala
@@ -33,7 +33,7 @@ object Monitoring {
     val RemoteFeeratePerKw = Kamon.histogram("channels.remote-feerate-per-kw")
 
     def recordHtlcsInFlight(remoteSpec: CommitmentSpec, previousRemoteSpec: CommitmentSpec): Unit = {
-      Seq(Tags.Directions.Incoming, Tags.Directions.Outgoing).foreach(direction => {
+      for (direction <- Tags.Directions.Incoming :: Tags.Directions.Outgoing :: Nil) {
         // NB: IN/OUT htlcs are inverted because this is the remote commit
         val filter = if (direction == Tags.Directions.Incoming) DirectedHtlc.outgoing else DirectedHtlc.incoming
         // NB: we need the `toSeq` because otherwise duplicate amounts would be removed (since htlcs are sets)
@@ -44,7 +44,7 @@ object Monitoring {
         val (value, previousValue) = (htlcs.sum.truncateToSatoshi.toLong, previousHtlcs.sum.truncateToSatoshi.toLong)
         HtlcValueInFlight.withTag(Tags.Direction, direction).record(value)
         HtlcValueInFlightGlobal.withTag(Tags.Direction, direction).increment(value - previousValue)
-      })
+      }
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Monitoring.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.crypto
+
+import kamon.Kamon
+
+object Monitoring {
+
+  object Metrics {
+    val OnionPayloadFormat = Kamon.counter("crypto.sphinx.onion-payload-format")
+  }
+
+  object Tags {
+    val LegacyOnion = "legacy"
+  }
+
+}


### PR DESCRIPTION
We add two sets of unrelated metrics:

- Onion payload format: this is used to track when we'll be able to completely remove the legacy format. Right now only 3760 of the 5571 public nodes support `var_onion_optin`, so looks like it's not for tomorrow ;)
- HTLCs in-flight: we track the number of HTLCs in flight and the amount, per-channel and globally. This can be used to regularly update `eclair.max-htlc-value-in-flight-msat` and `eclair.max-accepted-htlcs` to the sweet spot between security and maximizing relays
