### PR TITLE
Disable jdbc instrumentation by default

### DIFF
--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -46,6 +46,12 @@ kamon.instrumentation.akka {
   }
 }
 
+kanela.modules {
+  jdbc {
+    enabled = false
+  }
+}
+
 akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logger-startup-timeout = 30s


### PR DESCRIPTION
The module is still there and can be enabled if needed.