### PR TITLE
Use less strict isolation level for channel meta

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
@@ -16,6 +16,7 @@
 
 package fr.acinq.eclair.db.pg
 
+import com.zaxxer.hikari.util.IsolationLevel
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.CltvExpiry
 import fr.acinq.eclair.channel.HasCommitments
@@ -102,7 +103,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
    * Helper method to factor updating timestamp columns
    */
   private def updateChannelMetaTimestampColumn(channelId: ByteVector32, columnName: String): Unit = {
-    inTransaction { pg =>
+    inTransaction(IsolationLevel.TRANSACTION_READ_UNCOMMITTED) { pg =>
       using(pg.prepareStatement(s"UPDATE local_channels SET $columnName=? WHERE channel_id=?")) { statement =>
         statement.setTimestamp(1, Timestamp.from(Instant.now()))
         statement.setString(2, channelId.toHex)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
@@ -98,7 +98,7 @@ class ChannelsDbSpec extends AnyFunSuite {
       val db = dbs.channels
       implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(8))
       val channel = ChannelCodecsSpec.normal
-      val channelIds = (for(_ <- 0 until 10) yield randomBytes32).toList
+      val channelIds = (0 until 10).map(_ => randomBytes32).toList
       val futures = for (i <- 0 until 10000) yield {
         val channelId = channelIds(i % channelIds.size)
         Future(db.addOrUpdateChannel(channel.modify(_.commitments.channelId).setTo(channelId)))


### PR DESCRIPTION
We don't need `SERIALIZABLE` consistency guarantees when all we do is
updating timestamp columns. This happens concurrently to channel data
update and raised serialization errors in postgres.

Fixed #1786.