### PR TITLE
Implement the KeySend feature, spontaneous payments

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -48,6 +48,7 @@ eclair {
     payment_secret = optional
     basic_mpp = optional
     option_support_large_channel = optional
+	keysend = optional
   }
   override-features = [ // optional per-node features
     #  {

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -48,7 +48,6 @@ eclair {
     payment_secret = optional
     basic_mpp = optional
     option_support_large_channel = optional
-	keysend = optional
   }
   override-features = [ // optional per-node features
     #  {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -392,7 +392,9 @@ class EclairImpl(appKit: Kit) extends Eclair {
     val paymentPreimage = randomBytes32
     val paymentHash: ByteVector32 = Crypto.sha256(paymentPreimage)
     val keySendTlvRecords = Seq(GenericTlv(keySendTagValue, paymentPreimage))
-    val sendPayment = SendPaymentRequest(amount, paymentHash, recipientNodeId, maxAttempts = maxAttempts, externalId = externalId_opt, routeParams = Some(routeParams), userCustomTlvs = keySendTlvRecords)
+    // TODO For now MIN_CLTV_EXPIRY_DELTA is set to 9 (spec requirement). But the lnd implementation require 13 as a minimum (see https://github.com/lightningnetwork/lnd/blob/master/invoices/invoiceregistry.go#L675)
+    // The merge request #1483 will bump the MIN_CLTV_EXPIRY_DELTA to 18. Until then we use this "magic value" of 13 to be interoperable with all implementations
+    val sendPayment = SendPaymentRequest(amount, paymentHash, recipientNodeId, maxAttempts = maxAttempts, finalExpiryDelta = CltvExpiryDelta(13), externalId = externalId_opt, routeParams = Some(routeParams), userCustomTlvs = keySendTlvRecords)
     (appKit.paymentInitiator ? sendPayment).mapTo[UUID]
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -99,6 +99,8 @@ trait Eclair {
 
   def send(externalId_opt: Option[String], recipientNodeId: PublicKey, amount: MilliSatoshi, paymentHash: ByteVector32, invoice_opt: Option[PaymentRequest] = None, maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None)(implicit timeout: Timeout): Future[UUID]
 
+  def sendWithPreimage(externalId_opt: Option[String], recipientNodeId: PublicKey, amount: MilliSatoshi, maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None)(implicit timeout: Timeout): Future[UUID]
+
   def sentInfo(id: Either[UUID, ByteVector32])(implicit timeout: Timeout): Future[Seq[OutgoingPayment]]
 
   def sendOnChain(address: String, amount: Satoshi, confirmationTarget: Long): Future[ByteVector32]
@@ -132,8 +134,6 @@ trait Eclair {
   def onChainBalance(): Future[OnChainBalance]
 
   def onChainTransactions(count: Int, skip: Int): Future[Iterable[WalletTransaction]]
-
-  def sendWithPreimage(externalId_opt: Option[String], recipientNodeId: PublicKey, amount: MilliSatoshi, maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None)(implicit timeout: Timeout): Future[UUID]
 
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -390,9 +390,7 @@ class EclairImpl(appKit: Kit) extends Eclair {
     )
     val paymentHash: ByteVector32 = Crypto.sha256(paymentPreimage)
     val keySendTlvRecords = Seq(GenericTlv(UInt64(5482373484L), paymentPreimage))
-    // TODO For now MIN_CLTV_EXPIRY_DELTA is set to 9 (spec requirement). But the lnd implementation require 13 as a minimum (see https://github.com/lightningnetwork/lnd/blob/master/invoices/invoiceregistry.go#L675)
-    // The merge request #1483 will bump the MIN_CLTV_EXPIRY_DELTA to 18. Until then we use this "magic value" of 13 to be interoperable with all implementations
-    val sendPayment = SendPaymentRequest(amount, paymentHash, recipientNodeId, maxAttempts = maxAttempts, finalExpiryDelta = CltvExpiryDelta(13), externalId = externalId_opt, routeParams = Some(routeParams), userCustomTlvs = keySendTlvRecords)
+    val sendPayment = SendPaymentRequest(amount, paymentHash, recipientNodeId, maxAttempts, externalId = externalId_opt, routeParams = Some(routeParams), userCustomTlvs = keySendTlvRecords)
     (appKit.paymentInitiator ? sendPayment).mapTo[UUID]
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -39,7 +39,6 @@ import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentRequest, SendPa
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.router.{NetworkStats, RouteCalculation}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAddress, NodeAnnouncement, GenericTlv}
-import fr.acinq.eclair.wire.Onion.keySendTagValue
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
@@ -391,7 +390,7 @@ class EclairImpl(appKit: Kit) extends Eclair {
     )
     val paymentPreimage = randomBytes32
     val paymentHash: ByteVector32 = Crypto.sha256(paymentPreimage)
-    val keySendTlvRecords = Seq(GenericTlv(keySendTagValue, paymentPreimage))
+    val keySendTlvRecords = Seq(GenericTlv(UInt64(5482373484L), paymentPreimage))
     // TODO For now MIN_CLTV_EXPIRY_DELTA is set to 9 (spec requirement). But the lnd implementation require 13 as a minimum (see https://github.com/lightningnetwork/lnd/blob/master/invoices/invoiceregistry.go#L675)
     // The merge request #1483 will bump the MIN_CLTV_EXPIRY_DELTA to 18. Until then we use this "magic value" of 13 to be interoperable with all implementations
     val sendPayment = SendPaymentRequest(amount, paymentHash, recipientNodeId, maxAttempts = maxAttempts, finalExpiryDelta = CltvExpiryDelta(13), externalId = externalId_opt, routeParams = Some(routeParams), userCustomTlvs = keySendTlvRecords)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -39,6 +39,7 @@ import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentRequest, SendPa
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.router.{NetworkStats, RouteCalculation}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, NodeAddress, NodeAnnouncement, GenericTlv}
+import fr.acinq.eclair.wire.Onion.keySendTagValue
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
@@ -390,7 +391,7 @@ class EclairImpl(appKit: Kit) extends Eclair {
     )
     val paymentPreimage = randomBytes32
     val paymentHash: ByteVector32 = Crypto.sha256(paymentPreimage)
-    val keySendTlvRecords = Seq(GenericTlv(UInt64(5482373484L), paymentPreimage))
+    val keySendTlvRecords = Seq(GenericTlv(keySendTagValue, paymentPreimage))
     val sendPayment = SendPaymentRequest(amount, paymentHash, recipientNodeId, maxAttempts = maxAttempts, externalId = externalId_opt, routeParams = Some(routeParams), userCustomTlvs = keySendTlvRecords)
     (appKit.paymentInitiator ? sendPayment).mapTo[UUID]
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -218,8 +218,7 @@ object Features {
     ChannelRangeQueriesExtended,
     PaymentSecret,
     BasicMultiPartPayment,
-    Wumbo,
-    KeySend
+    Wumbo
   )
 
   // Features may depend on other features, as specified in Bolt 9.
@@ -229,7 +228,8 @@ object Features {
     // invoices in their payment history. We choose to treat such invoices as valid; this is a harmless spec violation.
     // PaymentSecret -> (VariableLengthOnion :: Nil),
     BasicMultiPartPayment -> (PaymentSecret :: Nil),
-    TrampolinePayment -> (PaymentSecret :: Nil)
+    TrampolinePayment -> (PaymentSecret :: Nil),
+    KeySend -> (VariableLengthOnion :: Nil)
   )
 
   case class FeatureException(message: String) extends IllegalArgumentException(message)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -192,6 +192,11 @@ object Features {
     val mandatory = 50
   }
 
+  case object KeySend extends Feature {
+    val rfcName = "keysend"
+    val mandatory = 54
+  }
+
   val knownFeatures: Set[Feature] = Set(
     OptionDataLossProtect,
     InitialRoutingSync,
@@ -202,7 +207,8 @@ object Features {
     BasicMultiPartPayment,
     Wumbo,
     TrampolinePayment,
-    StaticRemoteKey
+    StaticRemoteKey,
+    KeySend
   )
 
   private val supportedMandatoryFeatures: Set[Feature] = Set(
@@ -212,7 +218,8 @@ object Features {
     ChannelRangeQueriesExtended,
     PaymentSecret,
     BasicMultiPartPayment,
-    Wumbo
+    Wumbo,
+    KeySend
   )
 
   // Features may depend on other features, as specified in Bolt 9.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -82,6 +82,7 @@ case object PaymentType {
   val Standard = "Standard"
   val SwapIn = "SwapIn"
   val SwapOut = "SwapOut"
+  val KeySend = "KeySend"
 }
 
 /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
@@ -101,7 +101,7 @@ class MultiPartHandler(nodeParams: NodeParams, register: ActorRef, db: IncomingP
               // Insert a fake invoice and then restart the incoming payment handler
               val paymentRequest = PaymentRequest(nodeParams.chainHash, amount, paymentHash, nodeParams.privateKey, desc)
               log.debug("generated fake payment request={} from amount={} (KeySend)", PaymentRequest.write(paymentRequest), amount)
-              db.addIncomingPayment(paymentRequest, paymentPreimage)
+              db.addIncomingPayment(paymentRequest, paymentPreimage, paymentType = PaymentType.KeySend)
               ctx.self ! p
             case None =>
               Metrics.PaymentFailed.withTag(Tags.Direction, Tags.Directions.Received).withTag(Tags.Failure, "InvoiceNotFound").increment()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
@@ -93,9 +93,8 @@ class MultiPartHandler(nodeParams: NodeParams, register: ActorRef, db: IncomingP
                   pendingPayments = pendingPayments + (p.add.paymentHash -> (record.paymentPreimage, handler))
               }
           }
-          case None => p.payload.keySend match {
-            case Some(keySend) =>
-              val paymentPreimage = keySend.paymentPreimage
+          case None => p.payload.paymentPreimage match {
+            case Some(paymentPreimage) =>
               val amount = Some(p.payload.totalAmount)
               val paymentHash = Crypto.sha256(paymentPreimage)
               val desc = "Donation"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
@@ -98,7 +98,7 @@ class MultiPartHandler(nodeParams: NodeParams, register: ActorRef, db: IncomingP
               val amount = Some(p.payload.totalAmount)
               val paymentHash = Crypto.sha256(paymentPreimage)
               val desc = "Donation"
-              val features =  if (nodeParams.features.hasFeature(Features.BasicMultiPartPayment)) {
+              val features = if (nodeParams.features.hasFeature(Features.BasicMultiPartPayment)) {
                 PaymentRequestFeatures(Features.BasicMultiPartPayment.optional, Features.PaymentSecret.optional, Features.VariableLengthOnion.optional)
               } else {
                 PaymentRequestFeatures(Features.PaymentSecret.optional, Features.VariableLengthOnion.optional)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
@@ -105,7 +105,7 @@ class MultiPartHandler(nodeParams: NodeParams, register: ActorRef, db: IncomingP
               }
 
               // Insert a fake invoice and then restart the incoming payment handler
-              val paymentRequest = PaymentRequest(nodeParams.chainHash, amount, paymentHash, nodeParams.privateKey, desc, features = Some(features))
+              val paymentRequest = PaymentRequest(nodeParams.chainHash, amount, paymentHash, nodeParams.privateKey, desc, nodeParams.minFinalExpiryDelta, features = Some(features))
               log.debug("generated fake payment request={} from amount={} (KeySend)", PaymentRequest.write(paymentRequest), amount)
               db.addIncomingPayment(paymentRequest, paymentPreimage, paymentType = PaymentType.KeySend)
               ctx.self ! p

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
@@ -295,6 +295,7 @@ object Onion {
     FinalTlvPayload(TlvStream(AmountToForward(amount), OutgoingCltv(expiry), PaymentData(paymentSecret, totalAmount), TrampolineOnion(trampolinePacket)))
   }
 
+  val keySendTagValue = UInt64(5482373484L)
 }
 
 object OnionCodecs {
@@ -351,7 +352,7 @@ object OnionCodecs {
     .typecase(UInt64(66098), outgoingNodeId)
     .typecase(UInt64(66099), invoiceRoutingInfo)
     .typecase(UInt64(66100), trampolineOnion)
-    .typecase(UInt64(5482373484L), keySend)
+    .typecase(keySendTagValue, keySend)
 
   val tlvPerHopPayloadCodec: Codec[TlvStream[OnionTlv]] = TlvCodecs.lengthPrefixedTlvStream[OnionTlv](onionTlvCodec).complete
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
@@ -294,8 +294,6 @@ object Onion {
   def createTrampolinePayload(amount: MilliSatoshi, totalAmount: MilliSatoshi, expiry: CltvExpiry, paymentSecret: ByteVector32, trampolinePacket: OnionRoutingPacket): FinalPayload = {
     FinalTlvPayload(TlvStream(AmountToForward(amount), OutgoingCltv(expiry), PaymentData(paymentSecret, totalAmount), TrampolineOnion(trampolinePacket)))
   }
-
-  val keySendTagValue = UInt64(5482373484L)
 }
 
 object OnionCodecs {
@@ -352,7 +350,7 @@ object OnionCodecs {
     .typecase(UInt64(66098), outgoingNodeId)
     .typecase(UInt64(66099), invoiceRoutingInfo)
     .typecase(UInt64(66100), trampolineOnion)
-    .typecase(keySendTagValue, keySend)
+    .typecase(UInt64(5482373484L), keySend)
 
   val tlvPerHopPayloadCodec: Codec[TlvStream[OnionTlv]] = TlvCodecs.lengthPrefixedTlvStream[OnionTlv](onionTlvCodec).complete
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
@@ -162,6 +162,8 @@ object OnionTlv {
   /** An encrypted trampoline onion packet. */
   case class TrampolineOnion(packet: OnionRoutingPacket) extends OnionTlv
 
+  /** Pre-image included by the sender of a payment in case of a donation */
+  case class KeySend(paymentPreimage: ByteVector32) extends OnionTlv
 }
 
 object Onion {
@@ -228,6 +230,7 @@ object Onion {
     val expiry: CltvExpiry
     val paymentSecret: Option[ByteVector32]
     val totalAmount: MilliSatoshi
+    val keySend: Option[KeySend]
   }
 
   case class RelayLegacyPayload(outgoingChannelId: ShortChannelId, amountToForward: MilliSatoshi, outgoingCltv: CltvExpiry) extends ChannelRelayPayload with LegacyFormat
@@ -235,6 +238,7 @@ object Onion {
   case class FinalLegacyPayload(amount: MilliSatoshi, expiry: CltvExpiry) extends FinalPayload with LegacyFormat {
     override val paymentSecret = None
     override val totalAmount = amount
+    override val keySend = None
   }
 
   case class ChannelRelayTlvPayload(records: TlvStream[OnionTlv]) extends ChannelRelayPayload with TlvFormat {
@@ -264,6 +268,7 @@ object Onion {
       case MilliSatoshi(0) => amount
       case totalAmount => totalAmount
     }).getOrElse(amount)
+    override val keySend = records.get[KeySend]
   }
 
   def createNodeRelayPayload(amount: MilliSatoshi, expiry: CltvExpiry, nextNodeId: PublicKey): NodeRelayPayload =
@@ -334,6 +339,8 @@ object OnionCodecs {
 
   private val trampolineOnion: Codec[TrampolineOnion] = variableSizeBytesLong(varintoverflow, trampolineOnionPacketCodec).as[TrampolineOnion]
 
+  private val keySend: Codec[KeySend] = variableSizeBytesLong(varintoverflow, bytes32).as[KeySend]
+
   private val onionTlvCodec = discriminated[OnionTlv].by(varint)
     .typecase(UInt64(2), amountToForward)
     .typecase(UInt64(4), outgoingCltv)
@@ -344,6 +351,7 @@ object OnionCodecs {
     .typecase(UInt64(66098), outgoingNodeId)
     .typecase(UInt64(66099), invoiceRoutingInfo)
     .typecase(UInt64(66100), trampolineOnion)
+    .typecase(UInt64(5482373484L), keySend)
 
   val tlvPerHopPayloadCodec: Codec[TlvStream[OnionTlv]] = TlvCodecs.lengthPrefixedTlvStream[OnionTlv](onionTlvCodec).complete
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/Onion.scala
@@ -230,7 +230,7 @@ object Onion {
     val expiry: CltvExpiry
     val paymentSecret: Option[ByteVector32]
     val totalAmount: MilliSatoshi
-    val keySend: Option[KeySend]
+    val paymentPreimage: Option[ByteVector32]
   }
 
   case class RelayLegacyPayload(outgoingChannelId: ShortChannelId, amountToForward: MilliSatoshi, outgoingCltv: CltvExpiry) extends ChannelRelayPayload with LegacyFormat
@@ -238,7 +238,7 @@ object Onion {
   case class FinalLegacyPayload(amount: MilliSatoshi, expiry: CltvExpiry) extends FinalPayload with LegacyFormat {
     override val paymentSecret = None
     override val totalAmount = amount
-    override val keySend = None
+    override val paymentPreimage = None
   }
 
   case class ChannelRelayTlvPayload(records: TlvStream[OnionTlv]) extends ChannelRelayPayload with TlvFormat {
@@ -268,7 +268,7 @@ object Onion {
       case MilliSatoshi(0) => amount
       case totalAmount => totalAmount
     }).getOrElse(amount)
-    override val keySend = records.get[KeySend]
+    override val paymentPreimage = records.get[KeySend].map(_.paymentPreimage)
   }
 
   def createNodeRelayPayload(amount: MilliSatoshi, expiry: CltvExpiry, nextNodeId: PublicKey): NodeRelayPayload =

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -387,4 +387,18 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     paymentInitiator.expectMsg(SendPaymentToRouteRequest(1000 msat, 1200 msat, Some("42"), Some(parentId), pr, CltvExpiryDelta(123), route, Some(secret), 100 msat, CltvExpiryDelta(144), trampolines))
   }
 
+  test("call sendWithPreimage to perform a KeySend payment") { f =>
+    import f._
+
+    val eclair = new EclairImpl(kit)
+    val nodeId = randomKey.publicKey
+
+    eclair.sendWithPreimage(None, nodeId, 12345 msat)
+    val send = paymentInitiator.expectMsgType[SendPaymentRequest]
+    assert(send.externalId === None)
+    assert(send.recipientNodeId === nodeId)
+    assert(send.recipientAmount === 12345.msat)
+    assert(send.paymentRequest === None)
+  }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -387,7 +387,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     paymentInitiator.expectMsg(SendPaymentToRouteRequest(1000 msat, 1200 msat, Some("42"), Some(parentId), pr, CltvExpiryDelta(123), route, Some(secret), 100 msat, CltvExpiryDelta(144), trampolines))
   }
 
-  test("call sendWithPreimage to perform a KeySend payment") { f =>
+  test("call sendWithPreimage, which generate a random preimage, to perform a KeySend payment") { f =>
     import f._
 
     val eclair = new EclairImpl(kit)
@@ -399,6 +399,23 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     assert(send.recipientNodeId === nodeId)
     assert(send.recipientAmount === 12345.msat)
     assert(send.paymentRequest === None)
+  }
+
+  test("call sendWithPreimage, giving a specific preimage, to perform a KeySend payment") { f =>
+    import f._
+
+    val eclair = new EclairImpl(kit)
+    val nodeId = randomKey.publicKey
+    val paymentPreimage = ByteVector32(hex"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+    val expectedPaymentHash = Crypto.sha256(paymentPreimage)
+
+    eclair.sendWithPreimage(None, nodeId, 12345 msat, paymentPreimage = paymentPreimage)
+    val send = paymentInitiator.expectMsgType[SendPaymentRequest]
+    assert(send.externalId === None)
+    assert(send.recipientNodeId === nodeId)
+    assert(send.recipientAmount === 12345.msat)
+    assert(send.paymentRequest === None)
+    assert(send.paymentHash === expectedPaymentHash)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
@@ -23,7 +23,7 @@ import fr.acinq.eclair.FeatureSupport.Optional
 import fr.acinq.eclair.Features._
 import fr.acinq.eclair.TestConstants.Alice
 import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FULFILL_HTLC, Register}
-import fr.acinq.eclair.db.{IncomingPaymentStatus, PaymentType}
+import fr.acinq.eclair.db.IncomingPaymentStatus
 import fr.acinq.eclair.payment.PaymentReceived.PartialPayment
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.payment.receive.MultiPartHandler.{GetPendingPayments, PendingPayments, ReceivePayment}
@@ -31,7 +31,7 @@ import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM.HtlcPart
 import fr.acinq.eclair.payment.receive.{MultiPartPaymentFSM, PaymentHandler}
 import fr.acinq.eclair.wire.Onion.FinalTlvPayload
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.{ActivatedFeature, CltvExpiry, CltvExpiryDelta, Features, LongToBtcAmount, NodeParams, ShortChannelId, TestConstants, TestKitBaseClass, UInt64, randomBytes32, randomKey}
+import fr.acinq.eclair.{ActivatedFeature, CltvExpiry, CltvExpiryDelta, Features, LongToBtcAmount, NodeParams, ShortChannelId, TestConstants, TestKitBaseClass, randomBytes32, randomKey}
 import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
@@ -467,7 +467,7 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     })
   }
 
-  test("KeySend payment in a single HTLC") { f =>
+  test("PaymentHandler should handle single-part KeySend payment") { f =>
     import f._
 
     val amountMsat = 42000 msat
@@ -488,7 +488,7 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(received.get.status.asInstanceOf[IncomingPaymentStatus.Received].copy(receivedAt = 0) === IncomingPaymentStatus.Received(amountMsat, 0))
   }
 
-  test("KeySend payment without the feature activated") { f =>
+  test("PaymentHandler should reject KeySend payment when feature is disabled") { f =>
     import f._
 
     val amountMsat = 42000 msat

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/OnionCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/OnionCodecsSpec.scala
@@ -183,8 +183,8 @@ class OnionCodecsSpec extends AnyFunSuite {
   }
 
   test("encode/decode variable-length (tlv) final per-hop payload with custom user records") {
-    val tlvs = TlvStream[OnionTlv](Seq(AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42))), Seq(GenericTlv(5482373484L, hex"16c7ec71663784ff100b6eface1e60a97b92ea9d18b8ece5e558586bc7453828")))
-    val bin = hex"31 02020231 04012a ff0000000146c6616c2016c7ec71663784ff100b6eface1e60a97b92ea9d18b8ece5e558586bc7453828"
+    val tlvs = TlvStream[OnionTlv](Seq(AmountToForward(561 msat), OutgoingCltv(CltvExpiry(42))), Seq(GenericTlv(5432123456L, hex"16c7ec71663784ff100b6eface1e60a97b92ea9d18b8ece5e558586bc7453828")))
+    val bin = hex"31 02020231 04012a ff0000000143c7a0402016c7ec71663784ff100b6eface1e60a97b92ea9d18b8ece5e558586bc7453828"
 
     val encoded = finalPerHopPayloadCodec.encode(FinalTlvPayload(tlvs)).require.bytes
     assert(encoded === bin)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -233,7 +233,7 @@ trait Service extends ExtraDirectives with Logging {
                             case (amountMsat, nodeId, None, maxAttempts_opt, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, keySend) =>
                               keySend match {
                                 case Some(true) => complete(eclairApi.sendWithPreimage(externalId_opt, nodeId, amountMsat, maxAttempts_opt = maxAttempts_opt, feeThresholdSat_opt = feeThresholdSat_opt, maxFeePct_opt = maxFeePct_opt))
-                                case _ => reject(MalformedFormFieldRejection("paymentHash", "No payment type specified. Either give a paymentHash or use --keysend=true"))
+                                case _ => reject(MalformedFormFieldRejection("paymentHash", "No payment type specified. Either provide a paymentHash or use --keysend=true"))
                               }
                           }
                         } ~

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -36,7 +36,7 @@ import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.api.FormParamExtractors._
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.{PaymentEvent, PaymentRequest}
-import fr.acinq.eclair.{CltvExpiryDelta, Eclair, MilliSatoshi}
+import fr.acinq.eclair.{CltvExpiryDelta, Eclair, MilliSatoshi, randomBytes32}
 import grizzled.slf4j.Logging
 import scodec.bits.ByteVector
 


### PR DESCRIPTION
## What is KeySend?
For an explanation of the feature see the PR from [c-lightning](https://github.com/ElementsProject/lightning/pull/3611).

## Testing
Support for receiving and sending is added. This was tested against each Lightning implementations (`Sender -> Receiver`):
- `Eclair -> Eclair`
- `Eclair -> lnd`
- `Eclair -> c-lightning`
- `lnd -> Eclair`

Sending support [is not currently merged](https://github.com/ElementsProject/lightning/pull/3792) in c-lightning, so testing in this way `c-lightning -> Eclair` cannot be performed yet.