### PR TITLE
Add router API for invoice routing hints

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -38,7 +38,7 @@ import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceivePayment
 import fr.acinq.eclair.payment.relay.Relayer.{GetOutgoingChannels, OutgoingChannels, UsableBalance}
 import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentRequest, SendPaymentToRouteRequest, SendPaymentToRouteResponse}
 import fr.acinq.eclair.router.Router._
-import fr.acinq.eclair.router.{NetworkStats, RouteCalculation}
+import fr.acinq.eclair.router.{NetworkStats, RouteCalculation, Router}
 import fr.acinq.eclair.wire._
 import scodec.bits.ByteVector
 
@@ -195,7 +195,7 @@ class EclairImpl(appKit: Kit) extends Eclair {
   } yield peerinfos
 
   override def nodes(nodeIds_opt: Option[Set[PublicKey]])(implicit timeout: Timeout): Future[Iterable[NodeAnnouncement]] = {
-    (appKit.router ? Symbol("nodes"))
+    (appKit.router ? Router.GetNodes)
       .mapTo[Iterable[NodeAnnouncement]]
       .map(_.filter(n => nodeIds_opt.forall(_.contains(n.nodeId))))
   }
@@ -216,12 +216,12 @@ class EclairImpl(appKit: Kit) extends Eclair {
   }
 
   override def allChannels()(implicit timeout: Timeout): Future[Iterable[ChannelDesc]] = {
-    (appKit.router ? Symbol("channels")).mapTo[Iterable[ChannelAnnouncement]].map(_.map(c => ChannelDesc(c.shortChannelId, c.nodeId1, c.nodeId2)))
+    (appKit.router ? Router.GetChannels).mapTo[Iterable[ChannelAnnouncement]].map(_.map(c => ChannelDesc(c.shortChannelId, c.nodeId1, c.nodeId2)))
   }
 
   override def allUpdates(nodeId_opt: Option[PublicKey])(implicit timeout: Timeout): Future[Iterable[ChannelUpdate]] = nodeId_opt match {
-    case None => (appKit.router ? Symbol("updates")).mapTo[Iterable[ChannelUpdate]]
-    case Some(pk) => (appKit.router ? Symbol("channelsMap")).mapTo[Map[ShortChannelId, PublicChannel]].map { channels =>
+    case None => (appKit.router ? Router.GetChannelUpdates).mapTo[Iterable[ChannelUpdate]]
+    case Some(pk) => (appKit.router ? Router.GetChannelsMap).mapTo[Map[ShortChannelId, PublicChannel]].map { channels =>
       channels.values.flatMap {
         case PublicChannel(ann, _, _, Some(u1), _, _) if ann.nodeId1 == pk && u1.isNode1 => List(u1)
         case PublicChannel(ann, _, _, _, Some(u2), _) if ann.nodeId2 == pk && !u2.isNode1 => List(u2)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -162,25 +162,25 @@ class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[
       log.info("reinstating shortChannelId={} from nodeId={}", shortChannelId, nodeId)
       stay using d.copy(excludedChannels = d.excludedChannels - desc)
 
-    case Event(Symbol("nodes"), d) =>
+    case Event(GetNodes, d) =>
       sender ! d.nodes.values
       stay
 
-    case Event(Symbol("localChannels"), d) =>
+    case Event(GetLocalChannels, d) =>
       val scids = d.graph.getIncomingEdgesOf(nodeParams.nodeId).map(_.desc.shortChannelId)
       val localChannels = scids.flatMap(scid => d.channels.get(scid).map(c => LocalChannel(Right(c))).orElse(d.privateChannels.get(scid).map(c => LocalChannel(Left(c)))))
       sender ! localChannels
       stay
 
-    case Event(Symbol("channels"), d) =>
+    case Event(GetChannels, d) =>
       sender ! d.channels.values.map(_.ann)
       stay
 
-    case Event(Symbol("channelsMap"), d) =>
+    case Event(GetChannelsMap, d) =>
       sender ! d.channels
       stay
 
-    case Event(Symbol("updates"), d) =>
+    case Event(GetChannelUpdates, d) =>
       val updates: Iterable[ChannelUpdate] = d.channels.values.flatMap(d => d.update_1_opt ++ d.update_2_opt) ++ d.privateChannels.values.flatMap(d => d.update_1_opt ++ d.update_2_opt)
       sender ! updates
       stay
@@ -493,6 +493,11 @@ object Router {
   case object GetRoutingStateStreaming
   case object RoutingStateStreamingUpToDate
   case object GetRouterData
+  case object GetNodes
+  case object GetLocalChannels
+  case object GetChannels
+  case object GetChannelsMap
+  case object GetChannelUpdates
   // @formatter:on
 
   // @formatter:off

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -168,7 +168,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     {
       val fRes = eclair.nodes()
-      router.expectMsg(Symbol("nodes"))
+      router.expectMsg(Router.GetNodes)
       router.reply(allNodes)
       awaitCond(fRes.value match {
         case Some(Success(nodes)) =>
@@ -179,7 +179,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     }
     {
       val fRes = eclair.nodes(Some(Set(remoteNodeAnn1.nodeId, remoteNodeAnn2.nodeId)))
-      router.expectMsg(Symbol("nodes"))
+      router.expectMsg(Router.GetNodes)
       router.reply(allNodes)
       awaitCond(fRes.value match {
         case Some(Success(nodes)) =>
@@ -190,7 +190,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     }
     {
       val fRes = eclair.nodes(Some(Set(randomKey.publicKey)))
-      router.expectMsg(Symbol("nodes"))
+      router.expectMsg(Router.GetNodes)
       router.reply(allNodes)
       awaitCond(fRes.value match {
         case Some(Success(nodes)) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
@@ -34,6 +34,7 @@ import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceivePayment
 import fr.acinq.eclair.payment.receive.{ForwardHandler, PaymentHandler}
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentRequest
+import fr.acinq.eclair.router.Router
 import fr.acinq.eclair.transactions.{Scripts, Transactions}
 import fr.acinq.eclair.wire.{ChannelAnnouncement, ChannelUpdate, PermanentChannelFailure, UpdateAddHtlc}
 import fr.acinq.eclair.{LongToBtcAmount, MilliSatoshi, randomBytes32}
@@ -53,11 +54,11 @@ abstract class ChannelIntegrationSpec extends IntegrationSpec {
   def awaitAnnouncements(channels: Int): Unit = {
     val sender = TestProbe()
     awaitCond({
-      sender.send(nodes("A").router, Symbol("channels"))
+      sender.send(nodes("A").router, Router.GetChannels)
       sender.expectMsgType[Iterable[ChannelAnnouncement]].size == channels
     }, max = 60 seconds, interval = 1 second)
     awaitCond({
-      sender.send(nodes("A").router, Symbol("updates"))
+      sender.send(nodes("A").router, Router.GetChannelUpdates)
       sender.expectMsgType[Iterable[ChannelUpdate]].size == 2 * channels
     }, max = 60 seconds, interval = 1 second)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -29,7 +29,7 @@ import fr.acinq.eclair.crypto.keymanager.{LocalChannelKeyManager, LocalNodeKeyMa
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.router.Announcements._
 import fr.acinq.eclair.router.BaseRouterSpec.channelAnnouncement
-import fr.acinq.eclair.router.Router.{ChannelDesc, ChannelMeta, GossipDecision, PrivateChannel}
+import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire._
 import fr.acinq.eclair.{TestKitBaseClass, randomKey, _}
@@ -194,11 +194,11 @@ abstract class BaseRouterSpec extends TestKitBaseClass with FixtureAnyFunSuiteLi
         GossipDecision.Accepted(node_h))
       peerConnection.expectNoMsg()
       awaitCond({
-        sender.send(router, Symbol("nodes"))
+        sender.send(router, GetNodes)
         val nodes = sender.expectMsgType[Iterable[NodeAnnouncement]]
-        sender.send(router, Symbol("channels"))
+        sender.send(router, GetChannels)
         val channels = sender.expectMsgType[Iterable[ChannelAnnouncement]]
-        sender.send(router, Symbol("updates"))
+        sender.send(router, GetChannelUpdates)
         val updates = sender.expectMsgType[Iterable[ChannelUpdate]]
         nodes.size === 8 && channels.size === 5 && updates.size === 11
       }, max = 10 seconds, interval = 1 second)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -456,7 +456,7 @@ class RouterSpec extends BaseRouterSpec {
     val peerConnection = TestProbe()
     peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, g, update_ga))
     val sender = TestProbe()
-    sender.send(router, Symbol("localChannels"))
+    sender.send(router, GetLocalChannels)
     val localChannels = sender.expectMsgType[Seq[LocalChannel]]
     assert(localChannels.size === 2)
     assert(localChannels.map(_.getRemoteNodeId(a)).toSet === Set(b, g))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -450,6 +450,24 @@ class RouterSpec extends BaseRouterSpec {
     state.channels.foreach(c => assert(c.capacity === publicChannelCapacity))
   }
 
+  test("send local channels") { fixture =>
+    import fixture._
+    // We need a channel update from our private remote peer, otherwise we can't create invoice routing information.
+    val peerConnection = TestProbe()
+    peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, g, update_ga))
+    val sender = TestProbe()
+    sender.send(router, Symbol("localChannels"))
+    val localChannels = sender.expectMsgType[Seq[LocalChannel]]
+    assert(localChannels.size === 2)
+    assert(localChannels.map(_.getRemoteNodeId(a)).toSet === Set(b, g))
+    assert(localChannels.exists(_.isPrivate)) // a ---> g
+    assert(localChannels.exists(!_.isPrivate)) // a ---> b
+    assert(localChannels.flatMap(_.toExtraHop(a)).toSet === Set(
+      ExtraHop(b, channelId_ab, update_ba.feeBaseMsat, update_ba.feeProportionalMillionths, update_ba.cltvExpiryDelta),
+      ExtraHop(g, channelId_ag, update_ga.feeBaseMsat, update_ga.feeProportionalMillionths, update_ga.cltvExpiryDelta)
+    ))
+  }
+
   test("send network statistics") { fixture =>
     import fixture._
     val sender = TestProbe()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -459,10 +459,10 @@ class RouterSpec extends BaseRouterSpec {
     sender.send(router, GetLocalChannels)
     val localChannels = sender.expectMsgType[Seq[LocalChannel]]
     assert(localChannels.size === 2)
-    assert(localChannels.map(_.getRemoteNodeId(a)).toSet === Set(b, g))
+    assert(localChannels.map(_.remoteNodeId).toSet === Set(b, g))
     assert(localChannels.exists(_.isPrivate)) // a ---> g
     assert(localChannels.exists(!_.isPrivate)) // a ---> b
-    assert(localChannels.flatMap(_.toExtraHop(a)).toSet === Set(
+    assert(localChannels.flatMap(_.toExtraHop).toSet === Set(
       ExtraHop(b, channelId_ab, update_ba.feeBaseMsat, update_ba.feeProportionalMillionths, update_ba.cltvExpiryDelta),
       ExtraHop(g, channelId_ag, update_ga.feeBaseMsat, update_ga.feeProportionalMillionths, update_ga.cltvExpiryDelta)
     ))


### PR DESCRIPTION
The router can now return local channels, with all necessary information to build routing hints from these channels.

It's not eclair-core's responsibility to choose what channels to use in routing hints: this is really a wallet strategy, so each wallet should have its own heuristics to choose what channels to include (if any).

I think @btcontract was interested in these.