### PR TITLE
Fix commitments fuzz test

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -438,7 +438,7 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
       val t = FuzzTest(
         isFunder = Random.nextInt(2) == 0,
         pendingHtlcs = Random.nextInt(10),
-        feeRatePerKw = Random.nextInt(10000),
+        feeRatePerKw = Random.nextInt(10000).max(1),
         dustLimit = Random.nextInt(1000).sat,
         // We make sure both sides have enough to send/receive at least the initial pending HTLCs.
         toLocal = maxPendingHtlcAmount * 2 * 10 + Random.nextInt(1000000000).msat,
@@ -466,7 +466,7 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
       val t = FuzzTest(
         isFunder = Random.nextInt(2) == 0,
         pendingHtlcs = Random.nextInt(10),
-        feeRatePerKw = Random.nextInt(10000),
+        feeRatePerKw = Random.nextInt(10000).max(1),
         dustLimit = Random.nextInt(1000).sat,
         // We make sure both sides have enough to send/receive at least the initial pending HTLCs.
         toLocal = maxPendingHtlcAmount * 2 * 10 + Random.nextInt(1000000000).msat,


### PR DESCRIPTION
We must not let feeratePerKw be 0, otherwise we trigger FeerateMismatch errors which isn't what we want to test.

This test regression was introduced in #1473 
