### PR TITLE
Do not send shutdown with unsigned `update_fee`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -823,8 +823,10 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
       if (d.localShutdown.isDefined) {
         handleCommandError(ClosingAlreadyInProgress(d.channelId), c)
       } else if (Commitments.localHasUnsignedOutgoingHtlcs(d.commitments)) {
-        // TODO: simplistic behavior, we could also sign-then-close
+        // NB: simplistic behavior, we could also sign-then-close
         handleCommandError(CannotCloseWithUnsignedOutgoingHtlcs(d.channelId), c)
+      } else if (Commitments.localHasUnsignedOutgoingUpdateFee(d.commitments)) {
+        handleCommandError(CannotCloseWithUnsignedOutgoingUpdateFee(d.channelId), c)
       } else if (!Closing.isValidFinalScriptPubkey(localScriptPubKey)) {
         handleCommandError(InvalidFinalScript(d.channelId), c)
       } else {
@@ -842,16 +844,18 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
       //        we are waiting for a rev          => we stop sending further htlcs, we wait for their revocation, will resign immediately after, and then we will send our shutdown message
       //    we have no pending unsigned htlcs
       //      we already sent a shutdown message
-      //        there are pending signed htlcs    => send our shutdown message, go to SHUTDOWN
+      //        there are pending signed changes  => send our shutdown message, go to SHUTDOWN
       //        there are no htlcs                => send our shutdown message, go to NEGOTIATING
       //      we did not send a shutdown message
-      //        there are pending signed htlcs    => go to SHUTDOWN
+      //        there are pending signed changes  => go to SHUTDOWN
       //        there are no htlcs                => go to NEGOTIATING
 
       if (!Closing.isValidFinalScriptPubkey(remoteScriptPubKey)) {
         handleLocalError(InvalidFinalScript(d.channelId), d, Some(remoteShutdown))
       } else if (Commitments.remoteHasUnsignedOutgoingHtlcs(d.commitments)) {
         handleLocalError(CannotCloseWithUnsignedOutgoingHtlcs(d.channelId), d, Some(remoteShutdown))
+      } else if (Commitments.remoteHasUnsignedOutgoingUpdateFee(d.commitments)) {
+        handleLocalError(CannotCloseWithUnsignedOutgoingUpdateFee(d.channelId), d, Some(remoteShutdown))
       } else if (Commitments.localHasUnsignedOutgoingHtlcs(d.commitments)) { // do we have unsigned outgoing htlcs?
         require(d.localShutdown.isEmpty, "can't have pending unsigned outgoing htlcs after having sent Shutdown")
         // are we in the middle of a signature?
@@ -868,7 +872,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
             stay using d.copy(remoteShutdown = Some(remoteShutdown))
         }
       } else {
-        // so we don't have any unsigned outgoing htlcs
+        // so we don't have any unsigned outgoing changes
         val (localShutdown, sendList) = d.localShutdown match {
           case Some(localShutdown) =>
             (localShutdown, Nil)
@@ -877,9 +881,9 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
             // we need to send our shutdown if we didn't previously
             (localShutdown, localShutdown :: Nil)
         }
-        // are there pending signed htlcs on either side? we need to have received their last revocation!
-        if (d.commitments.hasNoPendingHtlcs) {
-          // there are no pending signed htlcs, let's go directly to NEGOTIATING
+        // are there pending signed changes on either side? we need to have received their last revocation!
+        if (d.commitments.hasNoPendingHtlcs && d.commitments.hasNoPendingFeeUpdate) {
+          // there are no pending signed changes, let's go directly to NEGOTIATING
           if (d.commitments.localParams.isFunder) {
             // we are funder, need to initiate the negotiation by sending the first closing_signed
             val (closingTx, closingSigned) = Closing.makeFirstClosingTx(keyManager, d.commitments, localShutdown.scriptPubKey, remoteShutdown.scriptPubKey, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets)
@@ -1107,7 +1111,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
           // we always reply with a revocation
           log.debug("received a new sig:\n{}", Commitments.specs2String(commitments1))
           context.system.eventStream.publish(ChannelSignatureReceived(self, commitments1))
-          if (commitments1.hasNoPendingHtlcs) {
+          if (commitments1.hasNoPendingHtlcs && commitments1.hasNoPendingFeeUpdate) {
             if (d.commitments.localParams.isFunder) {
               // we are funder, need to initiate the negotiation by sending the first closing_signed
               val (closingTx, closingSigned) = Closing.makeFirstClosingTx(keyManager, commitments1, localShutdown.scriptPubKey, remoteShutdown.scriptPubKey, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets)
@@ -1142,7 +1146,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
               log.debug("forwarding {} to relayer", forward)
               relayer ! forward
           }
-          if (commitments1.hasNoPendingHtlcs) {
+          if (commitments1.hasNoPendingHtlcs && commitments1.hasNoPendingFeeUpdate) {
             log.debug("switching to NEGOTIATING spec:\n{}", Commitments.specs2String(commitments1))
             if (d.commitments.localParams.isFunder) {
               // we are funder, need to initiate the negotiation by sending the first closing_signed

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -51,6 +51,7 @@ case class ChannelFundingError                 (override val channelId: ByteVect
 case class NoMoreHtlcsClosingInProgress        (override val channelId: ByteVector32) extends ChannelException(channelId, "cannot send new htlcs, closing in progress")
 case class ClosingAlreadyInProgress            (override val channelId: ByteVector32) extends ChannelException(channelId, "closing already in progress")
 case class CannotCloseWithUnsignedOutgoingHtlcs(override val channelId: ByteVector32) extends ChannelException(channelId, "cannot close when there are unsigned outgoing htlcs")
+case class CannotCloseWithUnsignedOutgoingUpdateFee    (override val channelId: ByteVector32) extends ChannelException(channelId, "cannot close when there is an unsigned fee update")
 case class ChannelUnavailable                  (override val channelId: ByteVector32) extends ChannelException(channelId, "channel is unavailable (offline or closing)")
 case class InvalidFinalScript                  (override val channelId: ByteVector32) extends ChannelException(channelId, "invalid final script")
 case class FundingTxTimedout                   (override val channelId: ByteVector32) extends ChannelException(channelId, "funding tx timed out")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -84,6 +84,8 @@ case class Commitments(channelVersion: ChannelVersion,
 
   def hasNoPendingHtlcs: Boolean = localCommit.spec.htlcs.isEmpty && remoteCommit.spec.htlcs.isEmpty && remoteNextCommitInfo.isRight
 
+  def hasNoPendingFeeUpdate: Boolean = (localChanges.signed ++ localChanges.acked ++ remoteChanges.signed ++ remoteChanges.acked).collectFirst { case _: UpdateFee => true }.isEmpty && remoteNextCommitInfo.isRight
+
   def hasPendingOrProposedHtlcs: Boolean = !hasNoPendingHtlcs ||
     localChanges.all.exists(_.isInstanceOf[UpdateAddHtlc]) ||
     remoteChanges.all.exists(_.isInstanceOf[UpdateAddHtlc])
@@ -514,6 +516,10 @@ object Commitments {
   def localHasUnsignedOutgoingHtlcs(commitments: Commitments): Boolean = commitments.localChanges.proposed.collectFirst { case u: UpdateAddHtlc => u }.isDefined
 
   def remoteHasUnsignedOutgoingHtlcs(commitments: Commitments): Boolean = commitments.remoteChanges.proposed.collectFirst { case u: UpdateAddHtlc => u }.isDefined
+
+  def localHasUnsignedOutgoingUpdateFee(commitments: Commitments): Boolean = commitments.localChanges.proposed.collectFirst { case u: UpdateFee => u }.isDefined
+
+  def remoteHasUnsignedOutgoingUpdateFee(commitments: Commitments): Boolean = commitments.remoteChanges.proposed.collectFirst { case u: UpdateFee => u }.isDefined
 
   def localHasChanges(commitments: Commitments): Boolean = commitments.remoteChanges.acked.nonEmpty || commitments.localChanges.proposed.nonEmpty
 


### PR DESCRIPTION
We didn't consider  pending `updating_fee`s when going from `NORMAL` to
`SHUTDOWN` or `NEGOTIATING`. This lead to a deadlock in the following
scenario:

```
                    A                 B
                    |-- update_fee -->|
                    |--- shutdown --->|
 A goes to SHUTDOWN |<-- shutdown ----| B goes to NEGOTIATING
                    |-- commit_sig -->|
                    |                 |
```
because B will ignore A's `commit_sig`, and A will stay in state
`SHUTDOWN` forever, waiting for B's `revoke_and_ack`.

This is an alternative to #1661.