### PR TITLE
Add API commands to sign & verify arbitrary messages

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -74,6 +74,9 @@ object ApiTypes {
 
 trait Eclair {
 
+  // String prefixed when signing arbitrary data to ensure we don't sign sensitive material
+  private val messagePrefix = ByteVector("Lightning Signed Message:".getBytes)
+
   def connect(target: Either[NodeURI, PublicKey])(implicit timeout: Timeout): Future[String]
 
   def disconnect(nodeId: PublicKey)(implicit timeout: Timeout): Future[String]
@@ -138,9 +141,9 @@ trait Eclair {
 
   def onChainTransactions(count: Int, skip: Int): Future[Iterable[WalletTransaction]]
 
-  def signMessage(base64Message: ByteVector): SignedMessage
+  def signMessage(base64Message: ByteVector, prefix: ByteVector = messagePrefix): SignedMessage
 
-  def verifyMessage(base64Message: ByteVector, signature: ByteVector64): VerifiedMessage
+  def verifyMessage(base64Message: ByteVector, signature: ByteVector64, prefix: ByteVector = messagePrefix): VerifiedMessage
 }
 
 class EclairImpl(appKit: Kit) extends Eclair {
@@ -401,11 +404,11 @@ class EclairImpl(appKit: Kit) extends Eclair {
     (appKit.paymentInitiator ? sendPayment).mapTo[UUID]
   }
 
-  override def signMessage(base64Message: ByteVector): SignedMessage = {
+  override def signMessage(base64Message: ByteVector, prefix: ByteVector): SignedMessage = {
     SignedMessage(appKit.nodeParams.privateKey.publicKey, ByteVector.empty, ByteVector64.Zeroes)
   }
 
-  override def verifyMessage(base64Message: ByteVector, signature: ByteVector64): VerifiedMessage = {
+  override def verifyMessage(base64Message: ByteVector, signature: ByteVector64, prefix: ByteVector): VerifiedMessage = {
     VerifiedMessage(false, None)
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -51,7 +51,7 @@ case class AuditResponse(sent: Seq[PaymentSent], received: Seq[PaymentReceived],
 
 case class TimestampQueryFilters(from: Long, to: Long)
 
-case class SignedMessage(nodeId: PublicKey, message: ByteVector, signature: ByteVector64)
+case class SignedMessage(nodeId: PublicKey, message: String, signature: ByteVector64)
 
 case class VerifiedMessage(valid: Boolean, signerNodeId: Option[PublicKey])
 
@@ -407,7 +407,7 @@ class EclairImpl(appKit: Kit) extends Eclair {
   override def signMessage(base64Message: ByteVector, prefix: ByteVector): SignedMessage = {
     val hash256Message = Crypto.hash256(prefix ++ base64Message)
     val signature = appKit.nodeParams.keyManager.signDigest(hash256Message)
-    SignedMessage(appKit.nodeParams.keyManager.nodeId, base64Message, signature)
+    SignedMessage(appKit.nodeParams.keyManager.nodeId, base64Message.toBase64, signature)
   }
 
   override def verifyMessage(base64Message: ByteVector, signature: ByteVector64, prefix: ByteVector): VerifiedMessage = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -411,6 +411,11 @@ class EclairImpl(appKit: Kit) extends Eclair {
   }
 
   override def verifyMessage(base64Message: ByteVector, signature: ByteVector64, prefix: ByteVector): VerifiedMessage = {
-    VerifiedMessage(false, None)
+    val hash256Message = Crypto.hash256(prefix ++ base64Message)
+    val (pubKeyFromSignature, _) = Crypto.recoverPublicKey(signature, hash256Message)
+    if (appKit.nodeParams.db.network.getNode(pubKeyFromSignature).isDefined)
+      VerifiedMessage(true, Some(pubKeyFromSignature))
+    else
+      VerifiedMessage(false, None)
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -416,12 +416,10 @@ class EclairImpl(appKit: Kit) extends Eclair {
     val signature = ByteVector64(recoverableSignature.tail)
     val recoveryId = recoverableSignature.head.toInt - 31
     val pubKeyFromSignature = Crypto.recoverPublicKey(signature, signedBytes, recoveryId)
-    if (!pubKeyFromSignature.isValid)
-      VerifiedMessage(false, None)
-
-    if (Crypto.verifySignature(signedBytes, signature, pubKeyFromSignature))
+    if (Crypto.verifySignature(signedBytes, signature, pubKeyFromSignature)) {
       VerifiedMessage(true, Some(pubKeyFromSignature))
-    else
+    } else {
       VerifiedMessage(false, None)
+    }
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -16,6 +16,7 @@
 
 package fr.acinq.eclair
 
+import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import akka.actor.ActorRef
@@ -69,7 +70,8 @@ object TimestampQueryFilters {
 }
 
 object SignedMessage {
-  def signedBytes(message: ByteVector): ByteVector32 = Crypto.hash256(ByteVector("Lightning Signed Message:".getBytes) ++ message)
+  def signedBytes(message: ByteVector): ByteVector32 =
+    Crypto.hash256(ByteVector("Lightning Signed Message:".getBytes(StandardCharsets.UTF_8)) ++ message)
 }
 
 object ApiTypes {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -405,7 +405,9 @@ class EclairImpl(appKit: Kit) extends Eclair {
   }
 
   override def signMessage(base64Message: ByteVector, prefix: ByteVector): SignedMessage = {
-    SignedMessage(appKit.nodeParams.privateKey.publicKey, ByteVector.empty, ByteVector64.Zeroes)
+    val hash256Message = Crypto.hash256(prefix ++ base64Message)
+    val signature = appKit.nodeParams.keyManager.signDigest(hash256Message)
+    SignedMessage(appKit.nodeParams.keyManager.nodeId, base64Message, signature)
   }
 
   override def verifyMessage(base64Message: ByteVector, signature: ByteVector64, prefix: ByteVector): VerifiedMessage = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -416,6 +416,9 @@ class EclairImpl(appKit: Kit) extends Eclair {
     val signature = ByteVector64(recoverableSignature.tail)
     val recoveryId = recoverableSignature.head.toInt - 31
     val pubKeyFromSignature = Crypto.recoverPublicKey(signature, signedBytes, recoveryId)
+    if (!pubKeyFromSignature.isValid)
+      VerifiedMessage(false, None)
+
     if (Crypto.verifySignature(signedBytes, signature, pubKeyFromSignature))
       VerifiedMessage(true, Some(pubKeyFromSignature))
     else

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -407,7 +407,7 @@ class EclairImpl(appKit: Kit) extends Eclair {
   override def signMessage(base64Message: ByteVector, prefix: ByteVector): SignedMessage = {
     val hash256Message = Crypto.hash256(prefix ++ base64Message)
     val signature = appKit.nodeParams.keyManager.signDigest(hash256Message)
-    SignedMessage(appKit.nodeParams.keyManager.nodeId, base64Message.toBase64, signature)
+    SignedMessage(appKit.nodeParams.nodeId, base64Message.toBase64, signature)
   }
 
   override def verifyMessage(base64Message: ByteVector, signature: ByteVector64, prefix: ByteVector): VerifiedMessage = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -53,7 +53,7 @@ case class TimestampQueryFilters(from: Long, to: Long)
 
 case class SignedMessage(nodeId: PublicKey, message: String, signature: ByteVector)
 
-case class VerifiedMessage(valid: Boolean, signerNodeId: Option[PublicKey])
+case class VerifiedMessage(valid: Boolean, publicKey: PublicKey)
 
 object TimestampQueryFilters {
   /** We use this in the context of timestamp filtering, when we don't need an upper bound. */
@@ -416,10 +416,6 @@ class EclairImpl(appKit: Kit) extends Eclair {
     val signature = ByteVector64(recoverableSignature.tail)
     val recoveryId = recoverableSignature.head.toInt - 31
     val pubKeyFromSignature = Crypto.recoverPublicKey(signature, signedBytes, recoveryId)
-    if (Crypto.verifySignature(signedBytes, signature, pubKeyFromSignature)) {
-      VerifiedMessage(true, Some(pubKeyFromSignature))
-    } else {
-      VerifiedMessage(false, None)
-    }
+    VerifiedMessage(true, pubKeyFromSignature)
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -412,9 +412,11 @@ class EclairImpl(appKit: Kit) extends Eclair {
 
   override def verifyMessage(base64Message: ByteVector, signature: ByteVector64, prefix: ByteVector): VerifiedMessage = {
     val hash256Message = Crypto.hash256(prefix ++ base64Message)
-    val (pubKeyFromSignature, _) = Crypto.recoverPublicKey(signature, hash256Message)
-    if (appKit.nodeParams.db.network.getNode(pubKeyFromSignature).isDefined)
-      VerifiedMessage(true, Some(pubKeyFromSignature))
+    val (pubKey1, pubKey2) = Crypto.recoverPublicKey(signature, hash256Message)
+    if (appKit.nodeParams.db.network.getNode(pubKey1).isDefined)
+      VerifiedMessage(true, Some(pubKey1))
+    else if (appKit.nodeParams.db.network.getNode(pubKey2).isDefined)
+      VerifiedMessage(true, Some(pubKey2))
     else
       VerifiedMessage(false, None)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
@@ -110,6 +110,15 @@ trait KeyManager {
    *         private key, bitcoinSig is the signature of the channel announcement with our funding private key
    */
   def signChannelAnnouncement(fundingKeyPath: DeterministicWallet.KeyPath, chainHash: ByteVector32, shortChannelId: ShortChannelId, remoteNodeId: PublicKey, remoteFundingKey: PublicKey, features: Features): (ByteVector64, ByteVector64)
+
+  /**
+   * Sign a digest, primarily used to prove ownership of the current node
+   *
+   * @param digest     SHA256 digest
+   * @param privateKey private key to sign with, default the one from the current node
+   * @return a signature generated with the private key given in parameter
+   */
+  def signDigest(digest: ByteVector32, privateKey: PrivateKey = nodeKey.privateKey): ByteVector64
 }
 
 object KeyManager {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
@@ -114,6 +114,10 @@ trait KeyManager {
   /**
    * Sign a digest, primarily used to prove ownership of the current node
    *
+   * When recovering a public key from an ECDSA signature for secp256k1, there are 4 possible matching curve points
+   * that can be found. The recoveryId identifies which of these points is the correct one to speed up recovery
+   * (otherwise we would need to check the signature's validity for each of these points to find the correct one).
+   *
    * @param digest     SHA256 digest
    * @param privateKey private key to sign with, default the one from the current node
    * @return a (signature, recoveryId) pair. signature is a signature of the digest parameter generated with the

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
@@ -116,9 +116,10 @@ trait KeyManager {
    *
    * @param digest     SHA256 digest
    * @param privateKey private key to sign with, default the one from the current node
-   * @return a signature generated with the private key given in parameter
+   * @return a (signature, recoveryId) pair. signature is a signature of the digest parameter generated with the
+             private key given in parameter. recoveryId is the corresponding recoveryId of the signature
    */
-  def signDigest(digest: ByteVector32, privateKey: PrivateKey = nodeKey.privateKey): ByteVector64
+  def signDigest(digest: ByteVector32, privateKey: PrivateKey = nodeKey.privateKey): (ByteVector64, Int)
 }
 
 object KeyManager {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/KeyManager.scala
@@ -115,13 +115,12 @@ trait KeyManager {
    * Sign a digest, primarily used to prove ownership of the current node
    *
    * When recovering a public key from an ECDSA signature for secp256k1, there are 4 possible matching curve points
-   * that can be found. The recoveryId identifies which of these points is the correct one to speed up recovery
-   * (otherwise we would need to check the signature's validity for each of these points to find the correct one).
+   * that can be found. The recoveryId identifies which of these points is the correct.
    *
    * @param digest     SHA256 digest
    * @param privateKey private key to sign with, default the one from the current node
    * @return a (signature, recoveryId) pair. signature is a signature of the digest parameter generated with the
-             private key given in parameter. recoveryId is the corresponding recoveryId of the signature
+   *         private key given in parameter. recoveryId is the corresponding recoveryId of the signature
    */
   def signDigest(digest: ByteVector32, privateKey: PrivateKey = nodeKey.privateKey): (ByteVector64, Int)
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
@@ -20,6 +20,7 @@ import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.DeterministicWallet.{derivePrivateKey, _}
 import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Crypto, DeterministicWallet}
+import fr.acinq.eclair.channel.{ChannelVersion, LocalParams}
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.transactions.Transactions.{CommitmentFormat, TransactionWithInputInfo, TxOwner}
@@ -153,4 +154,6 @@ class LocalKeyManager(seed: ByteVector, chainHash: ByteVector32) extends KeyMana
     val localFundingPrivKey = privateKeys.get(fundingKeyPath).privateKey
     Announcements.signChannelAnnouncement(chainHash, shortChannelId, localNodeSecret, remoteNodeId, localFundingPrivKey, remoteFundingKey, features)
   }
+
+  override def signDigest(digest: ByteVector32, privateKey: PrivateKey = nodeKey.privateKey): ByteVector64 = Crypto.sign(digest, privateKey)
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
@@ -20,7 +20,6 @@ import com.google.common.cache.{CacheBuilder, CacheLoader, LoadingCache}
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.DeterministicWallet.{derivePrivateKey, _}
 import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Crypto, DeterministicWallet}
-import fr.acinq.eclair.channel.{ChannelVersion, LocalParams}
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.transactions.Transactions.{CommitmentFormat, TransactionWithInputInfo, TxOwner}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/LocalKeyManager.scala
@@ -155,5 +155,10 @@ class LocalKeyManager(seed: ByteVector, chainHash: ByteVector32) extends KeyMana
     Announcements.signChannelAnnouncement(chainHash, shortChannelId, localNodeSecret, remoteNodeId, localFundingPrivKey, remoteFundingKey, features)
   }
 
-  override def signDigest(digest: ByteVector32, privateKey: PrivateKey = nodeKey.privateKey): ByteVector64 = Crypto.sign(digest, privateKey)
+  override def signDigest(digest: ByteVector32, privateKey: PrivateKey = nodeKey.privateKey): (ByteVector64, Int) = {
+    val signature = Crypto.sign(digest, privateKey)
+    val (pub1, _) = Crypto.recoverPublicKey(signature, digest)
+    val recoveryId = if (nodeId == pub1) 0 else 1
+    (signature, recoveryId)
+  }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -446,7 +446,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     val signedMessage: SignedMessage = eclair.signMessage(msg)
     assert(signedMessage.nodeId === testKeyManager.nodeId)
-    assert(signedMessage.message === msg)
+    assert(signedMessage.message === msg.toBase64)
     assert(signedMessage.signature === expectedSignature)
     assert(Crypto.verifySignature(dhash256, signedMessage.signature, testKeyManager.nodeKey.publicKey))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -442,7 +442,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     val verifiedMessage: VerifiedMessage = eclair.verifyMessage(msg, signedMessage.signature)
     assert(verifiedMessage.valid)
-    assert(verifiedMessage.signerNodeId === Some(kit.nodeParams.nodeId))
+    assert(verifiedMessage.publicKey === kit.nodeParams.nodeId)
 
     val prefix = "Lightning Signed Message:"
     val dhash256 = Crypto.hash256(ByteVector((prefix ++ msg).getBytes))
@@ -464,7 +464,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     val wrongMsg = "world, hello"
     val verifiedMessage: VerifiedMessage = eclair.verifyMessage(wrongMsg, signedMessage.signature)
     assert(verifiedMessage.valid)
-    assert(verifiedMessage.signerNodeId !== Some(kit.nodeParams.nodeId))
+    assert(verifiedMessage.publicKey !== kit.nodeParams.nodeId)
   }
 
   test("ensure that an invalid recoveryId cause the signature verification to fail") { f =>
@@ -479,7 +479,6 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     val invalidSignature = (if (signedMessage.signature.head.toInt == 31) 32 else 31).toByte +: signedMessage.signature.tail
     val verifiedMessage: VerifiedMessage = eclair.verifyMessage(msg, invalidSignature)
-    assert(!verifiedMessage.valid)
-    assert(verifiedMessage.signerNodeId === None)
+    assert(verifiedMessage.publicKey !== kit.nodeParams.nodeId)
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -21,11 +21,10 @@ import java.util.UUID
 import akka.testkit.TestProbe
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
-import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Crypto, DeterministicWallet}
+import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Crypto}
 import fr.acinq.eclair.TestConstants._
 import fr.acinq.eclair.blockchain.TestWallet
 import fr.acinq.eclair.channel.{CMD_FORCECLOSE, Register, _}
-import fr.acinq.eclair.crypto.LocalKeyManager
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.io.Peer.OpenChannel
 import fr.acinq.eclair.payment.PaymentRequest
@@ -36,7 +35,7 @@ import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentRequest, SendPa
 import fr.acinq.eclair.router.RouteCalculationSpec.makeUpdateShort
 import fr.acinq.eclair.router.Router.{GetNetworkStats, GetNetworkStatsResponse, PublicChannel}
 import fr.acinq.eclair.router.{Announcements, NetworkStats, Router, Stats}
-import fr.acinq.eclair.wire.{Color, NodeAddress, NodeAnnouncement}
+import fr.acinq.eclair.wire.{Color, NodeAnnouncement}
 import org.mockito.Mockito
 import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/LocalKeyManagerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/LocalKeyManagerSpec.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.crypto
 
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.DeterministicWallet.KeyPath
-import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Crypto, DeterministicWallet}
+import fr.acinq.bitcoin.{Block, ByteVector32, Crypto, DeterministicWallet}
 import fr.acinq.eclair.TestConstants
 import fr.acinq.eclair.channel.ChannelVersion
 import org.scalatest.funsuite.AnyFunSuite
@@ -69,7 +69,7 @@ class LocalKeyManagerSpec extends AnyFunSuite {
   }
 
   def makefundingKeyPath(entropy: ByteVector, isFunder: Boolean) = {
-    val items = for(i <- 0 to 7) yield entropy.drop(i * 4).take(4).toInt(signed = false) & 0xFFFFFFFFL
+    val items = for (i <- 0 to 7) yield entropy.drop(i * 4).take(4).toInt(signed = false) & 0xFFFFFFFFL
     val last = DeterministicWallet.hardened(if (isFunder) 1L else 0L)
     KeyPath(items :+ last)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/LocalKeyManagerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/LocalKeyManagerSpec.scala
@@ -143,19 +143,13 @@ class LocalKeyManagerSpec extends AnyFunSuite {
   }
 
   test("generate a signature from a digest") {
-    val seed = ByteVector.fromValidHex("deadbeef")
+    val seed = hex"deadbeef"
     val testKeyManager = new LocalKeyManager(seed, Block.RegtestGenesisBlock.hash)
-
-    val privkey = PrivateKey(hex"8d3f3c8ef68a047676329ad867ab3e1b75885989a1ecd0bae3cc6ce3064a00d4")
-    val expectedSignature = ByteVector64(hex"8f693e4db0f0e58ef02813d2414296b4d535f58343c136869e03db2a8a794a29238a580e4a3fcf0bbb0b7cde5fe5e53482056ed8cb201846af88bc897ba85e32")
-    val expectedRecoveryId = 1
-    val expectedPublicKey = PublicKey(hex"02ec8f6801d53fba134d032af7bc33ce1fd3d6373743f1317272d6a7d05ee9b30d")
     val digest = ByteVector32(hex"d7914fe546b684688bb95f4f888a92dfc680603a75f23eb823658031fff766d9") // sha256(sha256("hello"))
 
-    assert(privkey.publicKey === expectedPublicKey)
-
-    val (signature, recid) = testKeyManager.signDigest(digest, privkey)
-    assert(signature === expectedSignature)
-    assert(recid === expectedRecoveryId)
+    val (signature, recid) = testKeyManager.signDigest(digest)
+    val recoveredPubkey = Crypto.recoverPublicKey(signature, digest, recid)
+    assert(recoveredPubkey === testKeyManager.nodeId)
+    assert(Crypto.verifySignature(digest, signature, testKeyManager.nodeId))
   }
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/ExtraDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/ExtraDirectives.scala
@@ -20,14 +20,13 @@ import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.model.StatusCodes.NotFound
 import akka.http.scaladsl.model.{ContentTypes, HttpResponse}
 import akka.http.scaladsl.server.{Directive1, Directives, MalformedFormFieldRejection, Route}
-import fr.acinq.bitcoin.{ByteVector32, ByteVector64}
+import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.ApiTypes.ChannelIdentifier
 import fr.acinq.eclair.api.FormParamExtractors._
 import fr.acinq.eclair.api.JsonSupport._
 import fr.acinq.eclair.payment.PaymentRequest
 import fr.acinq.eclair.{MilliSatoshi, ShortChannelId}
-import scodec.bits.ByteVector
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success}

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/ExtraDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/ExtraDirectives.scala
@@ -20,13 +20,14 @@ import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.model.StatusCodes.NotFound
 import akka.http.scaladsl.model.{ContentTypes, HttpResponse}
 import akka.http.scaladsl.server.{Directive1, Directives, MalformedFormFieldRejection, Route}
-import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.{ByteVector32, ByteVector64}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.ApiTypes.ChannelIdentifier
 import fr.acinq.eclair.api.FormParamExtractors._
 import fr.acinq.eclair.api.JsonSupport._
 import fr.acinq.eclair.payment.PaymentRequest
 import fr.acinq.eclair.{MilliSatoshi, ShortChannelId}
+import scodec.bits.ByteVector
 
 import scala.concurrent.Future
 import scala.util.{Failure, Success}

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
@@ -61,8 +61,6 @@ object FormParamExtractors {
 
   implicit val base64DataUnmarshaller: Unmarshaller[String, ByteVector] = Unmarshaller.strict { str => ByteVector.fromValidBase64(str) }
 
-  implicit val signatureUnmarshaller: Unmarshaller[String, ByteVector64] = Unmarshaller.strict { bin => ByteVector64.fromValidHex(bin) }
-
   private def listUnmarshaller[T](unmarshal: String => T): Unmarshaller[String, List[T]] = Unmarshaller.strict { str =>
     Try(serialization.read[List[String]](str).map(unmarshal))
       .recoverWith(_ => Try(str.split(",").toList.map(unmarshal)))

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{ByteVector32, Satoshi}
+import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
 import fr.acinq.eclair.api.JsonSupport._
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.PaymentRequest
@@ -58,6 +58,10 @@ object FormParamExtractors {
   implicit val satoshiUnmarshaller: Unmarshaller[String, Satoshi] = Unmarshaller.strict { str => Satoshi(str.toLong) }
 
   implicit val millisatoshiUnmarshaller: Unmarshaller[String, MilliSatoshi] = Unmarshaller.strict { str => MilliSatoshi(str.toLong) }
+
+  implicit val base64DataUnmarshaller: Unmarshaller[String, ByteVector] = Unmarshaller.strict { str => ByteVector.fromValidBase64(str) }
+
+  implicit val signatureUnmarshaller: Unmarshaller[String, ByteVector64] = Unmarshaller.strict { bin => ByteVector64.fromValidHex(bin) }
 
   private def listUnmarshaller[T](unmarshal: String => T): Unmarshaller[String, List[T]] = Unmarshaller.strict { str =>
     Try(serialization.read[List[String]](str).map(unmarshal))

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
@@ -59,8 +59,6 @@ object FormParamExtractors {
 
   implicit val millisatoshiUnmarshaller: Unmarshaller[String, MilliSatoshi] = Unmarshaller.strict { str => MilliSatoshi(str.toLong) }
 
-  implicit val base64DataUnmarshaller: Unmarshaller[String, ByteVector] = Unmarshaller.strict { str => ByteVector.fromValidBase64(str) }
-
   private def listUnmarshaller[T](unmarshal: String => T): Unmarshaller[String, List[T]] = Unmarshaller.strict { str =>
     Try(serialization.read[List[String]](str).map(unmarshal))
       .recoverWith(_ => Try(str.split(",").toList.map(unmarshal)))

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
+import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.api.JsonSupport._
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.PaymentRequest

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{ByteVector32, Satoshi}
+import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
 import fr.acinq.eclair.api.JsonSupport._
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.PaymentRequest
@@ -58,6 +58,8 @@ object FormParamExtractors {
   implicit val satoshiUnmarshaller: Unmarshaller[String, Satoshi] = Unmarshaller.strict { str => Satoshi(str.toLong) }
 
   implicit val millisatoshiUnmarshaller: Unmarshaller[String, MilliSatoshi] = Unmarshaller.strict { str => MilliSatoshi(str.toLong) }
+
+  implicit val base64DataUnmarshaller: Unmarshaller[String, ByteVector] = Unmarshaller.strict { str => ByteVector.fromValidBase64(str) }
 
   private def listUnmarshaller[T](unmarshal: String => T): Unmarshaller[String, List[T]] = Unmarshaller.strict { str =>
     Try(serialization.read[List[String]](str).map(unmarshal))

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -32,11 +32,11 @@ import akka.stream.{Materializer, OverflowStrategy}
 import akka.util.Timeout
 import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
+import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.api.FormParamExtractors._
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.{PaymentEvent, PaymentRequest}
-import fr.acinq.eclair.{CltvExpiryDelta, Eclair, MilliSatoshi, randomBytes32}
+import fr.acinq.eclair.{CltvExpiryDelta, Eclair, MilliSatoshi}
 import grizzled.slf4j.Logging
 import scodec.bits.ByteVector
 
@@ -48,6 +48,7 @@ case class ErrorResponse(error: String)
 trait Service extends ExtraDirectives with Logging {
 
   // important! Must NOT import the unmarshaller as it is too generic...see https://github.com/akka/akka-http/issues/541
+
   import JsonSupport.{formats, marshaller, serialization}
 
   def password: String
@@ -226,7 +227,7 @@ trait Service extends ExtraDirectives with Logging {
                         path("sendtonode") {
                           formFields(amountMsatFormParam, nodeIdFormParam, paymentHashFormParam.?, "maxAttempts".as[Int].?, "feeThresholdSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?, "keysend".as[Boolean].?) {
                             case (amountMsat, nodeId, Some(paymentHash), maxAttempts_opt, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, keySend) =>
-                              keySend match  {
+                              keySend match {
                                 case Some(true) => reject(MalformedFormFieldRejection("paymentHash", "You cannot request a KeySend payment and specify a paymentHash"))
                                 case _ => complete(eclairApi.send(externalId_opt, nodeId, amountMsat, paymentHash, maxAttempts_opt = maxAttempts_opt, feeThresholdSat_opt = feeThresholdSat_opt, maxFeePct_opt = maxFeePct_opt))
                               }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -313,12 +313,12 @@ trait Service extends ExtraDirectives with Logging {
                           }
                         } ~
                         path("signmessage") {
-                          formFields("msg".as[String]) { message =>
+                          formFields("msg".as[ByteVector](base64DataUnmarshaller)) { message =>
                             complete(eclairApi.signMessage(message))
                           }
                         } ~
                         path("verifymessage") {
-                          formFields("msg".as[String], "sig".as[ByteVector](binaryDataUnmarshaller)) { (message, signature) =>
+                          formFields("msg".as[ByteVector](base64DataUnmarshaller), "sig".as[ByteVector](binaryDataUnmarshaller)) { (message, signature) =>
                             complete(eclairApi.verifyMessage(message, signature))
                           }
                         } ~ get {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -312,13 +312,13 @@ trait Service extends ExtraDirectives with Logging {
                           }
                         } ~
                         path("signmessage") {
-                          formFields("msg".as[ByteVector](base64DataUnmarshaller)) { base64Message =>
-                            complete(eclairApi.signMessage(base64Message))
+                          formFields("msg".as[String]) { message =>
+                            complete(eclairApi.signMessage(message))
                           }
                         } ~
                         path("verifymessage") {
-                          formFields("msg".as[ByteVector](base64DataUnmarshaller), "sig".as[ByteVector64](signatureUnmarshaller)) { (base64Message, signature) =>
-                            complete(eclairApi.verifyMessage(base64Message, signature))
+                          formFields("msg".as[String], "sig".as[ByteVector](binaryDataUnmarshaller)) { (message, signature) =>
+                            complete(eclairApi.verifyMessage(message, signature))
                           }
                         } ~ get {
                         path("ws") {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -321,10 +321,10 @@ trait Service extends ExtraDirectives with Logging {
                           formFields("msg".as[ByteVector](base64DataUnmarshaller), "sig".as[ByteVector](binaryDataUnmarshaller)) { (message, signature) =>
                             complete(eclairApi.verifyMessage(message, signature))
                           }
-                        } ~ get {
-                        path("ws") {
-                          handleWebSocketMessages(makeSocketHandler)
                         }
+                    } ~ get {
+                      path("ws") {
+                        handleWebSocketMessages(makeSocketHandler)
                       }
                     }
                   }


### PR DESCRIPTION
Fixes #1496

## End to End tests
`Sign` by -> `Verified` by
- [x] Eclair -> Eclair
- [x] Eclair -> Lnd
- [x] Eclair -> C-lightning
- [x] Lnd -> Eclair
- [x] C-lightning -> Eclair

## How to use the `signmessage` command
```
$> eclair-cli signmessage --msg=$(echo -n 'hello, world' | base64)
{
  "nodeId": "02ca7361934233f6d4defd4d792fb2ce2cd0b50c7605e6c5cd16006bcd5be2bf70",
  "message": "aGVsbG8gd29ybGQK",
  "signature": "1f730dce842c31b692dc041c2d0f00423d2a2a67b0c63c1a905d500f09652a5b1a036763a1603333fa589ae92d1f7963428ff170e976d0966a113f4b9f9d0efc7f"
}
```
## How to use the `verifymessage` command
```
$> eclair-clir verifymessage --msg=$(echo -n 'hello, world' | base64) --sig=1f730dce842c31b692dc041c2d0f00423d2a2a67b0c63c1a905d500f09652a5b1a036763a1603333fa589ae92d1f7963428ff170e976d0966a113f4b9f9d0efc7f
{
  "valid": true,
  "publicKey": "02ca7361934233f6d4defd4d792fb2ce2cd0b50c7605e6c5cd16006bcd5be2bf70"
}
```

## Signature format conversion
The signature we return are in hexadecimal format. Lnd & C-lightning use a zbase32 format. To convert from and to zbase32 you can use [zbase32](https://github.com/tv42/zbase32) and some basics Unix tools.

### Hexadecimal to zbase32
```
echo -n "${eclair_signature}" | xxd -revert -plain | zbase32-encode
```

### zbase32 to Hexadecimal
```
zbase32-decode "${zbase32_signature}" | xxd -cols 256 -plain
```

## Message format
We expect the `msg` argument, for both commands, to be a valid base64 string, to avoid issues with charset and encoding:
```
$> eclair-cli signmessage --msg=0123456789-invalid
The form field 'msg' was malformed:
Invalid base 64 character '-' at index 10
```