### PR TITLE
Remove support for initial_routing_sync

### DIFF
--- a/docs/Configure.md
+++ b/docs/Configure.md
@@ -61,7 +61,7 @@ Note that you can also disable some default features:
 
 ```conf
 eclair.features {
-    initial_routing_sync = disabled
+    option_support_large_channel = disabled
 }
 ```
 
@@ -77,7 +77,7 @@ eclair.override-features = [
     {
         nodeId = "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
         features {
-            initial_routing_sync = disabled
+            option_support_large_channel = disabled
             option_static_remotekey = optional
         }
     },

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -42,7 +42,6 @@ eclair {
   trampoline-payments-enable = false // TODO: @t-bast: once spec-ed this should use a global feature flag
   // see https://github.com/lightningnetwork/lightning-rfc/blob/master/09-features.md
   features {
-    initial_routing_sync = optional
     option_data_loss_protect = optional
     gossip_queries = optional
     gossip_queries_ex = optional

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -250,6 +250,7 @@ object NodeParams extends Logging {
       val featuresErr = Features.validateFeatureGraph(features)
       require(featuresErr.isEmpty, featuresErr.map(_.message))
       require(features.hasFeature(Features.VariableLengthOnion), s"${Features.VariableLengthOnion.rfcName} must be enabled")
+      require(!features.hasFeature(Features.InitialRoutingSync), s"${Features.InitialRoutingSync.rfcName} is not supported anymore, use ${Features.ChannelRangeQueries.rfcName} instead")
     }
 
     val pluginMessageParams = pluginParams.collect { case p: CustomFeaturePlugin => p }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -347,10 +347,6 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
           val flags_opt = if (canUseChannelRangeQueriesEx) Some(QueryChannelRangeTlv.QueryFlags(QueryChannelRangeTlv.QueryFlags.WANT_ALL)) else None
           log.info(s"sending sync channel range query with flags_opt=$flags_opt replacePrevious=$replacePrevious")
           router ! SendChannelQuery(d.chainHash, d.remoteNodeId, self, replacePrevious, flags_opt)
-        } else if (d.remoteInit.features.hasFeature(Features.InitialRoutingSync) && replacePrevious) {
-          // For "old" nodes that don't support channel queries, we send them the full routing table
-          log.info("peer requested a full routing table dump")
-          router ! GetRoutingState
         }
         stay
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -93,7 +93,6 @@ class StartupSpec extends AnyFunSuite {
 
     val legalFeaturesConf = ConfigFactory.parseMap(Map(
       s"features.${OptionDataLossProtect.rfcName}" -> "optional",
-      s"features.${InitialRoutingSync.rfcName}" -> "optional",
       s"features.${ChannelRangeQueries.rfcName}" -> "optional",
       s"features.${ChannelRangeQueriesExtended.rfcName}" -> "optional",
       s"features.${VariableLengthOnion.rfcName}" -> "optional",
@@ -104,9 +103,17 @@ class StartupSpec extends AnyFunSuite {
     // var_onion_optin cannot be disabled
     val noVariableLengthOnionConf = ConfigFactory.parseMap(Map(
       s"features.${OptionDataLossProtect.rfcName}" -> "optional",
-      s"features.${InitialRoutingSync.rfcName}" -> "optional",
       s"features.${ChannelRangeQueries.rfcName}" -> "optional",
       s"features.${ChannelRangeQueriesExtended.rfcName}" -> "optional"
+    ).asJava)
+
+    // initial_routing_sync cannot be enabled
+    val initialRoutingSyncConf = ConfigFactory.parseMap(Map(
+      s"features.${OptionDataLossProtect.rfcName}" -> "optional",
+      s"features.${InitialRoutingSync.rfcName}" -> "optional",
+      s"features.${ChannelRangeQueries.rfcName}" -> "optional",
+      s"features.${ChannelRangeQueriesExtended.rfcName}" -> "optional",
+      s"features.${VariableLengthOnion.rfcName}" -> "optional"
     ).asJava)
 
     // basic_mpp without payment_secret
@@ -116,6 +123,7 @@ class StartupSpec extends AnyFunSuite {
 
     assert(Try(makeNodeParamsWithDefaults(finalizeConf(legalFeaturesConf))).isSuccess)
     assert(Try(makeNodeParamsWithDefaults(finalizeConf(noVariableLengthOnionConf))).isFailure)
+    assert(Try(makeNodeParamsWithDefaults(finalizeConf(initialRoutingSyncConf))).isFailure)
     assert(Try(makeNodeParamsWithDefaults(finalizeConf(illegalFeaturesConf))).isFailure)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -154,7 +154,6 @@ object TestConstants {
       publicAddresses = NodeAddress.fromParts("localhost", 9731).get :: Nil,
       features = Features(
         Set(
-          ActivatedFeature(InitialRoutingSync, Optional),
           ActivatedFeature(OptionDataLossProtect, Optional),
           ActivatedFeature(ChannelRangeQueries, Optional),
           ActivatedFeature(ChannelRangeQueriesExtended, Optional),
@@ -261,7 +260,6 @@ object TestConstants {
       color = Color(4, 5, 6),
       publicAddresses = NodeAddress.fromParts("localhost", 9732).get :: Nil,
       features = Features(Set(
-        ActivatedFeature(InitialRoutingSync, Optional),
         ActivatedFeature(OptionDataLossProtect, Optional),
         ActivatedFeature(ChannelRangeQueries, Optional),
         ActivatedFeature(ChannelRangeQueriesExtended, Optional),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -85,7 +85,6 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
 
   val commonFeatures = ConfigFactory.parseMap(Map(
     s"eclair.features.${OptionDataLossProtect.rfcName}" -> "optional",
-    s"eclair.features.${InitialRoutingSync.rfcName}" -> "optional",
     s"eclair.features.${ChannelRangeQueries.rfcName}" -> "optional",
     s"eclair.features.${ChannelRangeQueriesExtended.rfcName}" -> "optional",
     s"eclair.features.${VariableLengthOnion.rfcName}" -> "optional",


### PR DESCRIPTION
We keep the `GetRoutingState` API available in the router as it's useful to query network information locally (or between actors), but we stop sending that data to remote nodes.

I've checked the last week on our node, and there were no queries using initial_routing_sync, so it feels ok to drop support.