### PR TITLE
fixup! Distribute connection-handling on multiple machines (#1566)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
 WORKDIR /usr/src
 COPY pom.xml pom.xml
 COPY eclair-core/pom.xml eclair-core/pom.xml
+COPY eclair-front/pom.xml eclair-front/pom.xml
 COPY eclair-node/pom.xml eclair-node/pom.xml
 COPY eclair-node-gui/pom.xml eclair-node-gui/pom.xml
 COPY eclair-node/modules/assembly.xml eclair-node/modules/assembly.xml


### PR DESCRIPTION
This fixes the Docker build which was failing due to the new child module `eclair-front`.

We should probably add a way to start an `eclair-front` from docker too.