### PR TITLE
Use bitcoin-lib 0.19

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
@@ -162,7 +162,7 @@ class NegotiatingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val tx = bob.stateData.asInstanceOf[DATA_NEGOTIATING].commitments.localCommit.publishableTxs.commitTx.tx
     sender.send(bob, aliceCloseSig.copy(feeSatoshis = 99000 sat)) // sig doesn't matter, it is checked later
     val error = bob2alice.expectMsgType[Error]
-    assert(new String(error.data.toArray).startsWith("invalid close fee: fee_satoshis=Satoshi(99000)"))
+    assert(new String(error.data.toArray).startsWith("invalid close fee: fee_satoshis=99000 sat"))
     assert(bob2blockchain.expectMsgType[PublishRawTx].tx === tx)
     bob2blockchain.expectMsgType[PublishTx]
     bob2blockchain.expectMsgType[WatchTxConfirmed]

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <akka.version>2.6.10</akka.version>
         <akka.http.version>10.2.0</akka.http.version>
         <sttp.version>1.7.2</sttp.version>
-        <bitcoinlib.version>0.18</bitcoinlib.version>
+        <bitcoinlib.version>0.19</bitcoinlib.version>
         <guava.version>24.0-android</guava.version>
         <kamon.version>2.1.0</kamon.version>
     </properties>


### PR DESCRIPTION
There are no functional changes, but bitcoin-lib 0.19 is based on secp256k1-kmp (instead of our own fork of secp256k1's JNI wrapper) which is cleaner, easier to maintain and used in our mobile apps.