### PR TITLE
Update funding timeout fundee

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -66,10 +66,10 @@ import scala.util.{Failure, Success}
  *
  * Created by PM on 25/01/2016.
  *
- * @param datadir       directory where eclair-core will write/read its data.
- * @param pluginParams  parameters for all configured plugins.
- * @param seeds_opt     optional seeds, if set eclair will use them instead of generating them and won't create a node_seed.dat and channel_seed.dat files.
- * @param db            optional databases to use, if not set eclair will create the necessary databases
+ * @param datadir      directory where eclair-core will write/read its data.
+ * @param pluginParams parameters for all configured plugins.
+ * @param seeds_opt    optional seeds, if set eclair will use them instead of generating them and won't create a node_seed.dat and channel_seed.dat files.
+ * @param db           optional databases to use, if not set eclair will create the necessary databases
  */
 class Setup(datadir: File,
             pluginParams: Seq[PluginParams],
@@ -185,6 +185,8 @@ class Setup(datadir: File,
       assert(!initialBlockDownload, s"bitcoind should be synchronized (initialblockdownload=$initialBlockDownload)")
       assert(progress > 0.999, s"bitcoind should be synchronized (progress=$progress)")
       assert(headers - blocks <= 1, s"bitcoind should be synchronized (headers=$headers blocks=$blocks)")
+      logger.info(s"current blockchain height=$blocks")
+      blockCount.set(blocks)
       Bitcoind(bitcoinClient)
     case ELECTRUM =>
       val addresses = config.hasPath("electrum") match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -335,7 +335,7 @@ final case class DATA_WAIT_FOR_FUNDING_SIGNED(channelId: ByteVector32,
 final case class DATA_WAIT_FOR_FUNDING_CONFIRMED(commitments: Commitments,
                                                  fundingTx: Option[Transaction],
                                                  initialRelayFees_opt: Option[(MilliSatoshi, Int)],
-                                                 waitingSince: Long, // how long have we been waiting for the funding tx to confirm
+                                                 waitingSinceBlock: Long, // how long have we been waiting for the funding tx to confirm
                                                  deferred: Option[FundingLocked],
                                                  lastSent: Either[FundingCreated, FundingSigned]) extends Data with HasCommitments
 final case class DATA_WAIT_FOR_FUNDING_LOCKED(commitments: Commitments, shortChannelId: ShortChannelId, lastSent: FundingLocked, initialRelayFees_opt: Option[(MilliSatoshi, Int)]) extends Data with HasCommitments
@@ -353,11 +353,11 @@ final case class DATA_NEGOTIATING(commitments: Commitments,
                                   closingTxProposed: List[List[ClosingTxProposed]], // one list for every negotiation (there can be several in case of disconnection)
                                   bestUnpublishedClosingTx_opt: Option[Transaction]) extends Data with HasCommitments {
   require(closingTxProposed.nonEmpty, "there must always be a list for the current negotiation")
-  require(!commitments.localParams.isFunder || closingTxProposed.forall(_.nonEmpty), "funder must have at least one closing signature for every negotation attempt because it initiates the closing")
+  require(!commitments.localParams.isFunder || closingTxProposed.forall(_.nonEmpty), "funder must have at least one closing signature for every negotiation attempt because it initiates the closing")
 }
 final case class DATA_CLOSING(commitments: Commitments,
                               fundingTx: Option[Transaction], // this will be non-empty if we are funder and we got in closing while waiting for our own tx to be published
-                              waitingSince: Long, // how long since we initiated the closing
+                              waitingSinceBlock: Long, // how long since we initiated the closing
                               mutualCloseProposed: List[Transaction], // all exchanged closing sigs are flattened, we use this only to keep track of what publishable tx they have
                               mutualClosePublished: List[Transaction] = Nil,
                               localCommitPublished: Option[LocalCommitPublished] = None,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
@@ -60,7 +60,7 @@ class HelpersSpec extends AnyFunSuite {
       DATA_CLOSING(
         commitments = commitments,
         fundingTx = None,
-        waitingSince = 0,
+        waitingSinceBlock = 0,
         mutualCloseProposed = tx1 :: tx2 :: tx3 :: Nil,
         mutualClosePublished = tx2 :: tx3 :: Nil,
         localCommitPublished = None,
@@ -75,7 +75,7 @@ class HelpersSpec extends AnyFunSuite {
       DATA_CLOSING(
         commitments = commitments,
         fundingTx = None,
-        waitingSince = 0,
+        waitingSinceBlock = 0,
         mutualCloseProposed = tx1 :: Nil,
         mutualClosePublished = tx1 :: Nil,
         localCommitPublished = Some(LocalCommitPublished(
@@ -97,7 +97,7 @@ class HelpersSpec extends AnyFunSuite {
       DATA_CLOSING(
         commitments = commitments,
         fundingTx = None,
-        waitingSince = 0,
+        waitingSinceBlock = 0,
         mutualCloseProposed = tx1 :: Nil,
         mutualClosePublished = tx1 :: Nil,
         localCommitPublished = Some(LocalCommitPublished(
@@ -121,7 +121,7 @@ class HelpersSpec extends AnyFunSuite {
       DATA_CLOSING(
         commitments = commitments,
         fundingTx = None,
-        waitingSince = 0,
+        waitingSinceBlock = 0,
         mutualCloseProposed = Nil,
         mutualClosePublished = Nil,
         localCommitPublished = Some(LocalCommitPublished(
@@ -149,7 +149,7 @@ class HelpersSpec extends AnyFunSuite {
       DATA_CLOSING(
         commitments = commitments,
         fundingTx = None,
-        waitingSince = 0,
+        waitingSinceBlock = 0,
         mutualCloseProposed = tx1 :: Nil,
         mutualClosePublished = tx1 :: Nil,
         localCommitPublished = Some(LocalCommitPublished(
@@ -179,7 +179,7 @@ class HelpersSpec extends AnyFunSuite {
       DATA_CLOSING(
         commitments = commitments.copy(remoteNextCommitInfo = Left(WaitingForRevocation(commitments.remoteCommit, null, 7L))),
         fundingTx = None,
-        waitingSince = 0,
+        waitingSinceBlock = 0,
         mutualCloseProposed = tx1 :: Nil,
         mutualClosePublished = tx1 :: Nil,
         localCommitPublished = Some(LocalCommitPublished(
@@ -215,7 +215,7 @@ class HelpersSpec extends AnyFunSuite {
       DATA_CLOSING(
         commitments = commitments,
         fundingTx = None,
-        waitingSince = 0,
+        waitingSinceBlock = 0,
         mutualCloseProposed = Nil,
         mutualClosePublished = Nil,
         localCommitPublished = None,
@@ -236,7 +236,7 @@ class HelpersSpec extends AnyFunSuite {
       DATA_CLOSING(
         commitments = commitments,
         fundingTx = None,
-        waitingSince = 0,
+        waitingSinceBlock = 0,
         mutualCloseProposed = Nil,
         mutualClosePublished = Nil,
         localCommitPublished = None,
@@ -259,7 +259,7 @@ class HelpersSpec extends AnyFunSuite {
       DATA_CLOSING(
         commitments = commitments,
         fundingTx = None,
-        waitingSince = 0,
+        waitingSinceBlock = 0,
         mutualCloseProposed = Nil,
         mutualClosePublished = Nil,
         localCommitPublished = Some(LocalCommitPublished(
@@ -306,7 +306,7 @@ class HelpersSpec extends AnyFunSuite {
       DATA_CLOSING(
         commitments = commitments,
         fundingTx = None,
-        waitingSince = 0,
+        waitingSinceBlock = 0,
         mutualCloseProposed = Nil,
         mutualClosePublished = Nil,
         localCommitPublished = Some(LocalCommitPublished(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/ChannelCodecsSpec.scala
@@ -335,7 +335,7 @@ class ChannelCodecsSpec extends AnyFunSuite {
     // let's decode the old data (this will use the old codec that provides default values for new fields)
     val data_new = stateDataCodec.decode(bin_old.toBitVector).require.value
     assert(data_new.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].fundingTx === None)
-    assert(System.currentTimeMillis.milliseconds.toSeconds - data_new.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].waitingSince < 3600) // we just set this timestamp to current time
+    assert(System.currentTimeMillis.milliseconds.toSeconds - data_new.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].waitingSinceBlock < 3600) // we just set this timestamp to current time
     // and re-encode it with the new codec
     val bin_new = ByteVector(stateDataCodec.encode(data_new).require.toByteVector.toArray)
     // data should now be encoded under the new format


### PR DESCRIPTION
Our previous timeout was based on timestamps, mostly because `blockCount` could be `0` on mobile using Electrum until a new block was received. Now that we're diverging from the mobile wallet codebase, we can use block heights instead which is more accurate.
    
See lightningnetwork/lightning-rfc#839

I've done some E2E tests on regtest for the "migration" code. There is one edge case where a channel in `WAIT_FOR_FUNDING_CONFIRMED` will not be automatically cleaned up: if the peer never connects back to you, the channel will stay in `OFFLINE` and won't check for funding timeout. I think this edge case is quite harmless and can be ignored (I don't think it's worth adding more code to fix it).