### PR TITLE
Add support for option_shutdown_anysegwit

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -50,6 +50,7 @@ eclair {
     basic_mpp = optional
     option_support_large_channel = optional
     option_anchor_outputs = disabled
+    option_shutdown_anysegwit = optional
     trampoline_payment = disabled
     keysend = disabled
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -188,6 +188,11 @@ object Features {
     val mandatory = 20
   }
 
+  case object ShutdownAnySegwit extends Feature {
+    val rfcName = "option_shutdown_anysegwit"
+    val mandatory = 26
+  }
+
   // TODO: @t-bast: update feature bits once spec-ed (currently reserved here: https://github.com/lightningnetwork/lightning-rfc/issues/605)
   // We're not advertising these bits yet in our announcements, clients have to assume support.
   // This is why we haven't added them yet to `areSupported`.
@@ -213,6 +218,7 @@ object Features {
     TrampolinePayment,
     StaticRemoteKey,
     AnchorOutputs,
+    ShutdownAnySegwit,
     KeySend
   )
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
@@ -209,7 +209,7 @@ class FeaturesSpec extends AnyFunSuite {
       hex"" -> Features.empty,
       hex"0100" -> Features(VariableLengthOnion -> Mandatory),
       hex"028a8a" -> Features(OptionDataLossProtect -> Optional, InitialRoutingSync -> Optional, ChannelRangeQueries -> Optional, VariableLengthOnion -> Optional, ChannelRangeQueriesExtended -> Optional, PaymentSecret -> Optional, BasicMultiPartPayment -> Optional),
-      hex"09004200" -> Features(Map[Feature, FeatureSupport](VariableLengthOnion -> Optional, PaymentSecret -> Mandatory), Set(UnknownFeature(24), UnknownFeature(27))),
+      hex"09004200" -> Features(Map[Feature, FeatureSupport](VariableLengthOnion -> Optional, PaymentSecret -> Mandatory, ShutdownAnySegwit -> Optional), Set(UnknownFeature(24))),
       hex"52000000" -> Features(Map.empty[Feature, FeatureSupport], Set(UnknownFeature(25), UnknownFeature(28), UnknownFeature(30)))
     )
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/StateTestsHelperMethods.scala
@@ -62,6 +62,8 @@ object StateTestsTags {
   val StaticRemoteKey = "static_remotekey"
   /** If set, channels will use option_anchor_outputs. */
   val AnchorOutputs = "anchor_outputs"
+  /** If set, channels will use option_shutdown_anysegwit. */
+  val ShutdownAnySegwit = "shutdown_anysegwit"
   /** If set, channels will be public (otherwise we don't announce them by default). */
   val ChannelsPublic = "channels_public"
   /** If set, no amount will be pushed when opening a channel (by default we push a small amount). */
@@ -111,6 +113,7 @@ trait StateTestsHelperMethods extends TestKitBase {
       .modify(_.features.activated).usingIf(tags.contains(StateTestsTags.Wumbo))(_.updated(Features.Wumbo, FeatureSupport.Optional))
       .modify(_.features.activated).usingIf(tags.contains(StateTestsTags.StaticRemoteKey))(_.updated(Features.StaticRemoteKey, FeatureSupport.Optional))
       .modify(_.features.activated).usingIf(tags.contains(StateTestsTags.AnchorOutputs))(_.updated(Features.StaticRemoteKey, FeatureSupport.Mandatory).updated(Features.AnchorOutputs, FeatureSupport.Optional))
+      .modify(_.features.activated).usingIf(tags.contains(StateTestsTags.ShutdownAnySegwit))(_.updated(Features.ShutdownAnySegwit, FeatureSupport.Optional))
   }
 
   def reachNormal(setup: SetupFixture, tags: Set[String] = Set.empty): Unit = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentRequestSpec.scala
@@ -399,7 +399,7 @@ class PaymentRequestSpec extends AnyFunSuite {
       // those are useful for nonreg testing of the areSupported method (which needs to be updated with every new supported mandatory bit)
       PaymentRequestFeatures(bin"          0010000000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),
       PaymentRequestFeatures(bin"     000001000000000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),
-      PaymentRequestFeatures(bin"     000100000000000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),
+      PaymentRequestFeatures(bin"     000100000000000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = true),
       PaymentRequestFeatures(bin"00000010000000000000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false),
       PaymentRequestFeatures(bin"00001000000000000000000000000000000") -> Result(allowMultiPart = false, requirePaymentSecret = false, areSupported = false)
     )


### PR DESCRIPTION
Opt-in to allow any future segwit script in shutdown as long as it complies with BIP 141 (see  https://github.com/lightningnetwork/lightning-rfc/pull/672).

This has been tested successfully against c-lightning v0.10.0 compiled with `--enable-experimental-features`.