### PR TITLE
Use file filter for scoverage upload

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,4 +35,4 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
-        directory: eclair-core
+        file: ./eclair-core/target/scoverage.xml


### PR DESCRIPTION
The `directory` configuration is ignored:
![image](https://user-images.githubusercontent.com/2028222/88053818-b8700400-cb5c-11ea-96e2-a311b1194a3d.png)


To my defense, it seems that the [codecov-action documentation](https://github.com/codecov/codecov-action#arguments) is inaccurate.