### PR TITLE
Add TCP keep-alive on ZMQ socket

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>org.zeromq</groupId>
             <artifactId>jeromq</artifactId>
-            <version>0.5.0</version>
+            <version>0.5.2</version>
         </dependency>
         <!-- SERIALIZATION -->
         <dependency>


### PR DESCRIPTION
One of ZMQ's drawbacks is that subscribers on an unreliable network may silently disconnect from publishers in case of network failures.

In our case, we want to reconnect immediately when that happens, so we set a tcp keep-alive to ensure this.
Thanks @engenegr for noticing this and testing the fix.

Fixes #1789