### PR TITLE
Refactor bitcoin clients

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
@@ -198,7 +198,7 @@ class ZmqWatcher(chainHash: ByteVector32, blockCount: AtomicLong, client: Extend
         context become watching(watches, watchedUtxos, block2tx1, nextTick)
       } else publish(tx)
 
-    case WatchEventConfirmed(BITCOIN_PARENT_TX_CONFIRMED(tx), blockHeight, _, _) =>
+    case WatchEventConfirmed(BITCOIN_PARENT_TX_CONFIRMED(tx), _, _, _) =>
       log.info(s"parent tx of txid=${tx.txid} has been confirmed")
       val blockCount = this.blockCount.get()
       val cltvTimeout = Scripts.cltvTimeout(tx)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
@@ -19,10 +19,13 @@ package fr.acinq.eclair.blockchain.bitcoind.rpc
 import fr.acinq.bitcoin._
 import fr.acinq.eclair.ShortChannelId.coordinates
 import fr.acinq.eclair.TxCoordinates
+import fr.acinq.eclair.blockchain.fee.{FeeratePerKB, FeeratePerKw}
 import fr.acinq.eclair.blockchain.{GetTxWithMetaResponse, UtxoStatus, ValidateResult}
+import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.wire.ChannelAnnouncement
 import org.json4s.Formats
 import org.json4s.JsonAST._
+import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -37,6 +40,8 @@ import scala.util.Try
  * [[fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet]].
  */
 class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
+
+  import ExtendedBitcoinClient._
 
   implicit val formats: Formats = org.json4s.DefaultFormats
 
@@ -84,6 +89,41 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
       index = txs.indexOf(JString(txid.toHex))
     } yield (height.toInt, index)
 
+  def fundTransaction(tx: Transaction, options: FundTransactionOptions)(implicit ec: ExecutionContext): Future[FundTransactionResponse] = {
+    rpcClient.invoke("fundrawtransaction", tx.toString(), options).map(json => {
+      val JString(hex) = json \ "hex"
+      val JInt(changePos) = json \ "changepos"
+      val JDecimal(fee) = json \ "fee"
+      val fundedTx = Transaction.read(hex)
+      val amountIn = toSatoshi(fee) + fundedTx.txOut.map(_.amount).sum
+      val changePos_opt = if (changePos >= 0) Some(changePos.intValue) else None
+      FundTransactionResponse(fundedTx, amountIn, changePos_opt)
+    })
+  }
+
+  /**
+   * @return the public key hash of a bech32 raw change address.
+   */
+  def getChangeAddress()(implicit ec: ExecutionContext): Future[ByteVector] = {
+    rpcClient.invoke("getrawchangeaddress", "bech32").collect {
+      case JString(changeAddress) =>
+        val (_, _, pubkeyHash) = Bech32.decodeWitnessAddress(changeAddress)
+        pubkeyHash
+    }
+  }
+
+  def signTransaction(tx: Transaction, previousTxs: Seq[PreviousTx])(implicit ec: ExecutionContext): Future[SignTransactionResponse] = {
+    rpcClient.invoke("signrawtransactionwithwallet", tx.toString(), previousTxs).map(json => {
+      val JString(hex) = json \ "hex"
+      val JBool(complete) = json \ "complete"
+      if (!complete) {
+        val message = (json \ "errors" \\ classOf[JString]).mkString(",")
+        throw JsonRPCError(Error(-1, message))
+      }
+      SignTransactionResponse(Transaction.read(hex), complete)
+    })
+  }
+
   /**
    * Publish a transaction on the bitcoin network.
    *
@@ -101,7 +141,7 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
         Future.successful(tx.txid)
       case e@JsonRPCError(Error(-25, _)) =>
         // "missing inputs (code: -25)": it may be that the tx has already been published and its output spent.
-        getRawTransaction(tx.txid).map { _ => tx.txid }.recoverWith { case _ => Future.failed(e) }
+        getRawTransaction(tx.txid).map(_ => tx.txid).recoverWith { case _ => Future.failed(e) }
     }
 
   def isTransactionOutputSpendable(txid: ByteVector32, outputIndex: Int, includeMempool: Boolean)(implicit ec: ExecutionContext): Future[Boolean] =
@@ -162,6 +202,21 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
       txs <- Future.sequence(txids.map(getTransaction(_)))
     } yield txs
 
+  def getMempoolTx(txid: ByteVector32)(implicit ec: ExecutionContext): Future[MempoolTx] = {
+    rpcClient.invoke("getmempoolentry", txid).map(json => {
+      val JInt(vsize) = json \ "vsize"
+      val JInt(weight) = json \ "weight"
+      val JInt(ancestorCount) = json \ "ancestorcount"
+      val JInt(descendantCount) = json \ "descendantcount"
+      val JDecimal(fees) = json \ "fees" \ "base"
+      val JDecimal(ancestorFees) = json \ "fees" \ "ancestor"
+      val JDecimal(descendantFees) = json \ "fees" \ "descendant"
+      val JBool(replaceable) = json \ "bip125-replaceable"
+      // NB: bitcoind counts the transaction itself as its own ancestor and descendant, which is confusing: we fix that by decrementing these counters.
+      MempoolTx(vsize.toLong, weight.toLong, replaceable, toSatoshi(fees), ancestorCount.toInt - 1, toSatoshi(ancestorFees), descendantCount.toInt - 1, toSatoshi(descendantFees))
+    })
+  }
+
   def getBlockCount(implicit ec: ExecutionContext): Future[Long] =
     rpcClient.invoke("getblockcount").collect {
       case JInt(count) => count.toLong
@@ -187,5 +242,52 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
   } recover {
     case t: Throwable => ValidateResult(c, Left(t))
   }
+
+}
+
+object ExtendedBitcoinClient {
+
+  case class FundTransactionOptions(feeRate: BigDecimal, replaceable: Boolean, lockUnspents: Boolean, changePosition: Option[Int])
+
+  object FundTransactionOptions {
+    def apply(feerate: FeeratePerKw, replaceable: Boolean = true, lockUtxos: Boolean = false, changePosition: Option[Int] = None): FundTransactionOptions = {
+      FundTransactionOptions(BigDecimal(FeeratePerKB(feerate).toLong).bigDecimal.scaleByPowerOfTen(-8), replaceable, lockUtxos, changePosition)
+    }
+  }
+
+  case class FundTransactionResponse(tx: Transaction, amountIn: Satoshi, changePosition: Option[Int]) {
+    val fee: Satoshi = amountIn - tx.txOut.map(_.amount).sum
+  }
+
+  case class PreviousTx(txid: ByteVector32, vout: Long, scriptPubKey: String, redeemScript: String, witnessScript: String, amount: BigDecimal)
+
+  object PreviousTx {
+    def apply(inputInfo: Transactions.InputInfo, witness: ScriptWitness): PreviousTx = PreviousTx(
+      inputInfo.outPoint.txid,
+      inputInfo.outPoint.index,
+      inputInfo.txOut.publicKeyScript.toHex,
+      inputInfo.redeemScript.toHex,
+      ScriptWitness.write(witness).toHex,
+      inputInfo.txOut.amount.toBtc.toBigDecimal
+    )
+  }
+
+  case class SignTransactionResponse(tx: Transaction, complete: Boolean)
+
+  /**
+   * Information about a transaction currently in the mempool.
+   *
+   * @param vsize           virtual transaction size as defined in BIP 141.
+   * @param weight          transaction weight as defined in BIP 141.
+   * @param replaceable     Whether this transaction could be replaced with RBF (BIP125).
+   * @param fees            transaction fees.
+   * @param ancestorCount   number of unconfirmed parent transactions.
+   * @param ancestorFees    transactions fees for the package consisting of this transaction and its unconfirmed parents.
+   * @param descendantCount number of unconfirmed child transactions.
+   * @param descendantFees  transactions fees for the package consisting of this transaction and its unconfirmed children (without its unconfirmed parents).
+   */
+  case class MempoolTx(vsize: Long, weight: Long, replaceable: Boolean, fees: Satoshi, ancestorCount: Int, ancestorFees: Satoshi, descendantCount: Int, descendantFees: Satoshi)
+
+  def toSatoshi(btcAmount: BigDecimal): Satoshi = Satoshi(btcAmount.bigDecimal.scaleByPowerOfTen(8).longValue)
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
@@ -95,9 +95,8 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
       val JInt(changePos) = json \ "changepos"
       val JDecimal(fee) = json \ "fee"
       val fundedTx = Transaction.read(hex)
-      val amountIn = toSatoshi(fee) + fundedTx.txOut.map(_.amount).sum
       val changePos_opt = if (changePos >= 0) Some(changePos.intValue) else None
-      FundTransactionResponse(fundedTx, amountIn, changePos_opt)
+      FundTransactionResponse(fundedTx, toSatoshi(fee), changePos_opt)
     })
   }
 
@@ -255,8 +254,8 @@ object ExtendedBitcoinClient {
     }
   }
 
-  case class FundTransactionResponse(tx: Transaction, amountIn: Satoshi, changePosition: Option[Int]) {
-    val fee: Satoshi = amountIn - tx.txOut.map(_.amount).sum
+  case class FundTransactionResponse(tx: Transaction, fee: Satoshi, changePosition: Option[Int]) {
+    val amountIn: Satoshi = fee + tx.txOut.map(_.amount).sum
   }
 
   case class PreviousTx(txid: ByteVector32, vout: Long, scriptPubKey: String, redeemScript: String, witnessScript: String, amount: BigDecimal)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcher.scala
@@ -191,7 +191,7 @@ class ElectrumWatcher(blockCount: AtomicLong, client: ActorRef) extends Actor wi
         context become running(height, tip, watches, scriptHashStatus, block2tx, sent :+ tx)
       }
 
-    case WatchEventConfirmed(BITCOIN_PARENT_TX_CONFIRMED(tx), blockHeight, _, _) =>
+    case WatchEventConfirmed(BITCOIN_PARENT_TX_CONFIRMED(tx), _, _, _) =>
       log.info(s"parent tx of txid=${tx.txid} has been confirmed")
       val blockCount = this.blockCount.get()
       val cltvTimeout = Scripts.cltvTimeout(tx)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/WatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/WatcherSpec.scala
@@ -16,12 +16,8 @@
 
 package fr.acinq.eclair.blockchain
 
-import akka.actor.{ActorRef, ActorSystem}
-import akka.testkit.TestProbe
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
-import fr.acinq.bitcoin.{Base58, OutPoint, SIGHASH_ALL, Satoshi, SatoshiLong, Script, ScriptFlags, ScriptWitness, SigVersion, Transaction, TxIn, TxOut}
-import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
-import org.json4s.JsonAST.{JString, JValue}
+import fr.acinq.bitcoin.{OutPoint, SIGHASH_ALL, Satoshi, SatoshiLong, Script, ScriptFlags, ScriptWitness, SigVersion, Transaction, TxIn, TxOut}
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 /**
@@ -45,35 +41,6 @@ class WatcherSpec extends AnyFunSuiteLike {
 }
 
 object WatcherSpec {
-
-  /**
-   * Create a new address and dumps its private key.
-   */
-  def getNewAddress(bitcoincli: ActorRef)(implicit system: ActorSystem): (String, PrivateKey) = {
-    val probe = TestProbe()
-    probe.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(address) = probe.expectMsgType[JValue]
-
-    probe.send(bitcoincli, BitcoinReq("dumpprivkey", address))
-    val JString(wif) = probe.expectMsgType[JValue]
-    val (priv, true) = PrivateKey.fromBase58(wif, Base58.Prefix.SecretKeyTestnet)
-    (address, priv)
-  }
-
-  /**
-   * Send to a given address, without generating blocks to confirm.
-   *
-   * @return the corresponding transaction.
-   */
-  def sendToAddress(bitcoincli: ActorRef, address: String, amount: Double)(implicit system: ActorSystem): Transaction = {
-    val probe = TestProbe()
-    probe.send(bitcoincli, BitcoinReq("sendtoaddress", address, amount))
-    val JString(txid) = probe.expectMsgType[JValue]
-
-    probe.send(bitcoincli, BitcoinReq("getrawtransaction", txid))
-    val JString(hex) = probe.expectMsgType[JValue]
-    Transaction.read(hex)
-  }
 
   /**
    * Create a transaction that spends a p2wpkh output from an input transaction and sends it to the same address.

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreWalletSpec.scala
@@ -19,12 +19,12 @@ package fr.acinq.eclair.blockchain.bitcoind
 import akka.actor.Status.Failure
 import akka.pattern.pipe
 import akka.testkit.TestProbe
-import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{Block, Btc, BtcDouble, ByteVector32, MilliBtc, MilliBtcDouble, OutPoint, Satoshi, SatoshiLong, Script, Transaction, TxIn, TxOut}
+import fr.acinq.bitcoin.{Block, Btc, BtcDouble, ByteVector32, MilliBtc, MilliBtcDouble, OutPoint, Satoshi, SatoshiLong, Script, Transaction}
 import fr.acinq.eclair.blockchain._
-import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.{FundTransactionResponse, SignTransactionResponse, WalletTransaction}
+import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.WalletTransaction
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
+import fr.acinq.eclair.blockchain.bitcoind.rpc.ExtendedBitcoinClient.{FundTransactionResponse, SignTransactionResponse}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, ExtendedBitcoinClient, JsonRPCError}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.transactions.Scripts
@@ -38,35 +38,21 @@ import org.scalatest.funsuite.AnyFunSuiteLike
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.jdk.CollectionConverters._
 import scala.util.{Random, Try}
 
 class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with AnyFunSuiteLike with BeforeAndAfterAll with Logging {
 
-  val commonConfig = ConfigFactory.parseMap(Map(
-    "eclair.chain" -> "regtest",
-    "eclair.spv" -> false,
-    "eclair.server.public-ips.1" -> "localhost",
-    "eclair.bitcoind.port" -> bitcoindPort,
-    "eclair.bitcoind.rpcport" -> bitcoindRpcPort,
-    "eclair.router-broadcast-interval" -> "2 second",
-    "eclair.auto-reconnect" -> false).asJava)
-  val config = ConfigFactory.load(commonConfig).getConfig("eclair")
+  implicit val formats: Formats = DefaultFormats
 
   val walletPassword = Random.alphanumeric.take(8).mkString
 
-  implicit val formats: Formats = DefaultFormats
-
   override def beforeAll(): Unit = {
     startBitcoind()
+    waitForBitcoindReady()
   }
 
   override def afterAll(): Unit = {
     stopBitcoind()
-  }
-
-  test("wait bitcoind ready") {
-    waitForBitcoindReady()
   }
 
   def getLocks(sender: TestProbe = TestProbe()): Set[OutPoint] = {
@@ -81,14 +67,9 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
   }
 
   test("unlock transaction inputs if publishing fails") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-    val wallet = new BitcoinCoreWallet(bitcoinClient)
     val sender = TestProbe()
     val pubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(randomKey.publicKey, randomKey.publicKey)))
+    val wallet = new BitcoinCoreWallet(bitcoinrpcclient)
 
     // create a huge tx so we make sure it has > 1 inputs
     wallet.makeFundingTx(pubkeyScript, Btc(250), FeeratePerKw(1000 sat)).pipeTo(sender.ref)
@@ -125,14 +106,9 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
   }
 
   test("unlock outpoints correctly") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-    val wallet = new BitcoinCoreWallet(bitcoinClient)
     val sender = TestProbe()
     val pubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(randomKey.publicKey, randomKey.publicKey)))
+    val wallet = new BitcoinCoreWallet(bitcoinrpcclient)
 
     {
       // test #1: unlock outpoints that are actually locked
@@ -167,14 +143,11 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
   test("absence of rounding") {
     val txIn = Transaction(1, Nil, Nil, 42)
     val hexOut = "02000000013361e994f6bd5cbe9dc9e8cb3acdc12bc1510a3596469d9fc03cfddd71b223720000000000feffffff02c821354a00000000160014b6aa25d6f2a692517f2cf1ad55f243a5ba672cac404b4c0000000000220020822eb4234126c5fc84910e51a161a9b7af94eb67a2344f7031db247e0ecc2f9200000000"
+    val wallet = new BitcoinCoreWallet(bitcoinrpcclient)
 
     0 to 9 foreach { satoshi =>
       val apiAmount = JDecimal(BigDecimal(s"0.0000000$satoshi"))
-      val bitcoinClient = new BasicBitcoinJsonRPCClient(
-        user = config.getString("bitcoind.rpcuser"),
-        password = config.getString("bitcoind.rpcpassword"),
-        host = config.getString("bitcoind.host"),
-        port = config.getInt("bitcoind.rpcport")) {
+      val bitcoinClient = new BasicBitcoinJsonRPCClient(user = "foo", password = "bar", host = "localhost", port = 0) {
         override def invoke(method: String, params: Any*)(implicit ec: ExecutionContext): Future[JValue] = method match {
           case "getbalances" => Future(JObject("mine" -> JObject("trusted" -> apiAmount, "untrusted_pending" -> apiAmount)))(ec)
           case "getmempoolinfo" => Future(JObject("mempoolminfee" -> JDecimal(0.0002)))(ec)
@@ -188,53 +161,16 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
       wallet.getBalance.pipeTo(sender.ref)
       assert(sender.expectMsgType[OnChainBalance] === OnChainBalance(Satoshi(satoshi), Satoshi(satoshi)))
 
-      wallet.fundTransaction(txIn, lockUnspents = false, FeeratePerKw(250 sat)).pipeTo(sender.ref)
-      val FundTransactionResponse(_, _, fee) = sender.expectMsgType[FundTransactionResponse]
-      assert(fee == Satoshi(satoshi))
+      wallet.fundTransaction(txIn, lockUtxos = false, FeeratePerKw(250 sat)).pipeTo(sender.ref)
+      val fundTxResponse = sender.expectMsgType[FundTransactionResponse]
+      assert(fundTxResponse.fee === Satoshi(satoshi))
     }
   }
 
-  test("handle errors when signing transactions") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-    val wallet = new BitcoinCoreWallet(bitcoinClient)
+  test("create/commit/rollback funding txs") {
     val sender = TestProbe()
-
-    // create a transaction that spends UTXOs that don't exist
-    wallet.getReceiveAddress.pipeTo(sender.ref)
-    val address = sender.expectMsgType[String]
-    val unknownTxids = Seq(
-      ByteVector32.fromValidHex("01" * 32),
-      ByteVector32.fromValidHex("02" * 32),
-      ByteVector32.fromValidHex("03" * 32)
-    )
-    val unsignedTx = Transaction(version = 2,
-      txIn = Seq(
-        TxIn(OutPoint(unknownTxids(0), 0), signatureScript = Nil, sequence = TxIn.SEQUENCE_FINAL),
-        TxIn(OutPoint(unknownTxids(1), 0), signatureScript = Nil, sequence = TxIn.SEQUENCE_FINAL),
-        TxIn(OutPoint(unknownTxids(2), 0), signatureScript = Nil, sequence = TxIn.SEQUENCE_FINAL)
-      ),
-      txOut = TxOut(1000000 sat, addressToPublicKeyScript(address, Block.RegtestGenesisBlock.hash)) :: Nil,
-      lockTime = 0)
-
-    // signing it should fail, and the error message should contain the txids of the UTXOs that could not be used
-    wallet.signTransaction(unsignedTx).pipeTo(sender.ref)
-    val Failure(JsonRPCError(error)) = sender.expectMsgType[Failure]
-    unknownTxids.foreach(id => assert(error.message.contains(id.toString())))
-  }
-
-  test("create/commit/rollback funding txes") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-    val extendedClient = new ExtendedBitcoinClient(bitcoinClient)
-    val wallet = new BitcoinCoreWallet(bitcoinClient)
-    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+    val wallet = new BitcoinCoreWallet(bitcoinrpcclient)
 
     wallet.getBalance.pipeTo(sender.ref)
     assert(sender.expectMsgType[OnChainBalance].confirmed > 0.sat)
@@ -243,11 +179,11 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
     val address = sender.expectMsgType[String]
     assert(Try(addressToPublicKeyScript(address, Block.RegtestGenesisBlock.hash)).isSuccess)
 
-    val fundingTxes = for (_ <- 0 to 3) yield {
+    val fundingTxs = for (_ <- 0 to 3) yield {
       val pubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(randomKey.publicKey, randomKey.publicKey)))
       wallet.makeFundingTx(pubkeyScript, Satoshi(500), FeeratePerKw(250 sat)).pipeTo(sender.ref)
       val fundingTx = sender.expectMsgType[MakeFundingTxResponse].fundingTx
-      extendedClient.publishTransaction(fundingTx.copy(txIn = Nil)).pipeTo(sender.ref) // try publishing an invalid version of the tx
+      bitcoinClient.publishTransaction(fundingTx.copy(txIn = Nil)).pipeTo(sender.ref) // try publishing an invalid version of the tx
       sender.expectMsgType[Failure]
       wallet.rollback(fundingTx).pipeTo(sender.ref) // rollback the locked outputs
       assert(sender.expectMsgType[Boolean])
@@ -259,23 +195,23 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
 
     assert(getLocks(sender).size === 4)
 
-    wallet.commit(fundingTxes(0)).pipeTo(sender.ref)
+    wallet.commit(fundingTxs(0)).pipeTo(sender.ref)
     assert(sender.expectMsgType[Boolean])
 
-    wallet.rollback(fundingTxes(1)).pipeTo(sender.ref)
+    wallet.rollback(fundingTxs(1)).pipeTo(sender.ref)
     assert(sender.expectMsgType[Boolean])
 
-    wallet.commit(fundingTxes(2)).pipeTo(sender.ref)
+    wallet.commit(fundingTxs(2)).pipeTo(sender.ref)
     assert(sender.expectMsgType[Boolean])
 
-    wallet.rollback(fundingTxes(3)).pipeTo(sender.ref)
+    wallet.rollback(fundingTxs(3)).pipeTo(sender.ref)
     assert(sender.expectMsgType[Boolean])
 
-    extendedClient.getTransaction(fundingTxes(0).txid).pipeTo(sender.ref)
-    sender.expectMsg(fundingTxes(0))
+    bitcoinClient.getTransaction(fundingTxs(0).txid).pipeTo(sender.ref)
+    sender.expectMsg(fundingTxs(0))
 
-    extendedClient.getTransaction(fundingTxes(2).txid).pipeTo(sender.ref)
-    sender.expectMsg(fundingTxes(2))
+    bitcoinClient.getTransaction(fundingTxs(2).txid).pipeTo(sender.ref)
+    sender.expectMsg(fundingTxs(2))
 
     // NB: from 0.17.0 on bitcoin core will clear locks when a tx is published
     assert(getLocks(sender).isEmpty)
@@ -284,19 +220,13 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
   test("encrypt wallet") {
     val sender = TestProbe()
     sender.send(bitcoincli, BitcoinReq("encryptwallet", walletPassword))
-    stopBitcoind()
-    startBitcoind()
-    waitForBitcoindReady()
+    sender.expectMsgType[JString]
+    restartBitcoind(sender)
   }
 
-  test("unlock failed funding txes") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-    val wallet = new BitcoinCoreWallet(bitcoinClient)
+  test("unlock failed funding txs") {
     val sender = TestProbe()
+    val wallet = new BitcoinCoreWallet(bitcoinrpcclient)
 
     wallet.getBalance.pipeTo(sender.ref)
     assert(sender.expectMsgType[OnChainBalance].confirmed > 0.sat)
@@ -328,12 +258,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
   }
 
   test("ensure feerate is always above min-relay-fee") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-    val wallet = new BitcoinCoreWallet(bitcoinClient)
+    val wallet = new BitcoinCoreWallet(bitcoinrpcclient)
     val sender = TestProbe()
 
     val pubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(randomKey.publicKey, randomKey.publicKey)))
@@ -346,13 +271,8 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
   }
 
   test("getReceivePubkey should return the raw pubkey for the receive address") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-    val wallet = new BitcoinCoreWallet(bitcoinClient)
     val sender = TestProbe()
+    val wallet = new BitcoinCoreWallet(bitcoinrpcclient)
 
     wallet.getReceiveAddress.pipeTo(sender.ref)
     val address = sender.expectMsgType[String]
@@ -363,13 +283,8 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
   }
 
   test("send and list transactions") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-    val wallet = new BitcoinCoreWallet(bitcoinClient)
     val sender = TestProbe()
+    val wallet = new BitcoinCoreWallet(bitcoinrpcclient)
 
     wallet.getBalance.pipeTo(sender.ref)
     val initialBalance = sender.expectMsgType[OnChainBalance]
@@ -392,7 +307,7 @@ class BitcoinCoreWalletSpec extends TestKitBaseClass with BitcoindService with A
     // NB: we use + because these amounts are already negative
     sender.expectMsg(initialBalance.copy(confirmed = initialBalance.confirmed + tx1.amount + tx1.fees))
 
-    generateBlocks(bitcoincli, 1)
+    generateBlocks(1)
     wallet.listTransactions(25, 0).pipeTo(sender.ref)
     val Some(tx2) = sender.expectMsgType[List[WalletTransaction]].collectFirst { case tx if tx.txid == txid => tx }
     assert(tx2.address === address)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -16,19 +16,20 @@
 
 package fr.acinq.eclair.blockchain.bitcoind
 
-import java.io.File
-import java.nio.file.Files
-
 import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.pipe
 import akka.testkit.{TestKitBase, TestProbe}
 import com.softwaremill.sttp.okhttp.OkHttpFutureBackend
+import fr.acinq.bitcoin.Crypto.PrivateKey
+import fr.acinq.bitcoin.{Base58, Btc, BtcAmount, MilliBtc, Satoshi, Transaction}
 import fr.acinq.eclair.TestUtils
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, BitcoinJsonRPCClient}
 import fr.acinq.eclair.integration.IntegrationSpec
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST._
 
+import java.io.File
+import java.nio.file.Files
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.io.Source
@@ -36,20 +37,18 @@ import scala.io.Source
 trait BitcoindService extends Logging {
   self: TestKitBase =>
 
-  implicit val system: ActorSystem
-  implicit val sttpBackend = OkHttpFutureBackend()
-
-  val bitcoindPort: Int = TestUtils.availablePort
-
-  val bitcoindRpcPort: Int = TestUtils.availablePort
-
-  val bitcoindZmqBlockPort: Int = TestUtils.availablePort
-
-  val bitcoindZmqTxPort: Int = TestUtils.availablePort
-
   import BitcoindService._
 
   import scala.sys.process._
+
+  implicit val system: ActorSystem
+  implicit val sttpBackend = OkHttpFutureBackend()
+
+  val defaultWallet: String = "miner"
+  val bitcoindPort: Int = TestUtils.availablePort
+  val bitcoindRpcPort: Int = TestUtils.availablePort
+  val bitcoindZmqBlockPort: Int = TestUtils.availablePort
+  val bitcoindZmqTxPort: Int = TestUtils.availablePort
 
   val INTEGRATION_TMP_DIR: File = TestUtils.newIntegrationTmpDir()
   logger.info(s"using tmp dir: $INTEGRATION_TMP_DIR")
@@ -57,9 +56,9 @@ trait BitcoindService extends Logging {
   val PATH_BITCOIND = new File(TestUtils.BUILD_DIRECTORY, "bitcoin-0.20.1/bin/bitcoind")
   val PATH_BITCOIND_DATADIR = new File(INTEGRATION_TMP_DIR, "datadir-bitcoin")
 
-  var bitcoind: Process = null
-  var bitcoinrpcclient: BitcoinJsonRPCClient = null
-  var bitcoincli: ActorRef = null
+  var bitcoind: Process = _
+  var bitcoinrpcclient: BitcoinJsonRPCClient = _
+  var bitcoincli: ActorRef = _
 
   def startBitcoind(): Unit = {
     Files.createDirectories(PATH_BITCOIND_DATADIR.toPath)
@@ -74,12 +73,12 @@ trait BitcoindService extends Logging {
     }
 
     bitcoind = s"$PATH_BITCOIND -datadir=$PATH_BITCOIND_DATADIR".run()
-    bitcoinrpcclient = new BasicBitcoinJsonRPCClient(user = "foo", password = "bar", host = "localhost", port = bitcoindRpcPort)
+    bitcoinrpcclient = new BasicBitcoinJsonRPCClient(user = "foo", password = "bar", host = "localhost", port = bitcoindRpcPort, wallet = Some(defaultWallet))
     bitcoincli = system.actorOf(Props(new Actor {
       override def receive: Receive = {
-        case BitcoinReq(method) => bitcoinrpcclient.invoke(method) pipeTo sender
-        case BitcoinReq(method, params) => bitcoinrpcclient.invoke(method, params) pipeTo sender
-        case BitcoinReq(method, param1, param2) => bitcoinrpcclient.invoke(method, param1, param2) pipeTo sender
+        case BitcoinReq(method) => bitcoinrpcclient.invoke(method).pipeTo(sender)
+        case BitcoinReq(method, params) => bitcoinrpcclient.invoke(method, params).pipeTo(sender)
+        case BitcoinReq(method, param1, param2) => bitcoinrpcclient.invoke(method, param1, param2).pipeTo(sender)
       }
     }))
   }
@@ -92,8 +91,15 @@ trait BitcoindService extends Logging {
     bitcoind.exitValue()
   }
 
-  def waitForBitcoindReady(): Unit = {
-    val sender = TestProbe()
+  def restartBitcoind(sender: TestProbe = TestProbe()): Unit = {
+    stopBitcoind()
+    startBitcoind()
+    waitForBitcoindUp(sender)
+    sender.send(bitcoincli, BitcoinReq("loadwallet", defaultWallet))
+    sender.expectMsgType[JValue]
+  }
+
+  private def waitForBitcoindUp(sender: TestProbe): Unit = {
     logger.info(s"waiting for bitcoind to initialize...")
     awaitCond({
       sender.send(bitcoincli, BitcoinReq("getnetworkinfo"))
@@ -105,27 +111,70 @@ trait BitcoindService extends Logging {
         case _ => false
       }
     }, max = 3 minutes, interval = 2 seconds)
-    logger.info(s"generating initial blocks...")
-    generateBlocks(bitcoincli, 150)
+  }
+
+  def waitForBitcoindReady(): Unit = {
+    val sender = TestProbe()
+    waitForBitcoindUp(sender)
+    sender.send(bitcoincli, BitcoinReq("createwallet", defaultWallet))
+    sender.expectMsgType[JValue]
+    logger.info(s"generating initial blocks to wallet=$defaultWallet...")
+    generateBlocks(150)
     awaitCond({
-      sender.send(bitcoincli, BitcoinReq("getbalance"))
-      val JDecimal(balance) = sender.expectMsgType[JDecimal](30 seconds)
-      balance > 100
+      sender.send(bitcoincli, BitcoinReq("getblockcount"))
+      val JInt(blockCount) = sender.expectMsgType[JInt](30 seconds)
+      blockCount >= 150
     }, max = 3 minutes, interval = 2 second)
   }
 
-  def generateBlocks(bitcoinCli: ActorRef, blockCount: Int, address: Option[String] = None, timeout: FiniteDuration = 10 seconds)(implicit system: ActorSystem): Unit = {
+  /** Generate blocks to a given address, or to our wallet if no address is provided. */
+  def generateBlocks(blockCount: Int, address: Option[String] = None, timeout: FiniteDuration = 10 seconds)(implicit system: ActorSystem): Unit = {
     val sender = TestProbe()
     val addressToUse = address match {
       case Some(addr) => addr
       case None =>
-        sender.send(bitcoinCli, BitcoinReq("getnewaddress"))
+        sender.send(bitcoincli, BitcoinReq("getnewaddress"))
         val JString(address) = sender.expectMsgType[JValue](timeout)
         address
     }
-    sender.send(bitcoinCli, BitcoinReq("generatetoaddress", blockCount, addressToUse))
+    sender.send(bitcoincli, BitcoinReq("generatetoaddress", blockCount, addressToUse))
     val JArray(blocks) = sender.expectMsgType[JValue](timeout)
     assert(blocks.size == blockCount)
+  }
+
+  /** Create a new wallet and returns an RPC client to interact with it. */
+  def createWallet(walletName: String, sender: TestProbe = TestProbe()): BitcoinJsonRPCClient = {
+    sender.send(bitcoincli, BitcoinReq("createwallet", walletName))
+    sender.expectMsgType[JValue]
+    new BasicBitcoinJsonRPCClient(user = "foo", password = "bar", host = "localhost", port = bitcoindRpcPort, wallet = Some(walletName))
+  }
+
+  def getNewAddress(sender: TestProbe = TestProbe(), rpcClient: BitcoinJsonRPCClient = bitcoinrpcclient): String = {
+    rpcClient.invoke("getnewaddress").pipeTo(sender.ref)
+    val JString(address) = sender.expectMsgType[JValue]
+    address
+  }
+
+  /** Dump the private key associated with the given address. */
+  def dumpPrivateKey(address: String, sender: TestProbe = TestProbe(), rpcClient: BitcoinJsonRPCClient = bitcoinrpcclient): PrivateKey = {
+    rpcClient.invoke("dumpprivkey", address).pipeTo(sender.ref)
+    val JString(wif) = sender.expectMsgType[JValue]
+    val (priv, _) = PrivateKey.fromBase58(wif, Base58.Prefix.SecretKeyTestnet)
+    priv
+  }
+
+  /** Send to a given address, without generating blocks to confirm. */
+  def sendToAddress(address: String, amount: BtcAmount, sender: TestProbe = TestProbe(), rpcClient: BitcoinJsonRPCClient = bitcoinrpcclient): Transaction = {
+    val amountDecimal = amount match {
+      case amount: Satoshi => amount.toBtc.toBigDecimal
+      case amount: MilliBtc => amount.toBtc.toBigDecimal
+      case amount: Btc => amount.toBigDecimal
+    }
+    rpcClient.invoke("sendtoaddress", address, amountDecimal).pipeTo(sender.ref)
+    val JString(txid) = sender.expectMsgType[JString]
+    rpcClient.invoke("getrawtransaction", txid).pipeTo(sender.ref)
+    val JString(rawTx) = sender.expectMsgType[JString]
+    Transaction.read(rawTx)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
@@ -19,201 +19,352 @@ package fr.acinq.eclair.blockchain.bitcoind
 import akka.actor.Status.Failure
 import akka.pattern.pipe
 import akka.testkit.TestProbe
-import com.typesafe.config.ConfigFactory
-import fr.acinq.bitcoin.{Btc, BtcDouble, Transaction}
-import fr.acinq.eclair.TestKitBaseClass
-import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
-import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, ExtendedBitcoinClient}
+import fr.acinq.bitcoin.SigVersion.SIGVERSION_WITNESS_V0
+import fr.acinq.bitcoin.{BtcDouble, OutPoint, SIGHASH_ALL, Satoshi, SatoshiLong, Script, ScriptFlags, ScriptWitness, Transaction, TxIn, TxOut}
+import fr.acinq.eclair.blockchain.bitcoind.rpc.ExtendedBitcoinClient._
+import fr.acinq.eclair.blockchain.bitcoind.rpc.{ExtendedBitcoinClient, JsonRPCError}
+import fr.acinq.eclair.transactions.Transactions
+import fr.acinq.eclair.{TestConstants, TestKitBaseClass, randomKey}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST._
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuiteLike
+import scodec.bits.ByteVector
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.jdk.CollectionConverters._
 
 class ExtendedBitcoinClientSpec extends TestKitBaseClass with BitcoindService with AnyFunSuiteLike with BeforeAndAfterAll with Logging {
-
-  val commonConfig = ConfigFactory.parseMap(Map(
-    "eclair.chain" -> "regtest",
-    "eclair.spv" -> false,
-    "eclair.server.public-ips.1" -> "localhost",
-    "eclair.bitcoind.port" -> bitcoindPort,
-    "eclair.bitcoind.rpcport" -> bitcoindRpcPort,
-    "eclair.router-broadcast-interval" -> "2 second",
-    "eclair.auto-reconnect" -> false).asJava)
-  val config = ConfigFactory.load(commonConfig).getConfig("eclair")
 
   implicit val formats: Formats = DefaultFormats
 
   override def beforeAll(): Unit = {
     startBitcoind()
+    waitForBitcoindReady()
   }
 
   override def afterAll(): Unit = {
     stopBitcoind()
   }
 
-  test("wait bitcoind ready") {
-    waitForBitcoindReady()
-  }
-
-  def sendToAddress(address: String, amount: Btc, sender: TestProbe = TestProbe()): Transaction = {
-    sender.send(bitcoincli, BitcoinReq("sendtoaddress", address, amount.toDouble))
-    val JString(txid1) = sender.expectMsgType[JString]
-    sender.send(bitcoincli, BitcoinReq("getrawtransaction", txid1))
-    val JString(rawTx) = sender.expectMsgType[JString]
-    Transaction.read(rawTx)
-  }
-
-  test("send transaction idempotent") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-
+  test("fund transactions") {
     val sender = TestProbe()
-    bitcoinClient.invoke("getnewaddress").pipeTo(sender.ref)
-    val JString(address) = sender.expectMsgType[JString]
-    bitcoinClient.invoke("createrawtransaction", Array.empty, Map(address -> 6)).pipeTo(sender.ref)
-    val JString(noinputTx) = sender.expectMsgType[JString]
-    bitcoinClient.invoke("fundrawtransaction", noinputTx).pipeTo(sender.ref)
-    val json = sender.expectMsgType[JValue]
-    val JString(unsignedtx) = json \ "hex"
-    val JInt(changePos) = json \ "changepos"
-    bitcoinClient.invoke("signrawtransactionwithwallet", unsignedtx).pipeTo(sender.ref)
-    val JString(signedTx) = sender.expectMsgType[JValue] \ "hex"
-    val tx = Transaction.read(signedTx)
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
 
-    // test starts here
-    val client = new ExtendedBitcoinClient(bitcoinClient)
-    // we publish it a first time
-    client.publishTransaction(tx).pipeTo(sender.ref)
+    val txToRemote = {
+      val txNotFunded = Transaction(2, Nil, TxOut(150000 sat, Script.pay2wpkh(randomKey.publicKey)) :: Nil, 0)
+      bitcoinClient.fundTransaction(txNotFunded, FundTransactionOptions(TestConstants.feeratePerKw)).pipeTo(sender.ref)
+      val fundTxResponse = sender.expectMsgType[FundTransactionResponse]
+      assert(fundTxResponse.changePosition.nonEmpty)
+      assert(fundTxResponse.amountIn > 0.sat)
+      assert(fundTxResponse.fee > 0.sat)
+      fundTxResponse.tx.txIn.foreach(txIn => assert(txIn.signatureScript.isEmpty && txIn.witness.isNull))
+      fundTxResponse.tx.txIn.foreach(txIn => assert(txIn.sequence === TxIn.SEQUENCE_FINAL - 2))
+
+      bitcoinClient.signTransaction(fundTxResponse.tx, Nil).pipeTo(sender.ref)
+      val signTxResponse = sender.expectMsgType[SignTransactionResponse]
+      assert(signTxResponse.complete)
+      assert(signTxResponse.tx.txOut.size === 2)
+
+      bitcoinClient.publishTransaction(signTxResponse.tx).pipeTo(sender.ref)
+      sender.expectMsg(signTxResponse.tx.txid)
+      generateBlocks(1)
+      signTxResponse.tx
+    }
+    {
+      // txs with no outputs are not supported.
+      val emptyTx = Transaction(2, Nil, Nil, 0)
+      bitcoinClient.fundTransaction(emptyTx, FundTransactionOptions(TestConstants.feeratePerKw)).pipeTo(sender.ref)
+      sender.expectMsgType[Failure]
+    }
+    {
+      // bitcoind requires that "all existing inputs must have their previous output transaction be in the wallet".
+      val txNonWalletInputs = Transaction(2, Seq(TxIn(OutPoint(txToRemote, 0), Nil, 0), TxIn(OutPoint(txToRemote, 1), Nil, 0)), Seq(TxOut(100000 sat, Script.pay2wpkh(randomKey.publicKey))), 0)
+      bitcoinClient.fundTransaction(txNonWalletInputs, FundTransactionOptions(TestConstants.feeratePerKw)).pipeTo(sender.ref)
+      sender.expectMsgType[Failure]
+    }
+    {
+      // we can increase the feerate.
+      bitcoinClient.fundTransaction(Transaction(2, Nil, TxOut(250000 sat, Script.pay2wpkh(randomKey.publicKey)) :: Nil, 0), FundTransactionOptions(TestConstants.feeratePerKw)).pipeTo(sender.ref)
+      val fundTxResponse1 = sender.expectMsgType[FundTransactionResponse]
+      bitcoinClient.fundTransaction(fundTxResponse1.tx, FundTransactionOptions(TestConstants.feeratePerKw * 2)).pipeTo(sender.ref)
+      val fundTxResponse2 = sender.expectMsgType[FundTransactionResponse]
+      assert(fundTxResponse1.tx !== fundTxResponse2.tx)
+      assert(fundTxResponse1.fee < fundTxResponse2.fee)
+    }
+    {
+      // we can control where the change output is inserted and opt-out of RBF.
+      val txManyOutputs = Transaction(2, Nil, TxOut(410000 sat, Script.pay2wpkh(randomKey.publicKey)) :: TxOut(230000 sat, Script.pay2wpkh(randomKey.publicKey)) :: Nil, 0)
+      bitcoinClient.fundTransaction(txManyOutputs, FundTransactionOptions(TestConstants.feeratePerKw, replaceable = false, changePosition = Some(1))).pipeTo(sender.ref)
+      val fundTxResponse = sender.expectMsgType[FundTransactionResponse]
+      assert(fundTxResponse.tx.txOut.size === 3)
+      assert(fundTxResponse.changePosition === Some(1))
+      assert(!Set(230000 sat, 410000 sat).contains(fundTxResponse.tx.txOut(1).amount))
+      assert(Set(230000 sat, 410000 sat) === Set(fundTxResponse.tx.txOut.head.amount, fundTxResponse.tx.txOut.last.amount))
+      fundTxResponse.tx.txIn.foreach(txIn => assert(txIn.sequence === TxIn.SEQUENCE_FINAL - 1))
+    }
+  }
+
+  test("sign transactions") {
+    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+
+    val nonWalletKey = randomKey
+    val opts = FundTransactionOptions(TestConstants.feeratePerKw, changePosition = Some(1))
+    bitcoinClient.fundTransaction(Transaction(2, Nil, Seq(TxOut(250000 sat, Script.pay2wpkh(nonWalletKey.publicKey))), 0), opts).pipeTo(sender.ref)
+    val fundedTx = sender.expectMsgType[FundTransactionResponse].tx
+    bitcoinClient.signTransaction(fundedTx, Nil).pipeTo(sender.ref)
+    val txToRemote = sender.expectMsgType[SignTransactionResponse].tx
+    bitcoinClient.publishTransaction(txToRemote).pipeTo(sender.ref)
+    sender.expectMsg(txToRemote.txid)
+    generateBlocks(1)
+
+    {
+      bitcoinClient.fundTransaction(Transaction(2, Nil, Seq(TxOut(400000 sat, Script.pay2wpkh(randomKey.publicKey))), 0), opts).pipeTo(sender.ref)
+      val fundTxResponse = sender.expectMsgType[FundTransactionResponse]
+      val txWithNonWalletInput = fundTxResponse.tx.copy(txIn = TxIn(OutPoint(txToRemote, 0), ByteVector.empty, 0) +: fundTxResponse.tx.txIn)
+      // bitcoind returns an error if there are unsigned non-wallet input.
+      bitcoinClient.signTransaction(txWithNonWalletInput, Nil).pipeTo(sender.ref)
+      val Failure(JsonRPCError(error)) = sender.expectMsgType[Failure]
+      assert(error.message.contains(txToRemote.txid.toHex))
+      // but if these inputs are signed, bitcoind signs the remaining wallet inputs.
+      val nonWalletSig = Transaction.signInput(txWithNonWalletInput, 0, Script.pay2pkh(nonWalletKey.publicKey), SIGHASH_ALL, txToRemote.txOut.head.amount, SIGVERSION_WITNESS_V0, nonWalletKey)
+      val nonWalletWitness = ScriptWitness(Seq(nonWalletSig, nonWalletKey.publicKey.value))
+      val txWithSignedNonWalletInput = txWithNonWalletInput.updateWitness(0, nonWalletWitness)
+      bitcoinClient.signTransaction(txWithSignedNonWalletInput, Nil).pipeTo(sender.ref)
+      val signTxResponse = sender.expectMsgType[SignTransactionResponse]
+      assert(signTxResponse.complete)
+      Transaction.correctlySpends(signTxResponse.tx, Seq(txToRemote), ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
+    }
+    {
+      // bitcoind does not sign inputs that have already been confirmed.
+      bitcoinClient.signTransaction(fundedTx, Nil).pipeTo(sender.ref)
+      val Failure(JsonRPCError(error)) = sender.expectMsgType[Failure]
+      assert(error.message.contains("not found or already spent"))
+    }
+    {
+      // bitcoind lets us double-spend ourselves.
+      bitcoinClient.fundTransaction(Transaction(2, Nil, Seq(TxOut(75000 sat, Script.pay2wpkh(randomKey.publicKey))), 0), opts).pipeTo(sender.ref)
+      val fundTxResponse = sender.expectMsgType[FundTransactionResponse]
+      bitcoinClient.signTransaction(fundTxResponse.tx, Nil).pipeTo(sender.ref)
+      assert(sender.expectMsgType[SignTransactionResponse].complete)
+      bitcoinClient.signTransaction(fundTxResponse.tx.copy(txOut = Seq(TxOut(85000 sat, Script.pay2wpkh(randomKey.publicKey)))), Nil).pipeTo(sender.ref)
+      assert(sender.expectMsgType[SignTransactionResponse].complete)
+    }
+    {
+      // create an unconfirmed utxo to a non-wallet address.
+      bitcoinClient.fundTransaction(Transaction(2, Nil, Seq(TxOut(125000 sat, Script.pay2wpkh(nonWalletKey.publicKey))), 0), opts).pipeTo(sender.ref)
+      bitcoinClient.signTransaction(sender.expectMsgType[FundTransactionResponse].tx, Nil).pipeTo(sender.ref)
+      val unconfirmedTx = sender.expectMsgType[SignTransactionResponse].tx
+      bitcoinClient.publishTransaction(unconfirmedTx).pipeTo(sender.ref)
+      sender.expectMsg(unconfirmedTx.txid)
+      // bitcoind lets us use this unconfirmed non-wallet input.
+      bitcoinClient.fundTransaction(Transaction(2, Nil, Seq(TxOut(350000 sat, Script.pay2wpkh(randomKey.publicKey))), 0), opts).pipeTo(sender.ref)
+      val fundTxResponse = sender.expectMsgType[FundTransactionResponse]
+      val txWithUnconfirmedInput = fundTxResponse.tx.copy(txIn = TxIn(OutPoint(unconfirmedTx, 0), ByteVector.empty, 0) +: fundTxResponse.tx.txIn)
+      val nonWalletSig = Transaction.signInput(txWithUnconfirmedInput, 0, Script.pay2pkh(nonWalletKey.publicKey), SIGHASH_ALL, unconfirmedTx.txOut.head.amount, SIGVERSION_WITNESS_V0, nonWalletKey)
+      val nonWalletWitness = ScriptWitness(Seq(nonWalletSig, nonWalletKey.publicKey.value))
+      val txWithSignedUnconfirmedInput = txWithUnconfirmedInput.updateWitness(0, nonWalletWitness)
+      val previousTx = PreviousTx(Transactions.InputInfo(OutPoint(unconfirmedTx.txid, 0), unconfirmedTx.txOut.head, Script.pay2pkh(nonWalletKey.publicKey)), nonWalletWitness)
+      bitcoinClient.signTransaction(txWithSignedUnconfirmedInput, Seq(previousTx)).pipeTo(sender.ref)
+      assert(sender.expectMsgType[SignTransactionResponse].complete)
+    }
+  }
+
+  test("publish transaction idempotent") {
+    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+
+    val priv = dumpPrivateKey(getNewAddress(sender), sender)
+    val noInputTx = Transaction(2, Nil, TxOut(6.btc.toSatoshi, Script.pay2wpkh(priv.publicKey)) :: Nil, 0)
+    bitcoinClient.fundTransaction(noInputTx, FundTransactionOptions(TestConstants.feeratePerKw)).pipeTo(sender.ref)
+    val fundTxResponse = sender.expectMsgType[FundTransactionResponse]
+    val changePos = fundTxResponse.changePosition.get
+    bitcoinClient.signTransaction(fundTxResponse.tx, Nil).pipeTo(sender.ref)
+    val tx = sender.expectMsgType[SignTransactionResponse].tx
+
+    // we publish the tx a first time
+    bitcoinClient.publishTransaction(tx).pipeTo(sender.ref)
     sender.expectMsg(tx.txid)
     // we publish the tx a second time to test idempotence
-    client.publishTransaction(tx).pipeTo(sender.ref)
+    bitcoinClient.publishTransaction(tx).pipeTo(sender.ref)
     sender.expectMsg(tx.txid)
     // let's confirm the tx
-    sender.send(bitcoincli, BitcoinReq("getnewaddress"))
-    val JString(generatingAddress) = sender.expectMsgType[JValue]
-    bitcoinClient.invoke("generatetoaddress", 1, generatingAddress).pipeTo(sender.ref)
-    sender.expectMsgType[JValue]
+    generateBlocks(1)
     // and publish the tx a third time to test idempotence
-    client.publishTransaction(tx).pipeTo(sender.ref)
+    bitcoinClient.publishTransaction(tx).pipeTo(sender.ref)
     sender.expectMsg(tx.txid)
 
     // now let's spend the output of the tx
     val spendingTx = {
+      val address = getNewAddress(sender)
       val pos = if (changePos == 0) 1 else 0
-      bitcoinClient.invoke("createrawtransaction", Array(Map("txid" -> tx.txid.toHex, "vout" -> pos)), Map(address -> 5.99999)).pipeTo(sender.ref)
-      val JString(unsignedtx) = sender.expectMsgType[JValue]
-      bitcoinClient.invoke("signrawtransactionwithwallet", unsignedtx).pipeTo(sender.ref)
-      val JString(signedTx) = sender.expectMsgType[JValue] \ "hex"
-      Transaction.read(signedTx)
+      bitcoinrpcclient.invoke("createrawtransaction", Array(Map("txid" -> tx.txid.toHex, "vout" -> pos)), Map(address -> 5.999)).pipeTo(sender.ref)
+      val JString(unsignedTx) = sender.expectMsgType[JValue]
+      bitcoinClient.signTransaction(Transaction.read(unsignedTx), Nil).pipeTo(sender.ref)
+      sender.expectMsgType[SignTransactionResponse].tx
     }
-    client.publishTransaction(spendingTx).pipeTo(sender.ref)
+    bitcoinClient.publishTransaction(spendingTx).pipeTo(sender.ref)
     sender.expectMsg(spendingTx.txid)
 
     // and publish the tx a fourth time to test idempotence
-    client.publishTransaction(tx).pipeTo(sender.ref)
+    bitcoinClient.publishTransaction(tx).pipeTo(sender.ref)
     sender.expectMsg(tx.txid)
     // let's confirm the tx
-    bitcoinClient.invoke("generatetoaddress", 1, generatingAddress).pipeTo(sender.ref)
-    sender.expectMsgType[JValue]
+    generateBlocks(1)
     // and publish the tx a fifth time to test idempotence
-    client.publishTransaction(tx).pipeTo(sender.ref)
+    bitcoinClient.publishTransaction(tx).pipeTo(sender.ref)
     sender.expectMsg(tx.txid)
-
-    // this one should be rejected
-    client.publishTransaction(Transaction.read("02000000000101b9e2a3f518fd74e696d258fed3c78c43f84504e76c99212e01cf225083619acf00000000000d0199800136b34b00000000001600145464ce1e5967773922506e285780339d72423244040047304402206795df1fd93c285d9028c384aacf28b43679f1c3f40215fd7bd1abbfb816ee5a022047a25b8c128e692d4717b6dd7b805aa24ecbbd20cfd664ab37a5096577d4a15d014730440220770f44121ed0e71ec4b482dded976f2febd7500dfd084108e07f3ce1e85ec7f5022025b32dc0d551c47136ce41bfb80f5a10de95c0babb22a3ae2d38e6688b32fcb20147522102c2662ab3e4fa18a141d3be3317c6ee134aff10e6cd0a91282a25bf75c0481ebc2102e952dd98d79aa796289fa438e4fdeb06ed8589ff2a0f032b0cfcb4d7b564bc3252aea58d1120")).pipeTo(sender.ref)
-    sender.expectMsgType[Failure]
   }
 
-  test("detect if tx has been doublespent") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-    val client = new ExtendedBitcoinClient(bitcoinClient)
+  test("publish invalid transactions") {
     val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+
+    // that tx has inputs that don't exist
+    val txWithUnknownInputs = Transaction.read("02000000000101b9e2a3f518fd74e696d258fed3c78c43f84504e76c99212e01cf225083619acf00000000000d0199800136b34b00000000001600145464ce1e5967773922506e285780339d72423244040047304402206795df1fd93c285d9028c384aacf28b43679f1c3f40215fd7bd1abbfb816ee5a022047a25b8c128e692d4717b6dd7b805aa24ecbbd20cfd664ab37a5096577d4a15d014730440220770f44121ed0e71ec4b482dded976f2febd7500dfd084108e07f3ce1e85ec7f5022025b32dc0d551c47136ce41bfb80f5a10de95c0babb22a3ae2d38e6688b32fcb20147522102c2662ab3e4fa18a141d3be3317c6ee134aff10e6cd0a91282a25bf75c0481ebc2102e952dd98d79aa796289fa438e4fdeb06ed8589ff2a0f032b0cfcb4d7b564bc3252aea58d1120")
+    bitcoinClient.publishTransaction(txWithUnknownInputs).pipeTo(sender.ref)
+    sender.expectMsgType[Failure]
+
+    bitcoinClient.fundTransaction(Transaction(2, Nil, TxOut(100000 sat, Script.pay2wpkh(randomKey.publicKey)) :: Nil, 0), FundTransactionOptions(TestConstants.feeratePerKw)).pipeTo(sender.ref)
+    val txUnsignedInputs = sender.expectMsgType[FundTransactionResponse].tx
+    bitcoinClient.publishTransaction(txUnsignedInputs).pipeTo(sender.ref)
+    sender.expectMsgType[Failure]
+
+    bitcoinClient.signTransaction(txUnsignedInputs, Nil).pipeTo(sender.ref)
+    val signTxResponse = sender.expectMsgType[SignTransactionResponse]
+    assert(signTxResponse.complete)
+
+    val txWithNoOutputs = signTxResponse.tx.copy(txOut = Nil)
+    bitcoinClient.publishTransaction(txWithNoOutputs).pipeTo(sender.ref)
+    sender.expectMsgType[Failure]
+
+    bitcoinClient.getBlockCount.pipeTo(sender.ref)
+    val blockCount = sender.expectMsgType[Long]
+    val txWithFutureCltv = signTxResponse.tx.copy(lockTime = blockCount + 1)
+    bitcoinClient.publishTransaction(txWithFutureCltv).pipeTo(sender.ref)
+    sender.expectMsgType[Failure]
+
+    bitcoinClient.publishTransaction(signTxResponse.tx).pipeTo(sender.ref)
+    sender.expectMsg(signTxResponse.tx.txid)
+  }
+
+  test("get mempool transaction") {
+    val sender = TestProbe()
+    val address = getNewAddress(sender)
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+
+    def spendWalletTx(tx: Transaction, fees: Satoshi): Transaction = {
+      val inputs = tx.txOut.indices.map(vout => Map("txid" -> tx.txid, "vout" -> vout))
+      val amount = tx.txOut.map(_.amount).sum - fees
+      bitcoinrpcclient.invoke("createrawtransaction", inputs, Map(address -> amount.toBtc.toBigDecimal)).pipeTo(sender.ref)
+      val JString(unsignedTx) = sender.expectMsgType[JValue]
+      bitcoinClient.signTransaction(Transaction.read(unsignedTx), Nil).pipeTo(sender.ref)
+      val signedTx = sender.expectMsgType[SignTransactionResponse].tx
+      bitcoinClient.publishTransaction(signedTx).pipeTo(sender.ref)
+      sender.expectMsg(signedTx.txid)
+      signedTx
+    }
+
+    val tx1 = sendToAddress(address, 0.5 btc, sender)
+    val tx2 = spendWalletTx(tx1, 5000 sat)
+    val tx3 = spendWalletTx(tx2, 7500 sat)
+
+    bitcoinClient.getMempoolTx(tx1.txid).pipeTo(sender.ref)
+    val mempoolTx1 = sender.expectMsgType[MempoolTx]
+    assert(mempoolTx1.ancestorCount === 0)
+    assert(mempoolTx1.descendantCount === 2)
+    assert(mempoolTx1.fees === mempoolTx1.ancestorFees)
+    assert(mempoolTx1.descendantFees === mempoolTx1.fees + 12500.sat)
+
+    bitcoinClient.getMempoolTx(tx2.txid).pipeTo(sender.ref)
+    val mempoolTx2 = sender.expectMsgType[MempoolTx]
+    assert(mempoolTx2.ancestorCount === 1)
+    assert(mempoolTx2.descendantCount === 1)
+    assert(mempoolTx2.fees === 5000.sat)
+    assert(mempoolTx2.descendantFees === 12500.sat)
+    assert(mempoolTx2.ancestorFees === mempoolTx1.fees + 5000.sat)
+
+    bitcoinClient.getMempoolTx(tx3.txid).pipeTo(sender.ref)
+    val mempoolTx3 = sender.expectMsgType[MempoolTx]
+    assert(mempoolTx3.ancestorCount === 2)
+    assert(mempoolTx3.descendantCount === 0)
+    assert(mempoolTx3.fees === 7500.sat)
+    assert(mempoolTx3.descendantFees === mempoolTx3.fees)
+    assert(mempoolTx3.ancestorFees === mempoolTx1.fees + 12500.sat)
+  }
+
+  test("detect if tx has been double-spent") {
+    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
 
     // first let's create a tx
     val address = "n2YKngjUp139nkjKvZGnfLRN6HzzYxJsje"
-    bitcoinClient.invoke("createrawtransaction", Array.empty, Map(address -> 6)).pipeTo(sender.ref)
+    bitcoinrpcclient.invoke("createrawtransaction", Array.empty, Map(address -> 6)).pipeTo(sender.ref)
     val JString(noinputTx1) = sender.expectMsgType[JString]
-    bitcoinClient.invoke("fundrawtransaction", noinputTx1).pipeTo(sender.ref)
+    bitcoinrpcclient.invoke("fundrawtransaction", noinputTx1).pipeTo(sender.ref)
     val json = sender.expectMsgType[JValue]
     val JString(unsignedtx1) = json \ "hex"
-    bitcoinClient.invoke("signrawtransactionwithwallet", unsignedtx1).pipeTo(sender.ref)
+    bitcoinrpcclient.invoke("signrawtransactionwithwallet", unsignedtx1).pipeTo(sender.ref)
     val JString(signedTx1) = sender.expectMsgType[JValue] \ "hex"
     val tx1 = Transaction.read(signedTx1)
 
     // let's then generate another tx that double spends the first one
     val inputs = tx1.txIn.map(txIn => Map("txid" -> txIn.outPoint.txid.toString, "vout" -> txIn.outPoint.index)).toArray
-    bitcoinClient.invoke("createrawtransaction", inputs, Map(address -> tx1.txOut.map(_.amount).sum.toLong * 1.0 / 1e8)).pipeTo(sender.ref)
+    bitcoinrpcclient.invoke("createrawtransaction", inputs, Map(address -> tx1.txOut.map(_.amount).sum.toLong * 1.0 / 1e8)).pipeTo(sender.ref)
     val JString(unsignedtx2) = sender.expectMsgType[JValue]
-    bitcoinClient.invoke("signrawtransactionwithwallet", unsignedtx2).pipeTo(sender.ref)
+    bitcoinrpcclient.invoke("signrawtransactionwithwallet", unsignedtx2).pipeTo(sender.ref)
     val JString(signedTx2) = sender.expectMsgType[JValue] \ "hex"
     val tx2 = Transaction.read(signedTx2)
 
     // tx1/tx2 haven't been published, so tx1 isn't double spent
-    client.doubleSpent(tx1).pipeTo(sender.ref)
+    bitcoinClient.doubleSpent(tx1).pipeTo(sender.ref)
     sender.expectMsg(false)
     // let's publish tx2
-    client.publishTransaction(tx2).pipeTo(sender.ref)
+    bitcoinClient.publishTransaction(tx2).pipeTo(sender.ref)
     sender.expectMsg(tx2.txid)
     // tx2 hasn't been confirmed so tx1 is still not considered double-spent
-    client.doubleSpent(tx1).pipeTo(sender.ref)
+    bitcoinClient.doubleSpent(tx1).pipeTo(sender.ref)
     sender.expectMsg(false)
     // let's confirm tx2
-    generateBlocks(bitcoincli, 1)
+    generateBlocks(1)
     // this time tx1 has been double spent
-    client.doubleSpent(tx1).pipeTo(sender.ref)
+    bitcoinClient.doubleSpent(tx1).pipeTo(sender.ref)
     sender.expectMsg(true)
   }
 
   test("find spending transaction of a given output") {
-    val bitcoinClient = new BasicBitcoinJsonRPCClient(
-      user = config.getString("bitcoind.rpcuser"),
-      password = config.getString("bitcoind.rpcpassword"),
-      host = config.getString("bitcoind.host"),
-      port = config.getInt("bitcoind.rpcport"))
-    val client = new ExtendedBitcoinClient(bitcoinClient)
     val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
 
-    client.getBlockCount.pipeTo(sender.ref)
+    bitcoinClient.getBlockCount.pipeTo(sender.ref)
     val blockCount = sender.expectMsgType[Long]
 
-    bitcoinClient.invoke("getnewaddress").pipeTo(sender.ref)
-    val JString(address) = sender.expectMsgType[JString]
-
+    val address = getNewAddress(sender)
     val tx1 = sendToAddress(address, 5 btc, sender)
 
     // Transaction is still in the mempool at that point
-    client.getTxConfirmations(tx1.txid).pipeTo(sender.ref)
+    bitcoinClient.getTxConfirmations(tx1.txid).pipeTo(sender.ref)
     sender.expectMsg(Some(0))
-    client.isTransactionOutputSpendable(tx1.txid, 0, includeMempool = false).pipeTo(sender.ref)
+    bitcoinClient.isTransactionOutputSpendable(tx1.txid, 0, includeMempool = false).pipeTo(sender.ref)
     sender.expectMsg(false)
-    client.isTransactionOutputSpendable(tx1.txid, 0, includeMempool = true).pipeTo(sender.ref)
+    bitcoinClient.isTransactionOutputSpendable(tx1.txid, 0, includeMempool = true).pipeTo(sender.ref)
     sender.expectMsg(true)
 
     // Let's confirm our transaction.
-    generateBlocks(bitcoincli, 1)
-    client.getBlockCount.pipeTo(sender.ref)
+    generateBlocks(1)
+    bitcoinClient.getBlockCount.pipeTo(sender.ref)
     val blockCount1 = sender.expectMsgType[Long]
     assert(blockCount1 === blockCount + 1)
-    client.getTxConfirmations(tx1.txid).pipeTo(sender.ref)
+    bitcoinClient.getTxConfirmations(tx1.txid).pipeTo(sender.ref)
     sender.expectMsg(Some(1))
-    client.isTransactionOutputSpendable(tx1.txid, 0, includeMempool = false).pipeTo(sender.ref)
+    bitcoinClient.isTransactionOutputSpendable(tx1.txid, 0, includeMempool = false).pipeTo(sender.ref)
     sender.expectMsg(true)
-    client.isTransactionOutputSpendable(tx1.txid, 0, includeMempool = true).pipeTo(sender.ref)
+    bitcoinClient.isTransactionOutputSpendable(tx1.txid, 0, includeMempool = true).pipeTo(sender.ref)
     sender.expectMsg(true)
 
-    generateBlocks(bitcoincli, 1)
-    client.lookForSpendingTx(None, tx1.txIn.head.outPoint.txid, tx1.txIn.head.outPoint.index.toInt).pipeTo(sender.ref)
+    generateBlocks(1)
+    bitcoinClient.lookForSpendingTx(None, tx1.txIn.head.outPoint.txid, tx1.txIn.head.outPoint.index.toInt).pipeTo(sender.ref)
     sender.expectMsg(tx1)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcherSpec.scala
@@ -20,16 +20,16 @@ import akka.Done
 import akka.actor.{ActorRef, Props}
 import akka.pattern.pipe
 import akka.testkit.{TestKit, TestProbe}
-import fr.acinq.bitcoin.{OutPoint, SatoshiLong, Script, Transaction, TxOut}
+import fr.acinq.bitcoin.{Btc, OutPoint, SatoshiLong, Script, Transaction, TxOut}
 import fr.acinq.eclair.blockchain.WatcherSpec._
 import fr.acinq.eclair.blockchain._
-import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.{FundTransactionResponse, SignTransactionResponse}
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.ExtendedBitcoinClient
+import fr.acinq.eclair.blockchain.bitcoind.rpc.ExtendedBitcoinClient.{FundTransactionResponse, SignTransactionResponse}
 import fr.acinq.eclair.blockchain.bitcoind.zmq.ZMQActor
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
-import fr.acinq.eclair.channel.{BITCOIN_FUNDING_DEPTHOK, BITCOIN_FUNDING_SPENT}
+import fr.acinq.eclair.channel._
 import fr.acinq.eclair.{TestKitBaseClass, randomBytes32}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST.JValue
@@ -107,13 +107,13 @@ class ZmqWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitcoind
     val probe = TestProbe()
     val blockCount = new AtomicLong()
     val watcher = system.actorOf(ZmqWatcher.props(randomBytes32, blockCount, new ExtendedBitcoinClient(bitcoinrpcclient)))
-    val (address, _) = getNewAddress(bitcoincli)
-    val tx = sendToAddress(bitcoincli, address, 1.0)
+    val address = getNewAddress(probe)
+    val tx = sendToAddress(address, Btc(1))
 
     val listener = TestProbe()
     probe.send(watcher, WatchConfirmed(listener.ref, tx.txid, tx.txOut.head.publicKeyScript, 4, BITCOIN_FUNDING_DEPTHOK))
     probe.send(watcher, WatchConfirmed(listener.ref, tx.txid, tx.txOut.head.publicKeyScript, 4, BITCOIN_FUNDING_DEPTHOK)) // setting the watch multiple times should be a no-op
-    generateBlocks(bitcoincli, 5)
+    generateBlocks(5)
     assert(listener.expectMsgType[WatchEventConfirmed].tx.txid === tx.txid)
     listener.expectNoMsg(1 second)
 
@@ -128,8 +128,9 @@ class ZmqWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitcoind
     val probe = TestProbe()
     val blockCount = new AtomicLong()
     val watcher = system.actorOf(ZmqWatcher.props(randomBytes32, blockCount, new ExtendedBitcoinClient(bitcoinrpcclient)))
-    val (address, priv) = getNewAddress(bitcoincli)
-    val tx = sendToAddress(bitcoincli, address, 1.0)
+    val address = getNewAddress(probe)
+    val priv = dumpPrivateKey(address, probe)
+    val tx = sendToAddress(address, Btc(1))
     val outputIndex = tx.txOut.indexWhere(_.publicKeyScript == Script.write(Script.pay2wpkh(priv.publicKey)))
     val (tx1, tx2) = createUnspentTxChain(tx, priv)
 
@@ -146,14 +147,14 @@ class ZmqWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitcoind
     )
     // Let's confirm tx and tx1: seeing tx1 in a block should trigger WatchEventSpent again, but not WatchEventSpentBasic
     // (which only triggers once).
-    generateBlocks(bitcoincli, 2)
+    generateBlocks(2)
     listener.expectMsg(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx1))
 
     // Let's submit tx2, and set a watch after it has been confirmed this time.
     probe.send(bitcoincli, BitcoinReq("sendrawtransaction", tx2.toString()))
     probe.expectMsgType[JValue]
     listener.expectNoMsg(1 second)
-    generateBlocks(bitcoincli, 1)
+    generateBlocks(1)
     probe.send(watcher, WatchSpentBasic(listener.ref, tx1, 0, BITCOIN_FUNDING_SPENT))
     probe.send(watcher, WatchSpent(listener.ref, tx1, 0, BITCOIN_FUNDING_SPENT))
     listener.expectMsgAllOf(
@@ -171,9 +172,9 @@ class ZmqWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitcoind
     val watcher = system.actorOf(ZmqWatcher.props(randomBytes32, blockCount, client))
 
     // create a chain of transactions that we don't broadcast yet
-    val (_, priv) = getNewAddress(bitcoincli)
+    val priv = dumpPrivateKey(getNewAddress(probe), probe)
     val tx1 = {
-      wallet.fundTransaction(Transaction(2, Nil, TxOut(150000 sat, Script.pay2wpkh(priv.publicKey)) :: Nil, 0), lockUnspents = true, FeeratePerKw(250 sat)).pipeTo(probe.ref)
+      wallet.fundTransaction(Transaction(2, Nil, TxOut(150000 sat, Script.pay2wpkh(priv.publicKey)) :: Nil, 0), lockUtxos = true, FeeratePerKw(250 sat)).pipeTo(probe.ref)
       val funded = probe.expectMsgType[FundTransactionResponse].tx
       wallet.signTransaction(funded).pipeTo(probe.ref)
       probe.expectMsgType[SignTransactionResponse].tx
@@ -186,14 +187,14 @@ class ZmqWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitcoind
     probe.send(watcher, WatchConfirmed(probe.ref, tx1, 3, BITCOIN_FUNDING_SPENT))
     client.publishTransaction(tx1).pipeTo(probe.ref)
     probe.expectMsg(tx1.txid)
-    generateBlocks(bitcoincli, 1)
+    generateBlocks(1)
     probe.expectNoMsg(1 second)
     client.publishTransaction(tx2).pipeTo(probe.ref)
     probe.expectMsgAllOf(tx2.txid, WatchEventSpent(BITCOIN_FUNDING_SPENT, tx2))
     probe.expectNoMsg(1 second)
-    generateBlocks(bitcoincli, 1)
+    generateBlocks(1)
     probe.expectMsg(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx2)) // tx2 is confirmed which triggers WatchEventSpent again
-    generateBlocks(bitcoincli, 1)
+    generateBlocks(1)
     assert(probe.expectMsgType[WatchEventConfirmed].tx === tx1) // tx1 now has 3 confirmations
     system.stop(watcher)
   }
@@ -205,22 +206,22 @@ class ZmqWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitcoind
     val client = new ExtendedBitcoinClient(bitcoinrpcclient)
     val watcher = system.actorOf(ZmqWatcher.props(randomBytes32, blockCount, client))
     awaitCond(blockCount.get > 0)
-    val (_, priv) = getNewAddress(bitcoincli)
+    val priv = dumpPrivateKey(getNewAddress(probe), probe)
 
     // tx1 has an absolute delay but no relative delay
     val initialBlockCount = blockCount.get
     val tx1 = {
-      wallet.fundTransaction(Transaction(2, Nil, TxOut(150000 sat, Script.pay2wpkh(priv.publicKey)) :: Nil, initialBlockCount + 5), lockUnspents = true, FeeratePerKw(250 sat)).pipeTo(probe.ref)
+      wallet.fundTransaction(Transaction(2, Nil, TxOut(150000 sat, Script.pay2wpkh(priv.publicKey)) :: Nil, initialBlockCount + 5), lockUtxos = true, FeeratePerKw(250 sat)).pipeTo(probe.ref)
       val funded = probe.expectMsgType[FundTransactionResponse].tx
       wallet.signTransaction(funded).pipeTo(probe.ref)
       probe.expectMsgType[SignTransactionResponse].tx
     }
     probe.send(watcher, PublishAsap(tx1))
-    generateBlocks(bitcoincli, 4)
+    generateBlocks(4)
     awaitCond(blockCount.get === initialBlockCount + 4)
     client.getMempool().pipeTo(probe.ref)
     assert(!probe.expectMsgType[Seq[Transaction]].exists(_.txid === tx1.txid)) // tx should not be broadcast yet
-    generateBlocks(bitcoincli, 1)
+    generateBlocks(1)
     awaitCond({
       client.getMempool().pipeTo(probe.ref)
       probe.expectMsgType[Seq[Transaction]].exists(_.txid === tx1.txid)
@@ -230,9 +231,9 @@ class ZmqWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitcoind
     val tx2 = createSpendP2WPKH(tx1, priv, priv.publicKey, 10000 sat, sequence = 2, lockTime = 0)
     probe.send(watcher, WatchConfirmed(probe.ref, tx1, 1, BITCOIN_FUNDING_DEPTHOK))
     probe.send(watcher, PublishAsap(tx2))
-    generateBlocks(bitcoincli, 1)
+    generateBlocks(1)
     assert(probe.expectMsgType[WatchEventConfirmed].tx === tx1)
-    generateBlocks(bitcoincli, 2)
+    generateBlocks(2)
     awaitCond({
       client.getMempool().pipeTo(probe.ref)
       probe.expectMsgType[Seq[Transaction]].exists(_.txid === tx2.txid)
@@ -243,14 +244,14 @@ class ZmqWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitcoind
     probe.send(watcher, WatchConfirmed(probe.ref, tx2, 1, BITCOIN_FUNDING_DEPTHOK))
     probe.send(watcher, WatchSpent(probe.ref, tx2, 0, BITCOIN_FUNDING_SPENT))
     probe.send(watcher, PublishAsap(tx3))
-    generateBlocks(bitcoincli, 1)
+    generateBlocks(1)
     assert(probe.expectMsgType[WatchEventConfirmed].tx === tx2)
     val currentBlockCount = blockCount.get
     // after 1 block, the relative delay is elapsed, but not the absolute delay
-    generateBlocks(bitcoincli, 1)
+    generateBlocks(1)
     awaitCond(blockCount.get == currentBlockCount + 1)
     probe.expectNoMsg(1 second)
-    generateBlocks(bitcoincli, 3)
+    generateBlocks(3)
     probe.expectMsg(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx3))
     client.getMempool().pipeTo(probe.ref)
     probe.expectMsgType[Seq[Transaction]].exists(_.txid === tx3.txid)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/electrum/ElectrumWatcherSpec.scala
@@ -17,8 +17,8 @@
 package fr.acinq.eclair.blockchain.electrum
 
 import akka.actor.Props
-import akka.testkit.{TestKit, TestProbe}
-import fr.acinq.bitcoin.{ByteVector32, SatoshiLong, Transaction, TxIn}
+import akka.testkit.TestProbe
+import fr.acinq.bitcoin.{Btc, ByteVector32, SatoshiLong, Transaction, TxIn}
 import fr.acinq.eclair.blockchain.WatcherSpec._
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService
@@ -51,7 +51,6 @@ class ElectrumWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bit
     logger.info("stopping bitcoind")
     stopBitcoind()
     super.afterAll()
-    TestKit.shutdownActorSystem(system)
   }
 
   val electrumAddress = ElectrumServerAddress(new InetSocketAddress("localhost", electrumPort), SSL.OFF)
@@ -62,14 +61,14 @@ class ElectrumWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bit
     val electrumClient = system.actorOf(Props(new ElectrumClientPool(blockCount, Set(electrumAddress))))
     val watcher = system.actorOf(Props(new ElectrumWatcher(blockCount, electrumClient)))
 
-    val (address, _) = getNewAddress(bitcoincli)
-    val tx = sendToAddress(bitcoincli, address, 1.0)
+    val address = getNewAddress(probe)
+    val tx = sendToAddress(address, Btc(1), probe)
 
     probe.send(watcher, WatchConfirmed(listener.ref, tx.txid, tx.txOut.head.publicKeyScript, 2, BITCOIN_FUNDING_DEPTHOK))
-    generateBlocks(bitcoincli, 2)
+    generateBlocks(2)
     assert(listener.expectMsgType[WatchEventConfirmed].tx === tx)
     probe.send(watcher, WatchConfirmed(listener.ref, tx, 4, BITCOIN_FUNDING_DEPTHOK))
-    generateBlocks(bitcoincli, 2)
+    generateBlocks(2)
     assert(listener.expectMsgType[WatchEventConfirmed].tx === tx)
     system.stop(watcher)
   }
@@ -80,8 +79,9 @@ class ElectrumWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bit
     val electrumClient = system.actorOf(Props(new ElectrumClientPool(blockCount, Set(electrumAddress))))
     val watcher = system.actorOf(Props(new ElectrumWatcher(blockCount, electrumClient)))
 
-    val (address, priv) = getNewAddress(bitcoincli)
-    val tx = sendToAddress(bitcoincli, address, 1.0)
+    val address = getNewAddress(probe)
+    val priv = dumpPrivateKey(address, probe)
+    val tx = sendToAddress(address, Btc(1))
 
     // create a tx that spends the previous output
     val spendingTx = createSpendP2WPKH(tx, priv, priv.publicKey, 1000 sat, TxIn.SEQUENCE_FINAL, 0)
@@ -90,7 +90,7 @@ class ElectrumWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bit
     listener.expectNoMsg(1 second)
     probe.send(bitcoincli, BitcoinReq("sendrawtransaction", spendingTx.toString))
     probe.expectMsgType[JValue]
-    generateBlocks(bitcoincli, 2)
+    generateBlocks(2)
     assert(listener.expectMsgType[WatchEventSpent].tx === spendingTx)
     system.stop(watcher)
   }
@@ -103,10 +103,11 @@ class ElectrumWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bit
     probe.expectMsgType[ElectrumClient.ElectrumReady]
     val watcher = system.actorOf(Props(new ElectrumWatcher(blockCount, electrumClient)))
 
-    val (address, priv1) = getNewAddress(bitcoincli)
-    val tx = sendToAddress(bitcoincli, address, 1.0)
-    val (_, priv2) = getNewAddress(bitcoincli)
-    val (_, priv3) = getNewAddress(bitcoincli)
+    val address = getNewAddress(probe)
+    val priv1 = dumpPrivateKey(address, probe)
+    val tx = sendToAddress(address, Btc(1))
+    val priv2 = dumpPrivateKey(getNewAddress(probe), probe)
+    val priv3 = dumpPrivateKey(getNewAddress(probe), probe)
     val tx1 = createSpendP2WPKH(tx, priv1, priv2.publicKey, 10000 sat, TxIn.SEQUENCE_FINAL, 0)
     val tx2 = createSpendP2WPKH(tx1, priv2, priv3.publicKey, 10000 sat, TxIn.SEQUENCE_FINAL, 0)
     probe.send(bitcoincli, BitcoinReq("sendrawtransaction", tx1.toString()))
@@ -137,8 +138,9 @@ class ElectrumWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bit
     probe.expectMsgType[ElectrumClient.ElectrumReady]
     val watcher = system.actorOf(Props(new ElectrumWatcher(blockCount, electrumClient)))
 
-    val (address, priv) = getNewAddress(bitcoincli)
-    val tx = sendToAddress(bitcoincli, address, 1.0)
+    val address = getNewAddress(probe)
+    val priv = dumpPrivateKey(address, probe)
+    val tx = sendToAddress(address, Btc(1))
     val (tx1, tx2) = createUnspentTxChain(tx, priv)
 
     // here we set watches * before * we publish our transactions
@@ -150,6 +152,47 @@ class ElectrumWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bit
     probe.send(bitcoincli, BitcoinReq("sendrawtransaction", tx2.toString()))
     probe.expectMsgType[JValue]
     listener.expectMsg(WatchEventSpent(BITCOIN_FUNDING_SPENT, tx2))
+    system.stop(watcher)
+  }
+
+  test("publish transactions with relative or absolute delays") {
+    import akka.pattern.pipe
+
+    val (probe, listener) = (TestProbe(), TestProbe())
+    val blockCount = new AtomicLong()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+    val electrumClient = system.actorOf(Props(new ElectrumClientPool(blockCount, Set(electrumAddress))))
+    bitcoinClient.getBlockCount.pipeTo(probe.ref)
+    val initialBlockCount = probe.expectMsgType[Long]
+    probe.send(electrumClient, ElectrumClient.AddStatusListener(probe.ref))
+    awaitCond(probe.expectMsgType[ElectrumClient.ElectrumReady].height >= initialBlockCount, message = s"waiting for tip at $initialBlockCount")
+    val watcher = system.actorOf(Props(new ElectrumWatcher(blockCount, electrumClient)))
+    val recipient = dumpPrivateKey(getNewAddress(probe), probe).publicKey
+
+    val address1 = getNewAddress(probe)
+    val priv1 = dumpPrivateKey(address1, probe)
+    val tx1 = sendToAddress(address1, Btc(0.2))
+    val address2 = getNewAddress(probe)
+    val priv2 = dumpPrivateKey(address2, probe)
+    val tx2 = sendToAddress(address2, Btc(0.2))
+    generateBlocks(1)
+    for (tx <- Seq(tx1, tx2)) {
+      probe.send(watcher, WatchConfirmed(listener.ref, tx, 1, BITCOIN_FUNDING_DEPTHOK))
+      assert(listener.expectMsgType[WatchEventConfirmed].tx === tx)
+    }
+
+    // spend tx1 with an absolute delay but no relative delay
+    val spend1 = createSpendP2WPKH(tx1, priv1, recipient, 5000 sat, sequence = 0, lockTime = blockCount.get + 1)
+    probe.send(watcher, WatchSpent(listener.ref, tx1, spend1.txIn.head.outPoint.index.toInt, BITCOIN_FUNDING_SPENT))
+    probe.send(watcher, PublishAsap(spend1))
+    // spend tx2 with a relative delay but no absolute delay
+    val spend2 = createSpendP2WPKH(tx2, priv2, recipient, 3000 sat, sequence = 1, lockTime = 0)
+    probe.send(watcher, WatchSpent(listener.ref, tx2, spend2.txIn.head.outPoint.index.toInt, BITCOIN_FUNDING_SPENT))
+    probe.send(watcher, PublishAsap(spend2))
+
+    generateBlocks(1)
+    listener.expectMsgAllOf(WatchEventSpent(BITCOIN_FUNDING_SPENT, spend1), WatchEventSpent(BITCOIN_FUNDING_SPENT, spend2))
+
     system.stop(watcher)
   }
 
@@ -165,37 +208,21 @@ class ElectrumWatcherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bit
     probe.send(electrumClient, ElectrumClient.AddStatusListener(probe.ref))
     awaitCond(probe.expectMsgType[ElectrumClient.ElectrumReady].height >= initialBlockCount, message = s"waiting for tip at $initialBlockCount")
     val watcher = system.actorOf(Props(new ElectrumWatcher(blockCount, electrumClient)))
+    val recipient = dumpPrivateKey(getNewAddress(probe), probe).publicKey
 
-    val (address1, priv1) = getNewAddress(bitcoincli)
-    val tx1 = sendToAddress(bitcoincli, address1, 0.2)
-    val (address2, priv2) = getNewAddress(bitcoincli)
-    val tx2 = sendToAddress(bitcoincli, address2, 0.2)
-    val (address3, priv3) = getNewAddress(bitcoincli)
-    val tx3 = sendToAddress(bitcoincli, address3, 0.2)
-    val (_, priv4) = getNewAddress(bitcoincli)
-    generateBlocks(bitcoincli, 1)
-    for (tx <- Seq(tx1, tx2, tx3)) {
-      probe.send(watcher, WatchConfirmed(listener.ref, tx, 1, BITCOIN_FUNDING_DEPTHOK))
-      assert(listener.expectMsgType[WatchEventConfirmed].tx === tx)
-    }
+    val address = getNewAddress(probe)
+    val priv = dumpPrivateKey(address, probe)
+    val tx = sendToAddress(address, Btc(0.2))
+    generateBlocks(1)
+    probe.send(watcher, WatchConfirmed(listener.ref, tx, 1, BITCOIN_FUNDING_DEPTHOK))
+    assert(listener.expectMsgType[WatchEventConfirmed].tx === tx)
 
-    // spend tx1 with an absolute delay but no relative delay
-    val spend1 = createSpendP2WPKH(tx1, priv1, priv4.publicKey, 5000 sat, sequence = 0, lockTime = blockCount.get + 1)
-    probe.send(watcher, WatchSpent(listener.ref, tx1, spend1.txIn.head.outPoint.index.toInt, BITCOIN_FUNDING_SPENT))
-    probe.send(watcher, PublishAsap(spend1))
-    // spend tx2 with a relative delay but no absolute delay
-    val spend2 = createSpendP2WPKH(tx2, priv2, priv4.publicKey, 3000 sat, sequence = 1, lockTime = 0)
-    probe.send(watcher, WatchSpent(listener.ref, tx2, spend2.txIn.head.outPoint.index.toInt, BITCOIN_FUNDING_SPENT))
-    probe.send(watcher, PublishAsap(spend2))
-    // spend tx3 with both relative and absolute delays
-    val spend3 = createSpendP2WPKH(tx3, priv3, priv4.publicKey, 6000 sat, sequence = 1, lockTime = blockCount.get + 2)
-    probe.send(watcher, WatchSpent(listener.ref, tx3, spend3.txIn.head.outPoint.index.toInt, BITCOIN_FUNDING_SPENT))
-    probe.send(watcher, PublishAsap(spend3))
-
-    generateBlocks(bitcoincli, 1)
-    listener.expectMsgAllOf(WatchEventSpent(BITCOIN_FUNDING_SPENT, spend1), WatchEventSpent(BITCOIN_FUNDING_SPENT, spend2))
-    generateBlocks(bitcoincli, 1)
-    listener.expectMsgAllOf(WatchEventSpent(BITCOIN_FUNDING_SPENT, spend1), WatchEventSpent(BITCOIN_FUNDING_SPENT, spend2), WatchEventSpent(BITCOIN_FUNDING_SPENT, spend3))
+    // spend tx with both relative and absolute delays
+    val spend = createSpendP2WPKH(tx, priv, recipient, 6000 sat, sequence = 1, lockTime = blockCount.get + 2)
+    probe.send(watcher, WatchSpent(listener.ref, tx, spend.txIn.head.outPoint.index.toInt, BITCOIN_FUNDING_SPENT))
+    probe.send(watcher, PublishAsap(spend))
+    generateBlocks(2)
+    listener.expectMsg(WatchEventSpent(BITCOIN_FUNDING_SPENT, spend))
 
     system.stop(watcher)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
@@ -100,7 +100,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     }, max = 20 seconds, interval = 1 second)
 
     // confirming the funding tx
-    generateBlocks(bitcoincli, 2)
+    generateBlocks(2)
 
     within(60 seconds) {
       var count = 0
@@ -131,7 +131,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
 
   test("wait for network announcements") {
     // generating more blocks so that all funding txes are buried under at least 6 blocks
-    generateBlocks(bitcoincli, 4)
+    generateBlocks(4)
     // A requires private channels, as a consequence:
     // - only A and B know about channel A-B (and there is no channel_announcement)
     // - A is not announced (no node_announcement)
@@ -642,11 +642,11 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     val channels = for (i <- 0 until 242) yield {
       // let's generate a block every 10 txs so that we can compute short ids
       if (i % 10 == 0) {
-        generateBlocks(bitcoincli, 1, Some(address))
+        generateBlocks(1, Some(address))
       }
       AnnouncementsBatchValidationSpec.simulateChannel
     }
-    generateBlocks(bitcoincli, 1, Some(address))
+    generateBlocks(1, Some(address))
     logger.info(s"simulated ${channels.size} channels")
 
     val remoteNodeId = PrivateKey(ByteVector32(ByteVector.fill(32)(1))).publicKey


### PR DESCRIPTION
And improve test coverage specifically for the calls we'll rely on for CPFP and RBF.
I wanted to separate this PR from the one that actually use these calls for RBF/CPFP to avoid a monster PR, as these refactoring/clean-ups make sense anyway.

I also split a test in the `ElectrumWatcherSpec` into two tests because it was a bit flaky (block count synchronization between `bitcoind` and `electrum` in the test suite is a bit flaky when a test generates multiple blocks in a sequence).