### PR TITLE
Fix bug in enforceMinimumFeerate

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProvider.scala
@@ -43,14 +43,16 @@ class FallbackFeeProvider(providers: Seq[FeeProvider], minFeeratePerByte: Feerat
 
 object FallbackFeeProvider {
 
-  private def enforceMinimumFeerate(feeratesPerKB: FeeratesPerKB, minFeeratePerKB: FeeratePerKB): FeeratesPerKB = feeratesPerKB.copy(
+  private def enforceMinimumFeerate(feeratesPerKB: FeeratesPerKB, minFeeratePerKB: FeeratePerKB): FeeratesPerKB = FeeratesPerKB(
     mempoolMinFee = feeratesPerKB.mempoolMinFee.max(minFeeratePerKB),
     block_1 = feeratesPerKB.block_1.max(minFeeratePerKB),
     blocks_2 = feeratesPerKB.blocks_2.max(minFeeratePerKB),
     blocks_6 = feeratesPerKB.blocks_6.max(minFeeratePerKB),
     blocks_12 = feeratesPerKB.blocks_12.max(minFeeratePerKB),
     blocks_36 = feeratesPerKB.blocks_36.max(minFeeratePerKB),
-    blocks_72 = feeratesPerKB.blocks_72.max(minFeeratePerKB)
+    blocks_72 = feeratesPerKB.blocks_72.max(minFeeratePerKB),
+    blocks_144 = feeratesPerKB.blocks_144.max(minFeeratePerKB),
+    blocks_1008 = feeratesPerKB.blocks_1008.max(minFeeratePerKB)
   )
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FallbackFeeProviderSpec.scala
@@ -71,11 +71,11 @@ class FallbackFeeProviderSpec extends AnyFunSuite {
   }
 
   test("ensure minimum feerate") {
-    val feeratePerKB = FeeratePerKB(1000 sat)
-    val constantFeeProvider = new ConstantFeeProvider(FeeratesPerKB(feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB, feeratePerKB))
-    val fallbackFeeProvider = new FallbackFeeProvider(constantFeeProvider :: Nil, FeeratePerByte(2 sat))
-    val expectedFeeratePerKB = FeeratePerKB(2000 sat)
-    assert(await(fallbackFeeProvider.getFeerates) === FeeratesPerKB(expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, expectedFeeratePerKB, feeratePerKB, feeratePerKB))
+    val constantFeeProvider = new ConstantFeeProvider(FeeratesPerKB(FeeratePerKB(64000 sat), FeeratePerKB(32000 sat), FeeratePerKB(16000 sat), FeeratePerKB(8000 sat), FeeratePerKB(4000 sat), FeeratePerKB(2000 sat), FeeratePerKB(1500 sat), FeeratePerKB(1000 sat), FeeratePerKB(1000 sat)))
+    val minFeeratePerByte = FeeratePerByte(2 sat)
+    val minFeeratePerKB = FeeratePerKB(minFeeratePerByte)
+    val fallbackFeeProvider = new FallbackFeeProvider(constantFeeProvider :: Nil, minFeeratePerByte)
+    assert(await(fallbackFeeProvider.getFeerates) === FeeratesPerKB(FeeratePerKB(64000 sat), FeeratePerKB(32000 sat), FeeratePerKB(16000 sat), FeeratePerKB(8000 sat), FeeratePerKB(4000 sat), minFeeratePerKB, minFeeratePerKB, minFeeratePerKB, minFeeratePerKB))
   }
 
 }


### PR DESCRIPTION
Using the `copy` method is risky because it's easy to forget newly added
fields. Also the test didn't make much sense.