### PR TITLE
Take mutual close txes into account in Electrum background check

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/CheckElectrumSetup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/CheckElectrumSetup.scala
@@ -152,6 +152,7 @@ class BasicWatcher(client: ActorRef, channels: Seq[HasCommitments], pWatchResult
   // we know those transactions are ok
   val okTxes = channels.flatMap {
     case d: DATA_CLOSING => WatchListener.okTransactions(d.commitments) ++ d.mutualCloseProposed.map(_.txid)
+    case d: DATA_NEGOTIATING => WatchListener.okTransactions(d.commitments) ++ d.closingTxProposed.flatten.map(_.unsignedTx.txid)
     case d: HasCommitments => WatchListener.okTransactions(d.commitments)
   }.toSet
 


### PR DESCRIPTION
We have a background task that periodically checks the blockchain to
detect unexpected transactions, as they could be cheating attempts.

When cooperatively closing a channel, in the `NEGOTIATING` state, peers
exchange signatures in order to converge on a feerate for the mutual
close transaction. Any transaction exchanged during this negotiation
process is valid and may be published, even if the counterparty dies
abruptly before converging, due to e.g. connectivity issues.

Therefore, the electrum background check needs to take those
transactions into account and not flag them as potential cheating
attempts. We already do that when we are in the `CLOSING` state, as
there may be competing mutual closes.