### PR TITLE
Allow overriding of Tor target

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -206,7 +206,7 @@ eclair {
     host = "127.0.0.1"
     port = 9051
     private-key-file = "tor.dat"
-    targets = [] // a list of [address:]port, for advanced use (e.g. to send traffic to front servers)
+    targets = [] // a list of address:port, for advanced use (e.g. to send traffic to front servers). See the tor man page for syntax details.
   }
 
   db {

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -206,6 +206,7 @@ eclair {
     host = "127.0.0.1"
     port = 9051
     private-key-file = "tor.dat"
+    targets = [] // a list of [address:]port, for advanced use (e.g. to send traffic to front servers)
   }
 
   db {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -16,13 +16,6 @@
 
 package fr.acinq.eclair
 
-import java.io.File
-import java.net.InetSocketAddress
-import java.sql.DriverManager
-import java.util.UUID
-import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
-
 import akka.Done
 import akka.actor.{ActorRef, ActorSystem, Props, SupervisorStrategy}
 import akka.pattern.after
@@ -57,8 +50,15 @@ import grizzled.slf4j.Logging
 import org.json4s.JsonAST.JArray
 import scodec.bits.ByteVector
 
+import java.io.File
+import java.net.InetSocketAddress
+import java.sql.DriverManager
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 import scala.concurrent._
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success}
 
 /**
@@ -360,6 +360,7 @@ class Setup(datadir: File,
         authentication = auth,
         privateKeyPath = new File(datadir, config.getString("tor.private-key-file")).toPath,
         virtualPort = config.getInt("server.port"),
+        targets = config.getStringList("tor.targets").asScala.toSeq,
         onionAdded = Some(promiseTorAddress))
 
       val controller = system.actorOf(SimpleSupervisor.props(Controller.props(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/tor/TorProtocolHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/tor/TorProtocolHandler.scala
@@ -43,15 +43,15 @@ case class TorException(private val msg: String) extends RuntimeException(s"Tor 
   * @param onionServiceVersion v2 or v3
   * @param authentication      Tor controller auth mechanism (password or safecookie)
   * @param privateKeyPath      path to a file that contains a Tor private key
-  * @param virtualPort         port of our protected local server (typically 9735)
-  * @param targetPorts         target ports of the public hidden service
+  * @param virtualPort         port for the public hidden service (typically 9735)
+  * @param targets             address of our protected server (format [host:]port), 127.0.0.1:[[virtualPort]] if empty
   * @param onionAdded          a Promise to track creation of the endpoint
   */
 class TorProtocolHandler(onionServiceVersion: OnionServiceVersion,
                          authentication: Authentication,
                          privateKeyPath: Path,
                          virtualPort: Int,
-                         targetPorts: Seq[Int],
+                         targets: Seq[String],
                          onionAdded: Option[Promise[NodeAddress]]
                         ) extends Actor with Stash with ActorLogging {
 
@@ -159,10 +159,10 @@ class TorProtocolHandler(onionServiceVersion: OnionServiceVersion,
   }
 
   private def computePort: String = {
-    if (targetPorts.isEmpty) {
+    if (targets.isEmpty) {
       s"Port=$virtualPort,$virtualPort"
     } else {
-      targetPorts.map(p => s"Port=$virtualPort,$p").mkString(" ")
+      targets.map(p => s"Port=$virtualPort,$p").mkString(" ")
     }
   }
 
@@ -194,10 +194,10 @@ object TorProtocolHandler {
             authentication: Authentication,
             privateKeyPath: Path,
             virtualPort: Int,
-            targetPorts: Seq[Int] = Seq(),
+            targets: Seq[String] = Seq(),
             onionAdded: Option[Promise[NodeAddress]] = None
            ): Props =
-    Props(new TorProtocolHandler(version, authentication, privateKeyPath, virtualPort, targetPorts, onionAdded))
+    Props(new TorProtocolHandler(version, authentication, privateKeyPath, virtualPort, targets, onionAdded))
 
   // those are defined in the spec
   private val ServerKey = ByteVector.view("Tor safe cookie authentication server-to-controller hash".getBytes())


### PR DESCRIPTION
This is useful to redirect incoming tor traffic to eclair-front.