### PR TITLE
Rework features compatibility

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -62,9 +62,10 @@ case class Features(activated: Set[ActivatedFeature], unknown: Set[UnknownFeatur
 
   def hasPluginFeature(feature: UnknownFeature): Boolean = unknown.contains(feature)
 
+  /** NB: this method is not reflexive, see [[Features.areCompatible]] if you want symmetric validation. */
   def areSupported(remoteFeatures: Features): Boolean = {
     // we allow unknown odd features (it's ok to be odd)
-    val unknownFeaturesOk = !remoteFeatures.unknown.exists(_.bitIndex % 2 == 0)
+    val unknownFeaturesOk = remoteFeatures.unknown.forall(_.bitIndex % 2 == 1)
     // we verify that we activated every mandatory feature they require
     val knownFeaturesOk = remoteFeatures.activated.forall {
       case ActivatedFeature(_, Optional) => true

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -127,7 +127,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
           d.pendingAuth.origin_opt.foreach(_ ! ConnectionResult.InitializationFailed(featureGraphErr.message))
           d.transport ! PoisonPill
           stay
-        } else if (!Features.areSupported(remoteInit.features)) {
+        } else if (!Features.areCompatible(d.localInit.features, remoteInit.features)) {
           log.warning("incompatible features, disconnecting")
           d.pendingAuth.origin_opt.foreach(_ ! ConnectionResult.InitializationFailed("incompatible features"))
           d.transport ! PoisonPill

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentRequest.scala
@@ -19,7 +19,7 @@ package fr.acinq.eclair.payment
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{Base58, Base58Check, Bech32, Block, ByteVector32, ByteVector64, Crypto}
 import fr.acinq.eclair.payment.PaymentRequest._
-import fr.acinq.eclair.{CltvExpiryDelta, FeatureSupport, Features, LongToBtcAmount, MilliSatoshi, ShortChannelId, randomBytes32}
+import fr.acinq.eclair.{CltvExpiryDelta, FeatureSupport, Features, LongToBtcAmount, MilliSatoshi, NodeParams, ShortChannelId, randomBytes32}
 import scodec.bits.{BitVector, ByteOrdering, ByteVector}
 import scodec.codecs.{list, ubyte}
 import scodec.{Codec, Err}
@@ -339,13 +339,14 @@ object PaymentRequest {
    */
   case class PaymentRequestFeatures(bitmask: BitVector) extends TaggedField {
     lazy val features: Features = Features(bitmask)
-    lazy val supported: Boolean = Features.areSupported(features)
     lazy val allowMultiPart: Boolean = features.hasFeature(Features.BasicMultiPartPayment)
     lazy val allowPaymentSecret: Boolean = features.hasFeature(Features.PaymentSecret)
     lazy val requirePaymentSecret: Boolean = features.hasFeature(Features.PaymentSecret, Some(FeatureSupport.Mandatory))
     lazy val allowTrampoline: Boolean = features.hasFeature(Features.TrampolinePayment)
 
     def toByteVector: ByteVector = features.toByteVector
+
+    def areSupported(nodeParams: NodeParams): Boolean = nodeParams.features.areSupported(features)
 
     override def toString: String = s"Features(${bitmask.toBin})"
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -52,7 +52,7 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, register: Actor
       val paymentCfg = SendPaymentConfig(paymentId, paymentId, r.externalId, r.paymentHash, r.recipientAmount, r.recipientNodeId, Upstream.Local(paymentId), r.paymentRequest, storeInDb = true, publishEvent = true, Nil)
       val finalExpiry = r.finalExpiry(nodeParams.currentBlockHeight)
       r.paymentRequest match {
-        case Some(invoice) if !invoice.features.supported =>
+        case Some(invoice) if !invoice.features.areSupported(nodeParams) =>
           sender ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(Nil, UnsupportedFeatures(invoice.features.features)) :: Nil)
         case Some(invoice) if invoice.features.allowMultiPart && nodeParams.features.hasFeature(BasicMultiPartPayment) =>
           invoice.paymentSecret match {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
@@ -102,37 +102,105 @@ class FeaturesSpec extends AnyFunSuite {
   }
 
   test("features compatibility") {
-    case class TestCase(ours: Features, theirs: Features, compatible: Boolean)
+    case class TestCase(ours: Features, theirs: Features, oursSupportTheirs: Boolean, theirsSupportOurs: Boolean, compatible: Boolean)
     val testCases = Seq(
       // Empty features
-      TestCase(Features.empty, Features.empty, compatible = true),
-      TestCase(Features.empty, Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Optional))), compatible = true),
-      TestCase(Features.empty, Features(Set.empty, Set(UnknownFeature(101), UnknownFeature(103))), compatible = true),
+      TestCase(
+        Features.empty,
+        Features.empty,
+        oursSupportTheirs = true,
+        theirsSupportOurs = true,
+        compatible = true
+      ),
+      TestCase(
+        Features.empty,
+        Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Optional))),
+        oursSupportTheirs = true,
+        theirsSupportOurs = true,
+        compatible = true
+      ),
+      TestCase(
+        Features.empty,
+        Features(Set.empty, Set(UnknownFeature(101), UnknownFeature(103))),
+        oursSupportTheirs = true,
+        theirsSupportOurs = true,
+        compatible = true
+      ),
       // Same feature set
-      TestCase(Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Mandatory))), Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Mandatory))), compatible = true),
+      TestCase(
+        Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Mandatory))),
+        Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Mandatory))),
+        oursSupportTheirs = true,
+        theirsSupportOurs = true,
+        compatible = true
+      ),
       // Many optional features
-      TestCase(Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Optional), ActivatedFeature(ChannelRangeQueries, Optional), ActivatedFeature(PaymentSecret, Optional))), Features(Set(ActivatedFeature(VariableLengthOnion, Optional), ActivatedFeature(ChannelRangeQueries, Optional), ActivatedFeature(ChannelRangeQueriesExtended, Optional))), compatible = true),
+      TestCase(
+        Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Optional), ActivatedFeature(ChannelRangeQueries, Optional), ActivatedFeature(PaymentSecret, Optional))),
+        Features(Set(ActivatedFeature(VariableLengthOnion, Optional), ActivatedFeature(ChannelRangeQueries, Optional), ActivatedFeature(ChannelRangeQueriesExtended, Optional))),
+        oursSupportTheirs = true,
+        theirsSupportOurs = true,
+        compatible = true
+      ),
       // We support their mandatory features
-      TestCase(Features(Set(ActivatedFeature(VariableLengthOnion, Optional))), Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Mandatory))), compatible = true),
+      TestCase(
+        Features(Set(ActivatedFeature(VariableLengthOnion, Optional))),
+        Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Mandatory))),
+        oursSupportTheirs = true,
+        theirsSupportOurs = true,
+        compatible = true
+      ),
       // They support our mandatory features
-      TestCase(Features(Set(ActivatedFeature(VariableLengthOnion, Mandatory))), Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Optional))), compatible = true),
+      TestCase(
+        Features(Set(ActivatedFeature(VariableLengthOnion, Mandatory))),
+        Features(Set(ActivatedFeature(InitialRoutingSync, Optional), ActivatedFeature(VariableLengthOnion, Optional))),
+        oursSupportTheirs = true,
+        theirsSupportOurs = true,
+        compatible = true
+      ),
       // They have unknown optional features
-      TestCase(Features(Set(ActivatedFeature(VariableLengthOnion, Optional))), Features(Set(ActivatedFeature(VariableLengthOnion, Optional)), Set(UnknownFeature(141))), compatible = true),
+      TestCase(
+        Features(Set(ActivatedFeature(VariableLengthOnion, Optional))),
+        Features(Set(ActivatedFeature(VariableLengthOnion, Optional)), Set(UnknownFeature(141))),
+        oursSupportTheirs = true,
+        theirsSupportOurs = true,
+        compatible = true
+      ),
       // They have unknown mandatory features
-      TestCase(Features(Set(ActivatedFeature(VariableLengthOnion, Optional))), Features(Set(ActivatedFeature(VariableLengthOnion, Optional)), Set(UnknownFeature(142))), compatible = false),
+      TestCase(
+        Features(Set(ActivatedFeature(VariableLengthOnion, Optional))),
+        Features(Set(ActivatedFeature(VariableLengthOnion, Optional)), Set(UnknownFeature(142))),
+        oursSupportTheirs = false,
+        theirsSupportOurs = true,
+        compatible = false
+      ),
       // We don't support one of their mandatory features
-      TestCase(Features(Set(ActivatedFeature(ChannelRangeQueries, Optional))), Features(Set(ActivatedFeature(ChannelRangeQueries, Mandatory), ActivatedFeature(VariableLengthOnion, Mandatory))), compatible = false),
+      TestCase(
+        Features(Set(ActivatedFeature(ChannelRangeQueries, Optional))),
+        Features(Set(ActivatedFeature(ChannelRangeQueries, Mandatory), ActivatedFeature(VariableLengthOnion, Mandatory))),
+        oursSupportTheirs = false,
+        theirsSupportOurs = true,
+        compatible = false
+      ),
       // They don't support one of our mandatory features
-      TestCase(Features(Set(ActivatedFeature(VariableLengthOnion, Mandatory), ActivatedFeature(PaymentSecret, Mandatory))), Features(Set(ActivatedFeature(VariableLengthOnion, Optional))), compatible = false),
+      TestCase(
+        Features(Set(ActivatedFeature(VariableLengthOnion, Mandatory), ActivatedFeature(PaymentSecret, Mandatory))),
+        Features(Set(ActivatedFeature(VariableLengthOnion, Optional))),
+        oursSupportTheirs = true,
+        theirsSupportOurs = false,
+        compatible = false
+      ),
       // nonreg testing of future features (needs to be updated with every new supported mandatory bit)
-      TestCase(Features.empty, Features(Set.empty, Set(UnknownFeature(22))), compatible = false),
-      TestCase(Features.empty, Features(Set.empty, Set(UnknownFeature(23))), compatible = true),
-      TestCase(Features.empty, Features(Set.empty, Set(UnknownFeature(24))), compatible = false),
-      TestCase(Features.empty, Features(Set.empty, Set(UnknownFeature(25))), compatible = true)
+      TestCase(Features.empty, Features(Set.empty, Set(UnknownFeature(22))), oursSupportTheirs = false, theirsSupportOurs = true, compatible = false),
+      TestCase(Features.empty, Features(Set.empty, Set(UnknownFeature(23))), oursSupportTheirs = true, theirsSupportOurs = true, compatible = true),
+      TestCase(Features.empty, Features(Set.empty, Set(UnknownFeature(24))), oursSupportTheirs = false, theirsSupportOurs = true, compatible = false),
+      TestCase(Features.empty, Features(Set.empty, Set(UnknownFeature(25))), oursSupportTheirs = true, theirsSupportOurs = true, compatible = true)
     )
 
     for (testCase <- testCases) {
-      assert(areCompatible(testCase.ours, testCase.theirs) === testCase.compatible)
+      assert(areCompatible(testCase.ours, testCase.theirs) === testCase.compatible, testCase)
+      assert(testCase.ours.areSupported(testCase.theirs) === testCase.oursSupportTheirs, testCase)
+      assert(testCase.theirs.areSupported(testCase.ours) === testCase.theirsSupportOurs, testCase)
     }
   }
 


### PR DESCRIPTION
The `supportedMandatoryFeatures` set made less and less sense as we start supporting more features and allowing users to turn features on and off depending on the peers they connect to.