### PR TITLE
Set a timefactor for typed actors tests

### DIFF
--- a/eclair-core/src/test/resources/application.conf
+++ b/eclair-core/src/test/resources/application.conf
@@ -13,7 +13,7 @@ akka {
     testkit.typed {
       # Factor by which to scale timeouts during tests, e.g. to account for shared
       # build system load.
-      timefactor = 1.0
+      timefactor = 5.0
 
       # Duration to wait for all required logging events in LoggingTestKit.expect.
       # Dilated by the timefactor.


### PR DESCRIPTION
We use the same timefactor (5x) than for untyped actors.