### PR TITLE
Fix API regression

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -47,9 +47,12 @@ trait Service extends EclairDirectives with WebSocket with Node with Channel wit
   implicit val mat: Materializer
 
   /**
-   * Collect routes from all sub-routers here. This is the main entrypoint for the global
-   * http request router of the API service.
+   * Collect routes from all sub-routers here.
+   * This is the main entrypoint for the global http request router of the API service.
+   * This is where we handle errors to ensure all routes are correctly tried before rejecting.
    */
-  val route: Route = nodeRoutes ~ channelRoutes ~ feeRoutes ~ pathFindingRoutes ~ invoiceRoutes ~ paymentRoutes ~ messageRoutes ~ onChainRoutes ~ webSocket
+  val route: Route = securedHandler {
+    nodeRoutes ~ channelRoutes ~ feeRoutes ~ pathFindingRoutes ~ invoiceRoutes ~ paymentRoutes ~ messageRoutes ~ onChainRoutes ~ webSocket
+  }
 
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -28,8 +28,6 @@ trait Service extends EclairDirectives with WebSocket with Node with Channel wit
 
   /**
    * Allows router access to the API password as configured in eclair.conf
-   *
-   * @return
    */
   def password: String
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
@@ -34,7 +34,6 @@ trait AuthDirective {
    */
   def authenticated: Directive0 = authenticateBasicAsync(realm = "Access restricted", userPassAuthenticator).tflatMap { _ => pass }
 
-
   private def userPassAuthenticator(credentials: Credentials): Future[Option[String]] = credentials match {
     case p@Credentials.Provided(id) if p.verify(password) => Future.successful(Some(id))
     case _ => akka.pattern.after(1 second, using = actorSystem.scheduler)(Future.successful(None))(actorSystem.dispatcher) // force a 1 sec pause to deter brute force

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/DefaultHeaders.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/DefaultHeaders.scala
@@ -27,10 +27,9 @@ trait DefaultHeaders {
   /**
    * Adds customHeaders to all http responses.
    */
-  def eclairHeaders:Directive0 = respondWithDefaultHeaders(customHeaders)
-
+  def eclairHeaders: Directive0 = respondWithDefaultHeaders(customHeaders)
 
   private val customHeaders = `Access-Control-Allow-Headers`("Content-Type, Authorization") ::
-      `Access-Control-Allow-Methods`(POST) ::
-      `Cache-Control`(public, `no-store`, `max-age`(0)) :: Nil
+    `Access-Control-Allow-Methods`(POST) ::
+    `Cache-Control`(public, `no-store`, `max-age`(0)) :: Nil
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/EclairDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/EclairDirectives.scala
@@ -22,26 +22,27 @@ import fr.acinq.eclair.api.Service
 
 import scala.concurrent.duration.DurationInt
 
-class EclairDirectives extends Directives with TimeoutDirective with ErrorDirective with AuthDirective with DefaultHeaders with ExtraDirectives { this: Service =>
+class EclairDirectives extends Directives with TimeoutDirective with ErrorDirective with AuthDirective with DefaultHeaders with ExtraDirectives {
+  this: Service =>
 
   /**
-   * Prepares inner routes to be exposed as public API with default headers, error handlers and basic authentication.
+   * Prepares inner routes to be exposed as public API with default headers and basic authentication.
    */
-  private def securedHandler:Directive0 = eclairHeaders & handled & authenticated
+  private def securedHandler: Directive0 = eclairHeaders & handled & authenticated
 
   /**
    * Provides a Timeout to the inner route either from request param or the default.
    */
-  private def standardHandler:Directive1[Timeout] = toStrictEntity(5 seconds) & withTimeout
+  private def standardHandler: Directive1[Timeout] = toStrictEntity(5 seconds) & withTimeout
 
   /**
    * Handles POST requests with given simple path. The inner route is wrapped in a standard handler and provides a Timeout as parameter.
    */
-  def postRequest(p:String):Directive1[Timeout] = securedHandler & post & path(p) & standardHandler
+  def postRequest(p: String): Directive1[Timeout] = securedHandler & post & path(p) & standardHandler
 
   /**
    * Handles GET requests with given simple path. The inner route is wrapped in a standard handler and provides a Timeout as parameter.
    */
-  def getRequest(p:String):Directive1[Timeout] = securedHandler & get & path(p) & standardHandler
+  def getRequest(p: String): Directive1[Timeout] = securedHandler & get & path(p) & standardHandler
 
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/EclairDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/EclairDirectives.scala
@@ -26,9 +26,10 @@ class EclairDirectives extends Directives with TimeoutDirective with ErrorDirect
   this: Service =>
 
   /**
-   * Prepares inner routes to be exposed as public API with default headers and basic authentication.
+   * Prepares inner routes to be exposed as public API with default headers, basic authentication and error handling.
+   * Must be applied *after* aggregating all the inner routes.
    */
-  private def securedHandler: Directive0 = eclairHeaders & handled & authenticated
+  def securedHandler: Directive0 = eclairHeaders & handled & authenticated
 
   /**
    * Provides a Timeout to the inner route either from request param or the default.
@@ -38,11 +39,11 @@ class EclairDirectives extends Directives with TimeoutDirective with ErrorDirect
   /**
    * Handles POST requests with given simple path. The inner route is wrapped in a standard handler and provides a Timeout as parameter.
    */
-  def postRequest(p: String): Directive1[Timeout] = securedHandler & post & path(p) & standardHandler
+  def postRequest(p: String): Directive1[Timeout] = standardHandler & post & path(p)
 
   /**
    * Handles GET requests with given simple path. The inner route is wrapped in a standard handler and provides a Timeout as parameter.
    */
-  def getRequest(p: String): Directive1[Timeout] = securedHandler & get & path(p) & standardHandler
+  def getRequest(p: String): Directive1[Timeout] = standardHandler & get & path(p)
 
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ErrorDirective.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ErrorDirective.scala
@@ -24,12 +24,9 @@ trait ErrorDirective {
   this: Service with EclairDirectives =>
 
   /**
-   * Handles API exceptions and rejections. Produces json formatted
-   * error responses.
+   * Handles API exceptions and rejections. Produces json formatted error responses.
    */
-  def handled: Directive0 = handleExceptions(apiExceptionHandler) &
-    handleRejections(apiRejectionHandler)
-
+  def handled: Directive0 = handleExceptions(apiExceptionHandler) & handleRejections(apiRejectionHandler)
 
   import fr.acinq.eclair.api.serde.JsonSupport.{formats, marshaller, serialization}
 
@@ -45,9 +42,7 @@ trait ErrorDirective {
   // map all the rejections to a JSON error object ErrorResponse
   private val apiRejectionHandler = RejectionHandler.default.mapRejectionResponse {
     case res@HttpResponse(_, _, ent: HttpEntity.Strict, _) =>
-      res.withEntity(
-        HttpEntity(ContentTypes.`application/json`, serialization.writePretty(ErrorResponse(ent.data.utf8String)))
-      )
+      res.withEntity(HttpEntity(ContentTypes.`application/json`, serialization.writePretty(ErrorResponse(ent.data.utf8String))))
   }
 
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
@@ -16,7 +16,6 @@
 
 package fr.acinq.eclair.api.directives
 
-import fr.acinq.eclair.api.serde.JsonSupport.serialization
 import akka.http.scaladsl.common.{NameReceptacle, NameUnmarshallerReceptacle}
 import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.model.StatusCodes.NotFound

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/TimeoutDirective.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/TimeoutDirective.scala
@@ -20,8 +20,8 @@ import akka.http.scaladsl.model.{ContentTypes, HttpRequest, HttpResponse, Status
 import akka.http.scaladsl.server.{Directive0, Directive1, Directives}
 import akka.util.Timeout
 import fr.acinq.eclair.api.serde.FormParamExtractors._
-import fr.acinq.eclair.api.serde.JsonSupport._
 import fr.acinq.eclair.api.serde.JsonSupport
+import fr.acinq.eclair.api.serde.JsonSupport._
 
 import scala.concurrent.duration.DurationInt
 
@@ -29,12 +29,11 @@ trait TimeoutDirective extends Directives {
 
   import JsonSupport.{formats, serialization}
 
-
   /**
    * Extracts a given request timeout from an optional form field. Provides either the
    * extracted Timeout or a default Timeout to the inner route.
    */
-  def withTimeout:Directive1[Timeout] = extractTimeout.tflatMap { timeout =>
+  def withTimeout: Directive1[Timeout] = extractTimeout.tflatMap { timeout =>
     withTimeoutRequest(timeout._1) & provide(timeout._1)
   }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Channel.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Channel.scala
@@ -20,9 +20,9 @@ import akka.http.scaladsl.server.{MalformedFormFieldRejection, Route}
 import akka.util.Timeout
 import fr.acinq.bitcoin.Satoshi
 import fr.acinq.eclair.MilliSatoshi
-import fr.acinq.eclair.api.serde.FormParamExtractors._
 import fr.acinq.eclair.api.Service
 import fr.acinq.eclair.api.directives.EclairDirectives
+import fr.acinq.eclair.api.serde.FormParamExtractors._
 import fr.acinq.eclair.blockchain.fee.FeeratePerByte
 import scodec.bits.ByteVector
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Invoice.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Invoice.scala
@@ -16,12 +16,11 @@
 
 package fr.acinq.eclair.api.handlers
 
-import akka.http.scaladsl.server.{MalformedFormFieldRejection, Route}
-import fr.acinq.bitcoin.{ByteVector32, Satoshi}
-import fr.acinq.eclair.api.serde.FormParamExtractors._
+import akka.http.scaladsl.server.Route
+import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.api.Service
 import fr.acinq.eclair.api.directives.EclairDirectives
-import fr.acinq.eclair.payment.PaymentRequest
+import fr.acinq.eclair.api.serde.FormParamExtractors._
 
 trait Invoice {
   this: Service with EclairDirectives =>
@@ -60,6 +59,6 @@ trait Invoice {
     }
   }
 
-  val invoiceRoutes: Route =  createInvoice ~ getInvoice ~ listInvoices ~ listPendingInvoices ~ parseInvoice
+  val invoiceRoutes: Route = createInvoice ~ getInvoice ~ listInvoices ~ listPendingInvoices ~ parseInvoice
 
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Message.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Message.scala
@@ -17,9 +17,9 @@
 package fr.acinq.eclair.api.handlers
 
 import akka.http.scaladsl.server.Route
-import fr.acinq.eclair.api.serde.FormParamExtractors._
 import fr.acinq.eclair.api.Service
 import fr.acinq.eclair.api.directives.EclairDirectives
+import fr.acinq.eclair.api.serde.FormParamExtractors._
 import scodec.bits.ByteVector
 
 trait Message {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Node.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Node.scala
@@ -20,8 +20,8 @@ import akka.http.scaladsl.server.Route
 import com.google.common.net.HostAndPort
 import fr.acinq.eclair.api.Service
 import fr.acinq.eclair.api.directives.EclairDirectives
-import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.api.serde.FormParamExtractors._
+import fr.acinq.eclair.io.NodeURI
 
 trait Node {
   this: Service with EclairDirectives =>

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Payment.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Payment.scala
@@ -19,13 +19,12 @@ package fr.acinq.eclair.api.handlers
 import akka.http.scaladsl.server.{MalformedFormFieldRejection, Route}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi}
-import fr.acinq.eclair.api.serde.FormParamExtractors.pubkeyListUnmarshaller
 import fr.acinq.eclair.api.Service
 import fr.acinq.eclair.api.directives.EclairDirectives
+import fr.acinq.eclair.api.serde.FormParamExtractors.{pubkeyListUnmarshaller, _}
 import fr.acinq.eclair.payment.PaymentRequest
 import fr.acinq.eclair.router.Router.{PredefinedChannelRoute, PredefinedNodeRoute}
 import fr.acinq.eclair.{CltvExpiryDelta, MilliSatoshi}
-import fr.acinq.eclair.api.serde.FormParamExtractors._
 
 import java.util.UUID
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/WebSocket.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/WebSocket.scala
@@ -38,7 +38,6 @@ trait WebSocket {
     handleWebSocketMessages(makeSocketHandler)
   }
 
-
   // Init the websocket message flow
   private lazy val makeSocketHandler: Flow[Message, TextMessage.Strict, NotUsed] = {
 
@@ -73,6 +72,5 @@ trait WebSocket {
       .merge(flowOutput) // Stream the data we want to the client
       .map(TextMessage.apply)
   }
-
 
 }


### PR DESCRIPTION
We incorrectly applied error handlers at each sub-route instead of applying it after grouping all sub-routes together. The result was that only `getinfo` (the first one tried) could actually be called.

The tests were changed to directly call the sub-routes so they didn't notice this issue. I fixed that by adding tests that failed with the previous code by simply using the top-level route.

I thought I had tested this E2E before merging #1690 but my (custom, poorly written) scripts in fact didn't correctly re-source my `.bash_aliases` so I was in fact testing `master` :facepalm: 

cc @tompro 