### PR TITLE
Update default path-finding weight ratios

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -174,16 +174,16 @@ eclair {
     // the values below will be used to perform route searching
     path-finding {
       max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
-      max-cltv = 1008             // max acceptable cltv expiry for the payment (1008 ~ 1 week)
+      max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
       fee-threshold-sat = 21       // if fee is below this value we skip the max-fee-pct check
       max-fee-pct = 0.03           // route will be discarded if fee is above this value (in percentage relative to the total payment amount); doesn't apply if fee < fee-threshold-sat
 
       // channel 'weight' is computed with the following formula: channelFee * (cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)
       // the following parameters can be used to ask the router to use heuristics to find i.e: 'cltv-optimized' routes, **the sum of the three ratios must be > 0 and <= 1**
-      heuristics-enable = true     // if true uses heuristics for path-finding
-      ratio-cltv = 0.15            // when computing the weight for a channel, consider its CLTV delta in this proportion
-      ratio-channel-age = 0.35     // when computing the weight for a channel, consider its AGE in this proportion
-      ratio-channel-capacity = 0.5 // when computing the weight for a channel, consider its CAPACITY in this proportion
+      heuristics-enable = true      // if true uses heuristics for path-finding
+      ratio-cltv = 0.05             // when computing the weight for a channel, consider its CLTV delta in this proportion
+      ratio-channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
+      ratio-channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
 
       mpp {
         min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -274,9 +274,9 @@ object Graph {
       case Some(wr) =>
         import RoutingHeuristics._
 
-        // Every edge is weighted by funding block height where older blocks add less weight, the window considered is 2 months.
+        // Every edge is weighted by funding block height where older blocks add less weight. The window considered is 1 year.
         val channelBlockHeight = ShortChannelId.coordinates(edge.desc.shortChannelId).blockHeight
-        val ageFactor = normalize(channelBlockHeight, min = currentBlockHeight - BLOCK_TIME_TWO_MONTHS, max = currentBlockHeight)
+        val ageFactor = normalize(channelBlockHeight, min = currentBlockHeight - BLOCK_TIME_ONE_YEAR, max = currentBlockHeight)
 
         // Every edge is weighted by channel capacity, larger channels add less weight
         val edgeMaxCapacity = edge.capacity.toMilliSatoshi
@@ -336,8 +336,8 @@ object Graph {
 
   object RoutingHeuristics {
 
-    // Number of blocks in two months
-    val BLOCK_TIME_TWO_MONTHS = 8640
+    // Number of blocks in one year
+    val BLOCK_TIME_ONE_YEAR = 52560
 
     // Low/High bound for channel capacity
     val CAPACITY_CHANNEL_LOW = MilliBtc(1).toMilliSatoshi

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -337,7 +337,7 @@ object Graph {
   object RoutingHeuristics {
 
     // Number of blocks in one year
-    val BLOCK_TIME_ONE_YEAR = 52560
+    val BLOCK_TIME_ONE_YEAR = 365 * 24 * 6
 
     // Low/High bound for channel capacity
     val CAPACITY_CHANNEL_LOW = MilliBtc(1).toMilliSatoshi


### PR DESCRIPTION
* The two months window for channel age was too small for today's network (where most channels are at least 6 months old)
* CLTV is less of an issue nowadays: there are fewer stuck payments and we're encouraging nodes to increase their CLTV because of the recent mempool congestions, so when your payment is stuck it's very painful regardless of the path you took