### PR TITLE
Update allnodes API

### DIFF
--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -33,7 +33,7 @@ and COMMAND is one of the available commands:
     - connect
     - disconnect
     - peers
-    - allnodes
+    - nodes
     - audit
 
   === Channel ===

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -35,6 +35,7 @@ import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentRequest, SendPa
 import fr.acinq.eclair.router.RouteCalculationSpec.makeUpdateShort
 import fr.acinq.eclair.router.Router.{GetNetworkStats, GetNetworkStatsResponse, PublicChannel}
 import fr.acinq.eclair.router.{Announcements, NetworkStats, Router, Stats}
+import fr.acinq.eclair.wire.{Color, NodeAnnouncement}
 import org.mockito.Mockito
 import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
@@ -150,6 +151,54 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     val expiredInvoice = invoice2.copy(timestamp = 0L)
     assertThrows[IllegalArgumentException](Await.result(eclair.send(None, nodeId, 123 msat, ByteVector32.Zeroes, invoice_opt = Some(expiredInvoice)), 50 millis))
+  }
+
+  test("return node announcements") { f =>
+    import f._
+
+    val eclair = new EclairImpl(kit)
+    val remoteNodeAnn1 = NodeAnnouncement(randomBytes64, Features.empty, 42L, randomKey.publicKey, Color(42, 42, 42), "LN-rocks", Nil)
+    val remoteNodeAnn2 = NodeAnnouncement(randomBytes64, Features.empty, 43L, randomKey.publicKey, Color(43, 43, 43), "LN-papers", Nil)
+    val allNodes = Seq(
+      NodeAnnouncement(randomBytes64, Features.empty, 561L, randomKey.publicKey, Color(0, 0, 0), "some-node", Nil),
+      remoteNodeAnn1,
+      remoteNodeAnn2,
+      NodeAnnouncement(randomBytes64, Features.empty, 1105L, randomKey.publicKey, Color(0, 0, 0), "some-other-node", Nil),
+    )
+
+    {
+      val fRes = eclair.nodes()
+      router.expectMsg(Symbol("nodes"))
+      router.reply(allNodes)
+      awaitCond(fRes.value match {
+        case Some(Success(nodes)) =>
+          assert(nodes.toSet === allNodes.toSet)
+          true
+        case _ => false
+      })
+    }
+    {
+      val fRes = eclair.nodes(Some(Set(remoteNodeAnn1.nodeId, remoteNodeAnn2.nodeId)))
+      router.expectMsg(Symbol("nodes"))
+      router.reply(allNodes)
+      awaitCond(fRes.value match {
+        case Some(Success(nodes)) =>
+          assert(nodes.toSet === Set(remoteNodeAnn1, remoteNodeAnn2))
+          true
+        case _ => false
+      })
+    }
+    {
+      val fRes = eclair.nodes(Some(Set(randomKey.publicKey)))
+      router.expectMsg(Symbol("nodes"))
+      router.reply(allNodes)
+      awaitCond(fRes.value match {
+        case Some(Success(nodes)) =>
+          assert(nodes.isEmpty)
+          true
+        case _ => false
+      })
+    }
   }
 
   test("allupdates can filter by nodeId") { f =>

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/ExtraDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/ExtraDirectives.scala
@@ -39,6 +39,7 @@ trait ExtraDirectives extends Directives {
   val channelIdFormParam = "channelId".as[ByteVector32](sha256HashUnmarshaller)
   val channelIdsFormParam = "channelIds".as[List[ByteVector32]](sha256HashesUnmarshaller)
   val nodeIdFormParam = "nodeId".as[PublicKey]
+  val nodeIdsFormParam = "nodeIds".as[List[PublicKey]](pubkeyListUnmarshaller)
   val paymentHashFormParam = "paymentHash".as[ByteVector32](sha256HashUnmarshaller)
   val fromFormParam = "from".as[Long]
   val toFormParam = "to".as[Long]

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -169,7 +169,12 @@ trait Service extends ExtraDirectives with Logging {
                           }
                         } ~
                         path("peers") {
-                          complete(eclairApi.peersInfo())
+                          complete(eclairApi.peers())
+                        } ~
+                        path("nodes") {
+                          formFields(nodeIdsFormParam.?) { nodeIds_opt =>
+                            complete(eclairApi.nodes(nodeIds_opt.map(_.toSet)))
+                          }
                         } ~
                         path("channels") {
                           formFields(nodeIdFormParam.?) { toRemoteNodeId_opt =>
@@ -180,9 +185,6 @@ trait Service extends ExtraDirectives with Logging {
                           withChannelIdentifier { channel =>
                             complete(eclairApi.channelInfo(channel))
                           }
-                        } ~
-                        path("allnodes") {
-                          complete(eclairApi.allNodes())
                         } ~
                         path("allchannels") {
                           complete(eclairApi.allChannels())

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -124,7 +124,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
   test("'peers' should ask the switchboard for current known peers") {
     val eclair = mock[Eclair]
     val mockService = new MockService(eclair)
-    eclair.peersInfo()(any[Timeout]) returns Future.successful(List(
+    eclair.peers()(any[Timeout]) returns Future.successful(List(
       PeerInfo(
         nodeId = aliceNodeId,
         state = "CONNECTED",
@@ -143,7 +143,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == OK)
         val response = entityAs[String]
-        eclair.peersInfo()(any[Timeout]).wasCalled(once)
+        eclair.peers()(any[Timeout]).wasCalled(once)
         matchTestJson("peers", response)
       }
   }


### PR DESCRIPTION
Rename to `nodes`.
Allow filtering for specific `nodeId`s.

Fixes #1460