### PR TITLE
Improve MPP-send for direct channels

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -334,8 +334,8 @@ object RouteCalculation {
       // If we have direct channels to the target, we can use them all.
       val numRoutes = routeParams.mpp.maxParts.max(directChannels.length)
       // If we have direct channels to the target, we can use them all, even if they have only a small balance left.
-      val routeAmount = (amount +: routeParams.mpp.minPartAmount +: directChannels.filter(!_.isEmpty).map(_.balance)).min
-      routeParams.copy(mpp = MultiPartParams(routeAmount, numRoutes))
+      val minPartAmount = (amount +: routeParams.mpp.minPartAmount +: directChannels.filter(!_.isEmpty).map(_.balance)).min
+      routeParams.copy(mpp = MultiPartParams(minPartAmount, numRoutes))
     }
     findRouteInternal(g, localNodeId, targetNodeId, routeParams1.mpp.minPartAmount, maxFee, routeParams1.mpp.maxParts, extraEdges, ignoredEdges, ignoredVertices, routeParams1, currentBlockHeight) match {
       case Right(routes) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -981,6 +981,13 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       assert(routes.forall(_.length == 1), routes)
       checkRouteAmounts(routes, amount, 0 msat)
     }
+    {
+      // We set min-part-amount to a value that would exclude channels 1 and 4, but it should be ignored when sending to a direct neighbor.
+      val Success(routes) = findMultiPartRoute(g, a, b, amount, 1 msat, routeParams = routeParams.copy(mpp = MultiPartParams(20000 msat, 3)), currentBlockHeight = 400000)
+      assert(routes.length === 4, routes)
+      assert(routes.forall(_.length == 1), routes)
+      checkRouteAmounts(routes, amount, 0 msat)
+    }
   }
 
   test("calculate multipart route to neighbor (single channel, known balance)") {


### PR DESCRIPTION
When the recipient is a direct peer, we can use the accurate knowledge of our local channels instead of hard-coded MPP parameters to choose the number of routes and the minimum route amount.

This change makes it possible to easily send all local funds in one payment when we're directly connected to the recipient.

@dpad85 I'll cherry-pick this commit on the `android-phoenix` branch once this is merged. It made me think that we probably want to change the default (15000 sats, 6 parts) for eclair-mobile MPP: no-one has complained yet, but maybe (1 000 sat, 10) would be better suited for a wallet.