### PR TITLE
More leeway for logging events in tests

### DIFF
--- a/eclair-core/src/test/resources/application.conf
+++ b/eclair-core/src/test/resources/application.conf
@@ -9,6 +9,16 @@ akka {
       # enable DEBUG logging of all LoggingFSMs for events, transitions and timers
       fsm = on
     }
+
+    testkit.typed {
+      # Factor by which to scale timeouts during tests, e.g. to account for shared
+      # build system load.
+      timefactor = 1.0
+
+      # Duration to wait for all required logging events in LoggingTestKit.expect.
+      # Dilated by the timefactor.
+      filter-leeway = 5s
+    }
   }
 
   test {


### PR DESCRIPTION
In some tests we are parsing logs to prevent race conditions. This
change adds more leeway to wait for logging events, because they may be
delayed when we run a lot of tests in parallel.