### PR TITLE
Add tlv stream to UpdateAddHtlc message

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/HtlcTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/HtlcTlv.scala
@@ -23,13 +23,14 @@ import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs._
 
-object UpdateAddHtlcTlv {
-  case class Data(data: ByteVector) extends Tlv
+sealed trait HtlcTlv extends Tlv
 
-  val codec: Codec[TlvStream[Data]] = tlvStream(
-    discriminated[Data].by(varint)
-      .typecase(UInt64(1L), variableSizeBytesLong(varintoverflow, bytes).as[Data])
+object HtlcTlv {
+  case class Data(data: ByteVector) extends HtlcTlv
+
+  val codec: Codec[TlvStream[HtlcTlv]] = tlvStream(
+    discriminated[HtlcTlv].by(varint)
+      .typecase(UInt64(0), variableSizeBytesLong(varintoverflow, bytes).as[Data])
   )
 }
-
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecs.scala
@@ -131,7 +131,7 @@ object LightningMessageCodecs {
       ("paymentHash" | bytes32) ::
       ("expiry" | cltvExpiry) ::
       ("onionRoutingPacket" | OnionCodecs.paymentOnionPacketCodec) ::
-      ("tlvStream" | UpdateAddHtlcTlv.codec)).as[UpdateAddHtlc]
+      ("tlvStream" | HtlcTlv.codec)).as[UpdateAddHtlc]
 
   val updateFulfillHtlcCodec: Codec[UpdateFulfillHtlc] = (
     ("channelId" | bytes32) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecs.scala
@@ -130,7 +130,8 @@ object LightningMessageCodecs {
       ("amountMsat" | millisatoshi) ::
       ("paymentHash" | bytes32) ::
       ("expiry" | cltvExpiry) ::
-      ("onionRoutingPacket" | OnionCodecs.paymentOnionPacketCodec)).as[UpdateAddHtlc]
+      ("onionRoutingPacket" | OnionCodecs.paymentOnionPacketCodec) ::
+      ("tlvStream" | UpdateAddHtlcTlv.codec)).as[UpdateAddHtlc]
 
   val updateFulfillHtlcCodec: Codec[UpdateFulfillHtlc] = (
     ("channelId" | bytes32) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
@@ -128,7 +128,8 @@ case class UpdateAddHtlc(channelId: ByteVector32,
                          amountMsat: MilliSatoshi,
                          paymentHash: ByteVector32,
                          cltvExpiry: CltvExpiry,
-                         onionRoutingPacket: OnionRoutingPacket) extends HtlcMessage with UpdateMessage with HasChannelId
+                         onionRoutingPacket: OnionRoutingPacket,
+                         tlvStream: TlvStream[UpdateAddHtlcTlv.Data] = TlvStream.empty) extends HtlcMessage with UpdateMessage with HasChannelId
 
 case class UpdateFulfillHtlc(channelId: ByteVector32,
                              id: Long,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
@@ -129,7 +129,7 @@ case class UpdateAddHtlc(channelId: ByteVector32,
                          paymentHash: ByteVector32,
                          cltvExpiry: CltvExpiry,
                          onionRoutingPacket: OnionRoutingPacket,
-                         tlvStream: TlvStream[UpdateAddHtlcTlv.Data] = TlvStream.empty) extends HtlcMessage with UpdateMessage with HasChannelId
+                         tlvStream: TlvStream[HtlcTlv] = TlvStream.empty) extends HtlcMessage with UpdateMessage with HasChannelId
 
 case class UpdateFulfillHtlc(channelId: ByteVector32,
                              id: Long,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/UpdateAddHtlcTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/UpdateAddHtlcTlv.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.wire.protocol
+
+import fr.acinq.eclair.UInt64
+import fr.acinq.eclair.wire.protocol.CommonCodecs._
+import fr.acinq.eclair.wire.protocol.TlvCodecs.tlvStream
+import scodec.Codec
+import scodec.bits.ByteVector
+import scodec.codecs._
+
+object UpdateAddHtlcTlv {
+  case class Data(data: ByteVector) extends Tlv
+
+  val codec: Codec[TlvStream[Data]] = tlvStream(
+    discriminated[Data].by(varint)
+      .typecase(UInt64(1L), variableSizeBytesLong(varintoverflow, bytes).as[Data])
+  )
+}
+
+


### PR DESCRIPTION
Storing some data in `UpdateAddHtlc` will in particular help an HC peer to correctly resolve its own in-flight payments when it resyncs with incomplete local data. What's needed from Eclair is to be aware that `UpdateAddHtlc` can have some tlv data so HC plugin can store a complete message.

Currently this fails some backwards-compat tests in `wire`, not sure why, some help would be appreciated.