### PR TITLE
Use a local actorsystem by default

### DIFF
--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -3,7 +3,7 @@ eclair {
 }
 
 akka {
-  actor.provider = cluster
+  actor.provider = local // set to cluster when using eclair-front
   remote {
     artery {
       canonical.hostname = "127.0.0.1"


### PR DESCRIPTION
Even after #1566, we want the default to be a standalone deployment.