### PR TITLE
Refactor integration tests

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/ForwardHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/ForwardHandler.scala
@@ -24,5 +24,7 @@ import akka.event.DiagnosticLoggingAdapter
  * Simple handler that forwards all messages to an actor
  */
 class ForwardHandler(actor: ActorRef) extends ReceiveHandler {
-  override def handle(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Receive = { case msg => actor forward msg}
+  override def handle(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Receive = {
+    case msg if !msg.isInstanceOf[ReceiveHandler] => actor forward msg
+  }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/ForwardHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/ForwardHandler.scala
@@ -25,6 +25,6 @@ import akka.event.DiagnosticLoggingAdapter
  */
 class ForwardHandler(actor: ActorRef) extends ReceiveHandler {
   override def handle(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Receive = {
-    case msg if !msg.isInstanceOf[ReceiveHandler] => actor forward msg
+    case msg => actor forward msg
   }
 }

--- a/eclair-core/src/test/resources/logback-test.xml
+++ b/eclair-core/src/test/resources/logback-test.xml
@@ -50,9 +50,9 @@
     <logger name="fr.acinq.eclair.db.FileBackupHandler" level="OFF"/>
 
     <root level="INFO">
-        <!--appender-ref ref="FILE"/>
-        <appender-ref ref="CONSOLEWARN"/>
-        <appender-ref ref="CONSOLE"/-->
+        <!--<appender-ref ref="FILE"/>-->
+        <!--<appender-ref ref="CONSOLEWARN"/>-->
+        <!--<appender-ref ref="CONSOLE"/>-->
     </root>
 
 </configuration>


### PR DESCRIPTION
The IntegrationSpec's force-close tests were very hard to work with; I found out (with great pain) that they relied on many unwritten assumptions about event ordering which made them very brittle and hard to extend (in preparation for anchor outputs).

So I decided to re-work these tests to make them more robust and easier to extend, with the following changes:

- we don't need one node per force-close scenario, we can use different channels to the same node which makes the spec simpler.
- force-close tests now have better isolation: they create the channel at the beginning of the test, and the test ends with that channel closed.
- common parts have been refactored to reduce code duplication.
- force-close tests use `push_msat` to ensure both peers have an output in the commit tx, which wasn't previously tested
