### PR TITLE
Remove `timedOutOutgoingHtlcs` from AbstractCommitments

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -53,8 +53,6 @@ trait AbstractCommitments {
 
   def getIncomingHtlcCrossSigned(htlcId: Long): Option[UpdateAddHtlc]
 
-  def timedOutOutgoingHtlcs(blockheight: Long): Set[UpdateAddHtlc]
-
   def localNodeId: PublicKey
 
   def remoteNodeId: PublicKey


### PR DESCRIPTION
It turns out that:

- `def timedOutOutgoingHtlcs(blockHeight: Long): Set[wire.UpdateAddHtlc]` defined in `AbstractCommitments` is currently only used in `Commitments` object and nowhere else.
- Logic in HC commitments object can be simplified if `timedOutOutgoingHtlcs` takes additional arguments besides `blockHeight`.

So it makes sense to just remove `timedOutOutgoingHtlcs` from `AbstractCommitments` and let HC commitments object to do things differently internally without implementing of (useless) `timedOutOutgoingHtlcs`.