### PR TITLE
Minor refactoring

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -101,7 +101,7 @@ object Channel {
     adds.foreach { add =>
       commits.originChannels.get(add.id) match {
         case Some(origin) => onFound(origin, add)
-        case None => log.info(s"cannot fail timedout htlc #${add.id} paymentHash=${add.paymentHash} (origin not found)") // same as for fulfilling the htlc (no big deal)
+        case None => log.info(s"cannot fail htlc #${add.id} paymentHash=${add.paymentHash} (origin not found)") // same as for fulfilling the htlc (no big deal)
       }
     }
 }


### PR DESCRIPTION
This turns a piece of channel code into a separate method, the reason is it's going to be reused exactly in HC.