### PR TITLE
Type fee rates info

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -95,6 +95,7 @@ eclair {
       36 = 50000
       72 = 20000
       144 = 15000
+      1008 = 5000
     }
 
     // number of blocks to target when computing fees for each transaction type

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -85,7 +85,7 @@ trait Eclair {
 
   def disconnect(nodeId: PublicKey)(implicit timeout: Timeout): Future[String]
 
-  def open(nodeId: PublicKey, fundingAmount: Satoshi, pushAmount_opt: Option[MilliSatoshi], fundingFeerateSatByte_opt: Option[Satoshi], flags_opt: Option[Int], openTimeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[ChannelCommandResponse]
+  def open(nodeId: PublicKey, fundingAmount: Satoshi, pushAmount_opt: Option[MilliSatoshi], fundingFeeratePerByte_opt: Option[FeeratePerByte], flags_opt: Option[Int], openTimeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[ChannelCommandResponse]
 
   def close(channels: List[ApiTypes.ChannelIdentifier], scriptPubKey_opt: Option[ByteVector])(implicit timeout: Timeout): Future[Map[ApiTypes.ChannelIdentifier, Either[Throwable, ChannelCommandResponse]]]
 
@@ -166,14 +166,14 @@ class EclairImpl(appKit: Kit) extends Eclair {
     (appKit.switchboard ? Peer.Disconnect(nodeId)).mapTo[String]
   }
 
-  override def open(nodeId: PublicKey, fundingAmount: Satoshi, pushAmount_opt: Option[MilliSatoshi], fundingFeerateSatByte_opt: Option[Satoshi], flags_opt: Option[Int], openTimeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[ChannelCommandResponse] = {
+  override def open(nodeId: PublicKey, fundingAmount: Satoshi, pushAmount_opt: Option[MilliSatoshi], fundingFeeratePerByte_opt: Option[FeeratePerByte], flags_opt: Option[Int], openTimeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[ChannelCommandResponse] = {
     // we want the open timeout to expire *before* the default ask timeout, otherwise user won't get a generic response
     val openTimeout = openTimeout_opt.getOrElse(Timeout(10 seconds))
     (appKit.switchboard ? Peer.OpenChannel(
       remoteNodeId = nodeId,
       fundingSatoshis = fundingAmount,
       pushMsat = pushAmount_opt.getOrElse(0 msat),
-      fundingTxFeeratePerKw_opt = fundingFeerateSatByte_opt.map(f => FeeratePerKw(FeeratePerByte(f))),
+      fundingTxFeeratePerKw_opt = fundingFeeratePerByte_opt.map(FeeratePerKw(_)),
       channelFlags = flags_opt.map(_.toByte),
       timeout_opt = Some(openTimeout))).mapTo[ChannelCommandResponse]
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -28,6 +28,7 @@ import fr.acinq.eclair.TimestampQueryFilters._
 import fr.acinq.eclair.blockchain.OnChainBalance
 import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet
 import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.WalletTransaction
+import fr.acinq.eclair.blockchain.fee.{FeeratePerByte, FeeratePerKw}
 import fr.acinq.eclair.channel.Register.{Forward, ForwardShortId}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.{IncomingPayment, NetworkFee, OutgoingPayment, Stats}
@@ -84,7 +85,7 @@ trait Eclair {
 
   def disconnect(nodeId: PublicKey)(implicit timeout: Timeout): Future[String]
 
-  def open(nodeId: PublicKey, fundingAmount: Satoshi, pushAmount_opt: Option[MilliSatoshi], fundingFeerateSatByte_opt: Option[Long], flags_opt: Option[Int], openTimeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[ChannelCommandResponse]
+  def open(nodeId: PublicKey, fundingAmount: Satoshi, pushAmount_opt: Option[MilliSatoshi], fundingFeerateSatByte_opt: Option[Satoshi], flags_opt: Option[Int], openTimeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[ChannelCommandResponse]
 
   def close(channels: List[ApiTypes.ChannelIdentifier], scriptPubKey_opt: Option[ByteVector])(implicit timeout: Timeout): Future[Map[ApiTypes.ChannelIdentifier, Either[Throwable, ChannelCommandResponse]]]
 
@@ -165,14 +166,14 @@ class EclairImpl(appKit: Kit) extends Eclair {
     (appKit.switchboard ? Peer.Disconnect(nodeId)).mapTo[String]
   }
 
-  override def open(nodeId: PublicKey, fundingAmount: Satoshi, pushAmount_opt: Option[MilliSatoshi], fundingFeerateSatByte_opt: Option[Long], flags_opt: Option[Int], openTimeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[ChannelCommandResponse] = {
+  override def open(nodeId: PublicKey, fundingAmount: Satoshi, pushAmount_opt: Option[MilliSatoshi], fundingFeerateSatByte_opt: Option[Satoshi], flags_opt: Option[Int], openTimeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[ChannelCommandResponse] = {
     // we want the open timeout to expire *before* the default ask timeout, otherwise user won't get a generic response
     val openTimeout = openTimeout_opt.getOrElse(Timeout(10 seconds))
     (appKit.switchboard ? Peer.OpenChannel(
       remoteNodeId = nodeId,
       fundingSatoshis = fundingAmount,
       pushMsat = pushAmount_opt.getOrElse(0 msat),
-      fundingTxFeeratePerKw_opt = fundingFeerateSatByte_opt.map(feerateByte2Kw),
+      fundingTxFeeratePerKw_opt = fundingFeerateSatByte_opt.map(f => FeeratePerKw(FeeratePerByte(f))),
       channelFlags = flags_opt.map(_.toByte),
       timeout_opt = Some(openTimeout))).mapTo[ChannelCommandResponse]
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -220,7 +220,8 @@ class Setup(datadir: File,
           blocks_12 = FeeratePerKB(Satoshi(config.getLong("on-chain-fees.default-feerates.12"))),
           blocks_36 = FeeratePerKB(Satoshi(config.getLong("on-chain-fees.default-feerates.36"))),
           blocks_72 = FeeratePerKB(Satoshi(config.getLong("on-chain-fees.default-feerates.72"))),
-          blocks_144 = FeeratePerKB(Satoshi(config.getLong("on-chain-fees.default-feerates.144")))
+          blocks_144 = FeeratePerKB(Satoshi(config.getLong("on-chain-fees.default-feerates.144"))),
+          blocks_1008 = FeeratePerKB(Satoshi(config.getLong("on-chain-fees.default-feerates.1008"))),
         )
         feeratesPerKB.set(confDefaultFeerates)
         feeratesPerKw.set(FeeratesPerKw(confDefaultFeerates))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/EclairWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/EclairWallet.scala
@@ -18,6 +18,7 @@ package fr.acinq.eclair.blockchain
 
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{Satoshi, Transaction}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import scodec.bits.ByteVector
 
 import scala.concurrent.Future
@@ -33,7 +34,7 @@ trait EclairWallet {
 
   def getReceivePubkey(receiveAddress: Option[String] = None): Future[PublicKey]
 
-  def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: Long): Future[MakeFundingTxResponse]
+  def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: FeeratePerKw): Future[MakeFundingTxResponse]
 
   /**
    * Committing *must* include publishing the transaction on the network.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProvider.scala
@@ -47,6 +47,7 @@ class BitcoinCoreFeeProvider(rpcClient: BitcoinJsonRPCClient, defaultFeerates: F
     blocks_36 <- estimateSmartFee(36)
     blocks_72 <- estimateSmartFee(72)
     blocks_144 <- estimateSmartFee(144)
+    blocks_1008 <- estimateSmartFee(1008)
   } yield FeeratesPerKB(
     block_1 = if (block_1.isValid) block_1 else defaultFeerates.block_1,
     blocks_2 = if (blocks_2.isValid) blocks_2 else defaultFeerates.blocks_2,
@@ -54,7 +55,8 @@ class BitcoinCoreFeeProvider(rpcClient: BitcoinJsonRPCClient, defaultFeerates: F
     blocks_12 = if (blocks_12.isValid) blocks_12 else defaultFeerates.blocks_12,
     blocks_36 = if (blocks_36.isValid) blocks_36 else defaultFeerates.blocks_36,
     blocks_72 = if (blocks_72.isValid) blocks_72 else defaultFeerates.blocks_72,
-    blocks_144 = if (blocks_144.isValid) blocks_144 else defaultFeerates.blocks_144)
+    blocks_144 = if (blocks_144.isValid) blocks_144 else defaultFeerates.blocks_144,
+    blocks_1008 = if (blocks_1008.isValid) blocks_1008 else defaultFeerates.blocks_1008)
 }
 
 object BitcoinCoreFeeProvider {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProvider.scala
@@ -36,7 +36,7 @@ class BitcoinCoreFeeProvider(rpcClient: BitcoinJsonRPCClient, defaultFeerates: F
    * @param nBlocks number of blocks until tx is confirmed
    * @return the current fee estimate in Satoshi/KB
    */
-  def estimateSmartFee(nBlocks: Int): Future[Long] =
+  def estimateSmartFee(nBlocks: Int): Future[FeeratePerKB] =
     rpcClient.invoke("estimatesmartfee", nBlocks).map(BitcoinCoreFeeProvider.parseFeeEstimate)
 
   override def getFeerates: Future[FeeratesPerKB] = for {
@@ -48,29 +48,28 @@ class BitcoinCoreFeeProvider(rpcClient: BitcoinJsonRPCClient, defaultFeerates: F
     blocks_72 <- estimateSmartFee(72)
     blocks_144 <- estimateSmartFee(144)
   } yield FeeratesPerKB(
-    block_1 = if (block_1 > 0) block_1 else defaultFeerates.block_1,
-    blocks_2 = if (blocks_2 > 0) blocks_2 else defaultFeerates.blocks_2,
-    blocks_6 = if (blocks_6 > 0) blocks_6 else defaultFeerates.blocks_6,
-    blocks_12 = if (blocks_12 > 0) blocks_12 else defaultFeerates.blocks_12,
-    blocks_36 = if (blocks_36 > 0) blocks_36 else defaultFeerates.blocks_36,
-    blocks_72 = if (blocks_72 > 0) blocks_72 else defaultFeerates.blocks_72,
-    blocks_144 = if (blocks_144 > 0) blocks_144 else defaultFeerates.blocks_144)
+    block_1 = if (block_1.isValid) block_1 else defaultFeerates.block_1,
+    blocks_2 = if (blocks_2.isValid) blocks_2 else defaultFeerates.blocks_2,
+    blocks_6 = if (blocks_6.isValid) blocks_6 else defaultFeerates.blocks_6,
+    blocks_12 = if (blocks_12.isValid) blocks_12 else defaultFeerates.blocks_12,
+    blocks_36 = if (blocks_36.isValid) blocks_36 else defaultFeerates.blocks_36,
+    blocks_72 = if (blocks_72.isValid) blocks_72 else defaultFeerates.blocks_72,
+    blocks_144 = if (blocks_144.isValid) blocks_144 else defaultFeerates.blocks_144)
 }
 
 object BitcoinCoreFeeProvider {
-  def parseFeeEstimate(json: JValue): Long = {
+  def parseFeeEstimate(json: JValue): FeeratePerKB = {
     json \ "errors" match {
       case JNothing =>
         json \ "feerate" match {
           case JDecimal(feerate) =>
             // estimatesmartfee returns a fee rate in Btc/KB
-            btc2satoshi(Btc(feerate)).toLong
+            FeeratePerKB(btc2satoshi(Btc(feerate)))
           case JInt(feerate) if feerate.toLong < 0 =>
-            // negative value means failure
-            feerate.toLong
+            // negative value means failure: should (hopefully) never happen
+            FeeratePerKB(feerate.toLong.sat)
           case JInt(feerate) =>
-            // should (hopefully) never happen
-            btc2satoshi(Btc(feerate.toLong)).toLong
+            FeeratePerKB(btc2satoshi(Btc(feerate.toLong)))
         }
       case JArray(errors) =>
         val error = errors.collect { case JString(error) => error }.mkString(", ")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProvider.scala
@@ -49,14 +49,14 @@ class BitcoinCoreFeeProvider(rpcClient: BitcoinJsonRPCClient, defaultFeerates: F
     blocks_144 <- estimateSmartFee(144)
     blocks_1008 <- estimateSmartFee(1008)
   } yield FeeratesPerKB(
-    block_1 = if (block_1.isValid) block_1 else defaultFeerates.block_1,
-    blocks_2 = if (blocks_2.isValid) blocks_2 else defaultFeerates.blocks_2,
-    blocks_6 = if (blocks_6.isValid) blocks_6 else defaultFeerates.blocks_6,
-    blocks_12 = if (blocks_12.isValid) blocks_12 else defaultFeerates.blocks_12,
-    blocks_36 = if (blocks_36.isValid) blocks_36 else defaultFeerates.blocks_36,
-    blocks_72 = if (blocks_72.isValid) blocks_72 else defaultFeerates.blocks_72,
-    blocks_144 = if (blocks_144.isValid) blocks_144 else defaultFeerates.blocks_144,
-    blocks_1008 = if (blocks_1008.isValid) blocks_1008 else defaultFeerates.blocks_1008)
+    block_1 = if (block_1.feerate > 0.sat) block_1 else defaultFeerates.block_1,
+    blocks_2 = if (blocks_2.feerate > 0.sat) blocks_2 else defaultFeerates.blocks_2,
+    blocks_6 = if (blocks_6.feerate > 0.sat) blocks_6 else defaultFeerates.blocks_6,
+    blocks_12 = if (blocks_12.feerate > 0.sat) blocks_12 else defaultFeerates.blocks_12,
+    blocks_36 = if (blocks_36.feerate > 0.sat) blocks_36 else defaultFeerates.blocks_36,
+    blocks_72 = if (blocks_72.feerate > 0.sat) blocks_72 else defaultFeerates.blocks_72,
+    blocks_144 = if (blocks_144.feerate > 0.sat) blocks_144 else defaultFeerates.blocks_144,
+    blocks_1008 = if (blocks_1008.feerate > 0.sat) blocks_1008 else defaultFeerates.blocks_1008)
 }
 
 object BitcoinCoreFeeProvider {
@@ -66,12 +66,12 @@ object BitcoinCoreFeeProvider {
         json \ "feerate" match {
           case JDecimal(feerate) =>
             // estimatesmartfee returns a fee rate in Btc/KB
-            FeeratePerKB(btc2satoshi(Btc(feerate)))
+            FeeratePerKB(Btc(feerate).toSatoshi)
           case JInt(feerate) if feerate.toLong < 0 =>
             // negative value means failure: should (hopefully) never happen
             FeeratePerKB(feerate.toLong.sat)
           case JInt(feerate) =>
-            FeeratePerKB(btc2satoshi(Btc(feerate.toLong)))
+            FeeratePerKB(Btc(feerate.toLong).toSatoshi)
         }
       case JArray(errors) =>
         val error = errors.collect { case JString(error) => error }.mkString(", ")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.blockchain.fee
 
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.json4s._
-import fr.acinq.bitcoin.{Block, ByteVector32}
+import fr.acinq.bitcoin.{Block, ByteVector32, Satoshi}
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST.{JInt, JValue}
 import org.json4s.jackson.Serialization
@@ -60,11 +60,11 @@ object BitgoFeeProvider {
     }
   }
 
-  def extractFeerate(feeRanges: Seq[BlockTarget], maxBlockDelay: Int): Long = {
+  def extractFeerate(feeRanges: Seq[BlockTarget], maxBlockDelay: Int): FeeratePerKB = {
     // first we keep only fee ranges with a max block delay below the limit
     val belowLimit = feeRanges.filter(_.block <= maxBlockDelay)
     // out of all the remaining fee ranges, we select the one with the minimum higher bound
-    belowLimit.map(_.fee).min
+    FeeratePerKB(Satoshi(belowLimit.map(_.fee).min))
   }
 
   def extractFeerates(feeRanges: Seq[BlockTarget]): FeeratesPerKB =

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
@@ -75,6 +75,7 @@ object BitgoFeeProvider {
       blocks_12 = extractFeerate(feeRanges, 12),
       blocks_36 = extractFeerate(feeRanges, 36),
       blocks_72 = extractFeerate(feeRanges, 72),
-      blocks_144 = extractFeerate(feeRanges, 144))
+      blocks_144 = extractFeerate(feeRanges, 144),
+      blocks_1008 = extractFeerate(feeRanges, 1008))
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProvider.scala
@@ -18,6 +18,7 @@ package fr.acinq.eclair.blockchain.fee
 
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.json4s._
+import fr.acinq.bitcoin.Satoshi
 import org.json4s.DefaultFormats
 import org.json4s.JsonAST.{JArray, JInt, JValue}
 import org.json4s.jackson.Serialization
@@ -26,8 +27,8 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * Created by PM on 16/11/2017.
-  */
+ * Created by PM on 16/11/2017.
+ */
 class EarnDotComFeeProvider(readTimeOut: Duration)(implicit http: SttpBackend[Future, Nothing], ec: ExecutionContext) extends FeeProvider {
 
   import EarnDotComFeeProvider._
@@ -64,11 +65,11 @@ object EarnDotComFeeProvider {
     })
   }
 
-  def extractFeerate(feeRanges: Seq[FeeRange], maxBlockDelay: Int): Long = {
+  def extractFeerate(feeRanges: Seq[FeeRange], maxBlockDelay: Int): FeeratePerKB = {
     // first we keep only fee ranges with a max block delay below the limit
     val belowLimit = feeRanges.filter(_.maxDelay <= maxBlockDelay)
     // out of all the remaining fee ranges, we select the one with the minimum higher bound and make sure it is > 0
-    Math.max(belowLimit.minBy(_.maxFee).maxFee, 1)
+    FeeratePerKB(Satoshi(Math.max(belowLimit.minBy(_.maxFee).maxFee, 1)))
   }
 
   def extractFeerates(feeRanges: Seq[FeeRange]): FeeratesPerKB =

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProvider.scala
@@ -80,6 +80,7 @@ object EarnDotComFeeProvider {
       blocks_12 = extractFeerate(feeRanges, 12),
       blocks_36 = extractFeerate(feeRanges, 36),
       blocks_72 = extractFeerate(feeRanges, 72),
-      blocks_144 = extractFeerate(feeRanges, 144))
+      blocks_144 = extractFeerate(feeRanges, 144),
+      blocks_1008 = extractFeerate(feeRanges, 1008))
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProvider.scala
@@ -16,20 +16,20 @@
 
 package fr.acinq.eclair.blockchain.fee
 
+import fr.acinq.eclair.LongToBtcAmount
 import grizzled.slf4j.Logging
 
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
-  * This provider will try all child providers in sequence, until one of them works
-  *
-  * @param providers a sequence of providers; they will be tried one after the others until one of them succeeds
-  * @param minFeeratePerByte a configurable minimum value for feerates
-  */
-class FallbackFeeProvider(providers: Seq[FeeProvider], minFeeratePerByte: Long)(implicit ec: ExecutionContext) extends FeeProvider with Logging {
-
+ * This provider will try all child providers in sequence, until one of them works
+ *
+ * @param providers         a sequence of providers; they will be tried one after the others until one of them succeeds
+ * @param minFeeratePerByte a configurable minimum value for feerates
+ */
+class FallbackFeeProvider(providers: Seq[FeeProvider], minFeeratePerByte: FeeratePerByte)(implicit ec: ExecutionContext) extends FeeProvider with Logging {
   require(providers.nonEmpty, "need at least one fee provider")
-  require(minFeeratePerByte > 0, "minimum fee rate must be strictly greater than 0")
+  require(minFeeratePerByte.feerate > 0.sat, "minimum fee rate must be strictly greater than 0")
 
   def getFeerates(fallbacks: Seq[FeeProvider]): Future[FeeratesPerKB] =
     fallbacks match {
@@ -37,19 +37,19 @@ class FallbackFeeProvider(providers: Seq[FeeProvider], minFeeratePerByte: Long)(
       case head +: remaining => head.getFeerates.recoverWith { case error => logger.warn(s"$head failed, falling back to next fee provider", error); getFeerates(remaining) }
     }
 
-  override def getFeerates: Future[FeeratesPerKB] = getFeerates(providers).map(FallbackFeeProvider.enforceMinimumFeerate(_, minFeeratePerByte))
+  override def getFeerates: Future[FeeratesPerKB] = getFeerates(providers).map(FallbackFeeProvider.enforceMinimumFeerate(_, FeeratePerKB(minFeeratePerByte)))
 
 }
 
 object FallbackFeeProvider {
 
-  def enforceMinimumFeerate(feeratesPerKB: FeeratesPerKB, minFeeratePerByte: Long) : FeeratesPerKB = feeratesPerKB.copy(
-    block_1 = Math.max(feeratesPerKB.block_1, minFeeratePerByte * 1000),
-    blocks_2 = Math.max(feeratesPerKB.blocks_2, minFeeratePerByte * 1000),
-    blocks_6 = Math.max(feeratesPerKB.blocks_6, minFeeratePerByte * 1000),
-    blocks_12 = Math.max(feeratesPerKB.blocks_12, minFeeratePerByte * 1000),
-    blocks_36 = Math.max(feeratesPerKB.blocks_36, minFeeratePerByte * 1000),
-    blocks_72 = Math.max(feeratesPerKB.blocks_72, minFeeratePerByte * 1000)
+  private def enforceMinimumFeerate(feeratesPerKB: FeeratesPerKB, minFeeratePerKB: FeeratePerKB): FeeratesPerKB = feeratesPerKB.copy(
+    block_1 = feeratesPerKB.block_1.max(minFeeratePerKB),
+    blocks_2 = feeratesPerKB.blocks_2.max(minFeeratePerKB),
+    blocks_6 = feeratesPerKB.blocks_6.max(minFeeratePerKB),
+    blocks_12 = feeratesPerKB.blocks_12.max(minFeeratePerKB),
+    blocks_36 = feeratesPerKB.blocks_36.max(minFeeratePerKB),
+    blocks_72 = feeratesPerKB.blocks_72.max(minFeeratePerKB)
   )
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeEstimator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeEstimator.scala
@@ -18,9 +18,9 @@ package fr.acinq.eclair.blockchain.fee
 
 trait FeeEstimator {
 
-  def getFeeratePerKb(target: Int): Long
+  def getFeeratePerKb(target: Int): FeeratePerKB
 
-  def getFeeratePerKw(target: Int): Long
+  def getFeeratePerKw(target: Int): FeeratePerKw
 
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
@@ -72,23 +72,28 @@ case class FeeratePerKw(feerate: Satoshi) extends Ordered[FeeratePerKw] {
 
 object FeeratePerKw {
   /**
-   * Minimum relay fee rate.
+   * Minimum relay fee rate in satoshi per kilo-vbyte (taken from Bitcoin Core).
    * Note that Bitcoin Core uses a *virtual size* and not the actual size in bytes: see [[MinimumFeeratePerKw]] below.
    */
   val MinimumRelayFeeRate = 1000
 
   /**
-   * why 253 and not 250 since feerate-per-kw is feerate-per-kb / 250 and the minimum relay fee rate is 1000 satoshi/Kb ?
+   * Why 253 and not 250 since feerate-per-kw should be feerate-per-kvb / 4 and the minimum relay fee rate is
+   * 1000 satoshi/kvb (see [[MinimumRelayFeeRate]])?
    *
-   * because bitcoin core uses neither the actual tx size in bytes or the tx weight to check fees, but a "virtual size"
-   * which is (3 * weight) / 4 ...
-   * so we want :
+   * Because Bitcoin Core uses neither the actual tx size in bytes nor the tx weight to check fees, but a "virtual size"
+   * which is (3 + weight) / 4.
+   * So we want:
    * fee > 1000 * virtual size
-   * feerate-per-kw * weight > 1000 * (3 * weight / 4)
-   * feerate_per-kw > 250 + 3000 / (4 * weight)
-   * with a conservative minimum weight of 400, we get a minimum feerate_per-kw of 253
+   * feerate-per-kw * weight > 1000 * (3 + weight / 4)
+   * feerate-per-kw > 250 + 3000 / (4 * weight)
    *
-   * see https://github.com/ElementsProject/lightning/pull/1251
+   * With a conservative minimum weight of 400, assuming the result of the division may be rounded up and using strict
+   * inequality to err on the side of safety, we get:
+   * feerate-per-kw > 252
+   * hence feerate-per-kw >= 253
+   *
+   * See also https://github.com/ElementsProject/lightning/pull/1251
    */
   val MinimumFeeratePerKw = FeeratePerKw(253 sat)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
@@ -16,7 +16,8 @@
 
 package fr.acinq.eclair.blockchain.fee
 
-import fr.acinq.eclair._
+import fr.acinq.bitcoin.Satoshi
+import fr.acinq.eclair.LongToBtcAmount
 
 import scala.concurrent.Future
 
@@ -29,11 +30,79 @@ trait FeeProvider {
 
 case object CannotRetrieveFeerates extends RuntimeException("cannot retrieve feerates: channels may be at risk")
 
-// stores fee rate in satoshi/kb (1 kb = 1000 bytes)
-case class FeeratesPerKB(block_1: Long, blocks_2: Long, blocks_6: Long, blocks_12: Long, blocks_36: Long, blocks_72: Long, blocks_144: Long) {
-  require(block_1 > 0 && blocks_2 > 0 && blocks_6 > 0 && blocks_12 > 0 && blocks_36 > 0 && blocks_72 > 0 && blocks_144 > 0, "all feerates must be strictly greater than 0")
+/** Fee rate in satoshi-per-bytes. */
+case class FeeratePerByte(feerate: Satoshi)
 
-  def feePerBlock(target: Int): Long = target match {
+object FeeratePerByte {
+  def apply(feeratePerKw: FeeratePerKw): FeeratePerByte = FeeratePerByte(feeratePerKw.feerate / 250)
+}
+
+/** Fee rate in satoshi-per-kilo-bytes (1 kb = 1000 bytes). */
+case class FeeratePerKB(feerate: Satoshi) extends Ordered[FeeratePerKB] {
+  // @formatter:off
+  def isValid: Boolean = feerate.toLong > 0
+  override def compare(that: FeeratePerKB): Int = feerate.compare(that.feerate)
+  def max(other: FeeratePerKB): FeeratePerKB = if (this > other) this else other
+  def min(other: FeeratePerKB): FeeratePerKB = if (this < other) this else other
+  def toLong: Long = feerate.toLong
+  // @formatter:on
+}
+
+object FeeratePerKB {
+  // @formatter:off
+  def apply(feeratePerByte: FeeratePerByte): FeeratePerKB = FeeratePerKB(feeratePerByte.feerate * 1000)
+  def apply(feeratePerKw: FeeratePerKw): FeeratePerKB = FeeratePerKB(feeratePerKw.feerate * 4)
+  // @formatter:on
+}
+
+/** Fee rate in satoshi-per-kilo-weight. */
+case class FeeratePerKw(feerate: Satoshi) extends Ordered[FeeratePerKw] {
+  // @formatter:off
+  def isValid: Boolean = feerate.toLong > 0
+  override def compare(that: FeeratePerKw): Int = feerate.compare(that.feerate)
+  def max(other: FeeratePerKw): FeeratePerKw = if (this > other) this else other
+  def min(other: FeeratePerKw): FeeratePerKw = if (this < other) this else other
+  def +(other: FeeratePerKw): FeeratePerKw = FeeratePerKw(feerate + other.feerate)
+  def *(d: Double): FeeratePerKw = FeeratePerKw(feerate * d)
+  def *(l: Long): FeeratePerKw = FeeratePerKw(feerate * l)
+  def /(l: Long): FeeratePerKw = FeeratePerKw(feerate / l)
+  def toLong: Long = feerate.toLong
+  // @formatter:on
+}
+
+object FeeratePerKw {
+  /**
+   * Minimum relay fee rate.
+   * Note that Bitcoin Core uses a *virtual size* and not the actual size in bytes: see [[MinimumFeeratePerKw]] below.
+   */
+  val MinimumRelayFeeRate = 1000
+
+  /**
+   * why 253 and not 250 since feerate-per-kw is feerate-per-kb / 250 and the minimum relay fee rate is 1000 satoshi/Kb ?
+   *
+   * because bitcoin core uses neither the actual tx size in bytes or the tx weight to check fees, but a "virtual size"
+   * which is (3 * weight) / 4 ...
+   * so we want :
+   * fee > 1000 * virtual size
+   * feerate-per-kw * weight > 1000 * (3 * weight / 4)
+   * feerate_per-kw > 250 + 3000 / (4 * weight)
+   * with a conservative minimum weight of 400, we get a minimum feerate_per-kw of 253
+   *
+   * see https://github.com/ElementsProject/lightning/pull/1251
+   */
+  val MinimumFeeratePerKw = FeeratePerKw(253 sat)
+
+  // @formatter:off
+  def apply(feeratePerKB: FeeratePerKB): FeeratePerKw = MinimumFeeratePerKw.max(FeeratePerKw(feeratePerKB.feerate / 4))
+  def apply(feeratePerByte: FeeratePerByte): FeeratePerKw = FeeratePerKw(FeeratePerKB(feeratePerByte))
+  // @formatter:on
+}
+
+/** Fee rates in satoshi-per-kilo-bytes (1 kb = 1000 bytes). */
+case class FeeratesPerKB(block_1: FeeratePerKB, blocks_2: FeeratePerKB, blocks_6: FeeratePerKB, blocks_12: FeeratePerKB, blocks_36: FeeratePerKB, blocks_72: FeeratePerKB, blocks_144: FeeratePerKB) {
+  require(block_1.isValid && blocks_2.isValid && blocks_6.isValid && blocks_12.isValid && blocks_36.isValid && blocks_72.isValid && blocks_144.isValid, "all feerates must be strictly greater than 0")
+
+  def feePerBlock(target: Int): FeeratePerKB = target match {
     case 1 => block_1
     case 2 => blocks_2
     case t if t <= 6 => blocks_6
@@ -45,10 +114,10 @@ case class FeeratesPerKB(block_1: Long, blocks_2: Long, blocks_6: Long, blocks_1
 }
 
 // stores fee rate in satoshi/kw (1 kw = 1000 weight units)
-case class FeeratesPerKw(block_1: Long, blocks_2: Long, blocks_6: Long, blocks_12: Long, blocks_36: Long, blocks_72: Long, blocks_144: Long) {
-  require(block_1 > 0 && blocks_2 > 0 && blocks_6 > 0 && blocks_12 > 0 && blocks_36 > 0 && blocks_72 > 0 && blocks_144 > 0, "all feerates must be strictly greater than 0")
+case class FeeratesPerKw(block_1: FeeratePerKw, blocks_2: FeeratePerKw, blocks_6: FeeratePerKw, blocks_12: FeeratePerKw, blocks_36: FeeratePerKw, blocks_72: FeeratePerKw, blocks_144: FeeratePerKw) {
+  require(block_1.isValid && blocks_2.isValid && blocks_6.isValid && blocks_12.isValid && blocks_36.isValid && blocks_72.isValid && blocks_144.isValid, "all feerates must be strictly greater than 0")
 
-  def feePerBlock(target: Int): Long = target match {
+  def feePerBlock(target: Int): FeeratePerKw = target match {
     case 1 => block_1
     case 2 => blocks_2
     case t if t <= 6 => blocks_6
@@ -61,16 +130,16 @@ case class FeeratesPerKw(block_1: Long, blocks_2: Long, blocks_6: Long, blocks_1
 
 object FeeratesPerKw {
   def apply(feerates: FeeratesPerKB): FeeratesPerKw = FeeratesPerKw(
-    block_1 = feerateKB2Kw(feerates.block_1),
-    blocks_2 = feerateKB2Kw(feerates.blocks_2),
-    blocks_6 = feerateKB2Kw(feerates.blocks_6),
-    blocks_12 = feerateKB2Kw(feerates.blocks_12),
-    blocks_36 = feerateKB2Kw(feerates.blocks_36),
-    blocks_72 = feerateKB2Kw(feerates.blocks_72),
-    blocks_144 = feerateKB2Kw(feerates.blocks_144))
+    block_1 = FeeratePerKw(feerates.block_1),
+    blocks_2 = FeeratePerKw(feerates.blocks_2),
+    blocks_6 = FeeratePerKw(feerates.blocks_6),
+    blocks_12 = FeeratePerKw(feerates.blocks_12),
+    blocks_36 = FeeratePerKw(feerates.blocks_36),
+    blocks_72 = FeeratePerKw(feerates.blocks_72),
+    blocks_144 = FeeratePerKw(feerates.blocks_144))
 
   /** Used in tests */
-  def single(feeratePerKw: Long): FeeratesPerKw = FeeratesPerKw(
+  def single(feeratePerKw: FeeratePerKw): FeeratesPerKw = FeeratesPerKw(
     block_1 = feeratePerKw,
     blocks_2 = feeratePerKw,
     blocks_6 = feeratePerKw,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
@@ -34,13 +34,12 @@ case object CannotRetrieveFeerates extends RuntimeException("cannot retrieve fee
 case class FeeratePerByte(feerate: Satoshi)
 
 object FeeratePerByte {
-  def apply(feeratePerKw: FeeratePerKw): FeeratePerByte = FeeratePerByte(feeratePerKw.feerate / 250)
+  def apply(feeratePerKw: FeeratePerKw): FeeratePerByte = FeeratePerByte(FeeratePerKB(feeratePerKw).feerate / 1000)
 }
 
-/** Fee rate in satoshi-per-kilo-bytes (1 kb = 1000 bytes). */
+/** Fee rate in satoshi-per-kilo-bytes (1 kB = 1000 bytes). */
 case class FeeratePerKB(feerate: Satoshi) extends Ordered[FeeratePerKB] {
   // @formatter:off
-  def isValid: Boolean = feerate.toLong > 0
   override def compare(that: FeeratePerKB): Int = feerate.compare(that.feerate)
   def max(other: FeeratePerKB): FeeratePerKB = if (this > other) this else other
   def min(other: FeeratePerKB): FeeratePerKB = if (this < other) this else other
@@ -58,7 +57,6 @@ object FeeratePerKB {
 /** Fee rate in satoshi-per-kilo-weight. */
 case class FeeratePerKw(feerate: Satoshi) extends Ordered[FeeratePerKw] {
   // @formatter:off
-  def isValid: Boolean = feerate.toLong > 0
   override def compare(that: FeeratePerKw): Int = feerate.compare(that.feerate)
   def max(other: FeeratePerKw): FeeratePerKw = if (this > other) this else other
   def min(other: FeeratePerKw): FeeratePerKw = if (this < other) this else other
@@ -105,7 +103,7 @@ object FeeratePerKw {
 
 /** Fee rates in satoshi-per-kilo-bytes (1 kb = 1000 bytes). */
 case class FeeratesPerKB(block_1: FeeratePerKB, blocks_2: FeeratePerKB, blocks_6: FeeratePerKB, blocks_12: FeeratePerKB, blocks_36: FeeratePerKB, blocks_72: FeeratePerKB, blocks_144: FeeratePerKB, blocks_1008: FeeratePerKB) {
-  require(block_1.isValid && blocks_2.isValid && blocks_6.isValid && blocks_12.isValid && blocks_36.isValid && blocks_72.isValid && blocks_144.isValid && blocks_1008.isValid, "all feerates must be strictly greater than 0")
+  require(block_1.feerate > 0.sat && blocks_2.feerate > 0.sat && blocks_6.feerate > 0.sat && blocks_12.feerate > 0.sat && blocks_36.feerate > 0.sat && blocks_72.feerate > 0.sat && blocks_144.feerate > 0.sat && blocks_1008.feerate > 0.sat, "all feerates must be strictly greater than 0")
 
   def feePerBlock(target: Int): FeeratePerKB = target match {
     case 1 => block_1
@@ -121,7 +119,7 @@ case class FeeratesPerKB(block_1: FeeratePerKB, blocks_2: FeeratePerKB, blocks_6
 
 // stores fee rate in satoshi/kw (1 kw = 1000 weight units)
 case class FeeratesPerKw(block_1: FeeratePerKw, blocks_2: FeeratePerKw, blocks_6: FeeratePerKw, blocks_12: FeeratePerKw, blocks_36: FeeratePerKw, blocks_72: FeeratePerKw, blocks_144: FeeratePerKw, blocks_1008: FeeratePerKw) {
-  require(block_1.isValid && blocks_2.isValid && blocks_6.isValid && blocks_12.isValid && blocks_36.isValid && blocks_72.isValid && blocks_144.isValid && blocks_1008.isValid, "all feerates must be strictly greater than 0")
+  require(block_1.feerate > 0.sat && blocks_2.feerate > 0.sat && blocks_6.feerate > 0.sat && blocks_12.feerate > 0.sat && blocks_36.feerate > 0.sat && blocks_72.feerate > 0.sat && blocks_144.feerate > 0.sat && blocks_1008.feerate > 0.sat, "all feerates must be strictly greater than 0")
 
   def feePerBlock(target: Int): FeeratePerKw = target match {
     case 1 => block_1

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
@@ -104,8 +104,8 @@ object FeeratePerKw {
 }
 
 /** Fee rates in satoshi-per-kilo-bytes (1 kb = 1000 bytes). */
-case class FeeratesPerKB(block_1: FeeratePerKB, blocks_2: FeeratePerKB, blocks_6: FeeratePerKB, blocks_12: FeeratePerKB, blocks_36: FeeratePerKB, blocks_72: FeeratePerKB, blocks_144: FeeratePerKB) {
-  require(block_1.isValid && blocks_2.isValid && blocks_6.isValid && blocks_12.isValid && blocks_36.isValid && blocks_72.isValid && blocks_144.isValid, "all feerates must be strictly greater than 0")
+case class FeeratesPerKB(block_1: FeeratePerKB, blocks_2: FeeratePerKB, blocks_6: FeeratePerKB, blocks_12: FeeratePerKB, blocks_36: FeeratePerKB, blocks_72: FeeratePerKB, blocks_144: FeeratePerKB, blocks_1008: FeeratePerKB) {
+  require(block_1.isValid && blocks_2.isValid && blocks_6.isValid && blocks_12.isValid && blocks_36.isValid && blocks_72.isValid && blocks_144.isValid && blocks_1008.isValid, "all feerates must be strictly greater than 0")
 
   def feePerBlock(target: Int): FeeratePerKB = target match {
     case 1 => block_1
@@ -114,13 +114,14 @@ case class FeeratesPerKB(block_1: FeeratePerKB, blocks_2: FeeratePerKB, blocks_6
     case t if t <= 12 => blocks_12
     case t if t <= 36 => blocks_36
     case t if t <= 72 => blocks_72
-    case _ => blocks_144
+    case t if t <= 144 => blocks_144
+    case _ => blocks_1008
   }
 }
 
 // stores fee rate in satoshi/kw (1 kw = 1000 weight units)
-case class FeeratesPerKw(block_1: FeeratePerKw, blocks_2: FeeratePerKw, blocks_6: FeeratePerKw, blocks_12: FeeratePerKw, blocks_36: FeeratePerKw, blocks_72: FeeratePerKw, blocks_144: FeeratePerKw) {
-  require(block_1.isValid && blocks_2.isValid && blocks_6.isValid && blocks_12.isValid && blocks_36.isValid && blocks_72.isValid && blocks_144.isValid, "all feerates must be strictly greater than 0")
+case class FeeratesPerKw(block_1: FeeratePerKw, blocks_2: FeeratePerKw, blocks_6: FeeratePerKw, blocks_12: FeeratePerKw, blocks_36: FeeratePerKw, blocks_72: FeeratePerKw, blocks_144: FeeratePerKw, blocks_1008: FeeratePerKw) {
+  require(block_1.isValid && blocks_2.isValid && blocks_6.isValid && blocks_12.isValid && blocks_36.isValid && blocks_72.isValid && blocks_144.isValid && blocks_1008.isValid, "all feerates must be strictly greater than 0")
 
   def feePerBlock(target: Int): FeeratePerKw = target match {
     case 1 => block_1
@@ -129,7 +130,8 @@ case class FeeratesPerKw(block_1: FeeratePerKw, blocks_2: FeeratePerKw, blocks_6
     case t if t <= 12 => blocks_12
     case t if t <= 36 => blocks_36
     case t if t <= 72 => blocks_72
-    case _ => blocks_144
+    case t if t <= 144 => blocks_144
+    case _ => blocks_1008
   }
 }
 
@@ -141,7 +143,8 @@ object FeeratesPerKw {
     blocks_12 = FeeratePerKw(feerates.blocks_12),
     blocks_36 = FeeratePerKw(feerates.blocks_36),
     blocks_72 = FeeratePerKw(feerates.blocks_72),
-    blocks_144 = FeeratePerKw(feerates.blocks_144))
+    blocks_144 = FeeratePerKw(feerates.blocks_144),
+    blocks_1008 = FeeratePerKw(feerates.blocks_1008))
 
   /** Used in tests */
   def single(feeratePerKw: FeeratePerKw): FeeratesPerKw = FeeratesPerKw(
@@ -151,6 +154,7 @@ object FeeratesPerKw {
     blocks_12 = feeratePerKw,
     blocks_36 = feeratePerKw,
     blocks_72 = feeratePerKw,
-    blocks_144 = feeratePerKw)
+    blocks_144 = feeratePerKw,
+    blocks_1008 = feeratePerKw)
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProvider.scala
@@ -39,7 +39,7 @@ class SmoothFeeProvider(provider: FeeProvider, windowSize: Int)(implicit ec: Exe
 
 object SmoothFeeProvider {
 
-  def avg(i: Seq[Long]): Long = i.sum / i.size
+  def avg(i: Seq[FeeratePerKB]): FeeratePerKB = FeeratePerKB(i.map(_.feerate).sum / i.size)
 
   def smooth(rates: Seq[FeeratesPerKB]): FeeratesPerKB =
     FeeratesPerKB(
@@ -50,4 +50,5 @@ object SmoothFeeProvider {
       blocks_36 = avg(rates.map(_.blocks_36)),
       blocks_72 = avg(rates.map(_.blocks_72)),
       blocks_144 = avg(rates.map(_.blocks_144)))
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProvider.scala
@@ -49,6 +49,7 @@ object SmoothFeeProvider {
       blocks_12 = avg(rates.map(_.blocks_12)),
       blocks_36 = avg(rates.map(_.blocks_36)),
       blocks_72 = avg(rates.map(_.blocks_72)),
-      blocks_144 = avg(rates.map(_.blocks_144)))
+      blocks_144 = avg(rates.map(_.blocks_144)),
+      blocks_1008 = avg(rates.map(_.blocks_1008)))
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -20,6 +20,7 @@ import akka.actor.ActorRef
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi, Transaction}
 import fr.acinq.eclair.ShortChannelId
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.Helpers.Closing.ClosingType
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate}
 
@@ -29,7 +30,7 @@ import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate}
 
 trait ChannelEvent
 
-case class ChannelCreated(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, isFunder: Boolean, temporaryChannelId: ByteVector32, initialFeeratePerKw: Long, fundingTxFeeratePerKw: Option[Long]) extends ChannelEvent
+case class ChannelCreated(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, isFunder: Boolean, temporaryChannelId: ByteVector32, initialFeeratePerKw: FeeratePerKw, fundingTxFeeratePerKw: Option[FeeratePerKw]) extends ChannelEvent
 
 case class ChannelRestored(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, isFunder: Boolean, channelId: ByteVector32, currentData: HasCommitments) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -18,6 +18,7 @@ package fr.acinq.eclair.channel
 
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi, Transaction}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.payment.relay.Origin
 import fr.acinq.eclair.wire.{AnnouncementSignatures, ChannelUpdate, Error, UpdateAddHtlc}
 import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, MilliSatoshi, UInt64}
@@ -58,8 +59,8 @@ case class FundingTxSpent                      (override val channelId: ByteVect
 case class HtlcsTimedoutDownstream             (override val channelId: ByteVector32, htlcs: Set[UpdateAddHtlc]) extends ChannelException(channelId, s"one or more htlcs timed out downstream: ids=${htlcs.take(10).map(_.id).mkString(",")}") // we only display the first 10 ids
 case class HtlcsWillTimeoutUpstream            (override val channelId: ByteVector32, htlcs: Set[UpdateAddHtlc]) extends ChannelException(channelId, s"one or more htlcs that should be fulfilled are close to timing out upstream: ids=${htlcs.take(10).map(_.id).mkString}") // we only display the first 10 ids
 case class HtlcOverriddenByLocalCommit         (override val channelId: ByteVector32, htlc: UpdateAddHtlc) extends ChannelException(channelId, s"htlc ${htlc.id} was overridden by local commit")
-case class FeerateTooSmall                     (override val channelId: ByteVector32, remoteFeeratePerKw: Long) extends ChannelException(channelId, s"remote fee rate is too small: remoteFeeratePerKw=$remoteFeeratePerKw")
-case class FeerateTooDifferent                 (override val channelId: ByteVector32, localFeeratePerKw: Long, remoteFeeratePerKw: Long) extends ChannelException(channelId, s"local/remote feerates are too different: remoteFeeratePerKw=$remoteFeeratePerKw localFeeratePerKw=$localFeeratePerKw")
+case class FeerateTooSmall                     (override val channelId: ByteVector32, remoteFeeratePerKw: FeeratePerKw) extends ChannelException(channelId, s"remote fee rate is too small: remoteFeeratePerKw=${remoteFeeratePerKw.toLong}")
+case class FeerateTooDifferent                 (override val channelId: ByteVector32, localFeeratePerKw: FeeratePerKw, remoteFeeratePerKw: FeeratePerKw) extends ChannelException(channelId, s"local/remote feerates are too different: remoteFeeratePerKw=${remoteFeeratePerKw.toLong} localFeeratePerKw=${localFeeratePerKw.toLong}")
 case class InvalidAnnouncementSignatures       (override val channelId: ByteVector32, annSigs: AnnouncementSignatures) extends ChannelException(channelId, s"invalid announcement signatures: $annSigs")
 case class InvalidCommitmentSignature          (override val channelId: ByteVector32, tx: Transaction) extends ChannelException(channelId, s"invalid commitment signature: tx=$tx")
 case class InvalidHtlcSignature                (override val channelId: ByteVector32, tx: Transaction) extends ChannelException(channelId, s"invalid htlc signature: tx=$tx")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteFeeratesDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteFeeratesDb.scala
@@ -18,7 +18,8 @@ package fr.acinq.eclair.db.sqlite
 
 import java.sql.Connection
 
-import fr.acinq.eclair.blockchain.fee.FeeratesPerKB
+import fr.acinq.bitcoin.Satoshi
+import fr.acinq.eclair.blockchain.fee.{FeeratePerKB, FeeratesPerKB}
 import fr.acinq.eclair.db.FeeratesDb
 
 
@@ -44,23 +45,23 @@ class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb {
 
   override def addOrUpdateFeerates(feeratesPerKB: FeeratesPerKB): Unit = {
     using(sqlite.prepareStatement("UPDATE feerates_per_kb SET rate_block_1=?, rate_blocks_2=?, rate_blocks_6=?, rate_blocks_12=?, rate_blocks_36=?, rate_blocks_72=?, rate_blocks_144=?, timestamp=?")) { update =>
-      update.setLong(1, feeratesPerKB.block_1)
-      update.setLong(2, feeratesPerKB.blocks_2)
-      update.setLong(3, feeratesPerKB.blocks_6)
-      update.setLong(4, feeratesPerKB.blocks_12)
-      update.setLong(5, feeratesPerKB.blocks_36)
-      update.setLong(6, feeratesPerKB.blocks_72)
-      update.setLong(7, feeratesPerKB.blocks_144)
+      update.setLong(1, feeratesPerKB.block_1.toLong)
+      update.setLong(2, feeratesPerKB.blocks_2.toLong)
+      update.setLong(3, feeratesPerKB.blocks_6.toLong)
+      update.setLong(4, feeratesPerKB.blocks_12.toLong)
+      update.setLong(5, feeratesPerKB.blocks_36.toLong)
+      update.setLong(6, feeratesPerKB.blocks_72.toLong)
+      update.setLong(7, feeratesPerKB.blocks_144.toLong)
       update.setLong(8, System.currentTimeMillis())
       if (update.executeUpdate() == 0) {
         using(sqlite.prepareStatement("INSERT INTO feerates_per_kb VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) { insert =>
-          insert.setLong(1, feeratesPerKB.block_1)
-          insert.setLong(2, feeratesPerKB.blocks_2)
-          insert.setLong(3, feeratesPerKB.blocks_6)
-          insert.setLong(4, feeratesPerKB.blocks_12)
-          insert.setLong(5, feeratesPerKB.blocks_36)
-          insert.setLong(6, feeratesPerKB.blocks_72)
-          insert.setLong(7, feeratesPerKB.blocks_144)
+          insert.setLong(1, feeratesPerKB.block_1.toLong)
+          insert.setLong(2, feeratesPerKB.blocks_2.toLong)
+          insert.setLong(3, feeratesPerKB.blocks_6.toLong)
+          insert.setLong(4, feeratesPerKB.blocks_12.toLong)
+          insert.setLong(5, feeratesPerKB.blocks_36.toLong)
+          insert.setLong(6, feeratesPerKB.blocks_72.toLong)
+          insert.setLong(7, feeratesPerKB.blocks_144.toLong)
           insert.setLong(8, System.currentTimeMillis())
           insert.executeUpdate()
         }
@@ -73,13 +74,13 @@ class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb {
       val rs = statement.executeQuery()
       if (rs.next()) {
         Some(FeeratesPerKB(
-          block_1 = rs.getLong("rate_block_1"),
-          blocks_2 = rs.getLong("rate_blocks_2"),
-          blocks_6 = rs.getLong("rate_blocks_6"),
-          blocks_12 = rs.getLong("rate_blocks_12"),
-          blocks_36 = rs.getLong("rate_blocks_36"),
-          blocks_72 = rs.getLong("rate_blocks_72"),
-          blocks_144 = rs.getLong("rate_blocks_144")))
+          block_1 = FeeratePerKB(Satoshi(rs.getLong("rate_block_1"))),
+          blocks_2 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_2"))),
+          blocks_6 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_6"))),
+          blocks_12 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_12"))),
+          blocks_36 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_36"))),
+          blocks_72 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_72"))),
+          blocks_144 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_144")))))
       } else {
         None
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteFeeratesDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteFeeratesDb.scala
@@ -21,30 +21,42 @@ import java.sql.Connection
 import fr.acinq.bitcoin.Satoshi
 import fr.acinq.eclair.blockchain.fee.{FeeratePerKB, FeeratesPerKB}
 import fr.acinq.eclair.db.FeeratesDb
+import grizzled.slf4j.Logging
 
-
-class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb {
+class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb with Logging {
 
   import SqliteUtils._
 
   val DB_NAME = "feerates"
-  val CURRENT_VERSION = 1
+  val CURRENT_VERSION = 2
 
   using(sqlite.createStatement(), inTransaction = true) { statement =>
     getVersion(statement, DB_NAME, CURRENT_VERSION) match {
+      case 1 =>
+        logger.warn("migrating feerates db version 1->2")
+        statement.executeUpdate("ALTER TABLE feerates_per_kb RENAME TO _feerates_per_kb_old")
+        statement.executeUpdate(
+          """
+            |CREATE TABLE feerates_per_kb (
+            |rate_block_1 INTEGER NOT NULL, rate_blocks_2 INTEGER NOT NULL, rate_blocks_6 INTEGER NOT NULL, rate_blocks_12 INTEGER NOT NULL, rate_blocks_36 INTEGER NOT NULL, rate_blocks_72 INTEGER NOT NULL, rate_blocks_144 INTEGER NOT NULL, rate_blocks_1008 INTEGER NOT NULL,
+            |timestamp INTEGER NOT NULL)""".stripMargin)
+        statement.executeUpdate("INSERT INTO feerates_per_kb (rate_block_1, rate_blocks_2, rate_blocks_6, rate_blocks_12, rate_blocks_36, rate_blocks_72, rate_blocks_144, rate_blocks_1008, timestamp) SELECT rate_block_1, rate_blocks_2, rate_blocks_6, rate_blocks_12, rate_blocks_36, rate_blocks_72, rate_blocks_144, rate_blocks_144, timestamp FROM _feerates_per_kb_old")
+        statement.executeUpdate("DROP table _feerates_per_kb_old")
+        setVersion(statement, DB_NAME, CURRENT_VERSION)
+        logger.warn("migration complete")
       case CURRENT_VERSION =>
         // Create feerates table. Rates are in kb.
         statement.executeUpdate(
           """
             |CREATE TABLE IF NOT EXISTS feerates_per_kb (
-            |rate_block_1 INTEGER NOT NULL, rate_blocks_2 INTEGER NOT NULL, rate_blocks_6 INTEGER NOT NULL, rate_blocks_12 INTEGER NOT NULL, rate_blocks_36 INTEGER NOT NULL, rate_blocks_72 INTEGER NOT NULL, rate_blocks_144 INTEGER NOT NULL,
+            |rate_block_1 INTEGER NOT NULL, rate_blocks_2 INTEGER NOT NULL, rate_blocks_6 INTEGER NOT NULL, rate_blocks_12 INTEGER NOT NULL, rate_blocks_36 INTEGER NOT NULL, rate_blocks_72 INTEGER NOT NULL, rate_blocks_144 INTEGER NOT NULL, rate_blocks_1008 INTEGER NOT NULL,
             |timestamp INTEGER NOT NULL)""".stripMargin)
       case unknownVersion => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
     }
   }
 
   override def addOrUpdateFeerates(feeratesPerKB: FeeratesPerKB): Unit = {
-    using(sqlite.prepareStatement("UPDATE feerates_per_kb SET rate_block_1=?, rate_blocks_2=?, rate_blocks_6=?, rate_blocks_12=?, rate_blocks_36=?, rate_blocks_72=?, rate_blocks_144=?, timestamp=?")) { update =>
+    using(sqlite.prepareStatement("UPDATE feerates_per_kb SET rate_block_1=?, rate_blocks_2=?, rate_blocks_6=?, rate_blocks_12=?, rate_blocks_36=?, rate_blocks_72=?, rate_blocks_144=?, rate_blocks_1008=?, timestamp=?")) { update =>
       update.setLong(1, feeratesPerKB.block_1.toLong)
       update.setLong(2, feeratesPerKB.blocks_2.toLong)
       update.setLong(3, feeratesPerKB.blocks_6.toLong)
@@ -52,9 +64,10 @@ class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb {
       update.setLong(5, feeratesPerKB.blocks_36.toLong)
       update.setLong(6, feeratesPerKB.blocks_72.toLong)
       update.setLong(7, feeratesPerKB.blocks_144.toLong)
-      update.setLong(8, System.currentTimeMillis())
+      update.setLong(8, feeratesPerKB.blocks_1008.toLong)
+      update.setLong(9, System.currentTimeMillis())
       if (update.executeUpdate() == 0) {
-        using(sqlite.prepareStatement("INSERT INTO feerates_per_kb VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) { insert =>
+        using(sqlite.prepareStatement("INSERT INTO feerates_per_kb VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")) { insert =>
           insert.setLong(1, feeratesPerKB.block_1.toLong)
           insert.setLong(2, feeratesPerKB.blocks_2.toLong)
           insert.setLong(3, feeratesPerKB.blocks_6.toLong)
@@ -62,7 +75,8 @@ class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb {
           insert.setLong(5, feeratesPerKB.blocks_36.toLong)
           insert.setLong(6, feeratesPerKB.blocks_72.toLong)
           insert.setLong(7, feeratesPerKB.blocks_144.toLong)
-          insert.setLong(8, System.currentTimeMillis())
+          insert.setLong(8, feeratesPerKB.blocks_1008.toLong)
+          insert.setLong(9, System.currentTimeMillis())
           insert.executeUpdate()
         }
       }
@@ -70,7 +84,7 @@ class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb {
   }
 
   override def getFeerates(): Option[FeeratesPerKB] = {
-    using(sqlite.prepareStatement("SELECT rate_block_1, rate_blocks_2, rate_blocks_6, rate_blocks_12, rate_blocks_36, rate_blocks_72, rate_blocks_144 FROM feerates_per_kb")) { statement =>
+    using(sqlite.prepareStatement("SELECT rate_block_1, rate_blocks_2, rate_blocks_6, rate_blocks_12, rate_blocks_36, rate_blocks_72, rate_blocks_144, rate_blocks_1008 FROM feerates_per_kb")) { statement =>
       val rs = statement.executeQuery()
       if (rs.next()) {
         Some(FeeratesPerKB(
@@ -80,7 +94,8 @@ class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb {
           blocks_12 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_12"))),
           blocks_36 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_36"))),
           blocks_72 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_72"))),
-          blocks_144 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_144")))))
+          blocks_144 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_144"))),
+          blocks_1008 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_1008")))))
       } else {
         None
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -28,6 +28,7 @@ import fr.acinq.bitcoin.{ByteVector32, DeterministicWallet, Satoshi, Script}
 import fr.acinq.eclair.Features.Wumbo
 import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair.blockchain.EclairWallet
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.io.Monitoring.Metrics
 import fr.acinq.eclair.wire._
@@ -375,11 +376,11 @@ object Peer {
   }
 
   case class Disconnect(nodeId: PublicKey)
-  case class OpenChannel(remoteNodeId: PublicKey, fundingSatoshis: Satoshi, pushMsat: MilliSatoshi, fundingTxFeeratePerKw_opt: Option[Long], channelFlags: Option[Byte], timeout_opt: Option[Timeout]) {
+  case class OpenChannel(remoteNodeId: PublicKey, fundingSatoshis: Satoshi, pushMsat: MilliSatoshi, fundingTxFeeratePerKw_opt: Option[FeeratePerKw], channelFlags: Option[Byte], timeout_opt: Option[Timeout]) {
     require(pushMsat <= fundingSatoshis, s"pushMsat must be less or equal to fundingSatoshis")
     require(fundingSatoshis >= 0.sat, s"fundingSatoshis must be positive")
     require(pushMsat >= 0.msat, s"pushMsat must be positive")
-    fundingTxFeeratePerKw_opt.foreach(feeratePerKw => require(feeratePerKw >= MinimumFeeratePerKw, s"fee rate $feeratePerKw is below minimum $MinimumFeeratePerKw rate/kw"))
+    fundingTxFeeratePerKw_opt.foreach(feeratePerKw => require(feeratePerKw >= FeeratePerKw.MinimumFeeratePerKw, s"fee rate $feeratePerKw is below minimum ${FeeratePerKw.MinimumFeeratePerKw} rate/kw"))
   }
   case object GetPeerInfo
   case class PeerInfo(nodeId: PublicKey, state: String, address: Option[InetSocketAddress], channels: Int)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -56,59 +56,6 @@ package object eclair {
     case Attempt.Failure(cause) => throw new RuntimeException(s"serialization error: $cause")
   }
 
-  /**
-   * Converts fee rate in satoshi-per-bytes to fee rate in satoshi-per-kw
-   *
-   * @param feeratePerByte fee rate in satoshi-per-bytes
-   * @return fee rate in satoshi-per-kw
-   */
-  def feerateByte2Kw(feeratePerByte: Long): Long = feerateKB2Kw(feeratePerByte * 1000)
-
-  /**
-   * Converts fee rate in satoshi-per-kw to fee rate in satoshi-per-byte
-   *
-   * @param feeratePerKw fee rate in satoshi-per-kw
-   * @return fee rate in satoshi-per-byte
-   */
-  def feerateKw2Byte(feeratePerKw: Long): Long = feeratePerKw / 250
-
-  /**
-   * why 253 and not 250 since feerate-per-kw is feerate-per-kb / 250 and the minimum relay fee rate is 1000 satoshi/Kb ?
-   *
-   * because bitcoin core uses neither the actual tx size in bytes or the tx weight to check fees, but a "virtual size"
-   * which is (3 * weight) / 4 ...
-   * so we want :
-   * fee > 1000 * virtual size
-   * feerate-per-kw * weight > 1000 * (3 * weight / 4)
-   * feerate_per-kw > 250 + 3000 / (4 * weight)
-   * with a conservative minimum weight of 400, we get a minimum feerate_per-kw of 253
-   *
-   * see https://github.com/ElementsProject/lightning/pull/1251
-   **/
-  val MinimumFeeratePerKw = 253
-
-  /**
-   * minimum relay fee rate, in satoshi per kilo
-   * bitcoin core uses virtual size and not the actual size in bytes, see above
-   **/
-  val MinimumRelayFeeRate = 1000
-
-  /**
-   * Converts fee rate in satoshi-per-kilobytes to fee rate in satoshi-per-kw
-   *
-   * @param feeratePerKB fee rate in satoshi-per-kilobytes
-   * @return fee rate in satoshi-per-kw
-   */
-  def feerateKB2Kw(feeratePerKB: Long): Long = Math.max(feeratePerKB / 4, MinimumFeeratePerKw)
-
-  /**
-   * Converts fee rate in satoshi-per-kw to fee rate in satoshi-per-kilobyte
-   *
-   * @param feeratePerKw fee rate in satoshi-per-kw
-   * @return fee rate in satoshi-per-kilobyte
-   */
-  def feerateKw2KB(feeratePerKw: Long): Long = feeratePerKw * 4
-
   def isPay2PubkeyHash(address: String): Boolean = address.startsWith("1") || address.startsWith("m") || address.startsWith("n")
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/CommitmentSpec.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/CommitmentSpec.scala
@@ -17,6 +17,7 @@
 package fr.acinq.eclair.transactions
 
 import fr.acinq.eclair.MilliSatoshi
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.wire._
 
 /**
@@ -69,7 +70,7 @@ case class IncomingHtlc(add: UpdateAddHtlc) extends DirectedHtlc
 
 case class OutgoingHtlc(add: UpdateAddHtlc) extends DirectedHtlc
 
-final case class CommitmentSpec(htlcs: Set[DirectedHtlc], feeratePerKw: Long, toLocal: MilliSatoshi, toRemote: MilliSatoshi) {
+final case class CommitmentSpec(htlcs: Set[DirectedHtlc], feeratePerKw: FeeratePerKw, toLocal: MilliSatoshi, toRemote: MilliSatoshi) {
 
   def findIncomingHtlcById(id: Long): Option[IncomingHtlc] = htlcs.collectFirst { case htlc: IncomingHtlc if htlc.add.id == id => htlc }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
@@ -91,7 +91,7 @@ object ChannelCodecs extends Logging {
 
   val commitmentSpecCodec: Codec[CommitmentSpec] = (
     ("htlcs" | setCodec(htlcCodec)) ::
-      ("feeratePerKw" | uint32) ::
+      ("feeratePerKw" | feeratePerKw) ::
       ("toLocal" | millisatoshi) ::
       ("toRemote" | millisatoshi)).as[CommitmentSpec]
 
@@ -281,7 +281,7 @@ object ChannelCodecs extends Logging {
    * We use the fact that the discriminated codec encodes using the first suitable codec it finds in the list to handle
    * database migration.
    *
-   * For example, a data encoded with type 01 will be decoded using [[DATA_WAIT_FOR_FUNDING_CONFIRMED_COMPAT_01_Codec]] and
+   * For example, a data encoded with type 01 will be decoded using [[LegacyChannelCodecs.DATA_WAIT_FOR_FUNDING_CONFIRMED_COMPAT_01_Codec]] and
    * encoded to a type 08 using [[DATA_WAIT_FOR_FUNDING_CONFIRMED_Codec]].
    *
    * More info here: https://github.com/scodec/scodec/issues/122

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/CommonCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/CommonCodecs.scala
@@ -20,6 +20,7 @@ import java.net.{Inet4Address, Inet6Address, InetAddress}
 
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.crypto.Mac32
 import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, MilliSatoshi, ShortChannelId, UInt64}
 import org.apache.commons.codec.binary.Base32
@@ -56,6 +57,8 @@ object CommonCodecs {
 
   val satoshi: Codec[Satoshi] = uint64overflow.xmapc(l => Satoshi(l))(_.toLong)
   val millisatoshi: Codec[MilliSatoshi] = uint64overflow.xmapc(l => MilliSatoshi(l))(_.toLong)
+
+  val feeratePerKw: Codec[FeeratePerKw] = uint32.xmapc(l => FeeratePerKw(Satoshi(l)))(_.toLong)
 
   val cltvExpiry: Codec[CltvExpiry] = uint32.xmapc(CltvExpiry)((_: CltvExpiry).toLong)
   val cltvExpiryDelta: Codec[CltvExpiryDelta] = uint16.xmapc(CltvExpiryDelta)((_: CltvExpiryDelta).toInt)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LegacyChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LegacyChannelCodecs.scala
@@ -100,7 +100,7 @@ private[wire] object LegacyChannelCodecs extends Logging {
 
   val commitmentSpecCodec: Codec[CommitmentSpec] = (
     ("htlcs" | setCodec(htlcCodec)) ::
-      ("feeratePerKw" | uint32) ::
+      ("feeratePerKw" | feeratePerKw) ::
       ("toLocal" | millisatoshi) ::
       ("toRemote" | millisatoshi)).as[CommitmentSpec].decodeOnly
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
@@ -72,7 +72,7 @@ object LightningMessageCodecs {
       ("maxHtlcValueInFlightMsat" | uint64) ::
       ("channelReserveSatoshis" | satoshi) ::
       ("htlcMinimumMsat" | millisatoshi) ::
-      ("feeratePerKw" | uint32) ::
+      ("feeratePerKw" | feeratePerKw) ::
       ("toSelfDelay" | cltvExpiryDelta) ::
       ("maxAcceptedHtlcs" | uint16) ::
       ("fundingPubkey" | publicKey) ::
@@ -161,7 +161,7 @@ object LightningMessageCodecs {
 
   val updateFeeCodec: Codec[UpdateFee] = (
     ("channelId" | bytes32) ::
-      ("feeratePerKw" | uint32)).as[UpdateFee]
+      ("feeratePerKw" | feeratePerKw)).as[UpdateFee]
 
   val announcementSignaturesCodec: Codec[AnnouncementSignatures] = (
     ("channelId" | bytes32) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets
 import com.google.common.base.Charsets
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshi, ShortChannelId, UInt64}
 import scodec.bits.ByteVector
@@ -76,7 +77,7 @@ case class OpenChannel(chainHash: ByteVector32,
                        maxHtlcValueInFlightMsat: UInt64, // this is not MilliSatoshi because it can exceed the total amount of MilliSatoshi
                        channelReserveSatoshis: Satoshi,
                        htlcMinimumMsat: MilliSatoshi,
-                       feeratePerKw: Long,
+                       feeratePerKw: FeeratePerKw,
                        toSelfDelay: CltvExpiryDelta,
                        maxAcceptedHtlcs: Int,
                        fundingPubkey: PublicKey,
@@ -151,7 +152,7 @@ case class RevokeAndAck(channelId: ByteVector32,
                         nextPerCommitmentPoint: PublicKey) extends HtlcMessage with HasChannelId
 
 case class UpdateFee(channelId: ByteVector32,
-                     feeratePerKw: Long) extends ChannelMessage with UpdateMessage with HasChannelId
+                     feeratePerKw: FeeratePerKw) extends ChannelMessage with UpdateMessage with HasChannelId
 
 case class AnnouncementSignatures(channelId: ByteVector32,
                                   shortChannelId: ShortChannelId,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -24,7 +24,7 @@ import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Crypto}
 import fr.acinq.eclair.TestConstants._
 import fr.acinq.eclair.blockchain.TestWallet
-import fr.acinq.eclair.blockchain.fee.FeeratePerKw
+import fr.acinq.eclair.blockchain.fee.{FeeratePerByte, FeeratePerKw}
 import fr.acinq.eclair.channel.{CMD_FORCECLOSE, Register, _}
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.io.Peer.OpenChannel
@@ -85,12 +85,12 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     val nodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
 
     // standard conversion
-    eclair.open(nodeId, fundingAmount = 10000000L sat, pushAmount_opt = None, fundingFeerateSatByte_opt = Some(5 sat), flags_opt = None, openTimeout_opt = None)
+    eclair.open(nodeId, fundingAmount = 10000000L sat, pushAmount_opt = None, fundingFeeratePerByte_opt = Some(FeeratePerByte(5 sat)), flags_opt = None, openTimeout_opt = None)
     val open = switchboard.expectMsgType[OpenChannel]
     assert(open.fundingTxFeeratePerKw_opt === Some(FeeratePerKw(1250 sat)))
 
     // check that minimum fee rate of 253 sat/bw is used
-    eclair.open(nodeId, fundingAmount = 10000000L sat, pushAmount_opt = None, fundingFeerateSatByte_opt = Some(1 sat), flags_opt = None, openTimeout_opt = None)
+    eclair.open(nodeId, fundingAmount = 10000000L sat, pushAmount_opt = None, fundingFeeratePerByte_opt = Some(FeeratePerByte(1 sat)), flags_opt = None, openTimeout_opt = None)
     val open1 = switchboard.expectMsgType[OpenChannel]
     assert(open1.fundingTxFeeratePerKw_opt === Some(FeeratePerKw.MinimumFeeratePerKw))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -24,6 +24,7 @@ import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Crypto}
 import fr.acinq.eclair.TestConstants._
 import fr.acinq.eclair.blockchain.TestWallet
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.{CMD_FORCECLOSE, Register, _}
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.io.Peer.OpenChannel
@@ -84,14 +85,14 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     val nodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
 
     // standard conversion
-    eclair.open(nodeId, fundingAmount = 10000000L sat, pushAmount_opt = None, fundingFeerateSatByte_opt = Some(5), flags_opt = None, openTimeout_opt = None)
+    eclair.open(nodeId, fundingAmount = 10000000L sat, pushAmount_opt = None, fundingFeerateSatByte_opt = Some(5 sat), flags_opt = None, openTimeout_opt = None)
     val open = switchboard.expectMsgType[OpenChannel]
-    assert(open.fundingTxFeeratePerKw_opt === Some(1250))
+    assert(open.fundingTxFeeratePerKw_opt === Some(FeeratePerKw(1250 sat)))
 
     // check that minimum fee rate of 253 sat/bw is used
-    eclair.open(nodeId, fundingAmount = 10000000L sat, pushAmount_opt = None, fundingFeerateSatByte_opt = Some(1), flags_opt = None, openTimeout_opt = None)
+    eclair.open(nodeId, fundingAmount = 10000000L sat, pushAmount_opt = None, fundingFeerateSatByte_opt = Some(1 sat), flags_opt = None, openTimeout_opt = None)
     val open1 = switchboard.expectMsgType[OpenChannel]
-    assert(open1.fundingTxFeeratePerKw_opt === Some(MinimumFeeratePerKw))
+    assert(open1.fundingTxFeeratePerKw_opt === Some(FeeratePerKw.MinimumFeeratePerKw))
   }
 
   test("call send with passing correct arguments") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/PackageSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/PackageSpec.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair
 
 import fr.acinq.bitcoin.Crypto.PrivateKey
-import fr.acinq.bitcoin.{Base58, Base58Check, Bech32, Block, ByteVector32, Crypto, Satoshi, Script}
+import fr.acinq.bitcoin.{Base58, Base58Check, Bech32, Block, ByteVector32, Crypto, Script}
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits._
 
@@ -100,11 +100,6 @@ class PackageSpec extends AnyFunSuite {
       addressToPublicKeyScript("1Qbbbbb", Block.LivenetGenesisBlock.hash)
     }
     assert(e.getMessage.contains("is neither a valid Base58 address") && e.getMessage.contains("nor a valid Bech32 address"))
-  }
-
-  test("convert fee rates and enforce a minimum feerate-per-kw") {
-    assert(feerateByte2Kw(1) == MinimumFeeratePerKw)
-    assert(feerateKB2Kw(1000) == MinimumFeeratePerKw)
   }
 
   test("compare short channel ids as unsigned longs") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -47,15 +47,15 @@ object TestConstants {
   val defaultBlockHeight = 400000
   val fundingSatoshis = 1000000L sat
   val pushMsat = 200000000L msat
-  val feeratePerKw = 10000L
+  val feeratePerKw = FeeratePerKw(10000 sat)
   val emptyOnionPacket = wire.OnionRoutingPacket(0, ByteVector.fill(33)(0), ByteVector.fill(1300)(0), ByteVector32.Zeroes)
 
   class TestFeeEstimator extends FeeEstimator {
     private var currentFeerates = FeeratesPerKw.single(feeratePerKw)
 
-    override def getFeeratePerKb(target: Int): Long = feerateKw2KB(currentFeerates.feePerBlock(target))
+    override def getFeeratePerKb(target: Int): FeeratePerKB = FeeratePerKB(currentFeerates.feePerBlock(target))
 
-    override def getFeeratePerKw(target: Int): Long = currentFeerates.feePerBlock(target)
+    override def getFeeratePerKw(target: Int): FeeratePerKw = currentFeerates.feePerBlock(target)
 
     def setFeerate(feeratesPerKw: FeeratesPerKw): Unit = {
       currentFeerates = feeratesPerKw

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/TestWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/TestWallet.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.blockchain
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Crypto, OutPoint, Satoshi, Transaction, TxIn, TxOut}
 import fr.acinq.eclair.LongToBtcAmount
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import scodec.bits._
 
 import scala.concurrent.Future
@@ -36,7 +37,7 @@ class TestWallet extends EclairWallet {
 
   override def getReceivePubkey(receiveAddress: Option[String] = None): Future[Crypto.PublicKey] = Future.successful(PublicKey(hex"028feba10d0eafd0fad8fe20e6d9206e6bd30242826de05c63f459a00aced24b12"))
 
-  override def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: Long): Future[MakeFundingTxResponse] =
+  override def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: FeeratePerKw): Future[MakeFundingTxResponse] =
     Future.successful(TestWallet.makeDummyFundingTx(pubkeyScript, amount))
 
   override def commit(tx: Transaction): Future[Boolean] = Future.successful(true)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
@@ -22,6 +22,7 @@ import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.DeterministicWallet.{ExtendedPrivateKey, derivePrivateKey}
 import fr.acinq.bitcoin._
 import fr.acinq.eclair.blockchain.electrum.db.sqlite.SqliteWalletDb
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.transactions.{Scripts, Transactions}
 import grizzled.slf4j.Logging
 import org.scalatest.funsuite.AnyFunSuite
@@ -36,7 +37,7 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
 
   val swipeRange = 10
   val dustLimit = 546 sat
-  val feeRatePerKw = 20000
+  val feeRatePerKw = FeeratePerKw(20000 sat)
   val minimumFee = 2000 sat
 
   val master = DeterministicWallet.generate(ByteVector32(ByteVector.fill(32)(1)))
@@ -99,10 +100,9 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
 
     val pub = PrivateKey(ByteVector32(ByteVector.fill(32)(1))).publicKey
     val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(0.5 btc, Script.pay2pkh(pub)) :: Nil, lockTime = 0)
-    val (state2, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, false)
+    val (state2, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = false)
     val Some((_, _, Some(fee))) = state2.computeTransactionDelta(tx1)
     assert(fee == fee1)
-    val actualFeeRate = Transactions.fee2rate(fee, tx1.weight())
 
     val state3 = state2.cancelTransaction(tx1)
     assert(state3 == state1)
@@ -116,15 +116,15 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
   test("complete transactions (insufficient funds)") {
     val state1 = addFunds(state, state.accountKeys.head, 5 btc)
     val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(6 btc, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-    val e = intercept[IllegalArgumentException] {
-      state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, false)
+    intercept[IllegalArgumentException] {
+      state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = false)
     }
   }
 
   test("compute the effect of tx") {
     val state1 = addFunds(state, state.accountKeys.head, 1 btc)
     val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(0.5 btc, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-    val (state2, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, false)
+    val (_, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = false)
 
     val Some((received, sent, Some(fee))) = state1.computeTransactionDelta(tx1)
     assert(fee == fee1)
@@ -136,7 +136,7 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
 
     {
       val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(5000000 sat, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, true)
+      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = true)
       val Some((_, _, Some(fee))) = state3.computeTransactionDelta(tx1)
       assert(fee == fee1)
       val actualFeeRate = Transactions.fee2rate(fee, tx1.weight())
@@ -144,7 +144,7 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
     }
     {
       val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(5000000.sat - dustLimit, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, true)
+      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = true)
       val Some((_, _, Some(fee))) = state3.computeTransactionDelta(tx1)
       assert(fee == fee1)
       val actualFeeRate = Transactions.fee2rate(fee, tx1.weight())
@@ -153,16 +153,16 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
     {
       // with a huge fee rate that will force us to use an additional input when we complete our tx
       val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(3000000 sat, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-      val (state3, tx1, fee1) = state1.completeTransaction(tx, 100 * feeRatePerKw, minimumFee, dustLimit, true)
+      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw * 100, minimumFee, dustLimit, allowSpendUnconfirmed = true)
       val Some((_, _, Some(fee))) = state3.computeTransactionDelta(tx1)
       assert(fee == fee1)
       val actualFeeRate = Transactions.fee2rate(fee, tx1.weight())
-      assert(isFeerateOk(actualFeeRate, 100 * feeRatePerKw))
+      assert(isFeerateOk(actualFeeRate, feeRatePerKw * 100))
     }
     {
       // with a tiny fee rate that will force us to use an additional input when we complete our tx
       val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(Btc(0.09), Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw / 10, minimumFee / 10, dustLimit, true)
+      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw / 10, minimumFee / 10, dustLimit, allowSpendUnconfirmed = true)
       val Some((_, _, Some(fee))) = state3.computeTransactionDelta(tx1)
       assert(fee == fee1)
       val actualFeeRate = Transactions.fee2rate(fee, tx1.weight())
@@ -178,7 +178,7 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
     assert(state3.balance == (350000000 sat, 0 sat))
 
     val (tx, fee) = state3.spendAll(Script.pay2wpkh(ByteVector.fill(20)(1)), feeRatePerKw)
-    val Some((received, sent, Some(fee1))) = state3.computeTransactionDelta(tx)
+    val Some((received, _, Some(fee1))) = state3.computeTransactionDelta(tx)
     assert(received === 0.sat)
     assert(fee == fee1)
     assert(tx.txOut.map(_.amount).sum + fee == state3.balance._1 + state3.balance._2)
@@ -191,20 +191,20 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
     val pub2 = state.accountKeys(1).publicKey
     val redeemScript = Scripts.multiSig2of2(pub1, pub2)
     val pubkeyScript = Script.pay2wsh(redeemScript)
-    val (tx, fee) = state3.spendAll(pubkeyScript, feeRatePerKw = 750)
-    val Some((received, sent, Some(fee1))) = state3.computeTransactionDelta(tx)
+    val (tx, fee) = state3.spendAll(pubkeyScript, FeeratePerKw(750 sat))
+    val Some((received, _, Some(fee1))) = state3.computeTransactionDelta(tx)
     assert(received === 0.sat)
     assert(fee == fee1)
     assert(tx.txOut.map(_.amount).sum + fee == state3.balance._1 + state3.balance._2)
 
     val tx1 = Transaction(version = 2, txIn = Nil, txOut = TxOut(tx.txOut.map(_.amount).sum, pubkeyScript) :: Nil, lockTime = 0)
-    assert(Try(state3.completeTransaction(tx1, 750, 0 sat, dustLimit, true)).isSuccess)
+    assert(Try(state3.completeTransaction(tx1, FeeratePerKw(750 sat), 0 sat, dustLimit, allowSpendUnconfirmed = true)).isSuccess)
   }
 
   test("fuzzy test") {
     val random = new Random()
     (0 to 10) foreach { _ =>
-      val funds = for (i <- 0 until random.nextInt(10)) yield {
+      val funds = for (_ <- 0 until random.nextInt(10)) yield {
         val index = random.nextInt(state.accountKeys.length)
         val amount = dustLimit + random.nextInt(10000000).sat
         (state.accountKeys(index), amount)
@@ -213,8 +213,8 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
       (0 until 30) foreach { _ =>
         val amount = dustLimit + random.nextInt(10000000).sat
         val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(amount, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-        Try(state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, true)) match {
-          case Success((state2, tx1, fee1)) =>
+        Try(state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = true)) match {
+          case Success((_, tx1, _)) =>
             tx1.txOut.foreach(o => require(o.amount >= dustLimit, "output is below dust limit"))
           case Failure(cause) if cause.getMessage != null && cause.getMessage.contains("insufficient funds") => ()
           case Failure(cause) => logger.error(s"unexpected $cause")
@@ -226,10 +226,10 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
 
 object ElectrumWalletBasicSpec {
   /**
-   *
    * @param actualFeeRate actual fee rate
    * @param targetFeeRate target fee rate
    * @return true if actual fee rate is within 10% of target
    */
-  def isFeerateOk(actualFeeRate: Long, targetFeeRate: Long): Boolean = Math.abs(actualFeeRate - targetFeeRate) < 0.1 * (actualFeeRate + targetFeeRate)
+  def isFeerateOk(actualFeeRate: FeeratePerKw, targetFeeRate: FeeratePerKw): Boolean =
+    Math.abs(actualFeeRate.toLong - targetFeeRate.toLong) < 0.1 * (actualFeeRate + targetFeeRate).toLong
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWalletBasicSpec.scala
@@ -37,7 +37,7 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
 
   val swipeRange = 10
   val dustLimit = 546 sat
-  val feeRatePerKw = FeeratePerKw(20000 sat)
+  val feerate = FeeratePerKw(20000 sat)
   val minimumFee = 2000 sat
 
   val master = DeterministicWallet.generate(ByteVector32(ByteVector.fill(32)(1)))
@@ -100,7 +100,7 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
 
     val pub = PrivateKey(ByteVector32(ByteVector.fill(32)(1))).publicKey
     val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(0.5 btc, Script.pay2pkh(pub)) :: Nil, lockTime = 0)
-    val (state2, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = false)
+    val (state2, tx1, fee1) = state1.completeTransaction(tx, feerate, minimumFee, dustLimit, allowSpendUnconfirmed = false)
     val Some((_, _, Some(fee))) = state2.computeTransactionDelta(tx1)
     assert(fee == fee1)
 
@@ -117,14 +117,14 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
     val state1 = addFunds(state, state.accountKeys.head, 5 btc)
     val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(6 btc, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
     intercept[IllegalArgumentException] {
-      state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = false)
+      state1.completeTransaction(tx, feerate, minimumFee, dustLimit, allowSpendUnconfirmed = false)
     }
   }
 
   test("compute the effect of tx") {
     val state1 = addFunds(state, state.accountKeys.head, 1 btc)
     val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(0.5 btc, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-    val (_, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = false)
+    val (_, tx1, fee1) = state1.completeTransaction(tx, feerate, minimumFee, dustLimit, allowSpendUnconfirmed = false)
 
     val Some((received, sent, Some(fee))) = state1.computeTransactionDelta(tx1)
     assert(fee == fee1)
@@ -136,37 +136,37 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
 
     {
       val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(5000000 sat, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = true)
+      val (state3, tx1, fee1) = state1.completeTransaction(tx, feerate, minimumFee, dustLimit, allowSpendUnconfirmed = true)
       val Some((_, _, Some(fee))) = state3.computeTransactionDelta(tx1)
       assert(fee == fee1)
       val actualFeeRate = Transactions.fee2rate(fee, tx1.weight())
-      assert(isFeerateOk(actualFeeRate, feeRatePerKw))
+      assert(isFeerateOk(actualFeeRate, feerate))
     }
     {
       val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(5000000.sat - dustLimit, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = true)
+      val (state3, tx1, fee1) = state1.completeTransaction(tx, feerate, minimumFee, dustLimit, allowSpendUnconfirmed = true)
       val Some((_, _, Some(fee))) = state3.computeTransactionDelta(tx1)
       assert(fee == fee1)
       val actualFeeRate = Transactions.fee2rate(fee, tx1.weight())
-      assert(isFeerateOk(actualFeeRate, feeRatePerKw))
+      assert(isFeerateOk(actualFeeRate, feerate))
     }
     {
       // with a huge fee rate that will force us to use an additional input when we complete our tx
       val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(3000000 sat, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw * 100, minimumFee, dustLimit, allowSpendUnconfirmed = true)
+      val (state3, tx1, fee1) = state1.completeTransaction(tx, feerate * 100, minimumFee, dustLimit, allowSpendUnconfirmed = true)
       val Some((_, _, Some(fee))) = state3.computeTransactionDelta(tx1)
       assert(fee == fee1)
       val actualFeeRate = Transactions.fee2rate(fee, tx1.weight())
-      assert(isFeerateOk(actualFeeRate, feeRatePerKw * 100))
+      assert(isFeerateOk(actualFeeRate, feerate * 100))
     }
     {
       // with a tiny fee rate that will force us to use an additional input when we complete our tx
       val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(Btc(0.09), Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-      val (state3, tx1, fee1) = state1.completeTransaction(tx, feeRatePerKw / 10, minimumFee / 10, dustLimit, allowSpendUnconfirmed = true)
+      val (state3, tx1, fee1) = state1.completeTransaction(tx, feerate / 10, minimumFee / 10, dustLimit, allowSpendUnconfirmed = true)
       val Some((_, _, Some(fee))) = state3.computeTransactionDelta(tx1)
       assert(fee == fee1)
       val actualFeeRate = Transactions.fee2rate(fee, tx1.weight())
-      assert(isFeerateOk(actualFeeRate, feeRatePerKw / 10))
+      assert(isFeerateOk(actualFeeRate, feerate / 10))
     }
   }
 
@@ -177,7 +177,7 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
     assert(state3.utxos.length == 3)
     assert(state3.balance == (350000000 sat, 0 sat))
 
-    val (tx, fee) = state3.spendAll(Script.pay2wpkh(ByteVector.fill(20)(1)), feeRatePerKw)
+    val (tx, fee) = state3.spendAll(Script.pay2wpkh(ByteVector.fill(20)(1)), feerate)
     val Some((received, _, Some(fee1))) = state3.computeTransactionDelta(tx)
     assert(received === 0.sat)
     assert(fee == fee1)
@@ -213,7 +213,7 @@ class ElectrumWalletBasicSpec extends AnyFunSuite with Logging {
       (0 until 30) foreach { _ =>
         val amount = dustLimit + random.nextInt(10000000).sat
         val tx = Transaction(version = 2, txIn = Nil, txOut = TxOut(amount, Script.pay2pkh(state1.accountKeys(0).publicKey)) :: Nil, lockTime = 0)
-        Try(state1.completeTransaction(tx, feeRatePerKw, minimumFee, dustLimit, allowSpendUnconfirmed = true)) match {
+        Try(state1.completeTransaction(tx, feerate, minimumFee, dustLimit, allowSpendUnconfirmed = true)) match {
           case Success((_, tx1, _)) =>
             tx1.txOut.foreach(o => require(o.amount >= dustLimit, "output is below dust limit"))
           case Failure(cause) if cause.getMessage != null && cause.getMessage.contains("insufficient funds") => ()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProviderSpec.scala
@@ -35,7 +35,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.util.Random
 
-
 class BitcoinCoreFeeProviderSpec extends TestKitBaseClass with BitcoindService with AnyFunSuiteLike with BeforeAndAfterAll with Logging {
 
   val commonConfig = ConfigFactory.parseMap(Map(
@@ -89,7 +88,7 @@ class BitcoinCoreFeeProviderSpec extends TestKitBaseClass with BitcoindService w
       port = config.getInt("bitcoind.rpcport"))
 
     // the regtest client doesn't have enough data to estimate fees yet, so it's suppose to fail
-    val regtestProvider = new BitcoinCoreFeeProvider(bitcoinClient, FeeratesPerKB(FeeratePerKB(1 sat), FeeratePerKB(2 sat), FeeratePerKB(3 sat), FeeratePerKB(4 sat), FeeratePerKB(5 sat), FeeratePerKB(6 sat), FeeratePerKB(7 sat)))
+    val regtestProvider = new BitcoinCoreFeeProvider(bitcoinClient, FeeratesPerKB(FeeratePerKB(1 sat), FeeratePerKB(2 sat), FeeratePerKB(3 sat), FeeratePerKB(4 sat), FeeratePerKB(5 sat), FeeratePerKB(6 sat), FeeratePerKB(7 sat), FeeratePerKB(8 sat)))
     val sender = TestProbe()
     regtestProvider.getFeerates.pipeTo(sender.ref)
     assert(sender.expectMsgType[Failure].cause.asInstanceOf[RuntimeException].getMessage.contains("Insufficient data or no feerate found"))
@@ -101,7 +100,8 @@ class BitcoinCoreFeeProviderSpec extends TestKitBaseClass with BitcoindService w
       12 -> FeeratePerKB(1200 sat),
       36 -> FeeratePerKB(1100 sat),
       72 -> FeeratePerKB(1000 sat),
-      144 -> FeeratePerKB(900 sat)
+      144 -> FeeratePerKB(900 sat),
+      1008 -> FeeratePerKB(400 sat)
     )
 
     val ref = FeeratesPerKB(
@@ -111,7 +111,8 @@ class BitcoinCoreFeeProviderSpec extends TestKitBaseClass with BitcoindService w
       blocks_12 = fees(12),
       blocks_36 = fees(36),
       blocks_72 = fees(72),
-      blocks_144 = fees(144))
+      blocks_144 = fees(144),
+      blocks_1008 = fees(1008))
 
     val mockBitcoinClient = new BasicBitcoinJsonRPCClient(
       user = config.getString("bitcoind.rpcuser"),
@@ -127,7 +128,7 @@ class BitcoinCoreFeeProviderSpec extends TestKitBaseClass with BitcoindService w
       }
     }
 
-    val mockProvider = new BitcoinCoreFeeProvider(mockBitcoinClient, FeeratesPerKB(FeeratePerKB(1 sat), FeeratePerKB(2 sat), FeeratePerKB(3 sat), FeeratePerKB(4 sat), FeeratePerKB(5 sat), FeeratePerKB(6 sat), FeeratePerKB(7 sat)))
+    val mockProvider = new BitcoinCoreFeeProvider(mockBitcoinClient, FeeratesPerKB(FeeratePerKB(1 sat), FeeratePerKB(2 sat), FeeratePerKB(3 sat), FeeratePerKB(4 sat), FeeratePerKB(5 sat), FeeratePerKB(6 sat), FeeratePerKB(7 sat), FeeratePerKB(8 sat)))
     mockProvider.getFeerates.pipeTo(sender.ref)
     assert(sender.expectMsgType[FeeratesPerKB] == ref)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProviderSpec.scala
@@ -66,7 +66,8 @@ class BitgoFeeProviderSpec extends AnyFunSuite {
       blocks_12 = FeeratePerKB(96254 sat),
       blocks_36 = FeeratePerKB(71098 sat),
       blocks_72 = FeeratePerKB(68182 sat),
-      blocks_144 = FeeratePerKB(16577 sat))
+      blocks_144 = FeeratePerKB(16577 sat),
+      blocks_1008 = FeeratePerKB(5070 sat))
     assert(feerates === ref)
   }
 
@@ -92,4 +93,5 @@ class BitgoFeeProviderSpec extends AnyFunSuite {
     }
     assert(e.getMessage.contains("timed out") || e.getMessage.contains("timeout"))
   }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProviderSpec.scala
@@ -20,14 +20,15 @@ import akka.actor.ActorSystem
 import akka.util.Timeout
 import com.softwaremill.sttp.okhttp.OkHttpFutureBackend
 import fr.acinq.bitcoin.Block
+import fr.acinq.eclair.LongToBtcAmount
 import org.json4s.DefaultFormats
 import org.scalatest.funsuite.AnyFunSuite
 
 import scala.concurrent.Await
 
 /**
-  * Created by PM on 27/01/2017.
-  */
+ * Created by PM on 27/01/2017.
+ */
 
 class BitgoFeeProviderSpec extends AnyFunSuite {
 
@@ -51,7 +52,7 @@ class BitgoFeeProviderSpec extends AnyFunSuite {
     val json = parse(sample_response)
     val feeRanges = parseFeeRanges(json)
     val fee = extractFeerate(feeRanges, 6)
-    assert(fee === 105566)
+    assert(fee === FeeratePerKB(105566 sat))
   }
 
   test("extract all fees") {
@@ -59,13 +60,13 @@ class BitgoFeeProviderSpec extends AnyFunSuite {
     val feeRanges = parseFeeRanges(json)
     val feerates = extractFeerates(feeRanges)
     val ref = FeeratesPerKB(
-      block_1 = 149453,
-      blocks_2 = 136797,
-      blocks_6 = 105566,
-      blocks_12 = 96254,
-      blocks_36 = 71098,
-      blocks_72 = 68182,
-      blocks_144 = 16577)
+      block_1 = FeeratePerKB(149453 sat),
+      blocks_2 = FeeratePerKB(136797 sat),
+      blocks_6 = FeeratePerKB(105566 sat),
+      blocks_12 = FeeratePerKB(96254 sat),
+      blocks_36 = FeeratePerKB(71098 sat),
+      blocks_72 = FeeratePerKB(68182 sat),
+      blocks_144 = FeeratePerKB(16577 sat))
     assert(feerates === ref)
   }
 
@@ -76,7 +77,7 @@ class BitgoFeeProviderSpec extends AnyFunSuite {
     implicit val sttp = OkHttpFutureBackend()
     implicit val timeout = Timeout(30 seconds)
     val bitgo = new BitgoFeeProvider(Block.LivenetGenesisBlock.hash, 5 seconds)
-    assert(Await.result(bitgo.getFeerates, timeout.duration).block_1 > 0)
+    assert(Await.result(bitgo.getFeerates, timeout.duration).block_1.toLong > 0)
   }
 
   test("check that read timeout is enforced") {
@@ -89,6 +90,6 @@ class BitgoFeeProviderSpec extends AnyFunSuite {
     val e = intercept[Exception] {
       Await.result(bitgo.getFeerates, timeout.duration)
     }
-    assert(e.getMessage.contains("Read timed out"))
+    assert(e.getMessage.contains("timed out") || e.getMessage.contains("timeout"))
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/DbFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/DbFeeProviderSpec.scala
@@ -17,18 +17,17 @@
 package fr.acinq.eclair.blockchain.fee
 
 import akka.util.Timeout
-import fr.acinq.eclair.TestConstants
 import fr.acinq.eclair.db.sqlite.SqliteFeeratesDb
+import fr.acinq.eclair.{LongToBtcAmount, TestConstants}
 import org.scalatest.funsuite.AnyFunSuite
 
+import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
-
 
 class DbFeeProviderSpec extends AnyFunSuite {
 
-  val feerates1: FeeratesPerKB = FeeratesPerKB(100, 200, 300, 400, 500, 600, 700)
+  val feerates1: FeeratesPerKB = FeeratesPerKB(FeeratePerKB(100 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat))
 
   test("db fee provider saves feerates in database") {
     val sqlite = TestConstants.sqliteInMemory()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/DbFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/DbFeeProviderSpec.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 
 class DbFeeProviderSpec extends AnyFunSuite {
 
-  val feerates1: FeeratesPerKB = FeeratesPerKB(FeeratePerKB(100 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat))
+  val feerates1: FeeratesPerKB = FeeratesPerKB(FeeratePerKB(100 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat))
 
   test("db fee provider saves feerates in database") {
     val sqlite = TestConstants.sqliteInMemory()
@@ -38,4 +38,5 @@ class DbFeeProviderSpec extends AnyFunSuite {
     assert(Await.result(provider.getFeerates, Timeout(30 seconds).duration) == feerates1)
     assert(db.getFeerates().get == feerates1)
   }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProviderSpec.scala
@@ -18,6 +18,7 @@ package fr.acinq.eclair.blockchain.fee
 
 import akka.util.Timeout
 import com.softwaremill.sttp.okhttp.OkHttpFutureBackend
+import fr.acinq.eclair.LongToBtcAmount
 import grizzled.slf4j.Logging
 import org.json4s.DefaultFormats
 import org.scalatest.funsuite.AnyFunSuite
@@ -25,8 +26,8 @@ import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.Await
 
 /**
-  * Created by PM on 27/01/2017.
-  */
+ * Created by PM on 27/01/2017.
+ */
 
 class EarnDotComFeeProviderSpec extends AnyFunSuite with Logging {
 
@@ -50,7 +51,7 @@ class EarnDotComFeeProviderSpec extends AnyFunSuite with Logging {
     val json = parse(sample_response)
     val feeRanges = parseFeeRanges(json)
     val fee = extractFeerate(feeRanges, 6)
-    assert(fee === 230 * 1000)
+    assert(fee === FeeratePerKB(230 * 1000 sat))
   }
 
   test("extract all fees") {
@@ -58,20 +59,20 @@ class EarnDotComFeeProviderSpec extends AnyFunSuite with Logging {
     val feeRanges = parseFeeRanges(json)
     val feerates = extractFeerates(feeRanges)
     val ref = FeeratesPerKB(
-      block_1 = 400 * 1000,
-      blocks_2 = 350 * 1000,
-      blocks_6 = 230 * 1000,
-      blocks_12 = 140 * 1000,
-      blocks_36 = 60 * 1000,
-      blocks_72 = 40 * 1000,
-      blocks_144 = 10 * 1000)
+      block_1 = FeeratePerKB(400 * 1000 sat),
+      blocks_2 = FeeratePerKB(350 * 1000 sat),
+      blocks_6 = FeeratePerKB(230 * 1000 sat),
+      blocks_12 = FeeratePerKB(140 * 1000 sat),
+      blocks_36 = FeeratePerKB(60 * 1000 sat),
+      blocks_72 = FeeratePerKB(40 * 1000 sat),
+      blocks_144 = FeeratePerKB(10 * 1000 sat))
     assert(feerates === ref)
   }
 
   test("make sure API hasn't changed") {
     import scala.concurrent.ExecutionContext.Implicits.global
     import scala.concurrent.duration._
-    implicit val sttpBackend  = OkHttpFutureBackend()
+    implicit val sttpBackend = OkHttpFutureBackend()
     implicit val timeout = Timeout(30 seconds)
     val provider = new EarnDotComFeeProvider(5 seconds)
     logger.info("earn.com livenet fees: " + Await.result(provider.getFeerates, 10 seconds))
@@ -80,7 +81,7 @@ class EarnDotComFeeProviderSpec extends AnyFunSuite with Logging {
   test("check that read timeout is enforced") {
     import scala.concurrent.ExecutionContext.Implicits.global
     import scala.concurrent.duration._
-    implicit val sttpBackend  = OkHttpFutureBackend()
+    implicit val sttpBackend = OkHttpFutureBackend()
     implicit val timeout = Timeout(5 second)
     val provider = new EarnDotComFeeProvider(1 millisecond)
     intercept[Exception] {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProviderSpec.scala
@@ -65,7 +65,8 @@ class EarnDotComFeeProviderSpec extends AnyFunSuite with Logging {
       blocks_12 = FeeratePerKB(140 * 1000 sat),
       blocks_36 = FeeratePerKB(60 * 1000 sat),
       blocks_72 = FeeratePerKB(40 * 1000 sat),
-      blocks_144 = FeeratePerKB(10 * 1000 sat))
+      blocks_144 = FeeratePerKB(10 * 1000 sat),
+      blocks_1008 = FeeratePerKB(10 * 1000 sat))
     assert(feerates === ref)
   }
 
@@ -88,4 +89,5 @@ class EarnDotComFeeProviderSpec extends AnyFunSuite with Logging {
       Await.result(provider.getFeerates, timeout.duration)
     }
   }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProviderSpec.scala
@@ -16,23 +16,20 @@
 
 package fr.acinq.eclair.blockchain.fee
 
+import fr.acinq.eclair.LongToBtcAmount
 import org.scalatest.funsuite.AnyFunSuite
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.Random
 
-
 class FallbackFeeProviderSpec extends AnyFunSuite {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
   /**
-    * This provider returns a constant value, but fails after ttl tries
-    *
-    * @param ttl
-    * @param feeratesPerKB
-    */
+   * This provider returns a constant value, but fails after ttl tries
+   */
   class FailingFeeProvider(ttl: Int, val feeratesPerKB: FeeratesPerKB) extends FeeProvider {
     var i = 0
 
@@ -43,7 +40,9 @@ class FallbackFeeProviderSpec extends AnyFunSuite {
       } else Future.failed(new RuntimeException())
   }
 
-  def dummyFeerates = FeeratesPerKB(1000 + Random.nextInt(10000), 1000 + Random.nextInt(10000), 1000 + Random.nextInt(10000), 1000 + Random.nextInt(10000), 1000 + Random.nextInt(10000), 1000 + Random.nextInt(10000), 1000 + Random.nextInt(10000))
+  def dummyFeerate = FeeratePerKB(1000.sat + Random.nextInt(10000).sat)
+
+  def dummyFeerates = FeeratesPerKB(dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate)
 
   def await[T](f: Future[T]): T = Await.result(f, 3 seconds)
 
@@ -54,7 +53,7 @@ class FallbackFeeProviderSpec extends AnyFunSuite {
     val provider5 = new FailingFeeProvider(5, dummyFeerates) // fails after 5 tries
     val provider7 = new FailingFeeProvider(Int.MaxValue, dummyFeerates) // "never" fails
 
-    val fallbackFeeProvider = new FallbackFeeProvider(provider0 :: provider1 :: provider3 :: provider5 :: provider7 :: Nil, 1)
+    val fallbackFeeProvider = new FallbackFeeProvider(provider0 :: provider1 :: provider3 :: provider5 :: provider7 :: Nil, FeeratePerByte(1 sat))
 
     assert(await(fallbackFeeProvider.getFeerates) === provider1.feeratesPerKB)
 
@@ -69,13 +68,14 @@ class FallbackFeeProviderSpec extends AnyFunSuite {
     assert(await(fallbackFeeProvider.getFeerates) === provider5.feeratesPerKB)
 
     assert(await(fallbackFeeProvider.getFeerates) === provider7.feeratesPerKB)
-
   }
 
   test("ensure minimum feerate") {
-    val constantFeeProvider = new ConstantFeeProvider(FeeratesPerKB(1000, 1000, 1000, 1000, 1000, 1000, 1000))
-    val fallbackFeeProvider = new FallbackFeeProvider(constantFeeProvider :: Nil, 2)
-    assert(await(fallbackFeeProvider.getFeerates) === FeeratesPerKB(2000, 2000, 2000, 2000, 2000, 2000, 1000))
+    val feeratePerKB = FeeratePerKB(1000 sat)
+    val constantFeeProvider = new ConstantFeeProvider(FeeratesPerKB(feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB))
+    val fallbackFeeProvider = new FallbackFeeProvider(constantFeeProvider :: Nil, FeeratePerByte(2 sat))
+    val expectedFeeratePerKB = FeeratePerKB(2000 sat)
+    assert(await(fallbackFeeProvider.getFeerates) === FeeratesPerKB(expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, feeratePerKB))
   }
 
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProviderSpec.scala
@@ -42,7 +42,7 @@ class FallbackFeeProviderSpec extends AnyFunSuite {
 
   def dummyFeerate = FeeratePerKB(1000.sat + Random.nextInt(10000).sat)
 
-  def dummyFeerates = FeeratesPerKB(dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate)
+  def dummyFeerates = FeeratesPerKB(dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate)
 
   def await[T](f: Future[T]): T = Await.result(f, 3 seconds)
 
@@ -72,11 +72,10 @@ class FallbackFeeProviderSpec extends AnyFunSuite {
 
   test("ensure minimum feerate") {
     val feeratePerKB = FeeratePerKB(1000 sat)
-    val constantFeeProvider = new ConstantFeeProvider(FeeratesPerKB(feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB))
+    val constantFeeProvider = new ConstantFeeProvider(FeeratesPerKB(feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB))
     val fallbackFeeProvider = new FallbackFeeProvider(constantFeeProvider :: Nil, FeeratePerByte(2 sat))
     val expectedFeeratePerKB = FeeratePerKB(2000 sat)
-    assert(await(fallbackFeeProvider.getFeerates) === FeeratesPerKB(expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, feeratePerKB))
+    assert(await(fallbackFeeProvider.getFeerates) === FeeratesPerKB(expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, feeratePerKB, feeratePerKB))
   }
-
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FeeProviderSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.blockchain.fee
+
+import fr.acinq.eclair.LongToBtcAmount
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw.MinimumFeeratePerKw
+import org.scalatest.funsuite.AnyFunSuite
+
+class FeeProviderSpec extends AnyFunSuite {
+
+  test("convert fee rates") {
+    assert(FeeratePerByte(FeeratePerKw(2000 sat)) === FeeratePerByte(8 sat))
+    assert(FeeratePerKB(FeeratePerByte(10 sat)) === FeeratePerKB(10000 sat))
+    assert(FeeratePerKB(FeeratePerKw(25 sat)) === FeeratePerKB(100 sat))
+    assert(FeeratePerKw(FeeratePerKB(10000 sat)) === FeeratePerKw(2500 sat))
+    assert(FeeratePerKw(FeeratePerByte(10 sat)) === FeeratePerKw(2500 sat))
+  }
+
+  test("enforce a minimum feerate-per-kw") {
+    assert(FeeratePerKw(FeeratePerKB(1000 sat)) === MinimumFeeratePerKw)
+    assert(FeeratePerKw(FeeratePerKB(500 sat)) === MinimumFeeratePerKw)
+    assert(FeeratePerKw(FeeratePerByte(1 sat)) === MinimumFeeratePerKw)
+  }
+
+  test("compare feerates") {
+    assert(FeeratePerKw(500 sat) > FeeratePerKw(499 sat))
+    assert(FeeratePerKw(500 sat) >= FeeratePerKw(500 sat))
+    assert(FeeratePerKw(499 sat) < FeeratePerKw(500 sat))
+    assert(FeeratePerKw(500 sat) <= FeeratePerKw(500 sat))
+    assert(FeeratePerKw(500 sat).max(FeeratePerKw(499 sat)) == FeeratePerKw(500 sat))
+    assert(FeeratePerKw(499 sat).max(FeeratePerKw(500 sat)) == FeeratePerKw(500 sat))
+    assert(FeeratePerKw(500 sat).min(FeeratePerKw(499 sat)) == FeeratePerKw(499 sat))
+    assert(FeeratePerKw(499 sat).min(FeeratePerKw(500 sat)) == FeeratePerKw(499 sat))
+  }
+
+  test("numeric operations") {
+    assert(FeeratePerKw(100 sat) * 0.4 === FeeratePerKw(40 sat))
+    assert(FeeratePerKw(501 sat) * 0.5 === FeeratePerKw(250 sat))
+    assert(FeeratePerKw(5 sat) * 5 === FeeratePerKw(25 sat))
+    assert(FeeratePerKw(100 sat) / 10 === FeeratePerKw(10 sat))
+    assert(FeeratePerKw(101 sat) / 10 === FeeratePerKw(10 sat))
+    assert(FeeratePerKw(100 sat) + FeeratePerKw(50 sat) === FeeratePerKw(150 sat))
+  }
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
@@ -24,15 +24,16 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 class SmoothFeeProviderSpec extends AnyFunSuite {
+
   test("smooth fee rates") {
     val rates = Array(
-      FeeratesPerKB(FeeratePerKB(100 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(650 sat)),
-      FeeratesPerKB(FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(750 sat)),
-      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat)),
-      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat)),
-      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat))
+      FeeratesPerKB(FeeratePerKB(100 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(650 sat), FeeratePerKB(700 sat)),
+      FeeratesPerKB(FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(750 sat), FeeratePerKB(800 sat)),
+      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat), FeeratePerKB(900 sat)),
+      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat), FeeratePerKB(900 sat)),
+      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat), FeeratePerKB(900 sat))
     )
-    val provider = new FeeProvider {
+    val provider: FeeProvider = new FeeProvider {
       var index = 0
 
       override def getFeerates: Future[FeeratesPerKB] = {
@@ -55,8 +56,9 @@ class SmoothFeeProviderSpec extends AnyFunSuite {
     assert(rate1 == rates(0))
     assert(rate2 == SmoothFeeProvider.smooth(Seq(rates(0), rates(1))))
     assert(rate3 == SmoothFeeProvider.smooth(Seq(rates(0), rates(1), rates(2))))
-    assert(rate3 == FeeratesPerKB(FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(750 sat)))
+    assert(rate3 == FeeratesPerKB(FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(750 sat), FeeratePerKB(800 sat)))
     assert(rate4 == SmoothFeeProvider.smooth(Seq(rates(1), rates(2), rates(3))))
     assert(rate5 == rates(4)) // since the last 3 values are the same
   }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
@@ -16,24 +16,24 @@
 
 package fr.acinq.eclair.blockchain.fee
 
+import fr.acinq.eclair.LongToBtcAmount
 import org.scalatest.funsuite.AnyFunSuite
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-
 class SmoothFeeProviderSpec extends AnyFunSuite {
   test("smooth fee rates") {
     val rates = Array(
-      FeeratesPerKB(100, 200, 300, 400, 500, 600, 650),
-      FeeratesPerKB(200, 300, 400, 500, 600, 700, 750),
-      FeeratesPerKB(300, 400, 500, 600, 700, 800, 850),
-      FeeratesPerKB(300, 400, 500, 600, 700, 800, 850),
-      FeeratesPerKB(300, 400, 500, 600, 700, 800, 850)
+      FeeratesPerKB(FeeratePerKB(100 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(650 sat)),
+      FeeratesPerKB(FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(750 sat)),
+      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat)),
+      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat)),
+      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat))
     )
     val provider = new FeeProvider {
-       var index = 0
+      var index = 0
 
       override def getFeerates: Future[FeeratesPerKB] = {
         val rate = rates(index)
@@ -55,7 +55,7 @@ class SmoothFeeProviderSpec extends AnyFunSuite {
     assert(rate1 == rates(0))
     assert(rate2 == SmoothFeeProvider.smooth(Seq(rates(0), rates(1))))
     assert(rate3 == SmoothFeeProvider.smooth(Seq(rates(0), rates(1), rates(2))))
-    assert(rate3 ==  FeeratesPerKB(200, 300, 400, 500, 600, 700, 750))
+    assert(rate3 == FeeratesPerKB(FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(750 sat)))
     assert(rate4 == SmoothFeeProvider.smooth(Seq(rates(1), rates(2), rates(3))))
     assert(rate5 == rates(4)) // since the last 3 values are the same
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptChannelStateSpec.scala
@@ -21,6 +21,7 @@ import fr.acinq.bitcoin.{Block, Btc, ByteVector32, Satoshi}
 import fr.acinq.eclair.FeatureSupport.Optional
 import fr.acinq.eclair.Features.Wumbo
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.blockchain.{MakeFundingTxResponse, TestWallet}
 import fr.acinq.eclair.channel.Channel.TickChannelOpenTimeout
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
@@ -44,7 +45,7 @@ class WaitForAcceptChannelStateSpec extends TestKitBaseClass with FixtureAnyFunS
 
   override def withFixture(test: OneArgTest): Outcome = {
     val noopWallet = new TestWallet {
-      override def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: Long): Future[MakeFundingTxResponse] = Promise[MakeFundingTxResponse].future // will never be completed
+      override def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: FeeratePerKw): Future[MakeFundingTxResponse] = Promise[MakeFundingTxResponse].future // will never be completed
     }
 
     import com.softwaremill.quicklens._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
@@ -21,6 +21,7 @@ import fr.acinq.bitcoin.{Block, Btc, ByteVector32}
 import fr.acinq.eclair.FeatureSupport.Optional
 import fr.acinq.eclair.Features.Wumbo
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.wire.{AcceptChannel, ChannelTlv, Error, Init, OpenChannel, TlvStream}
@@ -154,7 +155,7 @@ class WaitForOpenChannelStateSpec extends TestKitBaseClass with FixtureAnyFunSui
     import f._
     val open = alice2bob.expectMsgType[OpenChannel]
     // set a very small fee
-    val tinyFee = 253
+    val tinyFee = FeeratePerKw(253 sat)
     bob ! open.copy(feeratePerKw = tinyFee)
     val error = bob2alice.expectMsgType[Error]
     // we check that the error uses the temporary channel id
@@ -166,7 +167,7 @@ class WaitForOpenChannelStateSpec extends TestKitBaseClass with FixtureAnyFunSui
     import f._
     val open = alice2bob.expectMsgType[OpenChannel]
     // set a very small fee
-    val tinyFee = 252
+    val tinyFee = FeeratePerKw(252 sat)
     bob ! open.copy(feeratePerKw = tinyFee)
     val error = bob2alice.expectMsgType[Error]
     // we check that the error uses the temporary channel id

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedInternalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedInternalStateSpec.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.channel.states.b
 import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.blockchain.{MakeFundingTxResponse, TestWallet}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
@@ -41,7 +42,7 @@ class WaitForFundingCreatedInternalStateSpec extends TestKitBaseClass with Fixtu
 
   override def withFixture(test: OneArgTest): Outcome = {
     val noopWallet = new TestWallet {
-      override def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: Long): Future[MakeFundingTxResponse] = Promise[MakeFundingTxResponse].future  // will never be completed
+      override def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: FeeratePerKw): Future[MakeFundingTxResponse] = Promise[MakeFundingTxResponse].future  // will never be completed
     }
     val setup = init(wallet = noopWallet)
     import setup._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingCreatedStateSpec.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.channel.states.b
 
 import akka.testkit.{TestFSMRef, TestProbe}
-import fr.acinq.bitcoin.{ByteVector32, Satoshi}
+import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.channel._
@@ -72,7 +72,7 @@ class WaitForFundingCreatedStateSpec extends TestKitBaseClass with FixtureAnyFun
 
   test("recv FundingCreated (funder can't pay fees)", Tag("funder_below_reserve")) { f =>
     import f._
-    val fees = Satoshi(Transactions.DefaultCommitmentFormat.commitWeight * TestConstants.feeratePerKw / 1000)
+    val fees = Transactions.weight2fee(TestConstants.feeratePerKw, Transactions.DefaultCommitmentFormat.commitWeight)
     val reserve = Bob.channelParams.channelReserve
     val missing = 100.sat - fees - reserve
     val fundingCreated = alice2bob.expectMsgType[FundingCreated]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -1725,7 +1725,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("recv UpdateFee (local/remote feerates are too different)") { f =>
     import f._
 
-    bob.feeEstimator.setFeerate(FeeratesPerKw(FeeratePerKw(1000 sat), FeeratePerKw(2000 sat), FeeratePerKw(6000 sat), FeeratePerKw(12000 sat), FeeratePerKw(36000 sat), FeeratePerKw(72000 sat), FeeratePerKw(140000 sat)))
+    bob.feeEstimator.setFeerate(FeeratesPerKw(FeeratePerKw(1000 sat), FeeratePerKw(2000 sat), FeeratePerKw(6000 sat), FeeratePerKw(12000 sat), FeeratePerKw(36000 sat), FeeratePerKw(72000 sat), FeeratePerKw(140000 sat), FeeratePerKw(160000 sat)))
     val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
     val sender = TestProbe()
     val localFeerate = bob.feeEstimator.getFeeratePerKw(bob.feeTargets.commitmentBlockTarget)
@@ -2152,7 +2152,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
     val sender = TestProbe()
     val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-    val event = CurrentFeerates(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(200 sat), FeeratePerKw(600 sat), FeeratePerKw(1200 sat), FeeratePerKw(3600 sat), FeeratePerKw(7200 sat), FeeratePerKw(14400 sat)))
+    val event = CurrentFeerates(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(200 sat), FeeratePerKw(600 sat), FeeratePerKw(1200 sat), FeeratePerKw(3600 sat), FeeratePerKw(7200 sat), FeeratePerKw(14400 sat), FeeratePerKw(100800 sat)))
     sender.send(alice, event)
     alice2bob.expectMsg(UpdateFee(initialState.commitments.channelId, event.feeratesPerKw.feePerBlock(Alice.nodeParams.onChainFeeConf.feeTargets.commitmentBlockTarget)))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair.UInt64.Conversions._
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
-import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
+import fr.acinq.eclair.blockchain.fee.{FeeratePerKw, FeeratesPerKw}
 import fr.acinq.eclair.channel.Channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.channel.{ChannelErrorOccurred, _}
@@ -373,21 +373,21 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
 
     val sender = TestProbe()
-    bob.feeEstimator.setFeerate(FeeratesPerKw.single(20000))
-    sender.send(bob, CurrentFeerates(FeeratesPerKw.single(20000)))
+    bob.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(20000 sat)))
+    sender.send(bob, CurrentFeerates(FeeratesPerKw.single(FeeratePerKw(20000 sat))))
     bob2alice.expectNoMsg(100 millis) // we don't close because the commitment doesn't contain any HTLC
 
     val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
     val upstream = Upstream.Local(UUID.randomUUID())
     val add = CMD_ADD_HTLC(500000 msat, randomBytes32, CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, upstream)
     sender.send(bob, add)
-    val error = FeerateTooDifferent(channelId(bob), 20000, 10000)
+    val error = FeerateTooDifferent(channelId(bob), FeeratePerKw(20000 sat), FeeratePerKw(10000 sat))
     sender.expectMsg(Failure(AddHtlcFailed(channelId(bob), add.paymentHash, error, Origin.Local(upstream.id, Some(sender.ref)), Some(initialState.channelUpdate), Some(add))))
     bob2alice.expectNoMsg(100 millis) // we don't close the channel, we can simply avoid using it while we disagree on feerate
 
     // we now agree on feerate so we can send HTLCs
-    bob.feeEstimator.setFeerate(FeeratesPerKw.single(11000))
-    sender.send(bob, CurrentFeerates(FeeratesPerKw.single(11000)))
+    bob.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(11000 sat)))
+    sender.send(bob, CurrentFeerates(FeeratesPerKw.single(FeeratePerKw(11000 sat))))
     bob2alice.expectNoMsg(100 millis)
     sender.send(bob, add)
     sender.expectMsg(ChannelCommandResponse.Ok)
@@ -762,7 +762,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     val sender = TestProbe()
     val listener = TestProbe()
     system.eventStream.subscribe(listener.ref, classOf[AvailableBalanceChanged])
-    sender.send(alice, CMD_UPDATE_FEE(654564))
+    sender.send(alice, CMD_UPDATE_FEE(FeeratePerKw(654564 sat)))
     sender.expectMsg(ChannelCommandResponse.Ok)
     alice2bob.expectMsgType[UpdateFee]
     sender.send(alice, CMD_SIGN)
@@ -854,14 +854,14 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
     val sender = TestProbe()
 
-    sender.send(alice, CMD_UPDATE_FEE(TestConstants.feeratePerKw + 1000, commit = false))
+    sender.send(alice, CMD_UPDATE_FEE(TestConstants.feeratePerKw + FeeratePerKw(1000 sat), commit = false))
     sender.expectMsg(ChannelCommandResponse.Ok)
     sender.send(alice, CMD_SIGN)
     sender.expectMsg(ChannelCommandResponse.Ok)
 
     // actual test begins (note that channel sends a CMD_SIGN to itself when it receives RevokeAndAck and there are changes)
     val updateFee = alice2bob.expectMsgType[UpdateFee]
-    assert(updateFee.feeratePerKw == TestConstants.feeratePerKw + 1000)
+    assert(updateFee.feeratePerKw === TestConstants.feeratePerKw + FeeratePerKw(1000 sat))
     alice2bob.forward(bob)
     alice2bob.expectMsgType[CommitSig]
     alice2bob.forward(bob)
@@ -1605,7 +1605,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
     val sender = TestProbe()
     val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-    sender.send(alice, CMD_UPDATE_FEE(20000))
+    sender.send(alice, CMD_UPDATE_FEE(FeeratePerKw(20000 sat)))
     sender.expectMsg(ChannelCommandResponse.Ok)
     val fee = alice2bob.expectMsgType[UpdateFee]
     awaitCond(alice.stateData == initialState.copy(
@@ -1625,10 +1625,10 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
     val sender = TestProbe()
     val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-    sender.send(alice, CMD_UPDATE_FEE(20000))
+    sender.send(alice, CMD_UPDATE_FEE(FeeratePerKw(20000 sat)))
     sender.expectMsg(ChannelCommandResponse.Ok)
     val fee1 = alice2bob.expectMsgType[UpdateFee]
-    sender.send(alice, CMD_UPDATE_FEE(30000))
+    sender.send(alice, CMD_UPDATE_FEE(FeeratePerKw(30000 sat)))
     sender.expectMsg(ChannelCommandResponse.Ok)
     val fee2 = alice2bob.expectMsgType[UpdateFee]
     awaitCond(alice.stateData == initialState.copy(
@@ -1640,7 +1640,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
     val sender = TestProbe()
     val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-    sender.send(bob, CMD_UPDATE_FEE(20000))
+    sender.send(bob, CMD_UPDATE_FEE(FeeratePerKw(20000 sat)))
     sender.expectMsg(Failure(FundeeCannotSendUpdateFee(channelId(bob))))
     assert(initialState == bob.stateData)
   }
@@ -1648,7 +1648,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("recv UpdateFee") { f =>
     import f._
     val initialData = bob.stateData.asInstanceOf[DATA_NORMAL]
-    val fee = UpdateFee(ByteVector32.Zeroes, 12000)
+    val fee = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(12000 sat))
     bob ! fee
     awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ fee), remoteNextHtlcId = 0)))
   }
@@ -1656,7 +1656,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("recv UpdateFee (anchor outputs)", Tag("anchor_outputs")) { f =>
     import f._
     val initialData = bob.stateData.asInstanceOf[DATA_NORMAL]
-    val fee = UpdateFee(ByteVector32.Zeroes, 8000)
+    val fee = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(8000 sat))
     bob ! fee
     awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ fee), remoteNextHtlcId = 0)))
   }
@@ -1664,9 +1664,9 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("recv UpdateFee (two in a row)") { f =>
     import f._
     val initialData = bob.stateData.asInstanceOf[DATA_NORMAL]
-    val fee1 = UpdateFee(ByteVector32.Zeroes, 12000)
+    val fee1 = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(12000 sat))
     bob ! fee1
-    val fee2 = UpdateFee(ByteVector32.Zeroes, 14000)
+    val fee2 = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(14000 sat))
     bob ! fee2
     awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ fee2), remoteNextHtlcId = 0)))
   }
@@ -1675,7 +1675,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
     val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
     val sender = TestProbe()
-    sender.send(alice, UpdateFee(ByteVector32.Zeroes, 12000))
+    sender.send(alice, UpdateFee(ByteVector32.Zeroes, FeeratePerKw(12000 sat)))
     alice2bob.expectMsgType[Error]
     awaitCond(alice.stateName == CLOSING)
     // channel should be advertised as down
@@ -1689,7 +1689,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
     val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
     val sender = TestProbe()
-    val fee = UpdateFee(ByteVector32.Zeroes, 100000000)
+    val fee = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(100000000 sat))
     // we first update the feerates so that we don't trigger a 'fee too different' error
     bob.feeEstimator.setFeerate(FeeratesPerKw.single(fee.feeratePerKw))
     sender.send(bob, fee)
@@ -1708,7 +1708,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
     val sender = TestProbe()
     // This feerate is just above the threshold: (800000 (alice balance) - 20000 (reserve) - 660 (anchors)) / 1124 (commit tx weight) = 693363
-    val fee = UpdateFee(ByteVector32.Zeroes, 693364)
+    val fee = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(693364 sat))
     // we first update the feerates so that we don't trigger a 'fee too different' error
     bob.feeEstimator.setFeerate(FeeratesPerKw.single(fee.feeratePerKw))
     sender.send(bob, fee)
@@ -1725,12 +1725,12 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("recv UpdateFee (local/remote feerates are too different)") { f =>
     import f._
 
-    bob.feeEstimator.setFeerate(FeeratesPerKw(1000, 2000, 6000, 12000, 36000, 72000, 140000))
+    bob.feeEstimator.setFeerate(FeeratesPerKw(FeeratePerKw(1000 sat), FeeratePerKw(2000 sat), FeeratePerKw(6000 sat), FeeratePerKw(12000 sat), FeeratePerKw(36000 sat), FeeratePerKw(72000 sat), FeeratePerKw(140000 sat)))
     val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
     val sender = TestProbe()
     val localFeerate = bob.feeEstimator.getFeeratePerKw(bob.feeTargets.commitmentBlockTarget)
-    assert(localFeerate === 2000)
-    val remoteFeerate = 4000
+    assert(localFeerate === FeeratePerKw(2000 sat))
+    val remoteFeerate = FeeratePerKw(4000 sat)
     sender.send(bob, UpdateFee(ByteVector32.Zeroes, remoteFeerate))
     bob2alice.expectNoMsg(250 millis) // we don't close because the commitment doesn't contain any HTLC
 
@@ -1753,7 +1753,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     val sender = TestProbe()
     val expectedFeeratePerKw = bob.feeEstimator.getFeeratePerKw(bob.feeTargets.commitmentBlockTarget)
     assert(bobCommitments.localCommit.spec.feeratePerKw == expectedFeeratePerKw)
-    sender.send(bob, UpdateFee(ByteVector32.Zeroes, 252))
+    sender.send(bob, UpdateFee(ByteVector32.Zeroes, FeeratePerKw(252 sat)))
     val error = bob2alice.expectMsgType[Error]
     assert(new String(error.data.toArray) === "remote fee rate is too small: remoteFeeratePerKw=252")
     awaitCond(bob.stateName == CLOSING)
@@ -2152,7 +2152,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
     val sender = TestProbe()
     val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-    val event = CurrentFeerates(FeeratesPerKw(100, 200, 600, 1200, 3600, 7200, 14400))
+    val event = CurrentFeerates(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(200 sat), FeeratePerKw(600 sat), FeeratePerKw(1200 sat), FeeratePerKw(3600 sat), FeeratePerKw(7200 sat), FeeratePerKw(14400 sat)))
     sender.send(alice, event)
     alice2bob.expectMsg(UpdateFee(initialState.commitments.channelId, event.feeratesPerKw.feePerBlock(Alice.nodeParams.onChainFeeConf.feeTargets.commitmentBlockTarget)))
   }
@@ -2160,7 +2160,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("recv CurrentFeerate (when funder, doesn't trigger an UpdateFee)") { f =>
     import f._
     val sender = TestProbe()
-    val event = CurrentFeerates(FeeratesPerKw.single(10010))
+    val event = CurrentFeerates(FeeratesPerKw.single(FeeratePerKw(10010 sat)))
     sender.send(alice, event)
     alice2bob.expectNoMsg(500 millis)
   }
@@ -2168,7 +2168,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("recv CurrentFeerate (when fundee, commit-fee/network-fee are close)") { f =>
     import f._
     val sender = TestProbe()
-    val event = CurrentFeerates(FeeratesPerKw.single(11000))
+    val event = CurrentFeerates(FeeratesPerKw.single(FeeratePerKw(11000 sat)))
     sender.send(bob, event)
     bob2alice.expectNoMsg(500 millis)
   }
@@ -2180,8 +2180,8 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     crossSign(alice, bob, alice2bob, bob2alice)
 
     val sender = TestProbe()
-    bob.feeEstimator.setFeerate(FeeratesPerKw.single(14000))
-    val event = CurrentFeerates(FeeratesPerKw.single(14000))
+    bob.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(14000 sat)))
+    val event = CurrentFeerates(FeeratesPerKw.single(FeeratePerKw(14000 sat)))
     sender.send(bob, event)
     bob2alice.expectMsgType[Error]
     bob2blockchain.expectMsgType[PublishAsap] // commit tx
@@ -2194,8 +2194,8 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
 
     val sender = TestProbe()
-    bob.feeEstimator.setFeerate(FeeratesPerKw.single(1000))
-    val event = CurrentFeerates(FeeratesPerKw.single(1000))
+    bob.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(1000 sat)))
+    val event = CurrentFeerates(FeeratesPerKw.single(FeeratePerKw(1000 sat)))
     sender.send(bob, event)
     bob2alice.expectNoMsg(250 millis) // we don't close because the commitment doesn't contain any HTLC
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -19,7 +19,7 @@ package fr.acinq.eclair.channel.states.e
 import java.util.UUID
 
 import akka.actor.Status
-import akka.testkit.{TestActorRef, TestProbe}
+import akka.testkit.TestProbe
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{ByteVector32, ScriptFlags, Transaction}
 import fr.acinq.eclair.TestConstants.{Alice, TestFeeEstimator}
@@ -563,7 +563,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val currentFeeratePerKw = aliceStateData.commitments.localCommit.spec.feeratePerKw
     // we receive a feerate update that makes our current feerate too low compared to the network's (we multiply by 1.1
     // to ensure the network's feerate is 10% above our threshold).
-    val networkFeeratePerKw = (1.1 * currentFeeratePerKw / alice.underlyingActor.nodeParams.onChainFeeConf.maxFeerateMismatch.ratioLow).toLong
+    val networkFeeratePerKw = currentFeeratePerKw * (1.1 / alice.underlyingActor.nodeParams.onChainFeeConf.maxFeerateMismatch.ratioLow)
     val networkFeerate = FeeratesPerKw.single(networkFeeratePerKw)
 
     // alice is funder
@@ -593,7 +593,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val currentFeeratePerKw = aliceStateData.commitments.localCommit.spec.feeratePerKw
     // we receive a feerate update that makes our current feerate too low compared to the network's (we multiply by 1.1
     // to ensure the network's feerate is 10% above our threshold).
-    val networkFeeratePerKw = (1.1 * currentFeeratePerKw / alice.underlyingActor.nodeParams.onChainFeeConf.maxFeerateMismatch.ratioLow).toLong
+    val networkFeeratePerKw = currentFeeratePerKw * (1.1 / alice.underlyingActor.nodeParams.onChainFeeConf.maxFeerateMismatch.ratioLow)
     val networkFeerate = FeeratesPerKw.single(networkFeeratePerKw)
 
     // this time Alice will ignore feerate changes for the offline channel
@@ -613,7 +613,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     awaitCond(bob.stateName == OFFLINE)
 
     val localFeeratePerKw = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.spec.feeratePerKw
-    val networkFeeratePerKw = 2 * localFeeratePerKw
+    val networkFeeratePerKw = localFeeratePerKw * 2
     val networkFeerate = FeeratesPerKw.single(networkFeeratePerKw)
 
     // Alice ignores feerate changes while offline
@@ -666,7 +666,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val currentFeeratePerKw = bobStateData.commitments.localCommit.spec.feeratePerKw
     // we receive a feerate update that makes our current feerate too low compared to the network's (we multiply by 1.1
     // to ensure the network's feerate is 10% above our threshold).
-    val networkFeeratePerKw = (1.1 * currentFeeratePerKw / bob.underlyingActor.nodeParams.onChainFeeConf.maxFeerateMismatch.ratioLow).toLong
+    val networkFeeratePerKw = currentFeeratePerKw * (1.1 / bob.underlyingActor.nodeParams.onChainFeeConf.maxFeerateMismatch.ratioLow)
     val networkFeerate = FeeratesPerKw.single(networkFeeratePerKw)
 
     // bob is fundee

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -646,7 +646,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     import f._
     val sender = TestProbe()
     val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-    val event = CurrentFeerates(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(200 sat), FeeratePerKw(600 sat), FeeratePerKw(1200 sat), FeeratePerKw(3600 sat), FeeratePerKw(7200 sat), FeeratePerKw(14400 sat)))
+    val event = CurrentFeerates(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(200 sat), FeeratePerKw(600 sat), FeeratePerKw(1200 sat), FeeratePerKw(3600 sat), FeeratePerKw(7200 sat), FeeratePerKw(14400 sat), FeeratePerKw(100800 sat)))
     sender.send(alice, event)
     alice2bob.expectMsg(UpdateFee(initialState.commitments.channelId, event.feeratesPerKw.feePerBlock(alice.feeTargets.commitmentBlockTarget)))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -23,7 +23,7 @@ import akka.testkit.TestProbe
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Crypto, ScriptFlags, Transaction}
 import fr.acinq.eclair.blockchain._
-import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
+import fr.acinq.eclair.blockchain.fee.{FeeratePerKw, FeeratesPerKw}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.payment._
@@ -535,7 +535,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     import f._
     val sender = TestProbe()
     val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-    sender.send(alice, CMD_UPDATE_FEE(20000))
+    sender.send(alice, CMD_UPDATE_FEE(FeeratePerKw(20000 sat)))
     sender.expectMsg(ChannelCommandResponse.Ok)
     val fee = alice2bob.expectMsgType[UpdateFee]
     awaitCond(alice.stateData == initialState.copy(
@@ -547,7 +547,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     import f._
     val sender = TestProbe()
     val initialState = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-    sender.send(bob, CMD_UPDATE_FEE(20000))
+    sender.send(bob, CMD_UPDATE_FEE(FeeratePerKw(20000 sat)))
     sender.expectMsg(Failure(FundeeCannotSendUpdateFee(channelId(bob))))
     assert(initialState == bob.stateData)
   }
@@ -555,7 +555,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
   test("recv UpdateFee") { f =>
     import f._
     val initialData = bob.stateData.asInstanceOf[DATA_SHUTDOWN]
-    val fee = UpdateFee(ByteVector32.Zeroes, 12000)
+    val fee = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(12000 sat))
     bob ! fee
     awaitCond(bob.stateData == initialData.copy(commitments = initialData.commitments.copy(remoteChanges = initialData.commitments.remoteChanges.copy(proposed = initialData.commitments.remoteChanges.proposed :+ fee))))
   }
@@ -564,7 +564,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     import f._
     val tx = alice.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
     val sender = TestProbe()
-    sender.send(alice, UpdateFee(ByteVector32.Zeroes, 12000))
+    sender.send(alice, UpdateFee(ByteVector32.Zeroes, FeeratePerKw(12000 sat)))
     alice2bob.expectMsgType[Error]
     awaitCond(alice.stateName == CLOSING)
     alice2blockchain.expectMsg(PublishAsap(tx)) // commit tx
@@ -580,7 +580,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     import f._
     val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
     val sender = TestProbe()
-    val fee = UpdateFee(ByteVector32.Zeroes, 100000000)
+    val fee = UpdateFee(ByteVector32.Zeroes, FeeratePerKw(100000000 sat))
     // we first update the feerates so that we don't trigger a 'fee too different' error
     bob.feeEstimator.setFeerate(FeeratesPerKw.single(fee.feeratePerKw))
     sender.send(bob, fee)
@@ -596,7 +596,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     import f._
     val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
     val sender = TestProbe()
-    sender.send(bob, UpdateFee(ByteVector32.Zeroes, 65000))
+    sender.send(bob, UpdateFee(ByteVector32.Zeroes, FeeratePerKw(65000 sat)))
     val error = bob2alice.expectMsgType[Error]
     assert(new String(error.data.toArray) === "local/remote feerates are too different: remoteFeeratePerKw=65000 localFeeratePerKw=10000")
     awaitCond(bob.stateName == CLOSING)
@@ -609,7 +609,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     import f._
     val tx = bob.stateData.asInstanceOf[DATA_SHUTDOWN].commitments.localCommit.publishableTxs.commitTx.tx
     val sender = TestProbe()
-    sender.send(bob, UpdateFee(ByteVector32.Zeroes, 252))
+    sender.send(bob, UpdateFee(ByteVector32.Zeroes, FeeratePerKw(252 sat)))
     val error = bob2alice.expectMsgType[Error]
     assert(new String(error.data.toArray) === "remote fee rate is too small: remoteFeeratePerKw=252")
     awaitCond(bob.stateName == CLOSING)
@@ -646,7 +646,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     import f._
     val sender = TestProbe()
     val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-    val event = CurrentFeerates(FeeratesPerKw(100, 200, 600, 1200, 3600, 7200, 14400))
+    val event = CurrentFeerates(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(200 sat), FeeratePerKw(600 sat), FeeratePerKw(1200 sat), FeeratePerKw(3600 sat), FeeratePerKw(7200 sat), FeeratePerKw(14400 sat)))
     sender.send(alice, event)
     alice2bob.expectMsg(UpdateFee(initialState.commitments.channelId, event.feeratesPerKw.feePerBlock(alice.feeTargets.commitmentBlockTarget)))
   }
@@ -654,7 +654,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
   test("recv CurrentFeerate (when funder, doesn't trigger an UpdateFee)") { f =>
     import f._
     val sender = TestProbe()
-    val event = CurrentFeerates(FeeratesPerKw.single(10010))
+    val event = CurrentFeerates(FeeratesPerKw.single(FeeratePerKw(10010 sat)))
     sender.send(alice, event)
     alice2bob.expectNoMsg(500 millis)
   }
@@ -662,7 +662,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
   test("recv CurrentFeerate (when fundee, commit-fee/network-fee are close)") { f =>
     import f._
     val sender = TestProbe()
-    val event = CurrentFeerates(FeeratesPerKw.single(11000))
+    val event = CurrentFeerates(FeeratesPerKw.single(FeeratePerKw(11000 sat)))
     sender.send(bob, event)
     bob2alice.expectNoMsg(500 millis)
   }
@@ -670,7 +670,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
   test("recv CurrentFeerate (when fundee, commit-fee/network-fee are very different)") { f =>
     import f._
     val sender = TestProbe()
-    val event = CurrentFeerates(FeeratesPerKw.single(1000))
+    val event = CurrentFeerates(FeeratesPerKw.single(FeeratePerKw(1000 sat)))
     sender.send(bob, event)
     bob2alice.expectMsgType[Error]
     bob2blockchain.expectMsgType[PublishAsap] // commit tx

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
@@ -24,7 +24,7 @@ import akka.testkit.TestProbe
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64}
 import fr.acinq.eclair.TestConstants.Bob
 import fr.acinq.eclair.blockchain._
-import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
+import fr.acinq.eclair.blockchain.fee.{FeeratePerKw, FeeratesPerKw}
 import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
@@ -54,12 +54,12 @@ class NegotiatingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
       val sender = TestProbe()
       // alice initiates a closing
       if (test.tags.contains("fee2")) {
-        alice.feeEstimator.setFeerate(FeeratesPerKw.single(4319))
-        bob.feeEstimator.setFeerate(FeeratesPerKw.single(4319))
+        alice.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(4319 sat)))
+        bob.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(4319 sat)))
       }
       else {
-        alice.feeEstimator.setFeerate(FeeratesPerKw.single(10000))
-        bob.feeEstimator.setFeerate(FeeratesPerKw.single(10000))
+        alice.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(10000 sat)))
+        bob.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(10000 sat)))
       }
       sender.send(bob, CMD_CLOSE(None))
       bob2alice.expectMsgType[Shutdown]
@@ -70,11 +70,11 @@ class NegotiatingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
       // In order to force a fee negotiation, we will change the current fee before forwarding
       // the Shutdown message to alice, so that alice computes a different initial closing fee.
       if (test.tags.contains("fee2")) {
-        alice.feeEstimator.setFeerate(FeeratesPerKw.single(4316))
-        bob.feeEstimator.setFeerate(FeeratesPerKw.single(4316))
+        alice.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(4316 sat)))
+        bob.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(4316 sat)))
       } else {
-        alice.feeEstimator.setFeerate(FeeratesPerKw.single(5000))
-        bob.feeEstimator.setFeerate(FeeratesPerKw.single(5000))
+        alice.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(5000 sat)))
+        bob.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(5000 sat)))
       }
       alice2bob.forward(bob)
       awaitCond(bob.stateName == NEGOTIATING)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -113,7 +113,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
   test("start fee negotiation from configured block target") { f =>
     import f._
 
-    alice.feeEstimator.setFeerate(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(250 sat), FeeratePerKw(350 sat), FeeratePerKw(450 sat), FeeratePerKw(600 sat), FeeratePerKw(800 sat), FeeratePerKw(900 sat)))
+    alice.feeEstimator.setFeerate(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(250 sat), FeeratePerKw(350 sat), FeeratePerKw(450 sat), FeeratePerKw(600 sat), FeeratePerKw(800 sat), FeeratePerKw(900 sat), FeeratePerKw(1000 sat)))
 
     val sender = TestProbe()
     // alice initiates a closing

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -24,13 +24,13 @@ import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{ByteVector32, OutPoint, ScriptFlags, Transaction, TxIn}
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair.blockchain._
-import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
+import fr.acinq.eclair.blockchain.fee.{FeeratePerKw, FeeratesPerKw}
 import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
 import fr.acinq.eclair.payment._
-import fr.acinq.eclair.payment.relay.Relayer._
 import fr.acinq.eclair.payment.relay.Origin
+import fr.acinq.eclair.payment.relay.Relayer._
 import fr.acinq.eclair.transactions.{Scripts, Transactions}
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{CltvExpiry, LongToBtcAmount, TestConstants, TestKitBaseClass, randomBytes32}
@@ -38,7 +38,6 @@ import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.{Outcome, Tag}
 import scodec.bits.ByteVector
 
-import scala.compat.Platform
 import scala.concurrent.duration._
 
 /**
@@ -114,7 +113,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
   test("start fee negotiation from configured block target") { f =>
     import f._
 
-    alice.feeEstimator.setFeerate(FeeratesPerKw(100, 250, 350, 450, 600, 800, 900))
+    alice.feeEstimator.setFeerate(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(250 sat), FeeratePerKw(350 sat), FeeratePerKw(450 sat), FeeratePerKw(600 sat), FeeratePerKw(800 sat), FeeratePerKw(900 sat)))
 
     val sender = TestProbe()
     // alice initiates a closing
@@ -127,7 +126,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val aliceData = alice.stateData.asInstanceOf[DATA_NEGOTIATING]
     val mutualClosingFeeRate = alice.feeEstimator.getFeeratePerKw(alice.feeTargets.mutualCloseBlockTarget)
     val expectedFirstProposedFee = Closing.firstClosingFee(aliceData.commitments, aliceData.localShutdown.scriptPubKey, aliceData.remoteShutdown.scriptPubKey, mutualClosingFeeRate)(akka.event.NoLogging)
-    assert(alice.feeTargets.mutualCloseBlockTarget == 2 && mutualClosingFeeRate == 250)
+    assert(alice.feeTargets.mutualCloseBlockTarget == 2 && mutualClosingFeeRate == FeeratePerKw(250 sat))
     assert(closing.feeSatoshis == expectedFirstProposedFee)
   }
 
@@ -302,7 +301,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     bob2alice.forward(alice)
     // agreeing on a closing fee
     val aliceCloseFee = alice2bob.expectMsgType[ClosingSigned].feeSatoshis
-    bob.feeEstimator.setFeerate(FeeratesPerKw.single(100))
+    bob.feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(100 sat)))
     alice2bob.forward(bob)
     val bobCloseFee = bob2alice.expectMsgType[ClosingSigned].feeSatoshis
     bob2alice.forward(alice)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteFeeratesDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteFeeratesDbSpec.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.db
 
 import fr.acinq.eclair._
-import fr.acinq.eclair.blockchain.fee.FeeratesPerKB
+import fr.acinq.eclair.blockchain.fee.{FeeratePerKB, FeeratesPerKB}
 import fr.acinq.eclair.db.sqlite.SqliteFeeratesDb
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -33,13 +33,13 @@ class SqliteFeeratesDbSpec extends AnyFunSuite {
     val sqlite = TestConstants.sqliteInMemory()
     val db = new SqliteFeeratesDb(sqlite)
     val feerate = FeeratesPerKB(
-      block_1 = 150000,
-      blocks_2 = 120000,
-      blocks_6 = 100000,
-      blocks_12 = 90000,
-      blocks_36 = 70000,
-      blocks_72 = 50000,
-      blocks_144 = 20000)
+      block_1 = FeeratePerKB(150000 sat),
+      blocks_2 = FeeratePerKB(120000 sat),
+      blocks_6 = FeeratePerKB(100000 sat),
+      blocks_12 = FeeratePerKB(90000 sat),
+      blocks_36 = FeeratePerKB(70000 sat),
+      blocks_72 = FeeratePerKB(50000 sat),
+      blocks_144 = FeeratePerKB(20000 sat))
 
     db.addOrUpdateFeerates(feerate)
     assert(db.getFeerates().get == feerate)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteFeeratesDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteFeeratesDbSpec.scala
@@ -18,10 +18,21 @@ package fr.acinq.eclair.db
 
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.fee.{FeeratePerKB, FeeratesPerKB}
+import fr.acinq.eclair.db.sqlite.SqliteUtils.{getVersion, using}
 import fr.acinq.eclair.db.sqlite.SqliteFeeratesDb
 import org.scalatest.funsuite.AnyFunSuite
 
 class SqliteFeeratesDbSpec extends AnyFunSuite {
+
+  val feerate = FeeratesPerKB(
+    block_1 = FeeratePerKB(150000 sat),
+    blocks_2 = FeeratePerKB(120000 sat),
+    blocks_6 = FeeratePerKB(100000 sat),
+    blocks_12 = FeeratePerKB(90000 sat),
+    blocks_36 = FeeratePerKB(70000 sat),
+    blocks_72 = FeeratePerKB(50000 sat),
+    blocks_144 = FeeratePerKB(20000 sat),
+    blocks_1008 = FeeratePerKB(10000 sat))
 
   test("init sqlite 2 times in a row") {
     val sqlite = TestConstants.sqliteInMemory()
@@ -32,16 +43,49 @@ class SqliteFeeratesDbSpec extends AnyFunSuite {
   test("add/get feerates") {
     val sqlite = TestConstants.sqliteInMemory()
     val db = new SqliteFeeratesDb(sqlite)
-    val feerate = FeeratesPerKB(
-      block_1 = FeeratePerKB(150000 sat),
-      blocks_2 = FeeratePerKB(120000 sat),
-      blocks_6 = FeeratePerKB(100000 sat),
-      blocks_12 = FeeratePerKB(90000 sat),
-      blocks_36 = FeeratePerKB(70000 sat),
-      blocks_72 = FeeratePerKB(50000 sat),
-      blocks_144 = FeeratePerKB(20000 sat))
 
     db.addOrUpdateFeerates(feerate)
     assert(db.getFeerates().get == feerate)
   }
+
+  test("migration 1->2") {
+    val sqlite = TestConstants.sqliteInMemory()
+
+    using(sqlite.createStatement()) { statement =>
+      getVersion(statement, "feerates", 1) // this will set version to 1
+      statement.executeUpdate(
+        """
+          |CREATE TABLE IF NOT EXISTS feerates_per_kb (
+          |rate_block_1 INTEGER NOT NULL, rate_blocks_2 INTEGER NOT NULL, rate_blocks_6 INTEGER NOT NULL, rate_blocks_12 INTEGER NOT NULL, rate_blocks_36 INTEGER NOT NULL, rate_blocks_72 INTEGER NOT NULL, rate_blocks_144 INTEGER NOT NULL,
+          |timestamp INTEGER NOT NULL)""".stripMargin)
+    }
+
+    using(sqlite.createStatement()) { statement =>
+      assert(getVersion(statement, "feerates", 2) == 1) // version 1 is deployed now
+    }
+
+    // Version 1 was missing the 1008 block target.
+    using(sqlite.prepareStatement("INSERT INTO feerates_per_kb VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) { statement =>
+      statement.setLong(1, feerate.block_1.toLong)
+      statement.setLong(2, feerate.blocks_2.toLong)
+      statement.setLong(3, feerate.blocks_6.toLong)
+      statement.setLong(4, feerate.blocks_12.toLong)
+      statement.setLong(5, feerate.blocks_36.toLong)
+      statement.setLong(6, feerate.blocks_72.toLong)
+      statement.setLong(7, feerate.blocks_144.toLong)
+      statement.setLong(8, System.currentTimeMillis())
+      statement.executeUpdate()
+    }
+
+    val migratedDb = new SqliteFeeratesDb(sqlite)
+    using(sqlite.createStatement()) { statement =>
+      assert(getVersion(statement, "feerates", 2) == 2) // version changed from 1 -> 2
+    }
+
+    // When migrating, we simply copy the estimate for blocks 144 to blocks 1008.
+    assert(migratedDb.getFeerates() === Some(feerate.copy(blocks_1008 = feerate.blocks_144)))
+    migratedDb.addOrUpdateFeerates(feerate)
+    assert(migratedDb.getFeerates() === Some(feerate))
+  }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
@@ -25,7 +25,7 @@ import akka.testkit.{TestFSMRef, TestKit, TestProbe}
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.TestConstants.{Alice, Bob, TestFeeEstimator}
 import fr.acinq.eclair.blockchain._
-import fr.acinq.eclair.blockchain.fee.FeeratesPerKw
+import fr.acinq.eclair.blockchain.fee.{FeeratePerKw, FeeratesPerKw}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.payment.receive.{ForwardHandler, PaymentHandler}
 import fr.acinq.eclair.wire.Init
@@ -66,7 +66,7 @@ class RustyTestsSpec extends TestKitBaseClass with Matchers with FixtureAnyFunSu
     val aliceInit = Init(Alice.channelParams.features)
     val bobInit = Init(Bob.channelParams.features)
     // alice and bob will both have 1 000 000 sat
-    feeEstimator.setFeerate(FeeratesPerKw.single(10000))
+    feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(10000 sat)))
     alice ! INPUT_INIT_FUNDER(ByteVector32.Zeroes, 2000000 sat, 1000000000 msat, feeEstimator.getFeeratePerKw(target = 2), feeEstimator.getFeeratePerKw(target = 6), Alice.channelParams, pipe, bobInit, ChannelFlags.Empty, ChannelVersion.STANDARD)
     bob ! INPUT_INIT_FUNDEE(ByteVector32.Zeroes, Bob.channelParams, pipe, aliceInit)
     pipe ! (alice, bob)
@@ -91,7 +91,7 @@ class RustyTestsSpec extends TestKitBaseClass with Matchers with FixtureAnyFunSu
     }
   }
 
-  override def afterAll {
+  override def afterAll() {
     TestKit.shutdownActorSystem(system)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/SynchronizationPipe.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/SynchronizationPipe.scala
@@ -136,14 +136,14 @@ class SynchronizationPipe(latch: CountDownLatch) extends Actor with ActorLogging
         s"  Received htlcs: ${localCommit.spec.htlcs.collect { case IncomingHtlc(add) => (add.id, add.amountMsat) }.mkString(" ")}",
         s"  Balance us: ${localCommit.spec.toLocal}",
         s"  Balance them: ${localCommit.spec.toRemote}",
-        s"  Fee rate: ${localCommit.spec.feeratePerKw}",
+        s"  Fee rate: ${localCommit.spec.feeratePerKw.toLong}",
         "REMOTE COMMITS:",
         s" Commit ${remoteCommit.index}:",
         s"  Offered htlcs: ${remoteCommit.spec.htlcs.collect { case OutgoingHtlc(add) => (add.id, add.amountMsat) }.mkString(" ")}",
         s"  Received htlcs: ${remoteCommit.spec.htlcs.collect { case IncomingHtlc(add) => (add.id, add.amountMsat) }.mkString(" ")}",
         s"  Balance us: ${remoteCommit.spec.toLocal}",
         s"  Balance them: ${remoteCommit.spec.toRemote}",
-        s"  Fee rate: ${remoteCommit.spec.feeratePerKw}")
+        s"  Fee rate: ${remoteCommit.spec.feeratePerKw.toLong}")
         .foreach(s => {
           fout.write(rtrim(s))
           fout.newLine()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 import akka.actor.{ActorRef, Props, Status}
 import akka.testkit.TestProbe
 import fr.acinq.bitcoin.{ByteVector32, Crypto}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.IncomingPacket.FinalPacket
@@ -473,7 +474,7 @@ class RelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     sender.send(relayer, Status.Failure(AddHtlcFailed(channelId_bc, paymentHash, InsufficientFunds(channelId_bc, origin.amountOut, 100 sat, 0 sat, 0 sat), origin, Some(channelUpdate_bc), None)))
     assert(register.expectMsgType[Register.Forward[CMD_FAIL_HTLC]].message.reason === Right(TemporaryChannelFailure(channelUpdate_bc)))
 
-    sender.send(relayer, Status.Failure(AddHtlcFailed(channelId_bc, paymentHash, FeerateTooDifferent(channelId_bc, 1000, 300), origin, Some(channelUpdate_bc), None)))
+    sender.send(relayer, Status.Failure(AddHtlcFailed(channelId_bc, paymentHash, FeerateTooDifferent(channelId_bc, FeeratePerKw(1000 sat), FeeratePerKw(300 sat)), origin, Some(channelUpdate_bc), None)))
     assert(register.expectMsgType[Register.Forward[CMD_FAIL_HTLC]].message.reason === Right(TemporaryChannelFailure(channelUpdate_bc)))
 
     val channelUpdate_bc_disabled = channelUpdate_bc.copy(channelFlags = 2)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsBatchValidationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsBatchValidationSpec.scala
@@ -25,6 +25,7 @@ import fr.acinq.bitcoin.{Block, Satoshi, Script, Transaction}
 import fr.acinq.eclair.blockchain.ValidateResult
 import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, ExtendedBitcoinClient}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate}
 import fr.acinq.eclair.{CltvExpiryDelta, Features, LongToBtcAmount, ShortChannelId, randomKey}
@@ -93,7 +94,7 @@ object AnnouncementsBatchValidationSpec {
     // first we publish the funding tx
     val wallet = new BitcoinCoreWallet(extendedBitcoinClient.rpcClient)
     val fundingPubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(node1BitcoinKey.publicKey, node2BitcoinKey.publicKey)))
-    val fundingTxFuture = wallet.makeFundingTx(fundingPubkeyScript, amount, 10000)
+    val fundingTxFuture = wallet.makeFundingTx(fundingPubkeyScript, amount, FeeratePerKw(10000 sat))
     val res = Await.result(fundingTxFuture, 10 seconds)
     Await.result(extendedBitcoinClient.publishTransaction(res.fundingTx), 10 seconds)
     SimulatedChannel(node1Key, node2Key, node1BitcoinKey, node2BitcoinKey, amount, res.fundingTx, res.fundingTxOutputIndex)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/CommitmentSpecSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/CommitmentSpecSpec.scala
@@ -17,13 +17,14 @@
 package fr.acinq.eclair.transactions
 
 import fr.acinq.bitcoin.{ByteVector32, Crypto}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.wire.{UpdateAddHtlc, UpdateFailHtlc, UpdateFulfillHtlc}
 import fr.acinq.eclair.{CltvExpiry, LongToBtcAmount, TestConstants, randomBytes32}
 import org.scalatest.funsuite.AnyFunSuite
 
 class CommitmentSpecSpec extends AnyFunSuite {
   test("add, fulfill and fail htlcs from the sender side") {
-    val spec = CommitmentSpec(htlcs = Set(), feeratePerKw = 1000, toLocal = 5000000 msat, toRemote = 0 msat)
+    val spec = CommitmentSpec(htlcs = Set(), feeratePerKw = FeeratePerKw(1000 sat), toLocal = 5000000 msat, toRemote = 0 msat)
     val R = randomBytes32
     val H = Crypto.sha256(R)
 
@@ -45,7 +46,7 @@ class CommitmentSpecSpec extends AnyFunSuite {
   }
 
   test("add, fulfill and fail htlcs from the receiver side") {
-    val spec = CommitmentSpec(htlcs = Set(), feeratePerKw = 1000, toLocal = 0 msat, toRemote = (5000 * 1000) msat)
+    val spec = CommitmentSpec(htlcs = Set(), feeratePerKw = FeeratePerKw(1000 sat), toLocal = 0 msat, toRemote = (5000 * 1000) msat)
     val R = randomBytes32
     val H = Crypto.sha256(R)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TestVectorsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TestVectorsSpec.scala
@@ -18,6 +18,7 @@ package fr.acinq.eclair.transactions
 
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{ByteVector32, Crypto, Script, ScriptFlags, Transaction}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.ChannelVersion
 import fr.acinq.eclair.channel.Helpers.Funding
 import fr.acinq.eclair.crypto.Generators
@@ -59,7 +60,7 @@ trait TestVectorsSpec extends AnyFunSuite with Logging {
     tests
   }
 
-  def getFeerate(name: String): Long = tests(name)("local_feerate_per_kw").trim.toLong
+  def getFeerate(name: String): FeeratePerKw = FeeratePerKw(tests(name)("local_feerate_per_kw").trim.toLong.sat)
 
   def getToLocal(name: String): MilliSatoshi = tests(name)("to_local_msat").trim.toLong.msat
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/LightningMessageCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/LightningMessageCodecsSpec.scala
@@ -21,6 +21,7 @@ import java.net.{Inet4Address, InetAddress}
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64}
 import fr.acinq.eclair._
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire.LightningMessageCodecs._
 import fr.acinq.eclair.wire.ReplyChannelRangeTlv._
@@ -88,7 +89,7 @@ class LightningMessageCodecsSpec extends AnyFunSuite {
   }
 
   test("encode/decode open_channel") {
-    val defaultOpen = OpenChannel(ByteVector32.Zeroes, ByteVector32.Zeroes, 1 sat, 1 msat, 1 sat, UInt64(1), 1 sat, 1 msat, 1, CltvExpiryDelta(1), 1, publicKey(1), point(2), point(3), point(4), point(5), point(6), 0.toByte)
+    val defaultOpen = OpenChannel(ByteVector32.Zeroes, ByteVector32.Zeroes, 1 sat, 1 msat, 1 sat, UInt64(1), 1 sat, 1 msat, FeeratePerKw(1 sat), CltvExpiryDelta(1), 1, publicKey(1), point(2), point(3), point(4), point(5), point(6), 0.toByte)
     // Legacy encoding that omits the upfront_shutdown_script and trailing tlv stream.
     // To allow extending all messages with TLV streams, the upfront_shutdown_script was moved to a TLV stream extension
     // in https://github.com/lightningnetwork/lightning-rfc/pull/714 and made mandatory when including a TLV stream.
@@ -159,12 +160,12 @@ class LightningMessageCodecsSpec extends AnyFunSuite {
   }
 
   test("encode/decode all channel messages") {
-    val open = OpenChannel(randomBytes32, randomBytes32, 3 sat, 4 msat, 5 sat, UInt64(6), 7 sat, 8 msat, 9, CltvExpiryDelta(10), 11, publicKey(1), point(2), point(3), point(4), point(5), point(6), 0.toByte)
+    val open = OpenChannel(randomBytes32, randomBytes32, 3 sat, 4 msat, 5 sat, UInt64(6), 7 sat, 8 msat, FeeratePerKw(9 sat), CltvExpiryDelta(10), 11, publicKey(1), point(2), point(3), point(4), point(5), point(6), 0.toByte)
     val accept = AcceptChannel(randomBytes32, 3 sat, UInt64(4), 5 sat, 6 msat, 7, CltvExpiryDelta(8), 9, publicKey(1), point(2), point(3), point(4), point(5), point(6))
     val funding_created = FundingCreated(randomBytes32, bin32(0), 3, randomBytes64)
     val funding_signed = FundingSigned(randomBytes32, randomBytes64)
     val funding_locked = FundingLocked(randomBytes32, point(2))
-    val update_fee = UpdateFee(randomBytes32, 2)
+    val update_fee = UpdateFee(randomBytes32, FeeratePerKw(2 sat))
     val shutdown = Shutdown(randomBytes32, bin(47, 0))
     val closing_signed = ClosingSigned(randomBytes32, 2 sat, randomBytes64)
     val update_add_htlc = UpdateAddHtlc(randomBytes32, 2, 3 msat, bin32(0), CltvExpiry(4), TestConstants.emptyOnionPacket)

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
@@ -20,6 +20,7 @@ import java.util.UUID
 
 import akka.pattern.{AskTimeoutException, ask}
 import akka.util.Timeout
+import fr.acinq.eclair.blockchain.fee.FeeratePerKB
 import fr.acinq.eclair.gui.controllers._
 import fr.acinq.eclair.io.{NodeURI, Peer}
 import fr.acinq.eclair.payment._
@@ -121,7 +122,7 @@ class Handlers(fKit: Future[Kit])(implicit ec: ExecutionContext = ExecutionConte
    *
    * @return Future containing a Long in satoshi per kilobyte
    */
-  def getFundingFeeRatePerKb(): Future[Long] = {
+  def getFundingFeeRatePerKb(): Future[FeeratePerKB] = {
     for {
       kit <- fKit
       ratePerKw = {

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/OpenChannelController.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/controllers/OpenChannelController.scala
@@ -21,6 +21,7 @@ import java.lang.Boolean
 import com.google.common.base.Strings
 import fr.acinq.bitcoin.Satoshi
 import fr.acinq.eclair._
+import fr.acinq.eclair.blockchain.fee.{FeeratePerByte, FeeratePerKw}
 import fr.acinq.eclair.channel.{Channel, ChannelFlags}
 import fr.acinq.eclair.gui.utils.Constants
 import fr.acinq.eclair.gui.{FxApp, Handlers}
@@ -60,7 +61,7 @@ class OpenChannelController(val handlers: Handlers, val stage: Stage) extends Lo
 
     handlers.getFundingFeeRatePerKb().onComplete {
       case Success(feeSatKb) =>
-        feerateField.setText((feeSatKb / 1000).toString)
+        feerateField.setText(FeeratePerByte(feeSatKb.feerate / 1000).toString)
         feerateError.setText("")
       case Failure(t) =>
         logger.error(s"error when estimating funding fee from GUI: ${t.getLocalizedMessage}")
@@ -117,7 +118,7 @@ class OpenChannelController(val handlers: Handlers, val stage: Stage) extends Lo
           feerateError.setText("Fee rate must be greater than 0")
         case (Success(capacitySat), Success(pushMsat), Success(feeratePerByte_opt)) =>
           val channelFlags = if (publicChannel.isSelected) ChannelFlags.AnnounceChannel else ChannelFlags.Empty
-          handlers.open(nodeUri, Some(Peer.OpenChannel(nodeUri.nodeId, capacitySat, MilliSatoshi(pushMsat), feeratePerByte_opt.map(fr.acinq.eclair.feerateByte2Kw), Some(channelFlags), Some(30 seconds))))
+          handlers.open(nodeUri, Some(Peer.OpenChannel(nodeUri.nodeId, capacitySat, MilliSatoshi(pushMsat), feeratePerByte_opt.map(f => FeeratePerKw(FeeratePerByte(f.sat))), Some(channelFlags), Some(30 seconds))))
           stage.close()
         case (Failure(t), _, _) =>
           logger.error(s"could not parse capacity with cause=${t.getLocalizedMessage}")

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/FormParamExtractors.scala
@@ -21,8 +21,9 @@ import java.util.UUID
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
+import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.api.JsonSupport._
+import fr.acinq.eclair.blockchain.fee.FeeratePerByte
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.PaymentRequest
 import fr.acinq.eclair.{MilliSatoshi, ShortChannelId}
@@ -58,6 +59,8 @@ object FormParamExtractors {
   implicit val satoshiUnmarshaller: Unmarshaller[String, Satoshi] = Unmarshaller.strict { str => Satoshi(str.toLong) }
 
   implicit val millisatoshiUnmarshaller: Unmarshaller[String, MilliSatoshi] = Unmarshaller.strict { str => MilliSatoshi(str.toLong) }
+
+  implicit val feeratePerByteUnmarshaller: Unmarshaller[String, FeeratePerByte] = Unmarshaller.strict { str => FeeratePerByte(Satoshi(str.toLong)) }
 
   implicit val base64DataUnmarshaller: Unmarshaller[String, ByteVector] = Unmarshaller.strict { str => ByteVector.fromValidBase64(str) }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -24,6 +24,7 @@ import de.heikoseeberger.akkahttpjson4s.Json4sSupport
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, OutPoint, Satoshi, Transaction}
 import fr.acinq.eclair.ApiTypes.ChannelIdentifier
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.{ChannelCommandResponse, ChannelVersion, State}
 import fr.acinq.eclair.crypto.ShaChain
 import fr.acinq.eclair.db.{IncomingPaymentStatus, OutgoingPaymentStatus}
@@ -87,6 +88,12 @@ class CltvExpiryDeltaSerializer extends CustomSerializer[CltvExpiryDelta](_ => (
   null
 }, {
   case x: CltvExpiryDelta => JInt(x.toInt)
+}))
+
+class FeeratePerKwSerializer extends CustomSerializer[FeeratePerKw](_ => ( {
+  null
+}, {
+  case x: FeeratePerKw => JLong(x.toLong)
 }))
 
 class ShortChannelIdSerializer extends CustomSerializer[ShortChannelId](_ => ( {
@@ -312,6 +319,7 @@ object JsonSupport extends Json4sSupport {
     new MilliSatoshiSerializer +
     new CltvExpirySerializer +
     new CltvExpiryDeltaSerializer +
+    new FeeratePerKwSerializer +
     new ShortChannelIdSerializer +
     new ChannelIdentifierSerializer +
     new StateSerializer +

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -145,7 +145,7 @@ trait Service extends ExtraDirectives with Logging {
                           }
                         } ~
                         path("open") {
-                          formFields(nodeIdFormParam, "fundingSatoshis".as[Satoshi], "pushMsat".as[MilliSatoshi].?, "fundingFeerateSatByte".as[Long].?, "channelFlags".as[Int].?, "openTimeoutSeconds".as[Timeout].?) {
+                          formFields(nodeIdFormParam, "fundingSatoshis".as[Satoshi], "pushMsat".as[MilliSatoshi].?, "fundingFeerateSatByte".as[Satoshi].?, "channelFlags".as[Int].?, "openTimeoutSeconds".as[Timeout].?) {
                             (nodeId, fundingSatoshis, pushMsat, fundingFeerateSatByte, channelFlags, openTimeout_opt) =>
                               complete(eclairApi.open(nodeId, fundingSatoshis, pushMsat, fundingFeerateSatByte, channelFlags, openTimeout_opt))
                           }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -34,6 +34,7 @@ import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.api.FormParamExtractors._
+import fr.acinq.eclair.blockchain.fee.FeeratePerByte
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.{PaymentEvent, PaymentRequest}
 import fr.acinq.eclair.{CltvExpiryDelta, Eclair, MilliSatoshi}
@@ -145,7 +146,7 @@ trait Service extends ExtraDirectives with Logging {
                           }
                         } ~
                         path("open") {
-                          formFields(nodeIdFormParam, "fundingSatoshis".as[Satoshi], "pushMsat".as[MilliSatoshi].?, "fundingFeerateSatByte".as[Satoshi].?, "channelFlags".as[Int].?, "openTimeoutSeconds".as[Timeout].?) {
+                          formFields(nodeIdFormParam, "fundingSatoshis".as[Satoshi], "pushMsat".as[MilliSatoshi].?, "fundingFeerateSatByte".as[FeeratePerByte].?, "channelFlags".as[Int].?, "openTimeoutSeconds".as[Timeout].?) {
                             (nodeId, fundingSatoshis, pushMsat, fundingFeerateSatByte, channelFlags, openTimeout_opt) =>
                               complete(eclairApi.open(nodeId, fundingSatoshis, pushMsat, fundingFeerateSatByte, channelFlags, openTimeout_opt))
                           }


### PR DESCRIPTION
Type feerates info: fixes #1188.
Correct the comment about minimum feerate calculation: this is an alternative to #1425 
Add 1008 blocks target (may be useful for claim-main outputs to avoid the week-end fee spike): fixes #1486 