### PR TITLE
Fix Bolt 3 spec change that broke our test suite

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -784,7 +784,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       TestVector(name, CommitmentSpec(htlcs, FeeratePerKw(feerate_per_kw.toLong.sat), MilliSatoshi(to_local_msat.toLong), MilliSatoshi(to_remote_msat.toLong)), Satoshi(fee.toLong))
     }).toSeq
 
-    assert(tests.size === 15, "there were 15 tests at ec99f893f320e8c88f564c1c8566f3454f0f1f5f") // simple non-reg to make sure we are not missing tests
+    assert(tests.size === 30, "there were 15 tests at b201efe0546120c14bf154ce5f4e18da7243fe7a") // simple non-reg to make sure we are not missing tests
     tests.foreach(test => {
       logger.info(s"running BOLT 3 test: '${test.name}'")
       val fee = commitTxFee(dustLimit, test.spec, DefaultCommitmentFormat)


### PR DESCRIPTION
We just merged https://github.com/lightningnetwork/lightning-rfc/commit/b201efe0546120c14bf154ce5f4e18da7243fe7a in the spec which added Bolt 3 tests, thus invalidating one of our tests and failing the build.