### PR TITLE
Relax single tx input requirements

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
@@ -40,10 +40,13 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
 /**
- * A blockchain watcher that:
- * - receives bitcoin events (new blocks and new txes) directly from the bitcoin network
- * - also uses bitcoin-core rpc api, most notably for tx confirmation count and blockcount (because reorgs)
  * Created by PM on 21/02/2016.
+ */
+
+/**
+ * A blockchain watcher that:
+ *  - receives bitcoin events (new blocks and new txs) directly from the bitcoin network
+ *  - also uses bitcoin-core rpc api, most notably for tx confirmation count and block count (because reorgs)
  */
 class ZmqWatcher(chainHash: ByteVector32, blockCount: AtomicLong, client: ExtendedBitcoinClient)(implicit ec: ExecutionContext = ExecutionContext.global) extends Actor with ActorLogging {
 
@@ -180,13 +183,15 @@ class ZmqWatcher(chainHash: ByteVector32, blockCount: AtomicLong, client: Extend
     case PublishAsap(tx) =>
       val blockCount = this.blockCount.get()
       val cltvTimeout = Scripts.cltvTimeout(tx)
-      val csvTimeout = Scripts.csvTimeout(tx)
-      if (csvTimeout > 0) {
-        require(tx.txIn.size == 1, s"watcher only supports tx with 1 input, this tx has ${tx.txIn.size} inputs")
-        val parentTxid = tx.txIn.head.outPoint.txid
-        log.info(s"txid=${tx.txid} has a relative timeout of $csvTimeout blocks, watching parenttxid=$parentTxid tx={}", tx)
-        val parentPublicKey = fr.acinq.bitcoin.Script.write(fr.acinq.bitcoin.Script.pay2wsh(tx.txIn.head.witness.stack.last))
-        self ! WatchConfirmed(self, parentTxid, parentPublicKey, minDepth = 1, BITCOIN_PARENT_TX_CONFIRMED(tx))
+      val csvTimeouts = Scripts.csvTimeouts(tx)
+      if (csvTimeouts.nonEmpty) {
+        // watcher supports txs with multiple csv-delayed inputs: we watch all delayed parents and try to publish every
+        // time a parent's relative delays are satisfied, so we will eventually succeed.
+        csvTimeouts.foreach { case (parentTxId, csvTimeout) =>
+          log.info(s"txid=${tx.txid} has a relative timeout of $csvTimeout blocks, watching parentTxId=$parentTxId tx={}", tx)
+          val parentPublicKeyScript = Script.write(Script.pay2wsh(tx.txIn.find(_.outPoint.txid == parentTxId).get.witness.stack.last))
+          self ! WatchConfirmed(self, parentTxId, parentPublicKeyScript, minDepth = csvTimeout, BITCOIN_PARENT_TX_CONFIRMED(tx))
+        }
       } else if (cltvTimeout > blockCount) {
         log.info(s"delaying publication of txid=${tx.txid} until block=$cltvTimeout (curblock=$blockCount)")
         val block2tx1 = block2tx.updated(cltvTimeout, block2tx.getOrElse(cltvTimeout, Seq.empty[Transaction]) :+ tx)
@@ -197,11 +202,9 @@ class ZmqWatcher(chainHash: ByteVector32, blockCount: AtomicLong, client: Extend
       log.info(s"parent tx of txid=${tx.txid} has been confirmed")
       val blockCount = this.blockCount.get()
       val cltvTimeout = Scripts.cltvTimeout(tx)
-      val csvTimeout = Scripts.csvTimeout(tx)
-      val absTimeout = math.max(blockHeight + csvTimeout, cltvTimeout)
-      if (absTimeout > blockCount) {
-        log.info(s"delaying publication of txid=${tx.txid} until block=$absTimeout (curblock=$blockCount)")
-        val block2tx1 = block2tx.updated(absTimeout, block2tx.getOrElse(absTimeout, Seq.empty[Transaction]) :+ tx)
+      if (cltvTimeout > blockCount) {
+        log.info(s"delaying publication of txid=${tx.txid} until block=$cltvTimeout (curblock=$blockCount)")
+        val block2tx1 = block2tx.updated(cltvTimeout, block2tx.getOrElse(cltvTimeout, Seq.empty[Transaction]) :+ tx)
         context become watching(watches, watchedUtxos, block2tx1, nextTick)
       } else publish(tx)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
@@ -173,13 +173,15 @@ class ElectrumWatcher(blockCount: AtomicLong, client: ActorRef) extends Actor wi
     case PublishAsap(tx) =>
       val blockCount = this.blockCount.get()
       val cltvTimeout = Scripts.cltvTimeout(tx)
-      val csvTimeout = Scripts.csvTimeout(tx)
-      if (csvTimeout > 0) {
-        require(tx.txIn.size == 1, s"watcher only supports tx with 1 input, this tx has ${tx.txIn.size} inputs")
-        val parentTxid = tx.txIn.head.outPoint.txid
-        log.info(s"txid=${tx.txid} has a relative timeout of $csvTimeout blocks, watching parenttxid=$parentTxid tx={}", tx)
-        val parentPublicKeyScript = WatchConfirmed.extractPublicKeyScript(tx.txIn.head.witness)
-        self ! WatchConfirmed(self, parentTxid, parentPublicKeyScript, minDepth = 1, BITCOIN_PARENT_TX_CONFIRMED(tx))
+      val csvTimeouts = Scripts.csvTimeouts(tx)
+      if (csvTimeouts.nonEmpty) {
+        // watcher supports txs with multiple csv-delayed inputs: we watch all delayed parents and try to publish every
+        // time a parent's relative delays are satisfied, so we will eventually succeed.
+        csvTimeouts.foreach { case (parentTxId, csvTimeout) =>
+          log.info(s"txid=${tx.txid} has a relative timeout of $csvTimeout blocks, watching parentTxId=$parentTxId tx={}", tx)
+          val parentPublicKeyScript = WatchConfirmed.extractPublicKeyScript(tx.txIn.find(_.outPoint.txid == parentTxId).get.witness)
+          self ! WatchConfirmed(self, parentTxId, parentPublicKeyScript, minDepth = csvTimeout, BITCOIN_PARENT_TX_CONFIRMED(tx))
+        }
       } else if (cltvTimeout > blockCount) {
         log.info(s"delaying publication of txid=${tx.txid} until block=$cltvTimeout (curblock=$blockCount)")
         val block2tx1 = block2tx.updated(cltvTimeout, block2tx.getOrElse(cltvTimeout, Seq.empty[Transaction]) :+ tx)
@@ -193,11 +195,9 @@ class ElectrumWatcher(blockCount: AtomicLong, client: ActorRef) extends Actor wi
       log.info(s"parent tx of txid=${tx.txid} has been confirmed")
       val blockCount = this.blockCount.get()
       val cltvTimeout = Scripts.cltvTimeout(tx)
-      val csvTimeout = Scripts.csvTimeout(tx)
-      val absTimeout = math.max(blockHeight + csvTimeout, cltvTimeout)
-      if (absTimeout > blockCount) {
-        log.info(s"delaying publication of txid=${tx.txid} until block=$absTimeout (curblock=$blockCount)")
-        val block2tx1 = block2tx.updated(absTimeout, block2tx.getOrElse(absTimeout, Seq.empty[Transaction]) :+ tx)
+      if (cltvTimeout > blockCount) {
+        log.info(s"delaying publication of txid=${tx.txid} until block=$cltvTimeout (curblock=$blockCount)")
+        val block2tx1 = block2tx.updated(cltvTimeout, block2tx.getOrElse(cltvTimeout, Seq.empty[Transaction]) :+ tx)
         context become running(height, tip, watches, scriptHashStatus, block2tx1, sent)
       } else {
         publish(tx)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.transactions
 
 import fr.acinq.bitcoin.Crypto.{PrivateKey, ripemd160, sha256}
 import fr.acinq.bitcoin.Script.{pay2wpkh, pay2wsh, write}
-import fr.acinq.bitcoin.{Btc, ByteVector32, Crypto, MilliBtc, MilliBtcDouble, Protocol, SIGHASH_ALL, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE, Satoshi, SatoshiLong, Script, Transaction, TxOut, millibtc2satoshi}
+import fr.acinq.bitcoin.{Btc, ByteVector32, Crypto, MilliBtc, MilliBtcDouble, OutPoint, Protocol, SIGHASH_ALL, SIGHASH_ANYONECANPAY, SIGHASH_NONE, SIGHASH_SINGLE, Satoshi, SatoshiLong, Script, Transaction, TxIn, TxOut, millibtc2satoshi}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.Helpers.Funding
 import fr.acinq.eclair.transactions.CommitmentOutput.{InHtlc, OutHtlc}
@@ -53,6 +53,27 @@ class TransactionsSpec extends AnyFunSuite with Logging {
   val toLocalDelay = CltvExpiryDelta(144)
   val localDustLimit = Satoshi(546)
   val feeratePerKw = FeeratePerKw(22000 sat)
+
+  test("extract csv and cltv timeouts") {
+    val parentTxId1 = randomBytes32
+    val parentTxId2 = randomBytes32
+    val parentTxId3 = randomBytes32
+    val txIn = Seq(
+      TxIn(OutPoint(parentTxId1.reverse, 3), Nil, 3),
+      TxIn(OutPoint(parentTxId2.reverse, 1), Nil, 4),
+      TxIn(OutPoint(parentTxId3.reverse, 0), Nil, 5),
+      TxIn(OutPoint(randomBytes32, 4), Nil, 0),
+      TxIn(OutPoint(parentTxId1.reverse, 2), Nil, 5),
+    )
+    val tx = Transaction(2, txIn, Nil, 10)
+    val expected = Map(
+      parentTxId1 -> 5,
+      parentTxId2 -> 4,
+      parentTxId3 -> 5,
+    )
+    assert(expected === Scripts.csvTimeouts(tx))
+    assert(10 === Scripts.cltvTimeout(tx))
+  }
 
   test("encode/decode sequence and locktime (one example)") {
     val txnumber = 0x11F71FB268DL


### PR DESCRIPTION
In some places of the codebase we relied on the fact that lightning transactions had a single input. That was correct with the standard commitments format, but will not be the case with anchor outputs: 2nd-stage txs (htlc-txs) and 3rd-stage txs (claim-htlc-txs) can be RBF-ed and have any number of inputs and outputs.
