### PR TITLE
fixup! Settle HTLCs revoked commit (#1630)

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/ChannelTypesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/ChannelTypesSpec.scala
@@ -1,9 +1,9 @@
 package fr.acinq.eclair.channel
 
-import fr.acinq.bitcoin.{OutPoint, Transaction, TxIn, TxOut}
+import fr.acinq.bitcoin.{OutPoint, SatoshiLong, Transaction, TxIn, TxOut}
 import fr.acinq.eclair.channel.Helpers.Closing
+import fr.acinq.eclair.randomBytes32
 import fr.acinq.eclair.transactions.Transactions
-import fr.acinq.eclair.{LongToBtcAmount, randomBytes32}
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits.ByteVector
 


### PR DESCRIPTION
#1630 introduced a new test, while #1637 changed the implicit functions for btc amounts.
Git didn't detect a conflict, but #1630 should have been rebased before merging.