### PR TITLE
Add a serializer for `DoSync`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -464,7 +464,7 @@ object PeerConnection {
   case object InitTimeout
   case object SendPing
   case object ResumeAnnouncements
-  case class DoSync(replacePrevious: Boolean)
+  case class DoSync(replacePrevious: Boolean) extends RemoteTypes
   // @formatter:on
 
   val IGNORE_NETWORK_ANNOUNCEMENTS_PERIOD: FiniteDuration = 5 minutes

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -78,6 +78,8 @@ object EclairInternalsSerializer {
       ("pingDisconnect" | bool(8)) ::
       ("maxRebroadcastDelay" | finiteDurationCodec)).as[PeerConnection.Conf]
 
+  val peerConnectionDoSyncCodec: Codec[PeerConnection.DoSync] = bool(8).as[PeerConnection.DoSync]
+
   val peerConnectionKillReasonCodec: Codec[PeerConnection.KillReason] = discriminated[PeerConnection.KillReason].by(uint16)
     .typecase(0, provide(PeerConnection.KillReason.UserRequest))
     .typecase(1, provide(PeerConnection.KillReason.NoRemainingChannel))
@@ -179,5 +181,6 @@ object EclairInternalsSerializer {
     .typecase(50, lengthPrefixedChannelUpdateCodec.as[GossipDecision.RelatedChannelPruned])
     .typecase(51, lengthPrefixedChannelAnnouncementCodec.as[GossipDecision.ChannelClosed])
     .typecase(52, peerConnectionKillCodec)
+    .typecase(53, peerConnectionDoSyncCodec)
 
 }


### PR DESCRIPTION
This command is sent by the `Peer` to its `PeerConnection`, therefore it
needs to be a `RemoteType` and have its own codec.