### PR TITLE
Add `cpfp-bump-fees` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,22 @@ If you want to use a different wallet from the default one, you must set `eclair
 Eclair will return BTC from closed channels to the wallet configured.
 Any BTC found in the wallet can be used to fund the channels you choose to open.
 
+We also recommend tweaking the following parameters in `bitcoin.conf`:
+
+```conf
+# This parameter ensures that your wallet will not create chains of unconfirmed
+# transactions that would be rejected by other nodes.
+walletrejectlongchains=1
+# The following parameters set the maximum length of chains of unconfirmed
+# transactions to 20 instead of the default value of 25.
+limitancestorcount=20
+limitdescendantcount=20
+```
+
+Setting these parameters lets you unblock long chains of unconfirmed channel funding transactions by using child-pays-for-parent (CPFP) to make them confirm.
+
+With the default `bitcoind` parameters, if your node created a chain of 25 unconfirmed funding transactions with a low-feerate, you wouldn't be able to use CPFP to raise their fees because your CPFP transaction would likely be rejected by the rest of the network.
+
 #### Java Environment Variables
 
 Some advanced parameters can be changed with java environment variables. Most users won't need this and can skip this section.
@@ -220,6 +236,9 @@ so you can easily run your bitcoin node on both mainnet and testnet. For example
 ```conf
 server=1
 txindex=1
+walletrejectlongchains=1
+limitancestorcount=20
+limitdescendantcount=20
 [main]
 rpcuser=<your-mainnet-rpc-user-here>
 rpcpassword=<your-mainnet-rpc-password-here>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -20,7 +20,7 @@ import akka.actor.ActorRef
 import akka.pattern._
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Crypto, Satoshi}
+import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Crypto, OutPoint, Satoshi}
 import fr.acinq.eclair.TimestampQueryFilters._
 import fr.acinq.eclair.blockchain.OnChainBalance
 import fr.acinq.eclair.blockchain.bitcoind.BitcoinCoreWallet
@@ -116,6 +116,8 @@ trait Eclair {
   def sentInfo(id: Either[UUID, ByteVector32])(implicit timeout: Timeout): Future[Seq[OutgoingPayment]]
 
   def sendOnChain(address: String, amount: Satoshi, confirmationTarget: Long): Future[ByteVector32]
+
+  def cpfpBumpFees(targetFeeratePerByte: FeeratePerByte, outpoints: Set[OutPoint]): Future[ByteVector32]
 
   def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse]
 
@@ -269,9 +271,15 @@ class EclairImpl(appKit: Kit) extends Eclair {
     }
   }
 
+  override def cpfpBumpFees(targetFeeratePerByte: FeeratePerByte, outpoints: Set[OutPoint]): Future[ByteVector32] = {
+    appKit.wallet match {
+      case w: BitcoinCoreWallet => w.bitcoinClient.cpfp(outpoints, FeeratePerKw(targetFeeratePerByte)).map(_.txid)
+      case _ => Future.failed(new IllegalArgumentException("this call is only available with a bitcoin core backend"))
+    }
+  }
+
   override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] =
     findRouteBetween(appKit.nodeParams.nodeId, targetNodeId, amount, assistedRoutes)
-
 
   override def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] = {
     val maxFee = RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf).getMaxFee(amount)
@@ -445,6 +453,6 @@ class EclairImpl(appKit: Kit) extends Eclair {
     val signature = ByteVector64(recoverableSignature.tail)
     val recoveryId = recoverableSignature.head.toInt - 31
     val pubKeyFromSignature = Crypto.recoverPublicKey(signature, signedBytes, recoveryId)
-    VerifiedMessage(true, pubKeyFromSignature)
+    VerifiedMessage(valid = true, pubKeyFromSignature)
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
@@ -28,7 +28,7 @@ import org.json4s.JsonAST._
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 /**
  * Created by PM on 26/04/2016.
@@ -109,6 +109,72 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
         val (_, _, pubkeyHash) = Bech32.decodeWitnessAddress(changeAddress)
         pubkeyHash
     }
+  }
+
+  /**
+   * Create a child-pays-for-parent transaction to increase the effective feerate of a set of unconfirmed transactions.
+   * These unconfirmed transactions must:
+   *  - be in our mempool (evicted transactions cannot be used)
+   *  - have an output that can be spent by our bitcoin wallet (provided in the outpoints set)
+   *  - the total amount of the set of outpoints must be high enough to pay the target feerate
+   *
+   * @param outpoints     outpoints that should be spent by the CPFP transaction.
+   * @param targetFeerate feerate to apply to the package of unconfirmed transactions.
+   */
+  def cpfp(outpoints: Set[OutPoint], targetFeerate: FeeratePerKw)(implicit ec: ExecutionContext): Future[Transaction] = {
+    getMempoolPackage(outpoints.map(_.txid), Set.empty).transformWith {
+      case Failure(ex) => Future.failed(new IllegalArgumentException("unable to analyze mempool package: some transactions could not be found in your mempool", ex))
+      case Success(mempoolPackage) =>
+        getTxOutputs(outpoints).transformWith {
+          case Failure(ex) => Future.failed(new IllegalArgumentException("some transactions could not be found", ex))
+          case Success(txOutputs) =>
+            getChangeAddress().transformWith {
+              case Failure(ex) => Future.failed(new IllegalArgumentException("change address generation failed", ex))
+              case Success(changeAddress) =>
+                val amountIn = txOutputs.values.map(_.amount).sum
+                // We build a transaction with one P2WPKH output and many P2WPKH inputs
+                val txWeight = 164 + 272 * outpoints.size
+                val totalWeight = mempoolPackage.values.map(_.weight).sum + txWeight
+                val targetFees = Transactions.weight2fee(targetFeerate, totalWeight.toInt)
+                val currentFees = mempoolPackage.values.map(_.fees).sum
+                val missingFees = targetFees - currentFees
+                if (amountIn <= missingFees + 546.sat) {
+                  Future.failed(new IllegalArgumentException("input amount is not sufficient to cover the target feerate"))
+                } else {
+                  // NB: we can leave the pubKeyScript empty since the inputs should belong to our wallet.
+                  val unsignedTx = Transaction(2, outpoints.toSeq.map(o => TxIn(o, Seq.empty, 0)), TxOut(amountIn - missingFees, Script.pay2wpkh(changeAddress)) :: Nil, 0)
+                  signTransaction(unsignedTx, Nil).transformWith {
+                    case Failure(ex) => Future.failed(new IllegalArgumentException("tx signing failed: some inputs don't belong to our wallet", ex))
+                    case Success(signedTx) => publishTransaction(signedTx.tx).map(_ => signedTx.tx)
+                  }
+                }
+            }
+        }
+    }
+  }
+
+  /** Recursively fetch unconfirmed parents and return the complete unconfirmed ancestors tree. */
+  private def getMempoolPackage(leaves: Set[ByteVector32], skip: Set[ByteVector32])(implicit ec: ExecutionContext): Future[Map[ByteVector32, MempoolTx]] = {
+    val skip2 = skip ++ leaves
+    Future.sequence(leaves.map(txid => getMempoolTx(txid))).flatMap(txs => {
+      val current = txs.map(tx => tx.txid -> tx).toMap
+      val remainingParents = txs.flatMap(_.unconfirmedParents) -- skip2
+      if (remainingParents.isEmpty) {
+        Future.successful(current)
+      } else {
+        getMempoolPackage(remainingParents, skip2).map(_.concat(current))
+      }
+    })
+  }
+
+  /** Fetch transaction output details for the given outpoints. */
+  private def getTxOutputs(outpoints: Set[OutPoint])(implicit ec: ExecutionContext): Future[Map[OutPoint, TxOut]] = {
+    Future.sequence(outpoints.map(_.txid).map(txid => getTransaction(txid))).map(txs => {
+      outpoints.flatMap(o => txs.find(tx => tx.txid == o.txid && o.index < tx.txOut.length) match {
+        case Some(tx) => Some(o -> tx.txOut(o.index.toInt))
+        case None => None
+      }).toMap
+    })
   }
 
   def signTransaction(tx: Transaction, previousTxs: Seq[PreviousTx], allowIncomplete: Boolean = false)(implicit ec: ExecutionContext): Future[SignTransactionResponse] = {
@@ -219,8 +285,9 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) {
       val JDecimal(ancestorFees) = json \ "fees" \ "ancestor"
       val JDecimal(descendantFees) = json \ "fees" \ "descendant"
       val JBool(replaceable) = json \ "bip125-replaceable"
+      val unconfirmedParents = (json \ "depends").extract[List[String]].map(ByteVector32.fromValidHex).toSet
       // NB: bitcoind counts the transaction itself as its own ancestor and descendant, which is confusing: we fix that by decrementing these counters.
-      MempoolTx(txid, vsize.toLong, weight.toLong, replaceable, toSatoshi(fees), ancestorCount.toInt - 1, toSatoshi(ancestorFees), descendantCount.toInt - 1, toSatoshi(descendantFees))
+      MempoolTx(txid, vsize.toLong, weight.toLong, replaceable, toSatoshi(fees), ancestorCount.toInt - 1, toSatoshi(ancestorFees), descendantCount.toInt - 1, toSatoshi(descendantFees), unconfirmedParents)
     })
   }
 
@@ -284,17 +351,18 @@ object ExtendedBitcoinClient {
   /**
    * Information about a transaction currently in the mempool.
    *
-   * @param txid            transaction id.
-   * @param vsize           virtual transaction size as defined in BIP 141.
-   * @param weight          transaction weight as defined in BIP 141.
-   * @param replaceable     Whether this transaction could be replaced with RBF (BIP125).
-   * @param fees            transaction fees.
-   * @param ancestorCount   number of unconfirmed parent transactions.
-   * @param ancestorFees    transactions fees for the package consisting of this transaction and its unconfirmed parents.
-   * @param descendantCount number of unconfirmed child transactions.
-   * @param descendantFees  transactions fees for the package consisting of this transaction and its unconfirmed children (without its unconfirmed parents).
+   * @param txid               transaction id.
+   * @param vsize              virtual transaction size as defined in BIP 141.
+   * @param weight             transaction weight as defined in BIP 141.
+   * @param replaceable        Whether this transaction could be replaced with RBF (BIP125).
+   * @param fees               transaction fees.
+   * @param ancestorCount      number of unconfirmed parent transactions.
+   * @param ancestorFees       transactions fees for the package consisting of this transaction and its unconfirmed parents.
+   * @param descendantCount    number of unconfirmed child transactions.
+   * @param descendantFees     transactions fees for the package consisting of this transaction and its unconfirmed children (without its unconfirmed parents).
+   * @param unconfirmedParents unconfirmed transactions used as inputs for this transaction.
    */
-  case class MempoolTx(txid: ByteVector32, vsize: Long, weight: Long, replaceable: Boolean, fees: Satoshi, ancestorCount: Int, ancestorFees: Satoshi, descendantCount: Int, descendantFees: Satoshi)
+  case class MempoolTx(txid: ByteVector32, vsize: Long, weight: Long, replaceable: Boolean, fees: Satoshi, ancestorCount: Int, ancestorFees: Satoshi, descendantCount: Int, descendantFees: Satoshi, unconfirmedParents: Set[ByteVector32])
 
   def toSatoshi(btcAmount: BigDecimal): Satoshi = Satoshi(btcAmount.bigDecimal.scaleByPowerOfTen(8).longValue)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/ExtendedBitcoinClientSpec.scala
@@ -19,12 +19,14 @@ package fr.acinq.eclair.blockchain.bitcoind
 import akka.actor.Status.Failure
 import akka.pattern.pipe
 import akka.testkit.TestProbe
+import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.SigVersion.SIGVERSION_WITNESS_V0
-import fr.acinq.bitcoin.{BtcDouble, OutPoint, SIGHASH_ALL, Satoshi, SatoshiLong, Script, ScriptFlags, ScriptWitness, Transaction, TxIn, TxOut}
+import fr.acinq.bitcoin.{BtcDouble, Crypto, OutPoint, SIGHASH_ALL, Satoshi, SatoshiLong, Script, ScriptFlags, ScriptWitness, Transaction, TxIn, TxOut}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.ExtendedBitcoinClient._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{ExtendedBitcoinClient, JsonRPCError}
-import fr.acinq.eclair.transactions.Transactions
-import fr.acinq.eclair.{TestConstants, TestKitBaseClass, randomKey}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
+import fr.acinq.eclair.transactions.{Scripts, Transactions}
+import fr.acinq.eclair.{TestConstants, TestKitBaseClass, randomBytes32, randomKey}
 import grizzled.slf4j.Logging
 import org.json4s.JsonAST._
 import org.json4s.{DefaultFormats, Formats}
@@ -300,6 +302,197 @@ class ExtendedBitcoinClientSpec extends TestKitBaseClass with BitcoindService wi
     assert(mempoolTx3.fees === 7500.sat)
     assert(mempoolTx3.descendantFees === mempoolTx3.fees)
     assert(mempoolTx3.ancestorFees === mempoolTx1.fees + 12500.sat)
+  }
+
+  test("bump transaction fees with child-pays-for-parent (single tx)") {
+    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+    val tx = sendToAddress(getNewAddress(sender), 150000 sat, sender)
+    assert(tx.txOut.length === 2) // there must be a change output
+    val changeOutput = if (tx.txOut.head.amount === 150000.sat) 1 else 0
+
+    bitcoinClient.getMempoolTx(tx.txid).pipeTo(sender.ref)
+    val mempoolTx = sender.expectMsgType[MempoolTx]
+    val currentFeerate = FeeratePerKw(mempoolTx.fees * 1000 / tx.weight())
+
+    val targetFeerate = currentFeerate * 1.5
+    bitcoinClient.cpfp(Set(OutPoint(tx, changeOutput)), targetFeerate).pipeTo(sender.ref)
+    val cpfpTx = sender.expectMsgType[Transaction]
+    bitcoinClient.getMempoolTx(cpfpTx.txid).pipeTo(sender.ref)
+    val mempoolCpfpTx = sender.expectMsgType[MempoolTx]
+    assert(mempoolCpfpTx.ancestorFees === mempoolCpfpTx.fees + mempoolTx.fees)
+    val expectedFees = Transactions.weight2fee(targetFeerate, tx.weight() + cpfpTx.weight())
+    assert(expectedFees * 0.95 <= mempoolCpfpTx.ancestorFees && mempoolCpfpTx.ancestorFees <= expectedFees * 1.05)
+    assert(mempoolCpfpTx.replaceable)
+
+    generateBlocks(1)
+  }
+
+  test("bump transaction fees with child-pays-for-parent (small package)") {
+    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+
+    val fundingFeerate = FeeratePerKw(1000 sat)
+    val remoteFundingPrivKey = randomKey
+    val walletFundingPrivKey = dumpPrivateKey(getNewAddress(sender), sender)
+    val fundingScript = Scripts.multiSig2of2(remoteFundingPrivKey.publicKey, walletFundingPrivKey.publicKey)
+    val fundingTx = {
+      val txNotFunded = Transaction(2, Nil, TxOut(250000 sat, Script.pay2wsh(fundingScript)) :: Nil, 0)
+      bitcoinClient.fundTransaction(txNotFunded, FundTransactionOptions(fundingFeerate, changePosition = Some(1))).pipeTo(sender.ref)
+      val fundTxResponse = sender.expectMsgType[FundTransactionResponse]
+      assert(fundTxResponse.changePosition === Some(1))
+      bitcoinClient.signTransaction(fundTxResponse.tx, Nil).pipeTo(sender.ref)
+      val signTxResponse = sender.expectMsgType[SignTransactionResponse]
+      assert(signTxResponse.complete)
+      bitcoinClient.publishTransaction(signTxResponse.tx).pipeTo(sender.ref)
+      sender.expectMsg(signTxResponse.tx.txid)
+      signTxResponse.tx
+    }
+
+    val mutualCloseTx = {
+      val walletClosePubKey = dumpPrivateKey(getNewAddress(sender), sender).publicKey
+      val remoteClosePubKey = randomKey.publicKey
+      // NB: the output amounts are chosen so that the feerate is ~750 sat/kw
+      val unsignedTx = Transaction(2, TxIn(OutPoint(fundingTx, 0), Seq.empty, 0) :: Nil, TxOut(130000 sat, Script.pay2wpkh(walletClosePubKey)) :: TxOut(119500 sat, Script.pay2wpkh(remoteClosePubKey)) :: Nil, 0)
+      val walletSig = Transaction.signInput(unsignedTx, 0, fundingScript, SIGHASH_ALL, fundingTx.txOut.head.amount, SIGVERSION_WITNESS_V0, walletFundingPrivKey)
+      val remoteSig = Transaction.signInput(unsignedTx, 0, fundingScript, SIGHASH_ALL, fundingTx.txOut.head.amount, SIGVERSION_WITNESS_V0, remoteFundingPrivKey)
+      val witness = Scripts.witness2of2(Crypto.der2compact(walletSig), Crypto.der2compact(remoteSig), walletFundingPrivKey.publicKey, remoteFundingPrivKey.publicKey)
+      val signedTx = unsignedTx.updateWitness(0, witness)
+      bitcoinClient.publishTransaction(signedTx).pipeTo(sender.ref)
+      sender.expectMsg(signedTx.txid)
+      signedTx
+    }
+
+    val targetFeerate = FeeratePerKw(5000 sat)
+    bitcoinClient.cpfp(Set(OutPoint(fundingTx, 1), OutPoint(mutualCloseTx, 0)), targetFeerate).pipeTo(sender.ref)
+    val cpfpTx = sender.expectMsgType[Transaction]
+    bitcoinClient.getMempoolTx(cpfpTx.txid).pipeTo(sender.ref)
+    val mempoolCpfpTx = sender.expectMsgType[MempoolTx]
+    val packageWeight = fundingTx.weight() + mutualCloseTx.weight() + cpfpTx.weight()
+    val expectedFees = Transactions.weight2fee(targetFeerate, packageWeight)
+    assert(expectedFees * 0.95 <= mempoolCpfpTx.ancestorFees && mempoolCpfpTx.ancestorFees <= expectedFees * 1.05)
+    assert(mempoolCpfpTx.replaceable)
+
+    generateBlocks(1)
+  }
+
+  test("bump transaction fees with child-pays-for-parent (complex package)") {
+    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+    val currentFeerate = FeeratePerKw(500 sat)
+
+    // We create two separate trees of transactions that will be bumped together:
+    //           TxA1              TxB1
+    //           /  \                \
+    //          /    \                \
+    //       TxA2*   TxA5             TxB2
+    //        /        \                \
+    //       /          \                \
+    //    TxA3          TxA6*            TxB3*
+    //     /              \                \
+    //    /                \                \
+    // TxA4*               TxA7             TxB4
+
+    def createTx(dest: Seq[(PublicKey, Satoshi)], walletInput_opt: Option[OutPoint]): Transaction = {
+      val txIn = walletInput_opt match {
+        case Some(walletInput) => TxIn(walletInput, Seq.empty, 0) :: Nil
+        case None => Nil
+      }
+      val txOut = dest.map { case (pubKey, amount) => TxOut(amount, Script.pay2wpkh(pubKey)) }
+      val txNotFunded = Transaction(2, txIn, txOut, 0)
+      bitcoinClient.fundTransaction(txNotFunded, FundTransactionOptions(currentFeerate, changePosition = Some(txOut.length))).pipeTo(sender.ref)
+      val fundTxResponse = sender.expectMsgType[FundTransactionResponse]
+      bitcoinClient.signTransaction(fundTxResponse.tx, Nil).pipeTo(sender.ref)
+      val signTxResponse = sender.expectMsgType[SignTransactionResponse]
+      assert(signTxResponse.complete)
+      bitcoinClient.publishTransaction(signTxResponse.tx).pipeTo(sender.ref)
+      sender.expectMsg(signTxResponse.tx.txid)
+      signTxResponse.tx
+    }
+
+    val pubKeyA2 = dumpPrivateKey(getNewAddress(sender), sender).publicKey
+    val pubKeyA3 = dumpPrivateKey(getNewAddress(sender), sender).publicKey
+    val pubKeyA4 = dumpPrivateKey(getNewAddress(sender), sender).publicKey
+    val pubKeyA5 = dumpPrivateKey(getNewAddress(sender), sender).publicKey
+    val pubKeyA6 = dumpPrivateKey(getNewAddress(sender), sender).publicKey
+    val pubKeyA7 = dumpPrivateKey(getNewAddress(sender), sender).publicKey
+    val pubKeyB2 = dumpPrivateKey(getNewAddress(sender), sender).publicKey
+    val pubKeyB3 = dumpPrivateKey(getNewAddress(sender), sender).publicKey
+    val pubKeyB4 = dumpPrivateKey(getNewAddress(sender), sender).publicKey
+
+    // NB: we use the same amount to ensure that an additional input will be added and there will be a change output.
+    val txB1 = createTx(Seq((pubKeyB2, 100000 sat)), None)
+    val txB2 = createTx(Seq((pubKeyB3, 100000 sat)), Some(OutPoint(txB1, 0)))
+    val txB3 = createTx(Seq((pubKeyB4, 100000 sat)), Some(OutPoint(txB2, 0)))
+    val txB4 = createTx(Seq((randomKey.publicKey, 100000 sat)), Some(OutPoint(txB3, 0)))
+    val txA1 = createTx(Seq((pubKeyA2, 75000 sat), (pubKeyA5, 50000 sat)), None)
+    val txA2 = createTx(Seq((pubKeyA3, 75000 sat)), Some(OutPoint(txA1, 0)))
+    val txA3 = createTx(Seq((pubKeyA4, 75000 sat)), Some(OutPoint(txA2, 0)))
+    val txA4 = createTx(Seq((randomKey.publicKey, 75000 sat)), Some(OutPoint(txA3, 0)))
+    val txA5 = createTx(Seq((pubKeyA6, 50000 sat)), Some(OutPoint(txA1, 1)))
+    val txA6 = createTx(Seq((pubKeyA7, 50000 sat)), Some(OutPoint(txA5, 0)))
+    val txA7 = createTx(Seq((randomKey.publicKey, 50000 sat)), Some(OutPoint(txA6, 0)))
+
+    // We bump a subset of the mempool: TxA1 -> TxA6 and TxB1 -> TxB3
+    val targetFeerate = FeeratePerKw(5000 sat)
+    val bumpedOutpoints = Set(OutPoint(txA2, 1), OutPoint(txA4, 1), OutPoint(txA6, 1), OutPoint(txB3, 1))
+    bitcoinClient.cpfp(bumpedOutpoints, targetFeerate).pipeTo(sender.ref)
+    val cpfpTx = sender.expectMsgType[Transaction]
+    assert(cpfpTx.txIn.find(_.outPoint.txid == txB4.txid) === None)
+    assert(cpfpTx.txIn.find(_.outPoint.txid == txA7.txid) === None)
+
+    bitcoinClient.getMempoolTx(cpfpTx.txid).pipeTo(sender.ref)
+    val mempoolCpfpTx = sender.expectMsgType[MempoolTx]
+    val packageWeight = txA1.weight() + txA2.weight() + txA3.weight() + txA4.weight() + txA5.weight() + txA6.weight() + txB1.weight() + txB2.weight() + txB3.weight() + cpfpTx.weight()
+    val expectedFees = Transactions.weight2fee(targetFeerate, packageWeight)
+    assert(expectedFees * 0.95 <= mempoolCpfpTx.ancestorFees && mempoolCpfpTx.ancestorFees <= expectedFees * 1.05)
+    assert(mempoolCpfpTx.replaceable)
+
+    generateBlocks(1)
+  }
+
+  test("cannot bump transaction fees (unknown transaction)") {
+    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+    bitcoinClient.cpfp(Set(OutPoint(randomBytes32, 0), OutPoint(randomBytes32, 3)), FeeratePerKw(1500 sat)).pipeTo(sender.ref)
+    val failure = sender.expectMsgType[Failure]
+    assert(failure.cause.getMessage.contains("some transactions could not be found"))
+  }
+
+  test("cannot bump transaction fees (transaction already confirmed)") {
+    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+    val tx = sendToAddress(getNewAddress(sender), 45000 sat, sender)
+    generateBlocks(1)
+
+    bitcoinClient.cpfp(Set(OutPoint(tx, 0)), FeeratePerKw(2500 sat)).pipeTo(sender.ref)
+    val failure = sender.expectMsgType[Failure]
+    assert(failure.cause.getMessage.contains("some transactions could not be found"))
+  }
+
+  test("cannot bump transaction fees (non-wallet input)") {
+    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+    val txNotFunded = Transaction(2, Nil, TxOut(50000 sat, Script.pay2wpkh(randomKey.publicKey)) :: Nil, 0)
+    bitcoinClient.fundTransaction(txNotFunded, FundTransactionOptions(FeeratePerKw(1000 sat), changePosition = Some(1))).pipeTo(sender.ref)
+    val fundTxResponse = sender.expectMsgType[FundTransactionResponse]
+    bitcoinClient.signTransaction(fundTxResponse.tx, Nil).pipeTo(sender.ref)
+    val signTxResponse = sender.expectMsgType[SignTransactionResponse]
+    bitcoinClient.publishTransaction(signTxResponse.tx).pipeTo(sender.ref)
+    sender.expectMsg(signTxResponse.tx.txid)
+
+    bitcoinClient.cpfp(Set(OutPoint(signTxResponse.tx, 0)), FeeratePerKw(1500 sat)).pipeTo(sender.ref)
+    val failure = sender.expectMsgType[Failure]
+    assert(failure.cause.getMessage.contains("some inputs don't belong to our wallet"))
+  }
+
+  test("cannot bump transaction fees (amount too low)") {
+    val sender = TestProbe()
+    val bitcoinClient = new ExtendedBitcoinClient(bitcoinrpcclient)
+    val tx = sendToAddress(getNewAddress(sender), 2500 sat, sender)
+    bitcoinClient.cpfp(Set(OutPoint(tx, 0)), FeeratePerKw(25000 sat)).pipeTo(sender.ref)
+    val failure = sender.expectMsgType[Failure]
+    assert(failure.cause.getMessage.contains("input amount is not sufficient to cover the target feerate"))
   }
 
   test("detect if tx has been double-spent") {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
@@ -21,7 +21,7 @@ import akka.http.scaladsl.marshalling.ToResponseMarshaller
 import akka.http.scaladsl.model.StatusCodes.NotFound
 import akka.http.scaladsl.model.{ContentTypes, HttpResponse}
 import akka.http.scaladsl.server.{Directive1, Directives, MalformedFormFieldRejection, Route}
-import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.{ByteVector32, OutPoint}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.ApiTypes.ChannelIdentifier
 import fr.acinq.eclair.api.serde.FormParamExtractors._
@@ -41,6 +41,7 @@ trait ExtraDirectives extends Directives {
   val channelIdsFormParam: NameUnmarshallerReceptacle[List[ByteVector32]] = "channelIds".as[List[ByteVector32]](sha256HashesUnmarshaller)
   val nodeIdFormParam: NameReceptacle[PublicKey] = "nodeId".as[PublicKey]
   val nodeIdsFormParam: NameUnmarshallerReceptacle[List[PublicKey]] = "nodeIds".as[List[PublicKey]](pubkeyListUnmarshaller)
+  val outPointsFormParam: NameUnmarshallerReceptacle[List[OutPoint]] = "outpoints".as[List[OutPoint]](outPointListUnmarshaller)
   val paymentHashFormParam: NameUnmarshallerReceptacle[ByteVector32] = "paymentHash".as[ByteVector32](sha256HashUnmarshaller)
   val fromFormParam: NameReceptacle[Long] = "from".as[Long]
   val toFormParam: NameReceptacle[Long] = "to".as[Long]

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/OnChain.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/OnChain.scala
@@ -21,6 +21,7 @@ import fr.acinq.bitcoin.Satoshi
 import fr.acinq.eclair.api.Service
 import fr.acinq.eclair.api.directives.EclairDirectives
 import fr.acinq.eclair.api.serde.FormParamExtractors._
+import fr.acinq.eclair.blockchain.fee.FeeratePerByte
 
 trait OnChain {
   this: Service with EclairDirectives =>
@@ -38,6 +39,13 @@ trait OnChain {
     }
   }
 
+  val cpfpBumpFees: Route = postRequest("cpfpbumpfees") { implicit t =>
+    formFields("targetFeerateSatByte".as[FeeratePerByte], outPointsFormParam) {
+      (targetFeerate, outPoints) =>
+        complete(eclairApi.cpfpBumpFees(targetFeerate, outPoints.toSet))
+    }
+  }
+
   val onChainBalance: Route = postRequest("onchainbalance") { implicit t =>
     complete(eclairApi.onChainBalance())
   }
@@ -48,6 +56,6 @@ trait OnChain {
     }
   }
 
-  val onChainRoutes: Route = getNewAddress ~ sendOnChain ~ onChainBalance ~ onChainTransactions
+  val onChainRoutes: Route = getNewAddress ~ sendOnChain ~ cpfpBumpFees ~ onChainBalance ~ onChainTransactions
 
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/serde/FormParamExtractors.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/serde/FormParamExtractors.scala
@@ -17,11 +17,10 @@
 package fr.acinq.eclair.api.serde
 
 import java.util.UUID
-
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.util.Timeout
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{ByteVector32, Satoshi}
+import fr.acinq.bitcoin.{ByteVector32, OutPoint, Satoshi}
 import fr.acinq.eclair.api.serde.JsonSupport._
 import fr.acinq.eclair.blockchain.fee.FeeratePerByte
 import fr.acinq.eclair.io.NodeURI
@@ -61,6 +60,11 @@ object FormParamExtractors {
   implicit val millisatoshiUnmarshaller: Unmarshaller[String, MilliSatoshi] = Unmarshaller.strict { str => MilliSatoshi(str.toLong) }
 
   implicit val feeratePerByteUnmarshaller: Unmarshaller[String, FeeratePerByte] = Unmarshaller.strict { str => FeeratePerByte(Satoshi(str.toLong)) }
+
+  implicit val outPointListUnmarshaller: Unmarshaller[String, List[OutPoint]] = listUnmarshaller(outPoint => {
+    val parts = outPoint.split(":")
+    OutPoint(ByteVector32.fromValidHex(parts.head).reverse, parts.last.toLong)
+  })
 
   implicit val base64DataUnmarshaller: Unmarshaller[String, ByteVector] = Unmarshaller.strict { str => ByteVector.fromValidBase64(str) }
 

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -26,14 +26,14 @@ import akka.stream.Materializer
 import akka.util.Timeout
 import de.heikoseeberger.akkahttpjson4s.Json4sSupport
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{Block, ByteVector32, SatoshiLong}
+import fr.acinq.bitcoin.{Block, ByteVector32, OutPoint, SatoshiLong}
 import fr.acinq.eclair.ApiTypes.ChannelIdentifier
 import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
 import fr.acinq.eclair.Features.{ChannelRangeQueriesExtended, OptionDataLossProtect}
 import fr.acinq.eclair._
 import fr.acinq.eclair.api.directives.ErrorResponse
 import fr.acinq.eclair.api.serde.JsonSupport
-import fr.acinq.eclair.blockchain.fee.FeeratePerKw
+import fr.acinq.eclair.blockchain.fee.{FeeratePerByte, FeeratePerKw}
 import fr.acinq.eclair.channel.ChannelOpenResponse.ChannelOpened
 import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel._
@@ -437,6 +437,46 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == OK)
         eclair.send(None, any, 456 msat, any, any, any, Some(10 sat), Some(0.5))(any[Timeout]).wasCalled(once)
+      }
+  }
+
+  test("'cpfpbumpfees'") {
+    val eclair = mock[Eclair]
+    eclair.cpfpBumpFees(any, any) returns Future.successful(randomBytes32)
+    val mockService = new MockService(eclair)
+    val (txId1, txId2) = (randomBytes32, randomBytes32)
+
+    Post("/cpfpbumpfees", FormData("targetFeerateSatByte" -> "10", "outpoints" -> s"$txId1:2,$txId2:0,$txId1:13").toEntity) ~>
+      addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
+      Route.seal(mockService.route) ~>
+      check {
+        assert(handled)
+        assert(status == OK)
+        eclair.cpfpBumpFees(FeeratePerByte(10 sat), Set(OutPoint(txId1.reverse, 2), OutPoint(txId1.reverse, 13), OutPoint(txId2.reverse, 0))).wasCalled(once)
+      }
+
+    Post("/cpfpbumpfees", FormData("targetFeerateSatByte" -> "10").toEntity) ~>
+      addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
+      Route.seal(mockService.route) ~>
+      check {
+        assert(handled)
+        assert(status == BadRequest)
+      }
+
+    Post("/cpfpbumpfees", FormData("outpoints" -> s"$txId1:2").toEntity) ~>
+      addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
+      Route.seal(mockService.route) ~>
+      check {
+        assert(handled)
+        assert(status == BadRequest)
+      }
+
+    Post("/cpfpbumpfees", FormData("targetFeerateSatByte" -> "10", "outpoints" -> s"$txId1,2").toEntity) ~>
+      addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
+      Route.seal(mockService.route) ~>
+      check {
+        assert(handled)
+        assert(status == BadRequest)
       }
   }
 


### PR DESCRIPTION
We add a `cpfpbumpfees` API that lets you bump the fees of a package of unconfirmed transactions.

This lets node operators ensure their funding txs confirm before they hit the `2016` funding timeout (https://github.com/lightningnetwork/lightning-rfc/pull/839). It's also very useful when you have a long chain of unconfirmed funding transactions and/or mutual close transactions and want to bump them all at once.

If for example a node has the following set of unconfirmed transactions:

```txt
+-------------+
| Funding Tx1 |----------> channel output
| txid=111... |-----+
+-------------+     |                +-------------+
                    | change output  | Funding Tx2 |----------> channel output
                    +--------------->| txid=222... |-----+
                                     +-------------+     |                +-------------+
                                                         | change output  | Funding Tx3 |----------> channel output
                                                         +--------------->| txid=333... |----------> change output (index=1)
                                                                          +-------------+
+-------------+
| Funding Tx4 |----------> change output (index=0)
| txid=444... |----------> channel output
+-------------+

+------------------+
| Mutual Close Tx1 |----------> remote output
| txid=555...      |----------> local output (index=1)
+------------------+

+------------------+
| Mutual Close Tx2 |----------> local output (index=0)
| txid=666...      |----------> remote output
+------------------+
```

Assuming 40 sat/byte would be a good feerate for quick confirmation, the node operator can use the following command to get all these transactions confirmed quickly:

```sh
./eclair-cli cpfpbumpfees --targetFeerateSatByte=40 --outpoints=333...:1,444...:0,555...:1,666...:0
```

NB: this call must be made manually by the node operator, who needs to figure out which outpoints belong to him (which should be fairly easy using existing APIs). A good tree visualization of wallet unconfirmed transactions could be a useful addition to help node operators see the state of their unconfirmed packages and select what they want to bump.