### PR TITLE
Add channelId to websocket event

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/JsonSerializers.scala
@@ -299,6 +299,7 @@ class ChannelEventSerializer extends CustomSerializer[ChannelEvent](_ => ( {
   )
   case e: ChannelStateChanged => JObject(
     JField("type", JString("channel-state-changed")),
+    JField("channelId", JString(e.channelId.toHex)),
     JField("remoteNodeId", JString(e.remoteNodeId.toString())),
     JField("previousState", JString(e.previousState.toString)),
     JField("currentState", JString(e.currentState.toString))

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -540,8 +540,8 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         system.eventStream.publish(chcr)
         wsClient.expectMessage(expectedSerializedChcr)
 
-        val chsc = ChannelStateChanged(system.deadLetters, null, system.deadLetters, bobNodeId, OFFLINE, NORMAL, null)
-        val expectedSerializedChsc = """{"type":"channel-state-changed","remoteNodeId":"039dc0e0b1d25905e44fdf6f8e89755a5e219685840d0bc1d28d3308f9628a3585","previousState":"OFFLINE","currentState":"NORMAL"}"""
+        val chsc = ChannelStateChanged(system.deadLetters, ByteVector32.One, system.deadLetters, bobNodeId, OFFLINE, NORMAL, null)
+        val expectedSerializedChsc = """{"type":"channel-state-changed","channelId":"0100000000000000000000000000000000000000000000000000000000000000","remoteNodeId":"039dc0e0b1d25905e44fdf6f8e89755a5e219685840d0bc1d28d3308f9628a3585","previousState":"OFFLINE","currentState":"NORMAL"}"""
         assert(serialization.write(chsc) === expectedSerializedChsc)
         system.eventStream.publish(chsc)
         wsClient.expectMessage(expectedSerializedChsc)


### PR DESCRIPTION
Thanks to recent changes, the `channelId` is available in `ChannelStateChanged`.
We now propagate this information to websocket channel events.