### PR TITLE
Udpate to Bitcoin Core 0.21.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You will find detailed guides and frequently asked questions there.
 
 ### Configuring Bitcoin Core
 
-:warning: Eclair requires Bitcoin Core 0.18.1, 0.19.1 or 0.20.1. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
+:warning: Eclair requires Bitcoin Core 0.20.1 or 0.21.1. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
 
 Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
 

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -88,9 +88,9 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-0.20.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
-                <bitcoind.md5>265d32d3f7645d0a4fe27a698bb8b3b3</bitcoind.md5>
-                <bitcoind.sha1>5a814f983cd32a0dea67a9c3c36d494130cad7c5</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.21.1/bitcoin-0.21.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
+                <bitcoind.md5>e283a98b5e9f0b58e625e1dde661201d</bitcoind.md5>
+                <bitcoind.sha1>5101e29b39c33cc8e40d5f3b46dda37991b037a0</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -101,9 +101,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-0.20.1-osx64.tar.gz</bitcoind.url>
-                <bitcoind.md5>765fcc62c3ef470cbc23933c31c2e2f2</bitcoind.md5>
-                <bitcoind.sha1>2c1ba1a4c05448b81da2161aa3ab94c047681e7b</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.21.1/bitcoin-0.21.1-osx64.tar.gz</bitcoind.url>
+                <bitcoind.md5>dfd1f323678eede14ae2cf6afb26ff6a</bitcoind.md5>
+                <bitcoind.sha1>4273696f90a2648f90142438221f5d1ade16afa2</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -114,9 +114,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.20.1/bitcoin-0.20.1-win64.zip</bitcoind.url>
-                <bitcoind.md5>966568365067add2744ae4030c0d4165</bitcoind.md5>
-                <bitcoind.sha1>4fe72c5848a2ddc462083db891d6820a6f4ef2ee</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.21.1/bitcoin-0.21.1-win64.zip</bitcoind.url>
+                <bitcoind.md5>1c6f5081ea68dcec7eddb9e6cdfc508d</bitcoind.md5>
+                <bitcoind.sha1>a782cd413fc736f05fad3831d6a9f59dde779520</bitcoind.sha1>
             </properties>
         </profile>
     </profiles>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -53,7 +53,7 @@ trait BitcoindService extends Logging {
   val INTEGRATION_TMP_DIR: File = TestUtils.newIntegrationTmpDir()
   logger.info(s"using tmp dir: $INTEGRATION_TMP_DIR")
 
-  val PATH_BITCOIND = new File(TestUtils.BUILD_DIRECTORY, "bitcoin-0.20.1/bin/bitcoind")
+  val PATH_BITCOIND = new File(TestUtils.BUILD_DIRECTORY, "bitcoin-0.21.1/bin/bitcoind")
   val PATH_BITCOIND_DATADIR = new File(INTEGRATION_TMP_DIR, "datadir-bitcoin")
 
   var bitcoind: Process = _


### PR DESCRIPTION
Update the default version of `bitcoind` to 0.21.1.
Deprecate support for version 0.18.1 and 0.19.1.

Nothing impacting changed between 0.20.1 and 0.21.1.
The only change relevant to lightning would be the following:

```
A new fee_rate parameter/option denominated in satoshis per vbyte (sat/vB) is introduced to the sendtoaddress, sendmany, fundrawtransaction and walletcreatefundedpsbt RPCs as well as to the experimental new send RPC.
```

But we will be able to leverage it only once we deprecate versions of `bitcoind` older than 0.21.1.

There's also a change that may be useful in tests (in particular for the `TxPublisher`):

```
The generateblock RPC allows testers using regtest mode to generate blocks that consist of a custom set of transactions. (#17693)
```