### PR TITLE
Show reminder of failed tests at the end

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,7 @@
                 <version>2.0.0</version>
                 <configuration>
                     <parallel>true</parallel>
+                    <stdout>I</stdout>
                     <systemProperties>
                         <buildDirectory>${project.build.directory}</buildDirectory>
                     </systemProperties>


### PR DESCRIPTION
From scalatest's doc [1]:

> This minimizes or eliminates the need to search and scroll backwards
to find out what tests failed or were canceled. For large test suites,
the actual failure message could have scrolled off the top of the
buffer, making it otherwise impossible to see what failed.

[1] https://www.scalatest.org/user_guide/using_the_runner