### PR TITLE
Find the latest version of eclair-node jar

### DIFF
--- a/eclair-node/src/main/resources/eclair-node.bat
+++ b/eclair-node/src/main/resources/eclair-node.bat
@@ -48,7 +48,7 @@ rem "-J" is stripped, "-D" is left as is, and everything is appended to JAVA_OPT
 set _JAVA_PARAMS=
 set _APP_ARGS=
 
-for /f %%i in ('dir /b %APP_LIB_DIR%\eclair-node*') do set APP_ENTRYPOINT=%%i
+for /f %%i in ('dir /b /OD %APP_LIB_DIR%\eclair-node*') do set APP_ENTRYPOINT=%%i
 set CUSTOM_MAIN_CLASS="fr.acinq.eclair.Boot"
 set APP_CLASSPATH="%APP_LIB_DIR%;%APP_LIB_DIR%/%APP_ENTRYPOINT%"
 


### PR DESCRIPTION
Until the build process is updated so that changing the major version number x to x+1 appends the `.0` to the new version number in the filename, Windows needs a different strategy to find the highest version number.  I chose to use the eclair-node*.jar file with the latest write time.  This is a fix for #1619 .