### PR TITLE
Post restart plugin htlcs 2

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -309,7 +309,7 @@ class Setup(datadir: File,
       relayer = system.actorOf(SimpleSupervisor.props(Relayer.props(nodeParams, router, register, paymentHandler), "relayer", SupervisorStrategy.Resume))
       // Before initializing the switchboard (which re-connects us to the network) and the user-facing parts of the system,
       // we want to make sure the handler for post-restart broken HTLCs has finished initializing.
-      _ <- (relayer ? PluginCommitmemnts(pluginCommitments)).mapTo[Done]
+      _ <- (relayer ? PluginCommitments(pluginCommitments)).mapTo[Done]
       switchboard = system.actorOf(SimpleSupervisor.props(Switchboard.props(nodeParams, watcher, relayer, wallet), "switchboard", SupervisorStrategy.Resume))
       _ = system.actorOf(SimpleSupervisor.props(ClientSpawner.props(nodeParams.keyPair, nodeParams.socksProxy_opt, nodeParams.peerConnectionConf, switchboard, router), "client-spawner", SupervisorStrategy.Restart))
       server = system.actorOf(SimpleSupervisor.props(Server.props(nodeParams.keyPair, nodeParams.peerConnectionConf, switchboard, router, serverBindingAddress, Some(tcpBound)), "server", SupervisorStrategy.Restart))
@@ -416,4 +416,4 @@ case object IncompatibleDBException extends RuntimeException("database is not co
 
 case object IncompatibleNetworkDBException extends RuntimeException("network database is not compatible with this version of eclair")
 
-case class PluginCommitmemnts(commitments: Seq[HasAbstractCommitments])
+case class PluginCommitments(commitments: Seq[HasAbstractCommitments])

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -39,7 +39,7 @@ import fr.acinq.eclair.blockchain.electrum._
 import fr.acinq.eclair.blockchain.electrum.db.sqlite.SqliteWalletDb
 import fr.acinq.eclair.blockchain.fee.{ConstantFeeProvider, _}
 import fr.acinq.eclair.blockchain.{EclairWallet, _}
-import fr.acinq.eclair.channel.Register
+import fr.acinq.eclair.channel.{HasAbstractCommitments, Register}
 import fr.acinq.eclair.crypto.LocalKeyManager
 import fr.acinq.eclair.db.Databases.FileBackup
 import fr.acinq.eclair.db.{Databases, FileBackupHandler}
@@ -55,6 +55,7 @@ import fr.acinq.eclair.wire.NodeAddress
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST.JArray
 import scodec.bits.ByteVector
+import akka.pattern.ask
 
 import scala.concurrent._
 import scala.concurrent.duration._
@@ -65,12 +66,15 @@ import scala.util.{Failure, Success}
  *
  * Created by PM on 25/01/2016.
  *
- * @param datadir  directory where eclair-core will write/read its data.
- * @param seed_opt optional seed, if set eclair will use it instead of generating one and won't create a seed.dat file.
- * @param db       optional databases to use, if not set eclair will create the necessary databases
+ * @param datadir           directory where eclair-core will write/read its data.
+ * @param pluginParams      parameters for all configured plugins.
+ * @param pluginCommitments plugin-specific data types which contain an implementation of AbstractCommitments trait.
+ * @param seed_opt          optional seed, if set eclair will use it instead of generating one and won't create a seed.dat file.
+ * @param db                optional databases to use, if not set eclair will create the necessary databases
  */
 class Setup(datadir: File,
             pluginParams: Seq[PluginParams],
+            pluginCommitments: Seq[HasAbstractCommitments],
             seed_opt: Option[ByteVector] = None,
             db: Option[Databases] = None)(implicit system: ActorSystem) extends Logging {
 
@@ -217,7 +221,6 @@ class Setup(datadir: File,
       zmqTxConnected = Promise[Done]()
       tcpBound = Promise[Done]()
       routerInitialized = Promise[Done]()
-      postRestartCleanUpInitialized = Promise[Done]()
 
       defaultFeerates = {
         val confDefaultFeerates = FeeratesPerKB(
@@ -285,7 +288,7 @@ class Setup(datadir: File,
       _ = wallet.getReceiveAddress.map(address => logger.info(s"initial wallet address=$address"))
       // do not change the name of this actor. it is used in the configuration to specify a custom bounded mailbox
 
-      backupHandler = if (config.getBoolean("enable-db-backup")) {
+      _ = if (config.getBoolean("enable-db-backup")) {
         nodeParams.db match {
           case fileBackup: FileBackup => system.actorOf(SimpleSupervisor.props(
             FileBackupHandler.props(
@@ -300,15 +303,15 @@ class Setup(datadir: File,
         logger.warn("database backup is disabled")
         system.deadLetters
       }
-      audit = system.actorOf(SimpleSupervisor.props(Auditor.props(nodeParams), "auditor", SupervisorStrategy.Resume))
+      _ = system.actorOf(SimpleSupervisor.props(Auditor.props(nodeParams), "auditor", SupervisorStrategy.Resume))
       register = system.actorOf(SimpleSupervisor.props(Props(new Register), "register", SupervisorStrategy.Resume))
       paymentHandler = system.actorOf(SimpleSupervisor.props(PaymentHandler.props(nodeParams, register), "payment-handler", SupervisorStrategy.Resume))
-      relayer = system.actorOf(SimpleSupervisor.props(Relayer.props(nodeParams, router, register, paymentHandler, Some(postRestartCleanUpInitialized)), "relayer", SupervisorStrategy.Resume))
+      relayer = system.actorOf(SimpleSupervisor.props(Relayer.props(nodeParams, router, register, paymentHandler), "relayer", SupervisorStrategy.Resume))
       // Before initializing the switchboard (which re-connects us to the network) and the user-facing parts of the system,
       // we want to make sure the handler for post-restart broken HTLCs has finished initializing.
-      _ <- postRestartCleanUpInitialized.future
+      _ <- (relayer ? PluginCommitmemnts(pluginCommitments)).mapTo[Done]
       switchboard = system.actorOf(SimpleSupervisor.props(Switchboard.props(nodeParams, watcher, relayer, wallet), "switchboard", SupervisorStrategy.Resume))
-      clientSpawner = system.actorOf(SimpleSupervisor.props(ClientSpawner.props(nodeParams.keyPair, nodeParams.socksProxy_opt, nodeParams.peerConnectionConf, switchboard, router), "client-spawner", SupervisorStrategy.Restart))
+      _ = system.actorOf(SimpleSupervisor.props(ClientSpawner.props(nodeParams.keyPair, nodeParams.socksProxy_opt, nodeParams.peerConnectionConf, switchboard, router), "client-spawner", SupervisorStrategy.Restart))
       server = system.actorOf(SimpleSupervisor.props(Server.props(nodeParams.keyPair, nodeParams.peerConnectionConf, switchboard, router, serverBindingAddress, Some(tcpBound)), "server", SupervisorStrategy.Restart))
       paymentInitiator = system.actorOf(SimpleSupervisor.props(PaymentInitiator.props(nodeParams, router, register), "payment-initiator", SupervisorStrategy.Restart))
       _ = for (i <- 0 until config.getInt("autoprobe-count")) yield system.actorOf(SimpleSupervisor.props(Autoprobe.props(nodeParams, router, paymentInitiator), s"payment-autoprobe-$i", SupervisorStrategy.Restart))
@@ -412,3 +415,5 @@ case object EmptyAPIPasswordException extends RuntimeException("must set a passw
 case object IncompatibleDBException extends RuntimeException("database is not compatible with this version of eclair")
 
 case object IncompatibleNetworkDBException extends RuntimeException("network database is not compatible with this version of eclair")
+
+case class PluginCommitmemnts(commitments: Seq[HasAbstractCommitments])

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -44,6 +44,8 @@ case class LocalChannelDown(channel: ActorRef, channelId: ByteVector32, shortCha
 
 case class ChannelStateChanged(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, previousState: State, currentState: State, currentData: Data) extends ChannelEvent
 
+case class PluginWithHTLCStateChanged(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, previousState: State, currentState: State, currentData: HasAbstractCommitments) extends ChannelEvent
+
 case class ChannelSignatureSent(channel: ActorRef, commitments: Commitments) extends ChannelEvent
 
 case class ChannelSignatureReceived(channel: ActorRef, commitments: Commitments) extends ChannelEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -48,6 +48,8 @@ case class WaitingForRevocation(nextRemoteCommit: RemoteCommit, sent: CommitSig,
 // @formatter:on
 
 trait AbstractCommitments {
+  def getOutgoingFromRemoteHtlcsCrossSigned: Set[UpdateAddHtlc]
+
   def getOutgoingHtlcCrossSigned(htlcId: Long): Option[UpdateAddHtlc]
 
   def getIncomingHtlcCrossSigned(htlcId: Long): Option[UpdateAddHtlc]
@@ -105,6 +107,8 @@ case class Commitments(channelVersion: ChannelVersion,
       remoteCommit.spec.htlcs.collect(incoming).filter(expired) ++
       remoteNextCommitInfo.left.toSeq.flatMap(_.nextRemoteCommit.spec.htlcs.collect(incoming).filter(expired).toSet)
   }
+
+  def getOutgoingFromRemoteHtlcsCrossSigned: Set[UpdateAddHtlc] = remoteCommit.spec.htlcs.collect(outgoing)
 
   def getOutgoingHtlcCrossSigned(htlcId: Long): Option[UpdateAddHtlc] = for {
     localSigned <- remoteNextCommitInfo.left.toOption.map(_.nextRemoteCommit).getOrElse(remoteCommit).spec.findIncomingHtlcById(htlcId)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
@@ -71,35 +71,11 @@ class PostRestartHtlcCleaner(nodeParams: NodeParams, register: ActorRef) extends
     // When channels are restarted we immediately fail the incoming HTLCs that weren't relayed.
     case e@ChannelStateChanged(channel, _, _, WAIT_FOR_INIT_INTERNAL | OFFLINE | SYNCING | CLOSING, NORMAL | SHUTDOWN | CLOSING | CLOSED, data: HasCommitments) =>
       log.debug("channel {}: {} -> {}", data.channelId, e.previousState, e.currentState)
-      val acked = brokenHtlcs.notRelayed
-        .filter(_.add.channelId == data.channelId) // only consider htlcs coming from this channel
-        .filter {
-          case IncomingHtlc(htlc, preimage_opt) if data.commitments.getIncomingHtlcCrossSigned(htlc.id).isDefined =>
-            // this htlc is cross signed in the current commitment, we can settle it
-            preimage_opt match {
-              case Some(preimage) =>
-                log.info(s"fulfilling broken htlc=$htlc")
-                Metrics.Resolved.withTag(Tags.Success, value = true).withTag(Metrics.Relayed, value = false).increment()
-                if (e.currentState != CLOSED) {
-                  channel ! CMD_FULFILL_HTLC(htlc.id, preimage, commit = true)
-                }
-              case None =>
-                log.info(s"failing not relayed htlc=$htlc")
-                Metrics.Resolved.withTag(Tags.Success, value = false).withTag(Metrics.Relayed, value = false).increment()
-                if (e.currentState != CLOSING && e.currentState != CLOSED) {
-                  channel ! CMD_FAIL_HTLC(htlc.id, Right(TemporaryNodeFailure), commit = true)
-                }
-            }
-            false // the channel may very well be disconnected before we sign (=ack) the fail/fulfill, so we keep it for now
-          case _ =>
-            true // the htlc has already been settled, we can forget about it now
-        }
-      acked.foreach(htlc => log.info(s"forgetting htlc id=${htlc.add.id} channelId=${htlc.add.channelId}"))
-      val notRelayed1 = brokenHtlcs.notRelayed diff acked
-      Metrics.PendingNotRelayed.update(notRelayed1.size)
-      context become main(brokenHtlcs.copy(notRelayed = notRelayed1))
+      resolveNotRelayedBrokenHtlcs(brokenHtlcs, e.previousState, e.currentState, channel, data.commitments)
 
-    case _: ChannelStateChanged => // ignore other channel state changes
+    case e@PluginWithHTLCStateChanged(channel, _, _, WAIT_FOR_INIT_INTERNAL | OFFLINE | SYNCING | CLOSING, NORMAL | SHUTDOWN | CLOSING | CLOSED, data: HasAbstractCommitments) =>
+      log.debug("plugin channel {}: {} -> {}", data.channelId, e.previousState, e.currentState)
+      resolveNotRelayedBrokenHtlcs(brokenHtlcs, e.previousState, e.currentState, channel, data.commitments)
 
     case RES_ADD_SETTLED(o: Origin.Cold, htlc, fulfill: HtlcResult.Fulfill) =>
       log.info("htlc fulfilled downstream: ({},{})", htlc.channelId, htlc.id)
@@ -110,6 +86,36 @@ class PostRestartHtlcCleaner(nodeParams: NodeParams, register: ActorRef) extends
       handleDownstreamFailure(brokenHtlcs, o, htlc, fail)
 
     case GetBrokenHtlcs => sender ! brokenHtlcs
+  }
+
+  private def resolveNotRelayedBrokenHtlcs(brokenHtlcs: BrokenHtlcs, previousState: State, currentState: State, channel: ActorRef, commitments: AbstractCommitments): Unit = {
+    val acked = brokenHtlcs.notRelayed
+      .filter(_.add.channelId == commitments.channelId) // only consider htlcs coming from this channel
+      .filter {
+        case IncomingHtlc(htlc, preimage_opt) if commitments.getIncomingHtlcCrossSigned(htlc.id).isDefined =>
+          // this htlc is cross signed in the current commitment, we can settle it
+          preimage_opt match {
+            case Some(preimage) =>
+              log.info(s"fulfilling broken htlc=$htlc")
+              Metrics.Resolved.withTag(Tags.Success, value = true).withTag(Metrics.Relayed, value = false).increment()
+              if (currentState != CLOSED) {
+                channel ! CMD_FULFILL_HTLC(htlc.id, preimage, commit = true)
+              }
+            case None =>
+              log.info(s"failing not relayed htlc=$htlc")
+              Metrics.Resolved.withTag(Tags.Success, value = false).withTag(Metrics.Relayed, value = false).increment()
+              if (currentState != CLOSING && currentState != CLOSED) {
+                channel ! CMD_FAIL_HTLC(htlc.id, Right(TemporaryNodeFailure), commit = true)
+              }
+          }
+          false // the channel may very well be disconnected before we sign (=ack) the fail/fulfill, so we keep it for now
+        case _ =>
+          true // the htlc has already been settled, we can forget about it now
+      }
+    acked.foreach(htlc => log.info(s"forgetting htlc id=${htlc.add.id} channelId=${htlc.add.channelId}"))
+    val notRelayed1 = brokenHtlcs.notRelayed diff acked
+    Metrics.PendingNotRelayed.update(notRelayed1.size)
+    context become main(brokenHtlcs.copy(notRelayed = notRelayed1))
   }
 
   private def handleDownstreamFulfill(brokenHtlcs: BrokenHtlcs, origin: Origin.Cold, fulfilledHtlc: UpdateAddHtlc, paymentPreimage: ByteVector32): Unit =

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
@@ -59,7 +59,7 @@ class PostRestartHtlcCleaner(nodeParams: NodeParams, register: ActorRef, initial
   context.system.eventStream.subscribe(self, classOf[ChannelStateChanged])
 
   val brokenHtlcs = {
-    val channels = listLocalChannels(nodeParams.db.channels)
+    val channels: Seq[HasAbstractCommitments] = listLocalChannels(nodeParams.db.channels)
     cleanupRelayDb(channels, nodeParams.db.pendingRelay)
     checkBrokenHtlcs(channels, nodeParams.db.payments, nodeParams.privateKey)
   }
@@ -298,13 +298,12 @@ object PostRestartHtlcCleaner {
    * Outgoing HTLC sets that are still pending may either succeed or fail: we need to watch them to properly forward the
    * result upstream to preserve channels.
    */
-  private def checkBrokenHtlcs(channels: Seq[HasCommitments], paymentsDb: IncomingPaymentsDb, privateKey: PrivateKey)(implicit log: LoggingAdapter): BrokenHtlcs = {
+  private def checkBrokenHtlcs(channels: Seq[HasAbstractCommitments], paymentsDb: IncomingPaymentsDb, privateKey: PrivateKey)(implicit log: LoggingAdapter): BrokenHtlcs = {
     // We are interested in incoming HTLCs, that have been *cross-signed* (otherwise they wouldn't have been relayed).
     // They signed it first, so the HTLC will first appear in our commitment tx, and later on in their commitment when
     // we subsequently sign it. That's why we need to look in *their* commitment with direction=OUT.
     val htlcsIn = channels
-      .flatMap(_.commitments.remoteCommit.spec.htlcs)
-      .collect(outgoing)
+      .flatMap(_.commitments.getOutgoingFromRemoteHtlcsCrossSigned)
       .map(IncomingPacket.decrypt(_, privateKey))
       .collect {
         // When we're not the final recipient, we'll only consider HTLCs that aren't relayed downstream, so no need to look for a preimage.
@@ -321,31 +320,7 @@ object PostRestartHtlcCleaner {
     val relayedOut = channels
       .flatMap { c =>
         // Filter out HTLCs that will never reach the blockchain or have already been timed-out on-chain.
-        val htlcsToIgnore: Set[Long] = c match {
-          case d: DATA_CLOSING =>
-            val closingType_opt = Closing.isClosingTypeAlreadyKnown(d)
-            val overriddenHtlcs: Set[Long] = (closingType_opt match {
-              case Some(c: Closing.LocalClose) => Closing.overriddenOutgoingHtlcs(d, c.localCommitPublished.commitTx)
-              case Some(c: Closing.RemoteClose) => Closing.overriddenOutgoingHtlcs(d, c.remoteCommitPublished.commitTx)
-              case _ => Set.empty[UpdateAddHtlc]
-            }).map(_.id)
-            val irrevocablySpent = closingType_opt match {
-              case Some(c: Closing.LocalClose) => c.localCommitPublished.irrevocablySpent.values.toSet
-              case Some(c: Closing.RemoteClose) => c.remoteCommitPublished.irrevocablySpent.values.toSet
-              case _ => Set.empty[ByteVector32]
-            }
-            val timedoutHtlcs: Set[Long] = (closingType_opt match {
-              case Some(c: Closing.LocalClose) =>
-                val confirmedTxs = c.localCommitPublished.commitTx :: c.localCommitPublished.htlcTimeoutTxs.filter(tx => irrevocablySpent.contains(tx.txid))
-                confirmedTxs.flatMap(tx => Closing.timedoutHtlcs(d.commitments.commitmentFormat, c.localCommit, c.localCommitPublished, d.commitments.localParams.dustLimit, tx))
-              case Some(c: Closing.RemoteClose) =>
-                val confirmedTxs = c.remoteCommitPublished.commitTx :: c.remoteCommitPublished.claimHtlcTimeoutTxs.filter(tx => irrevocablySpent.contains(tx.txid))
-                confirmedTxs.flatMap(tx => Closing.timedoutHtlcs(d.commitments.commitmentFormat, c.remoteCommit, c.remoteCommitPublished, d.commitments.remoteParams.dustLimit, tx))
-              case _ => Seq.empty[UpdateAddHtlc]
-            }).map(_.id).toSet
-            overriddenHtlcs ++ timedoutHtlcs
-          case _ => Set.empty
-        }
+        val htlcsToIgnore: Set[Long] = c.nonRelayableHtlcIds(log)
         c.commitments.originChannels.collect { case (outgoingHtlcId, origin) if !htlcsToIgnore.contains(outgoingHtlcId) => (origin, c.channelId, outgoingHtlcId) }
       }
       .groupBy { case (origin, _, _) => origin }
@@ -387,14 +362,14 @@ object PostRestartHtlcCleaner {
    *
    * That's why we need to periodically clean up the pending relay db.
    */
-  private def cleanupRelayDb(channels: Seq[HasCommitments], relayDb: PendingRelayDb)(implicit log: LoggingAdapter): Unit = {
+  private def cleanupRelayDb(channels: Seq[HasAbstractCommitments], relayDb: PendingRelayDb)(implicit log: LoggingAdapter): Unit = {
     // We are interested in incoming HTLCs, that have been *cross-signed* (otherwise they wouldn't have been relayed).
     // If the HTLC is not in their commitment, it means that we have already fulfilled/failed it and that we can remove
     // the command from the pending relay db.
     val channel2Htlc: Set[(ByteVector32, Long)] =
     channels
-      .flatMap(_.commitments.remoteCommit.spec.htlcs)
-      .collect { case OutgoingHtlc(add) => (add.channelId, add.id) }
+      .flatMap(_.commitments.getOutgoingFromRemoteHtlcsCrossSigned)
+      .map(add => (add.channelId, add.id))
       .toSet
 
     val pendingRelay: Set[(ByteVector32, Long)] = relayDb.listPendingRelay()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.db._
 import fr.acinq.eclair.payment.Monitoring.Tags
 import fr.acinq.eclair.payment.{ChannelPaymentRelayed, IncomingPacket, PaymentFailed, PaymentSent}
 import fr.acinq.eclair.wire.{TemporaryNodeFailure, UpdateAddHtlc}
-import fr.acinq.eclair.{LongToBtcAmount, NodeParams, PluginCommitmemnts}
+import fr.acinq.eclair.{LongToBtcAmount, NodeParams, PluginCommitments}
 
 /**
  * Created by t-bast on 21/11/2019.
@@ -56,7 +56,7 @@ class PostRestartHtlcCleaner(nodeParams: NodeParams, register: ActorRef) extends
   override def receive: Receive = main(BrokenHtlcs(Seq.empty, Map.empty, Set.empty))
 
   def main(brokenHtlcs: BrokenHtlcs): Receive = {
-    case PluginCommitmemnts(pluginCommitmemnts) =>
+    case PluginCommitments(pluginCommitmemnts) =>
       val brokenHtlcs = {
         val channels: Seq[HasAbstractCommitments] = listLocalChannels(nodeParams.db.channels) ++ pluginCommitmemnts
         cleanupRelayDb(channels, nodeParams.db.pendingRelay)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.PendingRelayDb
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.{Logs, MilliSatoshi, NodeParams, ShortChannelId}
+import fr.acinq.eclair.{Logs, MilliSatoshi, NodeParams, PluginCommitmemnts, ShortChannelId}
 import grizzled.slf4j.Logging
 
 import scala.concurrent.Promise
@@ -46,14 +46,14 @@ import scala.concurrent.Promise
  * It also receives channel HTLC events (fulfill / failed) and relays those to the appropriate handlers.
  * It also maintains an up-to-date view of local channel balances.
  */
-class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paymentHandler: ActorRef, initialized: Option[Promise[Done]] = None) extends Actor with DiagnosticActorLogging {
+class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paymentHandler: ActorRef) extends Actor with DiagnosticActorLogging {
 
   import Relayer._
 
   // we pass these to helpers classes so that they have the logging context
   implicit def implicitLog: LoggingAdapter = log
 
-  private val postRestartCleaner = context.actorOf(PostRestartHtlcCleaner.props(nodeParams, register, initialized), "post-restart-htlc-cleaner")
+  private val postRestartCleaner = context.actorOf(PostRestartHtlcCleaner.props(nodeParams, register), "post-restart-htlc-cleaner")
   private val channelRelayer = context.spawn(Behaviors.supervise(ChannelRelayer(nodeParams, register)).onFailure(SupervisorStrategy.resume), "channel-relayer")
   private val nodeRelayer = context.spawn(Behaviors.supervise(NodeRelayer(nodeParams, router, register)).onFailure(SupervisorStrategy.resume), name = "node-relayer")
 
@@ -92,6 +92,8 @@ class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paym
     case g: GetOutgoingChannels => channelRelayer ! ChannelRelayer.GetOutgoingChannels(sender, g)
 
     case GetChildActors(replyTo) => replyTo ! ChildActors(postRestartCleaner, channelRelayer, nodeRelayer)
+
+    case pluginCommitments: PluginCommitmemnts => postRestartCleaner forward pluginCommitments
   }
 
   override def mdc(currentMessage: Any): MDC = {
@@ -108,8 +110,7 @@ class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paym
 
 object Relayer extends Logging {
 
-  def props(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paymentHandler: ActorRef, initialized: Option[Promise[Done]] = None): Props =
-    Props(new Relayer(nodeParams, router, register, paymentHandler, initialized))
+  def props(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paymentHandler: ActorRef): Props = Props(new Relayer(nodeParams, router, register, paymentHandler))
 
   // @formatter:off
   case class RelayForward(add: UpdateAddHtlc)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.PendingRelayDb
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.{Logs, MilliSatoshi, NodeParams, PluginCommitmemnts, ShortChannelId}
+import fr.acinq.eclair.{Logs, MilliSatoshi, NodeParams, PluginCommitments, ShortChannelId}
 import grizzled.slf4j.Logging
 
 import scala.concurrent.Promise
@@ -93,7 +93,7 @@ class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paym
 
     case GetChildActors(replyTo) => replyTo ! ChildActors(postRestartCleaner, channelRelayer, nodeRelayer)
 
-    case pluginCommitments: PluginCommitmemnts => postRestartCleaner forward pluginCommitments
+    case pluginCommitments: PluginCommitments => postRestartCleaner forward pluginCommitments
   }
 
   override def mdc(currentMessage: Any): MDC = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -32,7 +32,7 @@ import fr.acinq.eclair.io.{Peer, PeerConnection}
 import fr.acinq.eclair.router.Graph.WeightRatios
 import fr.acinq.eclair.router.RouteCalculation.ROUTE_MAX_LENGTH
 import fr.acinq.eclair.router.Router.{MultiPartParams, RouteParams, NORMAL => _, State => _}
-import fr.acinq.eclair.{CltvExpiryDelta, Kit, LongToBtcAmount, MilliSatoshi, Setup, TestKitBaseClass}
+import fr.acinq.eclair.{CltvExpiryDelta, Kit, LongToBtcAmount, MilliSatoshi, PluginCommitmemnts, Setup, TestKitBaseClass}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST.JValue
 import org.json4s.{DefaultFormats, Formats}
@@ -137,7 +137,7 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
     val datadir = new File(INTEGRATION_TMP_DIR, s"datadir-eclair-$name")
     datadir.mkdirs()
     implicit val system: ActorSystem = ActorSystem(s"system-$name", config)
-    val setup = new Setup(datadir, pluginParams = Seq.empty)
+    val setup = new Setup(datadir, pluginParams = Seq.empty, pluginCommitments = Seq.empty)
     val kit = Await.result(setup.bootstrap, 10 seconds)
     nodes = nodes + (name -> kit)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -32,7 +32,7 @@ import fr.acinq.eclair.io.{Peer, PeerConnection}
 import fr.acinq.eclair.router.Graph.WeightRatios
 import fr.acinq.eclair.router.RouteCalculation.ROUTE_MAX_LENGTH
 import fr.acinq.eclair.router.Router.{MultiPartParams, RouteParams, NORMAL => _, State => _}
-import fr.acinq.eclair.{CltvExpiryDelta, Kit, LongToBtcAmount, MilliSatoshi, PluginCommitmemnts, Setup, TestKitBaseClass}
+import fr.acinq.eclair.{CltvExpiryDelta, Kit, LongToBtcAmount, MilliSatoshi, PluginCommitments, Setup, TestKitBaseClass}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST.JValue
 import org.json4s.{DefaultFormats, Formats}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
@@ -35,7 +35,7 @@ import fr.acinq.eclair.router.Router.ChannelHop
 import fr.acinq.eclair.transactions.{DirectedHtlc, IncomingHtlc, OutgoingHtlc}
 import fr.acinq.eclair.wire.Onion.FinalLegacyPayload
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, LongToBtcAmount, NodeParams, PluginCommitmemnts, TestConstants, TestKitBaseClass, randomBytes32}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, LongToBtcAmount, NodeParams, PluginCommitments, TestConstants, TestKitBaseClass, randomBytes32}
 import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import scodec.bits.ByteVector
@@ -57,7 +57,7 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
   case class FixtureParam(nodeParams: NodeParams, register: TestProbe, sender: TestProbe, eventListener: TestProbe) {
     def createRelayer(): ActorRef = {
       val relayer = system.actorOf(Relayer.props(nodeParams, TestProbe().ref, register.ref, TestProbe().ref))
-      val future = (relayer ? PluginCommitmemnts(Nil)).mapTo[Done]
+      val future = (relayer ? PluginCommitments(Nil)).mapTo[Done]
       awaitCond(future.isCompleted)
       relayer
     }
@@ -292,7 +292,7 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
 
     val testCase = setupTrampolinePayments(nodeParams)
     val postRestart = system.actorOf(PostRestartHtlcCleaner.props(nodeParams, register.ref))
-    val future = (postRestart ? PluginCommitmemnts(Nil)).mapTo[Done]
+    val future = (postRestart ? PluginCommitments(Nil)).mapTo[Done]
     awaitCond(future.isCompleted)
     register.expectNoMsg(100 millis)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
@@ -21,11 +21,11 @@ import java.util.UUID
 import akka.Done
 import akka.actor.ActorRef
 import akka.testkit.TestProbe
+import akka.util.Timeout
 import fr.acinq.bitcoin.{Block, ByteVector32, Crypto}
 import fr.acinq.eclair.blockchain.WatchEventConfirmed
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.StateTestsHelperMethods
-import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.db.{OutgoingPayment, OutgoingPaymentStatus, PaymentType}
 import fr.acinq.eclair.payment.OutgoingPacket.buildCommand
 import fr.acinq.eclair.payment.PaymentPacketSpec._
@@ -35,10 +35,11 @@ import fr.acinq.eclair.router.Router.ChannelHop
 import fr.acinq.eclair.transactions.{DirectedHtlc, IncomingHtlc, OutgoingHtlc}
 import fr.acinq.eclair.wire.Onion.FinalLegacyPayload
 import fr.acinq.eclair.wire._
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, LongToBtcAmount, NodeParams, TestConstants, TestKitBaseClass, randomBytes32}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, LongToBtcAmount, NodeParams, PluginCommitmemnts, TestConstants, TestKitBaseClass, randomBytes32}
 import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import scodec.bits.ByteVector
+import akka.pattern.ask
 
 import scala.concurrent.Promise
 import scala.concurrent.duration._
@@ -51,9 +52,14 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
 
   import PostRestartHtlcCleanerSpec._
 
+  implicit val timeout: Timeout = Timeout(30 seconds)
+
   case class FixtureParam(nodeParams: NodeParams, register: TestProbe, sender: TestProbe, eventListener: TestProbe) {
     def createRelayer(): ActorRef = {
-      system.actorOf(Relayer.props(nodeParams, TestProbe().ref, register.ref, TestProbe().ref))
+      val relayer = system.actorOf(Relayer.props(nodeParams, TestProbe().ref, register.ref, TestProbe().ref))
+      val future = (relayer ? PluginCommitmemnts(Nil)).mapTo[Done]
+      awaitCond(future.isCompleted)
+      relayer
     }
   }
 
@@ -285,9 +291,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
     import f._
 
     val testCase = setupTrampolinePayments(nodeParams)
-    val initialized = Promise[Done]()
-    val postRestart = system.actorOf(PostRestartHtlcCleaner.props(nodeParams, register.ref, Some(initialized)))
-    awaitCond(initialized.isCompleted)
+    val postRestart = system.actorOf(PostRestartHtlcCleaner.props(nodeParams, register.ref))
+    val future = (postRestart ? PluginCommitmemnts(Nil)).mapTo[Done]
+    awaitCond(future.isCompleted)
     register.expectNoMsg(100 millis)
 
     val probe = TestProbe()

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/JavafxBoot.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/JavafxBoot.scala
@@ -34,7 +34,7 @@ object JavafxBoot extends App with Logging {
 
     if (headless) {
       implicit val system = ActorSystem("eclair-node-gui", config)
-      val setup = new Setup(datadir, pluginParams = Seq.empty)
+      val setup = new Setup(datadir, pluginParams = Seq.empty, pluginCommitments = Seq.empty)
       setup.bootstrap.map { kit =>
         Boot.startApiServiceIfEnabled(kit)
       }

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/FxApp.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/FxApp.scala
@@ -84,7 +84,7 @@ class FxApp extends Application with Logging {
           val datadir = new File(getParameters.getUnnamed.get(0))
           val config = NodeParams.loadConfiguration(datadir)
           implicit val system = ActorSystem("eclair-node-gui", config)
-          val setup = new Setup(datadir, pluginParams = Seq.empty)
+          val setup = new Setup(datadir, pluginParams = Seq.empty, pluginCommitments = Seq.empty)
 
           val unitConf = setup.config.getString("gui.unit")
           FxApp.unit = Try(CoinUtils.getUnitFromString(unitConf)) match {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -41,8 +41,9 @@ object Boot extends App with Logging {
     implicit val system: ActorSystem = ActorSystem("eclair-node", config)
     implicit val ec: ExecutionContext = system.dispatcher
 
-    val pluginParams = plugins.flatMap(_.params)
-    val setup = new Setup(datadir, pluginParams)
+    val pluginParams = plugins.collect { case plugin: PluginWithParams => plugin.params }
+    val pluginCommitments = plugins.collect { case plugin: PluginWithCommitments => plugin.commitments }.flatten
+    val setup = new Setup(datadir, pluginParams, pluginCommitments)
 
     if (config.getBoolean("eclair.enable-kamon")) {
       Kamon.init(config)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
@@ -16,14 +16,14 @@
 
 package fr.acinq.eclair
 
-import java.io.File
-import java.net.{JarURLConnection, URL, URLClassLoader}
-import grizzled.slf4j.Logging
 import scala.util.{Failure, Success, Try}
+import java.net.{JarURLConnection, URL, URLClassLoader}
+import fr.acinq.eclair.channel.HasAbstractCommitments
+import grizzled.slf4j.Logging
+import java.io.File
+
 
 trait Plugin {
-
-  def params: Option[PluginParams]
 
   def onSetup(setup: Setup): Unit
 
@@ -31,13 +31,19 @@ trait Plugin {
 
 }
 
+trait PluginWithParams extends Plugin {
+  def params: PluginParams
+}
+
+trait PluginWithCommitments extends Plugin {
+  def commitments: Seq[HasAbstractCommitments]
+}
+
 object Plugin extends Logging {
 
   /**
     * The files passed to this function must be jars containing a manifest entry for "Main-Class" with the
     * FQDN of the entry point of the plugin. The entry point is the implementation of the interface "fr.acinq.eclair.Plugin"
-    * @param jars
-    * @return
     */
   def loadPlugins(jars: Seq[File]): Seq[Plugin] = {
     val urls = jars.flatMap(openJar)


### PR DESCRIPTION
This is another way to achieve https://github.com/ACINQ/eclair/pull/1574, steps taken:

- defined a non-sealed `HasAbstractCommitments` trait which has a method `nonRelayableHtlcIds` which is overridden in `DATA_CLOSING`, overridden method contents is https://github.com/ACINQ/eclair/blob/master/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala#L326-L346. This allows htlc-enabled plugins to extend `HasAbstractCommitments` and provide their own rules for HTLC exclusion.

- added a `def getOutgoingFromRemoteHtlcsCrossSigned: Set[UpdateAddHtlc]` to `AbstractCommitments`, this comment describes what it does for normal commitments: https://github.com/ACINQ/eclair/blob/master/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala#L302-L304

- made `checkBrokenHtlcs` and `cleanupRelayDb` methods to work with a list of `HasAbstractCommitments`, not `HasCommitments` so plugin commitment objects can be mixed in and supplied to these methods along with normal channels.