### PR TITLE
Make result set an iterable

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbEventHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbEventHandler.scala
@@ -20,7 +20,7 @@ import akka.actor.{Actor, ActorLogging, Props}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.NodeParams
-import fr.acinq.eclair.channel.Helpers.Closing.{ClosingType, CurrentRemoteClose, LocalClose, MutualClose, NextRemoteClose, RecoveryClose, RevokedClose}
+import fr.acinq.eclair.channel.Helpers.Closing._
 import fr.acinq.eclair.channel.Monitoring.{Metrics => ChannelMetrics, Tags => ChannelTags}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/FeeratesDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/FeeratesDb.scala
@@ -16,9 +16,9 @@
 
 package fr.acinq.eclair.db
 
-import java.io.Closeable
-
 import fr.acinq.eclair.blockchain.fee.FeeratesPerKB
+
+import java.io.Closeable
 
 /**
  * This database stores the fee rates retrieved by a [[fr.acinq.eclair.blockchain.fee.FeeProvider]].

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/FileBackupHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/FileBackupHandler.scala
@@ -16,9 +16,6 @@
 
 package fr.acinq.eclair.db
 
-import java.io.File
-import java.nio.file.{Files, StandardCopyOption}
-
 import akka.actor.{Actor, ActorLogging, Props}
 import akka.dispatch.{BoundedMessageQueueSemantics, RequiresMessageQueue}
 import fr.acinq.eclair.KamonExt
@@ -26,6 +23,8 @@ import fr.acinq.eclair.channel.ChannelPersisted
 import fr.acinq.eclair.db.Databases.FileBackup
 import fr.acinq.eclair.db.Monitoring.Metrics
 
+import java.io.File
+import java.nio.file.{Files, StandardCopyOption}
 import scala.sys.process.Process
 import scala.util.{Failure, Success, Try}
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
@@ -16,14 +16,13 @@
 
 package fr.acinq.eclair.db
 
-import java.io.Closeable
-
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.ShortChannelId
 import fr.acinq.eclair.router.Router.PublicChannel
 import fr.acinq.eclair.wire.protocol.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement}
 
+import java.io.Closeable
 import scala.collection.immutable.SortedMap
 
 trait NetworkDb extends Closeable {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -16,14 +16,14 @@
 
 package fr.acinq.eclair.db
 
-import java.io.Closeable
-import java.util.UUID
-
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.router.Router.{ChannelHop, Hop, NodeHop}
 import fr.acinq.eclair.{MilliSatoshi, ShortChannelId}
+
+import java.io.Closeable
+import java.util.UUID
 
 trait PaymentsDb extends IncomingPaymentsDb with OutgoingPaymentsDb with PaymentsOverviewDb with Closeable
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PeersDb.scala
@@ -16,10 +16,10 @@
 
 package fr.acinq.eclair.db
 
-import java.io.Closeable
-
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.wire.protocol.NodeAddress
+
+import java.io.Closeable
 
 trait PeersDb extends Closeable {
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
@@ -75,8 +75,9 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
     inTransaction { pg =>
       using(pg.prepareStatement("SELECT data FROM nodes WHERE node_id=?")) { statement =>
         statement.setString(1, nodeId.value.toHex)
-        val rs = statement.executeQuery()
-        codecSequence(rs, nodeAnnouncementCodec).headOption
+        statement.executeQuery()
+          .mapCodec(nodeAnnouncementCodec)
+          .headOption
       }
     }
   }
@@ -93,8 +94,8 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
   override def listNodes(): Seq[NodeAnnouncement] = withMetrics("network/list-nodes", DbBackends.Postgres) {
     inTransaction { pg =>
       using(pg.createStatement()) { statement =>
-        val rs = statement.executeQuery("SELECT data FROM nodes")
-        codecSequence(rs, nodeAnnouncementCodec)
+        statement.executeQuery("SELECT data FROM nodes")
+          .mapCodec(nodeAnnouncementCodec).toSeq
       }
     }
   }
@@ -125,17 +126,15 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
   override def listChannels(): SortedMap[ShortChannelId, PublicChannel] = withMetrics("network/list-channels", DbBackends.Postgres) {
     inTransaction { pg =>
       using(pg.createStatement()) { statement =>
-        val rs = statement.executeQuery("SELECT channel_announcement, txid, capacity_sat, channel_update_1, channel_update_2 FROM channels")
-        var m = SortedMap.empty[ShortChannelId, PublicChannel]
-        while (rs.next()) {
-          val ann = channelAnnouncementCodec.decode(rs.getBitVectorOpt("channel_announcement").get).require.value
-          val txId = ByteVector32.fromValidHex(rs.getString("txid"))
-          val capacity = rs.getLong("capacity_sat")
-          val channel_update_1_opt = rs.getBitVectorOpt("channel_update_1").map(channelUpdateCodec.decode(_).require.value)
-          val channel_update_2_opt = rs.getBitVectorOpt("channel_update_2").map(channelUpdateCodec.decode(_).require.value)
-          m = m + (ann.shortChannelId -> PublicChannel(ann, txId, Satoshi(capacity), channel_update_1_opt, channel_update_2_opt, None))
-        }
-        m
+        statement.executeQuery("SELECT channel_announcement, txid, capacity_sat, channel_update_1, channel_update_2 FROM channels")
+          .foldLeft(SortedMap.empty[ShortChannelId, PublicChannel]) { (m, rs) =>
+              val ann = channelAnnouncementCodec.decode(rs.getBitVectorOpt("channel_announcement").get).require.value
+              val txId = ByteVector32.fromValidHex(rs.getString("txid"))
+              val capacity = rs.getLong("capacity_sat")
+              val channel_update_1_opt = rs.getBitVectorOpt("channel_update_1").map(channelUpdateCodec.decode(_).require.value)
+              val channel_update_2_opt = rs.getBitVectorOpt("channel_update_2").map(channelUpdateCodec.decode(_).require.value)
+              m + (ann.shortChannelId -> PublicChannel(ann, txId, Satoshi(capacity), channel_update_1_opt, channel_update_2_opt, None))
+          }
       }
     }
   }
@@ -182,8 +181,7 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
     inTransaction { pg =>
       using(pg.prepareStatement("SELECT short_channel_id from pruned WHERE short_channel_id=?")) { statement =>
         statement.setLong(1, shortChannelId.toLong)
-        val rs = statement.executeQuery()
-        rs.next()
+        statement.executeQuery().next()
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
@@ -181,7 +181,7 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
     inTransaction { pg =>
       using(pg.prepareStatement("SELECT short_channel_id from pruned WHERE short_channel_id=?")) { statement =>
         statement.setLong(1, shortChannelId.toLong)
-        statement.executeQuery().next()
+        statement.executeQuery().nonEmpty
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -31,7 +31,6 @@ import grizzled.slf4j.Logging
 
 import java.sql.{Connection, Statement}
 import java.util.UUID
-import scala.collection.immutable.Queue
 
 class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
 
@@ -232,124 +231,117 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
     using(sqlite.prepareStatement("SELECT * FROM sent WHERE timestamp >= ? AND timestamp < ?")) { statement =>
       statement.setLong(1, from)
       statement.setLong(2, to)
-      val rs = statement.executeQuery()
-      var sentByParentId = Map.empty[UUID, PaymentSent]
-      while (rs.next()) {
-        val parentId = UUID.fromString(rs.getString("parent_payment_id"))
-        val part = PaymentSent.PartialPayment(
-          UUID.fromString(rs.getString("payment_id")),
-          MilliSatoshi(rs.getLong("amount_msat")),
-          MilliSatoshi(rs.getLong("fees_msat")),
-          rs.getByteVector32("to_channel_id"),
-          None, // we don't store the route in the audit DB
-          rs.getLong("timestamp"))
-        val sent = sentByParentId.get(parentId) match {
-          case Some(s) => s.copy(parts = s.parts :+ part)
-          case None => PaymentSent(
-            parentId,
-            rs.getByteVector32("payment_hash"),
-            rs.getByteVector32("payment_preimage"),
-            MilliSatoshi(rs.getLong("recipient_amount_msat")),
-            PublicKey(rs.getByteVector("recipient_node_id")),
-            Seq(part))
-        }
-        sentByParentId = sentByParentId + (parentId -> sent)
-      }
-      sentByParentId.values.toSeq.sortBy(_.timestamp)
+      statement.executeQuery()
+        .foldLeft(Map.empty[UUID, PaymentSent]) { (sentByParentId, rs) =>
+          val parentId = UUID.fromString(rs.getString("parent_payment_id"))
+          val part = PaymentSent.PartialPayment(
+            UUID.fromString(rs.getString("payment_id")),
+            MilliSatoshi(rs.getLong("amount_msat")),
+            MilliSatoshi(rs.getLong("fees_msat")),
+            rs.getByteVector32("to_channel_id"),
+            None, // we don't store the route in the audit DB
+            rs.getLong("timestamp"))
+          val sent = sentByParentId.get(parentId) match {
+            case Some(s) => s.copy(parts = s.parts :+ part)
+            case None => PaymentSent(
+              parentId,
+              rs.getByteVector32("payment_hash"),
+              rs.getByteVector32("payment_preimage"),
+              MilliSatoshi(rs.getLong("recipient_amount_msat")),
+              PublicKey(rs.getByteVector("recipient_node_id")),
+              Seq(part))
+          }
+          sentByParentId + (parentId -> sent)
+        }.values.toSeq.sortBy(_.timestamp)
     }
 
   override def listReceived(from: Long, to: Long): Seq[PaymentReceived] =
     using(sqlite.prepareStatement("SELECT * FROM received WHERE timestamp >= ? AND timestamp < ?")) { statement =>
       statement.setLong(1, from)
       statement.setLong(2, to)
-      val rs = statement.executeQuery()
-      var receivedByHash = Map.empty[ByteVector32, PaymentReceived]
-      while (rs.next()) {
-        val paymentHash = rs.getByteVector32("payment_hash")
-        val part = PaymentReceived.PartialPayment(
-          MilliSatoshi(rs.getLong("amount_msat")),
-          rs.getByteVector32("from_channel_id"),
-          rs.getLong("timestamp"))
-        val received = receivedByHash.get(paymentHash) match {
-          case Some(r) => r.copy(parts = r.parts :+ part)
-          case None => PaymentReceived(paymentHash, Seq(part))
-        }
-        receivedByHash = receivedByHash + (paymentHash -> received)
-      }
-      receivedByHash.values.toSeq.sortBy(_.timestamp)
+      statement.executeQuery()
+        .foldLeft(Map.empty[ByteVector32, PaymentReceived]) { (receivedByHash, rs) =>
+          val paymentHash = rs.getByteVector32("payment_hash")
+          val part = PaymentReceived.PartialPayment(
+            MilliSatoshi(rs.getLong("amount_msat")),
+            rs.getByteVector32("from_channel_id"),
+            rs.getLong("timestamp"))
+          val received = receivedByHash.get(paymentHash) match {
+            case Some(r) => r.copy(parts = r.parts :+ part)
+            case None => PaymentReceived(paymentHash, Seq(part))
+          }
+          receivedByHash + (paymentHash -> received)
+        }.values.toSeq.sortBy(_.timestamp)
     }
 
   override def listRelayed(from: Long, to: Long): Seq[PaymentRelayed] = {
-    var trampolineByHash = Map.empty[ByteVector32, (MilliSatoshi, PublicKey)]
-    using(sqlite.prepareStatement("SELECT * FROM relayed_trampoline WHERE timestamp >= ? AND timestamp < ?")) { statement =>
+    val trampolineByHash = using(sqlite.prepareStatement("SELECT * FROM relayed_trampoline WHERE timestamp >= ? AND timestamp < ?")) { statement =>
       statement.setLong(1, from)
       statement.setLong(2, to)
-      val rs = statement.executeQuery()
-      while (rs.next()) {
-        val paymentHash = rs.getByteVector32("payment_hash")
-        val amount = MilliSatoshi(rs.getLong("amount_msat"))
-        val nodeId = PublicKey(rs.getByteVector("next_node_id"))
-        trampolineByHash += (paymentHash -> (amount, nodeId))
-      }
+      statement.executeQuery()
+        .map { rs =>
+          val paymentHash = rs.getByteVector32("payment_hash")
+          val amount = MilliSatoshi(rs.getLong("amount_msat"))
+          val nodeId = PublicKey(rs.getByteVector("next_node_id"))
+          paymentHash -> (amount, nodeId)
+        }
+        .toMap
     }
-    using(sqlite.prepareStatement("SELECT * FROM relayed WHERE timestamp >= ? AND timestamp < ?")) { statement =>
+    val relayedByHash = using(sqlite.prepareStatement("SELECT * FROM relayed WHERE timestamp >= ? AND timestamp < ?")) { statement =>
       statement.setLong(1, from)
       statement.setLong(2, to)
-      val rs = statement.executeQuery()
-      var relayedByHash = Map.empty[ByteVector32, Seq[RelayedPart]]
-      while (rs.next()) {
-        val paymentHash = rs.getByteVector32("payment_hash")
-        val part = RelayedPart(
-          rs.getByteVector32("channel_id"),
-          MilliSatoshi(rs.getLong("amount_msat")),
-          rs.getString("direction"),
-          rs.getString("relay_type"),
-          rs.getLong("timestamp"))
-        relayedByHash = relayedByHash + (paymentHash -> (relayedByHash.getOrElse(paymentHash, Nil) :+ part))
-      }
-      relayedByHash.flatMap {
-        case (paymentHash, parts) =>
-          // We may have been routing multiple payments for the same payment_hash (MPP) in both cases (trampoline and channel).
-          // NB: we may link the wrong in-out parts, but the overall sum will be correct: we sort by amounts to minimize the risk of mismatch.
-          val incoming = parts.filter(_.direction == "IN").map(p => PaymentRelayed.Part(p.amount, p.channelId)).sortBy(_.amount)
-          val outgoing = parts.filter(_.direction == "OUT").map(p => PaymentRelayed.Part(p.amount, p.channelId)).sortBy(_.amount)
-          parts.headOption match {
-            case Some(RelayedPart(_, _, _, "channel", timestamp)) => incoming.zip(outgoing).map {
-              case (in, out) => ChannelPaymentRelayed(in.amount, out.amount, paymentHash, in.channelId, out.channelId, timestamp)
-            }
-            case Some(RelayedPart(_, _, _, "trampoline", timestamp)) =>
-              val (nextTrampolineAmount, nextTrampolineNodeId) = trampolineByHash.getOrElse(paymentHash, (0 msat, PlaceHolderPubKey))
-              TrampolinePaymentRelayed(paymentHash, incoming, outgoing, nextTrampolineNodeId, nextTrampolineAmount, timestamp) :: Nil
-            case _ => Nil
+      statement.executeQuery()
+        .foldLeft(Map.empty[ByteVector32, Seq[RelayedPart]]) { (relayedByHash, rs) =>
+          val paymentHash = rs.getByteVector32("payment_hash")
+          val part = RelayedPart(
+            rs.getByteVector32("channel_id"),
+            MilliSatoshi(rs.getLong("amount_msat")),
+            rs.getString("direction"),
+            rs.getString("relay_type"),
+            rs.getLong("timestamp"))
+          relayedByHash + (paymentHash -> (relayedByHash.getOrElse(paymentHash, Nil) :+ part))
+        }
+    }
+    relayedByHash.flatMap {
+      case (paymentHash, parts) =>
+        // We may have been routing multiple payments for the same payment_hash (MPP) in both cases (trampoline and channel).
+        // NB: we may link the wrong in-out parts, but the overall sum will be correct: we sort by amounts to minimize the risk of mismatch.
+        val incoming = parts.filter(_.direction == "IN").map(p => PaymentRelayed.Part(p.amount, p.channelId)).sortBy(_.amount)
+        val outgoing = parts.filter(_.direction == "OUT").map(p => PaymentRelayed.Part(p.amount, p.channelId)).sortBy(_.amount)
+        parts.headOption match {
+          case Some(RelayedPart(_, _, _, "channel", timestamp)) => incoming.zip(outgoing).map {
+            case (in, out) => ChannelPaymentRelayed(in.amount, out.amount, paymentHash, in.channelId, out.channelId, timestamp)
           }
-      }.toSeq.sortBy(_.timestamp)
-    }
+          case Some(RelayedPart(_, _, _, "trampoline", timestamp)) =>
+            val (nextTrampolineAmount, nextTrampolineNodeId) = trampolineByHash.getOrElse(paymentHash, (0 msat, PlaceHolderPubKey))
+            TrampolinePaymentRelayed(paymentHash, incoming, outgoing, nextTrampolineNodeId, nextTrampolineAmount, timestamp) :: Nil
+          case _ => Nil
+        }
+    }.toSeq.sortBy(_.timestamp)
   }
 
   override def listNetworkFees(from: Long, to: Long): Seq[NetworkFee] =
     using(sqlite.prepareStatement("SELECT * FROM network_fees WHERE timestamp >= ? AND timestamp < ? ORDER BY timestamp")) { statement =>
       statement.setLong(1, from)
       statement.setLong(2, to)
-      val rs = statement.executeQuery()
-      var q: Queue[NetworkFee] = Queue()
-      while (rs.next()) {
-        q = q :+ NetworkFee(
-          remoteNodeId = PublicKey(rs.getByteVector("node_id")),
-          channelId = rs.getByteVector32("channel_id"),
-          txId = rs.getByteVector32("tx_id"),
-          fee = Satoshi(rs.getLong("fee_sat")),
-          txType = rs.getString("tx_type"),
-          timestamp = rs.getLong("timestamp"))
-      }
-      q
+      statement.executeQuery()
+        .map { rs =>
+          NetworkFee(
+            remoteNodeId = PublicKey(rs.getByteVector("node_id")),
+            channelId = rs.getByteVector32("channel_id"),
+            txId = rs.getByteVector32("tx_id"),
+            fee = Satoshi(rs.getLong("fee_sat")),
+            txType = rs.getString("tx_type"),
+            timestamp = rs.getLong("timestamp"))
+        }.toSeq
     }
 
   override def stats(from: Long, to: Long): Seq[Stats] = {
-    val networkFees = listNetworkFees(from, to).foldLeft(Map.empty[ByteVector32, Satoshi]) { case (feeByChannelId, f) =>
+    val networkFees = listNetworkFees(from, to).foldLeft(Map.empty[ByteVector32, Satoshi]) { (feeByChannelId, f) =>
       feeByChannelId + (f.channelId -> (feeByChannelId.getOrElse(f.channelId, 0 sat) + f.fee))
     }
     case class Relayed(amount: MilliSatoshi, fee: MilliSatoshi, direction: String)
-    val relayed = listRelayed(from, to).foldLeft(Map.empty[ByteVector32, Seq[Relayed]]) { case (previous, e) =>
+    val relayed = listRelayed(from, to).foldLeft(Map.empty[ByteVector32, Seq[Relayed]]) { (previous, e) =>
       // NB: we must avoid counting the fee twice: we associate it to the outgoing channels rather than the incoming ones.
       val current = e match {
         case c: ChannelPaymentRelayed => Map(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -27,7 +27,6 @@ import fr.acinq.eclair.wire.internal.channel.ChannelCodecs.stateDataCodec
 import grizzled.slf4j.Logging
 
 import java.sql.{Connection, Statement}
-import scala.collection.immutable.Queue
 
 class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
 
@@ -135,8 +134,8 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
 
   override def listLocalChannels(): Seq[HasCommitments] = withMetrics("channels/list-local-channels", DbBackends.Sqlite) {
     using(sqlite.createStatement) { statement =>
-      val rs = statement.executeQuery("SELECT data FROM local_channels WHERE is_closed=0")
-      codecSequence(rs, stateDataCodec)
+      statement.executeQuery("SELECT data FROM local_channels WHERE is_closed=0")
+        .mapCodec(stateDataCodec).toSeq
     }
   }
 
@@ -154,12 +153,9 @@ class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
     using(sqlite.prepareStatement("SELECT payment_hash, cltv_expiry FROM htlc_infos WHERE channel_id=? AND commitment_number=?")) { statement =>
       statement.setBytes(1, channelId.toArray)
       statement.setLong(2, commitmentNumber)
-      val rs = statement.executeQuery
-      var q: Queue[(ByteVector32, CltvExpiry)] = Queue()
-      while (rs.next()) {
-        q = q :+ (ByteVector32(rs.getByteVector32("payment_hash")), CltvExpiry(rs.getLong("cltv_expiry")))
-      }
-      q
+      statement.executeQuery
+        .map(rs => (ByteVector32(rs.getByteVector32("payment_hash")), CltvExpiry(rs.getLong("cltv_expiry"))))
+        .toSeq
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -82,8 +82,9 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb with Logging {
   override def getNode(nodeId: Crypto.PublicKey): Option[NodeAnnouncement] = withMetrics("network/get-node", DbBackends.Sqlite) {
     using(sqlite.prepareStatement("SELECT data FROM nodes WHERE node_id=?")) { statement =>
       statement.setBytes(1, nodeId.value.toArray)
-      val rs = statement.executeQuery()
-      codecSequence(rs, nodeAnnouncementCodec).headOption
+      statement.executeQuery()
+        .mapCodec(nodeAnnouncementCodec)
+        .headOption
     }
   }
 
@@ -96,8 +97,8 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb with Logging {
 
   override def listNodes(): Seq[NodeAnnouncement] = withMetrics("network/list-nodes", DbBackends.Sqlite) {
     using(sqlite.createStatement()) { statement =>
-      val rs = statement.executeQuery("SELECT data FROM nodes")
-      codecSequence(rs, nodeAnnouncementCodec)
+      statement.executeQuery("SELECT data FROM nodes")
+        .mapCodec(nodeAnnouncementCodec).toSeq
     }
   }
 
@@ -122,17 +123,15 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb with Logging {
 
   override def listChannels(): SortedMap[ShortChannelId, PublicChannel] = withMetrics("network/list-channels", DbBackends.Sqlite) {
     using(sqlite.createStatement()) { statement =>
-      val rs = statement.executeQuery("SELECT channel_announcement, txid, capacity_sat, channel_update_1, channel_update_2 FROM channels")
-      var m = SortedMap.empty[ShortChannelId, PublicChannel]
-      while (rs.next()) {
-        val ann = channelAnnouncementCodec.decode(rs.getBitVectorOpt("channel_announcement").get).require.value
-        val txId = ByteVector32.fromValidHex(rs.getString("txid"))
-        val capacity = rs.getLong("capacity_sat")
-        val channel_update_1_opt = rs.getBitVectorOpt("channel_update_1").map(channelUpdateCodec.decode(_).require.value)
-        val channel_update_2_opt = rs.getBitVectorOpt("channel_update_2").map(channelUpdateCodec.decode(_).require.value)
-        m = m + (ann.shortChannelId -> PublicChannel(ann, txId, Satoshi(capacity), channel_update_1_opt, channel_update_2_opt, None))
-      }
-      m
+      statement.executeQuery("SELECT channel_announcement, txid, capacity_sat, channel_update_1, channel_update_2 FROM channels")
+        .foldLeft(SortedMap.empty[ShortChannelId, PublicChannel]) { (m, rs) =>
+            val ann = channelAnnouncementCodec.decode(rs.getBitVectorOpt("channel_announcement").get).require.value
+            val txId = ByteVector32.fromValidHex(rs.getString("txid"))
+            val capacity = rs.getLong("capacity_sat")
+            val channel_update_1_opt = rs.getBitVectorOpt("channel_update_1").map(channelUpdateCodec.decode(_).require.value)
+            val channel_update_2_opt = rs.getBitVectorOpt("channel_update_2").map(channelUpdateCodec.decode(_).require.value)
+            m + (ann.shortChannelId -> PublicChannel(ann, txId, Satoshi(capacity), channel_update_1_opt, channel_update_2_opt, None))
+        }
     }
   }
 
@@ -171,8 +170,7 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb with Logging {
   override def isPruned(shortChannelId: ShortChannelId): Boolean = withMetrics("network/is-pruned", DbBackends.Sqlite) {
     using(sqlite.prepareStatement("SELECT short_channel_id from pruned WHERE short_channel_id=?")) { statement =>
       statement.setLong(1, shortChannelId.toLong)
-      val rs = statement.executeQuery()
-      rs.next()
+      statement.executeQuery().next()
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -170,7 +170,7 @@ class SqliteNetworkDb(sqlite: Connection) extends NetworkDb with Logging {
   override def isPruned(shortChannelId: ShortChannelId): Boolean = withMetrics("network/is-pruned", DbBackends.Sqlite) {
     using(sqlite.prepareStatement("SELECT short_channel_id from pruned WHERE short_channel_id=?")) { statement =>
       statement.setLong(1, shortChannelId.toLong)
-      statement.executeQuery().next()
+      statement.executeQuery().nonEmpty
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
@@ -21,7 +21,7 @@ import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db.Monitoring.Tags.DbBackends
 import fr.acinq.eclair.db.PeersDb
-import fr.acinq.eclair.db.sqlite.SqliteUtils.{codecSequence, getVersion, setVersion, using}
+import fr.acinq.eclair.db.sqlite.SqliteUtils.{getVersion, setVersion, using}
 import fr.acinq.eclair.wire.protocol._
 import scodec.bits.BitVector
 
@@ -69,21 +69,21 @@ class SqlitePeersDb(sqlite: Connection) extends PeersDb {
   override def getPeer(nodeId: PublicKey): Option[NodeAddress] = withMetrics("peers/get", DbBackends.Sqlite) {
     using(sqlite.prepareStatement("SELECT data FROM peers WHERE node_id=?")) { statement =>
       statement.setBytes(1, nodeId.value.toArray)
-      val rs = statement.executeQuery()
-      codecSequence(rs, CommonCodecs.nodeaddress).headOption
+      statement.executeQuery()
+        .mapCodec(CommonCodecs.nodeaddress)
+        .headOption
     }
   }
 
   override def listPeers(): Map[PublicKey, NodeAddress] = withMetrics("peers/list", DbBackends.Sqlite) {
     using(sqlite.createStatement()) { statement =>
-      val rs = statement.executeQuery("SELECT node_id, data FROM peers")
-      var m: Map[PublicKey, NodeAddress] = Map()
-      while (rs.next()) {
-        val nodeid = PublicKey(rs.getByteVector("node_id"))
-        val nodeaddress = CommonCodecs.nodeaddress.decode(BitVector(rs.getBytes("data"))).require.value
-        m += (nodeid -> nodeaddress)
-      }
-      m
+      statement.executeQuery("SELECT node_id, data FROM peers")
+        .map { rs =>
+          val nodeid = PublicKey(rs.getByteVector("node_id"))
+          val nodeaddress = CommonCodecs.nodeaddress.decode(BitVector(rs.getBytes("data"))).require.value
+          nodeid -> nodeaddress
+        }
+        .toMap
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteUtils.scala
@@ -16,9 +16,9 @@
 
 package fr.acinq.eclair.db.sqlite
 
-import java.sql.{Connection, Statement}
-
 import fr.acinq.eclair.db.jdbc.JdbcUtils
+
+import java.sql.Connection
 
 object SqliteUtils extends JdbcUtils {
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
@@ -216,7 +216,7 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     peer.send(reconnectionTask, Peer.Connect(remoteNodeId, None))
 
     // assert our mock server got an incoming connection (the client was spawned with the address from node_announcement)
-    awaitCond(mockServer.accept() != null, max = 30 seconds, interval = 1 second)
+    awaitCond(mockServer.accept() != null, max = 60 seconds, interval = 1 second)
     mockServer.close()
   }
 


### PR DESCRIPTION
This allows us to use the full power of scala collections, to iterate
over results, convert to options, etc. while staying purely functional
and immutable.

There is a catch though: the iterator is lazy, it must be materialized
before the result set is closed, by converting the end result in a
collection or an option. In other words, database methods must never
return an `Iterable` or `Iterator`.