### PR TITLE
Route search fix

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -1535,6 +1535,18 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     }
   }
 
+  test("skip routes which turn out to have too small routing capacity on splitting") {
+    val rts = RouteParams(randomize = false, 21000 msat, 0.03, 6, CltvExpiryDelta(2016), None, MultiPartParams(1000 msat, 2))
+    val amount = 60000 msat
+    val g = DirectedGraph(List(
+      makeEdge(1L, a, b, 50 msat, 100, minHtlc = 1 msat, balance_opt = Some(500000 msat)),
+      makeEdge(2L, b, c, 10 msat, 30, minHtlc = 1 msat, capacity = 15 sat),
+      makeEdge(4L, b, c, 10 msat, 30, minHtlc = 1 msat, capacity = 15 sat),
+      makeEdge(5L, b, c, 11 msat, 30, minHtlc = 1 msat, capacity = 55 sat),
+    ))
+    val Success(routes) = findMultiPartRoute(g, a, c, amount, 2500 msat, routeParams = rts, currentBlockHeight = 400000)
+  }
+
 }
 
 object RouteCalculationSpec {


### PR DESCRIPTION
I guess provided test describes this best so I'll walk through what it does:

- First, routes `((1, 2) and (1, 4))` are successfully found, but when `split` called it turns out their total capacity is `30 sat` while we try to send a `60 sat` payment.
- Next, what this code change does is it removes a number of lowest capacity channels and runs a search once again in hope that more appropriate routes will be found this time.
- Second attempt turns out to be successful with routes `((1, 5) and (1, 4))`.