### PR TITLE
Use secp256k1-kmp

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>fr.acinq.eclair</groupId>
         <artifactId>eclair_2.11</artifactId>
-        <version>0.4.2-android</version>
+        <version>0.4.11-android-SNAPSHOT</version>
     </parent>
 
     <artifactId>eclair-core_2.11</artifactId>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/ChaCha20Poly1305.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/ChaCha20Poly1305.scala
@@ -22,8 +22,8 @@ import fr.acinq.bitcoin.{ByteVector32, Protocol}
 import fr.acinq.eclair.crypto.ChaCha20Poly1305.{DecryptionError, EncryptionError, InvalidCounter}
 import grizzled.slf4j.Logger
 import grizzled.slf4j.Logging
-import org.spongycastle.crypto.engines.ChaCha7539Engine
-import org.spongycastle.crypto.params.{KeyParameter, ParametersWithIV}
+import org.bouncycastle.crypto.engines.ChaCha7539Engine
+import org.bouncycastle.crypto.params.{KeyParameter, ParametersWithIV}
 import scodec.bits.ByteVector
 
 /**
@@ -39,7 +39,7 @@ object Poly1305 {
     */
   def mac(key: ByteVector, datas: ByteVector*): ByteVector = {
     val out = new Array[Byte](16)
-    val poly = new org.spongycastle.crypto.macs.Poly1305()
+    val poly = new org.bouncycastle.crypto.macs.Poly1305()
     poly.init(new KeyParameter(key.toArray))
     datas.foreach(data => poly.update(data.toArray, 0, data.length.toInt))
     poly.doFinal(out, 0)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Mac.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Mac.scala
@@ -17,9 +17,9 @@
 package fr.acinq.eclair.crypto
 
 import fr.acinq.bitcoin.ByteVector32
-import org.spongycastle.crypto.digests.SHA256Digest
-import org.spongycastle.crypto.macs.HMac
-import org.spongycastle.crypto.params.KeyParameter
+import org.bouncycastle.crypto.digests.SHA256Digest
+import org.bouncycastle.crypto.macs.HMac
+import org.bouncycastle.crypto.params.KeyParameter
 import scodec.bits.ByteVector
 
 /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Noise.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Noise.scala
@@ -23,9 +23,9 @@ import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{Crypto, Protocol}
 import fr.acinq.eclair.randomBytes
 import grizzled.slf4j.Logging
-import org.spongycastle.crypto.digests.SHA256Digest
-import org.spongycastle.crypto.macs.HMac
-import org.spongycastle.crypto.params.KeyParameter
+import org.bouncycastle.crypto.digests.SHA256Digest
+import org.bouncycastle.crypto.macs.HMac
+import org.bouncycastle.crypto.params.KeyParameter
 import scodec.bits.ByteVector
 
 /**

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/NoiseSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/NoiseSpec.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.crypto
 
 import fr.acinq.eclair.crypto.Noise._
 import org.scalatest.funsuite.AnyFunSuite
-import org.spongycastle.crypto.ec.CustomNamedCurves
+import org.bouncycastle.crypto.ec.CustomNamedCurves
 import scodec.bits._
 
 

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>fr.acinq.eclair</groupId>
         <artifactId>eclair_2.11</artifactId>
-        <version>0.4.2-android</version>
+        <version>0.4.11-android-SNAPSHOT</version>
     </parent>
 
     <artifactId>eclair-node_2.11</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 	    <akka.version>2.3.14</akka.version>
 	    <akka.http.version>10.0.11</akka.http.version>
         <sttp.version>1.3.9</sttp.version>
-        <bitcoinlib.version>0.17</bitcoinlib.version>
+        <bitcoinlib.version>0.18</bitcoinlib.version>
         <guava.version>24.0-android</guava.version>
         <kamon.version>2.1.0</kamon.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>fr.acinq.eclair</groupId>
     <artifactId>eclair_2.11</artifactId>
-    <version>0.4.2-android</version>
+    <version>0.4.11-android-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
We get rid of our old JNI wrapper and switch to bitcoin-lib 0.18 which is based on secp256k1-kmp.
This will give us a consistent secp256k1 library on all our apps (since secp256k1-kmp also provides an Android library).
We also switch from spongycastle bouncycastle (bitcoin-lib 0.18 uses bouncycastle).