### PR TITLE
Update single-address wallet to accept a public key instead of an address

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>fr.acinq.eclair</groupId>
         <artifactId>eclair_2.11</artifactId>
-        <version>0.4.10-android-phoenix</version>
+        <version>0.4.11-android-phoenix-SNAPSHOT</version>
     </parent>
 
     <artifactId>eclair-core_2.11</artifactId>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/singleaddress/SingleAddressEclairWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/singleaddress/SingleAddressEclairWallet.scala
@@ -16,23 +16,27 @@
 
 package fr.acinq.eclair.blockchain.singleaddress
 
-import fr.acinq.bitcoin.{Crypto, Satoshi, Transaction}
+import fr.acinq.bitcoin.Crypto.PublicKey
+import fr.acinq.bitcoin.{ByteVector32, Crypto, Satoshi, Transaction, computeP2WpkhAddress}
 import fr.acinq.eclair.blockchain.{EclairWallet, MakeFundingTxResponse, OnChainBalance}
 import scodec.bits.ByteVector
 
 import scala.concurrent.Future
 
 /**
- * This is a minimal eclair wallet that doesn't manage funds, it can't be used to fund channels
- * @param finalAddress
+ * This is a minimal eclair wallet that doesn't manage funds, it can't be used to fund channels. It manages a single public key and will
+ * return the BIP84 (p2wpkh) address for this key.
+ * @param chainHash chain hash we're on
+ * @param receiveKey public key that will be used in all scripts and addresses for this wallet
  */
-class SingleAddressEclairWallet(finalAddress: String) extends EclairWallet {
+class SingleAddressEclairWallet(chainHash: ByteVector32, receiveKey: PublicKey) extends EclairWallet {
+  val finalAddress = computeP2WpkhAddress(receiveKey, chainHash)
 
   override def getBalance: Future[OnChainBalance] = Future.successful(OnChainBalance(Satoshi(0), Satoshi(0)))
 
   override def getReceiveAddress: Future[String] = Future.successful(finalAddress)
 
-  override def getReceivePubkey(receiveAddress: Option[String]): Future[Crypto.PublicKey] = ???
+  override def getReceivePubkey(receiveAddress: Option[String]): Future[Crypto.PublicKey] = Future.successful(receiveKey)
 
   override def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: Long): Future[MakeFundingTxResponse] = Future.failed(???)
 

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>fr.acinq.eclair</groupId>
         <artifactId>eclair_2.11</artifactId>
-        <version>0.4.10-android-phoenix</version>
+        <version>0.4.11-android-phoenix-SNAPSHOT</version>
     </parent>
 
     <artifactId>eclair-node_2.11</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>fr.acinq.eclair</groupId>
     <artifactId>eclair_2.11</artifactId>
-    <version>0.4.10-android-phoenix</version>
+    <version>0.4.11-android-phoenix-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
This will allow us to use this key as our static payment point for static-remote-key channels.
We use the BIP84 address for this key as our single address.