### PR TITLE
Separate configuration for peer-connection

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -123,11 +123,14 @@ eclair {
 
   revocation-timeout = 20 seconds // after sending a commit_sig, we will wait for at most that duration before disconnecting
 
-  auth-timeout = 10 seconds // will disconnect if connection authentication doesn't happen within that timeframe
-  init-timeout = 10 seconds // will disconnect if initialization doesn't happen within that timeframe
-  ping-interval = 30 seconds
-  ping-timeout = 10 seconds // will disconnect if peer takes longer than that to respond
-  ping-disconnect = true // disconnect if no answer to our pings
+  peer-connection {
+    auth-timeout = 10 seconds // will disconnect if connection authentication doesn't happen within that timeframe
+    init-timeout = 10 seconds // will disconnect if initialization doesn't happen within that timeframe
+    ping-interval = 30 seconds
+    ping-timeout = 10 seconds // will disconnect if peer takes longer than that to respond
+    ping-disconnect = true // disconnect if no answer to our pings
+  }
+
   auto-reconnect = true
   initial-random-reconnect-delay = 5 seconds // we add a random delay before the first reconnection attempt, capped by this value
   max-reconnect-interval = 1 hour // max interval between two reconnection attempts, after the exponential backoff period

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -30,7 +30,9 @@ import fr.acinq.eclair.NodeParams.WatcherType
 import fr.acinq.eclair.blockchain.fee.{FeeEstimator, FeeTargets, FeerateTolerance, OnChainFeeConf}
 import fr.acinq.eclair.channel.Channel
 import fr.acinq.eclair.crypto.KeyManager
+import fr.acinq.eclair.crypto.Noise.KeyPair
 import fr.acinq.eclair.db._
+import fr.acinq.eclair.io.PeerConnection
 import fr.acinq.eclair.router.Router.RouterConf
 import fr.acinq.eclair.tor.Socks5ProxyParams
 import fr.acinq.eclair.wire.{Color, EncodingType, NodeAddress}
@@ -49,9 +51,9 @@ case class NodeParams(keyManager: KeyManager,
                       color: Color,
                       publicAddresses: List[NodeAddress],
                       features: Features,
-                      pluginParams: Seq[PluginParams],
                       overrideFeatures: Map[PublicKey, Features],
                       syncWhitelist: Set[PublicKey],
+                      pluginParams: Seq[PluginParams],
                       dustLimit: Satoshi,
                       onChainFeeConf: OnChainFeeConf,
                       maxHtlcValueInFlightMsat: UInt64,
@@ -69,11 +71,6 @@ case class NodeParams(keyManager: KeyManager,
                       maxReserveToFundingRatio: Double,
                       db: Databases,
                       revocationTimeout: FiniteDuration,
-                      authTimeout: FiniteDuration,
-                      initTimeout: FiniteDuration,
-                      pingInterval: FiniteDuration,
-                      pingTimeout: FiniteDuration,
-                      pingDisconnect: Boolean,
                       autoReconnect: Boolean,
                       initialRandomReconnectDelay: FiniteDuration,
                       maxReconnectInterval: FiniteDuration,
@@ -85,12 +82,14 @@ case class NodeParams(keyManager: KeyManager,
                       multiPartPaymentExpiry: FiniteDuration,
                       minFundingSatoshis: Satoshi,
                       maxFundingSatoshis: Satoshi,
+                      peerConnectionConf: PeerConnection.Conf,
                       routerConf: RouterConf,
                       socksProxy_opt: Option[Socks5ProxyParams],
                       maxPaymentAttempts: Int,
                       enableTrampolinePayment: Boolean) {
   val privateKey = keyManager.nodeKey.privateKey
   val nodeId = keyManager.nodeId
+  val keyPair = KeyPair(nodeId.value, privateKey.value)
 
   def currentBlockHeight: Long = blockCount.get
 }
@@ -287,11 +286,6 @@ object NodeParams {
       maxReserveToFundingRatio = config.getDouble("max-reserve-to-funding-ratio"),
       db = database,
       revocationTimeout = FiniteDuration(config.getDuration("revocation-timeout").getSeconds, TimeUnit.SECONDS),
-      authTimeout = FiniteDuration(config.getDuration("auth-timeout").getSeconds, TimeUnit.SECONDS),
-      initTimeout = FiniteDuration(config.getDuration("init-timeout").getSeconds, TimeUnit.SECONDS),
-      pingInterval = FiniteDuration(config.getDuration("ping-interval").getSeconds, TimeUnit.SECONDS),
-      pingTimeout = FiniteDuration(config.getDuration("ping-timeout").getSeconds, TimeUnit.SECONDS),
-      pingDisconnect = config.getBoolean("ping-disconnect"),
       autoReconnect = config.getBoolean("auto-reconnect"),
       initialRandomReconnectDelay = FiniteDuration(config.getDuration("initial-random-reconnect-delay").getSeconds, TimeUnit.SECONDS),
       maxReconnectInterval = FiniteDuration(config.getDuration("max-reconnect-interval").getSeconds, TimeUnit.SECONDS),
@@ -303,6 +297,14 @@ object NodeParams {
       multiPartPaymentExpiry = FiniteDuration(config.getDuration("multi-part-payment-expiry").getSeconds, TimeUnit.SECONDS),
       minFundingSatoshis = Satoshi(config.getLong("min-funding-satoshis")),
       maxFundingSatoshis = Satoshi(config.getLong("max-funding-satoshis")),
+      peerConnectionConf = PeerConnection.Conf(
+        authTimeout = FiniteDuration(config.getDuration("peer-connection.auth-timeout").getSeconds, TimeUnit.SECONDS),
+        initTimeout = FiniteDuration(config.getDuration("peer-connection.init-timeout").getSeconds, TimeUnit.SECONDS),
+        pingInterval = FiniteDuration(config.getDuration("peer-connection.ping-interval").getSeconds, TimeUnit.SECONDS),
+        pingTimeout = FiniteDuration(config.getDuration("peer-connection.ping-timeout").getSeconds, TimeUnit.SECONDS),
+        pingDisconnect = config.getBoolean("peer-connection.ping-disconnect"),
+        maxRebroadcastDelay = FiniteDuration(config.getDuration("router.broadcast-interval").getSeconds, TimeUnit.SECONDS) // it makes sense to not delay rebroadcast by more than the rebroadcast period
+      ),
       routerConf = RouterConf(
         channelExcludeDuration = FiniteDuration(config.getDuration("router.channel-exclude-duration").getSeconds, TimeUnit.SECONDS),
         routerBroadcastInterval = FiniteDuration(config.getDuration("router.broadcast-interval").getSeconds, TimeUnit.SECONDS),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -308,8 +308,8 @@ class Setup(datadir: File,
       // we want to make sure the handler for post-restart broken HTLCs has finished initializing.
       _ <- postRestartCleanUpInitialized.future
       switchboard = system.actorOf(SimpleSupervisor.props(Switchboard.props(nodeParams, watcher, relayer, wallet), "switchboard", SupervisorStrategy.Resume))
-      clientSpawner = system.actorOf(SimpleSupervisor.props(ClientSpawner.props(nodeParams, switchboard, router), "client-spawner", SupervisorStrategy.Restart))
-      server = system.actorOf(SimpleSupervisor.props(Server.props(nodeParams, switchboard, router, serverBindingAddress, Some(tcpBound)), "server", SupervisorStrategy.Restart))
+      clientSpawner = system.actorOf(SimpleSupervisor.props(ClientSpawner.props(nodeParams.keyPair, nodeParams.socksProxy_opt, nodeParams.peerConnectionConf, switchboard, router), "client-spawner", SupervisorStrategy.Restart))
+      server = system.actorOf(SimpleSupervisor.props(Server.props(nodeParams.keyPair, nodeParams.peerConnectionConf, switchboard, router, serverBindingAddress, Some(tcpBound)), "server", SupervisorStrategy.Restart))
       paymentInitiator = system.actorOf(SimpleSupervisor.props(PaymentInitiator.props(nodeParams, router, register), "payment-initiator", SupervisorStrategy.Restart))
       _ = for (i <- 0 until config.getInt("autoprobe-count")) yield system.actorOf(SimpleSupervisor.props(Autoprobe.props(nodeParams, router, paymentInitiator), s"payment-autoprobe-$i", SupervisorStrategy.Restart))
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -302,6 +302,12 @@ final case class DATA_CLOSING(commitments: Commitments,
 
 final case class DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT(commitments: Commitments, remoteChannelReestablish: ChannelReestablish) extends Data with HasCommitments
 
+
+/**
+ * @param features current connection features, or last features used if the channel is disconnected. Note that these
+ *                 features are updated at each reconnection and may be different from the ones that were used when the
+ *                 channel was created. See [[ChannelVersion]] for permanent features associated to a channel.
+ */
 final case class LocalParams(nodeId: PublicKey,
                              fundingKeyPath: DeterministicWallet.KeyPath,
                              dustLimit: Satoshi,
@@ -315,6 +321,9 @@ final case class LocalParams(nodeId: PublicKey,
                              walletStaticPaymentBasepoint: Option[PublicKey],
                              features: Features)
 
+/**
+ * @param features see [[LocalParams.features]]
+ */
 final case class RemoteParams(nodeId: PublicKey,
                               dustLimit: Satoshi,
                               maxHtlcValueInFlightMsat: UInt64, // this is not MilliSatoshi because it can exceed the total amount of MilliSatoshi

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/ClientSpawner.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/ClientSpawner.scala
@@ -20,22 +20,23 @@ import java.net.InetSocketAddress
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.eclair.NodeParams
+import fr.acinq.eclair.crypto.Noise.KeyPair
+import fr.acinq.eclair.tor.Socks5ProxyParams
 
-class ClientSpawner(nodeParams: NodeParams, switchboard: ActorRef, router: ActorRef) extends Actor with ActorLogging {
+class ClientSpawner(keyPair: KeyPair, socks5ProxyParams_opt: Option[Socks5ProxyParams], peerConnectionConf: PeerConnection.Conf, switchboard: ActorRef, router: ActorRef) extends Actor with ActorLogging {
 
   context.system.eventStream.subscribe(self, classOf[ClientSpawner.ConnectionRequest])
 
   override def receive: Receive = {
     case req: ClientSpawner.ConnectionRequest =>
       log.info("initiating new connection to nodeId={} origin={}", req.remoteNodeId, sender)
-      context.actorOf(Client.props(nodeParams, switchboard, router, req.address, req.remoteNodeId, origin_opt = Some(req.origin)))
+      context.actorOf(Client.props(keyPair, socks5ProxyParams_opt, peerConnectionConf, switchboard, router, req.address, req.remoteNodeId, origin_opt = Some(req.origin)))
   }
 }
 
 object ClientSpawner {
 
-  def props(nodeParams: NodeParams, switchboard: ActorRef, router: ActorRef): Props = Props(new ClientSpawner(nodeParams, switchboard, router))
+  def props(keyPair: KeyPair, socks5ProxyParams_opt: Option[Socks5ProxyParams], peerConnectionConf: PeerConnection.Conf, switchboard: ActorRef, router: ActorRef): Props = Props(new ClientSpawner(keyPair, socks5ProxyParams_opt, peerConnectionConf, switchboard, router))
 
   case class ConnectionRequest(address: InetSocketAddress,
                                remoteNodeId: PublicKey,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Server.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Server.scala
@@ -23,15 +23,16 @@ import akka.actor.{Actor, ActorRef, DiagnosticActorLogging, Props}
 import akka.event.Logging.MDC
 import akka.io.Tcp.SO.KeepAlive
 import akka.io.{IO, Tcp}
+import fr.acinq.eclair.Logs
 import fr.acinq.eclair.Logs.LogCategory
-import fr.acinq.eclair.{Logs, NodeParams}
+import fr.acinq.eclair.crypto.Noise.KeyPair
 
 import scala.concurrent.Promise
 
 /**
  * Created by PM on 27/10/2015.
  */
-class Server(nodeParams: NodeParams, switchboard: ActorRef, router: ActorRef, address: InetSocketAddress, bound: Option[Promise[Done]] = None) extends Actor with DiagnosticActorLogging {
+class Server(keyPair: KeyPair, peerConnectionConf: PeerConnection.Conf, switchboard: ActorRef, router: ActorRef, address: InetSocketAddress, bound: Option[Promise[Done]] = None) extends Actor with DiagnosticActorLogging {
 
   import Tcp._
   import context.system
@@ -56,7 +57,8 @@ class Server(nodeParams: NodeParams, switchboard: ActorRef, router: ActorRef, ad
       log.info(s"connected to $remote")
       val connection = sender
       val peerConnection = context.actorOf(PeerConnection.props(
-        nodeParams = nodeParams,
+        keyPair = keyPair,
+        conf = peerConnectionConf,
         switchboard = switchboard,
         router = router
       ))
@@ -69,7 +71,7 @@ class Server(nodeParams: NodeParams, switchboard: ActorRef, router: ActorRef, ad
 
 object Server {
 
-  def props(nodeParams: NodeParams, switchboard: ActorRef, router: ActorRef, address: InetSocketAddress, bound: Option[Promise[Done]] = None): Props = Props(new Server(nodeParams, switchboard, router: ActorRef, address, bound))
+  def props(keyPair: KeyPair, peerConnectionConf: PeerConnection.Conf, switchboard: ActorRef, router: ActorRef, address: InetSocketAddress, bound: Option[Promise[Done]] = None): Props = Props(new Server(keyPair, peerConnectionConf, switchboard, router: ActorRef, address, bound))
 
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -72,7 +72,12 @@ class Switchboard(nodeParams: NodeParams, watcher: ActorRef, relayer: ActorRef, 
     case authenticated: PeerConnection.Authenticated =>
       // if this is an incoming connection, we might not yet have created the peer
       val peer = createOrGetPeer(authenticated.remoteNodeId, offlineChannels = Set.empty)
-      authenticated.peerConnection ! PeerConnection.InitializeConnection(peer)
+      val features = nodeParams.overrideFeatures.get(authenticated.remoteNodeId) match {
+        case Some(f) => f
+        case None => nodeParams.features.maskFeaturesForEclairMobile()
+      }
+      val doSync = nodeParams.syncWhitelist.isEmpty || nodeParams.syncWhitelist.contains(authenticated.remoteNodeId)
+      authenticated.peerConnection ! PeerConnection.InitializeConnection(peer, nodeParams.chainHash, features, doSync)
 
     case Symbol("peers") => sender ! context.children
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -32,7 +32,7 @@ import fr.acinq.eclair.db._
 import fr.acinq.eclair.db.pg.PgUtils.NoLock
 import fr.acinq.eclair.db.pg._
 import fr.acinq.eclair.db.sqlite._
-import fr.acinq.eclair.io.Peer
+import fr.acinq.eclair.io.{Peer, PeerConnection}
 import fr.acinq.eclair.router.Router.RouterConf
 import fr.acinq.eclair.wire.{Color, EncodingType, NodeAddress}
 import scodec.bits.ByteVector
@@ -177,11 +177,6 @@ object TestConstants {
       maxReserveToFundingRatio = 0.05,
       db = inMemoryDb(sqliteInMemory()),
       revocationTimeout = 20 seconds,
-      authTimeout = 10 seconds,
-      initTimeout = 10 seconds,
-      pingInterval = 30 seconds,
-      pingTimeout = 10 seconds,
-      pingDisconnect = true,
       autoReconnect = false,
       initialRandomReconnectDelay = 5 seconds,
       maxReconnectInterval = 1 hour,
@@ -193,6 +188,14 @@ object TestConstants {
       multiPartPaymentExpiry = 30 seconds,
       minFundingSatoshis = 1000 sat,
       maxFundingSatoshis = 16777215 sat,
+      peerConnectionConf = PeerConnection.Conf(
+        authTimeout = 10 seconds,
+        initTimeout = 10 seconds,
+        pingInterval = 30 seconds,
+        pingTimeout = 10 seconds,
+        pingDisconnect = true,
+        maxRebroadcastDelay = 5 seconds
+      ),
       routerConf = RouterConf(
         randomizeRouteSelection = false,
         channelExcludeDuration = 60 seconds,
@@ -267,11 +270,6 @@ object TestConstants {
       maxReserveToFundingRatio = 0.05,
       db = inMemoryDb(sqliteInMemory()),
       revocationTimeout = 20 seconds,
-      authTimeout = 10 seconds,
-      initTimeout = 10 seconds,
-      pingInterval = 30 seconds,
-      pingTimeout = 10 seconds,
-      pingDisconnect = true,
       autoReconnect = false,
       initialRandomReconnectDelay = 5 seconds,
       maxReconnectInterval = 1 hour,
@@ -283,6 +281,14 @@ object TestConstants {
       multiPartPaymentExpiry = 30 seconds,
       minFundingSatoshis = 1000 sat,
       maxFundingSatoshis = 16777215 sat,
+      peerConnectionConf = PeerConnection.Conf(
+        authTimeout = 10 seconds,
+        initTimeout = 10 seconds,
+        pingInterval = 30 seconds,
+        pingTimeout = 10 seconds,
+        pingDisconnect = true,
+        maxRebroadcastDelay = 5 seconds
+      ),
       routerConf = RouterConf(
         randomizeRouteSelection = false,
         channelExcludeDuration = 60 seconds,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -31,8 +31,8 @@ import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.router.RoutingSyncSpec
 import fr.acinq.eclair.wire._
+import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
-import org.scalatest.{Outcome, Tag}
 import scodec.bits._
 
 import scala.collection.mutable
@@ -61,11 +61,8 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     val transport = TestProbe()
     val peer = TestProbe()
     val remoteNodeId = Bob.nodeParams.nodeId
-
-    import com.softwaremill.quicklens._
-    val aliceParams = TestConstants.Alice.nodeParams//.peerConnectionConf
-//      .modify(_.syncWhitelist).setToIf(test.tags.contains("sync-whitelist-bob"))(Set(remoteNodeId))
-//      .modify(_.syncWhitelist).setToIf(test.tags.contains("sync-whitelist-random"))(Set(randomKey.publicKey))
+    
+    val aliceParams = TestConstants.Alice.nodeParams
 
     val peerConnection: TestFSMRef[PeerConnection.State, PeerConnection.Data, PeerConnection] = TestFSMRef(new PeerConnection(aliceParams.keyPair, aliceParams.peerConnectionConf, switchboard.ref, router.ref))
     withFixture(test.toNoArgTest(FixtureParam(aliceParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -63,27 +63,27 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     val remoteNodeId = Bob.nodeParams.nodeId
 
     import com.softwaremill.quicklens._
-    val aliceParams = TestConstants.Alice.nodeParams
-      .modify(_.syncWhitelist).setToIf(test.tags.contains("sync-whitelist-bob"))(Set(remoteNodeId))
-      .modify(_.syncWhitelist).setToIf(test.tags.contains("sync-whitelist-random"))(Set(randomKey.publicKey))
+    val aliceParams = TestConstants.Alice.nodeParams//.peerConnectionConf
+//      .modify(_.syncWhitelist).setToIf(test.tags.contains("sync-whitelist-bob"))(Set(remoteNodeId))
+//      .modify(_.syncWhitelist).setToIf(test.tags.contains("sync-whitelist-random"))(Set(randomKey.publicKey))
 
-    val peerConnection: TestFSMRef[PeerConnection.State, PeerConnection.Data, PeerConnection] = TestFSMRef(new PeerConnection(aliceParams, switchboard.ref, router.ref))
+    val peerConnection: TestFSMRef[PeerConnection.State, PeerConnection.Data, PeerConnection] = TestFSMRef(new PeerConnection(aliceParams.keyPair, aliceParams.peerConnectionConf, switchboard.ref, router.ref))
     withFixture(test.toNoArgTest(FixtureParam(aliceParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)))
   }
 
-  def connect(remoteNodeId: PublicKey, switchboard: TestProbe, router: TestProbe, connection: TestProbe, transport: TestProbe, peerConnection: TestFSMRef[PeerConnection.State, PeerConnection.Data, PeerConnection], peer: TestProbe, remoteInit: wire.Init = wire.Init(Bob.nodeParams.features), expectSync: Boolean = false): Unit = {
+  def connect(aliceParams: NodeParams, remoteNodeId: PublicKey, switchboard: TestProbe, router: TestProbe, connection: TestProbe, transport: TestProbe, peerConnection: TestFSMRef[PeerConnection.State, PeerConnection.Data, PeerConnection], peer: TestProbe, remoteInit: wire.Init = wire.Init(Bob.nodeParams.features), doSync: Boolean = false): Unit = {
     // let's simulate a connection
     val probe = TestProbe()
     probe.send(peerConnection, PeerConnection.PendingAuth(connection.ref, Some(remoteNodeId), address, origin_opt = None, transport_opt = Some(transport.ref)))
     transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
     switchboard.expectMsg(PeerConnection.Authenticated(peerConnection, remoteNodeId))
-    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref, aliceParams.chainHash, aliceParams.features, doSync))
     transport.expectMsgType[TransportHandler.Listener]
     val localInit = transport.expectMsgType[wire.Init]
     assert(localInit.networks === List(Block.RegtestGenesisBlock.hash))
     transport.send(peerConnection, remoteInit)
     transport.expectMsgType[TransportHandler.ReadAck]
-    if (expectSync) {
+    if (doSync) {
       router.expectMsgType[SendChannelQuery]
     } else {
       router.expectNoMsg(1 second)
@@ -94,7 +94,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
 
   test("establish connection") { f =>
     import f._
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
   }
 
   test("handle connection closed during authentication") { f =>
@@ -112,7 +112,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     val origin = TestProbe()
     probe.watch(peerConnection)
     probe.send(peerConnection, PeerConnection.PendingAuth(connection.ref, Some(remoteNodeId), address, origin_opt = Some(origin.ref), transport_opt = Some(transport.ref)))
-    probe.expectTerminated(peerConnection, nodeParams.authTimeout / transport.testKitSettings.TestTimeFactor + 1.second) // we don't want dilated time here
+    probe.expectTerminated(peerConnection, nodeParams.peerConnectionConf.authTimeout / transport.testKitSettings.TestTimeFactor + 1.second) // we don't want dilated time here
     origin.expectMsg(PeerConnection.ConnectionResult.AuthenticationFailed("authentication timed out"))
   }
 
@@ -123,8 +123,8 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     probe.watch(peerConnection)
     probe.send(peerConnection, PeerConnection.PendingAuth(connection.ref, Some(remoteNodeId), address, origin_opt = Some(origin.ref), transport_opt = Some(transport.ref)))
     transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
-    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
-    probe.expectTerminated(peerConnection, nodeParams.initTimeout / transport.testKitSettings.TestTimeFactor + 1.second) // we don't want dilated time here
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref, nodeParams.chainHash, nodeParams.features, doSync = true))
+    probe.expectTerminated(peerConnection, nodeParams.peerConnectionConf.initTimeout / transport.testKitSettings.TestTimeFactor + 1.second) // we don't want dilated time here
     origin.expectMsg(PeerConnection.ConnectionResult.InitializationFailed("initialization timed out"))
   }
 
@@ -135,7 +135,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     probe.watch(transport.ref)
     probe.send(peerConnection, PeerConnection.PendingAuth(connection.ref, Some(remoteNodeId), address, origin_opt = Some(origin.ref), transport_opt = Some(transport.ref)))
     transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
-    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref, nodeParams.chainHash, nodeParams.features, doSync = true))
     transport.expectMsgType[TransportHandler.Listener]
     transport.expectMsgType[wire.Init]
     transport.send(peerConnection, LightningMessageCodecs.initCodec.decode(hex"0000 00050100000000".bits).require.value)
@@ -151,7 +151,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     probe.watch(transport.ref)
     probe.send(peerConnection, PeerConnection.PendingAuth(connection.ref, Some(remoteNodeId), address, origin_opt = Some(origin.ref), transport_opt = Some(transport.ref)))
     transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
-    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref, nodeParams.chainHash, nodeParams.features, doSync = true))
     transport.expectMsgType[TransportHandler.Listener]
     transport.expectMsgType[wire.Init]
     transport.send(peerConnection, LightningMessageCodecs.initCodec.decode(hex"00050100000000 0000".bits).require.value)
@@ -167,7 +167,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     probe.watch(transport.ref)
     probe.send(peerConnection, PeerConnection.PendingAuth(connection.ref, Some(remoteNodeId), address, origin_opt = Some(origin.ref), transport_opt = Some(transport.ref)))
     transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
-    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref, nodeParams.chainHash, nodeParams.features, doSync = true))
     transport.expectMsgType[TransportHandler.Listener]
     transport.expectMsgType[wire.Init]
     // remote activated MPP but forgot payment secret
@@ -177,31 +177,6 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     origin.expectMsg(PeerConnection.ConnectionResult.InitializationFailed("basic_mpp is set but is missing a dependency (payment_secret)"))
   }
 
-  test("masks off MPP and PaymentSecret features") { f =>
-    import f._
-    val probe = TestProbe()
-
-    val testCases = Seq(
-      (bin"                00000010", bin"                00000010"), // option_data_loss_protect
-      (bin"        0000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex
-      (bin"        1000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret
-      (bin"        0100101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret
-      (bin"000000101000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret, basic_mpp
-      (bin"000010101000101010001010", bin"000010000000101010001010") // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret, basic_mpp and large_channel_support (optional)
-    )
-
-    for ((configuredFeatures, sentFeatures) <- testCases) {
-      val nodeParams = TestConstants.Alice.nodeParams.copy(features = Features(configuredFeatures))
-      val peerConnection = TestFSMRef(new PeerConnection(nodeParams, switchboard.ref, router.ref))
-      probe.send(peerConnection, PeerConnection.PendingAuth(connection.ref, Some(remoteNodeId), address, origin_opt = None, transport_opt = Some(transport.ref)))
-      transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
-      probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
-      transport.expectMsgType[TransportHandler.Listener]
-      val init = transport.expectMsgType[wire.Init]
-      assert(init.features.toByteVector === sentFeatures.bytes)
-    }
-  }
-
   test("disconnect if incompatible networks") { f =>
     import f._
     val probe = TestProbe()
@@ -209,7 +184,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     probe.watch(transport.ref)
     probe.send(peerConnection, PeerConnection.PendingAuth(connection.ref, Some(remoteNodeId), address, origin_opt = Some(origin.ref), transport_opt = Some(transport.ref)))
     transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
-    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref))
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref, nodeParams.chainHash, nodeParams.features, doSync = true))
     transport.expectMsgType[TransportHandler.Listener]
     transport.expectMsgType[wire.Init]
     transport.send(peerConnection, wire.Init(Bob.nodeParams.features, TlvStream(InitTlv.Networks(Block.LivenetGenesisBlock.hash :: Block.SegnetGenesisBlock.hash :: Nil))))
@@ -218,27 +193,15 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     origin.expectMsg(PeerConnection.ConnectionResult.InitializationFailed("incompatible networks"))
   }
 
-  test("sync if no whitelist is defined") { f =>
+  test("sync when requested") { f =>
     import f._
     val remoteInit = wire.Init(Features(Set(ActivatedFeature(ChannelRangeQueries, Optional))))
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer, remoteInit, expectSync = true)
-  }
-
-  test("sync if whitelist contains peer", Tag("sync-whitelist-bob")) { f =>
-    import f._
-    val remoteInit = wire.Init(Features(Set(ActivatedFeature(ChannelRangeQueries, Optional), ActivatedFeature(VariableLengthOnion, Optional))))
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer, remoteInit, expectSync = true)
-  }
-
-  test("don't sync if whitelist doesn't contain peer", Tag("sync-whitelist-random")) { f =>
-    import f._
-    val remoteInit = wire.Init(Features(Set(ActivatedFeature(ChannelRangeQueries, Optional)))) // bob supports channel range queries
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer, remoteInit, expectSync = false)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer, remoteInit, doSync = true)
   }
 
   test("reply to ping") { f =>
     import f._
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
     val ping = Ping(42, randomBytes(127))
     transport.send(peerConnection, ping)
     transport.expectMsg(TransportHandler.ReadAck(ping))
@@ -247,14 +210,14 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
 
   test("send a ping if no message after init") { f =>
     import f._
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
     // ~30s without an incoming message: peer should send a ping
     transport.expectMsgType[Ping](35 / transport.testKitSettings.TestTimeFactor seconds) // we don't want dilated time here
   }
 
   test("send a ping if no message received for 30s") { f =>
     import f._
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
     // we make the transport send a message, this will delay the sending of a ping
     val dummy = updates.head
     for (_ <- 1 to 5) { // the goal of this loop is to make sure that we don't send pings when we receive messages
@@ -268,7 +231,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
 
   test("ignore malicious ping") { f =>
     import f._
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
     // huge requested pong length
     val ping = Ping(Int.MaxValue, randomBytes(127))
     transport.send(peerConnection, ping)
@@ -280,7 +243,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     import f._
     val sender = TestProbe()
     val deathWatcher = TestProbe()
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
     // we manually trigger a ping because we don't want to wait too long in tests
     sender.send(peerConnection, PeerConnection.SendPing)
     transport.expectMsgType[Ping]
@@ -292,7 +255,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     import f._
     val probe = TestProbe()
     val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref, randomKey.publicKey))
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
     val rebroadcast = Rebroadcast(channels.map(_ -> gossipOrigin).toMap, updates.map(_ -> gossipOrigin).toMap, nodes.map(_ -> gossipOrigin).toMap)
     probe.send(peerConnection, rebroadcast)
     transport.expectNoMsg(10 / transport.testKitSettings.TestTimeFactor seconds) // we don't want dilated time here
@@ -300,7 +263,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
 
   test("filter gossip message (filtered by origin)") { f =>
     import f._
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
     val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref, randomKey.publicKey))
     val bobOrigin = RemoteGossip(peerConnection, remoteNodeId)
     val rebroadcast = Rebroadcast(
@@ -319,7 +282,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
 
   test("filter gossip message (filtered by timestamp)") { f =>
     import f._
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
     val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref, randomKey.publicKey))
     val rebroadcast = Rebroadcast(channels.map(_ -> gossipOrigin).toMap, updates.map(_ -> gossipOrigin).toMap, nodes.map(_ -> gossipOrigin).toMap)
     val timestamps = updates.map(_.timestamp).sorted.slice(10, 30)
@@ -337,7 +300,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
   test("does not filter our own gossip message") { f =>
     import f._
     val probe = TestProbe()
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
     val gossipOrigin = Set[GossipOrigin](RemoteGossip(TestProbe().ref, randomKey.publicKey))
     val rebroadcast = Rebroadcast(
       channels.map(_ -> gossipOrigin).toMap + (channels(5) -> Set(LocalGossip)),
@@ -355,7 +318,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
   test("react to peer's bad behavior") { f =>
     import f._
     val probe = TestProbe()
-    connect(remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
+    connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
 
     val query = QueryShortChannelIds(
       Alice.nodeParams.chainHash,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -102,7 +102,7 @@ class PeerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with StateTe
     import f._
 
     // this actor listens to connection requests and creates connections
-    system.actorOf(ClientSpawner.props(nodeParams, TestProbe().ref, TestProbe().ref))
+    system.actorOf(ClientSpawner.props(nodeParams.keyPair, nodeParams.socksProxy_opt, nodeParams.peerConnectionConf, TestProbe().ref, TestProbe().ref))
 
     // we create a dummy tcp server and update bob's announcement to point to it
     val mockServer = new ServerSocket(0, 1, InetAddress.getLocalHost) // port will be assigned automatically
@@ -128,7 +128,7 @@ class PeerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with StateTe
     import f._
 
     // this actor listens to connection requests and creates connections
-    system.actorOf(ClientSpawner.props(nodeParams, TestProbe().ref, TestProbe().ref))
+    system.actorOf(ClientSpawner.props(nodeParams.keyPair, nodeParams.socksProxy_opt, nodeParams.peerConnectionConf, TestProbe().ref, TestProbe().ref))
 
     // we create a dummy tcp server and update bob's announcement to point to it
     val mockServer = new ServerSocket(0, 1, InetAddress.getLocalHost) // port will be assigned automatically

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
@@ -56,7 +56,7 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
       aliceParams.db.network.addNode(bobAnnouncement)
     }
 
-    system.actorOf(ClientSpawner.props(aliceParams, TestProbe().ref, TestProbe().ref))
+    system.actorOf(ClientSpawner.props(aliceParams.keyPair, aliceParams.socksProxy_opt, aliceParams.peerConnectionConf, TestProbe().ref, TestProbe().ref))
 
     val monitor = TestProbe()
     val reconnectionTask: TestFSMRef[ReconnectionTask.State, ReconnectionTask.Data, ReconnectionTask] =

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
@@ -7,7 +7,7 @@ import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.TestConstants._
 import fr.acinq.eclair.blockchain.TestWallet
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.{Features, NodeParams, TestKitBaseClass}
+import fr.acinq.eclair.{Features, NodeParams, TestKitBaseClass, randomKey}
 import org.scalatest.funsuite.AnyFunSuiteLike
 import scodec.bits._
 
@@ -42,6 +42,44 @@ class SwitchboardSpec extends TestKitBaseClass with AnyFunSuiteLike {
     probe.send(switchboard, Peer.Connect(remoteNodeId, None))
     peer.expectMsg(Peer.Init(Set.empty))
     peer.expectMsg(Peer.Connect(remoteNodeId, None))
+  }
+
+  def sendFeatures(remoteNodeId: PublicKey, features: Features, syncWhitelist: Set[PublicKey], expectedFeatures: Features, expectedSync: Boolean) = {
+    val peer = TestProbe()
+    val peerConnection = TestProbe()
+    val nodeParams = Alice.nodeParams.copy(features = features, syncWhitelist = syncWhitelist)
+    val switchboard = TestActorRef(new TestSwitchboard(nodeParams, remoteNodeId, peer))
+    switchboard ! PeerConnection.Authenticated(peerConnection.ref, remoteNodeId)
+    peerConnection.expectMsg(PeerConnection.InitializeConnection(peer.ref, nodeParams.chainHash, expectedFeatures, doSync = expectedSync))
+  }
+
+  test("sync if no whitelist is defined") {
+    sendFeatures(randomKey.publicKey, Alice.nodeParams.features, Set.empty, Alice.nodeParams.features, expectedSync = true)
+  }
+
+  test("sync if whitelist contains peer") {
+    val remoteNodeId = randomKey.publicKey
+    sendFeatures(remoteNodeId, Alice.nodeParams.features, Set(remoteNodeId, randomKey.publicKey, randomKey.publicKey), Alice.nodeParams.features, expectedSync = true)
+  }
+
+  test("don't sync if whitelist doesn't contain peer") {
+    val remoteNodeId = randomKey.publicKey
+    sendFeatures(remoteNodeId, Alice.nodeParams.features, Set(randomKey.publicKey, randomKey.publicKey, randomKey.publicKey), Alice.nodeParams.features, expectedSync = false)
+  }
+
+  test("on peer authentication, mask off MPP and PaymentSecret features") {
+    val testCases = Seq(
+      (bin"                00000010", bin"                00000010"), // option_data_loss_protect
+      (bin"        0000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex
+      (bin"        1000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret
+      (bin"        0100101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret
+      (bin"000000101000101010001010", bin"        0000101010001010"), // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret, basic_mpp
+      (bin"000010101000101010001010", bin"000010000000101010001010") // option_data_loss_protect, initial_routing_sync, gossip_queries, var_onion_optin, gossip_queries_ex, payment_secret, basic_mpp and large_channel_support (optional)
+    )
+
+    for ((configuredFeatures, sentFeatures) <- testCases) {
+      sendFeatures(randomKey.publicKey, Features(configuredFeatures), Set.empty, Features(sentFeatures), expectedSync = true)
+    }
   }
 
 }


### PR DESCRIPTION
Features are now provided by the `switchboard`, in response to the
`PeerConnection.Authenticated` message.

The `switchboard` will also decide whether or not we sync with that
peer, depending on the `syncWhiteList` configuration.

This is an alternative to #1361. The `features`/`override-features`/`sync-whitelist` remain top-level parameters in `eclair.conf`, which was one of the main issues with #1361.