### PR TITLE
Find route between nodes. #1068

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -230,6 +230,12 @@ trait Service extends ExtraDirectives with Logging {
                             complete(eclairApi.findRoute(nodeId, amount))
                           }
                         } ~
+                        path("findroutebetweennodes") {
+                          formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam) {
+                            (sourceNodeId, targetNodeId, amount) =>
+                            complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount))
+                          }
+                        } ~
                         path("parseinvoice") {
                           formFields(invoiceFormParam) { invoice =>
                             complete(invoice)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -232,8 +232,7 @@ trait Service extends ExtraDirectives with Logging {
                         } ~
                         path("findroutebetweennodes") {
                           formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam) {
-                            (sourceNodeId, targetNodeId, amount) =>
-                            complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount))
+                            (sourceNodeId, targetNodeId, amount) => complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount))
                           }
                         } ~
                         path("parseinvoice") {


### PR DESCRIPTION
Added additional method to Eclair like findRoute but allowing for 2 nodeIds. Also added a new endpoint to the http Api "findroutebetweennodes" which takes sourceNode and targetNode as params.

This is the impl of feature request #1068. The ticket is rather old so I don't know whether this is still a thing, but straightforward so I gave it a try. Depending on pull request for #1690 I will either impl the API change there or with this pull.