### PR TITLE
Don't reveal unannounced channels on relay failures

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -20,7 +20,6 @@ import akka.actor.{ActorRef, PossiblyHarmful}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, DeterministicWallet, OutPoint, Satoshi, Transaction}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
-import fr.acinq.eclair.channel.TxPublisher.PublishTx
 import fr.acinq.eclair.payment.OutgoingPacket.Upstream
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.transactions.CommitmentSpec
@@ -210,7 +209,7 @@ object HtlcResult {
   case class RemoteFail(fail: UpdateFailHtlc) extends Fail
   case class RemoteFailMalformed(fail: UpdateFailMalformedHtlc) extends Fail
   case class OnChainFail(cause: ChannelException) extends Fail
-  case class Disconnected(channelUpdate: ChannelUpdate) extends Fail { assert(!Announcements.isEnabled(channelUpdate.channelFlags), "channel update must have disabled flag set") }
+  case class Disconnected(channelUpdate: Option[ChannelUpdate]) extends Fail { assert(channelUpdate.forall(u => !Announcements.isEnabled(u.channelFlags)), "channel update must have disabled flag set") }
 }
 final case class RES_ADD_SETTLED[+O <: Origin, +R <: HtlcResult](origin: O, htlc: UpdateAddHtlc, result: R) extends CommandSuccess[CMD_ADD_HTLC]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -362,7 +362,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
 
     register.expectMsg(ForwardShortId(paymentFSM, channelId_ab, cmd1))
     val update_bc_disabled = update_bc.copy(channelFlags = Announcements.makeChannelFlags(isNode1 = true, enable = false))
-    sender.send(paymentFSM, addCompleted(HtlcResult.Disconnected(update_bc_disabled)))
+    sender.send(paymentFSM, addCompleted(HtlcResult.Disconnected(Some(update_bc_disabled))))
 
     // then the payment lifecycle will ask for a new route excluding the channel
     routerForwarder.expectMsg(defaultRouteRequest(a, d, cfg).copy(ignore = Ignore(Set.empty, Set(ChannelDesc(channelId_ab, a, b)))))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/ChannelRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/ChannelRelayerSpec.scala
@@ -361,7 +361,8 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       TestCase(HtlcResult.RemoteFail(UpdateFailHtlc(channelId1, downstream_htlc.id, hex"deadbeef")), CMD_FAIL_HTLC(r.add.id, Left(hex"deadbeef"), commit = true)),
       TestCase(HtlcResult.RemoteFailMalformed(UpdateFailMalformedHtlc(channelId1, downstream_htlc.id, ByteVector32.One, FailureMessageCodecs.BADONION)), CMD_FAIL_MALFORMED_HTLC(r.add.id, ByteVector32.One, FailureMessageCodecs.BADONION, commit = true)),
       TestCase(HtlcResult.OnChainFail(HtlcOverriddenByLocalCommit(channelId1, downstream_htlc)), CMD_FAIL_HTLC(r.add.id, Right(PermanentChannelFailure), commit = true)),
-      TestCase(HtlcResult.Disconnected(u_disabled.channelUpdate), CMD_FAIL_HTLC(r.add.id, Right(TemporaryChannelFailure(u_disabled.channelUpdate)), commit = true))
+      TestCase(HtlcResult.Disconnected(Some(u_disabled.channelUpdate)), CMD_FAIL_HTLC(r.add.id, Right(TemporaryChannelFailure(u_disabled.channelUpdate)), commit = true)),
+      TestCase(HtlcResult.Disconnected(None), CMD_FAIL_HTLC(r.add.id, Right(UnknownNextPeer), commit = true))
     )
 
     testCases.foreach { testCase =>


### PR DESCRIPTION
We may not want to include a `channel_update` for unannounced channel errors because it leaks the channel outpoint (and the fact that an unannounced channel exists between these nodes). An attacker could probe unannounced channels by sending probes and relying on non-strict forwarding.

There are downsides to this change though:

- we can't communicate to an honest payer that feerates have changed since we generated the invoice: they won't be able to retry with the right fees, a new invoice will be needed. But on the other hand, we can't distinguish an honest payer from a malicious one, so our only solution would be to *always* return a dummy channel update *with our up-to-date fees* regardless of whether a channel exists or not?
- even if we fix this, there's another simple way for malicious nodes to probe an unannounced channel between nodes `A` and `B`: send a payment with a random `payment_hash` to `B` via `A`, and if you receive an error from `A` there is indeed a channel between them. `B` would need `A` to be nice and convert that error to an `unknown_next_peer` to be protected, but `B` cannot verify that `A` correctly translates (it would be at best a gentlemen's agreement)...