### PR TITLE
Add workaround for lnd sync issue

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1603,7 +1603,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
     // first and then go silent. This is due to a race condition on their side, so we trigger a reconnection, hoping that
     // we will eventually receive their channel_reestablish.
     case Event(_: FundingLocked, _) =>
-      log.error("received funding_locked before channel_reestablish (known lnd bug): disconnecting...")
+      log.warning("received funding_locked before channel_reestablish (known lnd bug): disconnecting...")
       peer ! Peer.Disconnect(remoteNodeId)
       stay
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1598,6 +1598,15 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
         goto(NEGOTIATING) using d.copy(closingTxProposed = closingTxProposed1) sending d.localShutdown
       }
 
+    // This handler is a workaround for an issue in lnd: starting with versions 0.10 / 0.11, they sometimes fail to send
+    // a channel_reestablish when reconnecting a channel that recently got confirmed, and instead send a funding_locked
+    // first and then go silent. This is due to a race condition on their side, so we trigger a reconnection, hoping that
+    // we will eventually receive their channel_reestablish.
+    case Event(_: FundingLocked, _) =>
+      log.error("received funding_locked before channel_reestablish (known lnd bug): disconnecting...")
+      peer ! Peer.Disconnect(remoteNodeId)
+      stay
+
     case Event(c: CurrentBlockCount, d: HasCommitments) => handleNewBlock(c, d)
 
     case Event(c: CurrentFeerates, d: HasCommitments) =>


### PR DESCRIPTION
When a channel gets confirmed while nodes are disconnected, recent versions of lnd sometimes fail to send their channel_reestablish message and instead send a funding_locked first (due to a race condition on their side).

When that happens, the channel stays stuck in the SYNCING state.
To avoid that, we trigger a reconnection until the race condition is eventually won by the channel_reestablish.
