### PR TITLE
Remove the `override-features` conf parameter

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -49,7 +49,6 @@ case class NodeParams(keyManager: KeyManager,
                       color: Color,
                       publicAddresses: List[NodeAddress],
                       features: Features,
-                      overrideFeatures: Map[PublicKey, Features],
                       syncWhitelist: Set[PublicKey],
                       dustLimit: Satoshi,
                       onChainFeeConf: OnChainFeeConf,
@@ -199,12 +198,6 @@ object NodeParams {
     val featuresErr = Features.validateFeatureGraph(features)
     require(featuresErr.isEmpty, featuresErr.map(_.message))
 
-    val overrideFeatures: Map[PublicKey, Features] = config.getConfigList("override-features").asScala.map { e =>
-      val p = PublicKey(ByteVector.fromValidHex(e.getString("nodeid")))
-      val f = Features.fromConfiguration(e)
-      p -> f
-    }.toMap
-
     val syncWhitelist: Set[PublicKey] = config.getStringList("sync-whitelist").asScala.map(s => PublicKey(ByteVector.fromValidHex(s))).toSet
 
     val socksProxy_opt = if (config.getBoolean("socks5.enabled")) {
@@ -250,7 +243,6 @@ object NodeParams {
       color = Color(color(0), color(1), color(2)),
       publicAddresses = addresses,
       features = features,
-      overrideFeatures = overrideFeatures,
       syncWhitelist = syncWhitelist,
       dustLimit = dustLimitSatoshis,
       onChainFeeConf = OnChainFeeConf(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -99,10 +99,7 @@ class PeerConnection(nodeParams: NodeParams, switchboard: ActorRef, router: Acto
     case Event(InitializeConnection(peer), d: BeforeInitData) =>
       d.transport ! TransportHandler.Listener(self)
       Metrics.PeerConnectionsConnecting.withTag(Tags.ConnectionState, Tags.ConnectionStates.Initializing).increment()
-      val localFeatures = nodeParams.overrideFeatures.get(d.remoteNodeId) match {
-        case Some(f) => f
-        case None => nodeParams.features.maskFeaturesForEclairMobile()
-      }
+      val localFeatures = nodeParams.features.maskFeaturesForEclairMobile()
       log.info(s"using features=$localFeatures")
       val localInit = wire.Init(localFeatures, TlvStream(InitTlv.Networks(nodeParams.chainHash :: Nil)))
       d.transport ! localInit

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -115,25 +115,6 @@ class StartupSpec extends AnyFunSuite {
     assert(Try(makeNodeParamsWithDefaults(finalizeConf(illegalFeaturesConf))).isFailure)
   }
 
-  test("parse human readable override features") {
-    val perNodeConf = ConfigFactory.parseString(
-      """
-        |  override-features = [ // optional per-node features
-        |      {
-        |        nodeid = "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-        |          features {
-        |             basic_mpp = mandatory
-        |          }
-        |      }
-        |  ]
-      """.stripMargin
-    )
-
-    val nodeParams = makeNodeParamsWithDefaults(perNodeConf.withFallback(defaultConf))
-    val perNodeFeatures = nodeParams.overrideFeatures(PublicKey(ByteVector.fromValidHex("02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")))
-    assert(perNodeFeatures.hasFeature(BasicMultiPartPayment, Some(Mandatory)))
-  }
-
   test("NodeParams should fail if htlc-minimum-msat is set to 0") {
     val noHtlcMinimumConf = ConfigFactory.parseString("htlc-minimum-msat = 0")
     assert(Try(makeNodeParamsWithDefaults(noHtlcMinimumConf.withFallback(defaultConf))).isFailure)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -143,7 +143,6 @@ object TestConstants {
         ActivatedFeature(ChannelRangeQueries, Optional),
         ActivatedFeature(ChannelRangeQueriesExtended, Optional),
         ActivatedFeature(VariableLengthOnion, Optional))),
-      overrideFeatures = Map.empty,
       syncWhitelist = Set.empty,
       dustLimit = 1100 sat,
       onChainFeeConf = OnChainFeeConf(
@@ -232,7 +231,6 @@ object TestConstants {
       color = Color(4, 5, 6),
       publicAddresses = NodeAddress.fromParts("localhost", 9732).get :: Nil,
       features = Features(Set(ActivatedFeature(VariableLengthOnion, Optional))),
-      overrideFeatures = Map.empty,
       syncWhitelist = Set.empty,
       dustLimit = 1000 sat,
       onChainFeeConf = OnChainFeeConf(


### PR DESCRIPTION
The per-node override was only used in the `init` message, and not in
e.g. channel operations, which means it was completely broken.

The use-case for this is Eclair Mobile, because we only sync the routing
table from the ACINQ node (because there is no public channel
validation as it is too expensive on mobile devices).

I'm not sure what to do with this. Should we only have this feature on
the `android` branch?

Related to #1361.