### PR TITLE
Use BitVector instead of ByteVector in UnknownMessage

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageCodecs.scala
@@ -298,7 +298,7 @@ object LightningMessageCodecs {
 
   val unknownMessageCodec: Codec[UnknownMessage] = (
     ("tag" | uint16) ::
-      ("message" | varsizebinarydata)
+      ("message" | variableSizeBits(uint16, bits))
     ).as[UnknownMessage]
 
   // NB: blank lines to minimize merge conflicts

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
@@ -25,7 +25,7 @@ import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Satoshi}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshi, ShortChannelId, UInt64}
-import scodec.bits.ByteVector
+import scodec.bits.{BitVector, ByteVector}
 
 import scala.util.Try
 
@@ -308,4 +308,4 @@ case class GossipTimestampFilter(chainHash: ByteVector32,
 
 //
 
-case class UnknownMessage(tag: Int, data: ByteVector) extends LightningMessage
+case class UnknownMessage(tag: Int, data: BitVector) extends LightningMessage

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -36,7 +36,7 @@ import fr.acinq.eclair.io.Peer._
 import fr.acinq.eclair.wire.{ChannelCodecsSpec, Color, NodeAddress, NodeAnnouncement, UnknownMessage}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.{Outcome, Tag}
-import scodec.bits.ByteVector
+import scodec.bits.{BitVector, ByteVector}
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -169,9 +169,9 @@ class PeerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with StateTe
     system.eventStream.subscribe(listener.ref, classOf[UnknownMessageReceived])
     connect(remoteNodeId, peer, peerConnection, channels = Set(ChannelCodecsSpec.normal))
 
-    peerConnection.send(peer, UnknownMessage(tag = TestConstants.pluginParams.tags.head, data = ByteVector.empty))
+    peerConnection.send(peer, UnknownMessage(tag = TestConstants.pluginParams.tags.head, data = BitVector.empty))
     listener.expectMsgType[UnknownMessageReceived]
-    peerConnection.send(peer, UnknownMessage(tag = 60005, data = ByteVector.empty)) // No plugin is subscribed to this tag
+    peerConnection.send(peer, UnknownMessage(tag = 60005, data = BitVector.empty)) // No plugin is subscribed to this tag
     listener.expectNoMessage()
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/LightningMessageCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/LightningMessageCodecsSpec.scala
@@ -26,7 +26,7 @@ import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.wire.LightningMessageCodecs._
 import fr.acinq.eclair.wire.ReplyChannelRangeTlv._
 import org.scalatest.funsuite.AnyFunSuite
-import scodec.bits.{ByteVector, HexStringSyntax}
+import scodec.bits.{BitVector, ByteVector, HexStringSyntax}
 
 /**
  * Created by PM on 31/05/2016.
@@ -195,7 +195,7 @@ class LightningMessageCodecsSpec extends AnyFunSuite {
     val pong = Pong(bin(10, 1))
     val channel_reestablish = ChannelReestablish(randomBytes32, 242842L, 42L, randomKey, randomKey.publicKey)
 
-    val unknown_message = UnknownMessage(tag = 60000, data = ByteVector32.One.bytes)
+    val unknown_message = UnknownMessage(tag = 60000, data = BitVector.one)
 
     val msgs: List[LightningMessage] =
       open :: accept :: funding_created :: funding_signed :: funding_locked :: update_fee :: shutdown :: closing_signed ::
@@ -214,7 +214,7 @@ class LightningMessageCodecsSpec extends AnyFunSuite {
 
   test("Unknown messages") {
     // Non-standard tag number so this message can only be handled by a codec with a fallback
-    val unknown = UnknownMessage(tag = 47282, data = ByteVector32.Zeroes.bytes)
+    val unknown = UnknownMessage(tag = 47282, data = BitVector.zero)
     assert(lightningMessageCodec.encode(unknown).isFailure)
     val encoded1 = lightningMessageCodecWithFallback.encode(unknown).require
     val decoded1 = lightningMessageCodecWithFallback.decode(encoded1).require.value


### PR DESCRIPTION
This is a minor change which I find to be more convenient while working on my first plugin. 

Spec following plugin is expected to define its own set of codecs and these codecs take `BitVector`, not `ByteVector` so with `UnknownMessage` containing a `BitVector` data we can pass it to codec directly and save on `.toBitVector` conversion.