### PR TITLE
Use proper data type for timestamps in Postgres

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/jdbc/JdbcUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/jdbc/JdbcUtils.scala
@@ -22,7 +22,7 @@ import org.sqlite.SQLiteConnection
 import scodec.Codec
 import scodec.bits.{BitVector, ByteVector}
 
-import java.sql.{Connection, ResultSet, Statement}
+import java.sql.{Connection, ResultSet, Statement, Timestamp}
 import java.util.UUID
 import javax.sql.DataSource
 import scala.collection.immutable.Queue
@@ -123,18 +123,16 @@ trait JdbcUtils {
 
     def getByteVector32FromHexNullable(columnLabel: String): Option[ByteVector32] = {
       val s = rs.getString(columnLabel)
-      if (rs.wasNull()) None else {
-        Some(ByteVector32(ByteVector.fromValidHex(s)))
-      }
+      if (rs.wasNull()) None else Some(ByteVector32(ByteVector.fromValidHex(s)))
     }
 
     def getBitVectorOpt(columnLabel: String): Option[BitVector] = Option(rs.getBytes(columnLabel)).map(BitVector(_))
 
     def getByteVector(columnLabel: String): ByteVector = ByteVector(rs.getBytes(columnLabel))
 
-    def getByteVectorNullable(columnLabel: String): ByteVector = {
+    def getByteVectorNullable(columnLabel: String): Option[ByteVector] = {
       val result = rs.getBytes(columnLabel)
-      if (rs.wasNull()) ByteVector.empty else ByteVector(result)
+      if (rs.wasNull()) None else Some(ByteVector(result))
     }
 
     def getByteVector32(columnLabel: String): ByteVector32 = ByteVector32(ByteVector(rs.getBytes(columnLabel)))
@@ -162,6 +160,11 @@ trait JdbcUtils {
     def getMilliSatoshiNullable(label: String): Option[MilliSatoshi] = {
       val result = rs.getLong(label)
       if (rs.wasNull()) None else Some(MilliSatoshi(result))
+    }
+
+    def getTimestampNullable(label: String): Option[Timestamp] = {
+      val result = rs.getTimestamp(label)
+      if (rs.wasNull()) None else Some(result)
     }
 
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -268,7 +268,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
   override def listRelayed(from: Long, to: Long): Seq[PaymentRelayed] =
     inTransaction { pg =>
       var trampolineByHash = Map.empty[ByteVector32, (MilliSatoshi, PublicKey)]
-      using(pg.prepareStatement("SELECT * FROM relayed_trampoline WHERE timestamp BETWEEN ? and ?")) { statement =>
+      using(pg.prepareStatement("SELECT * FROM relayed_trampoline WHERE timestamp BETWEEN ? and ? ORDER BY timestamp")) { statement =>
         statement.setTimestamp(1, Timestamp.from(Instant.ofEpochMilli(from)))
         statement.setTimestamp(2, Timestamp.from(Instant.ofEpochMilli(to)))
         val rs = statement.executeQuery()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -54,13 +54,13 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
       }
 
       def migration56(statement: Statement): Unit = {
-        statement.executeUpdate("ALTER TABLE sent               ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
-        statement.executeUpdate("ALTER TABLE received           ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
-        statement.executeUpdate("ALTER TABLE relayed            ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE sent ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE received ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE relayed ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
         statement.executeUpdate("ALTER TABLE relayed_trampoline ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
-        statement.executeUpdate("ALTER TABLE network_fees       ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
-        statement.executeUpdate("ALTER TABLE channel_events     ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
-        statement.executeUpdate("ALTER TABLE channel_errors     ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE network_fees ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE channel_events ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE channel_errors ALTER COLUMN timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + timestamp * interval '1 millisecond'")
       }
 
       getVersion(statement, DB_NAME) match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -212,7 +212,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
 
   override def listSent(from: Long, to: Long): Seq[PaymentSent] =
     inTransaction { pg =>
-      using(pg.prepareStatement("SELECT * FROM sent WHERE timestamp BETWEEN ? AND ? ORDER BY timestamp")) { statement =>
+      using(pg.prepareStatement("SELECT * FROM sent WHERE timestamp BETWEEN ? AND ?")) { statement =>
         statement.setTimestamp(1, Timestamp.from(Instant.ofEpochMilli(from)))
         statement.setTimestamp(2, Timestamp.from(Instant.ofEpochMilli(to)))
         val rs = statement.executeQuery()
@@ -244,7 +244,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
 
   override def listReceived(from: Long, to: Long): Seq[PaymentReceived] =
     inTransaction { pg =>
-      using(pg.prepareStatement("SELECT * FROM received WHERE timestamp BETWEEN ? AND ? ORDER BY timestamp")) { statement =>
+      using(pg.prepareStatement("SELECT * FROM received WHERE timestamp BETWEEN ? AND ?")) { statement =>
         statement.setTimestamp(1, Timestamp.from(Instant.ofEpochMilli(from)))
         statement.setTimestamp(2, Timestamp.from(Instant.ofEpochMilli(to)))
         val rs = statement.executeQuery()
@@ -268,7 +268,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
   override def listRelayed(from: Long, to: Long): Seq[PaymentRelayed] =
     inTransaction { pg =>
       var trampolineByHash = Map.empty[ByteVector32, (MilliSatoshi, PublicKey)]
-      using(pg.prepareStatement("SELECT * FROM relayed_trampoline WHERE timestamp BETWEEN ? and ? ORDER BY timestamp")) { statement =>
+      using(pg.prepareStatement("SELECT * FROM relayed_trampoline WHERE timestamp BETWEEN ? and ?")) { statement =>
         statement.setTimestamp(1, Timestamp.from(Instant.ofEpochMilli(from)))
         statement.setTimestamp(2, Timestamp.from(Instant.ofEpochMilli(to)))
         val rs = statement.executeQuery()
@@ -279,7 +279,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           trampolineByHash += (paymentHash -> (amount, nodeId))
         }
       }
-      using(pg.prepareStatement("SELECT * FROM relayed WHERE timestamp BETWEEN ? and ? ORDER BY timestamp")) { statement =>
+      using(pg.prepareStatement("SELECT * FROM relayed WHERE timestamp BETWEEN ? and ?")) { statement =>
         statement.setTimestamp(1, Timestamp.from(Instant.ofEpochMilli(from)))
         statement.setTimestamp(2, Timestamp.from(Instant.ofEpochMilli(to)))
         val rs = statement.executeQuery()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
@@ -27,7 +27,8 @@ import fr.acinq.eclair.db.pg.PgUtils.PgLock
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecs.stateDataCodec
 import grizzled.slf4j.Logging
 
-import java.sql.Statement
+import java.sql.{Statement, Timestamp}
+import java.time.Instant
 import javax.sql.DataSource
 import scala.collection.immutable.Queue
 
@@ -38,7 +39,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
   import lock._
 
   val DB_NAME = "channels"
-  val CURRENT_VERSION = 3
+  val CURRENT_VERSION = 4
 
   inTransaction { pg =>
     using(pg.createStatement()) { statement =>
@@ -51,14 +52,28 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
         statement.executeUpdate("ALTER TABLE local_channels ADD COLUMN closed_timestamp BIGINT")
       }
 
+      def migration34(statement: Statement): Unit = {
+        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN created_timestamp               SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + created_timestamp               * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN last_payment_sent_timestamp     SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + last_payment_sent_timestamp     * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN last_payment_received_timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + last_payment_received_timestamp * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN last_connected_timestamp        SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + last_connected_timestamp        * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN closed_timestamp                SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + closed_timestamp                * interval '1 millisecond'")
+
+        statement.executeUpdate("ALTER TABLE htlc_infos ALTER COLUMN commitment_number                   SET DATA TYPE BIGINT USING commitment_number::BIGINT")
+      }
+
       getVersion(statement, DB_NAME) match {
         case None =>
-          statement.executeUpdate("CREATE TABLE local_channels (channel_id TEXT NOT NULL PRIMARY KEY, data BYTEA NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT FALSE, created_timestamp BIGINT, last_payment_sent_timestamp BIGINT, last_payment_received_timestamp BIGINT, last_connected_timestamp BIGINT, closed_timestamp BIGINT)")
-          statement.executeUpdate("CREATE TABLE htlc_infos (channel_id TEXT NOT NULL, commitment_number TEXT NOT NULL, payment_hash TEXT NOT NULL, cltv_expiry BIGINT NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
+          statement.executeUpdate("CREATE TABLE local_channels (channel_id TEXT NOT NULL PRIMARY KEY, data BYTEA NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT FALSE, created_timestamp TIMESTAMP WITH TIME ZONE, last_payment_sent_timestamp TIMESTAMP WITH TIME ZONE, last_payment_received_timestamp TIMESTAMP WITH TIME ZONE, last_connected_timestamp TIMESTAMP WITH TIME ZONE, closed_timestamp TIMESTAMP WITH TIME ZONE)")
+          statement.executeUpdate("CREATE TABLE htlc_infos (channel_id TEXT NOT NULL, commitment_number BIGINT NOT NULL, payment_hash TEXT NOT NULL, cltv_expiry BIGINT NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
           statement.executeUpdate("CREATE INDEX htlc_infos_idx ON htlc_infos(channel_id, commitment_number)")
         case Some(v@2) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
           migration23(statement)
+          migration34(statement)
+        case Some(v@3) =>
+          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
+          migration34(statement)
         case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
       }
@@ -89,7 +104,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
   private def updateChannelMetaTimestampColumn(channelId: ByteVector32, columnName: String): Unit = {
     inTransaction { pg =>
       using(pg.prepareStatement(s"UPDATE local_channels SET $columnName=? WHERE channel_id=?")) { statement =>
-        statement.setLong(1, System.currentTimeMillis)
+        statement.setTimestamp(1, Timestamp.from(Instant.now()))
         statement.setString(2, channelId.toHex)
         statement.executeUpdate()
       }
@@ -152,7 +167,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
     withLock { pg =>
       using(pg.prepareStatement("SELECT payment_hash, cltv_expiry FROM htlc_infos WHERE channel_id=? AND commitment_number=?")) { statement =>
         statement.setString(1, channelId.toHex)
-        statement.setString(2, commitmentNumber.toString)
+        statement.setLong(2, commitmentNumber)
         val rs = statement.executeQuery
         var q: Queue[(ByteVector32, CltvExpiry)] = Queue()
         while (rs.next()) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
@@ -53,13 +53,13 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
       }
 
       def migration34(statement: Statement): Unit = {
-        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN created_timestamp               SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + created_timestamp               * interval '1 millisecond'")
-        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN last_payment_sent_timestamp     SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + last_payment_sent_timestamp     * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN created_timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + created_timestamp * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN last_payment_sent_timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + last_payment_sent_timestamp * interval '1 millisecond'")
         statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN last_payment_received_timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + last_payment_received_timestamp * interval '1 millisecond'")
-        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN last_connected_timestamp        SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + last_connected_timestamp        * interval '1 millisecond'")
-        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN closed_timestamp                SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + closed_timestamp                * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN last_connected_timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + last_connected_timestamp * interval '1 millisecond'")
+        statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN closed_timestamp SET DATA TYPE TIMESTAMP WITH TIME ZONE USING timestamp with time zone 'epoch' + closed_timestamp * interval '1 millisecond'")
 
-        statement.executeUpdate("ALTER TABLE htlc_infos ALTER COLUMN commitment_number                   SET DATA TYPE BIGINT USING commitment_number::BIGINT")
+        statement.executeUpdate("ALTER TABLE htlc_infos ALTER COLUMN commitment_number  SET DATA TYPE BIGINT USING commitment_number::BIGINT")
       }
 
       getVersion(statement, DB_NAME) match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -62,9 +62,9 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
 
     getVersion(statement, DB_NAME) match {
       case None =>
-        statement.executeUpdate("CREATE TABLE IF NOT EXISTS local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT 0, created_timestamp INTEGER, last_payment_sent_timestamp INTEGER, last_payment_received_timestamp INTEGER, last_connected_timestamp INTEGER, closed_timestamp INTEGER)")
-        statement.executeUpdate("CREATE TABLE IF NOT EXISTS htlc_infos (channel_id BLOB NOT NULL, commitment_number INTEGER NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
-        statement.executeUpdate("CREATE INDEX IF NOT EXISTS htlc_infos_idx ON htlc_infos(channel_id, commitment_number)")
+        statement.executeUpdate("CREATE TABLE local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT 0, created_timestamp INTEGER, last_payment_sent_timestamp INTEGER, last_payment_received_timestamp INTEGER, last_connected_timestamp INTEGER, closed_timestamp INTEGER)")
+        statement.executeUpdate("CREATE TABLE htlc_infos (channel_id BLOB NOT NULL, commitment_number INTEGER NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
+        statement.executeUpdate("CREATE INDEX htlc_infos_idx ON htlc_infos(channel_id, commitment_number)")
       case Some(v@1) =>
         logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
         migration12(statement)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -23,7 +23,6 @@ import fr.acinq.eclair.db.ChannelsDb
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db.Monitoring.Tags.DbBackends
-import fr.acinq.eclair.payment.{ChannelPaymentRelayed, PaymentEvent, PaymentReceived, PaymentRelayed, PaymentSent}
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecs.stateDataCodec
 import grizzled.slf4j.Logging
 
@@ -63,9 +62,9 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
 
     getVersion(statement, DB_NAME) match {
       case None =>
-        statement.executeUpdate("CREATE TABLE local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT 0, created_timestamp INTEGER, last_payment_sent_timestamp INTEGER, last_payment_received_timestamp INTEGER, last_connected_timestamp INTEGER, closed_timestamp INTEGER)")
-        statement.executeUpdate("CREATE TABLE htlc_infos (channel_id BLOB NOT NULL, commitment_number BLOB NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
-        statement.executeUpdate("CREATE INDEX htlc_infos_idx ON htlc_infos(channel_id, commitment_number)")
+        statement.executeUpdate("CREATE TABLE IF NOT EXISTS local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT 0, created_timestamp INTEGER, last_payment_sent_timestamp INTEGER, last_payment_received_timestamp INTEGER, last_connected_timestamp INTEGER, closed_timestamp INTEGER)")
+        statement.executeUpdate("CREATE TABLE IF NOT EXISTS htlc_infos (channel_id BLOB NOT NULL, commitment_number INTEGER NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
+        statement.executeUpdate("CREATE INDEX IF NOT EXISTS htlc_infos_idx ON htlc_infos(channel_id, commitment_number)")
       case Some(v@1) =>
         logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
         migration12(statement)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import com.zaxxer.hikari.HikariConfig
 import fr.acinq.eclair.db._
-import fr.acinq.eclair.db.pg.PgUtils.PgLock
+import fr.acinq.eclair.db.pg.PgUtils.{PgLock, getVersion, using}
 import fr.acinq.eclair.db.pg.PgUtils.PgLock.LockFailureHandler
 import org.postgresql.jdbc.PgConnection
 import org.sqlite.SQLiteConnection
@@ -64,6 +64,7 @@ object TestDatabases {
 
     // @formatter:off
     override val connection: PgConnection = pg.getPostgresDatabase.getConnection.asInstanceOf[PgConnection]
+    // NB: we use a lazy val here: databases won't be initialized until we reference that variable
     override lazy val db: Databases = Databases.PostgresDatabases(hikariConfig, UUID.randomUUID(), lock, jdbcUrlFile_opt = Some(jdbcUrlFile), readOnlyUser_opt = None)
     override def close(): Unit = pg.close()
     // @formatter:on
@@ -75,6 +76,26 @@ object TestDatabases {
     using(TestSqliteDatabases())(f)
     using(TestPgDatabases())(f)
     // @formatter:on
+  }
+
+  def migrationCheck(
+                      dbs: TestDatabases,
+                      initializeTables: Connection => Unit,
+                      dbName: String,
+                      targetVersion: Int,
+                      postCheck: Connection => Unit
+                    ): Unit = {
+    val connection = dbs.connection
+    // initialize the database to a previous version and populate data
+    initializeTables(connection)
+    // this will trigger the initialization of tables and the migration
+    val _ = dbs.db
+    // check that db version was updated
+    using(connection.createStatement()) { statement =>
+      assert(getVersion(statement, dbName).contains(targetVersion))
+    }
+    // post-migration checks
+    postCheck(connection)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
@@ -4,8 +4,8 @@ import akka.actor.ActorSystem
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import com.zaxxer.hikari.HikariConfig
 import fr.acinq.eclair.db._
-import fr.acinq.eclair.db.pg.PgUtils.{PgLock, getVersion, using}
 import fr.acinq.eclair.db.pg.PgUtils.PgLock.LockFailureHandler
+import fr.acinq.eclair.db.pg.PgUtils.{PgLock, getVersion, using}
 import org.postgresql.jdbc.PgConnection
 import org.sqlite.SQLiteConnection
 
@@ -78,12 +78,11 @@ object TestDatabases {
     // @formatter:on
   }
 
-  def migrationCheck(
-                      dbs: TestDatabases,
-                      initializeTables: Connection => Unit,
-                      dbName: String,
-                      targetVersion: Int,
-                      postCheck: Connection => Unit
+  def migrationCheck(dbs: TestDatabases,
+                     initializeTables: Connection => Unit,
+                     dbName: String,
+                     targetVersion: Int,
+                     postCheck: Connection => Unit
                     ): Unit = {
     val connection = dbs.connection
     // initialize the database to a previous version and populate data

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -183,7 +183,7 @@ class AuditDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migrate sqlite audit database v1 -> v5/v6") {
+  test("migrate sqlite audit database v1 -> v5") {
 
     val dbs = TestSqliteDatabases()
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
@@ -327,16 +327,15 @@ class ChannelsDbSpec extends AnyFunSuite {
 
 object ChannelsDbSpec {
 
-  case class TestCase(
-                       channelId: ByteVector32,
-                       data: ByteVector,
-                       isClosed: Boolean,
-                       createdTimestamp: Option[Long],
-                       lastPaymentSentTimestamp: Option[Long],
-                       lastPaymentReceivedTimestamp: Option[Long],
-                       lastConnectedTimestamp: Option[Long],
-                       closedTimestamp: Option[Long],
-                       commitmentNumbers: Seq[Int]
+  case class TestCase(channelId: ByteVector32,
+                      data: ByteVector,
+                      isClosed: Boolean,
+                      createdTimestamp: Option[Long],
+                      lastPaymentSentTimestamp: Option[Long],
+                      lastPaymentReceivedTimestamp: Option[Long],
+                      lastConnectedTimestamp: Option[Long],
+                      closedTimestamp: Option[Long],
+                      commitmentNumbers: Seq[Int]
                      )
 
   private val data = stateDataCodec.encode(ChannelCodecsSpec.normal).require.bytes


### PR DESCRIPTION
Did some refactoring in tests and introduced a new `migrationCheck`
helper method.

Note that the change of data type in sqlite for the `commitment_number`
field (from `BLOB` to `INTEGER`) is not a migration. If the table has
been created before, it will stay like it was. It doesn't matter due to
how sqlite stores data, and we make sure in tests that there is no
regression.