### PR TITLE
Use the `replyTo` pattern for Register messages

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -364,8 +364,8 @@ class EclairImpl(appKit: Kit) extends Eclair {
    * @param channel either a shortChannelId (BOLT encoded) or a channelId (32-byte hex encoded).
    */
   private def sendToChannel[T: ClassTag](channel: ApiTypes.ChannelIdentifier, request: Any)(implicit timeout: Timeout): Future[T] = (channel match {
-    case Left(channelId) => appKit.register ? Forward(channelId, request)
-    case Right(shortChannelId) => appKit.register ? ForwardShortId(shortChannelId, request)
+    case Left(channelId) => appKit.register ? Forward(ActorRef.noSender, channelId, request)
+    case Right(shortChannelId) => appKit.register ? ForwardShortId(ActorRef.noSender, shortChannelId, request)
   }).mapTo[T]
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -62,16 +62,20 @@ class Register extends Actor with ActorLogging {
 
     case Symbol("channelsTo") => sender ! channelsTo
 
-    case fwd@Forward(channelId, msg) =>
+    case fwd@Forward(replyTo, channelId, msg) =>
+      // for backward compatibility with legacy ask, we use the replyTo as sender
+      val compatReplyTo = if (replyTo == ActorRef.noSender) sender else replyTo
       channels.get(channelId) match {
-        case Some(channel) => channel forward msg
-        case None => sender ! Failure(ForwardFailure(fwd))
+        case Some(channel) => channel.tell(msg, compatReplyTo)
+        case None => compatReplyTo ! Failure(ForwardFailure(fwd))
       }
 
-    case fwd@ForwardShortId(shortChannelId, msg) =>
+    case fwd@ForwardShortId(replyTo, shortChannelId, msg) =>
+      // for backward compatibility with legacy ask, we use the replyTo as sender
+      val compatReplyTo = if (replyTo == ActorRef.noSender) sender else replyTo
       shortIds.get(shortChannelId).flatMap(channels.get) match {
-        case Some(channel) => channel forward msg
-        case None => sender ! Failure(ForwardShortIdFailure(fwd))
+        case Some(channel) => channel.tell(msg, compatReplyTo) // for backward compatibility, we use the replyTo as sender
+        case None => compatReplyTo ! Failure(ForwardShortIdFailure(fwd))
       }
   }
 }
@@ -79,8 +83,8 @@ class Register extends Actor with ActorLogging {
 object Register {
 
   // @formatter:off
-  case class Forward[T](channelId: ByteVector32, message: T)
-  case class ForwardShortId[T](shortChannelId: ShortChannelId, message: T)
+  case class Forward[T](replyTo: ActorRef, channelId: ByteVector32, message: T)
+  case class ForwardShortId[T](replyTo: ActorRef, shortChannelId: ShortChannelId, message: T)
 
   case class ForwardFailure[T](fwd: Forward[T]) extends RuntimeException(s"channel ${fwd.channelId} not found")
   case class ForwardShortIdFailure[T](fwd: ForwardShortId[T]) extends RuntimeException(s"channel ${fwd.shortChannelId} not found")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -74,7 +74,7 @@ class Register extends Actor with ActorLogging {
       // for backward compatibility with legacy ask, we use the replyTo as sender
       val compatReplyTo = if (replyTo == ActorRef.noSender) sender else replyTo
       shortIds.get(shortChannelId).flatMap(channels.get) match {
-        case Some(channel) => channel.tell(msg, compatReplyTo) // for backward compatibility, we use the replyTo as sender
+        case Some(channel) => channel.tell(msg, compatReplyTo)
         case None => compatReplyTo ! Failure(ForwardShortIdFailure(fwd))
       }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
@@ -55,7 +55,7 @@ object PendingRelayDb {
    * incoming htlcs, which would lead to unwanted channel closings.
    */
   def safeSend(register: ActorRef, db: PendingRelayDb, channelId: ByteVector32, cmd: Command with HasHtlcId)(implicit ctx: ActorContext): Unit = {
-    register ! Register.Forward(channelId, cmd)
+    register ! Register.Forward(ctx.self, channelId, cmd)
     // we store the command in a db (note that this happens *after* forwarding the command to the channel, so we don't add latency)
     db.addPendingRelay(channelId, cmd)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -183,6 +183,8 @@ class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paym
     }
 
     case ChannelCommandResponse.Ok => () // ignoring responses from channels
+
+    case GetChildActors(replyTo) => replyTo ! ChildActors(postRestartCleaner, channelRelayer, nodeRelayer)
   }
 
   override def mdc(currentMessage: Any): MDC = {
@@ -234,6 +236,10 @@ object Relayer extends Logging {
       isPublic = commitments.announceChannel)
   }
   case class OutgoingChannels(channels: Seq[OutgoingChannel])
+
+  // internal classes, used for testing
+  private[payment] case class GetChildActors(replyTo: ActorRef)
+  private[payment] case class ChildActors(postRestartCleaner: ActorRef, channelRelayer: ActorRef, nodeRelayer: ActorRef)
   // @formatter:on
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -103,7 +103,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
     case Event(RouteResponse(route +: _), WaitingForRoute(s, c, failures, ignore)) =>
       log.info(s"route found: attempt=${failures.size + 1}/${c.maxAttempts} route=${route.printNodes()} channels=${route.printChannels()}")
       val (cmd, sharedSecrets) = OutgoingPacket.buildCommand(cfg.upstream, paymentHash, route.hops, c.finalPayload)
-      register ! Register.ForwardShortId(route.hops.head.lastUpdate.shortChannelId, cmd)
+      register ! Register.ForwardShortId(self, route.hops.head.lastUpdate.shortChannelId, cmd)
       goto(WAITING_FOR_PAYMENT_COMPLETE) using WaitingForComplete(s, c, cmd, failures, sharedSecrets, ignore, route)
 
     case Event(Status.Failure(t), WaitingForRoute(s, _, failures, _)) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -18,6 +18,7 @@ package fr.acinq.eclair
 
 import java.util.UUID
 
+import akka.actor.ActorRef
 import akka.testkit.TestProbe
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
@@ -283,31 +284,31 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     val eclair = new EclairImpl(kit)
 
     eclair.forceClose(Left(ByteVector32.Zeroes) :: Nil)
-    register.expectMsg(Register.Forward(ByteVector32.Zeroes, CMD_FORCECLOSE))
+    register.expectMsg(Register.Forward(ActorRef.noSender, ByteVector32.Zeroes, CMD_FORCECLOSE))
 
     eclair.forceClose(Right(ShortChannelId("568749x2597x0")) :: Nil)
-    register.expectMsg(Register.ForwardShortId(ShortChannelId("568749x2597x0"), CMD_FORCECLOSE))
+    register.expectMsg(Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x0"), CMD_FORCECLOSE))
 
     eclair.forceClose(Left(ByteVector32.Zeroes) :: Right(ShortChannelId("568749x2597x0")) :: Nil)
     register.expectMsgAllOf(
-      Register.Forward(ByteVector32.Zeroes, CMD_FORCECLOSE),
-      Register.ForwardShortId(ShortChannelId("568749x2597x0"), CMD_FORCECLOSE)
+      Register.Forward(ActorRef.noSender, ByteVector32.Zeroes, CMD_FORCECLOSE),
+      Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x0"), CMD_FORCECLOSE)
     )
 
     eclair.close(Left(ByteVector32.Zeroes) :: Nil, None)
-    register.expectMsg(Register.Forward(ByteVector32.Zeroes, CMD_CLOSE(None)))
+    register.expectMsg(Register.Forward(ActorRef.noSender, ByteVector32.Zeroes, CMD_CLOSE(None)))
 
     eclair.close(Right(ShortChannelId("568749x2597x0")) :: Nil, None)
-    register.expectMsg(Register.ForwardShortId(ShortChannelId("568749x2597x0"), CMD_CLOSE(None)))
+    register.expectMsg(Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x0"), CMD_CLOSE(None)))
 
     eclair.close(Right(ShortChannelId("568749x2597x0")) :: Nil, Some(ByteVector.empty))
-    register.expectMsg(Register.ForwardShortId(ShortChannelId("568749x2597x0"), CMD_CLOSE(Some(ByteVector.empty))))
+    register.expectMsg(Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x0"), CMD_CLOSE(Some(ByteVector.empty))))
 
     eclair.close(Right(ShortChannelId("568749x2597x0")) :: Left(ByteVector32.One) :: Right(ShortChannelId("568749x2597x1")) :: Nil, None)
     register.expectMsgAllOf(
-      Register.ForwardShortId(ShortChannelId("568749x2597x0"), CMD_CLOSE(None)),
-      Register.Forward(ByteVector32.One, CMD_CLOSE(None)),
-      Register.ForwardShortId(ShortChannelId("568749x2597x1"), CMD_CLOSE(None))
+      Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x0"), CMD_CLOSE(None)),
+      Register.Forward(ActorRef.noSender, ByteVector32.One, CMD_CLOSE(None)),
+      Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x1"), CMD_CLOSE(None))
     )
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -101,8 +101,8 @@ class FuzzySpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with StateT
     }
 
     def main(channel: ActorRef): Receive = {
-      case Register.Forward(_, msg) => channel forward msg
-      case Register.ForwardShortId(_, msg) => channel forward msg
+      case fwd: Register.Forward[_] => channel forward fwd.message
+      case fwd: Register.ForwardShortId[_] => channel forward fwd.message
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/NodeRelayerSpec.scala
@@ -78,7 +78,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val parts = incomingMultiPart.dropRight(1).map(i => MultiPartPaymentFSM.HtlcPart(incomingAmount, i.add))
     sender.send(nodeRelayer, MultiPartPaymentFSM.MultiPartPaymentFailed(paymentHash, PaymentTimeout, Queue(parts: _*)))
 
-    incomingMultiPart.dropRight(1).foreach(p => register.expectMsg(Register.Forward(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(PaymentTimeout), commit = true))))
+    incomingMultiPart.dropRight(1).foreach(p => register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(PaymentTimeout), commit = true))))
     sender.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -90,7 +90,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val partial = MultiPartPaymentFSM.HtlcPart(incomingAmount, UpdateAddHtlc(randomBytes32, 15, 100 msat, paymentHash, CltvExpiry(42000), TestConstants.emptyOnionPacket))
     sender.send(nodeRelayer, MultiPartPaymentFSM.ExtraPaymentReceived(paymentHash, partial, Some(InvalidRealm)))
 
-    register.expectMsg(Register.Forward(partial.htlc.channelId, CMD_FAIL_HTLC(partial.htlc.id, Right(InvalidRealm), commit = true)))
+    register.expectMsg(Register.Forward(nodeRelayer, partial.htlc.channelId, CMD_FAIL_HTLC(partial.htlc.id, Right(InvalidRealm), commit = true)))
     sender.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -112,7 +112,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
       Onion.createNodeRelayPayload(outgoingAmount, outgoingExpiry, outgoingNodeId),
       nextTrampolinePacket)
     relayer.send(nodeRelayer, i1)
-    register.expectMsg(Register.Forward(i1.add.channelId, CMD_FAIL_HTLC(i1.add.id, Right(IncorrectOrUnknownPaymentDetails(1000 msat, nodeParams.currentBlockHeight)), commit = true)))
+    register.expectMsg(Register.Forward(nodeRelayer, i1.add.channelId, CMD_FAIL_HTLC(i1.add.id, Right(IncorrectOrUnknownPaymentDetails(1000 msat, nodeParams.currentBlockHeight)), commit = true)))
 
     // Receive new HTLC with different details, but for the same payment hash.
     val i2 = IncomingPacket.NodeRelayPacket(
@@ -121,7 +121,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
       Onion.createNodeRelayPayload(1250 msat, outgoingExpiry, outgoingNodeId),
       nextTrampolinePacket)
     relayer.send(nodeRelayer, i2)
-    register.expectMsg(Register.Forward(i2.add.channelId, CMD_FAIL_HTLC(i2.add.id, Right(IncorrectOrUnknownPaymentDetails(1500 msat, nodeParams.currentBlockHeight)), commit = true)))
+    register.expectMsg(Register.Forward(nodeRelayer, i2.add.channelId, CMD_FAIL_HTLC(i2.add.id, Right(IncorrectOrUnknownPaymentDetails(1500 msat, nodeParams.currentBlockHeight)), commit = true)))
 
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -135,7 +135,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     relayer.send(nodeRelayer, p)
 
     val failure = IncorrectOrUnknownPaymentDetails(2000000 msat, nodeParams.currentBlockHeight)
-    register.expectMsg(Register.Forward(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(failure), commit = true)))
+    register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(failure), commit = true)))
     outgoingPayFSM.expectNoMsg(100 millis)
   }
 
@@ -150,7 +150,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     relayer.send(nodeRelayer, p2)
 
     val failure = IncorrectOrUnknownPaymentDetails(1000000 msat, nodeParams.currentBlockHeight)
-    register.expectMsg(Register.Forward(p2.add.channelId, CMD_FAIL_HTLC(p2.add.id, Right(failure), commit = true)))
+    register.expectMsg(Register.Forward(nodeRelayer, p2.add.channelId, CMD_FAIL_HTLC(p2.add.id, Right(failure), commit = true)))
     register.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -163,7 +163,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val p = createValidIncomingPacket(2000000 msat, 2000000 msat, expiryIn, 1000000 msat, expiryOut)
     relayer.send(nodeRelayer, p)
 
-    register.expectMsg(Register.Forward(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineExpiryTooSoon), commit = true)))
+    register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineExpiryTooSoon), commit = true)))
     register.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -180,7 +180,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     )
     p.foreach(p => relayer.send(nodeRelayer, p))
 
-    p.foreach(p => register.expectMsg(Register.Forward(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineExpiryTooSoon), commit = true))))
+    p.foreach(p => register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineExpiryTooSoon), commit = true))))
     register.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -191,7 +191,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val p = createValidIncomingPacket(2000000 msat, 2000000 msat, CltvExpiry(500000), 1999000 msat, CltvExpiry(490000))
     relayer.send(nodeRelayer, p)
 
-    register.expectMsg(Register.Forward(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true)))
+    register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true)))
     register.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -205,7 +205,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     )
     p.foreach(p => relayer.send(nodeRelayer, p))
 
-    p.foreach(p => register.expectMsg(Register.Forward(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true))))
+    p.foreach(p => register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true))))
     register.expectNoMsg(100 millis)
     outgoingPayFSM.expectNoMsg(100 millis)
   }
@@ -219,7 +219,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     outgoingPayFSM.expectMsgType[SendMultiPartPayment]
 
     outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, LocalFailure(Nil, BalanceTooLow) :: Nil))
-    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TemporaryNodeFailure), commit = true))))
+    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TemporaryNodeFailure), commit = true))))
     register.expectNoMsg(100 millis)
     eventListener.expectNoMsg(100 millis)
   }
@@ -235,7 +235,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     // If we're having a hard time finding routes, raising the fee/cltv will likely help.
     val failures = LocalFailure(Nil, RouteNotFound) :: RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, PermanentNodeFailure)) :: LocalFailure(Nil, RouteNotFound) :: Nil
     outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, failures))
-    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true))))
+    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(TrampolineFeeInsufficient), commit = true))))
     register.expectNoMsg(100 millis)
     eventListener.expectNoMsg(100 millis)
   }
@@ -250,7 +250,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
 
     val failures = RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, FinalIncorrectHtlcAmount(42 msat))) :: UnreadableRemoteFailure(Nil) :: Nil
     outgoingPayFSM.send(nodeRelayer, PaymentFailed(outgoingPaymentId, paymentHash, failures))
-    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(FinalIncorrectHtlcAmount(42 msat)), commit = true))))
+    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FAIL_HTLC(p.add.id, Right(FinalIncorrectHtlcAmount(42 msat)), commit = true))))
     register.expectNoMsg(100 millis)
     eventListener.expectNoMsg(100 millis)
   }
@@ -282,7 +282,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
 
     // A first downstream HTLC is fulfilled: we should immediately forward the fulfill upstream.
     outgoingPayFSM.send(nodeRelayer, PreimageReceived(paymentHash, paymentPreimage))
-    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(p.add.channelId, CMD_FULFILL_HTLC(p.add.id, paymentPreimage, commit = true))))
+    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FULFILL_HTLC(p.add.id, paymentPreimage, commit = true))))
 
     // If the payment FSM sends us duplicate preimage events, we should not fulfill a second time upstream.
     outgoingPayFSM.send(nodeRelayer, PreimageReceived(paymentHash, paymentPreimage))
@@ -310,7 +310,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
 
     outgoingPayFSM.send(nodeRelayer, PreimageReceived(paymentHash, paymentPreimage))
     val incomingAdd = incomingSinglePart.add
-    register.expectMsg(Register.Forward(incomingAdd.channelId, CMD_FULFILL_HTLC(incomingAdd.id, paymentPreimage, commit = true)))
+    register.expectMsg(Register.Forward(nodeRelayer, incomingAdd.channelId, CMD_FULFILL_HTLC(incomingAdd.id, paymentPreimage, commit = true)))
 
     outgoingPayFSM.send(nodeRelayer, createSuccessEvent(outgoingCfg.id))
     val relayEvent = eventListener.expectMsgType[TrampolinePaymentRelayed]
@@ -343,7 +343,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     assert(outgoingPayment.assistedRoutes === hints)
 
     outgoingPayFSM.send(nodeRelayer, PreimageReceived(paymentHash, paymentPreimage))
-    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(p.add.channelId, CMD_FULFILL_HTLC(p.add.id, paymentPreimage, commit = true))))
+    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FULFILL_HTLC(p.add.id, paymentPreimage, commit = true))))
 
     outgoingPayFSM.send(nodeRelayer, createSuccessEvent(outgoingCfg.id))
     val relayEvent = eventListener.expectMsgType[TrampolinePaymentRelayed]
@@ -373,7 +373,7 @@ class NodeRelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     assert(outgoingPayment.assistedRoutes === hints)
 
     outgoingPayFSM.send(nodeRelayer, PreimageReceived(paymentHash, paymentPreimage))
-    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(p.add.channelId, CMD_FULFILL_HTLC(p.add.id, paymentPreimage, commit = true))))
+    incomingMultiPart.foreach(p => register.expectMsg(Register.Forward(nodeRelayer, p.add.channelId, CMD_FULFILL_HTLC(p.add.id, paymentPreimage, commit = true))))
 
     outgoingPayFSM.send(nodeRelayer, createSuccessEvent(outgoingCfg.id))
     val relayEvent = eventListener.expectMsgType[TrampolinePaymentRelayed]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -210,9 +210,13 @@ class RelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     val fulfill_ba = UpdateFulfillHtlc(channelId_bc, 72, paymentPreimage)
     sender.send(relayer, ForwardRemoteFulfill(fulfill_ba, origin2, add_bc))
 
+    // we need a reference to the node-relayer child actor
+    sender.send(relayer, Relayer.GetChildActors(sender.ref))
+    val nodeRelayer = sender.expectMsgType[Relayer.ChildActors].nodeRelayer
+
     // it should trigger a fulfill on the upstream HTLCs
-    register.expectMsg(Register.Forward(channelId_ab, CMD_FULFILL_HTLC(561, paymentPreimage, commit = true)))
-    register.expectMsg(Register.Forward(channelId_ab, CMD_FULFILL_HTLC(565, paymentPreimage, commit = true)))
+    register.expectMsg(Register.Forward(nodeRelayer, channelId_ab, CMD_FULFILL_HTLC(561, paymentPreimage, commit = true)))
+    register.expectMsg(Register.Forward(nodeRelayer, channelId_ab, CMD_FULFILL_HTLC(565, paymentPreimage, commit = true)))
   }
 
   test("relay an htlc-add at the final node to the payment handler") { f =>
@@ -557,12 +561,16 @@ class RelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     payFSM.expectMsg(forwardFulfill)
     system.actorSelection(relayer.path.child("node-relayer")).tell(PreimageReceived(paymentHash, preimage), payFSM.ref)
 
+    // we need a reference to the node-relayer child actor
+    sender.send(relayer, Relayer.GetChildActors(sender.ref))
+    val nodeRelayer = sender.expectMsgType[Relayer.ChildActors].nodeRelayer
+
     // the payment should be immediately fulfilled upstream.
     val upstream1 = register.expectMsgType[Register.Forward[CMD_FULFILL_HTLC]]
     val upstream2 = register.expectMsgType[Register.Forward[CMD_FULFILL_HTLC]]
     assert(Set(upstream1, upstream2) === Set(
-      Register.Forward(channelId_ab, CMD_FULFILL_HTLC(561, preimage, commit = true)),
-      Register.Forward(channelId_ab, CMD_FULFILL_HTLC(565, preimage, commit = true))
+      Register.Forward(nodeRelayer, channelId_ab, CMD_FULFILL_HTLC(561, preimage, commit = true)),
+      Register.Forward(nodeRelayer, channelId_ab, CMD_FULFILL_HTLC(565, preimage, commit = true))
     ))
 
     register.expectNoMsg(50 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -557,13 +557,13 @@ class RelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     }
     sender.send(relayer, forwardFulfill)
 
-    // the FSM responsible for the payment should receive the fulfill and emit a preimage event.
-    payFSM.expectMsg(forwardFulfill)
-    system.actorSelection(relayer.path.child("node-relayer")).tell(PreimageReceived(paymentHash, preimage), payFSM.ref)
-
     // we need a reference to the node-relayer child actor
     sender.send(relayer, Relayer.GetChildActors(sender.ref))
     val nodeRelayer = sender.expectMsgType[Relayer.ChildActors].nodeRelayer
+
+    // the FSM responsible for the payment should receive the fulfill and emit a preimage event.
+    payFSM.expectMsg(forwardFulfill)
+    nodeRelayer.tell(PreimageReceived(paymentHash, preimage), payFSM.ref)
 
     // the payment should be immediately fulfilled upstream.
     val upstream1 = register.expectMsgType[Register.Forward[CMD_FULFILL_HTLC]]


### PR DESCRIPTION
In preparation of the migration to typed actors, we need to remove the
use of `sender`, which doesn't exist in typed actors (and even returns
dead letters when mixing typed/untyped actors).

This also means that, in the tests, we should stop using the
`TestProbe.send()` method, which also relies on the recipient replying
to `sender`. Instead, we should use `targetActor ! msg` which guarantees
that the sender is void.

Using the `replyTo` pattern doesn't mix well with the `ask` pattern,
because we don't know the reference to the temporary actor. To deal with
that, we set `replyTo = ActorRef.noSender` which is a bit hackish.

NB: the [akka doc](https://doc.akka.io/docs/akka/current/typed/interaction-patterns.html#request-response-with-ask-from-outside-an-actor) shows the proper way of dealing with `ask` with typed actors:

```scala
val result: Future[CookieFabric.Reply] = cookieFabric.ask(ref => CookieFabric.GiveMeCookies(3, ref))
```