### PR TITLE
Post restart plugin htlcs

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -44,6 +44,8 @@ case class LocalChannelDown(channel: ActorRef, channelId: ByteVector32, shortCha
 
 case class ChannelStateChanged(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, previousState: State, currentState: State, currentData: Data) extends ChannelEvent
 
+case class PluginChannelStateChanged(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, previousState: State, currentState: State, currentData: AbstractCommitments) extends ChannelEvent
+
 case class ChannelSignatureSent(channel: ActorRef, commitments: Commitments) extends ChannelEvent
 
 case class ChannelSignatureReceived(channel: ActorRef, commitments: Commitments) extends ChannelEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -44,7 +44,7 @@ case class LocalChannelDown(channel: ActorRef, channelId: ByteVector32, shortCha
 
 case class ChannelStateChanged(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, previousState: State, currentState: State, currentData: Data) extends ChannelEvent
 
-case class PluginChannelStateChanged(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, previousState: State, currentState: State, currentData: AbstractCommitments) extends ChannelEvent
+case class PluginWithHTLCStateChanged(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, previousState: State, currentState: State, currentData: AbstractCommitments) extends ChannelEvent
 
 case class ChannelSignatureSent(channel: ActorRef, commitments: Commitments) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
@@ -77,7 +77,7 @@ class PostRestartHtlcCleaner(nodeParams: NodeParams, register: ActorRef) extends
     case e@ChannelStateChanged(channel, _, _, WAIT_FOR_INIT_INTERNAL | OFFLINE | SYNCING | CLOSING, NORMAL | SHUTDOWN | CLOSING | CLOSED, data: HasCommitments) =>
       resolveNotRelayedBrokenHtlcs(brokenHtlcs, e.previousState, e.currentState, channel, data.commitments)
 
-    case e@PluginChannelStateChanged(channel, _, _, WAIT_FOR_INIT_INTERNAL | OFFLINE | SYNCING | CLOSING, NORMAL | SHUTDOWN | CLOSING | CLOSED, commitments) =>
+    case e@PluginWithHTLCStateChanged(channel, _, _, WAIT_FOR_INIT_INTERNAL | OFFLINE | SYNCING | CLOSING, NORMAL | SHUTDOWN | CLOSING | CLOSED, commitments) =>
       resolveNotRelayedBrokenHtlcs(brokenHtlcs, e.previousState, e.currentState, channel, commitments)
 
     case RES_ADD_SETTLED(o: Origin.Cold, htlc, fulfill: HtlcResult.Fulfill) =>

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -41,7 +41,7 @@ object Boot extends App with Logging {
     implicit val system: ActorSystem = ActorSystem("eclair-node", config)
     implicit val ec: ExecutionContext = system.dispatcher
 
-    val pluginParams = plugins.flatMap(_.params)
+    val pluginParams = plugins.collect { case plugin: PluginWithParams => plugin.params }
     val setup = new Setup(datadir, pluginParams)
 
     if (config.getBoolean("eclair.enable-kamon")) {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
@@ -21,14 +21,17 @@ import java.net.{JarURLConnection, URL, URLClassLoader}
 import grizzled.slf4j.Logging
 import scala.util.{Failure, Success, Try}
 
-trait Plugin {
 
-  def params: Option[PluginParams]
+trait Plugin {
 
   def onSetup(setup: Setup): Unit
 
   def onKit(kit: Kit): Unit
 
+}
+
+trait PluginWithParams extends Plugin {
+  def params: PluginParams
 }
 
 object Plugin extends Logging {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
@@ -18,7 +18,10 @@ package fr.acinq.eclair
 
 import java.io.File
 import java.net.{JarURLConnection, URL, URLClassLoader}
+
+import fr.acinq.eclair.payment.relay.PostRestartHtlcCleaner.PluginHtlcs
 import grizzled.slf4j.Logging
+
 import scala.util.{Failure, Success, Try}
 
 
@@ -32,6 +35,10 @@ trait Plugin {
 
 trait PluginWithParams extends Plugin {
   def params: PluginParams
+}
+
+trait PluginWithHTLC extends Plugin {
+  def htlcs: PluginHtlcs
 }
 
 object Plugin extends Logging {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -35,7 +35,7 @@ import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.api.FormParamExtractors._
 import fr.acinq.eclair.blockchain.fee.FeeratePerByte
-import fr.acinq.eclair.channel.{ChannelClosed, ChannelCreated, ChannelEvent, ChannelStateChanged, WAIT_FOR_INIT_INTERNAL}
+import fr.acinq.eclair.channel.{ChannelClosed, ChannelCreated, ChannelStateChanged, WAIT_FOR_INIT_INTERNAL}
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.{PaymentEvent, PaymentRequest}
 import fr.acinq.eclair.router.Router.{PredefinedChannelRoute, PredefinedNodeRoute}


### PR DESCRIPTION
This enriches plugins with ability to provide their own broken and pending HTLCs on restart which are then used in PostRestartHtlcCleaner methods and events.

This is needed in particular as a final piece to enable HC entirely as a plugin, it builds upon plugin messaging and #1542.

Without this functionality it's not possible to correctly handle broken and pending HTLCs which were somehow routed through plugins (in case of HC that would be routings like `peer1 -> HC1 -> HC2 -> peer2` or  `peer1 -> normal -> HC -> peer2` and a like).