### PR TITLE
Use maven plugin to include tests

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -69,6 +69,13 @@
                         </manifestEntries>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This will result in `eclair-core_2.13-<version>-tests.jar` file and allow to easily reuse Eclair testing classes in plugins.