### PR TITLE
Verify feature graph in Init

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -118,15 +118,16 @@ class PeerConnection(nodeParams: NodeParams, switchboard: ActorRef, router: Acto
 
         log.info(s"peer is using features=${remoteInit.features}, networks=${remoteInit.networks.mkString(",")}")
 
-        val featureGraphErr = Features.validateFeatureGraph(remoteInit.features)
+        val featureGraphErr_opt = Features.validateFeatureGraph(remoteInit.features)
         if (remoteInit.networks.nonEmpty && !remoteInit.networks.contains(d.nodeParams.chainHash)) {
           log.warning(s"incompatible networks (${remoteInit.networks}), disconnecting")
           d.pendingAuth.origin_opt.foreach(_ ! ConnectionResult.InitializationFailed("incompatible networks"))
           d.transport ! PoisonPill
           stay
-        } else if (featureGraphErr.nonEmpty) {
-          log.warning(featureGraphErr.get.message)
-          d.pendingAuth.origin_opt.foreach(_ ! ConnectionResult.InitializationFailed(featureGraphErr.get.message))
+        } else if (featureGraphErr_opt.nonEmpty) {
+          val featureGraphErr = featureGraphErr_opt.get
+          log.warning(featureGraphErr.message)
+          d.pendingAuth.origin_opt.foreach(_ ! ConnectionResult.InitializationFailed(featureGraphErr.message))
           d.transport ! PoisonPill
           stay
         } else if (!Features.areSupported(remoteInit.features)) {


### PR DESCRIPTION
If our remote peer doesn't correctly set transitive feature dependencies, we close the connection until they fix it.