### PR TITLE
Add shorter CI timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
The default is 360 minutes which is very long.
Our builds are usually around 10 minutes, so 20 minutes is a good value to prevent overbilling builds that create infinite loops.