### PR TITLE
Quotes for Windows Service Install

### DIFF
--- a/docs/Tor.md
+++ b/docs/Tor.md
@@ -76,7 +76,7 @@ Open a CMD with administrator access
 
 ```shell
 cd c:\tor\Tor
-tor --service install -options -f c:\tor\Conf\torrc
+tor --service install -options -f "c:\tor\Conf\torrc"
 ```
 
 ### Configure Tor hidden service


### PR DESCRIPTION
My testing showed that when the path to the configuration file was specified without quotation marks, the installation of the service ignored the -f option.  This resulted in `IMPORTANT NOTE: The Tor service will run under the account "NT AUTHORITY\LocalService". This means that Tor will look for its configuration file under that account's Application Data directory, which is probably not the same as yours.`  After I added quotation marks, as shown at [miloserdov's instructions](https://miloserdov.org/?p=1839), this "IMPORTANT NOTE" went away, and Eclair can now see tor.