### PR TITLE
Allow mandatory static-remotekey

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -230,6 +230,7 @@ object Features {
     ChannelRangeQueries,
     VariableLengthOnion,
     ChannelRangeQueriesExtended,
+    StaticRemoteKey,
     PaymentSecret,
     BasicMultiPartPayment,
     Wumbo

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
@@ -57,8 +57,10 @@ class FeaturesSpec extends AnyFunSuite {
   test("'option_static_remotekey' feature") {
     assert(Features(hex"1000").hasFeature(StaticRemoteKey))
     assert(Features(hex"1000").hasFeature(StaticRemoteKey, Some(Mandatory)))
+    assert(areSupported(Features(hex"1000")))
     assert(Features(hex"2000").hasFeature(StaticRemoteKey))
     assert(Features(hex"2000").hasFeature(StaticRemoteKey, Some(Optional)))
+    assert(areSupported(Features(hex"2000")))
   }
 
   test("features dependencies") {


### PR DESCRIPTION
Since we optionally support static-remotekey, we should allow our peers
to make it mandatory if they wish.