### PR TITLE
Remove `Status.Failure` in register responses

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -16,7 +16,6 @@
 
 package fr.acinq.eclair.channel
 
-import akka.actor.Status.Failure
 import akka.actor.{Actor, ActorLogging, ActorRef, Terminated}
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
@@ -67,7 +66,7 @@ class Register extends Actor with ActorLogging {
       val compatReplyTo = if (replyTo == ActorRef.noSender) sender else replyTo
       channels.get(channelId) match {
         case Some(channel) => channel.tell(msg, compatReplyTo)
-        case None => compatReplyTo ! Failure(ForwardFailure(fwd))
+        case None => compatReplyTo ! ForwardFailure(fwd)
       }
 
     case fwd@ForwardShortId(replyTo, shortChannelId, msg) =>
@@ -75,7 +74,7 @@ class Register extends Actor with ActorLogging {
       val compatReplyTo = if (replyTo == ActorRef.noSender) sender else replyTo
       shortIds.get(shortChannelId).flatMap(channels.get) match {
         case Some(channel) => channel.tell(msg, compatReplyTo)
-        case None => compatReplyTo ! Failure(ForwardShortIdFailure(fwd))
+        case None => compatReplyTo ! ForwardShortIdFailure(fwd)
       }
   }
 }
@@ -86,7 +85,7 @@ object Register {
   case class Forward[T](replyTo: ActorRef, channelId: ByteVector32, message: T)
   case class ForwardShortId[T](replyTo: ActorRef, shortChannelId: ShortChannelId, message: T)
 
-  case class ForwardFailure[T](fwd: Forward[T]) extends RuntimeException(s"channel ${fwd.channelId} not found")
-  case class ForwardShortIdFailure[T](fwd: ForwardShortId[T]) extends RuntimeException(s"channel ${fwd.shortChannelId} not found")
+  case class ForwardFailure[T](fwd: Forward[T])
+  case class ForwardShortIdFailure[T](fwd: ForwardShortId[T])
   // @formatter:on
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelayer.scala
@@ -56,7 +56,7 @@ class ChannelRelayer(nodeParams: NodeParams, relayer: ActorRef, register: ActorR
           register ! Register.ForwardShortId(self, selectedShortChannelId, cmdAdd)
       }
 
-    case Status.Failure(Register.ForwardShortIdFailure(Register.ForwardShortId(_, shortChannelId, CMD_ADD_HTLC(_, _, _, _, Upstream.Relayed(add), _, _)))) =>
+    case Register.ForwardShortIdFailure(Register.ForwardShortId(_, shortChannelId, CMD_ADD_HTLC(_, _, _, _, Upstream.Relayed(add), _, _))) =>
       log.warning(s"couldn't resolve downstream channel $shortChannelId, failing htlc #${add.id}")
       val cmdFail = CMD_FAIL_HTLC(add.id, Right(UnknownNextPeer), commit = true)
       Metrics.recordPaymentRelayFailed(Tags.FailureType(cmdFail), Tags.RelayType.Channel)
@@ -83,7 +83,7 @@ class ChannelRelayer(nodeParams: NodeParams, relayer: ActorRef, register: ActorR
   override def mdc(currentMessage: Any): MDC = {
     val paymentHash_opt = currentMessage match {
       case relay: RelayHtlc => Some(relay.r.add.paymentHash)
-      case Status.Failure(Register.ForwardShortIdFailure(Register.ForwardShortId(_, _, c: CMD_ADD_HTLC))) => Some(c.paymentHash)
+      case Register.ForwardShortIdFailure(Register.ForwardShortId(_, _, c: CMD_ADD_HTLC)) => Some(c.paymentHash)
       case Status.Failure(addFailed: AddHtlcFailed) => Some(addFailed.paymentHash)
       case _ => None
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -296,7 +296,7 @@ class RelayerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     assert(fwd1.shortChannelId === channelUpdate_bc.shortChannelId)
     assert(fwd1.message.upstream === Upstream.Relayed(add_ab))
 
-    register.send(register.lastSender, Status.Failure(Register.ForwardShortIdFailure(fwd1)))
+    register.send(register.lastSender, Register.ForwardShortIdFailure(fwd1))
 
     val fwd2 = register.expectMsgType[Register.Forward[CMD_FAIL_HTLC]]
     assert(fwd2.channelId === channelId_ab)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/RelayerSpec.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.payment
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, Props, Status}
+import akka.actor.{ActorRef, Status}
 import akka.testkit.TestProbe
 import fr.acinq.bitcoin.{ByteVector32, Crypto}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
@@ -27,8 +27,8 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.IncomingPacket.FinalPacket
 import fr.acinq.eclair.payment.OutgoingPacket.{buildCommand, buildOnion, buildPacket}
 import fr.acinq.eclair.payment.relay.Origin._
-import fr.acinq.eclair.payment.relay.Relayer._
 import fr.acinq.eclair.payment.relay.Relayer
+import fr.acinq.eclair.payment.relay.Relayer._
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.PreimageReceived
 import fr.acinq.eclair.router.Router.{ChannelHop, Ignore, NodeHop}
 import fr.acinq.eclair.router.{Announcements, _}


### PR DESCRIPTION
This builds on #1514, please ignore the first commit.

Encapsulating error responses in a `Status.Failure` is convenient when
using the `ask` pattern because those messages are automatically
converted to a failed future.

It does however force us to use exceptions, and make things more
complicated, especially when moving to _typed_ actors.