### PR TITLE
Router handling of non-standard channel events

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -68,6 +68,8 @@ trait AbstractCommitments {
   def channelId: ByteVector32
 
   def announceChannel: Boolean
+
+  def hasBaseChainFunding: Boolean
 }
 
 /**
@@ -156,6 +158,8 @@ case class Commitments(channelVersion: ChannelVersion,
   val remoteNodeId: PublicKey = remoteParams.nodeId
 
   val announceChannel: Boolean = (channelFlags & 0x01) != 0
+
+  val hasBaseChainFunding: Boolean = true
 
   val capacity: Satoshi = commitInput.txOut.amount
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -216,13 +216,13 @@ class Router(val nodeParams: NodeParams, watcher: ActorRef, initialized: Option[
     case Event(PeerRoutingMessage(peerConnection, remoteNodeId, u: ChannelUpdate), d) =>
       stay using Validation.handleChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, Right(RemoteChannelUpdate(u, Set(RemoteGossip(peerConnection, remoteNodeId)))))
 
-    case Event(lcu: LocalChannelUpdate, d: Data) =>
+    case Event(lcu: LocalChannelUpdate, d: Data) if lcu.commitments.hasBaseChainFunding =>
       stay using Validation.handleLocalChannelUpdate(d, nodeParams.db.network, nodeParams.routerConf, nodeParams.nodeId, watcher, lcu)
 
     case Event(lcd: LocalChannelDown, d: Data) =>
       stay using Validation.handleLocalChannelDown(d, nodeParams.nodeId, lcd)
 
-    case Event(e: AvailableBalanceChanged, d: Data) =>
+    case Event(e: AvailableBalanceChanged, d: Data) if e.commitments.hasBaseChainFunding =>
       stay using Validation.handleAvailableBalanceChanged(d, e)
 
     case Event(s: SendChannelQuery, d) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -412,7 +412,7 @@ object Validation {
     } else {
       log.debug("ignoring announcement {} (unknown channel)", u)
       sendDecision(origins, GossipDecision.NoRelatedChannel(u))
-      d
+      d.copy(privateChannels = d.privateChannels - u.shortChannelId)
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
@@ -569,21 +569,21 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
     register.expectNoMsg(100 millis) // nothing should happen while channels are still offline.
 
     val cs = new AbstractCommitments {
-      def getOutgoingHtlcCrossSigned(htlcId: Long): Option[UpdateAddHtlc] = None
-      def getIncomingHtlcCrossSigned(htlcId: Long): Option[UpdateAddHtlc] = {
+      override def getOutgoingHtlcCrossSigned(htlcId: Long): Option[UpdateAddHtlc] = None
+      override def getIncomingHtlcCrossSigned(htlcId: Long): Option[UpdateAddHtlc] = {
         if (htlcId == 0L) Some(relayedHtlc1In.add)
         else if (htlcId == 1L) Some(nonRelayedHtlc2In.add)
         else None
       }
-      def timedOutOutgoingHtlcs(blockheight: Long): Set[UpdateAddHtlc] = Set.empty
-      def localNodeId: PublicKey = randomExtendedPrivateKey.publicKey
-      def remoteNodeId: PublicKey = randomExtendedPrivateKey.publicKey
-      def capacity: Satoshi = Long.MaxValue.sat
-      def availableBalanceForReceive: MilliSatoshi = Long.MaxValue.msat
-      def availableBalanceForSend: MilliSatoshi = 0.msat
-      def originChannels: Map[Long, Origin] = Map.empty
-      def channelId: ByteVector32 = channelId_ab_1
-      def announceChannel: Boolean = false
+      override def localNodeId: PublicKey = randomExtendedPrivateKey.publicKey
+      override def remoteNodeId: PublicKey = randomExtendedPrivateKey.publicKey
+      override def capacity: Satoshi = Long.MaxValue.sat
+      override def availableBalanceForReceive: MilliSatoshi = Long.MaxValue.msat
+      override def availableBalanceForSend: MilliSatoshi = 0.msat
+      override def originChannels: Map[Long, Origin] = Map.empty
+      override def channelId: ByteVector32 = channelId_ab_1
+      override def announceChannel: Boolean = false
+      override def hasBaseChainFunding: Boolean = true
     }
 
     // Non-standard channel goes to NORMAL state:


### PR DESCRIPTION
This tries to address what's described at https://gitter.im/ACINQ/developers?at=5fae6c8bc6fe0131d4f1ea88.

First, it seems like events from certain types of non-standard channels should be just blocked from `Router` altogether because validation is inherently connected with base chain data.

Second, I've decided to go with another `AbstractCommitments` parameter (instead of pattern matching) because some future non-standard channels may still have a base chain tx and so could be eligible for processing in `Router`.