### PR TITLE
Instructions for downloading Tor Bundle

### DIFF
--- a/docs/Tor.md
+++ b/docs/Tor.md
@@ -16,7 +16,7 @@ brew install tor
 
 #### Windows:
   
-[Download the "Expert Bundle"](https://www.torproject.org/download/tor/) from Tor's website and extract it to `C:\tor`.  A link to the "Expert Bundle" is on the "Download Tor Source Code" page.
+[Download the "Expert Bundle"](https://www.torproject.org/download/tor/) from Tor's website and extract it to `C:\tor`.
 
 ### Configuring Tor
 

--- a/docs/Tor.md
+++ b/docs/Tor.md
@@ -16,7 +16,7 @@ brew install tor
 
 #### Windows:
   
-[Download the "Expert Bundle"](https://www.torproject.org/download/download.html) from Tor's website and extract it to `C:\tor`.
+[Download the "Expert Bundle"](https://www.torproject.org/download/tor/) from Tor's website and extract it to `C:\tor`.  A link to the "Expert Bundle" is on the "Download Tor Source Code" page.
 
 ### Configuring Tor
 


### PR DESCRIPTION
torproject's website is a bit difficult to navigate.  Until they fix it, this change will help readers find the Windows "Expert Bundle."