### PR TITLE
[OpenChannel] Use TLV for channel version

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelTlv.scala
@@ -45,6 +45,9 @@ object OpenChannelTlv {
 
   val openTlvCodec: Codec[TlvStream[OpenChannelTlv]] = tlvStream(discriminated[OpenChannelTlv].by(varint)
     .typecase(UInt64(0), variableSizeBytesLong(varintoverflow, bytes).as[UpfrontShutdownScript])
+    // TODO: @t-bast: once enough active Phoenix users have upgraded to versions > 1.3.3, we should configure the ACINQ
+    // node to write with the new encoding (0x47000001).
+    // Once that's done, we can remove the old encoding below (0x47000000) for future Phoenix upgrades.
     .typecase(UInt64(0x47000000), bits(ChannelVersion.LENGTH_BITS).as[ChannelVersion].as[ChannelVersionTlv])
     .typecase(UInt64(0x47000001), variableSizeBytesLong(varintoverflow, bits(ChannelVersion.LENGTH_BITS)).as[ChannelVersion].as[ChannelVersionTlv])
   )

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelTlv.scala
@@ -46,6 +46,7 @@ object OpenChannelTlv {
   val openTlvCodec: Codec[TlvStream[OpenChannelTlv]] = tlvStream(discriminated[OpenChannelTlv].by(varint)
     .typecase(UInt64(0), variableSizeBytesLong(varintoverflow, bytes).as[UpfrontShutdownScript])
     .typecase(UInt64(0x47000000), bits(ChannelVersion.LENGTH_BITS).as[ChannelVersion].as[ChannelVersionTlv])
+    .typecase(UInt64(0x47000001), variableSizeBytesLong(varintoverflow, bits(ChannelVersion.LENGTH_BITS)).as[ChannelVersion].as[ChannelVersionTlv])
   )
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/OpenTlvSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/OpenTlvSpec.scala
@@ -16,11 +16,16 @@
 
 package fr.acinq.eclair.wire
 
+import fr.acinq.eclair.UInt64
 import fr.acinq.eclair.channel.ChannelVersion
+import fr.acinq.eclair.wire.ChannelTlv.UpfrontShutdownScript
+import fr.acinq.eclair.wire.CommonCodecs.{varint, varintoverflow}
 import fr.acinq.eclair.wire.OpenChannelTlv.ChannelVersionTlv
+import fr.acinq.eclair.wire.TlvCodecs.tlvStream
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits._
-import scodec.{Attempt, DecodeResult}
+import scodec.codecs.{bits, bytes, discriminated, variableSizeBytesLong}
+import scodec.{Attempt, Codec, DecodeResult}
 
 class OpenTlvSpec extends AnyFunSuite {
 
@@ -37,6 +42,17 @@ class OpenTlvSpec extends AnyFunSuite {
       assert(OpenChannelTlv.openTlvCodec.decode(testCase.encoded) === Attempt.successful(DecodeResult(TlvStream(ChannelVersionTlv(testCase.expected)), BitVector.empty)))
       assert(OpenChannelTlv.openTlvCodec.encode(TlvStream(ChannelVersionTlv(testCase.expected))) === Attempt.Successful(testCase.reEncoded))
     }
+  }
+
+  test("channel version tlv backwards-compatibility") {
+    // This is the codec that was used previously.
+    val previousCodec: Codec[TlvStream[OpenChannelTlv]] = tlvStream(discriminated[OpenChannelTlv].by(varint)
+      .typecase(UInt64(0), variableSizeBytesLong(varintoverflow, bytes).as[UpfrontShutdownScript])
+      .typecase(UInt64(0x47000000), bits(ChannelVersion.LENGTH_BITS).as[ChannelVersion].as[ChannelVersionTlv])
+    )
+
+    assert(previousCodec.decode(hex"fe47000001 04 00000001".bits).require.value === TlvStream(Nil, Seq(GenericTlv(UInt64(0x47000001), hex"00000001"))))
+    assert(previousCodec.decode(hex"fe47000001 04 00000009".bits).require.value === TlvStream(Nil, Seq(GenericTlv(UInt64(0x47000001), hex"00000009"))))
   }
 
 }


### PR DESCRIPTION
We were previously using an encoding that was incompatible with TLV.
We keep the old format, but also understand the channel version when provided in a TLV field.

For backwards-compatibility, if the old format is provided, it will be preferred.
Since Phoenix only reads `open_channel` messages, it only needs support to *decode* this new TLV.
It will be on the eclair-node side that we will to switch to write the new TLV instead of the old format once we're confident enough Phoenix users have upgraded.

NB: this PR doesn't merge to master, but to `android-phoenix`