### PR TITLE
Allow plugins to force reconnect

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -99,7 +99,7 @@ case class NodeParams(nodeKeyManager: NodeKeyManager,
   val pluginMessageTags: Set[Int] = pluginParams.collect { case p: CustomFeaturePlugin => p.messageTags }.toSet.flatten
 
   def forceReconnect(nodeId: PublicKey): Boolean = pluginParams.exists {
-    case p: CustomFeaturePlugin => p.forceReconnect(nodeId)
+    case p: ConnectionControlPlugin => p.forceReconnect(nodeId)
     case _ => false
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -98,7 +98,10 @@ case class NodeParams(nodeKeyManager: NodeKeyManager,
 
   val pluginMessageTags: Set[Int] = pluginParams.collect { case p: CustomFeaturePlugin => p.messageTags }.toSet.flatten
 
-  def forceReconnect(nodeId: PublicKey): Boolean = pluginParams.collectFirst { case p: CustomFeaturePlugin => p.forceReconnect(nodeId) }.isDefined
+  def forceReconnect(nodeId: PublicKey): Boolean = pluginParams.exists {
+    case p: CustomFeaturePlugin => p.forceReconnect(nodeId)
+    case _ => false
+  }
 
   def currentBlockHeight: Long = blockCount.get
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -98,6 +98,8 @@ case class NodeParams(nodeKeyManager: NodeKeyManager,
 
   val pluginMessageTags: Set[Int] = pluginParams.collect { case p: CustomFeaturePlugin => p.messageTags }.toSet.flatten
 
+  def forceReconnect(nodeId: PublicKey): Boolean = pluginParams.collectFirst { case p: CustomFeaturePlugin => p.forceReconnect(nodeId) }.isDefined
+
   def currentBlockHeight: Long = blockCount.get
 
   def featuresFor(nodeId: PublicKey): Features = overrideFeatures.getOrElse(nodeId, features)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/PluginParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/PluginParams.scala
@@ -17,6 +17,7 @@
 package fr.acinq.eclair
 
 import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.channel.Origin
 import fr.acinq.eclair.payment.relay.PostRestartHtlcCleaner.IncomingHtlc
 
@@ -33,6 +34,9 @@ trait CustomFeaturePlugin extends PluginParams {
 
   /** Feature bit that the plugin wants to advertise through Init message. */
   def feature: Feature
+
+  /** Once disconnect happens, should Eclair attempt periodic reconnects to a given remote node even if there is no normal channels left */
+  def forceReconnect(nodeId: PublicKey): Boolean
 
   /** Plugin feature is always defined as unknown and optional. */
   def pluginFeature: UnknownFeature = UnknownFeature(feature.optional)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/PluginParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/PluginParams.scala
@@ -35,11 +35,13 @@ trait CustomFeaturePlugin extends PluginParams {
   /** Feature bit that the plugin wants to advertise through Init message. */
   def feature: Feature
 
-  /** Once disconnect happens, should Eclair attempt periodic reconnects to a given remote node even if there is no normal channels left */
-  def forceReconnect(nodeId: PublicKey): Boolean
-
   /** Plugin feature is always defined as unknown and optional. */
   def pluginFeature: UnknownFeature = UnknownFeature(feature.optional)
+}
+
+trait ConnectionControlPlugin extends PluginParams {
+  /** Once disconnect happens, should Eclair attempt periodic reconnects to a given remote node even if there is no normal channels left */
+  def forceReconnect(nodeId: PublicKey): Boolean
 }
 
 /** Parameters for a plugin that defines custom commitment transactions (or non-standard HTLCs). */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -514,7 +514,7 @@ object PeerConnection {
     sealed trait Success extends ConnectionResult
     sealed trait Failure extends ConnectionResult
 
-    case object NoAddressFound extends ConnectionResult.Failure { override def toString: String = "no address found" }
+    case class NoAddressFound(remoteNodeId: PublicKey) extends ConnectionResult.Failure { override def toString: String = "no address found" }
     case class ConnectionFailed(address: InetSocketAddress) extends ConnectionResult.Failure { override def toString: String = s"connection failed to $address" }
     case class AuthenticationFailed(reason: String) extends ConnectionResult.Failure { override def toString: String = reason }
     case class InitializationFailed(reason: String) extends ConnectionResult.Failure { override def toString: String = reason }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
@@ -80,7 +80,7 @@ class ReconnectionTask(nodeParams: NodeParams, remoteNodeId: PublicKey) extends 
 
   when(IDLE) {
     case Event(Peer.Transition(previousPeerData, nextPeerData: Peer.DisconnectedData), d: IdleData) =>
-      if (nodeParams.autoReconnect && nextPeerData.channels.nonEmpty) { // we only reconnect if there are existing channels
+      if (nodeParams.autoReconnect && (nodeParams.forceReconnect(remoteNodeId) || nextPeerData.channels.nonEmpty)) { // we only reconnect if nodeParams explicitly instructs us to or there are existing channels
         val (initialDelay, firstNextReconnectionDelay) = (previousPeerData, d.previousData) match {
           case (Peer.Nothing, _) =>
             // When restarting, we add some randomization before the first reconnection attempt to avoid herd effect

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
@@ -134,7 +134,7 @@ class ReconnectionTask(nodeParams: NodeParams, remoteNodeId: PublicKey) extends 
         .map(hostAndPort2InetSocketAddress)
         .orElse(getPeerAddressFromDb(nodeParams.db.peers, nodeParams.db.network, remoteNodeId)) match {
         case Some(address) => connect(address, origin = sender)
-        case None => sender ! PeerConnection.ConnectionResult.NoAddressFound
+        case None => sender ! PeerConnection.ConnectionResult.NoAddressFound(remoteNodeId)
       }
       stay
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -131,11 +131,10 @@ object TestConstants {
     val mandatory = 50000
   }
 
-  val pluginParams: CustomFeaturePlugin = new CustomFeaturePlugin {
-    def messageTags: Set[Int] = Set(60003)
-    def forceReconnect(nodeId: PublicKey) = false
-    def feature: Feature = TestFeature
-    def name: String = "plugin for testing"
+  val pluginParams = new CustomFeaturePlugin {
+    override def messageTags: Set[Int] = Set(60003)
+    override def feature: Feature = TestFeature
+    override def name: String = "plugin for testing"
   }
 
   object Alice {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -21,7 +21,7 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
-import fr.acinq.bitcoin.Crypto.PrivateKey
+import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{Block, ByteVector32, Script}
 import fr.acinq.eclair.FeatureSupport.Optional
 import fr.acinq.eclair.Features._
@@ -133,6 +133,7 @@ object TestConstants {
 
   val pluginParams: CustomFeaturePlugin = new CustomFeaturePlugin {
     def messageTags: Set[Int] = Set(60003)
+    def forceReconnect(nodeId: PublicKey) = false
     def feature: Feature = TestFeature
     def name: String = "plugin for testing"
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -95,7 +95,7 @@ class PeerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with StateTe
     val probe = TestProbe()
     probe.send(peer, Peer.Init(Set.empty))
     probe.send(peer, Peer.Connect(remoteNodeId, address_opt = None))
-    probe.expectMsg(PeerConnection.ConnectionResult.NoAddressFound)
+    probe.expectMsg(PeerConnection.ConnectionResult.NoAddressFound(remoteNodeId))
   }
 
   test("successfully connect to peer at user request") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
@@ -50,6 +50,12 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import com.softwaremill.quicklens._
     val aliceParams = TestConstants.Alice.nodeParams
       .modify(_.autoReconnect).setToIf(test.tags.contains("auto_reconnect"))(true)
+      .modify(_.pluginParams).setToIf(test.tags.contains("plugin_force_reconnect"))(List(new CustomFeaturePlugin {
+        def name = "plugin with force-reconnect"
+        def messageTags: Set[Int] = Set(60000)
+        def feature: Feature = null
+        def forceReconnect(nodeId: PublicKey): Boolean = true
+      }))
 
     if (test.tags.contains("with_node_announcements")) {
       val bobAnnouncement = NodeAnnouncement(randomBytes64, Features.empty, 1, remoteNodeId, Color(100.toByte, 200.toByte, 300.toByte), "node-alias", fakeIPAddress :: Nil)
@@ -82,6 +88,16 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
 
     val peer = TestProbe()
     peer.send(reconnectionTask, Peer.Transition(PeerNothingData, Peer.DisconnectedData(Map.empty)))
+    monitor.expectNoMessage()
+  }
+
+  test("reconnect when there are no channels if plugin instructs to", Tag("auto_reconnect"), Tag("with_node_announcements"), Tag("plugin_force_reconnect")) { f =>
+    import f._
+
+    val peer = TestProbe()
+    peer.send(reconnectionTask, Peer.Transition(PeerNothingData, Peer.DisconnectedData(channels = Map.empty)))
+    val TransitionWithData(ReconnectionTask.IDLE, ReconnectionTask.WAITING, _, _) = monitor.expectMsgType[TransitionWithData]
+    val TransitionWithData(ReconnectionTask.WAITING, ReconnectionTask.CONNECTING, _, _: ReconnectionTask.ConnectingData) = monitor.expectMsgType[TransitionWithData]
     monitor.expectNoMessage()
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
@@ -50,12 +50,10 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import com.softwaremill.quicklens._
     val aliceParams = TestConstants.Alice.nodeParams
       .modify(_.autoReconnect).setToIf(test.tags.contains("auto_reconnect"))(true)
-      .modify(_.pluginParams).setToIf(test.tags.contains("plugin_force_reconnect"))(List(new CustomFeaturePlugin {
-        def name = "plugin with force-reconnect"
-        def messageTags: Set[Int] = Set(60000)
-        def feature: Feature = null
-        def forceReconnect(nodeId: PublicKey): Boolean = true
-      }))
+      .modify(_.pluginParams).setToIf(test.tags.contains("plugin_force_reconnect"))(List(new ConnectionControlPlugin {
+      override def forceReconnect(nodeId: PublicKey): Boolean = true
+      override def name = "plugin with force-reconnect"
+    }))
 
     if (test.tags.contains("with_node_announcements")) {
       val bobAnnouncement = NodeAnnouncement(randomBytes64, Features.empty, 1, remoteNodeId, Color(100.toByte, 200.toByte, 300.toByte), "node-alias", fakeIPAddress :: Nil)


### PR DESCRIPTION
Discussed at https://gitter.im/ACINQ/developers?at=5fa1289c2a3544071500e1b3, this will allow message-enabled plugins to keep a connection open to a given node even if there are no channels left.