### PR TITLE
(Minor) Fix eventually statements

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PgUtilsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PgUtilsSpec.scala
@@ -42,7 +42,7 @@ class PgUtilsSpec extends TestKitBaseClass with AnyFunSuiteLike with Eventually 
 
     // we close the first connection
     db.dataSource.close()
-    eventually(db.dataSource.isClosed)
+    eventually(assert(db.dataSource.isClosed))
     // we wait just a bit longer than the lease interval
     Thread.sleep(6_000)
 
@@ -52,7 +52,7 @@ class PgUtilsSpec extends TestKitBaseClass with AnyFunSuiteLike with Eventually 
 
     // we close the second connection
     db.dataSource.close()
-    eventually(db.dataSource.isClosed)
+    eventually(assert(db.dataSource.isClosed))
 
     // but we don't wait for the previous lease to expire, so we can't take over right now
     assert(intercept[LockFailureHandler.LockException] {
@@ -73,7 +73,7 @@ class PgUtilsSpec extends TestKitBaseClass with AnyFunSuiteLike with Eventually 
 
     // we close the first connection
     db.dataSource.close()
-    eventually(db.dataSource.isClosed)
+    eventually(assert(db.dataSource.isClosed))
 
     // here we change the config to simulate an involuntary change in the server we connect to
     val config1 = ConfigFactory.parseString("postgres.port=1234").withFallback(config)


### PR DESCRIPTION
With the move to akka _typed_, we will be using more and more
scalatest's `eventually` as a replacement for akka's `awaitCond`
(which isn't available in `testkit.typed`).

But there is a catch:
- `awaitCond` expects a boolean
- `eventually` expects a non-failure

Which means that we must use `eventually(assert(cond))`, and not
`eventually(cond)`.