### PR TITLE
Make `Setup.datadir` a val

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -67,7 +67,7 @@ import scala.util.{Failure, Success}
  * @param seeds_opt    optional seeds, if set eclair will use them instead of generating them and won't create a node_seed.dat and channel_seed.dat files.
  * @param db           optional databases to use, if not set eclair will create the necessary databases
  */
-class Setup(datadir: File,
+class Setup(val datadir: File,
             pluginParams: Seq[PluginParams],
             seeds_opt: Option[Seeds] = None,
             db: Option[Databases] = None)(implicit system: ActorSystem) extends Logging {


### PR DESCRIPTION
This will allow plugins to know where the Eclair datadir is and look for their files in that dir. Fixes https://github.com/ACINQ/eclair/issues/1830