### PR TITLE
#1206 Use multiplatform escape sequence, added cli findroutebetweennodes

### DIFF
--- a/contrib/eclair-cli.bash-completion
+++ b/contrib/eclair-cli.bash-completion
@@ -21,7 +21,7 @@ _eclair-cli()
         *)
             # works fine, but is too slow at the moment.
             # allopts=$($eclaircli help 2>&1 | awk '$1 ~ /^"/ { sub(/,/, ""); print $1}' | sed 's/[":]//g')
-            allopts="getinfo connect open close forceclose updaterelayfee peers channels channel allnodes allchannels allupdates findroute findroutetonode parseinvoice payinvoice sendtonode getsentinfo createinvoice getinvoice listinvoices listpendinginvoices getreceivedinfo audit networkfees channelstats"
+            allopts="getinfo connect open close forceclose updaterelayfee peers channels channel allnodes allchannels allupdates findroute findroutetonode findroutebetweennodes parseinvoice payinvoice sendtonode getsentinfo createinvoice getinvoice listinvoices listpendinginvoices getreceivedinfo audit networkfees channelstats"
 
             if ! [[ " $allopts " =~ " $prev " ]]; then          # prevent double arguments
                 if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then

--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -18,7 +18,7 @@ on <$api_url>.
 
 Usage
 -----
-\e[93meclair-cli\e[39m [\e[93mOPTIONS\e[39m]... <\e[93mCOMMAND\e[39m> [--command-param=command-value]...
+\x1b[93meclair-cli\x1b[39m [\x1b[93mOPTIONS\x1b[39m]... <\x1b[93mCOMMAND\x1b[39m> [--command-param=command-value]...
 
 where OPTIONS can be:
   -p <password>         API's password
@@ -51,6 +51,7 @@ and COMMAND is one of the available commands:
   === Path-finding ===
     - findroute
     - findroutetonode
+    - findroutebetweennodes
     - networkstats
 
   === Invoice ===


### PR DESCRIPTION
Using this escape sequence should solve the coloring issue on macOs. I don't have access to Win or Mac but it works fine in several Linux terminals so it won't get worse ;)

I also added the new "findroutebetweennodes" hint to the cli and completion file.