### PR TITLE
Make new API structures reusable by plugins

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -69,14 +69,12 @@ object Boot extends App with Logging {
     val config = system.settings.config.getConfig("eclair")
     if (config.getBoolean("api.enabled")) {
       logger.info(s"json API enabled on port=${config.getInt("api.port")}")
-      implicit val materializer = ActorMaterializer()
       val apiPassword = config.getString("api.password") match {
         case "" => throw EmptyAPIPasswordException
         case valid => valid
       }
       val apiRoute = new Service {
         override val actorSystem = system
-        override val mat = materializer
         override val password = apiPassword
         override val eclairApi: Eclair = new EclairImpl(kit)
       }.route

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -34,11 +34,6 @@ trait AbstractService extends EclairDirectives with Logging {
    * ActorSystem on which to run the http service.
    */
   implicit val actorSystem: ActorSystem
-
-  /**
-   * Materializer for sending and receiving tcp streams.
-   */
-  implicit val mat: Materializer
 }
 
 trait Service extends AbstractService with WebSocket with Node with Channel with Fees with PathFinding with Invoice with Payment with Message with OnChain {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -24,8 +24,7 @@ import fr.acinq.eclair.api.directives.EclairDirectives
 import fr.acinq.eclair.api.handlers._
 import grizzled.slf4j.Logging
 
-trait Service extends EclairDirectives with WebSocket with Node with Channel with Fees with PathFinding with Invoice with Payment with Message with OnChain with Logging {
-
+trait AbstractService extends EclairDirectives with Logging {
   /**
    * Allows router access to the API password as configured in eclair.conf
    */
@@ -45,7 +44,9 @@ trait Service extends EclairDirectives with WebSocket with Node with Channel wit
    * Materializer for sending and receiving tcp streams.
    */
   implicit val mat: Materializer
+}
 
+trait Service extends AbstractService with WebSocket with Node with Channel with Fees with PathFinding with Invoice with Payment with Message with OnChain {
   /**
    * Collect routes from all sub-routers here.
    * This is the main entrypoint for the global http request router of the API service.
@@ -54,5 +55,4 @@ trait Service extends EclairDirectives with WebSocket with Node with Channel wit
   val route: Route = securedHandler {
     nodeRoutes ~ channelRoutes ~ feeRoutes ~ pathFindingRoutes ~ invoiceRoutes ~ paymentRoutes ~ messageRoutes ~ onChainRoutes ~ webSocket
   }
-
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -18,7 +18,6 @@ package fr.acinq.eclair.api
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server._
-import akka.stream.Materializer
 import fr.acinq.eclair.Eclair
 import fr.acinq.eclair.api.directives.EclairDirectives
 import fr.acinq.eclair.api.handlers._

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -31,11 +31,6 @@ trait AbstractService extends EclairDirectives with Logging {
   def password: String
 
   /**
-   * The API of Eclair core.
-   */
-  val eclairApi: Eclair
-
-  /**
    * ActorSystem on which to run the http service.
    */
   implicit val actorSystem: ActorSystem
@@ -47,6 +42,11 @@ trait AbstractService extends EclairDirectives with Logging {
 }
 
 trait Service extends AbstractService with WebSocket with Node with Channel with Fees with PathFinding with Invoice with Payment with Message with OnChain {
+  /**
+   * The API of Eclair core.
+   */
+  val eclairApi: Eclair
+
   /**
    * Collect routes from all sub-routers here.
    * This is the main entrypoint for the global http request router of the API service.

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
@@ -18,13 +18,13 @@ package fr.acinq.eclair.api.directives
 
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.directives.Credentials
-import fr.acinq.eclair.api.Service
+import fr.acinq.eclair.api.AbstractService
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
 
 trait AuthDirective {
-  this: Service with EclairDirectives =>
+  this: AbstractService with EclairDirectives =>
 
   /**
    * A directive0 that passes whenever valid basic credentials are provided. We

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/EclairDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/EclairDirectives.scala
@@ -17,10 +17,9 @@
 package fr.acinq.eclair.api.directives
 
 import akka.http.scaladsl.server.{Directive0, Directive1, Directives}
-import akka.util.Timeout
-import fr.acinq.eclair.api.{AbstractService, Service}
-
 import scala.concurrent.duration.DurationInt
+import fr.acinq.eclair.api.AbstractService
+import akka.util.Timeout
 
 class EclairDirectives extends Directives with TimeoutDirective with ErrorDirective with AuthDirective with DefaultHeaders with ExtraDirectives {
   this: AbstractService =>

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/EclairDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/EclairDirectives.scala
@@ -18,12 +18,12 @@ package fr.acinq.eclair.api.directives
 
 import akka.http.scaladsl.server.{Directive0, Directive1, Directives}
 import akka.util.Timeout
-import fr.acinq.eclair.api.Service
+import fr.acinq.eclair.api.{AbstractService, Service}
 
 import scala.concurrent.duration.DurationInt
 
 class EclairDirectives extends Directives with TimeoutDirective with ErrorDirective with AuthDirective with DefaultHeaders with ExtraDirectives {
-  this: Service =>
+  this: AbstractService =>
 
   /**
    * Prepares inner routes to be exposed as public API with default headers, basic authentication and error handling.

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ErrorDirective.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ErrorDirective.scala
@@ -18,10 +18,10 @@ package fr.acinq.eclair.api.directives
 
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, StatusCodes}
 import akka.http.scaladsl.server.{Directive0, ExceptionHandler, RejectionHandler}
-import fr.acinq.eclair.api.Service
+import fr.acinq.eclair.api.AbstractService
 
 trait ErrorDirective {
-  this: Service with EclairDirectives =>
+  this: AbstractService with EclairDirectives =>
 
   /**
    * Handles API exceptions and rejections. Produces json formatted error responses.

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -74,7 +74,6 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
     override def password: String = "mock"
 
     override implicit val actorSystem: ActorSystem = system
-    override implicit val mat: Materializer = materializer
   }
 
   def mockApi(eclair: Eclair = mock[Eclair]): MockService = {


### PR DESCRIPTION
New `AbstractService` can be used by a plugin to only define its custom routes and reuse everything else.