### PR TITLE
Fix channelstats (for real?)

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -108,7 +108,7 @@ trait Eclair {
 
   def networkFees(from_opt: Option[Long], to_opt: Option[Long])(implicit timeout: Timeout): Future[Seq[NetworkFee]]
 
-  def channelStats()(implicit timeout: Timeout): Future[Seq[Stats]]
+  def channelStats(from_opt: Option[Long], to_opt: Option[Long])(implicit timeout: Timeout): Future[Seq[Stats]]
 
   def networkStats()(implicit timeout: Timeout): Future[Option[NetworkStats]]
 
@@ -317,7 +317,10 @@ class EclairImpl(appKit: Kit) extends Eclair {
     Future(appKit.nodeParams.db.audit.listNetworkFees(filter.from, filter.to))
   }
 
-  override def channelStats()(implicit timeout: Timeout): Future[Seq[Stats]] = Future(appKit.nodeParams.db.audit.stats)
+  override def channelStats(from_opt: Option[Long], to_opt: Option[Long])(implicit timeout: Timeout): Future[Seq[Stats]] = {
+    val filter = getDefaultTimestampFilters(from_opt, to_opt)
+    Future(appKit.nodeParams.db.audit.stats(filter.from, filter.to))
+  }
 
   override def networkStats()(implicit timeout: Timeout): Future[Option[NetworkStats]] = (appKit.router ? GetNetworkStats).mapTo[GetNetworkStatsResponse].map(_.stats)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -45,7 +45,7 @@ trait AuditDb extends Closeable {
 
   def listNetworkFees(from: Long, to: Long): Seq[NetworkFee]
 
-  def stats: Seq[Stats]
+  def stats(from: Long, to: Long): Seq[Stats]
 
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -53,4 +53,4 @@ case class ChannelLifecycleEvent(channelId: ByteVector32, remoteNodeId: PublicKe
 
 case class NetworkFee(remoteNodeId: PublicKey, channelId: ByteVector32, txId: ByteVector32, fee: Satoshi, txType: String, timestamp: Long)
 
-case class Stats(channelId: ByteVector32, avgPaymentAmount: Satoshi, paymentCount: Int, relayFee: Satoshi, networkFee: Satoshi)
+case class Stats(channelId: ByteVector32, direction: String, avgPaymentAmount: Satoshi, paymentCount: Int, relayFee: Satoshi, networkFee: Satoshi)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -302,21 +302,21 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
     val networkFees = listNetworkFees(from, to).foldLeft(Map.empty[ByteVector32, Satoshi]) { case (feeByChannelId, f) =>
       feeByChannelId + (f.channelId -> (feeByChannelId.getOrElse(f.channelId, 0 sat) + f.fee))
     }
-    case class Relayed(amount: MilliSatoshi, fee: MilliSatoshi)
+    case class Relayed(amount: MilliSatoshi, fee: MilliSatoshi, direction: String)
     val relayed = listRelayed(from, to).foldLeft(Map.empty[ByteVector32, Seq[Relayed]]) { case (previous, e) =>
       // NB: we must avoid counting the fee twice: we associate it to the outgoing channels rather than the incoming ones.
       val current = e match {
         case c: ChannelPaymentRelayed => Map(
-          c.fromChannelId -> (Relayed(c.amountIn, 0 msat) +: previous.getOrElse(c.fromChannelId, Nil)),
-          c.toChannelId -> (Relayed(c.amountOut, c.amountIn - c.amountOut) +: previous.getOrElse(c.toChannelId, Nil)),
+          c.fromChannelId -> (Relayed(c.amountIn, 0 msat, "IN") +: previous.getOrElse(c.fromChannelId, Nil)),
+          c.toChannelId -> (Relayed(c.amountOut, c.amountIn - c.amountOut, "OUT") +: previous.getOrElse(c.toChannelId, Nil)),
         )
         case t: TrampolinePaymentRelayed =>
           // We ensure a trampoline payment is counted only once per channel and per direction (if multiple HTLCs were
           // sent from/to the same channel, we group them).
-          val in = t.incoming.groupBy(_.channelId).map { case (channelId, parts) => (channelId, Relayed(parts.map(_.amount).sum, 0 msat)) }.toSeq
+          val in = t.incoming.groupBy(_.channelId).map { case (channelId, parts) => (channelId, Relayed(parts.map(_.amount).sum, 0 msat, "IN")) }.toSeq
           val out = t.outgoing.groupBy(_.channelId).map { case (channelId, parts) =>
             val fee = (t.amountIn - t.amountOut) * parts.length / t.outgoing.length // we split the fee among outgoing channels
-            (channelId, Relayed(parts.map(_.amount).sum, fee))
+            (channelId, Relayed(parts.map(_.amount).sum, fee, "OUT"))
           }.toSeq
           (in ++ out).groupBy(_._1).map { case (channelId, payments) => (channelId, payments.map(_._2) ++ previous.getOrElse(channelId, Nil)) }
       }
@@ -324,18 +324,20 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
     }
     // Channels opened by our peers won't have any entry in the network_fees table, but we still want to compute stats for them.
     val allChannels = networkFees.keySet ++ relayed.keySet
-    allChannels.map(channelId => {
+    allChannels.toSeq.flatMap(channelId => {
       val networkFee = networkFees.getOrElse(channelId, 0 sat)
-      val r = relayed.getOrElse(channelId, Nil)
-      val paymentCount = r.length
-      if (paymentCount == 0) {
-        Stats(channelId, 0 sat, 0, 0 sat, networkFee)
-      } else {
-        val avgPaymentAmount = r.map(_.amount).sum / paymentCount
-        val relayFee = r.map(_.fee).sum
-        Stats(channelId, avgPaymentAmount.truncateToSatoshi, paymentCount, relayFee.truncateToSatoshi, networkFee)
+      val (in, out) = relayed.getOrElse(channelId, Nil).partition(_.direction == "IN")
+      ((in, "IN") :: (out, "OUT") :: Nil).map { case (r, direction) =>
+        val paymentCount = r.length
+        if (paymentCount == 0) {
+          Stats(channelId, direction, 0 sat, 0, 0 sat, networkFee)
+        } else {
+          val avgPaymentAmount = r.map(_.amount).sum / paymentCount
+          val relayFee = r.map(_.fee).sum
+          Stats(channelId, direction, avgPaymentAmount.truncateToSatoshi, paymentCount, relayFee.truncateToSatoshi, networkFee)
+        }
       }
-    }).toSeq
+    })
   }
 
   // used by mobile apps

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
@@ -115,12 +115,18 @@ class SqliteAuditDbSpec extends AnyFunSuite {
 
     // NB: we only count a relay fee for the outgoing channel, no the incoming one.
     assert(db.stats(0, System.currentTimeMillis + 1).toSet === Set(
-      Stats(channelId = c1, avgPaymentAmount = 42 sat, paymentCount = 3, relayFee = 4 sat, networkFee = 0 sat),
-      Stats(channelId = c2, avgPaymentAmount = 28 sat, paymentCount = 2, relayFee = 4 sat, networkFee = 500 sat),
-      Stats(channelId = c3, avgPaymentAmount = 0 sat, paymentCount = 0, relayFee = 0 sat, networkFee = 400 sat),
-      Stats(channelId = c4, avgPaymentAmount = 22 sat, paymentCount = 2, relayFee = 9 sat, networkFee = 500 sat),
-      Stats(channelId = c5, avgPaymentAmount = 43 sat, paymentCount = 3, relayFee = 0 sat, networkFee = 0 sat),
-      Stats(channelId = c6, avgPaymentAmount = 39 sat, paymentCount = 5, relayFee = 5 sat, networkFee = 0 sat),
+      Stats(channelId = c1, direction = "IN", avgPaymentAmount = 0 sat, paymentCount = 0, relayFee = 0 sat, networkFee = 0 sat),
+      Stats(channelId = c1, direction = "OUT", avgPaymentAmount = 42 sat, paymentCount = 3, relayFee = 4 sat, networkFee = 0 sat),
+      Stats(channelId = c2, direction = "IN", avgPaymentAmount = 0 sat, paymentCount = 0, relayFee = 0 sat, networkFee = 500 sat),
+      Stats(channelId = c2, direction = "OUT", avgPaymentAmount = 28 sat, paymentCount = 2, relayFee = 4 sat, networkFee = 500 sat),
+      Stats(channelId = c3, direction = "IN", avgPaymentAmount = 0 sat, paymentCount = 0, relayFee = 0 sat, networkFee = 400 sat),
+      Stats(channelId = c3, direction = "OUT", avgPaymentAmount = 0 sat, paymentCount = 0, relayFee = 0 sat, networkFee = 400 sat),
+      Stats(channelId = c4, direction = "IN", avgPaymentAmount = 0 sat, paymentCount = 0, relayFee = 0 sat, networkFee = 500 sat),
+      Stats(channelId = c4, direction = "OUT", avgPaymentAmount = 22 sat, paymentCount = 2, relayFee = 9 sat, networkFee = 500 sat),
+      Stats(channelId = c5, direction = "IN", avgPaymentAmount = 43 sat, paymentCount = 3, relayFee = 0 sat, networkFee = 0 sat),
+      Stats(channelId = c5, direction = "OUT", avgPaymentAmount = 0 sat, paymentCount = 0, relayFee = 0 sat, networkFee = 0 sat),
+      Stats(channelId = c6, direction = "IN", avgPaymentAmount = 39 sat, paymentCount = 4, relayFee = 0 sat, networkFee = 0 sat),
+      Stats(channelId = c6, direction = "OUT", avgPaymentAmount = 40 sat, paymentCount = 1, relayFee = 5 sat, networkFee = 0 sat),
     ))
   }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -283,7 +283,9 @@ trait Service extends ExtraDirectives with Logging {
                           }
                         } ~
                         path("channelstats") {
-                          complete(eclairApi.channelStats())
+                          formFields(fromFormParam.?, toFormParam.?) { (from_opt, to_opt) =>
+                            complete(eclairApi.channelStats(from_opt, to_opt))
+                          }
                         } ~
                         path("usablebalances") {
                           complete(eclairApi.usableBalances())


### PR DESCRIPTION
The `channelstats` API only returns results for the *outgoing* channels used when relaying.
It is misleading for users that the *incoming* channels aren't included in that API's results: they may incorrectly conclude that the incoming channels have no activity and should be closed.

This PR raises a couple questions though:

- I chose to attribute the fee only to the outgoing channel: maybe we should also reflect it in the incoming channel, since that channel participated in getting us this fee? But then if you sum the fees from all the results of the `channelstats` the result would be twice the fees you really collected, which may be an issue.
- I changed the trampoline behaviour regarding the `amount` reported compared to before: I now only take into account the amount that goes through this channel whereas before we used the total payment amount. Which one do you think is better?

Maybe those questions indicate that we should do more in-depth changes to that API, but now is probably not the right time for that.

Fixes #1465