### PR TITLE
Posgres: fix concurrency in channels db

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
@@ -71,7 +71,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
         """
           | INSERT INTO local_channels (channel_id, data, is_closed)
           | VALUES (?, ?, FALSE)
-          | ON CONFLICT ON CONSTRAINT local_channels_pkey
+          | ON CONFLICT (channel_id)
           | DO UPDATE SET data = EXCLUDED.data ;
           | """.stripMargin)) { statement =>
         statement.setString(1, state.channelId.toHex)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgUtils.scala
@@ -60,7 +60,10 @@ object PgUtils extends JdbcUtils {
           logger.error(s"cannot obtain lock on the database ($other).")
       }
 
-      case class LockException(lockFailure: LockFailure) extends RuntimeException("a lock exception occurred")
+      case class LockException(lockFailure: LockFailure) extends RuntimeException("a lock exception occurred", lockFailure match {
+        case LockFailure.GeneralLockException(cause) => cause // when the origin is an exception, we provide it to have a nice stack trace
+        case _ => null
+      })
 
       /**
        * This handler is useful in tests

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
@@ -26,7 +26,7 @@ import fr.acinq.eclair.db.sqlite.SqliteChannelsDb
 import fr.acinq.eclair.db.sqlite.SqliteUtils.ExtendedResultSet._
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecs.stateDataCodec
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecsSpec
-import fr.acinq.eclair.{CltvExpiry, randomBytes32}
+import fr.acinq.eclair.{CltvExpiry, ShortChannelId, randomBytes32}
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits.ByteVector
 
@@ -55,7 +55,9 @@ class ChannelsDbSpec extends AnyFunSuite {
       val db = dbs.channels
       dbs.pendingRelay // needed by db.removeChannel
 
-      val channel = ChannelCodecsSpec.normal
+      val channel1 = ChannelCodecsSpec.normal
+      val channel2a = ChannelCodecsSpec.normal.modify(_.commitments.channelId).setTo(randomBytes32)
+      val channel2b = channel2a.modify(_.shortChannelId).setTo(ShortChannelId(189371))
 
       val commitNumber = 42
       val paymentHash1 = ByteVector32.Zeroes
@@ -63,22 +65,28 @@ class ChannelsDbSpec extends AnyFunSuite {
       val paymentHash2 = ByteVector32(ByteVector.fill(32)(1))
       val cltvExpiry2 = CltvExpiry(656)
 
-      intercept[SQLException](db.addHtlcInfo(channel.channelId, commitNumber, paymentHash1, cltvExpiry1)) // no related channel
+      intercept[SQLException](db.addHtlcInfo(channel1.channelId, commitNumber, paymentHash1, cltvExpiry1)) // no related channel
 
       assert(db.listLocalChannels().toSet === Set.empty)
-      db.addOrUpdateChannel(channel)
-      db.addOrUpdateChannel(channel)
-      assert(db.listLocalChannels() === List(channel))
+      db.addOrUpdateChannel(channel1)
+      db.addOrUpdateChannel(channel1)
+      assert(db.listLocalChannels() === List(channel1))
+      db.addOrUpdateChannel(channel2a)
+      assert(db.listLocalChannels() === List(channel1, channel2a))
+      db.addOrUpdateChannel(channel2b)
+      assert(db.listLocalChannels() === List(channel1, channel2b))
 
-      assert(db.listHtlcInfos(channel.channelId, commitNumber).toList == Nil)
-      db.addHtlcInfo(channel.channelId, commitNumber, paymentHash1, cltvExpiry1)
-      db.addHtlcInfo(channel.channelId, commitNumber, paymentHash2, cltvExpiry2)
-      assert(db.listHtlcInfos(channel.channelId, commitNumber).toList.toSet == Set((paymentHash1, cltvExpiry1), (paymentHash2, cltvExpiry2)))
-      assert(db.listHtlcInfos(channel.channelId, 43).toList == Nil)
+      assert(db.listHtlcInfos(channel1.channelId, commitNumber).toList == Nil)
+      db.addHtlcInfo(channel1.channelId, commitNumber, paymentHash1, cltvExpiry1)
+      db.addHtlcInfo(channel1.channelId, commitNumber, paymentHash2, cltvExpiry2)
+      assert(db.listHtlcInfos(channel1.channelId, commitNumber).toList.toSet == Set((paymentHash1, cltvExpiry1), (paymentHash2, cltvExpiry2)))
+      assert(db.listHtlcInfos(channel1.channelId, 43).toList == Nil)
 
-      db.removeChannel(channel.channelId)
+      db.removeChannel(channel1.channelId)
+      assert(db.listLocalChannels() === List(channel2b))
+      assert(db.listHtlcInfos(channel1.channelId, commitNumber).toList == Nil)
+      db.removeChannel(channel2b.channelId)
       assert(db.listLocalChannels() === Nil)
-      assert(db.listHtlcInfos(channel.channelId, commitNumber).toList == Nil)
     }
   }
 


### PR DESCRIPTION
The upsert pattern in `channelsDb.addOrUpdateChannel` is apparently not compatible with concurrent transactions when they are in `SERIALIZABLE` mode.

A simple test shows the issue and the following exception is thrown:
```
Canceled on identification as a pivot, during conflict out checking
```

I tried reducing the isolation level, but 1) I'm not sure what the consequences are in terms of locking the db and 2) it didn't entirely fix the issue.

As per the [postgres doc](https://www.postgresql.org/docs/current/plpgsql-control-structures.html#PLPGSQL-UPSERT-EXAMPLE), the recommended construct for the _upsert_ pattern is with the `ON CONFLICT` clause:

> It is recommended that applications use INSERT with ON CONFLICT DO
UPDATE rather than actually using this pattern.

I'm not sure about the performance of this (we mostly do updates, so we will run into the `ON CONFLICT` a lot), but let's first make it work.