### PR TITLE
Basic performance analysis

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.27.2.1</version>
+            <version>3.34.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -154,9 +154,7 @@ trait Eclair {
   def verifyMessage(message: ByteVector, recoverableSignature: ByteVector): VerifiedMessage
 }
 
-class EclairImpl(appKit: Kit) extends Eclair {
-
-  implicit val ec: ExecutionContext = appKit.system.dispatcher
+class EclairImpl(appKit: Kit)(implicit ec: ExecutionContext) extends Eclair {
 
   // We constrain external identifiers. This allows uuid, long and pubkey to be used.
   private val externalIdMaxLength = 66

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -511,7 +511,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
               val fundingMinDepth = Helpers.minDepthForFunding(nodeParams, fundingAmount)
               watchFundingTx(commitments)
               blockchain ! WatchFundingConfirmed(self, commitInput.outPoint.txid, fundingMinDepth)
-              goto(WAIT_FOR_FUNDING_CONFIRMED) using DATA_WAIT_FOR_FUNDING_CONFIRMED(commitments, None, initialRelayFees_opt, nodeParams.currentBlockHeight, None, Right(fundingSigned)) storing() sending fundingSigned
+              goto(WAIT_FOR_FUNDING_CONFIRMED) using DATA_WAIT_FOR_FUNDING_CONFIRMED(commitments, None, initialRelayFees_opt, nodeParams.currentBlockHeight, None, Right(fundingSigned)) storingThenSending(fundingSigned)
           }
       }
 
@@ -615,7 +615,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
           // as soon as it reaches NORMAL state, and before it is announced on the network
           // (this id might be updated when the funding tx gets deeply buried, if there was a reorg in the meantime)
           val shortChannelId = ShortChannelId(blockHeight, txIndex, commitments.commitInput.outPoint.index.toInt)
-          goto(WAIT_FOR_FUNDING_LOCKED) using DATA_WAIT_FOR_FUNDING_LOCKED(commitments, shortChannelId, fundingLocked, initialRelayFees_opt) storing() sending fundingLocked
+          goto(WAIT_FOR_FUNDING_LOCKED) using DATA_WAIT_FOR_FUNDING_LOCKED(commitments, shortChannelId, fundingLocked, initialRelayFees_opt) storingThenSending(fundingLocked)
         case Failure(t) =>
           log.error(t, s"rejecting channel with invalid funding tx: ${fundingTx.bin}")
           goto(CLOSED)
@@ -805,7 +805,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
               context.system.eventStream.publish(ChannelSignatureSent(self, commitments1))
               // we expect a quick response from our peer
               setTimer(RevocationTimeout.toString, RevocationTimeout(commitments1.remoteCommit.index, peer), timeout = nodeParams.revocationTimeout, repeat = false)
-              handleCommandSuccess(c, d.copy(commitments = commitments1)).storing().sending(commit).acking(commitments1.localChanges.signed)
+              handleCommandSuccess(c, d.copy(commitments = commitments1)).storingThenSending(commit).acking(commitments1.localChanges.signed)
             case Left(cause) => handleCommandError(cause, c)
           }
         case Left(waitForRevocation) =>
@@ -827,7 +827,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
             context.system.eventStream.publish(AvailableBalanceChanged(self, d.channelId, d.shortChannelId, commitments1))
           }
           context.system.eventStream.publish(ChannelSignatureReceived(self, commitments1))
-          stay using d.copy(commitments = commitments1) storing() sending revocation
+          stay using d.copy(commitments = commitments1) storingThenSending(revocation)
         case Left(cause) => handleLocalError(cause, d, Some(commit))
       }
 
@@ -854,7 +854,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
             val localShutdown = Shutdown(d.channelId, commitments1.localParams.defaultFinalScriptPubKey)
             // note: it means that we had pending htlcs to sign, therefore we go to SHUTDOWN, not to NEGOTIATING
             require(commitments1.remoteCommit.spec.htlcs.nonEmpty, "we must have just signed new htlcs, otherwise we would have sent our Shutdown earlier")
-            goto(SHUTDOWN) using DATA_SHUTDOWN(commitments1, localShutdown, d.remoteShutdown.get) storing() sending localShutdown
+            goto(SHUTDOWN) using DATA_SHUTDOWN(commitments1, localShutdown, d.remoteShutdown.get) storingThenSending(localShutdown)
           } else {
             stay using d.copy(commitments = commitments1) storing()
           }
@@ -876,7 +876,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
         handleCommandError(InvalidFinalScript(d.channelId), c)
       } else {
         val shutdown = Shutdown(d.channelId, localScriptPubKey)
-        handleCommandSuccess(c, d.copy(localShutdown = Some(shutdown))) storing() sending shutdown
+        handleCommandSuccess(c, d.copy(localShutdown = Some(shutdown))) storingThenSending(shutdown)
       }
 
     case Event(remoteShutdown@Shutdown(_, remoteScriptPubKey), d: DATA_NORMAL) =>
@@ -931,14 +931,14 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
           if (d.commitments.localParams.isFunder) {
             // we are funder, need to initiate the negotiation by sending the first closing_signed
             val (closingTx, closingSigned) = Closing.makeFirstClosingTx(keyManager, d.commitments, localShutdown.scriptPubKey, remoteShutdown.scriptPubKey, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets)
-            goto(NEGOTIATING) using DATA_NEGOTIATING(d.commitments, localShutdown, remoteShutdown, List(List(ClosingTxProposed(closingTx, closingSigned))), bestUnpublishedClosingTx_opt = None) storing() sending sendList :+ closingSigned
+            goto(NEGOTIATING) using DATA_NEGOTIATING(d.commitments, localShutdown, remoteShutdown, List(List(ClosingTxProposed(closingTx, closingSigned))), bestUnpublishedClosingTx_opt = None) storingThenSending(sendList :+ closingSigned)
           } else {
             // we are fundee, will wait for their closing_signed
-            goto(NEGOTIATING) using DATA_NEGOTIATING(d.commitments, localShutdown, remoteShutdown, closingTxProposed = List(List()), bestUnpublishedClosingTx_opt = None) storing() sending sendList
+            goto(NEGOTIATING) using DATA_NEGOTIATING(d.commitments, localShutdown, remoteShutdown, closingTxProposed = List(List()), bestUnpublishedClosingTx_opt = None) storingThenSending(sendList)
           }
         } else {
           // there are some pending signed changes, we need to wait for them to be settled (fail/fulfill htlcs and sign fee updates)
-          goto(SHUTDOWN) using DATA_SHUTDOWN(d.commitments, localShutdown, remoteShutdown) storing() sending sendList
+          goto(SHUTDOWN) using DATA_SHUTDOWN(d.commitments, localShutdown, remoteShutdown) storingThenSending(sendList)
         }
       }
 
@@ -962,7 +962,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
         Some(Helpers.makeAnnouncementSignatures(nodeParams, d.commitments, shortChannelId))
       } else None
       // we use GOTO instead of stay because we want to fire transitions
-      goto(NORMAL) using d.copy(shortChannelId = shortChannelId, buried = true, channelUpdate = channelUpdate) storing() sending localAnnSigs_opt.toSeq
+      goto(NORMAL) using d.copy(shortChannelId = shortChannelId, buried = true, channelUpdate = channelUpdate) storingThenSending(localAnnSigs_opt.toSeq)
 
     case Event(remoteAnnSigs: AnnouncementSignatures, d: DATA_NORMAL) if d.commitments.announceChannel =>
       // channels are publicly announced if both parties want it (defined as feature bit)
@@ -1150,7 +1150,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
               context.system.eventStream.publish(ChannelSignatureSent(self, commitments1))
               // we expect a quick response from our peer
               setTimer(RevocationTimeout.toString, RevocationTimeout(commitments1.remoteCommit.index, peer), timeout = nodeParams.revocationTimeout, repeat = false)
-              handleCommandSuccess(c, d.copy(commitments = commitments1)).storing().sending(commit).acking(commitments1.localChanges.signed)
+              handleCommandSuccess(c, d.copy(commitments = commitments1)).storingThenSending(commit).acking(commitments1.localChanges.signed)
             case Left(cause) => handleCommandError(cause, c)
           }
         case Left(waitForRevocation) =>
@@ -1168,17 +1168,17 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
             if (d.commitments.localParams.isFunder) {
               // we are funder, need to initiate the negotiation by sending the first closing_signed
               val (closingTx, closingSigned) = Closing.makeFirstClosingTx(keyManager, commitments1, localShutdown.scriptPubKey, remoteShutdown.scriptPubKey, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets)
-              goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, List(List(ClosingTxProposed(closingTx, closingSigned))), bestUnpublishedClosingTx_opt = None) storing() sending revocation :: closingSigned :: Nil
+              goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, List(List(ClosingTxProposed(closingTx, closingSigned))), bestUnpublishedClosingTx_opt = None) storingThenSending(revocation :: closingSigned :: Nil)
             } else {
               // we are fundee, will wait for their closing_signed
-              goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, closingTxProposed = List(List()), bestUnpublishedClosingTx_opt = None) storing() sending revocation
+              goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, closingTxProposed = List(List()), bestUnpublishedClosingTx_opt = None) storingThenSending(revocation)
             }
           } else {
             if (Commitments.localHasChanges(commitments1)) {
               // if we have newly acknowledged changes let's sign them
               self ! CMD_SIGN()
             }
-            stay using d.copy(commitments = commitments1) storing() sending revocation
+            stay using d.copy(commitments = commitments1) storingThenSending(revocation)
           }
         case Left(cause) => handleLocalError(cause, d, Some(commit))
       }
@@ -1204,7 +1204,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
             if (d.commitments.localParams.isFunder) {
               // we are funder, need to initiate the negotiation by sending the first closing_signed
               val (closingTx, closingSigned) = Closing.makeFirstClosingTx(keyManager, commitments1, localShutdown.scriptPubKey, remoteShutdown.scriptPubKey, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets)
-              goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, List(List(ClosingTxProposed(closingTx, closingSigned))), bestUnpublishedClosingTx_opt = None) storing() sending closingSigned
+              goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, List(List(ClosingTxProposed(closingTx, closingSigned))), bestUnpublishedClosingTx_opt = None) storingThenSending(closingSigned)
             } else {
               // we are fundee, will wait for their closing_signed
               goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, closingTxProposed = List(List()), bestUnpublishedClosingTx_opt = None) storing()
@@ -1269,7 +1269,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
             val closingTxProposed1 = d.closingTxProposed match {
               case previousNegotiations :+ currentNegotiation => previousNegotiations :+ (currentNegotiation :+ ClosingTxProposed(closingTx, closingSigned))
             }
-            stay using d.copy(closingTxProposed = closingTxProposed1, bestUnpublishedClosingTx_opt = Some(signedClosingTx)) storing() sending closingSigned
+            stay using d.copy(closingTxProposed = closingTxProposed1, bestUnpublishedClosingTx_opt = Some(signedClosingTx)) storingThenSending(closingSigned)
           }
         case Left(cause) => handleLocalError(cause, d, Some(c))
       }
@@ -1589,7 +1589,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
             // would punish us by taking all the funds in the channel
             val exc = PleasePublishYourCommitment(d.channelId)
             val error = Error(d.channelId, exc.getMessage)
-            goto(WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) using DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT(d.commitments, channelReestablish) storing() sending error
+            goto(WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) using DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT(d.commitments, channelReestablish) storingThenSending(error)
           } else {
             // they lied! the last per_commitment_secret they claimed to have received from us is invalid
             throw InvalidRevokedCommitProof(d.channelId, d.commitments.localCommit.index, nextRemoteRevocationNumber, yourLastPerCommitmentSecret)
@@ -1602,7 +1602,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
           // not that if they don't comply, we could publish our own commitment (it is not stale, otherwise we would be in the case above)
           val exc = PleasePublishYourCommitment(d.channelId)
           val error = Error(d.channelId, exc.getMessage)
-          goto(WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) using DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT(d.commitments, channelReestablish) storing() sending error
+          goto(WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) using DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT(d.commitments, channelReestablish) storingThenSending(error)
         case _ =>
           // normal case, our data is up-to-date
           if (channelReestablish.nextLocalCommitmentNumber == 1 && d.commitments.localCommit.index == 0) {
@@ -1685,7 +1685,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
         // we could use the last closing_signed we sent, but network fees may have changed while we were offline so it is better to restart from scratch
         val (closingTx, closingSigned) = Closing.makeFirstClosingTx(keyManager, d.commitments, d.localShutdown.scriptPubKey, d.remoteShutdown.scriptPubKey, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets)
         val closingTxProposed1 = d.closingTxProposed :+ List(ClosingTxProposed(closingTx, closingSigned))
-        goto(NEGOTIATING) using d.copy(closingTxProposed = closingTxProposed1) storing() sending d.localShutdown :: closingSigned :: Nil
+        goto(NEGOTIATING) using d.copy(closingTxProposed = closingTxProposed1) storingThenSending(d.localShutdown :: closingSigned :: Nil)
       } else {
         // we start a new round of negotiation
         val closingTxProposed1 = if (d.closingTxProposed.last.isEmpty) d.closingTxProposed else d.closingTxProposed :+ List()
@@ -2343,7 +2343,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
           // NB: if there is a revoked commitment, we can't be in DATA_WAIT_FOR_FUNDING_CONFIRMED so we don't have the case where fundingTx is defined
           case _ => DATA_CLOSING(d.commitments, fundingTx = None, waitingSinceBlock = nodeParams.currentBlockHeight, mutualCloseProposed = Nil, revokedCommitPublished = revokedCommitPublished :: Nil)
         }
-        goto(CLOSING) using nextData storing() calling doPublish(revokedCommitPublished) sending error
+        goto(CLOSING) using nextData storingThenSending(error) calling doPublish(revokedCommitPublished)
       case None =>
         // the published tx was neither their current commitment nor a revoked one
         log.error(s"couldn't identify txid=${tx.txid}, something very bad is going on!!!")
@@ -2480,17 +2480,24 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
 
   case class MyState(state: FSM.State[fr.acinq.eclair.channel.State, Data]) {
 
-    def storing(unused: Unit = ()): FSM.State[fr.acinq.eclair.channel.State, Data] = {
+    def storingThenSending(msgs: Seq[LightningMessage]): FSM.State[fr.acinq.eclair.channel.State, Data] = {
       state.stateData match {
         case d: HasCommitments =>
           log.debug("updating database record for channelId={}", d.channelId)
-          nodeParams.db.channels.addOrUpdateChannel(d)
-          context.system.eventStream.publish(ChannelPersisted(self, remoteNodeId, d.channelId, d))
+          writerSender ! ChannelWriterSender.StoreThenSend(d, msgs)
           state
         case _ =>
           log.error(s"can't store data=${state.stateData} in state=${state.stateName}")
           state
       }
+    }
+
+    def storingThenSending(msg: LightningMessage): FSM.State[fr.acinq.eclair.channel.State, Data] = {
+      storingThenSending(Seq(msg))
+    }
+
+    def storing(unused: Unit = ()): FSM.State[fr.acinq.eclair.channel.State, Data] = {
+      storingThenSending(Seq.empty)
     }
 
     def sending(msgs: Seq[LightningMessage]): FSM.State[fr.acinq.eclair.channel.State, Data] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelWriterSender.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelWriterSender.scala
@@ -1,0 +1,36 @@
+package fr.acinq.eclair.channel
+
+import akka.actor.ActorRef
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import fr.acinq.eclair.channel.Channel.OutgoingMessage
+import fr.acinq.eclair.db.ChannelsDb
+import fr.acinq.eclair.wire.protocol.LightningMessage
+
+object ChannelWriterSender {
+
+  sealed trait Command
+  case class ResetPeerConnection(connection: ActorRef) extends Command
+  case class Store(d: HasCommitments) extends Command
+  case class StoreThenSend(d: HasCommitments, m: LightningMessage) extends Command
+  case class Send(m: LightningMessage) extends Command
+
+  def apply(db: ChannelsDb, peer: ActorRef, connection: ActorRef): Behavior[Command] =
+    Behaviors.setup { context =>
+      Behaviors.receiveMessage {
+        case ResetPeerConnection(newConnection) =>
+          apply(db, peer, newConnection)
+        case Store(d) =>
+          db.addOrUpdateChannel(d)
+          Behaviors.same
+        case StoreThenSend(d, m) =>
+          db.addOrUpdateChannel(d)
+          peer ! OutgoingMessage(m, connection)
+          Behaviors.same
+        case Send(m) =>
+          peer ! OutgoingMessage(m, connection)
+          Behaviors.same
+      }
+    }
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PendingRelayDb.scala
@@ -16,13 +16,13 @@
 
 package fr.acinq.eclair.db
 
-import java.io.Closeable
-
-import akka.actor.{ActorContext, ActorRef}
+import akka.actor.ActorRef
 import akka.event.LoggingAdapter
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.wire.protocol.{UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFulfillHtlc, UpdateMessage}
+
+import java.io.Closeable
 
 /**
  * This database stores CMD_FULFILL_HTLC and CMD_FAIL_HTLC that we have received from downstream
@@ -58,7 +58,7 @@ object PendingRelayDb {
     // htlc settlement commands don't have replyTo
     register ! Register.Forward(ActorRef.noSender, channelId, cmd)
     // we store the command in a db (note that this happens *after* forwarding the command to the channel, so we don't add latency)
-    db.addPendingRelay(channelId, cmd)
+    //db.addPendingRelay(channelId, cmd)
   }
 
   def ackCommand(db: PendingRelayDb, channelId: ByteVector32, cmd: HtlcSettlementCommand): Unit = {
@@ -77,7 +77,7 @@ object PendingRelayDb {
       db.removePendingRelay(u.channelId, u.id)
   }
 
-  def getPendingFailsAndFulfills(db: PendingRelayDb, channelId: ByteVector32)(implicit  log: LoggingAdapter): Seq[HtlcSettlementCommand] = {
+  def getPendingFailsAndFulfills(db: PendingRelayDb, channelId: ByteVector32)(implicit log: LoggingAdapter): Seq[HtlcSettlementCommand] = {
     db.listPendingRelay(channelId)
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -80,18 +80,19 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
   }
 
   override def addOrUpdateChannel(state: HasCommitments): Unit = withMetrics("channels/add-or-update-channel", DbBackends.Sqlite) {
-    val data = commitmentsCodec.encode(state.commitments).require.toByteArray
-    using(sqlite.prepareStatement("UPDATE local_channels SET data=? WHERE channel_id=?")) { update =>
-      update.setBytes(1, data)
-      update.setBytes(2, state.channelId.toArray)
-      if (update.executeUpdate() == 0) {
-        using(sqlite.prepareStatement("INSERT INTO local_channels (channel_id, data, is_closed) VALUES (?, ?, 0)")) { statement =>
-          statement.setBytes(1, state.channelId.toArray)
-          statement.setBytes(2, data)
-          statement.executeUpdate()
-        }
-      }
-    }
+    val data = stateDataCodec.encode(state).require.toByteArray
+    logger.debug(s"this is just to force the compiler to evaluate the variable size=${data.size}")
+//    using(sqlite.prepareStatement("UPDATE local_channels SET data=? WHERE channel_id=?")) { update =>
+//      update.setBytes(1, data)
+//      update.setBytes(2, state.channelId.toArray)
+//      if (update.executeUpdate() == 0) {
+//        using(sqlite.prepareStatement("INSERT INTO local_channels (channel_id, data, is_closed) VALUES (?, ?, 0)")) { statement =>
+//          statement.setBytes(1, state.channelId.toArray)
+//          statement.setBytes(2, data)
+//          statement.executeUpdate()
+//        }
+//      }
+//    }
   }
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -141,13 +141,13 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
   }
 
   override def addHtlcInfo(channelId: ByteVector32, commitmentNumber: Long, paymentHash: ByteVector32, cltvExpiry: CltvExpiry): Unit = withMetrics("channels/add-htlc-info", DbBackends.Sqlite) {
-    using(sqlite.prepareStatement("INSERT INTO htlc_infos VALUES (?, ?, ?, ?)")) { statement =>
-      statement.setBytes(1, channelId.toArray)
-      statement.setLong(2, commitmentNumber)
-      statement.setBytes(3, paymentHash.toArray)
-      statement.setLong(4, cltvExpiry.toLong)
-      statement.executeUpdate()
-    }
+//    using(sqlite.prepareStatement("INSERT INTO htlc_infos VALUES (?, ?, ?, ?)")) { statement =>
+//      statement.setBytes(1, channelId.toArray)
+//      statement.setLong(2, commitmentNumber)
+//      statement.setBytes(3, paymentHash.toArray)
+//      statement.setLong(4, cltvExpiry.toLong)
+//      statement.executeUpdate()
+//    }
   }
 
   override def listHtlcInfos(channelId: ByteVector32, commitmentNumber: Long): Seq[(ByteVector32, CltvExpiry)] = withMetrics("channels/list-htlc-infos", DbBackends.Sqlite) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -24,6 +24,7 @@ import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db.Monitoring.Tags.DbBackends
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecs.stateDataCodec
+import fr.acinq.eclair.wire.internal.channel.version2.ChannelCodecs2.Codecs.commitmentsCodec
 import grizzled.slf4j.Logging
 
 import java.sql.{Connection, Statement}
@@ -79,7 +80,7 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
   }
 
   override def addOrUpdateChannel(state: HasCommitments): Unit = withMetrics("channels/add-or-update-channel", DbBackends.Sqlite) {
-    val data = stateDataCodec.encode(state).require.toByteArray
+    val data = commitmentsCodec.encode(state.commitments).require.toByteArray
     using(sqlite.prepareStatement("UPDATE local_channels SET data=? WHERE channel_id=?")) { update =>
       update.setBytes(1, data)
       update.setBytes(2, state.channelId.toArray)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -80,8 +80,7 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
   }
 
   override def addOrUpdateChannel(state: HasCommitments): Unit = withMetrics("channels/add-or-update-channel", DbBackends.Sqlite) {
-    val data = stateDataCodec.encode(state).require.toByteArray
-    logger.debug(s"this is just to force the compiler to evaluate the variable size=${data.size}")
+//    val data = stateDataCodec.encode(state).require.toByteArray
 //    using(sqlite.prepareStatement("UPDATE local_channels SET data=? WHERE channel_id=?")) { update =>
 //      update.setBytes(1, data)
 //      update.setBytes(2, state.channelId.toArray)
@@ -99,11 +98,11 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
    * Helper method to factor updating timestamp columns
    */
   private def updateChannelMetaTimestampColumn(channelId: ByteVector32, columnName: String): Unit = {
-    using(sqlite.prepareStatement(s"UPDATE local_channels SET $columnName=? WHERE channel_id=?")) { statement =>
-      statement.setLong(1, System.currentTimeMillis)
-      statement.setBytes(2, channelId.toArray)
-      statement.executeUpdate()
-    }
+//    using(sqlite.prepareStatement(s"UPDATE local_channels SET $columnName=? WHERE channel_id=?")) { statement =>
+//      statement.setLong(1, System.currentTimeMillis)
+//      statement.setBytes(2, channelId.toArray)
+//      statement.executeUpdate()
+//    }
   }
 
   override def updateChannelMeta(channelId: ByteVector32, event: ChannelEvent.EventType): Unit = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -26,6 +26,7 @@ import fr.acinq.eclair.wire.protocol.ChannelUpdate
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedMap
 import scala.collection.mutable
+import scala.util.Random
 
 object Graph {
 
@@ -229,7 +230,8 @@ object Graph {
           if (canRelayAmount && boundaries(neighborWeight) && !ignoredEdges.contains(edge.desc) && !ignoredVertices.contains(neighbor)) {
             val previousNeighborWeight = bestWeights.getOrElse(neighbor, RichWeight(MilliSatoshi(Long.MaxValue), Int.MaxValue, CltvExpiryDelta(Int.MaxValue), Double.MaxValue))
             // if this path between neighbor and the target has a shorter distance than previously known, we select it
-            if (neighborWeight.weight < previousNeighborWeight.weight) {
+            if (neighborWeight.weight < previousNeighborWeight.weight ||
+              (neighborWeight.weight == previousNeighborWeight.weight && Random.nextInt(1) == 0)) {
               // update the best edge for this vertex
               bestEdges.put(neighbor, edge)
               // add this updated node to the list for further exploration

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2.scala
@@ -29,9 +29,9 @@ import fr.acinq.eclair.wire.protocol.UpdateMessage
 import scodec.codecs._
 import scodec.{Attempt, Codec}
 
-private[channel] object ChannelCodecs2 {
+object ChannelCodecs2 {
 
-  private[version2] object Codecs {
+  object Codecs {
 
     val keyPathCodec: Codec[KeyPath] = ("path" | listOfN(uint16, uint32)).xmap[KeyPath](l => new KeyPath(l), keyPath => keyPath.path.toList).as[KeyPath]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -51,6 +51,8 @@ import scala.util.Success
 class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with IdiomaticMockito with ParallelTestExecution {
   implicit val timeout: Timeout = Timeout(30 seconds)
 
+  import scala.concurrent.ExecutionContext.Implicits.global
+
   case class FixtureParam(register: TestProbe, router: TestProbe, paymentInitiator: TestProbe, switchboard: TestProbe, paymentHandler: TestProbe, kit: Kit)
 
   override def withFixture(test: OneArgTest): Outcome = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/PerformanceIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/PerformanceIntegrationSpec.scala
@@ -52,11 +52,20 @@ class PerformanceIntegrationSpec extends IntegrationSpec {
     nodes.values.foreach(_.system.eventStream.subscribe(eventListener.ref, classOf[ChannelStateChanged]))
 
     connect(nodes("A"), nodes("B"), 100_000_000 sat, 0 msat)
+    connect(nodes("A"), nodes("B"), 100_000_000 sat, 0 msat)
+    connect(nodes("A"), nodes("B"), 100_000_000 sat, 0 msat)
+    connect(nodes("A"), nodes("B"), 100_000_000 sat, 0 msat)
+    connect(nodes("A"), nodes("B"), 100_000_000 sat, 0 msat)
+    connect(nodes("A"), nodes("B"), 100_000_000 sat, 0 msat)
+    connect(nodes("A"), nodes("B"), 100_000_000 sat, 0 msat)
+    connect(nodes("A"), nodes("B"), 100_000_000 sat, 0 msat)
 
     // confirming the funding tx
     generateBlocks(6)
 
     within(60 seconds) {
+      eventListener.expectMsgType[ChannelStateChanged](60 seconds).currentState == NORMAL
+      eventListener.expectMsgType[ChannelStateChanged](60 seconds).currentState == NORMAL
       eventListener.expectMsgType[ChannelStateChanged](60 seconds).currentState == NORMAL
     }
   }
@@ -67,7 +76,7 @@ class PerformanceIntegrationSpec extends IntegrationSpec {
     awaitCond({
       sender.send(nodes("A").router, Router.GetRoutingState)
       val routingState = sender.expectMsgType[Router.RoutingState]
-      routingState.channels.nonEmpty
+      routingState.channels.size == 8
     }, 60 seconds)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/PerformanceIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/PerformanceIntegrationSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.integration
+
+import akka.Done
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import fr.acinq.bitcoin.SatoshiLong
+import fr.acinq.eclair.MilliSatoshiLong
+import fr.acinq.eclair.channel._
+import fr.acinq.eclair.payment._
+import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceivePayment
+import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentRequest
+import fr.acinq.eclair.router.Router
+
+import java.util.UUID
+import java.util.concurrent.Executors
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
+
+/**
+ * Created by PM on 15/03/2017.
+ */
+
+class PerformanceIntegrationSpec extends IntegrationSpec {
+
+  test("start eclair nodes") {
+    instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.node-alias" -> "A", "eclair.max-funding-satoshis" -> 100_000_000, "eclair.server.port" -> 29730).asJava).withFallback(commonFeatures).withFallback(commonConfig)) // A's channels are private
+    instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.node-alias" -> "B", "eclair.max-funding-satoshis" -> 100_000_000, "eclair.server.port" -> 29731).asJava).withFallback(commonFeatures).withFallback(commonConfig))
+  }
+
+  test("connect nodes") {
+    // A---B
+
+    val sender = TestProbe()
+    val eventListener = TestProbe()
+    nodes.values.foreach(_.system.eventStream.subscribe(eventListener.ref, classOf[ChannelStateChanged]))
+
+    connect(nodes("A"), nodes("B"), 100_000_000 sat, 0 msat)
+
+    // confirming the funding tx
+    generateBlocks(6)
+
+    within(60 seconds) {
+      eventListener.expectMsgType[ChannelStateChanged](60 seconds).currentState == NORMAL
+    }
+  }
+
+  test("wait for channels balance") {
+    // Channels balance should now be available in the router
+    val sender = TestProbe()
+    awaitCond({
+      sender.send(nodes("A").router, Router.GetRoutingState)
+      val routingState = sender.expectMsgType[Router.RoutingState]
+      routingState.channels.nonEmpty
+    }, 60 seconds)
+  }
+
+  def sendPayment(): Unit = {
+    val sender = TestProbe()
+    val amountMsat = 100_000.msat
+    // first we retrieve a payment hash from D
+    sender.send(nodes("B").paymentHandler, ReceivePayment(Some(amountMsat), "1 coffee"))
+    val pr = sender.expectMsgType[PaymentRequest]
+    // then we make the actual payment
+    sender.send(nodes("A").paymentInitiator, SendPaymentRequest(amountMsat, pr.paymentHash, nodes("B").nodeParams.nodeId, fallbackFinalExpiryDelta = finalCltvExpiryDelta, routeParams = integrationTestRouteParams, maxAttempts = 1))
+    val paymentId = sender.expectMsgType[UUID]
+    val ps = sender.expectMsgType[PaymentSent]
+    assert(ps.id == paymentId)
+  }
+
+  test("send a large number of htlcs A->B") {
+    val SENDERS_COUNT = 8
+    val PAYMENTS_COUNT = 1_000
+    val ec = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(SENDERS_COUNT))
+    val start = System.currentTimeMillis()
+    (0 until PAYMENTS_COUNT).foreach(_ => Future(sendPayment())(ec))
+    val f = Future(Done)(ec)
+    awaitCond(f.isCompleted, 1 hour)
+    val end = System.currentTimeMillis()
+    val duration = end - start
+    println(s"$PAYMENTS_COUNT payments in ${duration}ms ${PAYMENTS_COUNT * 1000 / duration}htlc/s (senders=$SENDERS_COUNT)")
+  }
+
+}

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -17,7 +17,6 @@
 package fr.acinq.eclair
 
 import java.io.File
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.{ActorMaterializer, BindFailedException}
@@ -25,6 +24,7 @@ import fr.acinq.eclair.api.Service
 import grizzled.slf4j.Logging
 import kamon.Kamon
 
+import java.util.concurrent.Executors
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
@@ -39,7 +39,7 @@ object Boot extends App with Logging {
     val plugins = Plugin.loadPlugins(args.map(new File(_)))
     plugins.foreach(plugin => logger.info(s"loaded plugin ${plugin.getClass.getSimpleName}"))
     implicit val system: ActorSystem = ActorSystem("eclair-node", config)
-    implicit val ec: ExecutionContext = system.dispatcher
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
 
     val setup = new Setup(datadir, plugins.map(_.params))
 


### PR DESCRIPTION
Added a very simple performance test and applied a few "optimizations" to try and pinpoint performance bottlenecks.

Here are the results:

incremental change | result
-----------------------|------
baseline|1000 payments in 72078ms 13htlc/s (senders=8)
store asynchronously|1000 payments in 72078ms 13htlc/s (senders=8)
update sqlite to 3.34.0|1000 payments in 72078ms 13htlc/s (senders=8)
bypass htlc_infos db writes|1000 payments in 78584ms 12htlc/s (senders=8)
bypass payments db calls|1000 payments in 43378ms 23htlc/s (senders=8)
store only the channels commitment|1000 payments in 41594ms 24htlc/s (senders=8)
serialize channel data but do not store it|1000 payments in 18072ms 55htlc/s (senders=8)
bypass channel db writes|1000 payments in 20479ms 48htlc/s (senders=8)
bypass pending relay db calls|1000 payments in 15181ms 65htlc/s (senders=8)
use multiple channels in parallel|1000 payments in 14812ms 67htlc/s (senders=8)

First thing to do imo is rearchitecture the payments handler, probably with `payment_hash`-indexed child actors, like we do for relayers. This will make us gain 2x, maybe more if it allows us to take full advantage of multiple channels (which we don't currently, see last test).

Further improvements won't be as simple, but at least we know where the gains are.