### PR TITLE
Activate anchor output in channels

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -78,11 +78,11 @@ case class Features(activated: Set[ActivatedFeature], unknown: Set[UnknownFeatur
   }
 
   /**
-    * Eclair-mobile thinks feature bit 15 (payment_secret) is gossip_queries_ex which creates issues, so we mask
-    * off basic_mpp and payment_secret. As long as they're provided in the invoice it's not an issue.
-    * We use a long enough mask to account for future features.
-    * TODO: remove that once eclair-mobile is patched.
-    */
+   * Eclair-mobile thinks feature bit 15 (payment_secret) is gossip_queries_ex which creates issues, so we mask
+   * off basic_mpp and payment_secret. As long as they're provided in the invoice it's not an issue.
+   * We use a long enough mask to account for future features.
+   * TODO: remove that once eclair-mobile is patched.
+   */
   def maskFeaturesForEclairMobile(): Features = {
     Features(
       activated = activated.filter {
@@ -184,6 +184,11 @@ object Features {
     val mandatory = 18
   }
 
+  case object AnchorOutputs extends Feature {
+    val rfcName = "option_anchor_outputs"
+    val mandatory = 20
+  }
+
   // TODO: @t-bast: update feature bits once spec-ed (currently reserved here: https://github.com/lightningnetwork/lightning-rfc/issues/605)
   // We're not advertising these bits yet in our announcements, clients have to assume support.
   // This is why we haven't added them yet to `areSupported`.
@@ -208,6 +213,7 @@ object Features {
     Wumbo,
     TrampolinePayment,
     StaticRemoteKey,
+    AnchorOutputs,
     KeySend
   )
 
@@ -228,6 +234,7 @@ object Features {
     // invoices in their payment history. We choose to treat such invoices as valid; this is a harmless spec violation.
     // PaymentSecret -> (VariableLengthOnion :: Nil),
     BasicMultiPartPayment -> (PaymentSecret :: Nil),
+    AnchorOutputs -> (StaticRemoteKey :: Nil),
     TrampolinePayment -> (PaymentSecret :: Nil),
     KeySend -> (VariableLengthOnion :: Nil)
   )

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -32,6 +32,7 @@ import fr.acinq.eclair.io.Peer
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.relay.{Origin, Relayer}
 import fr.acinq.eclair.router.Announcements
+import fr.acinq.eclair.transactions.Transactions.TxOwner
 import fr.acinq.eclair.transactions._
 import fr.acinq.eclair.wire._
 import scodec.bits.ByteVector
@@ -387,7 +388,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
       // let's create the first commitment tx that spends the yet uncommitted funding tx
       val (localSpec, localCommitTx, remoteSpec, remoteCommitTx) = Funding.makeFirstCommitTxs(keyManager, channelVersion, temporaryChannelId, localParams, remoteParams, fundingAmount, pushMsat, initialFeeratePerKw, fundingTx.hash, fundingTxOutputIndex, remoteFirstPerCommitmentPoint)
       require(fundingTx.txOut(fundingTxOutputIndex).publicKeyScript == localCommitTx.input.txOut.publicKeyScript, s"pubkey script mismatch!")
-      val localSigOfRemoteTx = keyManager.sign(remoteCommitTx, keyManager.fundingPublicKey(localParams.fundingKeyPath))
+      val localSigOfRemoteTx = keyManager.sign(remoteCommitTx, keyManager.fundingPublicKey(localParams.fundingKeyPath), TxOwner.Remote, channelVersion.commitmentFormat)
       // signature of their initial commitment tx that pays remote pushMsat
       val fundingCreated = FundingCreated(
         temporaryChannelId = temporaryChannelId,
@@ -430,12 +431,12 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
 
       // check remote signature validity
       val fundingPubKey = keyManager.fundingPublicKey(localParams.fundingKeyPath)
-      val localSigOfLocalTx = keyManager.sign(localCommitTx, fundingPubKey)
+      val localSigOfLocalTx = keyManager.sign(localCommitTx, fundingPubKey, TxOwner.Local, channelVersion.commitmentFormat)
       val signedLocalCommitTx = Transactions.addSigs(localCommitTx, fundingPubKey.publicKey, remoteParams.fundingPubKey, localSigOfLocalTx, remoteSig)
       Transactions.checkSpendable(signedLocalCommitTx) match {
-        case Failure(cause) => handleLocalError(InvalidCommitmentSignature(temporaryChannelId, signedLocalCommitTx.tx), d, None)
+        case Failure(_) => handleLocalError(InvalidCommitmentSignature(temporaryChannelId, signedLocalCommitTx.tx), d, None)
         case Success(_) =>
-          val localSigOfRemoteTx = keyManager.sign(remoteCommitTx, fundingPubKey)
+          val localSigOfRemoteTx = keyManager.sign(remoteCommitTx, fundingPubKey, TxOwner.Remote, channelVersion.commitmentFormat)
           val channelId = toLongId(fundingTxHash, fundingTxOutputIndex)
           // watch the funding tx transaction
           val commitInput = localCommitTx.input
@@ -473,7 +474,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
     case Event(msg@FundingSigned(_, remoteSig), d@DATA_WAIT_FOR_FUNDING_SIGNED(channelId, localParams, remoteParams, fundingTx, fundingTxFee, localSpec, localCommitTx, remoteCommit, channelFlags, channelVersion, fundingCreated)) =>
       // we make sure that their sig checks out and that our first commit tx is spendable
       val fundingPubKey = keyManager.fundingPublicKey(localParams.fundingKeyPath)
-      val localSigOfLocalTx = keyManager.sign(localCommitTx, fundingPubKey)
+      val localSigOfLocalTx = keyManager.sign(localCommitTx, fundingPubKey, TxOwner.Local, channelVersion.commitmentFormat)
       val signedLocalCommitTx = Transactions.addSigs(localCommitTx, fundingPubKey.publicKey, remoteParams.fundingPubKey, localSigOfLocalTx, remoteSig)
       Transactions.checkSpendable(signedLocalCommitTx) match {
         case Failure(cause) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -21,7 +21,6 @@ import akka.event.Logging.MDC
 import akka.pattern.pipe
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{ByteVector32, OutPoint, Satoshi, Script, ScriptFlags, Transaction}
-import fr.acinq.eclair.Features.StaticRemoteKey
 import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
@@ -292,10 +291,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
         case Success(_) =>
           context.system.eventStream.publish(ChannelCreated(self, peer, remoteNodeId, isFunder = false, open.temporaryChannelId, open.feeratePerKw, None))
           val fundingPubkey = keyManager.fundingPublicKey(localParams.fundingKeyPath).publicKey
-          val channelVersion = Features.canUseFeature(localParams.features, remoteInit.features, StaticRemoteKey) match {
-            case false => ChannelVersion.STANDARD
-            case true => ChannelVersion.STATIC_REMOTEKEY
-          }
+          val channelVersion = ChannelVersion.pickChannelVersion(localParams.features, remoteInit.features)
           val channelKeyPath = keyManager.channelKeyPath(localParams, channelVersion)
           // TODO: maybe also check uniqueness of temporary channel id
           val minimumDepth = Helpers.minDepthForFunding(nodeParams, open.fundingSatoshis)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -22,7 +22,7 @@ import akka.actor.ActorRef
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, DeterministicWallet, OutPoint, Satoshi, Transaction}
 import fr.acinq.eclair.transactions.CommitmentSpec
-import fr.acinq.eclair.transactions.Transactions.{CommitTx, CommitmentFormat, DefaultCommitmentFormat}
+import fr.acinq.eclair.transactions.Transactions.{AnchorOutputsCommitmentFormat, CommitTx, CommitmentFormat, DefaultCommitmentFormat}
 import fr.acinq.eclair.wire.{AcceptChannel, ChannelAnnouncement, ChannelReestablish, ChannelUpdate, ClosingSigned, FailureMessage, FundingCreated, FundingLocked, FundingSigned, Init, OnionRoutingPacket, OpenChannel, Shutdown, UpdateAddHtlc}
 import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshi, ShortChannelId, UInt64}
 import scodec.bits.{BitVector, ByteVector}
@@ -257,7 +257,11 @@ case class ChannelVersion(bits: BitVector) {
 
   require(bits.size == ChannelVersion.LENGTH_BITS, "channel version takes 4 bytes")
 
-  val commitmentFormat: CommitmentFormat = DefaultCommitmentFormat
+  val commitmentFormat: CommitmentFormat = if (isSet(USE_ANCHOR_OUTPUTS_BIT)) {
+    AnchorOutputsCommitmentFormat
+  } else {
+    DefaultCommitmentFormat
+  }
 
   def |(other: ChannelVersion) = ChannelVersion(bits | other.bits)
   def &(other: ChannelVersion) = ChannelVersion(bits & other.bits)
@@ -271,15 +275,28 @@ case class ChannelVersion(bits: BitVector) {
 
 object ChannelVersion {
   import scodec.bits._
+
   val LENGTH_BITS: Int = 4 * 8
 
   private val USE_PUBKEY_KEYPATH_BIT = 0 // bit numbers start at 0
   private val USE_STATIC_REMOTEKEY_BIT = 1
+  private val USE_ANCHOR_OUTPUTS_BIT = 2
 
   private def setBit(bit: Int) = ChannelVersion(BitVector.low(LENGTH_BITS).set(bit).reverse)
+
+  def pickChannelVersion(localFeatures: Features, remoteFeatures: Features): ChannelVersion = {
+    if (Features.canUseFeature(localFeatures, remoteFeatures, Features.AnchorOutputs)) {
+      ANCHOR_OUTPUTS
+    } else if (Features.canUseFeature(localFeatures, remoteFeatures, Features.StaticRemoteKey)) {
+      STATIC_REMOTEKEY
+    } else {
+      STANDARD
+    }
+  }
 
   val ZEROES = ChannelVersion(bin"00000000000000000000000000000000")
   val STANDARD = ZEROES | setBit(USE_PUBKEY_KEYPATH_BIT)
   val STATIC_REMOTEKEY = STANDARD | setBit(USE_STATIC_REMOTEKEY_BIT) // PUBKEY_KEYPATH + STATIC_REMOTEKEY
+  val ANCHOR_OUTPUTS = STATIC_REMOTEKEY | setBit(USE_ANCHOR_OUTPUTS_BIT) // PUBKEY_KEYPATH + STATIC_REMOTEKEY + ANCHOR_OUTPUTS
 }
 // @formatter:on

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -257,7 +257,7 @@ case class ChannelVersion(bits: BitVector) {
 
   require(bits.size == ChannelVersion.LENGTH_BITS, "channel version takes 4 bytes")
 
-  val commitmentFormat: CommitmentFormat = if (isSet(USE_ANCHOR_OUTPUTS_BIT)) {
+  val commitmentFormat: CommitmentFormat = if (hasAnchorOutputs) {
     AnchorOutputsCommitmentFormat
   } else {
     DefaultCommitmentFormat
@@ -271,6 +271,7 @@ case class ChannelVersion(bits: BitVector) {
 
   def hasPubkeyKeyPath: Boolean = isSet(USE_PUBKEY_KEYPATH_BIT)
   def hasStaticRemotekey: Boolean = isSet(USE_STATIC_REMOTEKEY_BIT)
+  def hasAnchorOutputs: Boolean = isSet(USE_ANCHOR_OUTPUTS_BIT)
 }
 
 object ChannelVersion {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -114,7 +114,7 @@ object Helpers {
     // BOLT #2: The receiving node MUST fail the channel if: max_accepted_htlcs is greater than 483.
     if (open.maxAcceptedHtlcs > Channel.MAX_ACCEPTED_HTLCS) throw InvalidMaxAcceptedHtlcs(open.temporaryChannelId, open.maxAcceptedHtlcs, Channel.MAX_ACCEPTED_HTLCS)
 
-    // BOLT #2: The receiving node MUST fail the channel if: push_msat is greater than funding_satoshis * 1000.
+    // BOLT #2: The receiving node MUST fail the channel if: it considers feerate_per_kw too small for timely processing.
     if (isFeeTooSmall(open.feeratePerKw)) throw FeerateTooSmall(open.temporaryChannelId, open.feeratePerKw)
 
     // BOLT #2: The receiving node MUST fail the channel if: dust_limit_satoshis is greater than channel_reserve_satoshis.
@@ -127,6 +127,7 @@ object Helpers {
       throw ChannelReserveNotMet(open.temporaryChannelId, toLocalMsat, toRemoteMsat, open.channelReserveSatoshis)
     }
 
+    // BOLT #2: The receiving node MUST fail the channel if: it considers feerate_per_kw too small for timely processing or unreasonably large.
     val localFeeratePerKw = nodeParams.onChainFeeConf.feeEstimator.getFeeratePerKw(target = nodeParams.onChainFeeConf.feeTargets.commitmentBlockTarget)
     if (isFeeDiffTooHigh(localFeeratePerKw, open.feeratePerKw, nodeParams.onChainFeeConf.maxFeerateMismatch)) throw FeerateTooDifferent(open.temporaryChannelId, localFeeratePerKw, open.feeratePerKw)
     // only enforce dust limit check on mainnet
@@ -221,7 +222,6 @@ object Helpers {
   /**
    * This indicates whether our side of the channel is above the reserve requested by our counterparty. In other words,
    * this tells if we can use the channel to make a payment.
-   *
    */
   def aboveReserve(commitments: Commitments)(implicit log: LoggingAdapter): Boolean = {
     val remoteCommit = commitments.remoteNextCommitInfo match {
@@ -235,6 +235,7 @@ object Helpers {
     result
   }
 
+  /** NB: this is a blocking call, use carefully! */
   def getFinalScriptPubKey(wallet: EclairWallet, chainHash: ByteVector32): ByteVector = {
     import scala.concurrent.duration._
     val finalAddress = Await.result(wallet.getReceiveAddress, 40 seconds)
@@ -242,6 +243,7 @@ object Helpers {
     Script.write(addressToPublicKeyScript(finalAddress, chainHash))
   }
 
+  /** NB: this is a blocking call, use carefully! */
   def getWalletPaymentBasepoint(wallet: EclairWallet): PublicKey = {
     Await.result(wallet.getReceivePubkey(), 40 seconds)
   }
@@ -369,7 +371,7 @@ object Helpers {
 
     /**
      * As soon as a tx spending the funding tx has reached min_depth, we know what the closing type will be, before
-     * the whole closing process finishes(e.g. there may still be delayed or unconfirmed child transactions). It can
+     * the whole closing process finishes (e.g. there may still be delayed or unconfirmed child transactions). It can
      * save us from attempting to publish some transactions.
      *
      * Note that we can't tell for mutual close before it is already final, because only one tx needs to be confirmed.
@@ -532,7 +534,7 @@ object Helpers {
       // first we will claim our main output as soon as the delay is over
       val mainDelayedTx = generateTx("main-delayed-output") {
         Transactions.makeClaimDelayedOutputTx(tx, localParams.dustLimit, localRevocationPubkey, remoteParams.toSelfDelay, localDelayedPubkey, localParams.defaultFinalScriptPubKey, feeratePerKwDelayed).right.map(claimDelayed => {
-          val sig = keyManager.sign(claimDelayed, keyManager.delayedPaymentPoint(channelKeyPath), localPerCommitmentPoint)
+          val sig = keyManager.sign(claimDelayed, keyManager.delayedPaymentPoint(channelKeyPath), localPerCommitmentPoint, SIGHASH_ALL)
           Transactions.addSigs(claimDelayed, sig)
         })
       }
@@ -562,7 +564,7 @@ object Helpers {
         txinfo: TransactionWithInputInfo =>
           generateTx("claim-htlc-delayed") {
             Transactions.makeClaimDelayedOutputTx(txinfo.tx, localParams.dustLimit, localRevocationPubkey, remoteParams.toSelfDelay, localDelayedPubkey, localParams.defaultFinalScriptPubKey, feeratePerKwDelayed).right.map(claimDelayed => {
-              val sig = keyManager.sign(claimDelayed, keyManager.delayedPaymentPoint(channelKeyPath), localPerCommitmentPoint)
+              val sig = keyManager.sign(claimDelayed, keyManager.delayedPaymentPoint(channelKeyPath), localPerCommitmentPoint, SIGHASH_ALL)
               Transactions.addSigs(claimDelayed, sig)
             })
           }
@@ -613,7 +615,7 @@ object Helpers {
         case OutgoingHtlc(add: UpdateAddHtlc) if preimages.exists(r => sha256(r) == add.paymentHash) => generateTx("claim-htlc-success") {
           val preimage = preimages.find(r => sha256(r) == add.paymentHash).get
           Transactions.makeClaimHtlcSuccessTx(remoteCommitTx.tx, outputs, localParams.dustLimit, localHtlcPubkey, remoteHtlcPubkey, remoteRevocationPubkey, localParams.defaultFinalScriptPubKey, add, feeratePerKwHtlc, commitments.commitmentFormat).right.map(txinfo => {
-            val sig = keyManager.sign(txinfo, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint)
+            val sig = keyManager.sign(txinfo, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint, SIGHASH_ALL)
             Transactions.addSigs(txinfo, sig, preimage)
           })
         }
@@ -623,7 +625,7 @@ object Helpers {
         // outgoing htlc: they may or may not have the preimage, the only thing to do is try to get back our funds after timeout
         case IncomingHtlc(add: UpdateAddHtlc) => generateTx("claim-htlc-timeout") {
           Transactions.makeClaimHtlcTimeoutTx(remoteCommitTx.tx, outputs, localParams.dustLimit, localHtlcPubkey, remoteHtlcPubkey, remoteRevocationPubkey, localParams.defaultFinalScriptPubKey, add, feeratePerKwHtlc, commitments.commitmentFormat).right.map(txinfo => {
-            val sig = keyManager.sign(txinfo, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint)
+            val sig = keyManager.sign(txinfo, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint, SIGHASH_ALL)
             Transactions.addSigs(txinfo, sig)
           })
         }
@@ -663,7 +665,7 @@ object Helpers {
 
       val mainTx = generateTx("claim-p2wpkh-output") {
         Transactions.makeClaimP2WPKHOutputTx(tx, commitments.localParams.dustLimit, localPubkey, commitments.localParams.defaultFinalScriptPubKey, feeratePerKwMain).right.map(claimMain => {
-          val sig = keyManager.sign(claimMain, keyManager.paymentPoint(channelKeyPath), remotePerCommitmentPoint)
+          val sig = keyManager.sign(claimMain, keyManager.paymentPoint(channelKeyPath), remotePerCommitmentPoint, SIGHASH_ALL)
           Transactions.addSigs(claimMain, localPubkey, sig)
         })
       }
@@ -718,7 +720,7 @@ object Helpers {
               None
             case _ => generateTx("claim-p2wpkh-output") {
               Transactions.makeClaimP2WPKHOutputTx(tx, localParams.dustLimit, localPaymentPubkey, localParams.defaultFinalScriptPubKey, feeratePerKwMain).right.map(claimMain => {
-                val sig = keyManager.sign(claimMain, keyManager.paymentPoint(channelKeyPath), remotePerCommitmentPoint)
+                val sig = keyManager.sign(claimMain, keyManager.paymentPoint(channelKeyPath), remotePerCommitmentPoint, SIGHASH_ALL)
                 Transactions.addSigs(claimMain, localPaymentPubkey, sig)
               })
             }
@@ -1025,7 +1027,7 @@ object Helpers {
       val relevantOutpoints = tx.txIn.map(_.outPoint).filter { outPoint =>
         // is this the commit tx itself ? (we could do this outside of the loop...)
         val isCommitTx = remoteCommitPublished.commitTx.txid == tx.txid
-        // does the tx spend an output of the local commitment tx?
+        // does the tx spend an output of the remote commitment tx?
         val spendsTheCommitTx = remoteCommitPublished.commitTx.txid == outPoint.txid
         isCommitTx || spendsTheCommitTx
       }
@@ -1049,7 +1051,7 @@ object Helpers {
       val relevantOutpoints = tx.txIn.map(_.outPoint).filter { outPoint =>
         // is this the commit tx itself ? (we could do this outside of the loop...)
         val isCommitTx = revokedCommitPublished.commitTx.txid == tx.txid
-        // does the tx spend an output of the local commitment tx?
+        // does the tx spend an output of the remote commitment tx?
         val spendsTheCommitTx = revokedCommitPublished.commitTx.txid == outPoint.txid
         // is the tx one of our 3rd stage delayed txes? (a 3rd stage tx is a tx spending the output of an htlc tx, which
         // is itself spending the output of the commitment tx)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
@@ -23,7 +23,7 @@ import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.DeterministicWallet.ExtendedPublicKey
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Crypto, DeterministicWallet, Protocol}
 import fr.acinq.eclair.channel.{ChannelVersion, LocalParams}
-import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo
+import fr.acinq.eclair.transactions.Transactions.{CommitmentFormat, TransactionWithInputInfo, TxOwner}
 import fr.acinq.eclair.{Features, ShortChannelId}
 
 trait KeyManager {
@@ -62,35 +62,40 @@ trait KeyManager {
   def newFundingKeyPath(isFunder: Boolean): DeterministicWallet.KeyPath
 
   /**
-   * @param tx        input transaction
-   * @param publicKey extended public key
+   * @param tx               input transaction
+   * @param publicKey        extended public key
+   * @param txOwner          owner of the transaction (local/remote)
+   * @param commitmentFormat format of the commitment tx
    * @return a signature generated with the private key that matches the input
    *         extended public key
    */
-  def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey): ByteVector64
+  def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, txOwner: TxOwner, commitmentFormat: CommitmentFormat): ByteVector64
 
   /**
    * This method is used to spend funds sent to htlc keys/delayed keys
    *
-   * @param tx          input transaction
-   * @param publicKey   extended public key
-   * @param remotePoint remote point
-   * @param sighashType sighash flags
+   * @param tx               input transaction
+   * @param publicKey        extended public key
+   * @param remotePoint      remote point
+   * @param txOwner          owner of the transaction (local/remote)
+   * @param commitmentFormat format of the commitment tx
    * @return a signature generated with a private key generated from the input keys's matching
    *         private key and the remote point.
    */
-  def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, remotePoint: PublicKey, sighashType: Int): ByteVector64
+  def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, remotePoint: PublicKey, txOwner: TxOwner, commitmentFormat: CommitmentFormat): ByteVector64
 
   /**
    * Ths method is used to spend revoked transactions, with the corresponding revocation key
    *
-   * @param tx           input transaction
-   * @param publicKey    extended public key
-   * @param remoteSecret remote secret
+   * @param tx               input transaction
+   * @param publicKey        extended public key
+   * @param remoteSecret     remote secret
+   * @param txOwner          owner of the transaction (local/remote)
+   * @param commitmentFormat format of the commitment tx
    * @return a signature generated with a private key generated from the input keys's matching
    *         private key and the remote secret.
    */
-  def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, remoteSecret: PrivateKey): ByteVector64
+  def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, remoteSecret: PrivateKey, txOwner: TxOwner, commitmentFormat: CommitmentFormat): ByteVector64
 
   /**
    * Sign a channel announcement message

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
@@ -22,9 +22,9 @@ import java.nio.ByteOrder
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.DeterministicWallet.ExtendedPublicKey
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Crypto, DeterministicWallet, Protocol}
-import fr.acinq.eclair.{Features, ShortChannelId}
 import fr.acinq.eclair.channel.{ChannelVersion, LocalParams}
 import fr.acinq.eclair.transactions.Transactions.TransactionWithInputInfo
+import fr.acinq.eclair.{Features, ShortChannelId}
 
 trait KeyManager {
   def nodeKey: DeterministicWallet.ExtendedPrivateKey
@@ -54,77 +54,78 @@ trait KeyManager {
   }
 
   /**
-   *
    * @param isFunder true if we're funding this channel
    * @return a partial key path for a new funding public key. This key path will be extended:
    *         - with a specific "chain" prefix
    *         - with a specific "funding pubkey" suffix
    */
-  def newFundingKeyPath(isFunder: Boolean) : DeterministicWallet.KeyPath
+  def newFundingKeyPath(isFunder: Boolean): DeterministicWallet.KeyPath
 
   /**
-    *
-    * @param tx        input transaction
-    * @param publicKey extended public key
-    * @return a signature generated with the private key that matches the input
-    *         extended public key
-    */
+   * @param tx        input transaction
+   * @param publicKey extended public key
+   * @return a signature generated with the private key that matches the input
+   *         extended public key
+   */
   def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey): ByteVector64
 
   /**
-    * This method is used to spend funds send to htlc keys/delayed keys
-    *
-    * @param tx          input transaction
-    * @param publicKey   extended public key
-    * @param remotePoint remote point
-    * @return a signature generated with a private key generated from the input keys's matching
-    *         private key and the remote point.
-    */
-  def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, remotePoint: PublicKey): ByteVector64
+   * This method is used to spend funds sent to htlc keys/delayed keys
+   *
+   * @param tx          input transaction
+   * @param publicKey   extended public key
+   * @param remotePoint remote point
+   * @param sighashType sighash flags
+   * @return a signature generated with a private key generated from the input keys's matching
+   *         private key and the remote point.
+   */
+  def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, remotePoint: PublicKey, sighashType: Int): ByteVector64
 
   /**
-    * Ths method is used to spend revoked transactions, with the corresponding revocation key
-    *
-    * @param tx           input transaction
-    * @param publicKey    extended public key
-    * @param remoteSecret remote secret
-    * @return a signature generated with a private key generated from the input keys's matching
-    *         private key and the remote secret.
-    */
+   * Ths method is used to spend revoked transactions, with the corresponding revocation key
+   *
+   * @param tx           input transaction
+   * @param publicKey    extended public key
+   * @param remoteSecret remote secret
+   * @return a signature generated with a private key generated from the input keys's matching
+   *         private key and the remote secret.
+   */
   def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, remoteSecret: PrivateKey): ByteVector64
 
   /**
-    * Sign a channel announcement message
-    *
-    * @param fundingKeyPath BIP32 path of the funding public key
-    * @param chainHash chain hash
-    * @param shortChannelId short channel id
-    * @param remoteNodeId remote node id
-    * @param remoteFundingKey remote funding pubkey
-    * @param features channel features
-    * @return a (nodeSig, bitcoinSig) pair. nodeSig is the signature of the channel announcement with our node's
-    *         private key, bitcoinSig is the signature of the channel announcement with our funding private key
-    */
+   * Sign a channel announcement message
+   *
+   * @param fundingKeyPath   BIP32 path of the funding public key
+   * @param chainHash        chain hash
+   * @param shortChannelId   short channel id
+   * @param remoteNodeId     remote node id
+   * @param remoteFundingKey remote funding pubkey
+   * @param features         channel features
+   * @return a (nodeSig, bitcoinSig) pair. nodeSig is the signature of the channel announcement with our node's
+   *         private key, bitcoinSig is the signature of the channel announcement with our funding private key
+   */
   def signChannelAnnouncement(fundingKeyPath: DeterministicWallet.KeyPath, chainHash: ByteVector32, shortChannelId: ShortChannelId, remoteNodeId: PublicKey, remoteFundingKey: PublicKey, features: Features): (ByteVector64, ByteVector64)
 }
 
 object KeyManager {
   /**
-    * Create a BIP32 path from a public key. This path will be used to derive channel keys. 
-    * Having channel keys derived from the funding public keys makes it very easy to retrieve your funds when've you've lost your data:
-    * - connect to your peer and use DLP to get them to publish their remote commit tx
-    * - retrieve the commit tx from the bitcoin network, extract your funding pubkey from its witness data
-    * - recompute your channel keys and spend your output  
-    *
-    * @param fundingPubKey funding public key
-    * @return a BIP32 path
-    */
-  def channelKeyPath(fundingPubKey: PublicKey) : DeterministicWallet.KeyPath = {
+   * Create a BIP32 path from a public key. This path will be used to derive channel keys.
+   * Having channel keys derived from the funding public keys makes it very easy to retrieve your funds when've you've lost your data:
+   * - connect to your peer and use DLP to get them to publish their remote commit tx
+   * - retrieve the commit tx from the bitcoin network, extract your funding pubkey from its witness data
+   * - recompute your channel keys and spend your output
+   *
+   * @param fundingPubKey funding public key
+   * @return a BIP32 path
+   */
+  def channelKeyPath(fundingPubKey: PublicKey): DeterministicWallet.KeyPath = {
     val buffer = Crypto.sha256(fundingPubKey.value)
     val bis = new ByteArrayInputStream(buffer.toArray)
+
     def next() = Protocol.uint32(bis, ByteOrder.BIG_ENDIAN)
+
     DeterministicWallet.KeyPath(Seq(next(), next(), next(), next(), next(), next(), next(), next()))
   }
 
-  def channelKeyPath(fundingPubKey: DeterministicWallet.ExtendedPublicKey) : DeterministicWallet.KeyPath = channelKeyPath(fundingPubKey.publicKey)
+  def channelKeyPath(fundingPubKey: DeterministicWallet.ExtendedPublicKey): DeterministicWallet.KeyPath = channelKeyPath(fundingPubKey.publicKey)
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
@@ -32,7 +32,6 @@ object LocalKeyManager {
     case Block.LivenetGenesisBlock.hash => DeterministicWallet.hardened(47) :: DeterministicWallet.hardened(1) :: Nil
   }
 
-
   // WARNING: if you change this path, you will change your node id even if the seed remains the same!!!
   // Note that the node path and the above channel path are on different branches so even if the
   // node key is compromised there is no way to retrieve the wallet keys
@@ -43,11 +42,11 @@ object LocalKeyManager {
 }
 
 /**
-  * This class manages secrets and private keys.
-  * It exports points and public keys, and provides signing methods
-  *
-  * @param seed seed from which keys will be derived
-  */
+ * This class manages secrets and private keys.
+ * It exports points and public keys, and provides signing methods
+ *
+ * @param seed seed from which keys will be derived
+ */
 class LocalKeyManager(seed: ByteVector, chainHash: ByteVector32) extends KeyManager {
   private val master = DeterministicWallet.generate(seed)
 
@@ -57,14 +56,14 @@ class LocalKeyManager(seed: ByteVector, chainHash: ByteVector32) extends KeyMana
   private val privateKeys: LoadingCache[KeyPath, ExtendedPrivateKey] = CacheBuilder.newBuilder()
     .maximumSize(6 * 200) // 6 keys per channel * 200 channels
     .build[KeyPath, ExtendedPrivateKey](new CacheLoader[KeyPath, ExtendedPrivateKey] {
-    override def load(keyPath: KeyPath): ExtendedPrivateKey = derivePrivateKey(master, keyPath)
-  })
+      override def load(keyPath: KeyPath): ExtendedPrivateKey = derivePrivateKey(master, keyPath)
+    })
 
   private val publicKeys: LoadingCache[KeyPath, ExtendedPublicKey] = CacheBuilder.newBuilder()
     .maximumSize(6 * 200) // 6 keys per channel * 200 channels
     .build[KeyPath, ExtendedPublicKey](new CacheLoader[KeyPath, ExtendedPublicKey] {
-    override def load(keyPath: KeyPath): ExtendedPublicKey = publicKey(privateKeys.get(keyPath))
-  })
+      override def load(keyPath: KeyPath): ExtendedPublicKey = publicKey(privateKeys.get(keyPath))
+    })
 
   private def internalKeyPath(channelKeyPath: DeterministicWallet.KeyPath, index: Long): List[Long] = (LocalKeyManager.channelKeyBasePath(chainHash) ++ channelKeyPath.path) :+ index
 
@@ -82,7 +81,9 @@ class LocalKeyManager(seed: ByteVector, chainHash: ByteVector32) extends KeyMana
 
   override def newFundingKeyPath(isFunder: Boolean): KeyPath = {
     val last = DeterministicWallet.hardened(if (isFunder) 1 else 0)
+
     def next() = secureRandom.nextInt() & 0xFFFFFFFFL
+
     DeterministicWallet.KeyPath(Seq(next(), next(), next(), next(), next(), next(), next(), next(), last))
   }
 
@@ -101,42 +102,41 @@ class LocalKeyManager(seed: ByteVector, chainHash: ByteVector32) extends KeyMana
   override def commitmentPoint(channelKeyPath: DeterministicWallet.KeyPath, index: Long) = Generators.perCommitPoint(shaSeed(channelKeyPath), index)
 
   /**
-    *
-    * @param tx        input transaction
-    * @param publicKey extended public key
-    * @return a signature generated with the private key that matches the input
-    *         extended public key
-    */
+   * @param tx        input transaction
+   * @param publicKey extended public key
+   * @return a signature generated with the private key that matches the input
+   *         extended public key
+   */
   def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey): ByteVector64 = {
     val privateKey = privateKeys.get(publicKey.path)
     Transactions.sign(tx, privateKey.privateKey)
   }
 
   /**
-    * This method is used to spend funds send to htlc keys/delayed keys
-    *
-    * @param tx          input transaction
-    * @param publicKey   extended public key
-    * @param remotePoint remote point
-    * @return a signature generated with a private key generated from the input keys's matching
-    *         private key and the remote point.
-    */
-  def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, remotePoint: PublicKey): ByteVector64 = {
+   * This method is used to spend funds sent to htlc keys/delayed keys
+   *
+   * @param tx          input transaction
+   * @param publicKey   extended public key
+   * @param remotePoint remote point
+   * @param sighashType sighash flags
+   * @return a signature generated with a private key generated from the input keys's matching
+   *         private key and the remote point.
+   */
+  def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, remotePoint: PublicKey, sighashType: Int): ByteVector64 = {
     val privateKey = privateKeys.get(publicKey.path)
     val currentKey = Generators.derivePrivKey(privateKey.privateKey, remotePoint)
-    Transactions.sign(tx, currentKey)
+    Transactions.sign(tx, currentKey, sighashType)
   }
 
-  
   /**
-    * Ths method is used to spend revoked transactions, with the corresponding revocation key
-    *
-    * @param tx           input transaction
-    * @param publicKey    extended public key
-    * @param remoteSecret remote secret
-    * @return a signature generated with a private key generated from the input keys's matching
-    *         private key and the remote secret.
-    */
+   * Ths method is used to spend revoked transactions, with the corresponding revocation key
+   *
+   * @param tx           input transaction
+   * @param publicKey    extended public key
+   * @param remoteSecret remote secret
+   * @return a signature generated with a private key generated from the input keys's matching
+   *         private key and the remote secret.
+   */
   def sign(tx: TransactionWithInputInfo, publicKey: ExtendedPublicKey, remoteSecret: PrivateKey): ByteVector64 = {
     val privateKey = privateKeys.get(publicKey.path)
     val currentKey = Generators.revocationPrivKey(privateKey.privateKey, remoteSecret)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -47,7 +47,6 @@ package object eclair {
 
   def toLongId(fundingTxHash: ByteVector32, fundingOutputIndex: Int): ByteVector32 = {
     require(fundingOutputIndex < 65536, "fundingOutputIndex must not be greater than FFFF")
-    require(fundingTxHash.size == 32, "fundingTxHash must be of length 32B")
     val channelId = ByteVector32(fundingTxHash.take(30) :+ (fundingTxHash(30) ^ (fundingOutputIndex >> 8)).toByte :+ (fundingTxHash(31) ^ fundingOutputIndex).toByte)
     channelId
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
@@ -36,7 +36,7 @@ object Scripts {
    */
   def der(sig: ByteVector64, sighash: Int = SIGHASH_ALL): ByteVector = Crypto.compact2der(sig) :+ sighash.toByte
 
-  def htlcRemoteSighash(commitmentFormat: CommitmentFormat): Int = commitmentFormat match {
+  private def htlcRemoteSighash(commitmentFormat: CommitmentFormat): Int = commitmentFormat match {
     case DefaultCommitmentFormat => SIGHASH_ALL
     case AnchorOutputsCommitmentFormat => SIGHASH_SINGLE | SIGHASH_ANYONECANPAY
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
@@ -31,10 +31,10 @@ object Scripts {
   /**
    * Convert a raw ECDSA signature (r,s) to a der-encoded signature that can be used in bitcoin scripts.
    *
-   * @param sig     raw ECDSA signature (r,s)
-   * @param sighash sighash flags
+   * @param sig         raw ECDSA signature (r,s)
+   * @param sighashType sighash flags
    */
-  def der(sig: ByteVector64, sighash: Int = SIGHASH_ALL): ByteVector = Crypto.compact2der(sig) :+ sighash.toByte
+  def der(sig: ByteVector64, sighashType: Int = SIGHASH_ALL): ByteVector = Crypto.compact2der(sig) :+ sighashType.toByte
 
   private def htlcRemoteSighash(commitmentFormat: CommitmentFormat): Int = commitmentFormat match {
     case DefaultCommitmentFormat => SIGHASH_ALL

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -727,15 +727,15 @@ object Transactions {
   val PlaceHolderSig = ByteVector64(ByteVector.fill(64)(0xaa))
   assert(der(PlaceHolderSig).size == 72)
 
-  private def sign(tx: Transaction, redeemScript: ByteVector, amount: Satoshi, key: PrivateKey, sighash: Int): ByteVector64 = {
-    val sigDER = Transaction.signInput(tx, inputIndex = 0, redeemScript, sighash, amount, SIGVERSION_WITNESS_V0, key)
+  private def sign(tx: Transaction, redeemScript: ByteVector, amount: Satoshi, key: PrivateKey, sighashType: Int): ByteVector64 = {
+    val sigDER = Transaction.signInput(tx, inputIndex = 0, redeemScript, sighashType, amount, SIGVERSION_WITNESS_V0, key)
     val sig64 = Crypto.der2compact(sigDER)
     sig64
   }
 
-  def sign(txinfo: TransactionWithInputInfo, key: PrivateKey, sighash: Int): ByteVector64 = {
+  def sign(txinfo: TransactionWithInputInfo, key: PrivateKey, sighashType: Int): ByteVector64 = {
     require(txinfo.tx.txIn.lengthCompare(1) == 0, "only one input allowed")
-    sign(txinfo.tx, txinfo.input.redeemScript, txinfo.input.txOut.amount, key, sighash)
+    sign(txinfo.tx, txinfo.input.redeemScript, txinfo.input.txOut.amount, key, sighashType)
   }
 
   def sign(txinfo: TransactionWithInputInfo, key: PrivateKey, txOwner: TxOwner, commitmentFormat: CommitmentFormat): ByteVector64 = sign(txinfo, key, txinfo.sighash(txOwner, commitmentFormat))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -788,8 +788,8 @@ object Transactions {
   def checkSpendable(txinfo: TransactionWithInputInfo): Try[Unit] =
     Try(Transaction.correctlySpends(txinfo.tx, Map(txinfo.tx.txIn.head.outPoint -> txinfo.input.txOut), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS))
 
-  def checkSig(txinfo: TransactionWithInputInfo, sig: ByteVector64, pubKey: PublicKey): Boolean = {
-    val data = Transaction.hashForSigning(txinfo.tx, inputIndex = 0, txinfo.input.redeemScript, SIGHASH_ALL, txinfo.input.txOut.amount, SIGVERSION_WITNESS_V0)
+  def checkSig(txinfo: TransactionWithInputInfo, sig: ByteVector64, pubKey: PublicKey, sighashType: Int): Boolean = {
+    val data = Transaction.hashForSigning(txinfo.tx, inputIndex = 0, txinfo.input.redeemScript, sighashType, txinfo.input.txOut.amount, SIGVERSION_WITNESS_V0)
     Crypto.verifySignature(data, sig, pubKey)
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -72,6 +72,13 @@ object Transactions {
     def apply(outPoint: OutPoint, txOut: TxOut, redeemScript: Seq[ScriptElt]) = new InputInfo(outPoint, txOut, Script.write(redeemScript))
   }
 
+  /** Owner of a given transaction (local/remote). */
+  sealed trait TxOwner
+  object TxOwner {
+    case object Local extends TxOwner
+    case object Remote extends TxOwner
+  }
+
   sealed trait TransactionWithInputInfo {
     def input: InputInfo
     def tx: Transaction
@@ -80,11 +87,22 @@ object Transactions {
       val vsize = (tx.weight() + 3) / 4
       Satoshi(fr.acinq.eclair.MinimumRelayFeeRate * vsize / 1000)
     }
+    /** Sighash flags to use when signing the transaction. */
+    def sighash(txOwner: TxOwner, commitmentFormat: CommitmentFormat): Int = SIGHASH_ALL
   }
 
   case class CommitTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
-  case class HtlcSuccessTx(input: InputInfo, tx: Transaction, paymentHash: ByteVector32) extends TransactionWithInputInfo
-  case class HtlcTimeoutTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
+  sealed trait HtlcTx extends TransactionWithInputInfo {
+    override def sighash(txOwner: TxOwner, commitmentFormat: CommitmentFormat): Int = commitmentFormat match {
+      case DefaultCommitmentFormat => SIGHASH_ALL
+      case AnchorOutputsCommitmentFormat => txOwner match {
+        case TxOwner.Local => SIGHASH_ALL
+        case TxOwner.Remote => SIGHASH_SINGLE | SIGHASH_ANYONECANPAY
+      }
+    }
+  }
+  case class HtlcSuccessTx(input: InputInfo, tx: Transaction, paymentHash: ByteVector32) extends HtlcTx
+  case class HtlcTimeoutTx(input: InputInfo, tx: Transaction) extends HtlcTx
   case class ClaimHtlcSuccessTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
   case class ClaimHtlcTimeoutTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
   case class ClaimAnchorOutputTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
@@ -709,16 +727,18 @@ object Transactions {
   val PlaceHolderSig = ByteVector64(ByteVector.fill(64)(0xaa))
   assert(der(PlaceHolderSig).size == 72)
 
-  private def sign(tx: Transaction, redeemScript: ByteVector, amount: Satoshi, key: PrivateKey, sighashType: Int): ByteVector64 = {
-    val sigDER = Transaction.signInput(tx, inputIndex = 0, redeemScript, sighashType, amount, SIGVERSION_WITNESS_V0, key)
+  private def sign(tx: Transaction, redeemScript: ByteVector, amount: Satoshi, key: PrivateKey, sighash: Int): ByteVector64 = {
+    val sigDER = Transaction.signInput(tx, inputIndex = 0, redeemScript, sighash, amount, SIGVERSION_WITNESS_V0, key)
     val sig64 = Crypto.der2compact(sigDER)
     sig64
   }
 
-  def sign(txinfo: TransactionWithInputInfo, key: PrivateKey, sighashType: Int = SIGHASH_ALL): ByteVector64 = {
+  def sign(txinfo: TransactionWithInputInfo, key: PrivateKey, sighash: Int): ByteVector64 = {
     require(txinfo.tx.txIn.lengthCompare(1) == 0, "only one input allowed")
-    sign(txinfo.tx, txinfo.input.redeemScript, txinfo.input.txOut.amount, key, sighashType)
+    sign(txinfo.tx, txinfo.input.redeemScript, txinfo.input.txOut.amount, key, sighash)
   }
+
+  def sign(txinfo: TransactionWithInputInfo, key: PrivateKey, txOwner: TxOwner, commitmentFormat: CommitmentFormat): ByteVector64 = sign(txinfo, key, txinfo.sighash(txOwner, commitmentFormat))
 
   def addSigs(commitTx: CommitTx, localFundingPubkey: PublicKey, remoteFundingPubkey: PublicKey, localSig: ByteVector64, remoteSig: ByteVector64): CommitTx = {
     val witness = Scripts.witness2of2(localSig, remoteSig, localFundingPubkey, remoteFundingPubkey)
@@ -788,8 +808,9 @@ object Transactions {
   def checkSpendable(txinfo: TransactionWithInputInfo): Try[Unit] =
     Try(Transaction.correctlySpends(txinfo.tx, Map(txinfo.tx.txIn.head.outPoint -> txinfo.input.txOut), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS))
 
-  def checkSig(txinfo: TransactionWithInputInfo, sig: ByteVector64, pubKey: PublicKey, sighashType: Int): Boolean = {
-    val data = Transaction.hashForSigning(txinfo.tx, inputIndex = 0, txinfo.input.redeemScript, sighashType, txinfo.input.txOut.amount, SIGVERSION_WITNESS_V0)
+  def checkSig(txinfo: TransactionWithInputInfo, sig: ByteVector64, pubKey: PublicKey, txOwner: TxOwner, commitmentFormat: CommitmentFormat): Boolean = {
+    val sighash = txinfo.sighash(txOwner, commitmentFormat)
+    val data = Transaction.hashForSigning(txinfo.tx, inputIndex = 0, txinfo.input.redeemScript, sighash, txinfo.input.txOut.amount, SIGVERSION_WITNESS_V0)
     Crypto.verifySignature(data, sig, pubKey)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
@@ -61,7 +61,6 @@ class FeaturesSpec extends AnyFunSuite {
     assert(Features(hex"2000").hasFeature(StaticRemoteKey, Some(Optional)))
   }
 
-
   test("features dependencies") {
     val testCases = Map(
       bin"                        " -> true,
@@ -82,7 +81,14 @@ class FeaturesSpec extends AnyFunSuite {
       bin"000000101000000000000000" -> true, // we allow not setting var_onion_optin
       bin"000000011000000000000000" -> true, // we allow not setting var_onion_optin
       bin"000000011000001000000000" -> true,
-      bin"000000100100000100000000" -> true
+      bin"000000100100000100000000" -> true,
+      // option_anchor_outputs depends on option_static_remotekey
+      bin"001000000000000000000000" -> false,
+      bin"000100000000000000000000" -> false,
+      bin"001000000010000000000000" -> true,
+      bin"001000000001000000000000" -> true,
+      bin"000100000010000000000000" -> true,
+      bin"000100000001000000000000" -> true
     )
 
     for ((testCase, valid) <- testCases) {
@@ -112,6 +118,8 @@ class FeaturesSpec extends AnyFunSuite {
     assert(areSupported(Features(Set(ActivatedFeature(BasicMultiPartPayment, Optional)))))
     assert(areSupported(Features(Set(ActivatedFeature(Wumbo, Mandatory)))))
     assert(areSupported(Features(Set(ActivatedFeature(Wumbo, Optional)))))
+    assert(!areSupported(Features(Set(ActivatedFeature(AnchorOutputs, Mandatory))))) // NB: we're not ready to fully support anchor outputs
+    assert(areSupported(Features(Set(ActivatedFeature(AnchorOutputs, Optional)))))
 
     val testCases = Map(
       bin"            00000000000000001011" -> true,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/ChannelTypesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/ChannelTypesSpec.scala
@@ -1,12 +1,48 @@
 package fr.acinq.eclair.channel
 
+import fr.acinq.eclair.transactions.Transactions
 import org.scalatest.funsuite.AnyFunSuite
 
 class ChannelTypesSpec extends AnyFunSuite {
+
   test("standard channel features include deterministic channel key path") {
     assert(!ChannelVersion.ZEROES.hasPubkeyKeyPath)
     assert(ChannelVersion.STANDARD.hasPubkeyKeyPath)
     assert(ChannelVersion.STATIC_REMOTEKEY.hasStaticRemotekey)
     assert(ChannelVersion.STATIC_REMOTEKEY.hasPubkeyKeyPath)
   }
+
+  test("anchor outputs includes static remote key") {
+    assert(ChannelVersion.ANCHOR_OUTPUTS.hasPubkeyKeyPath)
+    assert(ChannelVersion.ANCHOR_OUTPUTS.hasStaticRemotekey)
+  }
+
+  test("channel version determines commitment format") {
+    assert(ChannelVersion.ZEROES.commitmentFormat === Transactions.DefaultCommitmentFormat)
+    assert(ChannelVersion.STANDARD.commitmentFormat === Transactions.DefaultCommitmentFormat)
+    assert(ChannelVersion.STATIC_REMOTEKEY.commitmentFormat === Transactions.DefaultCommitmentFormat)
+    assert(ChannelVersion.ANCHOR_OUTPUTS.commitmentFormat === Transactions.AnchorOutputsCommitmentFormat)
+  }
+
+  test("pick channel version based on local and remote features") {
+    import fr.acinq.eclair.FeatureSupport._
+    import fr.acinq.eclair.Features._
+    import fr.acinq.eclair.{ActivatedFeature, Features}
+
+    case class TestCase(localFeatures: Features, remoteFeatures: Features, expectedChannelVersion: ChannelVersion)
+    val testCases = Seq(
+      TestCase(Features.empty, Features.empty, ChannelVersion.STANDARD),
+      TestCase(Features(Set(ActivatedFeature(StaticRemoteKey, Optional))), Features.empty, ChannelVersion.STANDARD),
+      TestCase(Features.empty, Features(Set(ActivatedFeature(StaticRemoteKey, Optional))), ChannelVersion.STANDARD),
+      TestCase(Features(Set(ActivatedFeature(StaticRemoteKey, Optional))), Features(Set(ActivatedFeature(StaticRemoteKey, Optional))), ChannelVersion.STATIC_REMOTEKEY),
+      TestCase(Features(Set(ActivatedFeature(StaticRemoteKey, Optional))), Features(Set(ActivatedFeature(StaticRemoteKey, Mandatory))), ChannelVersion.STATIC_REMOTEKEY),
+      TestCase(Features(Set(ActivatedFeature(StaticRemoteKey, Optional), ActivatedFeature(AnchorOutputs, Optional))), Features(Set(ActivatedFeature(StaticRemoteKey, Optional))), ChannelVersion.STATIC_REMOTEKEY),
+      TestCase(Features(Set(ActivatedFeature(StaticRemoteKey, Mandatory), ActivatedFeature(AnchorOutputs, Optional))), Features(Set(ActivatedFeature(StaticRemoteKey, Optional), ActivatedFeature(AnchorOutputs, Optional))), ChannelVersion.ANCHOR_OUTPUTS)
+    )
+
+    for (testCase <- testCases) {
+      assert(ChannelVersion.pickChannelVersion(testCase.localFeatures, testCase.remoteFeatures) === testCase.expectedChannelVersion)
+    }
+  }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/RecoverySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/RecoverySpec.scala
@@ -8,7 +8,7 @@ import fr.acinq.eclair.blockchain.WatchEventSpent
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.crypto.{Generators, KeyManager}
 import fr.acinq.eclair.transactions.Scripts
-import fr.acinq.eclair.transactions.Transactions.{ClaimP2WPKHOutputTx, InputInfo}
+import fr.acinq.eclair.transactions.Transactions.{ClaimP2WPKHOutputTx, DefaultCommitmentFormat, InputInfo, TxOwner}
 import fr.acinq.eclair.wire.{ChannelReestablish, CommitSig, Error, Init, RevokeAndAck}
 import fr.acinq.eclair.{TestConstants, TestKitBaseClass, _}
 import org.scalatest.Outcome
@@ -117,7 +117,8 @@ class RecoverySpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Sta
       ClaimP2WPKHOutputTx(InputInfo(OutPoint(bobCommitTx, bobCommitTx.txOut.indexOf(ourOutput)), ourOutput, Script.pay2pkh(ourToRemotePubKey)), tx),
       keyManager.paymentPoint(channelKeyPath),
       ce.myCurrentPerCommitmentPoint,
-      SIGHASH_ALL)
+      TxOwner.Local,
+      DefaultCommitmentFormat)
     val tx1 = tx.updateWitness(0, ScriptWitness(Scripts.der(sig) :: ourToRemotePubKey.value :: Nil))
     Transaction.correctlySpends(tx1, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/RecoverySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/RecoverySpec.scala
@@ -116,7 +116,8 @@ class RecoverySpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Sta
     val sig = keyManager.sign(
       ClaimP2WPKHOutputTx(InputInfo(OutPoint(bobCommitTx, bobCommitTx.txOut.indexOf(ourOutput)), ourOutput, Script.pay2pkh(ourToRemotePubKey)), tx),
       keyManager.paymentPoint(channelKeyPath),
-      ce.myCurrentPerCommitmentPoint)
+      ce.myCurrentPerCommitmentPoint,
+      SIGHASH_ALL)
     val tx1 = tx.updateWitness(0, ScriptWitness(Scripts.der(sig) :: ourToRemotePubKey.value :: Nil))
     Transaction.correctlySpends(tx1, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptChannelStateSpec.scala
@@ -29,7 +29,7 @@ import fr.acinq.eclair.wire.{AcceptChannel, ChannelTlv, Error, Init, OpenChannel
 import fr.acinq.eclair.{ActivatedFeature, CltvExpiryDelta, Features, LongToBtcAmount, TestConstants, TestKitBaseClass}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.{Outcome, Tag}
-import scodec.bits.{ByteVector, HexStringSyntax}
+import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise}
@@ -66,7 +66,7 @@ class WaitForAcceptChannelStateSpec extends TestKitBaseClass with FixtureAnyFunS
     val aliceInit = Init(aliceParams.features)
     val bobInit = Init(bobParams.features)
     within(30 seconds) {
-      val fundingAmount = if(test.tags.contains("wumbo")) Btc(5).toSatoshi else TestConstants.fundingSatoshis
+      val fundingAmount = if (test.tags.contains("wumbo")) Btc(5).toSatoshi else TestConstants.fundingSatoshis
       alice ! INPUT_INIT_FUNDER(ByteVector32.Zeroes, fundingAmount, TestConstants.pushMsat, TestConstants.feeratePerKw, TestConstants.feeratePerKw, aliceParams, alice2bob.ref, bobInit, ChannelFlags.Empty, channelVersion)
       bob ! INPUT_INIT_FUNDEE(ByteVector32.Zeroes, bobParams, bob2alice.ref, aliceInit)
       alice2bob.expectMsgType[OpenChannel]
@@ -160,7 +160,7 @@ class WaitForAcceptChannelStateSpec extends TestKitBaseClass with FixtureAnyFunS
     awaitCond(alice.stateName == CLOSED)
   }
 
-  test("recv AcceptChannel (wumbo size channel)", Tag("wumbo"), Tag("high-max-funding-size"))  { f =>
+  test("recv AcceptChannel (wumbo size channel)", Tag("wumbo"), Tag("high-max-funding-size")) { f =>
     import f._
     val accept = bob2alice.expectMsgType[AcceptChannel]
     assert(accept.minimumDepth == 13) // with wumbo tag we use fundingSatoshis=5BTC

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -50,11 +50,11 @@ import fr.acinq.eclair.router.Graph.WeightRatios
 import fr.acinq.eclair.router.RouteCalculation.ROUTE_MAX_LENGTH
 import fr.acinq.eclair.router.Router.{GossipDecision, MultiPartParams, PublicChannel, RouteParams, NORMAL => _, State => _}
 import fr.acinq.eclair.router.{Announcements, AnnouncementsBatchValidationSpec, Router}
-import fr.acinq.eclair.transactions.Transactions
+import fr.acinq.eclair.transactions.{Scripts, Transactions}
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{CltvExpiryDelta, Kit, LongToBtcAmount, MilliSatoshi, Setup, ShortChannelId, TestKitBaseClass, randomBytes32}
 import grizzled.slf4j.Logging
-import org.json4s.DefaultFormats
+import org.json4s.{DefaultFormats, Formats}
 import org.json4s.JsonAST.{JString, JValue}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuiteLike
@@ -125,8 +125,11 @@ class IntegrationSpec extends TestKitBaseClass with BitcoindService with AnyFunS
     s"eclair.features.${StaticRemoteKey.rfcName}" -> "optional"
   ).asJava))
 
+  val withAnchorOutputs = withStaticRemoteKey.withFallback(ConfigFactory.parseMap(Map(
+    s"eclair.features.${AnchorOutputs.rfcName}" -> "optional"
+  ).asJava))
 
-  implicit val formats = DefaultFormats
+  implicit val formats: Formats = DefaultFormats
 
   override def beforeAll: Unit = {
     startBitcoind()
@@ -172,15 +175,15 @@ class IntegrationSpec extends TestKitBaseClass with BitcoindService with AnyFunS
   test("starting eclair nodes") {
     instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.node-alias" -> "A", "eclair.expiry-delta-blocks" -> 130, "eclair.server.port" -> 29730, "eclair.api.port" -> 28080, "eclair.channel-flags" -> 0).asJava).withFallback(commonFeatures).withFallback(commonConfig)) // A's channels are private
     instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.node-alias" -> "B", "eclair.expiry-delta-blocks" -> 131, "eclair.server.port" -> 29731, "eclair.api.port" -> 28081, "eclair.trampoline-payments-enable" -> true).asJava).withFallback(commonFeatures).withFallback(commonConfig))
-    instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.expiry-delta-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082, "eclair.trampoline-payments-enable" -> true).asJava).withFallback(withStaticRemoteKey).withFallback(withWumbo).withFallback(commonConfig))
+    instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.node-alias" -> "C", "eclair.expiry-delta-blocks" -> 132, "eclair.server.port" -> 29732, "eclair.api.port" -> 28082, "eclair.trampoline-payments-enable" -> true).asJava).withFallback(withAnchorOutputs).withFallback(withWumbo).withFallback(commonConfig))
     instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.node-alias" -> "D", "eclair.expiry-delta-blocks" -> 133, "eclair.server.port" -> 29733, "eclair.api.port" -> 28083, "eclair.trampoline-payments-enable" -> true).asJava).withFallback(commonFeatures).withFallback(commonConfig))
-    instantiateEclairNode("E", ConfigFactory.parseMap(Map("eclair.node-alias" -> "E", "eclair.expiry-delta-blocks" -> 134, "eclair.server.port" -> 29734, "eclair.api.port" -> 28084).asJava).withFallback(commonConfig))
+    instantiateEclairNode("E", ConfigFactory.parseMap(Map("eclair.node-alias" -> "E", "eclair.expiry-delta-blocks" -> 134, "eclair.server.port" -> 29734, "eclair.api.port" -> 28084).asJava).withFallback(withAnchorOutputs).withFallback(commonConfig))
     instantiateEclairNode("F1", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F1", "eclair.expiry-delta-blocks" -> 135, "eclair.server.port" -> 29735, "eclair.api.port" -> 28085).asJava).withFallback(withWumbo).withFallback(commonConfig))
     instantiateEclairNode("F2", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F2", "eclair.expiry-delta-blocks" -> 136, "eclair.server.port" -> 29736, "eclair.api.port" -> 28086).asJava).withFallback(commonConfig))
     instantiateEclairNode("F3", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F3", "eclair.expiry-delta-blocks" -> 137, "eclair.server.port" -> 29737, "eclair.api.port" -> 28087, "eclair.trampoline-payments-enable" -> true).asJava).withFallback(commonFeatures).withFallback(commonConfig))
     instantiateEclairNode("F4", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F4", "eclair.expiry-delta-blocks" -> 138, "eclair.server.port" -> 29738, "eclair.api.port" -> 28088).asJava).withFallback(commonConfig))
     instantiateEclairNode("F5", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F5", "eclair.expiry-delta-blocks" -> 139, "eclair.server.port" -> 29739, "eclair.api.port" -> 28089).asJava).withFallback(commonConfig))
-    instantiateEclairNode("F6", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F6", "eclair.expiry-delta-blocks" -> 140, "eclair.server.port" -> 29740, "eclair.api.port" -> 28090).asJava).withFallback(withStaticRemoteKey).withFallback(commonConfig)) // supports optional option_static_remotekey
+    instantiateEclairNode("F6", ConfigFactory.parseMap(Map("eclair.node-alias" -> "F6", "eclair.expiry-delta-blocks" -> 140, "eclair.server.port" -> 29740, "eclair.api.port" -> 28090).asJava).withFallback(withAnchorOutputs).withFallback(commonConfig))
     instantiateEclairNode("G", ConfigFactory.parseMap(Map("eclair.node-alias" -> "G", "eclair.expiry-delta-blocks" -> 141, "eclair.server.port" -> 29741, "eclair.api.port" -> 28091, "eclair.fee-base-msat" -> 1010, "eclair.fee-proportional-millionths" -> 102, "eclair.trampoline-payments-enable" -> true).asJava).withFallback(commonConfig))
 
     // by default C has a normal payment handler, but this can be overridden in tests
@@ -860,10 +863,10 @@ class IntegrationSpec extends TestKitBaseClass with BitcoindService with AnyFunS
     assert(outgoingPayments.forall(p => p.status.isInstanceOf[OutgoingPaymentStatus.Failed]), outgoingPayments)
   }
 
-  test("send payments and close the channel C -> F6 with option_static_remotekey") {
+  test("send payments and close the channel C -> F6 with option_anchor_outputs/option_static_remotekey") {
     // initially all the balance is on C side and F6 doesn't have an output
     val sender = TestProbe()
-    sender.send(nodes("F6").register, 'channelsTo)
+    sender.send(nodes("F6").register, Symbol("channelsTo"))
     // retrieve the channelId of C <--> F6
     val Some(channelId) = sender.expectMsgType[Map[ByteVector32, PublicKey]].find(_._2 == nodes("C").nodeParams.nodeId).map(_._1)
 
@@ -871,8 +874,8 @@ class IntegrationSpec extends TestKitBaseClass with BitcoindService with AnyFunS
     val initialStateDataF6 = sender.expectMsgType[DATA_NORMAL]
     val initialCommitmentIndex = initialStateDataF6.commitments.localCommit.index
 
-    // the 'to remote' address is a simple P2WPKH spending to the remote payment basepoint
-    val toRemoteAddress = Script.pay2wpkh(initialStateDataF6.commitments.remoteParams.paymentBasepoint)
+    // the 'to remote' address is a simple script spending to the remote payment basepoint with a 1-block CSV delay
+    val toRemoteAddress = Script.pay2wsh(Scripts.toRemoteDelayed(initialStateDataF6.commitments.remoteParams.paymentBasepoint))
 
     // toRemote output of C as seen by F6
     val Some(toRemoteOutC) = initialStateDataF6.commitments.localCommit.publishableTxs.commitTx.tx.txOut.find(_.publicKeyScript == Script.write(toRemoteAddress))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
@@ -382,9 +382,7 @@ class PaymentRequestSpec extends AnyFunSuite {
   }
 
   test("supported payment request features") {
-
     case class Result(allowMultiPart: Boolean, requirePaymentSecret: Boolean, areSupported: Boolean) // "supported" is based on the "it's okay to be odd" rule"
-
     val featureBits = Map(
       PaymentRequestFeatures(bin"               00000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = true),
       PaymentRequestFeatures(bin"               00011000001000000000") -> Result(allowMultiPart = true, requirePaymentSecret = false, areSupported = true),
@@ -395,9 +393,9 @@ class PaymentRequestSpec extends AnyFunSuite {
       PaymentRequestFeatures(bin"               01000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = true),
       PaymentRequestFeatures(bin"          0000010000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = true),
       PaymentRequestFeatures(bin"          0000011000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = true),
-      PaymentRequestFeatures(bin"          0000110000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),
+      PaymentRequestFeatures(bin"          0000110000001000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),
       // those are useful for nonreg testing of the areSupported method (which needs to be updated with every new supported mandatory bit)
-      PaymentRequestFeatures(bin"          0000100000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),
+      PaymentRequestFeatures(bin"          0000100000001000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),
       PaymentRequestFeatures(bin"          0010000000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),
       PaymentRequestFeatures(bin"     000001000000000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),
       PaymentRequestFeatures(bin"     000100000000000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TestVectorsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TestVectorsSpec.scala
@@ -425,7 +425,7 @@ class StaticRemoteKeyTestVectorSpec extends TestVectorsSpec {
 class AnchorOutputsTestVectorSpec extends TestVectorsSpec {
   // @formatter:off
   override def filename: String = "/bolt3-tx-test-vectors-anchor-outputs-format.txt"
-  override def channelVersion: ChannelVersion = ChannelVersion.STATIC_REMOTEKEY
+  override def channelVersion: ChannelVersion = ChannelVersion.ANCHOR_OUTPUTS
   override def commitmentFormat: CommitmentFormat = AnchorOutputsCommitmentFormat
   // @formatter:on
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TestVectorsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TestVectorsSpec.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.transactions
 
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
-import fr.acinq.bitcoin.{ByteVector32, Crypto, SIGHASH_ANYONECANPAY, SIGHASH_SINGLE, Script, ScriptFlags, Transaction}
+import fr.acinq.bitcoin.{ByteVector32, Crypto, Script, ScriptFlags, Transaction}
 import fr.acinq.eclair.channel.ChannelVersion
 import fr.acinq.eclair.channel.Helpers.Funding
 import fr.acinq.eclair.crypto.Generators
@@ -200,9 +200,9 @@ trait TestVectorsSpec extends AnyFunSuite with Logging {
         remotePaymentBasePoint = Remote.payment_basepoint,
         localIsFunder = true,
         outputs = outputs)
-      val local_sig = Transactions.sign(tx, Local.funding_privkey)
+      val local_sig = Transactions.sign(tx, Local.funding_privkey, TxOwner.Local, commitmentFormat)
       logger.info(s"# local_signature = ${Scripts.der(local_sig).dropRight(1).toHex}")
-      val remote_sig = Transactions.sign(tx, Remote.funding_privkey)
+      val remote_sig = Transactions.sign(tx, Remote.funding_privkey, TxOwner.Remote, commitmentFormat)
       logger.info(s"remote_signature: ${Scripts.der(remote_sig).dropRight(1).toHex}")
       Transactions.addSigs(tx, Local.funding_pubkey, Remote.funding_pubkey, local_sig, remote_sig)
     }
@@ -239,12 +239,12 @@ trait TestVectorsSpec extends AnyFunSuite with Logging {
 
     htlcTxs.collect {
       case tx: HtlcSuccessTx =>
-        val remoteSig = Transactions.sign(tx, Remote.htlc_privkey, Scripts.htlcRemoteSighash(commitmentFormat))
+        val remoteSig = Transactions.sign(tx, Remote.htlc_privkey, TxOwner.Remote, commitmentFormat)
         val htlcIndex = htlcScripts.indexOf(Script.parse(tx.input.redeemScript))
         logger.info(s"# signature for output ${tx.input.outPoint.index} (htlc $htlcIndex)")
         logger.info(s"remote_htlc_signature: ${Scripts.der(remoteSig).dropRight(1).toHex}")
       case tx: HtlcTimeoutTx =>
-        val remoteSig = Transactions.sign(tx, Remote.htlc_privkey, Scripts.htlcRemoteSighash(commitmentFormat))
+        val remoteSig = Transactions.sign(tx, Remote.htlc_privkey, TxOwner.Remote, commitmentFormat)
         val htlcIndex = htlcScripts.indexOf(Script.parse(tx.input.redeemScript))
         logger.info(s"# signature for output ${tx.input.outPoint.index} (htlc $htlcIndex)")
         logger.info(s"remote_htlc_signature: ${Scripts.der(remoteSig).dropRight(1).toHex}")
@@ -252,8 +252,8 @@ trait TestVectorsSpec extends AnyFunSuite with Logging {
 
     val signedTxs = htlcTxs collect {
       case tx: HtlcSuccessTx =>
-        val localSig = Transactions.sign(tx, Local.htlc_privkey)
-        val remoteSig = Transactions.sign(tx, Remote.htlc_privkey, Scripts.htlcRemoteSighash(commitmentFormat))
+        val localSig = Transactions.sign(tx, Local.htlc_privkey, TxOwner.Local, commitmentFormat)
+        val remoteSig = Transactions.sign(tx, Remote.htlc_privkey, TxOwner.Remote, commitmentFormat)
         val preimage = paymentPreimages.find(p => Crypto.sha256(p) == tx.paymentHash).get
         val tx1 = Transactions.addSigs(tx, localSig, remoteSig, preimage, commitmentFormat)
         Transaction.correctlySpends(tx1.tx, Seq(commitTx.tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
@@ -262,8 +262,8 @@ trait TestVectorsSpec extends AnyFunSuite with Logging {
         logger.info(s"output htlc_success_tx $htlcIndex: ${tx1.tx}")
         tx1
       case tx: HtlcTimeoutTx =>
-        val localSig = Transactions.sign(tx, Local.htlc_privkey)
-        val remoteSig = Transactions.sign(tx, Remote.htlc_privkey, Scripts.htlcRemoteSighash(commitmentFormat))
+        val localSig = Transactions.sign(tx, Local.htlc_privkey, TxOwner.Local, commitmentFormat)
+        val remoteSig = Transactions.sign(tx, Remote.htlc_privkey, TxOwner.Remote, commitmentFormat)
         val tx1 = Transactions.addSigs(tx, localSig, remoteSig, commitmentFormat)
         Transaction.correctlySpends(tx1.tx, Seq(commitTx.tx), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
         logger.info(s"# local_signature = ${Scripts.der(localSig).dropRight(1).toHex}")


### PR DESCRIPTION
With this PR, it's possible to activate anchor outputs and have fully operating channels that use the anchor commitment format.
Interop testing has been done with lnd, and there is only one pending issue during mutual close, where they incorrectly compute the closing amounts (we are discussing this on the spec PR, it should be resolved soon).

However, for the sake of simplicity, this PR doesn't handle unilateral close scenario. This will be done in another, separate PR.
We don't do any kind of automatic fee bumping either; this will be done later, once we have PSBT support and once `bitcoind` offers the `psbtbumpfee` RPC (see https://github.com/bitcoin/bitcoin/pull/18654).
