### PR TITLE
Handle invoices with 0 amount

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
@@ -451,13 +451,16 @@ object PaymentRequest {
     }
 
     def decode(input: String): Option[MilliSatoshi] =
-      input match {
+      (input match {
         case "" => None
         case a if a.last == 'p' => Some(MilliSatoshi(a.dropRight(1).toLong / 10L)) // 1 pico-bitcoin == 10 milli-satoshis
         case a if a.last == 'n' => Some(MilliSatoshi(a.dropRight(1).toLong * 100L))
         case a if a.last == 'u' => Some(MilliSatoshi(a.dropRight(1).toLong * 100000L))
         case a if a.last == 'm' => Some(MilliSatoshi(a.dropRight(1).toLong * 100000000L))
         case a => Some(MilliSatoshi(a.toLong * 100000000000L))
+      }).flatMap {
+        case MilliSatoshi(0) => None
+        case amount => Some(amount)
       }
 
     def encode(amount: Option[MilliSatoshi]): String = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
@@ -53,6 +53,15 @@ class PaymentRequestSpec extends AnyFunSuite {
     assert('m' === Amount.unit((1 btc).toMilliSatoshi))
   }
 
+  test("decode empty amount") {
+    assert(Amount.decode("") === None)
+    assert(Amount.decode("0") === None)
+    assert(Amount.decode("0p") === None)
+    assert(Amount.decode("0n") === None)
+    assert(Amount.decode("0u") === None)
+    assert(Amount.decode("0m") === None)
+  }
+
   test("check that we can still decode non-minimal amount encoding") {
     assert(Amount.decode("1000u") === Some(100000000 msat))
     assert(Amount.decode("1000000n") === Some(100000000 msat))
@@ -75,7 +84,6 @@ class PaymentRequestSpec extends AnyFunSuite {
 
   test("verify that padding is zero") {
     val codec = PaymentRequest.Codecs.alignedBytesCodec(bits)
-
     assert(codec.decode(bin"1010101000").require == DecodeResult(bin"10101010", BitVector.empty))
     assert(codec.decode(bin"1010101001").isFailure) // non-zero padding
   }


### PR DESCRIPTION
We handled empty amounts (field not specified at all) but not the case
where the amount was specified and equal to 0.

Fixes #1478