### PR TITLE
Catch all connection failures and reconnect

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
@@ -53,8 +53,8 @@ class ReconnectionTask(nodeParams: NodeParams, remoteNodeId: PublicKey) extends 
   startWith(IDLE, IdleData(Nothing))
 
   when(CONNECTING) {
-    case Event(_: PeerConnection.ConnectionResult.ConnectionFailed, d: ConnectingData) =>
-      log.info(s"connection failed, next reconnection in ${d.nextReconnectionDelay.toSeconds} seconds")
+    case Event(failure: PeerConnection.ConnectionResult.Failure, d: ConnectingData) =>
+      log.info(s"connection failed (reason=$failure), next reconnection in ${d.nextReconnectionDelay.toSeconds} seconds")
       setReconnectTimer(d.nextReconnectionDelay)
       goto(WAITING) using WaitingData(nextReconnectionDelay(d.nextReconnectionDelay, nodeParams.maxReconnectInterval))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
@@ -207,7 +207,7 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
 
     // at this point, we are attempting to connect to the peer
     // let's assume that an incoming connection arrives from the peer right before our outgoing connection, but we haven't
-    // yes received the peer transition
+    // yet received the peer transition
     reconnectionTask ! PeerConnection.ConnectionResult.AlreadyConnected
     // we will schedule a reconnection
     val TransitionWithData(ReconnectionTask.CONNECTING, ReconnectionTask.WAITING, _, _) = monitor.expectMsgType[TransitionWithData]


### PR DESCRIPTION
The `ReconnectionTask` was only catching
`ConnectionResult.Failure.ConnectionFailed`, which is a subset of
possible failures. It should instead have caught
`ConnectionResult.Failure`.

All authentication and initialization failures were not caught and
didn't trigger reconnections.

Fixes #1748.