### PR TITLE
[ChannelRelay] Prioritize lowest capacity channels

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
@@ -207,7 +207,7 @@ class ChannelRelay private(nodeParams: NodeParams,
         candidateChannels
           .map { case (shortChannelId, channelInfo) =>
             val relayResult = relayOrFail(Some(channelInfo.channelUpdate))
-            context.log.debug(s"candidate channel: shortChannelId={} capacitySat={} balanceMsat={} channelUpdate={} relayResult={}", shortChannelId, channelInfo.commitments.commitInput.txOut.amount, channelInfo.commitments.availableBalanceForSend, channelInfo.channelUpdate, relayResult)
+            context.log.debug(s"candidate channel: shortChannelId={} balanceMsat={} capacitySat={} channelUpdate={} relayResult={}", shortChannelId, channelInfo.commitments.availableBalanceForSend, channelInfo.commitments.commitInput.txOut.amount, channelInfo.channelUpdate, relayResult)
             (shortChannelId, channelInfo, relayResult)
           }
           .collect {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import akka.actor.ActorRef
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.DeterministicWallet.ExtendedPrivateKey
-import fr.acinq.bitcoin.{Block, ByteVector32, Crypto, DeterministicWallet}
+import fr.acinq.bitcoin.{Block, ByteVector32, Crypto, DeterministicWallet, OutPoint, Satoshi, TxOut}
 import fr.acinq.eclair.FeatureSupport.Optional
 import fr.acinq.eclair.Features._
 import fr.acinq.eclair.channel._
@@ -29,8 +29,8 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.IncomingPacket.{ChannelRelayPacket, FinalPacket, NodeRelayPacket, decrypt}
 import fr.acinq.eclair.payment.OutgoingPacket._
 import fr.acinq.eclair.payment.PaymentRequest.PaymentRequestFeatures
-import fr.acinq.eclair.payment.OutgoingPacket.Upstream
 import fr.acinq.eclair.router.Router.{ChannelHop, NodeHop}
+import fr.acinq.eclair.transactions.Transactions.InputInfo
 import fr.acinq.eclair.wire.Onion.{FinalLegacyPayload, FinalTlvPayload, RelayLegacyPayload}
 import fr.acinq.eclair.wire.OnionTlv.{AmountToForward, OutgoingCltv, PaymentData}
 import fr.acinq.eclair.wire._
@@ -396,9 +396,10 @@ object PaymentPacketSpec {
     packetType.create(sessionKey, nodes, payloadsBin, associatedData).packet
   }
 
-  def makeCommitments(channelId: ByteVector32, testAvailableBalanceForSend: MilliSatoshi = 50000000 msat, testAvailableBalanceForReceive: MilliSatoshi = 50000000 msat): Commitments = {
+  def makeCommitments(channelId: ByteVector32, testAvailableBalanceForSend: MilliSatoshi = 50000000 msat, testAvailableBalanceForReceive: MilliSatoshi = 50000000 msat, testCapacity: Satoshi = 100000 sat): Commitments = {
     val params = LocalParams(null, null, null, null, null, null, null, 0, isFunder = true, null, None, null)
-    new Commitments(ChannelVersion.STANDARD, params, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, null, null, channelId) {
+    val commitInput = InputInfo(OutPoint(randomBytes32, 1), TxOut(testCapacity, Nil), Nil)
+    new Commitments(ChannelVersion.STANDARD, params, null, 0.toByte, null, null, null, null, 0, 0, Map.empty, null, commitInput, null, channelId) {
       override lazy val availableBalanceForSend: MilliSatoshi = testAvailableBalanceForSend.max(0 msat)
       override lazy val availableBalanceForReceive: MilliSatoshi = testAvailableBalanceForReceive.max(0 msat)
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/ChannelRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/ChannelRelayerSpec.scala
@@ -22,7 +22,7 @@ import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
 import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Crypto}
+import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Crypto, Satoshi}
 import fr.acinq.eclair.TestConstants.emptyOnionPacket
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel._
@@ -269,21 +269,22 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     import f._
 
     /** This is just a simplified helper function with random values for fields we are not using here */
-    def dummyLocalUpdate(shortChannelId: ShortChannelId, remoteNodeId: PublicKey, availableBalanceForSend: MilliSatoshi) = {
+    def dummyLocalUpdate(shortChannelId: ShortChannelId, remoteNodeId: PublicKey, availableBalanceForSend: MilliSatoshi, capacity: Satoshi) = {
       val channelId = randomBytes32
-      val update = Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, randomKey, remoteNodeId, shortChannelId, CltvExpiryDelta(10), 100 msat, 1000 msat, 100, 10000000 msat, enable = true)
-      val commitments = PaymentPacketSpec.makeCommitments(ByteVector32.Zeroes, availableBalanceForSend)
+      val update = Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, randomKey, remoteNodeId, shortChannelId, CltvExpiryDelta(10), 100 msat, 1000 msat, 100, capacity.toMilliSatoshi)
+      val commitments = PaymentPacketSpec.makeCommitments(ByteVector32.Zeroes, availableBalanceForSend, testCapacity = capacity)
       LocalChannelUpdate(null, channelId, shortChannelId, remoteNodeId, None, update, commitments)
     }
 
     val (a, b) = (randomKey.publicKey, randomKey.publicKey)
 
     val channelUpdates = Map(
-      ShortChannelId(11111) -> dummyLocalUpdate(ShortChannelId(11111), a, 100000000 msat),
-      ShortChannelId(12345) -> dummyLocalUpdate(ShortChannelId(12345), a, 20000000 msat),
-      ShortChannelId(22222) -> dummyLocalUpdate(ShortChannelId(22222), a, 10000000 msat),
-      ShortChannelId(33333) -> dummyLocalUpdate(ShortChannelId(33333), a, 100000 msat),
-      ShortChannelId(44444) -> dummyLocalUpdate(ShortChannelId(44444), b, 1000000 msat),
+      ShortChannelId(11111) -> dummyLocalUpdate(ShortChannelId(11111), a, 100000000 msat, 200000 sat),
+      ShortChannelId(12345) -> dummyLocalUpdate(ShortChannelId(12345), a, 10000000 msat, 200000 sat),
+      ShortChannelId(22222) -> dummyLocalUpdate(ShortChannelId(22222), a, 10000000 msat, 100000 sat),
+      ShortChannelId(22223) -> dummyLocalUpdate(ShortChannelId(22223), a, 9000000 msat, 50000 sat),
+      ShortChannelId(33333) -> dummyLocalUpdate(ShortChannelId(33333), a, 100000 msat, 50000 sat),
+      ShortChannelId(44444) -> dummyLocalUpdate(ShortChannelId(44444), b, 1000000 msat, 10000 sat),
     )
 
     channelUpdates.values.foreach(u => channelRelayer ! WrappedLocalChannelUpdate(u))
@@ -292,19 +293,21 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       val payload = RelayLegacyPayload(ShortChannelId(12345), 998900 msat, CltvExpiry(60))
       val r = createValidIncomingPacket(1000000 msat, CltvExpiry(70), payload)
       channelRelayer ! Relay(r)
-      // select the channel to the same node, with the lowest balance but still high enough to handle the payment
-      val cmd1 = expectFwdAdd(register, ShortChannelId(22222), payload.amountToForward, payload.outgoingCltv).message
+      // select the channel to the same node, with the lowest capacity and balance but still high enough to handle the payment
+      val cmd1 = expectFwdAdd(register, ShortChannelId(22223), payload.amountToForward, payload.outgoingCltv).message
       cmd1.replyTo ! RES_ADD_FAILED(cmd1, ChannelUnavailable(randomBytes32), None)
-      // select 2nd-to-best channel
-      val cmd2 = expectFwdAdd(register, ShortChannelId(12345), payload.amountToForward, payload.outgoingCltv).message
-      cmd2.replyTo ! RES_ADD_FAILED(cmd2, TooManyAcceptedHtlcs(randomBytes32, 42), Some(channelUpdates(ShortChannelId(12345)).channelUpdate))
-      // select 3rd-to-best channel
-      val cmd3 = expectFwdAdd(register, ShortChannelId(11111), payload.amountToForward, payload.outgoingCltv).message
-      cmd3.replyTo ! RES_ADD_FAILED(cmd3, HtlcValueTooHighInFlight(randomBytes32, UInt64(100000000), 100000000 msat), Some(channelUpdates(ShortChannelId(11111)).channelUpdate))
+      // select 2nd-to-best channel: higher capacity and balance
+      val cmd2 = expectFwdAdd(register, ShortChannelId(22222), payload.amountToForward, payload.outgoingCltv).message
+      cmd2.replyTo ! RES_ADD_FAILED(cmd2, TooManyAcceptedHtlcs(randomBytes32, 42), Some(channelUpdates(ShortChannelId(22222)).channelUpdate))
+      // select 3rd-to-best channel: same balance but higher capacity
+      val cmd3 = expectFwdAdd(register, ShortChannelId(12345), payload.amountToForward, payload.outgoingCltv).message
+      cmd3.replyTo ! RES_ADD_FAILED(cmd3, TooManyAcceptedHtlcs(randomBytes32, 42), Some(channelUpdates(ShortChannelId(12345)).channelUpdate))
+      // select 4th-to-best channel: same capacity but higher balance
+      val cmd4 = expectFwdAdd(register, ShortChannelId(11111), payload.amountToForward, payload.outgoingCltv).message
+      cmd4.replyTo ! RES_ADD_FAILED(cmd4, HtlcValueTooHighInFlight(randomBytes32, UInt64(100000000), 100000000 msat), Some(channelUpdates(ShortChannelId(11111)).channelUpdate))
       // all the suitable channels have been tried
       expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, Right(TemporaryChannelFailure(channelUpdates(ShortChannelId(12345)).channelUpdate)), commit = true))
     }
-
     {
       // higher amount payment (have to increased incoming htlc amount for fees to be sufficient)
       val payload = RelayLegacyPayload(ShortChannelId(12345), 50000000 msat, CltvExpiry(60))
@@ -312,7 +315,6 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       channelRelayer ! Relay(r)
       expectFwdAdd(register, ShortChannelId(11111), payload.amountToForward, payload.outgoingCltv).message
     }
-
     {
       // lower amount payment
       val payload = RelayLegacyPayload(ShortChannelId(12345), 1000 msat, CltvExpiry(60))
@@ -320,7 +322,6 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       channelRelayer ! Relay(r)
       expectFwdAdd(register, ShortChannelId(33333), payload.amountToForward, payload.outgoingCltv).message
     }
-
     {
       // payment too high, no suitable channel found, we keep the requested one
       val payload = RelayLegacyPayload(ShortChannelId(12345), 1000000000 msat, CltvExpiry(60))
@@ -328,7 +329,6 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       channelRelayer ! Relay(r)
       expectFwdAdd(register, ShortChannelId(12345), payload.amountToForward, payload.outgoingCltv).message
     }
-
     {
       // invalid cltv expiry, no suitable channel found
       val payload = RelayLegacyPayload(ShortChannelId(12345), 998900 msat, CltvExpiry(40))
@@ -458,10 +458,10 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     assert(channels8.size === 1)
     assert(channels8.head.channelUpdate.shortChannelId === ShortChannelId(42))
   }
+
 }
 
 object ChannelRelayerSpec {
-
   val paymentPreimage = randomBytes32
   val paymentHash = Crypto.sha256(paymentPreimage)
 
@@ -482,10 +482,10 @@ object ChannelRelayerSpec {
     ChannelRelayPacket(add_ab, payload, emptyOnionPacket)
   }
 
-  def createLocalUpdate(shortChannelId: ShortChannelId, balance: MilliSatoshi = 10000000 msat, enabled: Boolean = true, htlcMinimum: MilliSatoshi = 0 msat): LocalChannelUpdate = {
+  def createLocalUpdate(shortChannelId: ShortChannelId, balance: MilliSatoshi = 10000000 msat, capacity: Satoshi = 500000 sat, enabled: Boolean = true, htlcMinimum: MilliSatoshi = 0 msat): LocalChannelUpdate = {
     val channelId = channelIds(shortChannelId)
-    val update = ChannelUpdate(ByteVector64(randomBytes(64)), Block.RegtestGenesisBlock.hash, shortChannelId, 0, 1, Announcements.makeChannelFlags(isNode1 = true, enabled), CltvExpiryDelta(100), htlcMinimum, 1000 msat, 100, Some(500000000 msat))
-    val commitments = PaymentPacketSpec.makeCommitments(channelId, testAvailableBalanceForSend = balance)
+    val update = ChannelUpdate(ByteVector64(randomBytes(64)), Block.RegtestGenesisBlock.hash, shortChannelId, 0, 1, Announcements.makeChannelFlags(isNode1 = true, enabled), CltvExpiryDelta(100), htlcMinimum, 1000 msat, 100, Some(capacity.toMilliSatoshi))
+    val commitments = PaymentPacketSpec.makeCommitments(channelId, testAvailableBalanceForSend = balance, testCapacity = capacity)
     LocalChannelUpdate(null, channelId, shortChannelId, outgoingNodeId, None, update, commitments)
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/ChannelRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/ChannelRelayerSpec.scala
@@ -16,7 +16,7 @@
 
 package fr.acinq.eclair.payment.relay
 
-import akka.actor.testkit.typed.scaladsl.{LogCapturing, LoggingTestKit, ScalaTestWithActorTestKit, TestProbe}
+import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
 import akka.actor.typed
 import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
@@ -37,7 +37,7 @@ import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import scodec.bits.HexStringSyntax
 
-class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with FixtureAnyFunSuiteLike with LogCapturing {
+class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with FixtureAnyFunSuiteLike {
 
   import ChannelRelayerSpec._
 
@@ -48,20 +48,21 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val nodeParams = TestConstants.Bob.nodeParams
     val register = TestProbe[Any]("register")
     val channelRelayer = testKit.spawn(ChannelRelayer.apply(nodeParams, register.ref.toClassic))
-    try withFixture(test.toNoArgTest(FixtureParam(nodeParams, channelRelayer, register)))
-    finally {
+    try {
+      withFixture(test.toNoArgTest(FixtureParam(nodeParams, channelRelayer, register)))
+    } finally {
       testKit.stop(channelRelayer)
     }
   }
 
-  def expectFwdFail(register: TestProbe[Any], channelId: ByteVector32, cmd: channel.Command) = {
+  def expectFwdFail(register: TestProbe[Any], channelId: ByteVector32, cmd: channel.Command): Register.Forward[channel.Command] = {
     val fwd = register.expectMessageType[Register.Forward[channel.Command]]
     assert(fwd.channelId === channelId)
     assert(fwd.message === cmd)
     fwd
   }
 
-  def expectFwdAdd(register: TestProbe[Any], shortChannelId: ShortChannelId, outAmount: MilliSatoshi, outExpiry: CltvExpiry) = {
+  def expectFwdAdd(register: TestProbe[Any], shortChannelId: ShortChannelId, outAmount: MilliSatoshi, outExpiry: CltvExpiry): Register.ForwardShortId[CMD_ADD_HTLC] = {
     val fwd = register.expectMessageType[Register.ForwardShortId[CMD_ADD_HTLC]]
     assert(fwd.shortChannelId === shortChannelId)
     assert(fwd.message.amount === outAmount)
@@ -72,34 +73,6 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     fwd
   }
 
-  /** we parse logs to make sure the listener has received the event and prevent race conditions */
-  def publishUpdate(e: LocalChannelUpdate) = {
-    LoggingTestKit.debug(s"updating local channel info for channelId=${e.channelId} shortChannelId=${e.shortChannelId}").expect {
-      system.eventStream ! EventStream.Publish(e)
-    }(testKit.system)
-  }
-
-  /** we parse logs to make sure the listener has received the event and prevent race conditions */
-  def publishDown(e: LocalChannelDown) = {
-    LoggingTestKit.debug(s"removed local channel info for channelId=${e.channelId} shortChannelId=${e.shortChannelId}").expect {
-      system.eventStream ! EventStream.Publish(e)
-    }(testKit.system)
-  }
-
-  /** we parse logs to make sure the listener has received the event and prevent race conditions */
-  def publishBalanceChanged(e: AvailableBalanceChanged) = {
-    LoggingTestKit.debug(s"available balance changed for channelId=${e.channelId} shortChannelId=${e.shortChannelId}").expect {
-      system.eventStream ! EventStream.Publish(e)
-    }(testKit.system)
-  }
-
-  /** we parse logs to make sure the listener has received the event and prevent race conditions */
-  def publishShortChannelIdAssigned(e: ShortChannelIdAssigned) = {
-    LoggingTestKit.debug(s"shortChannelId changed for channelId=${e.channelId}").expect {
-      system.eventStream ! EventStream.Publish(e)
-    }(testKit.system)
-  }
-
   test("relay htlc-add") { f =>
     import f._
 
@@ -107,7 +80,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(1100000 msat, CltvExpiry(400100), payload)
     val u = createLocalUpdate(shortId1)
 
-    publishUpdate(u)
+    channelRelayer ! WrappedLocalChannelUpdate(u)
     channelRelayer ! Relay(r)
 
     expectFwdAdd(register, shortId1, outgoingAmount, outgoingExpiry)
@@ -121,7 +94,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(1100000 msat, CltvExpiry(400100), payload)
     val u = createLocalUpdate(shortId1)
 
-    publishUpdate(u)
+    channelRelayer ! WrappedLocalChannelUpdate(u)
     channelRelayer ! Relay(r)
 
     expectFwdAdd(register, shortId1, outgoingAmount, outgoingExpiry)
@@ -135,11 +108,11 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
 
     // we tell the relayer about the first channel
     val u1 = createLocalUpdate(shortId1)
-    publishUpdate(u1)
+    channelRelayer ! WrappedLocalChannelUpdate(u1)
 
     // this is another channel, with less balance (it will be preferred)
     val u2 = createLocalUpdate(shortId2, 8000000 msat)
-    publishUpdate(u2)
+    channelRelayer ! WrappedLocalChannelUpdate(u2)
 
     channelRelayer ! Relay(r)
 
@@ -175,7 +148,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(1100000 msat, CltvExpiry(400100), payload)
     val u = createLocalUpdate(shortId1)
 
-    publishUpdate(u)
+    channelRelayer ! WrappedLocalChannelUpdate(u)
     channelRelayer ! Relay(r)
 
     val fwd = expectFwdAdd(register, shortId1, outgoingAmount, outgoingExpiry)
@@ -192,8 +165,8 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val u = createLocalUpdate(shortId1)
     val d = LocalChannelDown(null, channelId = channelIds(shortId1), shortId1, outgoingNodeId)
 
-    publishUpdate(u)
-    publishDown(d)
+    channelRelayer ! WrappedLocalChannelUpdate(u)
+    channelRelayer ! WrappedLocalChannelDown(d)
     channelRelayer ! Relay(r)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, Right(UnknownNextPeer), commit = true))
@@ -206,7 +179,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(1100000 msat, CltvExpiry(400100), payload)
     val u = createLocalUpdate(shortId1, enabled = false)
 
-    publishUpdate(u)
+    channelRelayer ! WrappedLocalChannelUpdate(u)
     channelRelayer ! Relay(r)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, Right(ChannelDisabled(u.channelUpdate.messageFlags, u.channelUpdate.channelFlags, u.channelUpdate)), commit = true))
@@ -219,7 +192,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(1100000 msat, CltvExpiry(400100), payload)
     val u = createLocalUpdate(shortId1, htlcMinimum = outgoingAmount + 1.msat)
 
-    publishUpdate(u)
+    channelRelayer ! WrappedLocalChannelUpdate(u)
     channelRelayer ! Relay(r)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, Right(AmountBelowMinimum(outgoingAmount, u.channelUpdate)), commit = true))
@@ -232,7 +205,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(1100000 msat, CltvExpiry(400100), payload)
     val u = createLocalUpdate(shortId1)
 
-    publishUpdate(u)
+    channelRelayer ! WrappedLocalChannelUpdate(u)
     channelRelayer ! Relay(r)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, Right(IncorrectCltvExpiry(payload.outgoingCltv, u.channelUpdate)), commit = true))
@@ -245,7 +218,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(1100000 msat, CltvExpiry(400100), payload)
     val u = createLocalUpdate(shortId1)
 
-    publishUpdate(u)
+    channelRelayer ! WrappedLocalChannelUpdate(u)
     channelRelayer ! Relay(r)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, Right(IncorrectCltvExpiry(payload.outgoingCltv, u.channelUpdate)), commit = true))
@@ -258,7 +231,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(outgoingAmount + 1.msat, CltvExpiry(400100), payload)
     val u = createLocalUpdate(shortId1)
 
-    publishUpdate(u)
+    channelRelayer ! WrappedLocalChannelUpdate(u)
     channelRelayer ! Relay(r)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, Right(FeeInsufficient(r.add.amountMsat, u.channelUpdate)), commit = true))
@@ -284,7 +257,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     )
 
     testCases.foreach { testCase =>
-      publishUpdate(u)
+      channelRelayer ! WrappedLocalChannelUpdate(u)
       channelRelayer ! Relay(r)
       val fwd = expectFwdAdd(register, shortId1, outgoingAmount, outgoingExpiry)
       fwd.message.replyTo ! RES_ADD_FAILED(fwd.message, testCase.exc, Some(testCase.update))
@@ -313,7 +286,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       ShortChannelId(44444) -> dummyLocalUpdate(ShortChannelId(44444), b, 1000000 msat),
     )
 
-    channelUpdates.values.foreach(publishUpdate)
+    channelUpdates.values.foreach(u => channelRelayer ! WrappedLocalChannelUpdate(u))
 
     {
       val payload = RelayLegacyPayload(ShortChannelId(12345), 998900 msat, CltvExpiry(60))
@@ -385,7 +358,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     )
 
     testCases.foreach { testCase =>
-      publishUpdate(u)
+      channelRelayer ! WrappedLocalChannelUpdate(u)
       channelRelayer ! Relay(r)
       val fwd = expectFwdAdd(register, shortId1, outgoingAmount, outgoingExpiry)
       fwd.message.replyTo ! RES_SUCCESS(fwd.message, channelId1)
@@ -413,7 +386,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     )
 
     testCases.foreach { testCase =>
-      publishUpdate(u)
+      channelRelayer ! WrappedLocalChannelUpdate(u)
       channelRelayer ! Relay(r)
 
       val fwd1 = expectFwdAdd(register, shortId1, outgoingAmount, outgoingExpiry)
@@ -445,8 +418,8 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       channels
     }
 
-    publishUpdate(LocalChannelUpdate(null, channelId_ab, channelUpdate_ab.shortChannelId, a, None, channelUpdate_ab, makeCommitments(channelId_ab, -2000 msat, 300000 msat)))
-    publishUpdate(LocalChannelUpdate(null, channelId_bc, channelUpdate_bc.shortChannelId, c, None, channelUpdate_bc, makeCommitments(channelId_bc, 400000 msat, -5000 msat)))
+    channelRelayer ! WrappedLocalChannelUpdate(LocalChannelUpdate(null, channelId_ab, channelUpdate_ab.shortChannelId, a, None, channelUpdate_ab, makeCommitments(channelId_ab, -2000 msat, 300000 msat)))
+    channelRelayer ! WrappedLocalChannelUpdate(LocalChannelUpdate(null, channelId_bc, channelUpdate_bc.shortChannelId, c, None, channelUpdate_bc, makeCommitments(channelId_bc, 400000 msat, -5000 msat)))
 
     val channels1 = getOutgoingChannels(true)
     assert(channels1.size === 2)
@@ -455,32 +428,32 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     assert(channels1.last.channelUpdate === channelUpdate_bc)
     assert(channels1.last.toUsableBalance === Relayer.UsableBalance(c, channelUpdate_bc.shortChannelId, 400000 msat, 0 msat, isPublic = false))
 
-    publishBalanceChanged(AvailableBalanceChanged(null, channelId_bc, channelUpdate_bc.shortChannelId, makeCommitments(channelId_bc, 200000 msat, 500000 msat)))
+    channelRelayer ! WrappedAvailableBalanceChanged(AvailableBalanceChanged(null, channelId_bc, channelUpdate_bc.shortChannelId, makeCommitments(channelId_bc, 200000 msat, 500000 msat)))
     val channels2 = getOutgoingChannels(true)
     assert(channels2.last.commitments.availableBalanceForReceive === 500000.msat && channels2.last.commitments.availableBalanceForSend === 200000.msat)
 
-    publishBalanceChanged(AvailableBalanceChanged(null, channelId_ab, channelUpdate_ab.shortChannelId, makeCommitments(channelId_ab, 100000 msat, 200000 msat)))
-    publishDown(LocalChannelDown(null, channelId_bc, channelUpdate_bc.shortChannelId, c))
+    channelRelayer ! WrappedAvailableBalanceChanged(AvailableBalanceChanged(null, channelId_ab, channelUpdate_ab.shortChannelId, makeCommitments(channelId_ab, 100000 msat, 200000 msat)))
+    channelRelayer ! WrappedLocalChannelDown(LocalChannelDown(null, channelId_bc, channelUpdate_bc.shortChannelId, c))
     val channels3 = getOutgoingChannels(true)
     assert(channels3.size === 1 && channels3.head.commitments.availableBalanceForSend === 100000.msat)
 
-    publishUpdate(LocalChannelUpdate(null, channelId_ab, channelUpdate_ab.shortChannelId, a, None, channelUpdate_ab.copy(channelFlags = 2), makeCommitments(channelId_ab, 100000 msat, 200000 msat)))
+    channelRelayer ! WrappedLocalChannelUpdate(LocalChannelUpdate(null, channelId_ab, channelUpdate_ab.shortChannelId, a, None, channelUpdate_ab.copy(channelFlags = 2), makeCommitments(channelId_ab, 100000 msat, 200000 msat)))
     val channels4 = getOutgoingChannels(true)
     assert(channels4.isEmpty)
     val channels5 = getOutgoingChannels(false)
     assert(channels5.size === 1)
 
-    publishUpdate(LocalChannelUpdate(null, channelId_ab, channelUpdate_ab.shortChannelId, a, None, channelUpdate_ab, makeCommitments(channelId_ab, 100000 msat, 200000 msat)))
+    channelRelayer ! WrappedLocalChannelUpdate(LocalChannelUpdate(null, channelId_ab, channelUpdate_ab.shortChannelId, a, None, channelUpdate_ab, makeCommitments(channelId_ab, 100000 msat, 200000 msat)))
     val channels6 = getOutgoingChannels(true)
     assert(channels6.size === 1)
 
     // Simulate a chain re-org that changes the shortChannelId:
-    publishShortChannelIdAssigned(ShortChannelIdAssigned(null, channelId_ab, ShortChannelId(42), Some(channelUpdate_ab.shortChannelId)))
+    channelRelayer ! WrappedShortChannelIdAssigned(ShortChannelIdAssigned(null, channelId_ab, ShortChannelId(42), Some(channelUpdate_ab.shortChannelId)))
     val channels7 = getOutgoingChannels(true)
     assert(channels7.isEmpty)
 
     // We should receive the updated channel update containing the new shortChannelId:
-    publishUpdate(LocalChannelUpdate(null, channelId_ab, ShortChannelId(42), a, None, channelUpdate_ab.copy(shortChannelId = ShortChannelId(42)), makeCommitments(channelId_ab, 100000 msat, 200000 msat)))
+    channelRelayer ! WrappedLocalChannelUpdate(LocalChannelUpdate(null, channelId_ab, ShortChannelId(42), a, None, channelUpdate_ab.copy(shortChannelId = ShortChannelId(42)), makeCommitments(channelId_ab, 100000 msat, 200000 msat)))
     val channels8 = getOutgoingChannels(true)
     assert(channels8.size === 1)
     assert(channels8.head.channelUpdate.shortChannelId === ShortChannelId(42))


### PR DESCRIPTION
This makes it more difficult for attackers to "squat" high-capacity channels by sending HTLCs and then hodling them (filling up the 483 available pending HTLC slots).

It results in less locked liquidity during this kind of attacks because we preserve the highest-capacity channels.

Note: I also changed the way we test channel updates in the first commit because I didn't like the dependency on watching for logs, but if you don't like it I can revert that.
