### PR TITLE
Stop masking feature bits

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -77,23 +77,6 @@ case class Features(activated: Set[ActivatedFeature], unknown: Set[UnknownFeatur
     buf.reverse.bytes
   }
 
-  /**
-    * Eclair-mobile thinks feature bit 15 (payment_secret) is gossip_queries_ex which creates issues, so we mask
-    * off basic_mpp and payment_secret. As long as they're provided in the invoice it's not an issue.
-    * We use a long enough mask to account for future features.
-    * TODO: remove that once eclair-mobile is patched.
-    */
-  def maskFeaturesForEclairMobile(): Features = {
-    Features(
-      activated = activated.filter {
-        case ActivatedFeature(PaymentSecret, _) => false
-        case ActivatedFeature(BasicMultiPartPayment, _) => false
-        case _ => true
-      },
-      unknown = unknown
-    )
-  }
-
 }
 
 object Features {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -101,7 +101,7 @@ class PeerConnection(nodeParams: NodeParams, switchboard: ActorRef, router: Acto
       Metrics.PeerConnectionsConnecting.withTag(Tags.ConnectionState, Tags.ConnectionStates.Initializing).increment()
       val localFeatures = nodeParams.overrideFeatures.get(d.remoteNodeId) match {
         case Some(f) => f
-        case None => nodeParams.features.maskFeaturesForEclairMobile()
+        case None => nodeParams.features
       }
       log.info(s"using features=$localFeatures")
       val localInit = wire.Init(localFeatures, TlvStream(InitTlv.Networks(nodeParams.chainHash :: Nil)))


### PR DESCRIPTION
Remove a legacy work-around for very old eclair-mobile users.

NB: this is a PR to the `android` branch. It should then be merged in the `android-phoenix` branch as well.