### PR TITLE
Update to Bitcoin Core 0.20.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You will find detailed guides and frequently asked questions there.
 
 ### Configuring Bitcoin Core
 
-:warning: Eclair requires Bitcoin Core 0.19.1 or 0.20.1. If you are upgrading an existing wallet, you need to create a new address and send all your funds to that address.
+:warning: Eclair requires Bitcoin Core 0.18.1, 0.19.1 or 0.20.1. If you are upgrading an existing wallet, you need to create a new address and send all your funds to that address.
 
 Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
 Eclair will use any BTC it finds in the default Bitcoin Core wallet to fund any channels you choose to open. Eclair will return BTC from closed channels to this wallet. You can have multiple Bitcoin Core wallets but make sure that the default one is always available.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You will find detailed guides and frequently asked questions there.
 
 ### Configuring Bitcoin Core
 
-:warning: Eclair requires Bitcoin Core 0.18.1 or 0.19.1. If you are upgrading an existing wallet, you need to create a new address and send all your funds to that address.
+:warning: Eclair requires Bitcoin Core 0.19.1 or 0.20.1. If you are upgrading an existing wallet, you need to create a new address and send all your funds to that address.
 
 Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
 Eclair will use any BTC it finds in the default Bitcoin Core wallet to fund any channels you choose to open. Eclair will return BTC from closed channels to this wallet. You can have multiple Bitcoin Core wallets but make sure that the default one is always available.

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -80,9 +80,9 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.19.1/bitcoin-0.19.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
-                <bitcoind.md5>c2e41019caab82e6c5cb45f44964f44e</bitcoind.md5>
-                <bitcoind.sha1>efabbb93827fa35d16a8ba73360e5fbf6b86a91c</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-0.20.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
+                <bitcoind.md5>265d32d3f7645d0a4fe27a698bb8b3b3</bitcoind.md5>
+                <bitcoind.sha1>5a814f983cd32a0dea67a9c3c36d494130cad7c5</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -93,9 +93,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.19.1/bitcoin-0.19.1-osx64.tar.gz</bitcoind.url>
-                <bitcoind.md5>6687a2df8b8a167b3afb9e0107deeb7d</bitcoind.md5>
-                <bitcoind.sha1>a02469a77781cd1413df120133be131bd388a997</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-0.20.1-osx64.tar.gz</bitcoind.url>
+                <bitcoind.md5>765fcc62c3ef470cbc23933c31c2e2f2</bitcoind.md5>
+                <bitcoind.sha1>2c1ba1a4c05448b81da2161aa3ab94c047681e7b</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -106,9 +106,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.19.1/bitcoin-0.19.1-win64.zip</bitcoind.url>
-                <bitcoind.md5>0ef5729d71a8b996b7753f564259cef9</bitcoind.md5>
-                <bitcoind.sha1>13d056bfb26d6d18b656b57ab2ab36dd38fa4043</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-0.20.1-win64.zip</bitcoind.url>
+                <bitcoind.md5>966568365067add2744ae4030c0d4165</bitcoind.md5>
+                <bitcoind.sha1>4fe72c5848a2ddc462083db891d6820a6f4ef2ee</bitcoind.sha1>
             </properties>
         </profile>
     </profiles>

--- a/eclair-core/src/test/resources/integration/bitcoin.conf
+++ b/eclair-core/src/test/resources/integration/bitcoin.conf
@@ -7,7 +7,7 @@ txindex=1
 zmqpubrawblock=tcp://127.0.0.1:28334
 zmqpubrawtx=tcp://127.0.0.1:28335
 rpcworkqueue=64
-addresstype=bech32
+fallbackfee=0.0002
 [regtest]
 bind=127.0.0.1
 port=28333

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -55,7 +55,7 @@ trait BitcoindService extends Logging {
   val INTEGRATION_TMP_DIR = new File(TestUtils.BUILD_DIRECTORY, s"integration-${UUID.randomUUID()}")
   logger.info(s"using tmp dir: $INTEGRATION_TMP_DIR")
 
-  val PATH_BITCOIND = new File(TestUtils.BUILD_DIRECTORY, "bitcoin-0.19.1/bin/bitcoind")
+  val PATH_BITCOIND = new File(TestUtils.BUILD_DIRECTORY, "bitcoin-0.20.1/bin/bitcoind")
   val PATH_BITCOIND_DATADIR = new File(INTEGRATION_TMP_DIR, "datadir-bitcoin")
 
   var bitcoind: Process = null


### PR DESCRIPTION
The only impactful change is that by default on regtest and testnet the `fallbackfee` (used when there is not enough historical data to correctly estimate the feerate) is now set to 0, whereas it was set to 0.0002 btc in previous versions. This change only impacts regtest and testnet, on mainnet this parameter has always been set to 0.

We set it manually in tests `bitcoin.conf` to preserve the past behavior (as recommended by bitcoind's release notes).
