### PR TITLE
Retrieve bitcoin's mempool-min-fee

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/Monitoring.scala
@@ -26,6 +26,8 @@ object Monitoring {
     val RpcBasicInvokeDuration = Kamon.timer("bitcoin.rpc.basic.invoke.duration")
     val RpcBatchInvokeDuration = Kamon.timer("bitcoin.rpc.batch.invoke.duration")
     val BitcoinBalance = Kamon.gauge("bitcoin.balance", "Bitcoin balance (mBTC)")
+    val MempoolMinFeeratePerKw = Kamon.gauge("bitcoin.mempool.min-feerate-per-kw", "Minimum feerate (sat/kw) for a tx to be accepted in our mempool")
+    val CannotRetrieveFeeratesCount = Kamon.counter("bitcoin.rpc.feerates.error", "Number of failures to retrieve on-chain feerates")
   }
 
   object Tags {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProvider.scala
@@ -69,6 +69,7 @@ object BitgoFeeProvider {
 
   def extractFeerates(feeRanges: Seq[BlockTarget]): FeeratesPerKB =
     FeeratesPerKB(
+      mempoolMinFee = extractFeerate(feeRanges, 1008),
       block_1 = extractFeerate(feeRanges, 1),
       blocks_2 = extractFeerate(feeRanges, 2),
       blocks_6 = extractFeerate(feeRanges, 6),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProvider.scala
@@ -74,6 +74,7 @@ object EarnDotComFeeProvider {
 
   def extractFeerates(feeRanges: Seq[FeeRange]): FeeratesPerKB =
     FeeratesPerKB(
+      mempoolMinFee = extractFeerate(feeRanges, 1008),
       block_1 = extractFeerate(feeRanges, 1),
       blocks_2 = extractFeerate(feeRanges, 2),
       blocks_6 = extractFeerate(feeRanges, 6),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProvider.scala
@@ -44,6 +44,7 @@ class FallbackFeeProvider(providers: Seq[FeeProvider], minFeeratePerByte: Feerat
 object FallbackFeeProvider {
 
   private def enforceMinimumFeerate(feeratesPerKB: FeeratesPerKB, minFeeratePerKB: FeeratePerKB): FeeratesPerKB = feeratesPerKB.copy(
+    mempoolMinFee = feeratesPerKB.mempoolMinFee.max(minFeeratePerKB),
     block_1 = feeratesPerKB.block_1.max(minFeeratePerKB),
     blocks_2 = feeratesPerKB.blocks_2.max(minFeeratePerKB),
     blocks_6 = feeratesPerKB.blocks_6.max(minFeeratePerKB),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
@@ -102,8 +102,8 @@ object FeeratePerKw {
 }
 
 /** Fee rates in satoshi-per-kilo-bytes (1 kb = 1000 bytes). */
-case class FeeratesPerKB(block_1: FeeratePerKB, blocks_2: FeeratePerKB, blocks_6: FeeratePerKB, blocks_12: FeeratePerKB, blocks_36: FeeratePerKB, blocks_72: FeeratePerKB, blocks_144: FeeratePerKB, blocks_1008: FeeratePerKB) {
-  require(block_1.feerate > 0.sat && blocks_2.feerate > 0.sat && blocks_6.feerate > 0.sat && blocks_12.feerate > 0.sat && blocks_36.feerate > 0.sat && blocks_72.feerate > 0.sat && blocks_144.feerate > 0.sat && blocks_1008.feerate > 0.sat, "all feerates must be strictly greater than 0")
+case class FeeratesPerKB(mempoolMinFee: FeeratePerKB, block_1: FeeratePerKB, blocks_2: FeeratePerKB, blocks_6: FeeratePerKB, blocks_12: FeeratePerKB, blocks_36: FeeratePerKB, blocks_72: FeeratePerKB, blocks_144: FeeratePerKB, blocks_1008: FeeratePerKB) {
+  require(mempoolMinFee.feerate > 0.sat && block_1.feerate > 0.sat && blocks_2.feerate > 0.sat && blocks_6.feerate > 0.sat && blocks_12.feerate > 0.sat && blocks_36.feerate > 0.sat && blocks_72.feerate > 0.sat && blocks_144.feerate > 0.sat && blocks_1008.feerate > 0.sat, "all feerates must be strictly greater than 0")
 
   def feePerBlock(target: Int): FeeratePerKB = target match {
     case 1 => block_1
@@ -118,8 +118,8 @@ case class FeeratesPerKB(block_1: FeeratePerKB, blocks_2: FeeratePerKB, blocks_6
 }
 
 // stores fee rate in satoshi/kw (1 kw = 1000 weight units)
-case class FeeratesPerKw(block_1: FeeratePerKw, blocks_2: FeeratePerKw, blocks_6: FeeratePerKw, blocks_12: FeeratePerKw, blocks_36: FeeratePerKw, blocks_72: FeeratePerKw, blocks_144: FeeratePerKw, blocks_1008: FeeratePerKw) {
-  require(block_1.feerate > 0.sat && blocks_2.feerate > 0.sat && blocks_6.feerate > 0.sat && blocks_12.feerate > 0.sat && blocks_36.feerate > 0.sat && blocks_72.feerate > 0.sat && blocks_144.feerate > 0.sat && blocks_1008.feerate > 0.sat, "all feerates must be strictly greater than 0")
+case class FeeratesPerKw(mempoolMinFee: FeeratePerKw, block_1: FeeratePerKw, blocks_2: FeeratePerKw, blocks_6: FeeratePerKw, blocks_12: FeeratePerKw, blocks_36: FeeratePerKw, blocks_72: FeeratePerKw, blocks_144: FeeratePerKw, blocks_1008: FeeratePerKw) {
+  require(mempoolMinFee.feerate > 0.sat && block_1.feerate > 0.sat && blocks_2.feerate > 0.sat && blocks_6.feerate > 0.sat && blocks_12.feerate > 0.sat && blocks_36.feerate > 0.sat && blocks_72.feerate > 0.sat && blocks_144.feerate > 0.sat && blocks_1008.feerate > 0.sat, "all feerates must be strictly greater than 0")
 
   def feePerBlock(target: Int): FeeratePerKw = target match {
     case 1 => block_1
@@ -135,6 +135,7 @@ case class FeeratesPerKw(block_1: FeeratePerKw, blocks_2: FeeratePerKw, blocks_6
 
 object FeeratesPerKw {
   def apply(feerates: FeeratesPerKB): FeeratesPerKw = FeeratesPerKw(
+    mempoolMinFee = FeeratePerKw(feerates.mempoolMinFee),
     block_1 = FeeratePerKw(feerates.block_1),
     blocks_2 = FeeratePerKw(feerates.blocks_2),
     blocks_6 = FeeratePerKw(feerates.blocks_6),
@@ -146,6 +147,7 @@ object FeeratesPerKw {
 
   /** Used in tests */
   def single(feeratePerKw: FeeratePerKw): FeeratesPerKw = FeeratesPerKw(
+    mempoolMinFee = feeratePerKw,
     block_1 = feeratePerKw,
     blocks_2 = feeratePerKw,
     blocks_6 = feeratePerKw,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
@@ -101,7 +101,11 @@ object FeeratePerKw {
   // @formatter:on
 }
 
-/** Fee rates in satoshi-per-kilo-bytes (1 kb = 1000 bytes). */
+/**
+ * Fee rates in satoshi-per-kilo-bytes (1 kb = 1000 bytes).
+ * The mempoolMinFee is the minimal fee required for a tx to enter the mempool (and then be relayed to other nodes and eventually get confirmed).
+ * If our fee provider doesn't expose this data, using its biggest block target should be a good enough estimation.
+ */
 case class FeeratesPerKB(mempoolMinFee: FeeratePerKB, block_1: FeeratePerKB, blocks_2: FeeratePerKB, blocks_6: FeeratePerKB, blocks_12: FeeratePerKB, blocks_36: FeeratePerKB, blocks_72: FeeratePerKB, blocks_144: FeeratePerKB, blocks_1008: FeeratePerKB) {
   require(mempoolMinFee.feerate > 0.sat && block_1.feerate > 0.sat && blocks_2.feerate > 0.sat && blocks_6.feerate > 0.sat && blocks_12.feerate > 0.sat && blocks_36.feerate > 0.sat && blocks_72.feerate > 0.sat && blocks_144.feerate > 0.sat && blocks_1008.feerate > 0.sat, "all feerates must be strictly greater than 0")
 
@@ -117,7 +121,7 @@ case class FeeratesPerKB(mempoolMinFee: FeeratePerKB, block_1: FeeratePerKB, blo
   }
 }
 
-// stores fee rate in satoshi/kw (1 kw = 1000 weight units)
+/** Fee rates in satoshi-per-kilo-weight (1 kw = 1000 weight units). */
 case class FeeratesPerKw(mempoolMinFee: FeeratePerKw, block_1: FeeratePerKw, blocks_2: FeeratePerKw, blocks_6: FeeratePerKw, blocks_12: FeeratePerKw, blocks_36: FeeratePerKw, blocks_72: FeeratePerKw, blocks_144: FeeratePerKw, blocks_1008: FeeratePerKw) {
   require(mempoolMinFee.feerate > 0.sat && block_1.feerate > 0.sat && blocks_2.feerate > 0.sat && blocks_6.feerate > 0.sat && blocks_12.feerate > 0.sat && blocks_36.feerate > 0.sat && blocks_72.feerate > 0.sat && blocks_144.feerate > 0.sat && blocks_1008.feerate > 0.sat, "all feerates must be strictly greater than 0")
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProvider.scala
@@ -43,6 +43,7 @@ object SmoothFeeProvider {
 
   def smooth(rates: Seq[FeeratesPerKB]): FeeratesPerKB =
     FeeratesPerKB(
+      mempoolMinFee = avg(rates.map(_.mempoolMinFee)),
       block_1 = avg(rates.map(_.block_1)),
       blocks_2 = avg(rates.map(_.blocks_2)),
       blocks_6 = avg(rates.map(_.blocks_6)),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteFeeratesDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteFeeratesDb.scala
@@ -88,6 +88,8 @@ class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb with Logging {
       val rs = statement.executeQuery()
       if (rs.next()) {
         Some(FeeratesPerKB(
+          // NB: we don't bother storing this value in the DB, because it's unused on mobile.
+          mempoolMinFee = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_1008"))),
           block_1 = FeeratePerKB(Satoshi(rs.getLong("rate_block_1"))),
           blocks_2 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_2"))),
           blocks_6 = FeeratePerKB(Satoshi(rs.getLong("rate_blocks_6"))),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/BitgoFeeProviderSpec.scala
@@ -60,6 +60,7 @@ class BitgoFeeProviderSpec extends AnyFunSuite {
     val feeRanges = parseFeeRanges(json)
     val feerates = extractFeerates(feeRanges)
     val ref = FeeratesPerKB(
+      mempoolMinFee = FeeratePerKB(5070 sat),
       block_1 = FeeratePerKB(149453 sat),
       blocks_2 = FeeratePerKB(136797 sat),
       blocks_6 = FeeratePerKB(105566 sat),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/DbFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/DbFeeProviderSpec.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 
 class DbFeeProviderSpec extends AnyFunSuite {
 
-  val feerates1: FeeratesPerKB = FeeratesPerKB(FeeratePerKB(100 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat))
+  val feerates1: FeeratesPerKB = FeeratesPerKB(FeeratePerKB(800 sat), FeeratePerKB(100 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat))
 
   test("db fee provider saves feerates in database") {
     val sqlite = TestConstants.sqliteInMemory()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/EarnDotComFeeProviderSpec.scala
@@ -59,6 +59,7 @@ class EarnDotComFeeProviderSpec extends AnyFunSuite with Logging {
     val feeRanges = parseFeeRanges(json)
     val feerates = extractFeerates(feeRanges)
     val ref = FeeratesPerKB(
+      mempoolMinFee = FeeratePerKB(10 * 1000 sat),
       block_1 = FeeratePerKB(400 * 1000 sat),
       blocks_2 = FeeratePerKB(350 * 1000 sat),
       blocks_6 = FeeratePerKB(230 * 1000 sat),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProviderSpec.scala
@@ -42,7 +42,7 @@ class FallbackFeeProviderSpec extends AnyFunSuite {
 
   def dummyFeerate = FeeratePerKB(1000.sat + Random.nextInt(10000).sat)
 
-  def dummyFeerates = FeeratesPerKB(dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate)
+  def dummyFeerates = FeeratesPerKB(dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate, dummyFeerate)
 
   def await[T](f: Future[T]): T = Await.result(f, 3 seconds)
 
@@ -72,10 +72,10 @@ class FallbackFeeProviderSpec extends AnyFunSuite {
 
   test("ensure minimum feerate") {
     val feeratePerKB = FeeratePerKB(1000 sat)
-    val constantFeeProvider = new ConstantFeeProvider(FeeratesPerKB(feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB))
+    val constantFeeProvider = new ConstantFeeProvider(FeeratesPerKB(feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB))
     val fallbackFeeProvider = new FallbackFeeProvider(constantFeeProvider :: Nil, FeeratePerByte(2 sat))
     val expectedFeeratePerKB = FeeratePerKB(2000 sat)
-    assert(await(fallbackFeeProvider.getFeerates) === FeeratesPerKB(expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, feeratePerKB, feeratePerKB))
+    assert(await(fallbackFeeProvider.getFeerates) === FeeratesPerKB(expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, feeratePerKB, feeratePerKB))
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/SmoothFeeProviderSpec.scala
@@ -27,11 +27,11 @@ class SmoothFeeProviderSpec extends AnyFunSuite {
 
   test("smooth fee rates") {
     val rates = Array(
-      FeeratesPerKB(FeeratePerKB(100 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(650 sat), FeeratePerKB(700 sat)),
-      FeeratesPerKB(FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(750 sat), FeeratePerKB(800 sat)),
-      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat), FeeratePerKB(900 sat)),
-      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat), FeeratePerKB(900 sat)),
-      FeeratesPerKB(FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat), FeeratePerKB(900 sat))
+      FeeratesPerKB(FeeratePerKB(50 sat), FeeratePerKB(100 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(650 sat), FeeratePerKB(700 sat)),
+      FeeratesPerKB(FeeratePerKB(60 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(750 sat), FeeratePerKB(800 sat)),
+      FeeratesPerKB(FeeratePerKB(70 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat), FeeratePerKB(900 sat)),
+      FeeratesPerKB(FeeratePerKB(70 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat), FeeratePerKB(900 sat)),
+      FeeratesPerKB(FeeratePerKB(70 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(800 sat), FeeratePerKB(850 sat), FeeratePerKB(900 sat))
     )
     val provider: FeeProvider = new FeeProvider {
       var index = 0
@@ -56,7 +56,7 @@ class SmoothFeeProviderSpec extends AnyFunSuite {
     assert(rate1 == rates(0))
     assert(rate2 == SmoothFeeProvider.smooth(Seq(rates(0), rates(1))))
     assert(rate3 == SmoothFeeProvider.smooth(Seq(rates(0), rates(1), rates(2))))
-    assert(rate3 == FeeratesPerKB(FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(750 sat), FeeratePerKB(800 sat)))
+    assert(rate3 == FeeratesPerKB(FeeratePerKB(60 sat), FeeratePerKB(200 sat), FeeratePerKB(300 sat), FeeratePerKB(400 sat), FeeratePerKB(500 sat), FeeratePerKB(600 sat), FeeratePerKB(700 sat), FeeratePerKB(750 sat), FeeratePerKB(800 sat)))
     assert(rate4 == SmoothFeeProvider.smooth(Seq(rates(1), rates(2), rates(3))))
     assert(rate5 == rates(4)) // since the last 3 values are the same
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -1692,7 +1692,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("recv UpdateFee (local/remote feerates are too different)") { f =>
     import f._
 
-    bob.feeEstimator.setFeerate(FeeratesPerKw(FeeratePerKw(1000 sat), FeeratePerKw(2000 sat), FeeratePerKw(6000 sat), FeeratePerKw(12000 sat), FeeratePerKw(36000 sat), FeeratePerKw(72000 sat), FeeratePerKw(140000 sat), FeeratePerKw(160000 sat)))
+    bob.feeEstimator.setFeerate(FeeratesPerKw(FeeratePerKw(500 sat), FeeratePerKw(1000 sat), FeeratePerKw(2000 sat), FeeratePerKw(6000 sat), FeeratePerKw(12000 sat), FeeratePerKw(36000 sat), FeeratePerKw(72000 sat), FeeratePerKw(140000 sat), FeeratePerKw(160000 sat)))
     val tx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.publishableTxs.commitTx.tx
     val sender = TestProbe()
     val localFeerate = bob.feeEstimator.getFeeratePerKw(bob.feeTargets.commitmentBlockTarget)
@@ -2121,7 +2121,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
     val sender = TestProbe()
     val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-    val event = CurrentFeerates(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(200 sat), FeeratePerKw(600 sat), FeeratePerKw(1200 sat), FeeratePerKw(3600 sat), FeeratePerKw(7200 sat), FeeratePerKw(14400 sat), FeeratePerKw(100800 sat)))
+    val event = CurrentFeerates(FeeratesPerKw(FeeratePerKw(50 sat), FeeratePerKw(100 sat), FeeratePerKw(200 sat), FeeratePerKw(600 sat), FeeratePerKw(1200 sat), FeeratePerKw(3600 sat), FeeratePerKw(7200 sat), FeeratePerKw(14400 sat), FeeratePerKw(100800 sat)))
     alice ! event
     alice2bob.expectMsg(UpdateFee(initialState.commitments.channelId, event.feeratesPerKw.feePerBlock(Alice.nodeParams.onChainFeeConf.feeTargets.commitmentBlockTarget)))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -642,7 +642,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
   test("recv CurrentFeerate (when funder, triggers an UpdateFee)") { f =>
     import f._
     val initialState = alice.stateData.asInstanceOf[DATA_SHUTDOWN]
-    val event = CurrentFeerates(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(200 sat), FeeratePerKw(600 sat), FeeratePerKw(1200 sat), FeeratePerKw(3600 sat), FeeratePerKw(7200 sat), FeeratePerKw(14400 sat), FeeratePerKw(100800 sat)))
+    val event = CurrentFeerates(FeeratesPerKw(FeeratePerKw(50 sat), FeeratePerKw(100 sat), FeeratePerKw(200 sat), FeeratePerKw(600 sat), FeeratePerKw(1200 sat), FeeratePerKw(3600 sat), FeeratePerKw(7200 sat), FeeratePerKw(14400 sat), FeeratePerKw(100800 sat)))
     alice ! event
     alice2bob.expectMsg(UpdateFee(initialState.commitments.channelId, event.feeratesPerKw.feePerBlock(alice.feeTargets.commitmentBlockTarget)))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -109,7 +109,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
   test("start fee negotiation from configured block target") { f =>
     import f._
 
-    alice.feeEstimator.setFeerate(FeeratesPerKw(FeeratePerKw(100 sat), FeeratePerKw(250 sat), FeeratePerKw(350 sat), FeeratePerKw(450 sat), FeeratePerKw(600 sat), FeeratePerKw(800 sat), FeeratePerKw(900 sat), FeeratePerKw(1000 sat)))
+    alice.feeEstimator.setFeerate(FeeratesPerKw(FeeratePerKw(50 sat), FeeratePerKw(100 sat), FeeratePerKw(250 sat), FeeratePerKw(350 sat), FeeratePerKw(450 sat), FeeratePerKw(600 sat), FeeratePerKw(800 sat), FeeratePerKw(900 sat), FeeratePerKw(1000 sat)))
 
     val sender = TestProbe()
     // alice initiates a closing

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteFeeratesDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteFeeratesDbSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.funsuite.AnyFunSuite
 class SqliteFeeratesDbSpec extends AnyFunSuite {
 
   val feerate = FeeratesPerKB(
+    mempoolMinFee = FeeratePerKB(10000 sat),
     block_1 = FeeratePerKB(150000 sat),
     blocks_2 = FeeratePerKB(120000 sat),
     blocks_6 = FeeratePerKB(100000 sat),
@@ -83,7 +84,7 @@ class SqliteFeeratesDbSpec extends AnyFunSuite {
     }
 
     // When migrating, we simply copy the estimate for blocks 144 to blocks 1008.
-    assert(migratedDb.getFeerates() === Some(feerate.copy(blocks_1008 = feerate.blocks_144)))
+    assert(migratedDb.getFeerates() === Some(feerate.copy(blocks_1008 = feerate.blocks_144, mempoolMinFee = feerate.blocks_144)))
     migratedDb.addOrUpdateFeerates(feerate)
     assert(migratedDb.getFeerates() === Some(feerate))
   }


### PR DESCRIPTION
* Retrieve the minimum fee required to enter our mempool
* Add a metric to track this value
* Remove fallback fee providers when Bitcoin Core is used
* Add a metric to track feerate retrieval errors

For fallback fee providers that don't have any mempool information, we default to the 1008 block target. It doesn't matter as these fee providers will not be used anyway.