### PR TITLE
Publish txs with min-relay-fee met

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
@@ -27,6 +27,7 @@ import org.json4s.JsonAST._
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.math.BigDecimal.long2bigDecimal
 import scala.util.{Failure, Success}
 
 /**
@@ -49,7 +50,7 @@ class BitcoinCoreWallet(rpcClient: BitcoinJsonRPCClient)(implicit ec: ExecutionC
         logger.warn(s"cannot retrieve mempool minimum fee: $other")
         requestedFeeRatePerKB
     }).flatMap(feeRatePerKB => {
-      rpcClient.invoke("fundrawtransaction", hex, Options(lockUnspents, BigDecimal(feeRatePerKB.toLong).bigDecimal.scaleByPowerOfTen(-8))).map(json => {
+      rpcClient.invoke("fundrawtransaction", hex, Options(lockUnspents, feeRatePerKB.toLong.bigDecimal.scaleByPowerOfTen(-8))).map(json => {
         val JString(hex) = json \ "hex"
         val JInt(changepos) = json \ "changepos"
         val JDecimal(fee) = json \ "fee"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWallet.scala
@@ -18,7 +18,6 @@ package fr.acinq.eclair.blockchain.bitcoind
 
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin._
-import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BitcoinJsonRPCClient, Error, ExtendedBitcoinClient, JsonRPCError}
 import fr.acinq.eclair.blockchain.fee.{FeeratePerKB, FeeratePerKw}


### PR DESCRIPTION
When our mempool is full, its min-relay-fee may be constantly changing.
To ensure our txs can be published, we need to check the min-relay-fee when we fund the transaction, and raise it if necessary.

Fixes #1686 