### PR TITLE
Path-finding: log edge direction

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -87,7 +87,7 @@ object RouteCalculation {
 
       log.info(s"finding routes ${r.source}->${r.target} with assistedChannels={} ignoreNodes={} ignoreChannels={} excludedChannels={}", assistedChannels.keys.mkString(","), r.ignore.nodes.map(_.value).mkString(","), r.ignore.channels.mkString(","), d.excludedChannels.mkString(","))
       log.info("finding routes with randomize={} params={}", params.randomize, params)
-      log.info("routing graph: {}", d.graph.edgeSet().map(e => s"${e.desc.shortChannelId}->${e.balance_opt}/${e.capacity}").mkString(", "))
+      log.info("routing graph: {}", d.graph.edgeSet().map(e => s"${e.desc.a}->${e.desc.shortChannelId}->${e.desc.b}->${e.balance_opt}/${e.capacity}").mkString(", "))
       val tags = TagSet.Empty.withTag(Tags.MultiPart, r.allowMultiPart).withTag(Tags.Amount, Tags.amountBucket(r.amount))
       KamonExt.time(Metrics.FindRouteDuration.withTags(tags.withTag(Tags.NumberOfRoutes, routesToFind.toLong))) {
         val result = if (r.allowMultiPart) {


### PR DESCRIPTION
We were previously ommitting the nodeId from graph edge, which means we add duplicate edges but couldn't know which one was for which direction.

With that change it should be very easy to reproduce and understand path-finding issues.

NB: this is a PR to the `android-phoenix` branch.