### PR TITLE
Send to channel route

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -275,7 +275,7 @@ object PaymentInitiator {
                                        parentId: Option[UUID],
                                        paymentRequest: PaymentRequest,
                                        fallbackFinalExpiryDelta: CltvExpiryDelta = Channel.MIN_CLTV_EXPIRY_DELTA,
-                                       route: Seq[PublicKey],
+                                       route: PredefinedRoute,
                                        trampolineSecret: Option[ByteVector32],
                                        trampolineFees: MilliSatoshi,
                                        trampolineExpiryDelta: CltvExpiryDelta,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.router
 
 import akka.actor.{ActorContext, ActorRef, Status}
-import akka.event.{DiagnosticLoggingAdapter, LoggingAdapter}
+import akka.event.DiagnosticLoggingAdapter
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
 import fr.acinq.eclair.Logs.LogCategory
@@ -38,7 +38,7 @@ import scala.util.{Failure, Random, Success, Try}
 
 object RouteCalculation {
 
-  def finalizeRoute(d: Data, fr: FinalizeRoute)(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Data = {
+  def finalizeRoute(d: Data, localNodeId: PublicKey, fr: FinalizeRoute)(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Data = {
     Logs.withMdc(log)(Logs.mdc(
       category_opt = Some(LogCategory.PAYMENT),
       parentPaymentId_opt = fr.paymentContext.map(_.parentId),
@@ -46,21 +46,44 @@ object RouteCalculation {
       paymentHash_opt = fr.paymentContext.map(_.paymentHash))) {
       implicit val sender: ActorRef = ctx.self // necessary to preserve origin when sending messages to other actors
 
-      val assistedChannels: Map[ShortChannelId, AssistedChannel] = fr.assistedRoutes.flatMap(toAssistedChannels(_, fr.hops.last, fr.amount)).toMap
+      val assistedChannels: Map[ShortChannelId, AssistedChannel] = fr.assistedRoutes.flatMap(toAssistedChannels(_, fr.route.targetNodeId, fr.amount)).toMap
       val extraEdges = assistedChannels.values.map(ac =>
         GraphEdge(ChannelDesc(ac.extraHop.shortChannelId, ac.extraHop.nodeId, ac.nextNodeId), toFakeUpdate(ac.extraHop, ac.htlcMaximum), htlcMaxToCapacity(ac.htlcMaximum), Some(ac.htlcMaximum))
       ).toSet
       val g = extraEdges.foldLeft(d.graph) { case (g: DirectedGraph, e: GraphEdge) => g.addEdge(e) }
-      // split into sublists [(a,b),(b,c), ...] then get the edges between each of those pairs
-      fr.hops.sliding(2).map { case List(v1, v2) => g.getEdgesBetween(v1, v2) }.toList match {
-        case edges if edges.nonEmpty && edges.forall(_.nonEmpty) =>
-          // select the largest edge (using balance when available, otherwise capacity).
-          val selectedEdges = edges.map(es => es.maxBy(e => e.balance_opt.getOrElse(e.capacity.toMilliSatoshi)))
-          val hops = selectedEdges.map(d => ChannelHop(d.desc.a, d.desc.b, d.update))
-          ctx.sender ! RouteResponse(Route(fr.amount, hops) :: Nil)
-        case _ => // some nodes in the supplied route aren't connected in our graph
-          ctx.sender ! Status.Failure(new IllegalArgumentException("Not all the nodes in the supplied route are connected with public channels"))
+
+      fr.route match {
+        case PredefinedNodeRoute(hops) =>
+          // split into sublists [(a,b),(b,c), ...] then get the edges between each of those pairs
+          hops.sliding(2).map { case List(v1, v2) => g.getEdgesBetween(v1, v2) }.toList match {
+            case edges if edges.nonEmpty && edges.forall(_.nonEmpty) =>
+              // select the largest edge (using balance when available, otherwise capacity).
+              val selectedEdges = edges.map(es => es.maxBy(e => e.balance_opt.getOrElse(e.capacity.toMilliSatoshi)))
+              val hops = selectedEdges.map(d => ChannelHop(d.desc.a, d.desc.b, d.update))
+              ctx.sender ! RouteResponse(Route(fr.amount, hops) :: Nil)
+            case _ =>
+              // some nodes in the supplied route aren't connected in our graph
+              ctx.sender ! Status.Failure(new IllegalArgumentException("Not all the nodes in the supplied route are connected with public channels"))
+          }
+        case PredefinedChannelRoute(targetNodeId, channels) =>
+          val (end, hops) = channels.foldLeft((localNodeId, Seq.empty[ChannelHop])) {
+            case ((start, current), shortChannelId) =>
+              d.channels.get(shortChannelId).flatMap(c => start match {
+                case c.ann.nodeId1 => g.getEdge(ChannelDesc(shortChannelId, c.ann.nodeId1, c.ann.nodeId2))
+                case c.ann.nodeId2 => g.getEdge(ChannelDesc(shortChannelId, c.ann.nodeId2, c.ann.nodeId1))
+                case _ => None
+              }) match {
+                case Some(edge) => (edge.desc.b, current :+ ChannelHop(edge.desc.a, edge.desc.b, edge.update))
+                case None => (start, current)
+              }
+          }
+          if (end != targetNodeId || hops.length != channels.length) {
+            ctx.sender ! Status.Failure(new IllegalArgumentException("The sequence of channels provided cannot be used to build a route to the target node"))
+          } else {
+            ctx.sender ! RouteResponse(Route(fr.amount, hops) :: Nil)
+          }
       }
+
       d
     }
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -35,7 +35,7 @@ import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceivePayment
 import fr.acinq.eclair.payment.receive.PaymentHandler
 import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentRequest, SendPaymentToRouteRequest}
 import fr.acinq.eclair.router.RouteCalculationSpec.makeUpdateShort
-import fr.acinq.eclair.router.Router.{GetNetworkStats, GetNetworkStatsResponse, PublicChannel}
+import fr.acinq.eclair.router.Router.{GetNetworkStats, GetNetworkStatsResponse, PredefinedNodeRoute, PublicChannel}
 import fr.acinq.eclair.router.{Announcements, NetworkStats, Router, Stats}
 import fr.acinq.eclair.wire.{Color, NodeAnnouncement}
 import org.mockito.Mockito
@@ -379,7 +379,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     import f._
 
     val eclair = new EclairImpl(kit)
-    val route = Seq(randomKey.publicKey)
+    val route = PredefinedNodeRoute(Seq(randomKey.publicKey))
     val trampolines = Seq(randomKey.publicKey, randomKey.publicKey)
     val parentId = UUID.randomUUID()
     val secret = randomBytes32
@@ -488,4 +488,5 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     val verifiedMessage: VerifiedMessage = eclair.verifyMessage(bytesMsg, invalidSignature)
     assert(verifiedMessage.publicKey !== kit.nodeParams.nodeId)
   }
+
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/ExtraDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/ExtraDirectives.scala
@@ -70,4 +70,10 @@ trait ExtraDirectives extends Directives {
       provide((channelId ++ channelIds ++ shortChannelId ++ shortChannelIds).distinct)
   }
 
+  def withRoute: Directive1[Either[Seq[ShortChannelId], Seq[PublicKey]]] = formFields(shortChannelIdsFormParam.?, nodeIdsFormParam.?).tflatMap {
+    case (None, None) => reject(MalformedFormFieldRejection("nodeIds/shortChannelIds", "Must specify either nodeIds or shortChannelIds (but not both)"))
+    case (Some(shortChannelIds), _) => provide(Left(shortChannelIds))
+    case (_, Some(nodeIds)) => provide(Right(nodeIds))
+  }
+
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -151,7 +151,7 @@ class CommandResponseSerializer extends CustomSerializer[CommandResponse[Command
   null
 }, {
   case RES_SUCCESS(_: CloseCommand, channelId) => JString(s"closed channel $channelId")
-  case x: CommandResponse[Command] => JString(x.toString)
+  case RES_FAILURE(_: Command, ex: Throwable) => JString(ex.getMessage)
 }))
 
 class TransactionSerializer extends CustomSerializer[TransactionWithInputInfo](_ => ( {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -258,7 +258,11 @@ trait Service extends ExtraDirectives with Logging {
                                   case Left(shortChannelIds) => PredefinedChannelRoute(invoice.nodeId, shortChannelIds)
                                   case Right(nodeIds) => PredefinedNodeRoute(nodeIds)
                                 }
-                                complete(eclairApi.sendToRoute(amountMsat, recipientAmountMsat_opt, externalId_opt, parentId_opt, invoice, CltvExpiryDelta(finalCltvExpiry), route, trampolineSecret_opt, trampolineFeesMsat_opt, trampolineCltvExpiry_opt.map(CltvExpiryDelta), trampolineNodes_opt.getOrElse(Nil)))
+                                if (route.targetNodeId != invoice.nodeId) {
+                                  reject(MalformedFormFieldRejection("nodeIds", "The last node in the route must be the invoice owner"))
+                                } else {
+                                  complete(eclairApi.sendToRoute(amountMsat, recipientAmountMsat_opt, externalId_opt, parentId_opt, invoice, CltvExpiryDelta(finalCltvExpiry), route, trampolineSecret_opt, trampolineFeesMsat_opt, trampolineCltvExpiry_opt.map(CltvExpiryDelta), trampolineNodes_opt.getOrElse(Nil)))
+                                }
                               }
                             }
                           }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -258,11 +258,7 @@ trait Service extends ExtraDirectives with Logging {
                                   case Left(shortChannelIds) => PredefinedChannelRoute(invoice.nodeId, shortChannelIds)
                                   case Right(nodeIds) => PredefinedNodeRoute(nodeIds)
                                 }
-                                if (route.targetNodeId != invoice.nodeId) {
-                                  reject(MalformedFormFieldRejection("nodeIds", "The last node in the route must be the invoice owner"))
-                                } else {
-                                  complete(eclairApi.sendToRoute(amountMsat, recipientAmountMsat_opt, externalId_opt, parentId_opt, invoice, CltvExpiryDelta(finalCltvExpiry), route, trampolineSecret_opt, trampolineFeesMsat_opt, trampolineCltvExpiry_opt.map(CltvExpiryDelta), trampolineNodes_opt.getOrElse(Nil)))
-                                }
+                                complete(eclairApi.sendToRoute(amountMsat, recipientAmountMsat_opt, externalId_opt, parentId_opt, invoice, CltvExpiryDelta(finalCltvExpiry), route, trampolineSecret_opt, trampolineFeesMsat_opt, trampolineCltvExpiry_opt.map(CltvExpiryDelta), trampolineNodes_opt.getOrElse(Nil)))
                               }
                             }
                           }

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -27,7 +27,7 @@ import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest, WSProbe
 import akka.stream.Materializer
 import akka.util.Timeout
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
-import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{Block, ByteVector32}
 import fr.acinq.eclair.ApiTypes.ChannelIdentifier
 import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
@@ -433,9 +433,10 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
     val payment = SendPaymentToRouteResponse(UUID.fromString("487da196-a4dc-4b1e-92b4-3e5e905e9f3f"), UUID.fromString("2ad8c6d7-99cb-4238-8f67-89024b8eed0d"), None)
     val expected = """{"paymentId":"487da196-a4dc-4b1e-92b4-3e5e905e9f3f","parentId":"2ad8c6d7-99cb-4238-8f67-89024b8eed0d"}"""
     val externalId = UUID.randomUUID().toString
-    val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(1234 msat), ByteVector32.Zeroes, randomKey, "Some invoice", CltvExpiryDelta(24))
-    val expectedRoute = PredefinedNodeRoute(Seq(PublicKey(hex"0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9"), PublicKey(hex"0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3"), PublicKey(hex"026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28")))
-    val csvNodes = "0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9, 0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3, 026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28"
+    val privKey = PrivateKey(hex"4141414141414141414141414141414141414141414141414141414141414141")
+    val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(1234 msat), ByteVector32.Zeroes, privKey, "Some invoice", CltvExpiryDelta(24))
+    val expectedRoute = PredefinedNodeRoute(Seq(PublicKey(hex"0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9"), PublicKey(hex"0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3"), PublicKey(hex"02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619")))
+    val csvNodes = "0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9, 0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3, 02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"
     val jsonNodes = serialization.write(expectedRoute.nodes)
 
     val eclair = mock[Eclair]
@@ -463,6 +464,17 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(status == OK)
         assert(entityAs[String] == expected)
         eclair.sendToRoute(1234 msat, None, None, None, pr, CltvExpiryDelta(190), expectedRoute, None, None, None, Nil)(any[Timeout]).wasCalled(once)
+      }
+
+    // this test uses an invalid route: the last node is not the creator of the invoice
+    val invalidRoute = PredefinedNodeRoute(Seq(PublicKey(hex"0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9"), PublicKey(hex"0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3"), PublicKey(hex"026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28")))
+    Post("/sendtoroute", FormData("nodeIds" -> serialization.write(invalidRoute.nodes), "amountMsat" -> "1234", "finalCltvExpiry" -> "190", "externalId" -> externalId, "invoice" -> PaymentRequest.write(pr)).toEntity) ~>
+      addCredentials(BasicHttpCredentials("", mockService.password)) ~>
+      addHeader("Content-Type", "application/json") ~>
+      Route.seal(mockService.route) ~>
+      check {
+        assert(handled)
+        assert(status == BadRequest)
       }
   }
 

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -27,7 +27,7 @@ import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest, WSProbe
 import akka.stream.Materializer
 import akka.util.Timeout
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
-import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
+import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{Block, ByteVector32}
 import fr.acinq.eclair.ApiTypes.ChannelIdentifier
 import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
@@ -433,10 +433,9 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
     val payment = SendPaymentToRouteResponse(UUID.fromString("487da196-a4dc-4b1e-92b4-3e5e905e9f3f"), UUID.fromString("2ad8c6d7-99cb-4238-8f67-89024b8eed0d"), None)
     val expected = """{"paymentId":"487da196-a4dc-4b1e-92b4-3e5e905e9f3f","parentId":"2ad8c6d7-99cb-4238-8f67-89024b8eed0d"}"""
     val externalId = UUID.randomUUID().toString
-    val privKey = PrivateKey(hex"4141414141414141414141414141414141414141414141414141414141414141")
-    val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(1234 msat), ByteVector32.Zeroes, privKey, "Some invoice", CltvExpiryDelta(24))
-    val expectedRoute = PredefinedNodeRoute(Seq(PublicKey(hex"0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9"), PublicKey(hex"0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3"), PublicKey(hex"02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619")))
-    val csvNodes = "0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9, 0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3, 02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619"
+    val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(1234 msat), ByteVector32.Zeroes, randomKey, "Some invoice", CltvExpiryDelta(24))
+    val expectedRoute = PredefinedNodeRoute(Seq(PublicKey(hex"0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9"), PublicKey(hex"0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3"), PublicKey(hex"026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28")))
+    val csvNodes = "0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9, 0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3, 026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28"
     val jsonNodes = serialization.write(expectedRoute.nodes)
 
     val eclair = mock[Eclair]
@@ -464,17 +463,6 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(status == OK)
         assert(entityAs[String] == expected)
         eclair.sendToRoute(1234 msat, None, None, None, pr, CltvExpiryDelta(190), expectedRoute, None, None, None, Nil)(any[Timeout]).wasCalled(once)
-      }
-
-    // this test uses an invalid route: the last node is not the creator of the invoice
-    val invalidRoute = PredefinedNodeRoute(Seq(PublicKey(hex"0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9"), PublicKey(hex"0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3"), PublicKey(hex"026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28")))
-    Post("/sendtoroute", FormData("nodeIds" -> serialization.write(invalidRoute.nodes), "amountMsat" -> "1234", "finalCltvExpiry" -> "190", "externalId" -> externalId, "invoice" -> PaymentRequest.write(pr)).toEntity) ~>
-      addCredentials(BasicHttpCredentials("", mockService.password)) ~>
-      addHeader("Content-Type", "application/json") ~>
-      Route.seal(mockService.route) ~>
-      check {
-        assert(handled)
-        assert(status == BadRequest)
       }
   }
 


### PR DESCRIPTION
While `sendtoroute` was letting you provide a custom route as a list of nodes, it made it difficult to have fine-grain control over the channels used by payments.

The API now allows choosing the exact channels that will be used for the payment; in particular, this will be helpful when consolidating and rebalancing multiple channels to a given node.

Fixes #1472

We also fix a serialization regression introduced in #1520 
