### PR TITLE
More aggressively re-emit private channel updates

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -702,7 +702,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     bob2alice.forward(alice)
     alice2bob.forward(bob)
 
-    //  at this point the channel still isn't deeply buried: channel_update isn't sent again
+    // at this point the channel still isn't deeply buried: channel_update isn't sent again
     alice2bob.expectNoMsg()
     bob2alice.expectNoMsg()
 
@@ -727,5 +727,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     // this time peers re-send their channel_update
     alice2bob.expectMsgType[ChannelUpdate]
     bob2alice.expectMsgType[ChannelUpdate]
+    // and the channel is enabled
+    channelUpdateListener.expectMsgType[LocalChannelUpdate]
   }
 }


### PR DESCRIPTION
We had a delay mechanism before re-enabling reconnected channels to avoid creating frequent channel updates on flappy connections and flooding the network with unnecessary gossip.

We don't need this protection for private channels since they're not gossiped to the rest of the network. And in the case of private channels to mobile wallets, we don't want to add any delay, otherwise the reconnected channel will not be in the router's graph and we'll have issues routing payments to that wallet (especially if they quickly disconnect, before our 10-seconds delay).