### PR TITLE
Remove bintray repository

### DIFF
--- a/eclair-front/pom.xml
+++ b/eclair-front/pom.xml
@@ -70,17 +70,6 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-kamon-io-releases</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/kamon-io/releases</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>fr.acinq.eclair</groupId>

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -69,17 +69,6 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>bintray-kamon-io-releases</id>
-            <name>bintray</name>
-            <url>https://dl.bintray.com/kamon-io/releases</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>fr.acinq.eclair</groupId>


### PR DESCRIPTION
Bintray has been discontinued and artifacts have been migrated to Maven
Central.