### PR TITLE
Fix ConnectionControlPlugin

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -79,7 +79,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: EclairWa
       val h = d.channels.filter(_._2 == actor).keys
       log.info(s"channel closed: channelId=${h.mkString("/")}")
       val channels1 = d.channels -- h
-      if (channels1.isEmpty) {
+      if (!nodeParams.forceReconnect(remoteNodeId) && channels1.isEmpty) {
         // we have no existing channels, we can forget about this peer
         stopPeer()
       } else {
@@ -185,7 +185,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: EclairWa
         Logs.withMdc(diagLog)(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
           log.info("connection lost")
         }
-        if (d.channels.isEmpty) {
+        if (!nodeParams.forceReconnect(remoteNodeId) && d.channels.isEmpty) {
           // we have no existing channels, we can forget about this peer
           stopPeer()
         } else {


### PR DESCRIPTION
Adding `forceReconnect` to `ReconnectionTask` was not enough to properly enable connection control by a plugin, without these changes a connection without normal channels will still be removed from db and node won't be able to automatically reconnect on restart.