### PR TITLE
Add DB entry for payment router error

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -201,6 +201,7 @@ object HopSummary {
 case class FailureSummary(failureType: FailureType.Value, failureMessage: String, failedRoute: List[HopSummary])
 
 object FailureType extends Enumeration {
+  type FailureType = Value
   val LOCAL = Value(1, "Local")
   val REMOTE = Value(2, "Remote")
   val UNREADABLE_REMOTE = Value(3, "UnreadableRemote")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -24,6 +24,7 @@ import fr.acinq.bitcoin.{Block, Crypto}
 import fr.acinq.eclair._
 import fr.acinq.eclair.channel.{ChannelFlags, ChannelUnavailable}
 import fr.acinq.eclair.crypto.Sphinx
+import fr.acinq.eclair.db.{FailureSummary, FailureType, OutgoingPaymentStatus}
 import fr.acinq.eclair.payment.OutgoingPacket.Upstream
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle._
@@ -275,6 +276,10 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.id === cfg.id)
     assert(result.paymentHash === paymentHash)
     assert(result.failures === Seq(LocalFailure(Nil, RouteNotFound)))
+
+    val Some(outgoing) = nodeParams.db.payments.getOutgoingPayment(cfg.id)
+    assert(outgoing.status.isInstanceOf[OutgoingPaymentStatus.Failed])
+    assert(outgoing.status.asInstanceOf[OutgoingPaymentStatus.Failed].failures === Seq(FailureSummary(FailureType.LOCAL, RouteNotFound.getMessage, Nil)))
 
     sender.expectTerminated(payFsm)
     sender.expectNoMsg(100 millis)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -27,6 +27,7 @@ import fr.acinq.eclair.ApiTypes.ChannelIdentifier
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.{ChannelOpenResponse, ChannelVersion, CloseCommand, Command, CommandResponse, RES_SUCCESS, State}
 import fr.acinq.eclair.crypto.ShaChain
+import fr.acinq.eclair.db.FailureType.FailureType
 import fr.acinq.eclair.db.{IncomingPaymentStatus, OutgoingPaymentStatus}
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.router.Router.RouteResponse
@@ -224,6 +225,12 @@ class FailureMessageSerializer extends CustomSerializer[FailureMessage](_ => ( {
   case m: FailureMessage => JString(m.message)
 }))
 
+class FailureTypeSerializer extends CustomSerializer[FailureType](_ => ( {
+  null
+}, {
+  case ft: FailureType => JString(ft.toString)
+}))
+
 class NodeAddressSerializer extends CustomSerializer[NodeAddress](_ => ( {
   null
 }, {
@@ -346,6 +353,7 @@ object JsonSupport extends Json4sSupport {
     new RouteResponseSerializer +
     new ThrowableSerializer +
     new FailureMessageSerializer +
+    new FailureTypeSerializer +
     new NodeAddressSerializer +
     new DirectedHtlcSerializer +
     new PaymentRequestSerializer +


### PR DESCRIPTION
When using MPP, if we can't find a route, we need to add an entry to the
DB. Otherwise when users query their payment status, nothing will be
returned which is a bad UX.

Fixes #1512