### PR TITLE
PaymentLifecycle handle disconnected peers

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -93,6 +93,9 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
     case Event(RES_ADD_FAILED(_, t: ChannelException, _), d: WaitingForComplete) =>
       handleLocalFail(d, t, isFatal = false)
 
+    case Event(_: Register.ForwardShortIdFailure[CMD_ADD_HTLC], d: WaitingForComplete) =>
+      handleLocalFail(d, DisconnectedException, isFatal = false)
+
     case Event(RES_ADD_SETTLED(_, htlc, fulfill: HtlcResult.Fulfill), d: WaitingForComplete) =>
       Metrics.PaymentAttempt.withTag(Tags.MultiPart, value = false).record(d.failures.size + 1)
       val p = PartialPayment(id, d.c.finalPayload.amount, d.cmd.amount - d.c.finalPayload.amount, htlc.channelId, Some(cfg.fullRoute(d.route)))


### PR DESCRIPTION
When a peer is disconnected, the register will return a forward failure.
This can happen if the peer is connected when we start the payment FSM and then disconnects before we send them an HTLC.