### PR TITLE
Add an option to avoid bitcoin sig checking for ChannelAnnouncement

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Announcements.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Announcements.scala
@@ -149,12 +149,10 @@ object Announcements {
     )
   }
 
-  def checkSigs(ann: ChannelAnnouncement): Boolean = {
+  def checkSigs(ann: ChannelAnnouncement, checkBitcoinSigs: Boolean = true): Boolean = {
     val witness = channelAnnouncementWitnessEncode(ann.chainHash, ann.shortChannelId, ann.nodeId1, ann.nodeId2, ann.bitcoinKey1, ann.bitcoinKey2, ann.features, ann.unknownFields)
-    verifySignature(witness, ann.nodeSignature1, ann.nodeId1) &&
-      verifySignature(witness, ann.nodeSignature2, ann.nodeId2) &&
-      verifySignature(witness, ann.bitcoinSignature1, ann.bitcoinKey1) &&
-      verifySignature(witness, ann.bitcoinSignature2, ann.bitcoinKey2)
+    val nodeSigs = verifySignature(witness, ann.nodeSignature1, ann.nodeId1) && verifySignature(witness, ann.nodeSignature2, ann.nodeId2)
+    if (checkBitcoinSigs) nodeSigs && verifySignature(witness, ann.bitcoinSignature1, ann.bitcoinKey1) && verifySignature(witness, ann.bitcoinSignature2, ann.bitcoinKey2) else nodeSigs
   }
 
   def checkSig(ann: NodeAnnouncement): Boolean = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsSpec.scala
@@ -44,6 +44,7 @@ class AnnouncementsSpec extends AnyFunSuite {
     val (node_b_sig, bitcoin_b_sig) = signChannelAnnouncement(Block.RegtestGenesisBlock.hash, ShortChannelId(42L), node_b, node_a.publicKey, bitcoin_b, bitcoin_a.publicKey, Features.empty)
     val ann = makeChannelAnnouncement(Block.RegtestGenesisBlock.hash, ShortChannelId(42L), node_a.publicKey, node_b.publicKey, bitcoin_a.publicKey, bitcoin_b.publicKey, node_a_sig, node_b_sig, bitcoin_a_sig, bitcoin_b_sig)
     assert(checkSigs(ann))
+    assert(checkSigs(ann, checkBitcoinSigs = false))
     assert(checkSigs(ann.copy(nodeId1 = randomKey.publicKey)) === false)
   }
 


### PR DESCRIPTION
This change will make it easier to check public hosted channels' announcements which don't have a chain funding part.