### PR TITLE
Move fee provider conf

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -36,10 +36,6 @@ eclair {
     zmqtx = "tcp://127.0.0.1:29000"
   }
 
-  min-feerate = 2 // minimum feerate in satoshis per byte
-  smooth-feerate-window = 6 // 1 = no smoothing
-  feerate-provider-timeout = 5 seconds // max time we'll wait for answers from a fee provider before we fallback to the next one
-
   node-alias = "eclair"
   node-color = "49daaa"
 
@@ -92,6 +88,10 @@ eclair {
   fee-proportional-millionths = 100 // fee charged per transferred satoshi in millionths of a satoshi (100 = 0.01%)
 
   on-chain-fees {
+    min-feerate = 2 // minimum feerate in satoshis per byte
+    smoothing-window = 6 // 1 = no smoothing
+    provider-timeout = 5 seconds // max time we'll wait for answers from a fee provider before we fallback to the next one
+
     default-feerates { // those are per target block, in satoshis per kilobyte
       1 = 210000
       2 = 180000

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -88,7 +88,7 @@ eclair {
   fee-proportional-millionths = 100 // fee charged per transferred satoshi in millionths of a satoshi (100 = 0.01%)
 
   on-chain-fees {
-    min-feerate = 2 // minimum feerate in satoshis per byte
+    min-feerate = 1 // minimum feerate in satoshis per byte
     smoothing-window = 6 // 1 = no smoothing
     provider-timeout = 5 seconds // max time we'll wait for answers from a fee provider before we fallback to the next one
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -194,7 +194,11 @@ object NodeParams extends Logging {
       "global-features" -> "features",
       "local-features" -> "features",
       // v0.4.1
-      "on-chain-fees.max-feerate-mismatch" -> "on-chain-fees.feerate-tolerance.ratio-low / on-chain-fees.feerate-tolerance.ratio-high"
+      "on-chain-fees.max-feerate-mismatch" -> "on-chain-fees.feerate-tolerance.ratio-low / on-chain-fees.feerate-tolerance.ratio-high",
+      // v0.4.3
+      "min-feerate" -> "on-chain-fees.min-feerate",
+      "smooth-feerate-window" -> "on-chain-fees.smoothing-window",
+      "feerate-provider-timeout" -> "on-chain-fees.provider-timeout"
     )
     deprecatedKeyPaths.foreach {
       case (old, new_) => require(!config.hasPath(old), s"configuration key '$old' has been replaced by '$new_'")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -238,9 +238,9 @@ class Setup(datadir: File,
         feeratesPerKw.set(FeeratesPerKw(confDefaultFeerates))
         confDefaultFeerates
       }
-      minFeeratePerByte = FeeratePerByte(Satoshi(config.getLong("min-feerate")))
-      smoothFeerateWindow = config.getInt("smooth-feerate-window")
-      readTimeout = FiniteDuration(config.getDuration("feerate-provider-timeout", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
+      minFeeratePerByte = FeeratePerByte(Satoshi(config.getLong("on-chain-fees.min-feerate")))
+      smoothFeerateWindow = config.getInt("on-chain-fees.smoothing-window")
+      readTimeout = FiniteDuration(config.getDuration("on-chain-fees.provider-timeout", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
       feeProvider = (nodeParams.chainHash, bitcoin) match {
         case (Block.RegtestGenesisBlock.hash, _) =>
           new FallbackFeeProvider(new ConstantFeeProvider(defaultFeerates) :: Nil, minFeeratePerByte)


### PR DESCRIPTION
Took the opportunity to improve the naming as well.

I also considered putting them under a  `providers` section, WDYT?
```
on-chain-fees {
  providers {
    min-feerate = 1 // minimum feerate in satoshis per byte
    smoothing-window = 6 // 1 = no smoothing
    timeout = 5 seconds // max time we'll wait for answers from a fee provider before we fallback to the next one
  }
...
}
```