### PR TITLE
Increase docker timeouts for electrumx in tests

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumxService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumxService.scala
@@ -24,6 +24,8 @@ import fr.acinq.eclair.TestUtils
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService
 import org.scalatest.Suite
 
+import scala.concurrent.duration.DurationInt
+
 trait ElectrumxService extends DockerTestKit {
   self: Suite with BitcoindService =>
 
@@ -44,6 +46,11 @@ trait ElectrumxService extends DockerTestKit {
       .withEnv(s"DAEMON_URL=http://foo:bar@host.docker.internal:$bitcoindRpcPort", "COIN=BitcoinSegwit", "NET=regtest", s"TCP_PORT=$electrumPort")
       //.withLogLineReceiver(LogLineReceiver(true, println))
   }
+
+  //override DockerKit timeouts
+  override val StartContainersTimeout = 60 seconds
+
+  override val StopContainersTimeout = 60 seconds
 
   override def dockerContainers: List[DockerContainer] = electrumxContainer :: super.dockerContainers
 


### PR DESCRIPTION
This caused flaky tests.