### PR TITLE
Fix NodeRelayer flaky test

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -299,7 +299,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     payFSM ! Status.Failure(BalanceTooLow)
 
     incoming.foreach { p =>
-      val fwd = register.expectMessageType[Register.Forward[CMD_FAIL_HTLC]] // TODO: timing out?
+      val fwd = register.expectMessageType[Register.Forward[CMD_FAIL_HTLC]]
       assert(fwd.channelId === p.add.channelId)
       assert(fwd.message === CMD_FAIL_HTLC(p.add.id, Right(TemporaryNodeFailure), commit = true))
     }


### PR DESCRIPTION
This test was randomly failing because of a race condition: we sometimes sent the payment failure before the payment FSM asked for routes, so it was ignored and the test could not progress.