### PR TITLE
Add per-node feerate tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ name                         | description                                      
 
 Quotes are not required unless the value contains special characters. Full syntax guide [here](https://github.com/lightbend/config/blob/master/HOCON.md).
 
-&rarr; see [`reference.conf`](eclair-core/src/main/resources/reference.conf) for full reference. There are many more options!
+&rarr; see [here](./docs/Configure.md) for more configuration options.
 
 #### Configure Bitcoin Core wallet
 

--- a/docs/Configure.md
+++ b/docs/Configure.md
@@ -1,0 +1,176 @@
+# Configuring Eclair
+
+Eclair reads its configuration file, and writes its logs, to `~/.eclair` by default.
+You can change this behavior with the `eclair.datadir` parameter:
+
+```sh
+eclair-node.sh -Declair.datadir="/path/to/custom/eclair/data/folder"
+```
+
+## Change your node's configuration
+
+The first step is to **actually create the configuration file**.
+Go to `eclair.datadir` and create a file named `eclair.conf`.
+The dncoding should be UTF-8.
+
+Options are set as key-value pairs and follow the [HOCON syntax](https://github.com/lightbend/config/blob/master/HOCON.md).
+Values do not need to be surrounded by quotes, except if they contain special characters.
+
+## Options reference
+
+Here are some of the most common options:
+
+name                         | description                                                | default value
+-----------------------------|------------------------------------------------------------|--------------
+ eclair.chain                | Which blockchain to use: *regtest*, *testnet* or *mainnet* | mainnet
+ eclair.server.port          | Lightning TCP port                                         | 9735
+ eclair.api.port             | API HTTP port                                              | 8080
+ eclair.api.enabled          | Enables the JSON API                                       | false
+ eclair.api.password         | Password protecting the API (BASIC auth)                   | _no default_
+ eclair.bitcoind.rpcuser     | Bitcoin Core RPC user                                      | foo
+ eclair.bitcoind.rpcpassword | Bitcoin Core RPC password                                  | bar
+ eclair.bitcoind.zmqblock    | Bitcoin Core ZMQ block address                             | "tcp://127.0.0.1:29000"
+ eclair.bitcoind.zmqtx       | Bitcoin Core ZMQ tx address                                | "tcp://127.0.0.1:29000"
+ eclair.bitcoind.wallet      | Bitcoin Core wallet name                                   | ""
+ eclair.server.public-ips    | List of node public ip                                     | _no default_
+
+&rarr; see [`reference.conf`](https://github.com/ACINQ/eclair/blob/master/eclair-core/src/main/resources/reference.conf) for full reference. There are many more options!
+
+## Customize features
+
+Eclair ships with a set of features that are activated by default, and some experimental or optional features that can be activated by users.
+The list of supported features can be found in the [reference configuration](https://github.com/ACINQ/eclair/blob/master/eclair-core/src/main/resources/reference.conf).
+
+To enable a non-default feature, you simply need to add the following to your `eclair.conf`:
+
+```conf
+eclair.features {
+    official_feature_name = optional|mandatory
+}
+```
+
+For example, to activate `option_static_remotekey`:
+
+```conf
+eclair.features {
+    option_static_remotekey = optional
+}
+```
+
+Note that you can also disable some default features:
+
+```conf
+eclair.features {
+    initial_routing_sync = disabled
+}
+```
+
+It's usually risky to activate non-default features or disable default features: make sure you fully understand a feature (and the current implementation status, detailed in the release notes) before doing so.
+
+Eclair supports per-peer features. Suppose you are connected to Alice and Bob, you can use a different set of features with Alice than the one you use with Bob.
+When experimenting with non-default features, we recommend using this to scope the peers you want to experiment with.
+
+This is done with the `override-features` configuration parameter in your `eclair.conf`:
+
+```conf
+eclair.override-features = [
+    {
+        nodeId = "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        features {
+            initial_routing_sync = disabled
+            option_static_remotekey = optional
+        }
+    },
+    {
+        nodeId = "<another nodeId>"
+        features {
+            option_static_remotekey = optional
+            option_support_large_channel = optional
+        }
+    },
+]
+```
+
+## Customize feerate tolerance
+
+In order to secure your channels' funds against attacks, your eclair node keeps an up-to-date estimate of on-chain feerates (based on your Bitcoin node's estimations).
+When that estimate deviates from what your peers estimate, eclair may automatically close channels that are at risk to guarantee the safety of your funds.
+
+Since predicting the future is hard and imperfect, eclair has a tolerance for deviations, governed by the following parameters:
+
+```conf
+on-chain-fees {
+    feerate-tolerance {
+      ratio-low = 0.5 // will allow remote fee rates as low as half our local feerate
+      ratio-high = 10.0 // will allow remote fee rates as high as 10 times our local feerate
+    }
+}
+```
+
+We do not recommend changing these values unless you really know what you're doing.
+But if you have a trust relationship with some specific peers and know they will never try to cheat you, you can increase the tolerance specifically for those peers.
+On the other hand, if you have channels with peers you suspect may try to attack you, you can decrease the tolerance specifically for those peers.
+
+```conf
+on-chain-fees {
+    override-feerate-tolerance = [
+        {
+            nodeid = "<nodeId of a trusted peer>"
+            feerate-tolerance {
+                ratio-low = 0.1 // will allow remote fee rates as low as 10% our local feerate
+                ratio-high = 15.0 // will allow remote fee rates as high as 15 times our local feerate
+            }
+        },
+        {
+            nodeid = "<nodeId of a peer we don't trust at all>"
+            feerate-tolerance {
+                // will only allow remote fees between 75% and 200% of our local feerate
+                ratio-low = 0.75
+                ratio-high = 2.0
+            }
+        }
+    ]
+}
+```
+
+## Examples
+
+### Basic configuration
+
+This is a common configuration file which overrides the default server port, node's label and node's color and enables the API (needed to interact with your node with `eclair-cli`):
+
+```conf
+# server port
+eclair.server.port=9737
+
+# node's label
+eclair.node-alias="my node"
+# rgb node's color
+eclair.node-color=49daaa
+
+eclair.api.enabled=true
+# You should set a real password here.
+eclair.api.password=foobar
+# Make sure this port isn't accessible from the internet!
+eclair.api.port=8080
+```
+
+### Regtest mode
+
+To run with Bitcoin's `regtest` mode, you need to set the `chain` reference:
+
+```conf
+eclair.chain = "regtest"
+```
+
+You usually also need to disable the feerate mismatch
+
+### Public node
+
+To make your node public, add a public ip:
+
+```conf
+eclair.server.public-ips=[x.x.x.x]
+```
+
+You'll also have to make sure that the node is accessible from the outside world (port forwarding, firewall,...).

--- a/docs/Configure.md
+++ b/docs/Configure.md
@@ -11,7 +11,7 @@ eclair-node.sh -Declair.datadir="/path/to/custom/eclair/data/folder"
 
 The first step is to **actually create the configuration file**.
 Go to `eclair.datadir` and create a file named `eclair.conf`.
-The dncoding should be UTF-8.
+The encoding should be UTF-8.
 
 Options are set as key-value pairs and follow the [HOCON syntax](https://github.com/lightbend/config/blob/master/HOCON.md).
 Values do not need to be surrounded by quotes, except if they contain special characters.

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -115,13 +115,13 @@ eclair {
       ratio-high = 10.0 // will allow remote fee rates as high as 10 times our local feerate
     }
     override-feerate-tolerance = [ // optional per-node feerate tolerance
-      //      {
-      //        nodeid = "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      //        feerate-tolerance {
-      //          ratio-low = 0.1
-      //          ratio-high = 20.0
-      //        }
-      //      }
+      #  {
+      #    nodeid = "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      #    feerate-tolerance {
+      #      ratio-low = 0.1
+      #      ratio-high = 20.0
+      #    }
+      #  }
     ]
 
     close-on-offline-feerate-mismatch = true // do not change this unless you know what you are doing

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -114,6 +114,16 @@ eclair {
       ratio-low = 0.5 // will allow remote fee rates as low as half our local feerate
       ratio-high = 10.0 // will allow remote fee rates as high as 10 times our local feerate
     }
+    override-feerate-tolerance = [ // optional per-node feerate tolerance
+      //      {
+      //        nodeid = "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      //        feerate-tolerance {
+      //          ratio-low = 0.1
+      //          ratio-high = 20.0
+      //        }
+      //      }
+    ]
+
     close-on-offline-feerate-mismatch = true // do not change this unless you know what you are doing
 
     // funder will send an UpdateFee message if the difference between current commitment fee and actual current network fee is greater

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -277,9 +277,14 @@ object NodeParams {
       onChainFeeConf = OnChainFeeConf(
         feeTargets = feeTargets,
         feeEstimator = feeEstimator,
-        maxFeerateMismatch = FeerateTolerance(config.getDouble("on-chain-fees.feerate-tolerance.ratio-low"), config.getDouble("on-chain-fees.feerate-tolerance.ratio-high")),
         closeOnOfflineMismatch = config.getBoolean("on-chain-fees.close-on-offline-feerate-mismatch"),
-        updateFeeMinDiffRatio = config.getDouble("on-chain-fees.update-fee-min-diff-ratio")
+        updateFeeMinDiffRatio = config.getDouble("on-chain-fees.update-fee-min-diff-ratio"),
+        defaultFeerateTolerance = FeerateTolerance(config.getDouble("on-chain-fees.feerate-tolerance.ratio-low"), config.getDouble("on-chain-fees.feerate-tolerance.ratio-high")),
+        perNodeFeerateTolerance = config.getConfigList("on-chain-fees.override-feerate-tolerance").asScala.map { e =>
+          val nodeId = PublicKey(ByteVector.fromValidHex(e.getString("nodeid")))
+          val tolerance = FeerateTolerance(e.getDouble("feerate-tolerance.ratio-low"), e.getDouble("feerate-tolerance.ratio-high"))
+          nodeId -> tolerance
+        }.toMap
       ),
       maxHtlcValueInFlightMsat = UInt64(config.getLong("max-htlc-value-in-flight-msat")),
       maxAcceptedHtlcs = maxAcceptedHtlcs,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeEstimator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeEstimator.scala
@@ -16,16 +16,19 @@
 
 package fr.acinq.eclair.blockchain.fee
 
+import fr.acinq.bitcoin.Crypto.PublicKey
+
 trait FeeEstimator {
-
+  // @formatter:off
   def getFeeratePerKb(target: Int): FeeratePerKB
-
   def getFeeratePerKw(target: Int): FeeratePerKw
-
+  // @formatter:on
 }
 
 case class FeeTargets(fundingBlockTarget: Int, commitmentBlockTarget: Int, mutualCloseBlockTarget: Int, claimMainBlockTarget: Int)
 
 case class FeerateTolerance(ratioLow: Double, ratioHigh: Double)
 
-case class OnChainFeeConf(feeTargets: FeeTargets, feeEstimator: FeeEstimator, maxFeerateMismatch: FeerateTolerance, closeOnOfflineMismatch: Boolean, updateFeeMinDiffRatio: Double)
+case class OnChainFeeConf(feeTargets: FeeTargets, feeEstimator: FeeEstimator, closeOnOfflineMismatch: Boolean, updateFeeMinDiffRatio: Double, private val defaultFeerateTolerance: FeerateTolerance, private val perNodeFeerateTolerance: Map[PublicKey, FeerateTolerance]) {
+  def maxFeerateMismatchFor(nodeId: PublicKey): FeerateTolerance = perNodeFeerateTolerance.getOrElse(nodeId, defaultFeerateTolerance)
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -273,7 +273,7 @@ object Commitments {
     // we allowed mismatches between our feerates and our remote's as long as commitments didn't contain any HTLC at risk
     // we need to verify that we're not disagreeing on feerates anymore before offering new HTLCs
     val localFeeratePerKw = feeConf.feeEstimator.getFeeratePerKw(target = feeConf.feeTargets.commitmentBlockTarget)
-    if (Helpers.isFeeDiffTooHigh(localFeeratePerKw, commitments.localCommit.spec.feeratePerKw, feeConf.maxFeerateMismatch)) {
+    if (Helpers.isFeeDiffTooHigh(localFeeratePerKw, commitments.localCommit.spec.feeratePerKw, feeConf.maxFeerateMismatchFor(commitments.remoteNodeId))) {
       return Left(FeerateTooDifferent(commitments.channelId, localFeeratePerKw = localFeeratePerKw, remoteFeeratePerKw = commitments.localCommit.spec.feeratePerKw))
     }
 
@@ -334,7 +334,7 @@ object Commitments {
     // we allowed mismatches between our feerates and our remote's as long as commitments didn't contain any HTLC at risk
     // we need to verify that we're not disagreeing on feerates anymore before accepting new HTLCs
     val localFeeratePerKw = feeConf.feeEstimator.getFeeratePerKw(target = feeConf.feeTargets.commitmentBlockTarget)
-    if (Helpers.isFeeDiffTooHigh(localFeeratePerKw, commitments.localCommit.spec.feeratePerKw, feeConf.maxFeerateMismatch)) {
+    if (Helpers.isFeeDiffTooHigh(localFeeratePerKw, commitments.localCommit.spec.feeratePerKw, feeConf.maxFeerateMismatchFor(commitments.remoteNodeId))) {
       throw FeerateTooDifferent(commitments.channelId, localFeeratePerKw = localFeeratePerKw, remoteFeeratePerKw = commitments.localCommit.spec.feeratePerKw)
     }
 
@@ -470,7 +470,7 @@ object Commitments {
       Metrics.RemoteFeeratePerKw.withoutTags().record(fee.feeratePerKw.toLong)
       val localFeeratePerKw = feeConf.feeEstimator.getFeeratePerKw(target = feeConf.feeTargets.commitmentBlockTarget)
       log.info("remote feeratePerKw={}, local feeratePerKw={}, ratio={}", fee.feeratePerKw, localFeeratePerKw, fee.feeratePerKw.toLong.toDouble / localFeeratePerKw.toLong)
-      if (Helpers.isFeeDiffTooHigh(localFeeratePerKw, fee.feeratePerKw, feeConf.maxFeerateMismatch) && commitments.hasPendingOrProposedHtlcs) {
+      if (Helpers.isFeeDiffTooHigh(localFeeratePerKw, fee.feeratePerKw, feeConf.maxFeerateMismatchFor(commitments.remoteNodeId)) && commitments.hasPendingOrProposedHtlcs) {
         Failure(FeerateTooDifferent(commitments.channelId, localFeeratePerKw = localFeeratePerKw, remoteFeeratePerKw = fee.feeratePerKw))
       } else {
         // NB: we check that the funder can afford this new fee even if spec allows to do it at next signature

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -95,7 +95,7 @@ object Helpers {
   /**
    * Called by the fundee
    */
-  def validateParamsFundee(nodeParams: NodeParams, features: Features, open: OpenChannel): Unit = {
+  def validateParamsFundee(nodeParams: NodeParams, features: Features, open: OpenChannel, remoteNodeId: PublicKey): Unit = {
     // BOLT #2: if the chain_hash value, within the open_channel, message is set to a hash of a chain that is unknown to the receiver:
     // MUST reject the channel.
     if (nodeParams.chainHash != open.chainHash) throw InvalidChainHash(open.temporaryChannelId, local = nodeParams.chainHash, remote = open.chainHash)
@@ -129,7 +129,7 @@ object Helpers {
 
     // BOLT #2: The receiving node MUST fail the channel if: it considers feerate_per_kw too small for timely processing or unreasonably large.
     val localFeeratePerKw = nodeParams.onChainFeeConf.feeEstimator.getFeeratePerKw(target = nodeParams.onChainFeeConf.feeTargets.commitmentBlockTarget)
-    if (isFeeDiffTooHigh(localFeeratePerKw, open.feeratePerKw, nodeParams.onChainFeeConf.maxFeerateMismatch)) throw FeerateTooDifferent(open.temporaryChannelId, localFeeratePerKw, open.feeratePerKw)
+    if (isFeeDiffTooHigh(localFeeratePerKw, open.feeratePerKw, nodeParams.onChainFeeConf.maxFeerateMismatchFor(remoteNodeId))) throw FeerateTooDifferent(open.temporaryChannelId, localFeeratePerKw, open.feeratePerKw)
     // only enforce dust limit check on mainnet
     if (nodeParams.chainHash == Block.LivenetGenesisBlock.hash) {
       if (open.dustLimitSatoshis < Channel.MIN_DUSTLIMIT) throw DustLimitTooSmall(open.temporaryChannelId, open.dustLimitSatoshis, Channel.MIN_DUSTLIMIT)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -158,9 +158,10 @@ object TestConstants {
       onChainFeeConf = OnChainFeeConf(
         feeTargets = FeeTargets(6, 2, 2, 6),
         feeEstimator = new TestFeeEstimator,
-        maxFeerateMismatch = FeerateTolerance(0.5, 8.0),
         closeOnOfflineMismatch = true,
-        updateFeeMinDiffRatio = 0.1
+        updateFeeMinDiffRatio = 0.1,
+        defaultFeerateTolerance = FeerateTolerance(0.5, 8.0),
+        perNodeFeerateTolerance = Map.empty
       ),
       maxHtlcValueInFlightMsat = UInt64(150000000),
       maxAcceptedHtlcs = 100,
@@ -252,9 +253,10 @@ object TestConstants {
       onChainFeeConf = OnChainFeeConf(
         feeTargets = FeeTargets(6, 2, 2, 6),
         feeEstimator = new TestFeeEstimator,
-        maxFeerateMismatch = FeerateTolerance(0.75, 1.5),
         closeOnOfflineMismatch = true,
-        updateFeeMinDiffRatio = 0.1
+        updateFeeMinDiffRatio = 0.1,
+        defaultFeerateTolerance = FeerateTolerance(0.75, 1.5),
+        perNodeFeerateTolerance = Map.empty
       ),
       maxHtlcValueInFlightMsat = UInt64.MaxValue, // Bob has no limit on the combined max value of in-flight htlcs
       maxAcceptedHtlcs = 30,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -43,7 +43,7 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
 
   implicit val log: akka.event.LoggingAdapter = akka.event.NoLogging
 
-  val feeConfNoMismatch = OnChainFeeConf(FeeTargets(6, 2, 2, 6), new TestFeeEstimator, FeerateTolerance(0.00001, 100000.0), closeOnOfflineMismatch = false, 1.0)
+  val feeConfNoMismatch = OnChainFeeConf(FeeTargets(6, 2, 2, 6), new TestFeeEstimator, closeOnOfflineMismatch = false, 1.0, FeerateTolerance(0.00001, 100000.0), Map.empty)
 
   override def withFixture(test: OneArgTest): Outcome = {
     val setup = init()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
@@ -53,7 +53,7 @@ trait StateTestsHelperMethods extends TestKitBase with FixtureTestSuite with Par
                           relayerB: TestProbe,
                           channelUpdateListener: TestProbe,
                           wallet: EclairWallet) {
-    def currentBlockHeight = alice.underlyingActor.nodeParams.currentBlockHeight
+    def currentBlockHeight: Long = alice.underlyingActor.nodeParams.currentBlockHeight
   }
 
   def init(nodeParamsA: NodeParams = TestConstants.Alice.nodeParams, nodeParamsB: NodeParams = TestConstants.Bob.nodeParams, wallet: EclairWallet = new TestWallet): SetupFixture = {


### PR DESCRIPTION
When we have a trusted relationship with some of our peers (business relations, family members, our own mobile wallet, etc) it makes sense to relax the feerate mismatch constraint.

This must be done per-node, to avoid leaving the gates open for attackers.