### PR TITLE
Symmetrical HTLC limits

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -65,8 +65,9 @@ eclair {
 
   dust-limit-satoshis = 546
   max-remote-dust-limit-satoshis = 600
-  max-htlc-value-in-flight-msat = 5000000000 // 50 mBTC
   htlc-minimum-msat = 1
+  // The following parameters apply to each HTLC direction (incoming or outgoing), which means that the total HTLC limits will be twice what is set here
+  max-htlc-value-in-flight-msat = 5000000000 // 50 mBTC
   max-accepted-htlcs = 30
 
   reserve-to-funding-ratio = 0.01 // recommended by BOLT #2

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -106,7 +106,7 @@ object TestConstants {
         defaultFeerateTolerance = FeerateTolerance(0.5, 8.0, anchorOutputsFeeratePerKw),
         perNodeFeerateTolerance = Map.empty
       ),
-      maxHtlcValueInFlightMsat = UInt64(150000000),
+      maxHtlcValueInFlightMsat = UInt64(500000000),
       maxAcceptedHtlcs = 100,
       expiryDelta = CltvExpiryDelta(144),
       fulfillSafetyBeforeTimeout = CltvExpiryDelta(6),


### PR DESCRIPTION
The spec defines `max_accepted_htlcs` and `max_htlc_value_in_flight_msat` to let nodes reduce their exposure to pending HTLCs. This only applies to received HTLCs, and we use the remote peer's values for outgoing HTLCs.

But when we're more restrictive than our peer, it makes sense to apply our limits to outgoing HTLCs as well.