### PR TITLE
fixes JAVA_OPTS expansion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ RUN chmod +x eclair-cli && mv eclair-cli /sbin/eclair-cli
 
 # we only need the eclair-node.zip to run
 COPY --from=BUILD /usr/src/eclair-node/target/eclair-node-*.zip ./eclair-node.zip
-RUN unzip eclair-node.zip && mv eclair-node-* eclair-node
+RUN unzip eclair-node.zip && mv eclair-node-* eclair-node && chmod +x eclair-node/bin/eclair-node.sh
 
 ENV ECLAIR_DATADIR=/data
 ENV JAVA_OPTS=
@@ -63,4 +63,4 @@ ENV JAVA_OPTS=
 RUN mkdir -p "$ECLAIR_DATADIR"
 VOLUME [ "/data" ]
 
-ENTRYPOINT JAVA_OPTS="$JAVA_OPTS" bash eclair-node/bin/eclair-node.sh -Declair.datadir=$ECLAIR_DATADIR
+ENTRYPOINT JAVA_OPTS="${JAVA_OPTS}" eclair-node/bin/eclair-node.sh "-Declair.datadir=${ECLAIR_DATADIR}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,4 +63,4 @@ ENV JAVA_OPTS=
 RUN mkdir -p "$ECLAIR_DATADIR"
 VOLUME [ "/data" ]
 
-ENTRYPOINT $JAVA_OPTS bash eclair-node/bin/eclair-node.sh -Declair.datadir=$ECLAIR_DATADIR
+ENTRYPOINT JAVA_OPTS="$JAVA_OPTS" bash eclair-node/bin/eclair-node.sh -Declair.datadir=$ECLAIR_DATADIR


### PR DESCRIPTION
Fixes #1560


That's the quick&easy solution but personally I don't like it, too much implicit things going on. The `ENTRYPOINT` directive uses the *shell form* which means that this line:
```
ENTRYPOINT JAVA_OPTS="$JAVA_OPTS" bash eclair-node/bin/eclair-node.sh -Declair.datadir=$ECLAIR_DATADIR
```
gets executed as this:
```
sh -c JAVA_OPTS="$JAVA_OPTS" bash eclair-node/bin/eclair-node.sh -Declair.datadir=$ECLAIR_DATADIR
```
Variables assignment before a shell command gets expanded and appended in a one-time environment used by the shell command. I've never liked this construct and prefer the more explicit use of `env`:
```
sh -c env JAVA_OPTS="$JAVA_OPTS" bash eclair-node/bin/eclair-node.sh -Declair.datadir=$ECLAIR_DATADIR
```
And to be even more explicit we might as well use the *executable form* of `ENTRYPOINT`:
```
ENTRYPOINT ["/usr/bin/env", "JAVA_OPTS=$JAVA_OPTS", "bash", "eclair-node/bin/eclair-node.sh", "-Declair.datadir=$ECLAIR_DATADIR"]
```
Which gets rid of the unnecessary `sh` invocation.

### Some optimization
By the way since the script `eclair-node.sh` has a shebang and is executable we can remove the invocation of bash:
```
ENTRYPOINT ["/usr/bin/env", "JAVA_OPTS=$JAVA_OPTS", "eclair-node/bin/eclair-node.sh", "-Declair.datadir=$ECLAIR_DATADIR"]
```
Resulting in 2 spawned processes (`env` & `bash`) instead of 3 (`sh`, `bash` & `bash` again).

@t-bast What are your thoughts on this?
