### PR TITLE
Improve blockchain watchers

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/WatcherTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/WatcherTypes.scala
@@ -26,8 +26,8 @@ import scodec.bits.ByteVector
 import scala.util.{Failure, Success, Try}
 
 /**
-  * Created by PM on 19/01/2016.
-  */
+ * Created by PM on 19/01/2016.
+ */
 
 // @formatter:off
 
@@ -35,11 +35,19 @@ sealed trait Watch {
   def channel: ActorRef
   def event: BitcoinEvent
 }
-// we need a public key script to use electrum apis
+
+/**
+ * Watch for confirmation of a given transaction.
+ *
+ * @param channel         channel to notify once the transaction is confirmed.
+ * @param txId            txid of the transaction to watch.
+ * @param publicKeyScript when using electrum, we need to specify a public key script; any of the output scripts should work.
+ * @param minDepth        number of confirmations.
+ * @param event           channel event related to the transaction.
+ */
 final case class WatchConfirmed(channel: ActorRef, txId: ByteVector32, publicKeyScript: ByteVector, minDepth: Long, event: BitcoinEvent) extends Watch
 object WatchConfirmed {
-  // if we have the entire transaction, we can get the redeemScript from the witness, and re-compute the publicKeyScript
-  // we support both p2pkh and p2wpkh scripts
+  // if we have the entire transaction, we can get the publicKeyScript from any of the outputs
   def apply(channel: ActorRef, tx: Transaction, minDepth: Long, event: BitcoinEvent): WatchConfirmed = WatchConfirmed(channel, tx.txid, tx.txOut.map(_.publicKeyScript).headOption.getOrElse(ByteVector.empty), minDepth, event)
 
   def extractPublicKeyScript(witness: ScriptWitness): ByteVector = Try(PublicKey(witness.stack.last)) match {
@@ -52,37 +60,90 @@ object WatchConfirmed {
   }
 }
 
+/**
+ * Watch for transactions spending the given outpoint.
+ *
+ * NB: an event will be triggered *every time* a transaction spends the given outpoint. This can be useful when:
+ *  - we see a spending transaction in the mempool, but it is then replaced (RBF)
+ *  - we see a spending transaction in the mempool, but a conflicting transaction "wins" and gets confirmed in a block
+ *
+ * @param channel         channel to notify when the outpoint is spent.
+ * @param txId            txid of the outpoint to watch.
+ * @param outputIndex     index of the outpoint to watch.
+ * @param publicKeyScript electrum requires us to specify a public key script; the script of the outpoint must be provided.
+ * @param event           channel event related to the outpoint.
+ */
 final case class WatchSpent(channel: ActorRef, txId: ByteVector32, outputIndex: Int, publicKeyScript: ByteVector, event: BitcoinEvent) extends Watch
 object WatchSpent {
   // if we have the entire transaction, we can get the publicKeyScript from the relevant output
   def apply(channel: ActorRef, tx: Transaction, outputIndex: Int, event: BitcoinEvent): WatchSpent = WatchSpent(channel, tx.txid, outputIndex, tx.txOut(outputIndex).publicKeyScript, event)
 }
-final case class WatchSpentBasic(channel: ActorRef, txId: ByteVector32, outputIndex: Int, publicKeyScript: ByteVector, event: BitcoinEvent) extends Watch // we use this when we don't care about the spending tx, and we also assume txid already exists
+
+/**
+ * Watch for the first transaction spending the given outpoint. We assume that txid is already confirmed or in the
+ * mempool (i.e. the outpoint exists).
+ *
+ * NB: an event will be triggered only once when we see a transaction that spends the given outpoint. If you want to
+ * react to the transaction spending the outpoint, you should use [[WatchSpent]] instead.
+ *
+ * @param channel         channel to notify when the outpoint is spent.
+ * @param txId            txid of the outpoint to watch.
+ * @param outputIndex     index of the outpoint to watch.
+ * @param publicKeyScript electrum requires us to specify a public key script; the script of the outpoint must be provided.
+ * @param event           channel event related to the outpoint.
+ */
+final case class WatchSpentBasic(channel: ActorRef, txId: ByteVector32, outputIndex: Int, publicKeyScript: ByteVector, event: BitcoinEvent) extends Watch
 object WatchSpentBasic {
   // if we have the entire transaction, we can get the publicKeyScript from the relevant output
   def apply(channel: ActorRef, tx: Transaction, outputIndex: Int, event: BitcoinEvent): WatchSpentBasic = WatchSpentBasic(channel, tx.txid, outputIndex, tx.txOut(outputIndex).publicKeyScript, event)
 }
-// TODO: notify me if confirmation number gets below minDepth?
+
+// TODO: not implemented yet: notify me if confirmation number gets below minDepth?
 final case class WatchLost(channel: ActorRef, txId: ByteVector32, minDepth: Long, event: BitcoinEvent) extends Watch
 
+/** Even triggered when a watch condition is met. */
 trait WatchEvent {
   def event: BitcoinEvent
 }
-final case class WatchEventConfirmed(event: BitcoinEvent, blockHeight: Int, txIndex: Int, tx: Transaction) extends WatchEvent
-final case class WatchEventSpent(event: BitcoinEvent, tx: Transaction) extends WatchEvent
-final case class WatchEventSpentBasic(event: BitcoinEvent) extends WatchEvent
-final case class WatchEventLost(event: BitcoinEvent) extends WatchEvent
 
 /**
-  * Publish the provided tx as soon as possible depending on locktime and csv
-  */
+ * This event is sent when a [[WatchConfirmed]] condition is met.
+ *
+ * @param event       channel event related to the transaction that has been confirmed.
+ * @param blockHeight block in which the transaction was confirmed.
+ * @param txIndex     index of the transaction in the block.
+ * @param tx          transaction that has been confirmed.
+ */
+final case class WatchEventConfirmed(event: BitcoinEvent, blockHeight: Int, txIndex: Int, tx: Transaction) extends WatchEvent
+
+/**
+ * This event is sent when a [[WatchSpent]] condition is met.
+ *
+ * @param event channel event related to the outpoint that was spent.
+ * @param tx    transaction spending the watched outpoint.
+ */
+final case class WatchEventSpent(event: BitcoinEvent, tx: Transaction) extends WatchEvent
+
+/**
+ * This event is sent when a [[WatchSpentBasic]] condition is met.
+ *
+ * @param event channel event related to the outpoint that was spent.
+ */
+final case class WatchEventSpentBasic(event: BitcoinEvent) extends WatchEvent
+
+// TODO: not implemented yet.
+final case class WatchEventLost(event: BitcoinEvent) extends WatchEvent
+
+/** Publish the provided tx as soon as possible depending on locktime and csv */
 final case class PublishAsap(tx: Transaction)
-final case class ValidateRequest(ann: ChannelAnnouncement)
+
 sealed trait UtxoStatus
 object UtxoStatus {
   case object Unspent extends UtxoStatus
   case class Spent(spendingTxConfirmed: Boolean) extends UtxoStatus
 }
+
+final case class ValidateRequest(ann: ChannelAnnouncement)
 final case class ValidateResult(c: ChannelAnnouncement, fundingTx: Either[Throwable, (Transaction, UtxoStatus)])
 
 final case class GetTxWithMeta(txid: ByteVector32)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
@@ -97,29 +97,29 @@ class ZmqWatcher(blockCount: AtomicLong, client: ExtendedBitcoinClient)(implicit
       context become watching(watches, watchedUtxos, block2tx, None)
 
     case TriggerEvent(w, e) if watches.contains(w) =>
-      log.info(s"triggering $w")
+      log.info("triggering {}", w)
       w.channel ! e
       w match {
         case _: WatchSpent =>
-          // NB: WatchSpent are permanent because we need to detect multiple spending of the funding tx
+          // NB: WatchSpent are permanent because we need to detect multiple spending of the funding tx or the commit tx
           // They are never cleaned up but it is not a big deal for now (1 channel == 1 watch)
           ()
         case _ =>
-          context become watching(watches - w, removeWatchedUtxos(watchedUtxos, w), block2tx, None)
+          context become watching(watches - w, removeWatchedUtxos(watchedUtxos, w), block2tx, nextTick)
       }
 
     case CurrentBlockCount(count) =>
       val toPublish = block2tx.filterKeys(_ <= count)
       toPublish.values.flatten.foreach(tx => publish(tx))
-      context become watching(watches, watchedUtxos, block2tx -- toPublish.keys, None)
+      context become watching(watches, watchedUtxos, block2tx -- toPublish.keys, nextTick)
 
     case w: Watch if !watches.contains(w) =>
       w match {
         case WatchSpentBasic(_, txid, outputIndex, _, _) =>
-          // not: we assume parent tx was published, we just need to make sure this particular output has not been spent
+          // NB: we assume parent tx was published, we just need to make sure this particular output has not been spent
           client.isTransactionOutputSpendable(txid, outputIndex, includeMempool = true).collect {
             case false =>
-              log.info(s"output=$outputIndex of txid=$txid has already been spent")
+              log.info("output={} of txid={} has already been spent", outputIndex, txid)
               self ! TriggerEvent(w, WatchEventSpentBasic(w.event))
           }
 
@@ -130,13 +130,13 @@ class ZmqWatcher(blockCount: AtomicLong, client: ExtendedBitcoinClient)(implicit
               // parent tx was published, we need to make sure this particular output has not been spent
               client.isTransactionOutputSpendable(txid, outputIndex, includeMempool = true).collect {
                 case false =>
-                  log.info(s"$txid:$outputIndex has already been spent, looking for the spending tx in the mempool")
+                  log.info("{}:{} has already been spent, looking for the spending tx in the mempool", txid, outputIndex)
                   client.getMempool().map { mempoolTxs =>
                     mempoolTxs.filter(tx => tx.txIn.exists(i => i.outPoint.txid == txid && i.outPoint.index == outputIndex)) match {
                       case Nil =>
-                        log.warning(s"$txid:$outputIndex has already been spent, spending tx not in the mempool, looking in the blockchain...")
+                        log.warning("{}:{} has already been spent, spending tx not in the mempool, looking in the blockchain...", txid, outputIndex)
                         client.lookForSpendingTx(None, txid, outputIndex).map { tx =>
-                          log.warning(s"found the spending tx of $txid:$outputIndex in the blockchain: txid=${tx.txid}")
+                          log.warning("found the spending tx of {}:{} in the blockchain: txid={}", txid, outputIndex, tx.txid)
                           self ! NewTransaction(tx)
                         }
                       case txs =>
@@ -151,7 +151,7 @@ class ZmqWatcher(blockCount: AtomicLong, client: ExtendedBitcoinClient)(implicit
 
         case _: WatchLost => () // TODO: not implemented
 
-        case w => log.warning(s"ignoring $w")
+        case w => log.warning("ignoring {}", w)
       }
 
       log.debug("adding watch {} for {}", w, sender)
@@ -165,24 +165,25 @@ class ZmqWatcher(blockCount: AtomicLong, client: ExtendedBitcoinClient)(implicit
       if (csvTimeout > 0) {
         require(tx.txIn.size == 1, s"watcher only supports tx with 1 input, this tx has ${tx.txIn.size} inputs")
         val parentTxid = tx.txIn.head.outPoint.txid
-        log.info(s"txid=${tx.txid} has a relative timeout of $csvTimeout blocks, watching parenttxid=$parentTxid tx=$tx")
+        log.info("txid={} has a relative timeout of {} blocks, watching parenttxid={} tx={}", tx.txid, csvTimeout, parentTxid, tx)
         val parentPublicKey = fr.acinq.bitcoin.Script.write(fr.acinq.bitcoin.Script.pay2wsh(tx.txIn.head.witness.stack.last))
         self ! WatchConfirmed(self, parentTxid, parentPublicKey, minDepth = 1, BITCOIN_PARENT_TX_CONFIRMED(tx))
       } else if (cltvTimeout > blockCount) {
-        log.info(s"delaying publication of txid=${tx.txid} until block=$cltvTimeout (curblock=$blockCount)")
+        log.info("delaying publication of txid={} until block={} (curblock={})", tx.txid, cltvTimeout, blockCount)
         val block2tx1 = block2tx.updated(cltvTimeout, block2tx.getOrElse(cltvTimeout, Seq.empty[Transaction]) :+ tx)
-        context become watching(watches, watchedUtxos, block2tx1, None)
+        context become watching(watches, watchedUtxos, block2tx1, nextTick)
       } else publish(tx)
 
     case WatchEventConfirmed(BITCOIN_PARENT_TX_CONFIRMED(tx), blockHeight, _, _) =>
-      log.info(s"parent tx of txid=${tx.txid} has been confirmed")
+      log.info("parent tx of txid={} has been confirmed", tx.txid)
       val blockCount = this.blockCount.get()
+      val cltvTimeout = Scripts.cltvTimeout(tx)
       val csvTimeout = Scripts.csvTimeout(tx)
-      val absTimeout = blockHeight + csvTimeout
+      val absTimeout = math.max(blockHeight + csvTimeout, cltvTimeout)
       if (absTimeout > blockCount) {
-        log.info(s"delaying publication of txid=${tx.txid} until block=$absTimeout (curblock=$blockCount)")
+        log.info("delaying publication of txid={} until block={} (curblock={})", tx.txid, absTimeout, blockCount)
         val block2tx1 = block2tx.updated(absTimeout, block2tx.getOrElse(absTimeout, Seq.empty[Transaction]) :+ tx)
-        context become watching(watches, watchedUtxos, block2tx1, None)
+        context become watching(watches, watchedUtxos, block2tx1, nextTick)
       } else publish(tx)
 
     case ValidateRequest(ann) => client.validate(ann).pipeTo(sender)
@@ -193,7 +194,7 @@ class ZmqWatcher(blockCount: AtomicLong, client: ExtendedBitcoinClient)(implicit
       // we remove watches associated to dead actor
       val deprecatedWatches = watches.filter(_.channel == channel)
       val watchedUtxos1 = deprecatedWatches.foldLeft(watchedUtxos) { case (m, w) => removeWatchedUtxos(m, w) }
-      context.become(watching(watches -- deprecatedWatches, watchedUtxos1, block2tx, None))
+      context.become(watching(watches -- deprecatedWatches, watchedUtxos1, block2tx, nextTick))
 
     case Symbol("watches") => sender ! watches
 
@@ -204,14 +205,12 @@ class ZmqWatcher(blockCount: AtomicLong, client: ExtendedBitcoinClient)(implicit
   val singleThreadExecutionContext = ExecutionContext.fromExecutor(Executors.newSingleThreadExecutor())
 
   def publish(tx: Transaction, isRetry: Boolean = false): Unit = {
-    log.info(s"publishing tx (isRetry=$isRetry): txid=${tx.txid} tx=$tx")
+    log.info("publishing tx (isRetry={}): txid={} tx={}", isRetry, tx.txid, tx)
     client.publishTransaction(tx)(singleThreadExecutionContext).recover {
       case t: Throwable if t.getMessage.contains("(code: -25)") && !isRetry => // we retry only once
         import akka.pattern.after
-
-        import scala.concurrent.duration._
         after(3 seconds, context.system.scheduler)(Future.successful({})).map(_ => publish(tx, isRetry = true))
-      case t: Throwable => log.error(s"cannot publish tx: reason=${t.getMessage} txid=${tx.txid} tx=$tx")
+      case t: Throwable => log.error("cannot publish tx: reason={} txid={} tx={}", t.getMessage, tx.txid, tx)
     }
   }
 
@@ -237,7 +236,7 @@ object ZmqWatcher {
 
   case object TickNewBlock
 
-  def utxo(w: Watch): Option[OutPoint] =
+  private def utxo(w: Watch): Option[OutPoint] =
     w match {
       case w: WatchSpent => Some(OutPoint(w.txId.reverse, w.outputIndex))
       case w: WatchSpentBasic => Some(OutPoint(w.txId.reverse, w.outputIndex))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
@@ -83,25 +83,25 @@ class ElectrumWatcher(blockCount: AtomicLong, client: ActorRef) extends Actor wi
       val scriptHash = computeScriptHash(publicKeyScript)
       log.info(s"added watch-spent on output=$txid:$outputIndex scriptHash=$scriptHash")
       client ! ElectrumClient.ScriptHashSubscription(scriptHash, self)
-      context.watch(watch.channel)
+      context.watch(watch.replyTo)
       context become running(height, tip, watches + watch, scriptHashStatus, block2tx, sent)
 
     case watch@WatchSpentBasic(_, txid, outputIndex, publicKeyScript, _) =>
       val scriptHash = computeScriptHash(publicKeyScript)
       log.info(s"added watch-spent-basic on output=$txid:$outputIndex scriptHash=$scriptHash")
       client ! ElectrumClient.ScriptHashSubscription(scriptHash, self)
-      context.watch(watch.channel)
+      context.watch(watch.replyTo)
       context become running(height, tip, watches + watch, scriptHashStatus, block2tx, sent)
 
     case watch@WatchConfirmed(_, txid, publicKeyScript, _, _) =>
       val scriptHash = computeScriptHash(publicKeyScript)
       log.info(s"added watch-confirmed on txid=$txid scriptHash=$scriptHash")
       client ! ElectrumClient.ScriptHashSubscription(scriptHash, self)
-      context.watch(watch.channel)
+      context.watch(watch.replyTo)
       context become running(height, tip, watches + watch, scriptHashStatus, block2tx, sent)
 
     case Terminated(actor) =>
-      val watches1 = watches.filterNot(_.channel == actor)
+      val watches1 = watches.filterNot(_.replyTo == actor)
       context become running(height, tip, watches1, scriptHashStatus, block2tx, sent)
 
     case ElectrumClient.ScriptHashSubscriptionResponse(scriptHash, status) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcherSpec.scala
@@ -20,21 +20,25 @@ import java.util.concurrent.atomic.AtomicLong
 
 import akka.Done
 import akka.actor.{ActorRef, Props}
+import akka.pattern.pipe
 import akka.testkit.{TestKit, TestProbe}
-import fr.acinq.bitcoin.{OutPoint, Script}
+import fr.acinq.bitcoin.{OutPoint, Script, Transaction, TxOut}
 import fr.acinq.eclair.blockchain.WatcherSpec._
 import fr.acinq.eclair.blockchain._
+import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.{FundTransactionResponse, SignTransactionResponse}
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.ExtendedBitcoinClient
 import fr.acinq.eclair.blockchain.bitcoind.zmq.ZMQActor
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.{BITCOIN_FUNDING_DEPTHOK, BITCOIN_FUNDING_SPENT}
-import fr.acinq.eclair.{TestKitBaseClass, randomBytes32}
+import fr.acinq.eclair.{LongToBtcAmount, TestKitBaseClass, randomBytes32}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST.JValue
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuiteLike
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Promise
 import scala.concurrent.duration._
 
@@ -131,13 +135,18 @@ class ZmqWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitcoind
     val (tx1, tx2) = createUnspentTxChain(tx, priv)
 
     val listener = TestProbe()
+    probe.send(watcher, WatchSpentBasic(listener.ref, tx, outputIndex, BITCOIN_FUNDING_SPENT))
     probe.send(watcher, WatchSpent(listener.ref, tx, outputIndex, BITCOIN_FUNDING_SPENT))
     listener.expectNoMsg(1 second)
     probe.send(bitcoincli, BitcoinReq("sendrawtransaction", tx1.toString()))
     probe.expectMsgType[JValue]
     // tx and tx1 aren't confirmed yet, but we trigger the WatchEventSpent when we see tx1 in the mempool.
-    listener.expectMsg(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx1))
-    // Let's confirm tx and tx1: seeing tx1 in a block should trigger WatchEventSpent again.
+    listener.expectMsgAllOf(
+      WatchEventSpentBasic(BITCOIN_FUNDING_SPENT),
+      WatchEventSpent(BITCOIN_FUNDING_SPENT, tx1)
+    )
+    // Let's confirm tx and tx1: seeing tx1 in a block should trigger WatchEventSpent again, but not WatchEventSpentBasic
+    // (which only triggers once).
     generateBlocks(bitcoincli, 2)
     listener.expectMsg(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx1))
 
@@ -146,8 +155,102 @@ class ZmqWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitcoind
     probe.expectMsgType[JValue]
     listener.expectNoMsg(1 second)
     generateBlocks(bitcoincli, 1)
+    probe.send(watcher, WatchSpentBasic(listener.ref, tx1, 0, BITCOIN_FUNDING_SPENT))
     probe.send(watcher, WatchSpent(listener.ref, tx1, 0, BITCOIN_FUNDING_SPENT))
-    listener.expectMsg(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx2))
+    listener.expectMsgAllOf(
+      WatchEventSpentBasic(BITCOIN_FUNDING_SPENT),
+      WatchEventSpent(BITCOIN_FUNDING_SPENT, tx2)
+    )
+    system.stop(watcher)
+  }
+
+  test("watch for unknown spent transactions") {
+    val probe = TestProbe()
+    val blockCount = new AtomicLong()
+    val wallet = new BitcoinCoreWallet(bitcoinrpcclient)
+    val client = new ExtendedBitcoinClient(bitcoinrpcclient)
+    val watcher = system.actorOf(ZmqWatcher.props(blockCount, client))
+
+    // create a chain of transactions that we don't broadcast yet
+    val (_, priv) = getNewAddress(bitcoincli)
+    val tx1 = {
+      wallet.fundTransaction(Transaction(2, Nil, TxOut(150000 sat, Script.pay2wpkh(priv.publicKey)) :: Nil, 0), lockUnspents = true, FeeratePerKw(250 sat)).pipeTo(probe.ref)
+      val funded = probe.expectMsgType[FundTransactionResponse].tx
+      wallet.signTransaction(funded).pipeTo(probe.ref)
+      probe.expectMsgType[SignTransactionResponse].tx
+    }
+    val outputIndex = tx1.txOut.indexWhere(_.publicKeyScript == Script.write(Script.pay2wpkh(priv.publicKey)))
+    val tx2 = createSpendP2WPKH(tx1, priv, priv.publicKey, 10000 sat, 1, 0)
+
+    // setup watches before we publish transactions
+    probe.send(watcher, WatchSpent(probe.ref, tx1, outputIndex, BITCOIN_FUNDING_SPENT))
+    probe.send(watcher, WatchConfirmed(probe.ref, tx1, 3, BITCOIN_FUNDING_SPENT))
+    client.publishTransaction(tx1).pipeTo(probe.ref)
+    probe.expectMsg(tx1.txid)
+    generateBlocks(bitcoincli, 1)
+    probe.expectNoMsg(1 second)
+    client.publishTransaction(tx2).pipeTo(probe.ref)
+    probe.expectMsgAllOf(tx2.txid, WatchEventSpent(BITCOIN_FUNDING_SPENT, tx2))
+    probe.expectNoMsg(1 second)
+    generateBlocks(bitcoincli, 1)
+    probe.expectMsg(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx2)) // tx2 is confirmed which triggers WatchEventSpent again
+    generateBlocks(bitcoincli, 1)
+    assert(probe.expectMsgType[WatchEventConfirmed].tx === tx1) // tx1 now has 3 confirmations
+    system.stop(watcher)
+  }
+
+  test("publish transactions with relative and absolute delays") {
+    val probe = TestProbe()
+    val blockCount = new AtomicLong()
+    val wallet = new BitcoinCoreWallet(bitcoinrpcclient)
+    val client = new ExtendedBitcoinClient(bitcoinrpcclient)
+    val watcher = system.actorOf(ZmqWatcher.props(blockCount, client))
+    awaitCond(blockCount.get > 0)
+    val (_, priv) = getNewAddress(bitcoincli)
+
+    // tx1 has an absolute delay but no relative delay
+    val tx1 = {
+      wallet.fundTransaction(Transaction(2, Nil, TxOut(150000 sat, Script.pay2wpkh(priv.publicKey)) :: Nil, blockCount.get + 5), lockUnspents = true, FeeratePerKw(250 sat)).pipeTo(probe.ref)
+      val funded = probe.expectMsgType[FundTransactionResponse].tx
+      wallet.signTransaction(funded).pipeTo(probe.ref)
+      probe.expectMsgType[SignTransactionResponse].tx
+    }
+    probe.send(watcher, PublishAsap(tx1))
+    generateBlocks(bitcoincli, 5)
+    awaitCond({
+      client.getMempool().pipeTo(probe.ref)
+      probe.expectMsgType[Seq[Transaction]].exists(_.txid === tx1.txid)
+    }, max = 20 seconds, interval = 1 second)
+
+    // tx2 has a relative delay but no absolute delay
+    val tx2 = createSpendP2WPKH(tx1, priv, priv.publicKey, 10000 sat, sequence = 2, lockTime = 0)
+    probe.send(watcher, WatchConfirmed(probe.ref, tx1, 1, BITCOIN_FUNDING_DEPTHOK))
+    probe.send(watcher, PublishAsap(tx2))
+    generateBlocks(bitcoincli, 1)
+    assert(probe.expectMsgType[WatchEventConfirmed].tx === tx1)
+    generateBlocks(bitcoincli, 2)
+    awaitCond({
+      client.getMempool().pipeTo(probe.ref)
+      probe.expectMsgType[Seq[Transaction]].exists(_.txid === tx2.txid)
+    }, max = 20 seconds, interval = 1 second)
+
+    // tx3 has both relative and absolute delays
+    val tx3 = createSpendP2WPKH(tx2, priv, priv.publicKey, 10000 sat, sequence = 1, lockTime = blockCount.get + 5)
+    probe.send(watcher, WatchConfirmed(probe.ref, tx2, 1, BITCOIN_FUNDING_DEPTHOK))
+    probe.send(watcher, WatchSpent(probe.ref, tx2, 0, BITCOIN_FUNDING_SPENT))
+    probe.send(watcher, PublishAsap(tx3))
+    generateBlocks(bitcoincli, 1)
+    assert(probe.expectMsgType[WatchEventConfirmed].tx === tx2)
+    val currentBlockCount = blockCount.get
+    // after 1 block, the relative delay is elapsed, but not the absolute delay
+    generateBlocks(bitcoincli, 1)
+    awaitCond(blockCount.get == currentBlockCount + 1)
+    probe.expectNoMsg(1 second)
+    generateBlocks(bitcoincli, 3)
+    probe.expectMsg(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx3))
+    client.getMempool().pipeTo(probe.ref)
+    probe.expectMsgType[Seq[Transaction]].exists(_.txid === tx3.txid)
+
     system.stop(watcher)
   }
 


### PR DESCRIPTION
- Correctly handle the case where a tx has both a sequence and locktime set (anchor output htlcs)
- Add tx publish tests to ZmqWatcher and ElectrumWatcher
- Add documentation on watcher types