### PR TITLE
Add metadata to local_channels table

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -16,9 +16,6 @@
 
 package fr.acinq.eclair
 
-import java.nio.charset.StandardCharsets
-import java.util.UUID
-
 import akka.actor.ActorRef
 import akka.pattern._
 import akka.util.Timeout
@@ -30,7 +27,8 @@ import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet
 import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet.WalletTransaction
 import fr.acinq.eclair.blockchain.fee.{FeeratePerByte, FeeratePerKw}
 import fr.acinq.eclair.channel._
-import fr.acinq.eclair.db.{IncomingPayment, NetworkFee, OutgoingPayment, Stats}
+import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
+import fr.acinq.eclair.db.{IncomingPayment, OutgoingPayment}
 import fr.acinq.eclair.io.Peer.{GetPeerInfo, PeerInfo}
 import fr.acinq.eclair.io.{NodeURI, Peer, PeerConnection}
 import fr.acinq.eclair.payment._
@@ -42,6 +40,8 @@ import fr.acinq.eclair.router.{NetworkStats, RouteCalculation, Router}
 import fr.acinq.eclair.wire._
 import scodec.bits.ByteVector
 
+import java.nio.charset.StandardCharsets
+import java.util.UUID
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -36,9 +36,8 @@ import fr.acinq.eclair.blockchain.{EclairWallet, _}
 import fr.acinq.eclair.channel.Register
 import fr.acinq.eclair.crypto.keymanager.{LocalChannelKeyManager, LocalNodeKeyManager}
 import fr.acinq.eclair.db.Databases.FileBackup
-import fr.acinq.eclair.db.{Databases, FileBackupHandler}
+import fr.acinq.eclair.db.{DbEventHandler, Databases, FileBackupHandler}
 import fr.acinq.eclair.io.{ClientSpawner, Server, Switchboard}
-import fr.acinq.eclair.payment.Auditor
 import fr.acinq.eclair.payment.receive.PaymentHandler
 import fr.acinq.eclair.payment.relay.Relayer
 import fr.acinq.eclair.payment.send.{Autoprobe, PaymentInitiator}
@@ -308,7 +307,7 @@ class Setup(datadir: File,
         logger.warn("database backup is disabled")
         system.deadLetters
       }
-      audit = system.actorOf(SimpleSupervisor.props(Auditor.props(nodeParams), "auditor", SupervisorStrategy.Resume))
+      dbEventHandler = system.actorOf(SimpleSupervisor.props(DbEventHandler.props(nodeParams), "db-event-handler", SupervisorStrategy.Resume))
       register = system.actorOf(SimpleSupervisor.props(Props(new Register), "register", SupervisorStrategy.Resume))
       paymentHandler = system.actorOf(SimpleSupervisor.props(PaymentHandler.props(nodeParams, register), "payment-handler", SupervisorStrategy.Resume))
       relayer = system.actorOf(SimpleSupervisor.props(Relayer.props(nodeParams, router, register, paymentHandler, Some(postRestartCleanUpInitialized)), "relayer", SupervisorStrategy.Resume))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -16,12 +16,14 @@
 
 package fr.acinq.eclair.db
 
-import java.io.Closeable
-
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.channel._
+import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
+import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
 import fr.acinq.eclair.payment.{PaymentReceived, PaymentRelayed, PaymentSent}
+
+import java.io.Closeable
 
 trait AuditDb extends Closeable {
 
@@ -49,8 +51,10 @@ trait AuditDb extends Closeable {
 
 }
 
-case class ChannelLifecycleEvent(channelId: ByteVector32, remoteNodeId: PublicKey, capacity: Satoshi, isFunder: Boolean, isPrivate: Boolean, event: String)
+object AuditDb {
 
-case class NetworkFee(remoteNodeId: PublicKey, channelId: ByteVector32, txId: ByteVector32, fee: Satoshi, txType: String, timestamp: Long)
+  case class NetworkFee(remoteNodeId: PublicKey, channelId: ByteVector32, txId: ByteVector32, fee: Satoshi, txType: String, timestamp: Long)
 
-case class Stats(channelId: ByteVector32, direction: String, avgPaymentAmount: Satoshi, paymentCount: Int, relayFee: Satoshi, networkFee: Satoshi)
+  case class Stats(channelId: ByteVector32, direction: String, avgPaymentAmount: Satoshi, paymentCount: Int, relayFee: Satoshi, networkFee: Satoshi)
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -20,14 +20,14 @@ import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
-import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
+import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.payment.{PaymentReceived, PaymentRelayed, PaymentSent}
 
 import java.io.Closeable
 
 trait AuditDb extends Closeable {
 
-  def add(channelLifecycle: ChannelLifecycleEvent): Unit
+  def add(channelLifecycle: ChannelEvent): Unit
 
   def add(paymentSent: PaymentSent): Unit
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -16,15 +16,21 @@
 
 package fr.acinq.eclair.db
 
-import java.io.Closeable
-
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.CltvExpiry
 import fr.acinq.eclair.channel.HasCommitments
+import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
+import fr.acinq.eclair.payment.PaymentEvent
+
+import java.io.Closeable
 
 trait ChannelsDb extends Closeable {
 
   def addOrUpdateChannel(state: HasCommitments): Unit
+
+  def updateChannelMeta(channelId: ByteVector32, event: ChannelLifecycleEvent.EventType)
+
+  def updateChannelMeta(channelId: ByteVector32, event: PaymentEvent)
 
   def removeChannel(channelId: ByteVector32): Unit
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -19,8 +19,7 @@ package fr.acinq.eclair.db
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.CltvExpiry
 import fr.acinq.eclair.channel.HasCommitments
-import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
-import fr.acinq.eclair.payment.PaymentEvent
+import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 
 import java.io.Closeable
 
@@ -28,9 +27,7 @@ trait ChannelsDb extends Closeable {
 
   def addOrUpdateChannel(state: HasCommitments): Unit
 
-  def updateChannelMeta(channelId: ByteVector32, event: ChannelLifecycleEvent.EventType)
-
-  def updateChannelMeta(channelId: ByteVector32, event: PaymentEvent)
+  def updateChannelMeta(channelId: ByteVector32, event: ChannelEvent.EventType)
 
   def removeChannel(channelId: ByteVector32): Unit
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -19,6 +19,8 @@ package fr.acinq.eclair.db.pg
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi, SatoshiLong}
 import fr.acinq.eclair.channel.{ChannelErrorOccurred, LocalError, NetworkFeePaid, RemoteError}
+import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
+import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.payment._
@@ -72,7 +74,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
         statement.setLong(3, e.capacity.toLong)
         statement.setBoolean(4, e.isFunder)
         statement.setBoolean(5, e.isPrivate)
-        statement.setString(6, e.event)
+        statement.setString(6, e.event.label)
         statement.setLong(7, System.currentTimeMillis)
         statement.executeUpdate()
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -20,7 +20,7 @@ import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi, SatoshiLong}
 import fr.acinq.eclair.channel.{ChannelErrorOccurred, LocalError, NetworkFeePaid, RemoteError}
 import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
-import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
+import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.payment._
@@ -66,7 +66,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
     }
   }
 
-  override def add(e: ChannelLifecycleEvent): Unit = withMetrics("audit/add-channel-lifecycle") {
+  override def add(e: ChannelEvent): Unit = withMetrics("audit/add-channel-lifecycle") {
     inTransaction { pg =>
       using(pg.prepareStatement("INSERT INTO channel_events VALUES (?, ?, ?, ?, ?, ?, ?)")) { statement =>
         statement.setString(1, e.channelId.toHex)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -20,7 +20,7 @@ import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{ByteVector32, Satoshi, SatoshiLong}
 import fr.acinq.eclair.channel.{ChannelErrorOccurred, LocalError, NetworkFeePaid, RemoteError}
 import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
-import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
+import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.payment._
@@ -109,7 +109,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
     }
   }
 
-  override def add(e: ChannelLifecycleEvent): Unit = withMetrics("audit/add-channel-lifecycle") {
+  override def add(e: ChannelEvent): Unit = withMetrics("audit/add-channel-lifecycle") {
     using(sqlite.prepareStatement("INSERT INTO channel_events VALUES (?, ?, ?, ?, ?, ?, ?)")) { statement =>
       statement.setBytes(1, e.channelId.toArray)
       statement.setBytes(2, e.remoteNodeId.value.toArray)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -19,6 +19,8 @@ package fr.acinq.eclair.db.sqlite
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{ByteVector32, Satoshi, SatoshiLong}
 import fr.acinq.eclair.channel.{ChannelErrorOccurred, LocalError, NetworkFeePaid, RemoteError}
+import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
+import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.payment._
@@ -114,7 +116,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
       statement.setLong(3, e.capacity.toLong)
       statement.setBoolean(4, e.isFunder)
       statement.setBoolean(5, e.isPrivate)
-      statement.setString(6, e.event)
+      statement.setString(6, e.event.label)
       statement.setLong(7, System.currentTimeMillis)
       statement.executeUpdate()
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -16,16 +16,17 @@
 
 package fr.acinq.eclair.db.sqlite
 
-import java.sql.{Connection, Statement}
-
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.CltvExpiry
 import fr.acinq.eclair.channel.HasCommitments
 import fr.acinq.eclair.db.ChannelsDb
+import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
+import fr.acinq.eclair.payment.{PaymentEvent, PaymentReceived, PaymentSent}
 import fr.acinq.eclair.wire.ChannelCodecs.stateDataCodec
 import grizzled.slf4j.Logging
 
+import java.sql.{Connection, Statement}
 import scala.collection.immutable.Queue
 
 class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
@@ -34,7 +35,7 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
   import SqliteUtils._
 
   val DB_NAME = "channels"
-  val CURRENT_VERSION = 2
+  val CURRENT_VERSION = 3
 
   // The SQLite documentation states that "It is not possible to enable or disable foreign key constraints in the middle
   // of a multi-statement transaction (when SQLite is not in autocommit mode).".
@@ -49,13 +50,26 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
       statement.executeUpdate("ALTER TABLE local_channels ADD COLUMN is_closed BOOLEAN NOT NULL DEFAULT 0")
     }
 
+    def migration23(statement: Statement) = {
+      statement.executeUpdate("ALTER TABLE local_channels ADD COLUMN created_timestamp INTEGER")
+      statement.executeUpdate("ALTER TABLE local_channels ADD COLUMN last_payment_sent_timestamp INTEGER")
+      statement.executeUpdate("ALTER TABLE local_channels ADD COLUMN last_payment_received_timestamp INTEGER")
+      statement.executeUpdate("ALTER TABLE local_channels ADD COLUMN last_connected_timestamp INTEGER")
+      statement.executeUpdate("ALTER TABLE local_channels ADD COLUMN closed_timestamp INTEGER")
+    }
+
     getVersion(statement, DB_NAME, CURRENT_VERSION) match {
       case 1 =>
         logger.warn(s"migrating db $DB_NAME, found version=1 current=$CURRENT_VERSION")
         migration12(statement)
+        migration23(statement)
+        setVersion(statement, DB_NAME, CURRENT_VERSION)
+      case 2 =>
+        logger.warn(s"migrating db $DB_NAME, found version=2 current=$CURRENT_VERSION")
+        migration23(statement)
         setVersion(statement, DB_NAME, CURRENT_VERSION)
       case CURRENT_VERSION =>
-        statement.executeUpdate("CREATE TABLE IF NOT EXISTS local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT 0)")
+        statement.executeUpdate("CREATE TABLE IF NOT EXISTS local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT 0, created_timestamp INTEGER, last_payment_sent_timestamp INTEGER, last_payment_received_timestamp INTEGER, last_connected_timestamp INTEGER, closed_timestamp INTEGER)")
         statement.executeUpdate("CREATE TABLE IF NOT EXISTS htlc_infos (channel_id BLOB NOT NULL, commitment_number BLOB NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
         statement.executeUpdate("CREATE INDEX IF NOT EXISTS htlc_infos_idx ON htlc_infos(channel_id, commitment_number)")
       case unknownVersion => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
@@ -69,13 +83,43 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
       update.setBytes(1, data)
       update.setBytes(2, state.channelId.toArray)
       if (update.executeUpdate() == 0) {
-        using(sqlite.prepareStatement("INSERT INTO local_channels VALUES (?, ?, 0)")) { statement =>
+        using(sqlite.prepareStatement("INSERT INTO local_channels (channel_id, data, is_closed) VALUES (?, ?, 0)")) { statement =>
           statement.setBytes(1, state.channelId.toArray)
           statement.setBytes(2, data)
           statement.executeUpdate()
         }
       }
     }
+  }
+
+  /**
+   * Helper method to factor updating timestamp columns
+   */
+  private def updateChannelMetaTimestampColumn(channelId: ByteVector32, columnName: String): Unit = {
+    using(sqlite.prepareStatement(s"UPDATE local_channels SET $columnName=? WHERE channel_id=?")) { statement =>
+      statement.setLong(1, System.currentTimeMillis)
+      statement.setBytes(2, channelId.toArray)
+      statement.executeUpdate()
+    }
+  }
+
+  override def updateChannelMeta(channelId: ByteVector32, event: ChannelLifecycleEvent.EventType): Unit = {
+    val timestampColumn_opt = event match {
+      case ChannelLifecycleEvent.EventType.Created => Some("created_timestamp")
+      case ChannelLifecycleEvent.EventType.Connected => Some("last_connected_timestamp")
+      case _: ChannelLifecycleEvent.EventType.Closed => Some("closed_timestamp")
+      case _ => None
+    }
+    timestampColumn_opt.foreach(updateChannelMetaTimestampColumn(channelId, _))
+  }
+
+  override def updateChannelMeta(channelId: ByteVector32, event: PaymentEvent): Unit = {
+    val timestampColumn_opt = event match {
+      case _: PaymentSent => Some("last_payment_sent_timestamp")
+      case _: PaymentReceived => Some("last_payment_received_timestamp")
+      case _ => None
+    }
+    timestampColumn_opt.foreach(updateChannelMetaTimestampColumn(channelId, _))
   }
 
   override def removeChannel(channelId: ByteVector32): Unit = withMetrics("channels/remove-channel") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
@@ -20,7 +20,10 @@ import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{ByteVector32, SatoshiLong, Transaction}
 import fr.acinq.eclair.TestConstants.{TestPgDatabases, TestSqliteDatabases, forAllDbs}
 import fr.acinq.eclair._
+import fr.acinq.eclair.channel.Helpers.Closing.MutualClose
 import fr.acinq.eclair.channel.{ChannelErrorOccurred, LocalError, NetworkFeePaid, RemoteError}
+import fr.acinq.eclair.db.AuditDb.Stats
+import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
 import fr.acinq.eclair.db.jdbc.JdbcUtils.using
 import fr.acinq.eclair.db.sqlite.SqliteAuditDb
 import fr.acinq.eclair.payment._
@@ -33,7 +36,7 @@ import scala.util.Random
 
 class SqliteAuditDbSpec extends AnyFunSuite {
 
-  val ZERO_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
+  val ZERO_UUID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
 
   test("init sqlite 2 times in a row") {
     forAllDbs { dbs =>
@@ -57,7 +60,7 @@ class SqliteAuditDbSpec extends AnyFunSuite {
       val e5 = PaymentSent(UUID.randomUUID(), randomBytes32, randomBytes32, 84100 msat, randomKey.publicKey, pp5a :: pp5b :: Nil)
       val pp6 = PaymentSent.PartialPayment(UUID.randomUUID(), 42000 msat, 1000 msat, randomBytes32, None, timestamp = (System.currentTimeMillis.milliseconds + 10.minutes).toMillis)
       val e6 = PaymentSent(UUID.randomUUID(), randomBytes32, randomBytes32, 42000 msat, randomKey.publicKey, pp6 :: Nil)
-      val e7 = ChannelLifecycleEvent(randomBytes32, randomKey.publicKey, 456123000 sat, isFunder = true, isPrivate = false, "mutual")
+      val e7 = ChannelLifecycleEvent(randomBytes32, randomKey.publicKey, 456123000 sat, isFunder = true, isPrivate = false, ChannelLifecycleEvent.EventType.Closed(MutualClose(null)))
       val e8 = ChannelErrorOccurred(null, randomBytes32, randomKey.publicKey, null, LocalError(new RuntimeException("oops")), isFatal = true)
       val e9 = ChannelErrorOccurred(null, randomBytes32, randomKey.publicKey, null, RemoteError(wire.Error(randomBytes32, "remote oops")), isFatal = true)
       val e10 = TrampolinePaymentRelayed(randomBytes32, Seq(PaymentRelayed.Part(20000 msat, randomBytes32), PaymentRelayed.Part(22000 msat, randomBytes32)), Seq(PaymentRelayed.Part(10000 msat, randomBytes32), PaymentRelayed.Part(12000 msat, randomBytes32), PaymentRelayed.Part(15000 msat, randomBytes32)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteAuditDbSpec.scala
@@ -23,7 +23,7 @@ import fr.acinq.eclair._
 import fr.acinq.eclair.channel.Helpers.Closing.MutualClose
 import fr.acinq.eclair.channel.{ChannelErrorOccurred, LocalError, NetworkFeePaid, RemoteError}
 import fr.acinq.eclair.db.AuditDb.Stats
-import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
+import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.db.jdbc.JdbcUtils.using
 import fr.acinq.eclair.db.sqlite.SqliteAuditDb
 import fr.acinq.eclair.payment._
@@ -60,7 +60,7 @@ class SqliteAuditDbSpec extends AnyFunSuite {
       val e5 = PaymentSent(UUID.randomUUID(), randomBytes32, randomBytes32, 84100 msat, randomKey.publicKey, pp5a :: pp5b :: Nil)
       val pp6 = PaymentSent.PartialPayment(UUID.randomUUID(), 42000 msat, 1000 msat, randomBytes32, None, timestamp = (System.currentTimeMillis.milliseconds + 10.minutes).toMillis)
       val e6 = PaymentSent(UUID.randomUUID(), randomBytes32, randomBytes32, 42000 msat, randomKey.publicKey, pp6 :: Nil)
-      val e7 = ChannelLifecycleEvent(randomBytes32, randomKey.publicKey, 456123000 sat, isFunder = true, isPrivate = false, ChannelLifecycleEvent.EventType.Closed(MutualClose(null)))
+      val e7 = ChannelEvent(randomBytes32, randomKey.publicKey, 456123000 sat, isFunder = true, isPrivate = false, ChannelEvent.EventType.Closed(MutualClose(null)))
       val e8 = ChannelErrorOccurred(null, randomBytes32, randomKey.publicKey, null, LocalError(new RuntimeException("oops")), isFatal = true)
       val e9 = ChannelErrorOccurred(null, randomBytes32, randomKey.publicKey, null, RemoteError(wire.Error(randomBytes32, "remote oops")), isFatal = true)
       val e10 = TrampolinePaymentRelayed(randomBytes32, Seq(PaymentRelayed.Part(20000 msat, randomBytes32), PaymentRelayed.Part(22000 msat, randomBytes32)), Seq(PaymentRelayed.Part(10000 msat, randomBytes32), PaymentRelayed.Part(12000 msat, randomBytes32), PaymentRelayed.Part(15000 msat, randomBytes32)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -20,9 +20,10 @@ import com.softwaremill.quicklens._
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.TestConstants.{TestPgDatabases, TestSqliteDatabases, forAllDbs}
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
-import fr.acinq.eclair.db.sqlite.SqliteChannelsDb
+import fr.acinq.eclair.db.jdbc.JdbcUtils.using
+import fr.acinq.eclair.db.pg.PgUtils
+import fr.acinq.eclair.db.sqlite.{SqliteChannelsDb, SqliteUtils}
 import fr.acinq.eclair.db.sqlite.SqliteUtils.ExtendedResultSet._
-import fr.acinq.eclair.db.sqlite.SqliteUtils.{getVersion, using}
 import fr.acinq.eclair.wire.ChannelCodecs.stateDataCodec
 import fr.acinq.eclair.wire.ChannelCodecsSpec
 import fr.acinq.eclair.{CltvExpiry, randomBytes32}
@@ -136,7 +137,7 @@ class SqliteChannelsDbSpec extends AnyFunSuite {
 
         // create a v1 channels database
         using(sqlite.createStatement()) { statement =>
-          getVersion(statement, "channels", 1)
+          SqliteUtils.getVersion(statement, "channels", 1)
           statement.execute("PRAGMA foreign_keys = ON")
           statement.executeUpdate("CREATE TABLE IF NOT EXISTS local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL)")
           statement.executeUpdate("CREATE TABLE IF NOT EXISTS htlc_infos (channel_id BLOB NOT NULL, commitment_number BLOB NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
@@ -155,7 +156,7 @@ class SqliteChannelsDbSpec extends AnyFunSuite {
         // check that db migration works
         val db = new SqliteChannelsDb(sqlite)
         using(sqlite.createStatement()) { statement =>
-          assert(getVersion(statement, "channels", 1) == 3) // version changed from 1 -> 3
+          assert(SqliteUtils.getVersion(statement, "channels", 1) == 3) // version changed from 1 -> 3
         }
         assert(db.listLocalChannels() === List(channel))
         db.updateChannelMeta(channel.channelId, ChannelEvent.EventType.Created) // this call must not fail
@@ -164,13 +165,41 @@ class SqliteChannelsDbSpec extends AnyFunSuite {
 
   test("migrate channel database v2 -> v3") {
     forAllDbs {
-      case _: TestPgDatabases => // no migration
+      case dbs: TestPgDatabases =>
+        val pg = dbs.connection
+
+        // create a v2 channels database
+        using(pg.createStatement()) { statement =>
+          PgUtils.getVersion(statement, "channels", 2)
+          statement.executeUpdate("CREATE TABLE IF NOT EXISTS local_channels (channel_id TEXT NOT NULL PRIMARY KEY, data BYTEA NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT FALSE)")
+          statement.executeUpdate("CREATE TABLE IF NOT EXISTS htlc_infos (channel_id TEXT NOT NULL, commitment_number TEXT NOT NULL, payment_hash TEXT NOT NULL, cltv_expiry BIGINT NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
+          statement.executeUpdate("CREATE INDEX IF NOT EXISTS htlc_infos_idx ON htlc_infos(channel_id, commitment_number)")
+        }
+
+        // insert 1 row
+        val channel = ChannelCodecsSpec.normal
+        val data = stateDataCodec.encode(channel).require.toByteArray
+        using(pg.prepareStatement("INSERT INTO local_channels (channel_id, data, is_closed) VALUES (?, ?, ?)")) { statement =>
+          statement.setString(1, channel.channelId.toHex)
+          statement.setBytes(2, data)
+          statement.setBoolean(3, false)
+          statement.executeUpdate()
+        }
+
+        // check that db migration works
+        val db = dbs.channels()
+        using(pg.createStatement()) { statement =>
+          assert(PgUtils.getVersion(statement, "channels", 2) == 3) // version changed from 2 -> 3
+        }
+        assert(db.listLocalChannels() === List(channel))
+        db.updateChannelMeta(channel.channelId, ChannelEvent.EventType.Created) // this call must not fail
+
       case dbs: TestSqliteDatabases =>
         val sqlite = dbs.connection
 
         // create a v2 channels database
         using(sqlite.createStatement()) { statement =>
-          getVersion(statement, "channels", 2)
+          SqliteUtils.getVersion(statement, "channels", 2)
           statement.execute("PRAGMA foreign_keys = ON")
           statement.executeUpdate("CREATE TABLE IF NOT EXISTS local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT 0)")
           statement.executeUpdate("CREATE TABLE IF NOT EXISTS htlc_infos (channel_id BLOB NOT NULL, commitment_number BLOB NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
@@ -188,9 +217,9 @@ class SqliteChannelsDbSpec extends AnyFunSuite {
         }
 
         // check that db migration works
-        val db = new SqliteChannelsDb(sqlite)
+        val db = dbs.channels()
         using(sqlite.createStatement()) { statement =>
-          assert(getVersion(statement, "channels", 2) == 3) // version changed from 2 -> 3
+          assert(SqliteUtils.getVersion(statement, "channels", 2) == 3) // version changed from 2 -> 3
         }
         assert(db.listLocalChannels() === List(channel))
         db.updateChannelMeta(channel.channelId, ChannelEvent.EventType.Created) // this call must not fail

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -16,17 +16,21 @@
 
 package fr.acinq.eclair.db
 
-import java.sql.SQLException
-
+import com.softwaremill.quicklens._
 import fr.acinq.bitcoin.ByteVector32
-import fr.acinq.eclair.CltvExpiry
 import fr.acinq.eclair.TestConstants.{TestPgDatabases, TestSqliteDatabases, forAllDbs}
+import fr.acinq.eclair.db.DbEventHandler.ChannelLifecycleEvent
 import fr.acinq.eclair.db.sqlite.SqliteChannelsDb
+import fr.acinq.eclair.db.sqlite.SqliteUtils.ExtendedResultSet._
 import fr.acinq.eclair.db.sqlite.SqliteUtils.{getVersion, using}
+import fr.acinq.eclair.payment.{PaymentReceived, PaymentSent}
 import fr.acinq.eclair.wire.ChannelCodecs.stateDataCodec
 import fr.acinq.eclair.wire.ChannelCodecsSpec
+import fr.acinq.eclair.{CltvExpiry, MilliSatoshiLong, randomBytes32, randomKey}
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits.ByteVector
+
+import java.sql.SQLException
 
 class SqliteChannelsDbSpec extends AnyFunSuite {
 
@@ -69,7 +73,64 @@ class SqliteChannelsDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migrate channel database v1 -> v2") {
+  test("channel metadata") {
+    forAllDbs { dbs =>
+      val db = dbs.channels()
+      val connection = dbs.connection
+
+      val channel1 = ChannelCodecsSpec.normal
+      val channel2 = channel1.modify(_.commitments.channelId).setTo(randomBytes32)
+
+      def getTimestamp(channelId: ByteVector32, columnName: String): Option[Long] = {
+        using(connection.prepareStatement(s"SELECT $columnName FROM local_channels WHERE channel_id=?")) { statement =>
+          // data type differs depending on underlying database system
+          dbs match {
+            case _: TestPgDatabases => statement.setString(1, channelId.toHex)
+            case _: TestSqliteDatabases => statement.setBytes(1, channelId.toArray)
+          }
+          val rs = statement.executeQuery()
+          rs.next()
+          rs.getLongNullable(columnName)
+        }
+      }
+
+      // first we add channels
+      db.addOrUpdateChannel(channel1)
+      db.addOrUpdateChannel(channel2)
+
+      // make sure initially all metadata are empty
+      assert(getTimestamp(channel1.channelId, "created_timestamp").isEmpty)
+      assert(getTimestamp(channel1.channelId, "last_payment_sent_timestamp").isEmpty)
+      assert(getTimestamp(channel1.channelId, "last_payment_received_timestamp").isEmpty)
+      assert(getTimestamp(channel1.channelId, "last_connected_timestamp").isEmpty)
+      assert(getTimestamp(channel1.channelId, "closed_timestamp").isEmpty)
+
+      db.updateChannelMeta(channel1.channelId, ChannelLifecycleEvent.EventType.Created)
+      assert(getTimestamp(channel1.channelId, "created_timestamp").nonEmpty)
+
+      db.updateChannelMeta(channel1.channelId, PaymentSent(null, randomBytes32, randomBytes32, 40000 msat, randomKey.publicKey, PaymentSent.PartialPayment(null, 42000 msat, 1000 msat, randomBytes32, None) :: Nil))
+      assert(getTimestamp(channel1.channelId, "last_payment_sent_timestamp").nonEmpty)
+
+      db.updateChannelMeta(channel1.channelId, PaymentReceived(randomBytes32, PaymentReceived.PartialPayment(42000 msat, randomBytes32) :: Nil))
+      assert(getTimestamp(channel1.channelId, "last_payment_received_timestamp").nonEmpty)
+
+      db.updateChannelMeta(channel1.channelId, ChannelLifecycleEvent.EventType.Connected)
+      assert(getTimestamp(channel1.channelId, "last_connected_timestamp").nonEmpty)
+
+      db.updateChannelMeta(channel1.channelId, ChannelLifecycleEvent.EventType.Closed(null))
+      assert(getTimestamp(channel1.channelId, "closed_timestamp").nonEmpty)
+
+      // make sure all metadata are still empty for channel 2
+      assert(getTimestamp(channel2.channelId, "created_timestamp").isEmpty)
+      assert(getTimestamp(channel2.channelId, "last_payment_sent_timestamp").isEmpty)
+      assert(getTimestamp(channel2.channelId, "last_payment_received_timestamp").isEmpty)
+      assert(getTimestamp(channel2.channelId, "last_connected_timestamp").isEmpty)
+      assert(getTimestamp(channel2.channelId, "closed_timestamp").isEmpty)
+
+    }
+  }
+
+  test("migrate channel database v1 -> v3") {
     forAllDbs {
       case _: TestPgDatabases => // no migration
       case dbs: TestSqliteDatabases =>
@@ -96,9 +157,45 @@ class SqliteChannelsDbSpec extends AnyFunSuite {
         // check that db migration works
         val db = new SqliteChannelsDb(sqlite)
         using(sqlite.createStatement()) { statement =>
-          assert(getVersion(statement, "channels", 1) == 2) // version changed from 1 -> 2
+          assert(getVersion(statement, "channels", 1) == 3) // version changed from 1 -> 3
         }
         assert(db.listLocalChannels() === List(channel))
+        db.updateChannelMeta(channel.channelId, ChannelLifecycleEvent.EventType.Created) // this call must not fail
+    }
+  }
+
+  test("migrate channel database v2 -> v3") {
+    forAllDbs {
+      case _: TestPgDatabases => // no migration
+      case dbs: TestSqliteDatabases =>
+        val sqlite = dbs.connection
+
+        // create a v2 channels database
+        using(sqlite.createStatement()) { statement =>
+          getVersion(statement, "channels", 2)
+          statement.execute("PRAGMA foreign_keys = ON")
+          statement.executeUpdate("CREATE TABLE IF NOT EXISTS local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT 0)")
+          statement.executeUpdate("CREATE TABLE IF NOT EXISTS htlc_infos (channel_id BLOB NOT NULL, commitment_number BLOB NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
+          statement.executeUpdate("CREATE INDEX IF NOT EXISTS htlc_infos_idx ON htlc_infos(channel_id, commitment_number)")
+        }
+
+        // insert 1 row
+        val channel = ChannelCodecsSpec.normal
+        val data = stateDataCodec.encode(channel).require.toByteArray
+        using(sqlite.prepareStatement("INSERT INTO local_channels VALUES (?, ?, ?)")) { statement =>
+          statement.setBytes(1, channel.channelId.toArray)
+          statement.setBytes(2, data)
+          statement.setBoolean(3, false)
+          statement.executeUpdate()
+        }
+
+        // check that db migration works
+        val db = new SqliteChannelsDb(sqlite)
+        using(sqlite.createStatement()) { statement =>
+          assert(getVersion(statement, "channels", 2) == 3) // version changed from 2 -> 3
+        }
+        assert(db.listLocalChannels() === List(channel))
+        db.updateChannelMeta(channel.channelId, ChannelLifecycleEvent.EventType.Created) // this call must not fail
     }
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteChannelsDbSpec.scala
@@ -125,7 +125,6 @@ class SqliteChannelsDbSpec extends AnyFunSuite {
       assert(getTimestamp(channel2.channelId, "last_payment_received_timestamp").isEmpty)
       assert(getTimestamp(channel2.channelId, "last_connected_timestamp").isEmpty)
       assert(getTimestamp(channel2.channelId, "closed_timestamp").isEmpty)
-
     }
   }
 


### PR DESCRIPTION
(First commit is a refactor/cleanup and can be reviewed independently).

Here is the rationale for implementing channel metadata as additional
columns in the `local_channels` table of the `channels` db, as opposed
to a dedicated `channel_metadata` table of a `audit` db:

1) There is a migration to do (in the `local_channels` table, no less!),
but it's just a table migration, as opposed to a data migration, if we
had to populate a new table in a separate database.
2) We don't need to worry about creating a new metadata line when a new
channel is created (compared to doing add-or-update stuff). It's only
_updating_ optional columns in a best-effort manner.
3) We don't need to worry about inconsistencies between two tables
located in two separated databases (that's a big one).
4) We may want to use the metadata during operations, not just for
audit purposes. For example to close channels that have stayed unused
for a long time.
5) The audit db is an append-only log of events and shouldn't be used
for anything else. There is no `UPDATE` sql statement in
`*AuditDb.scala`. The `channel_metadata` would break that heuristic.

