### PR TITLE
Explicit channel type negotiation

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -54,10 +54,21 @@ eclair {
     trampoline_payment = disabled
     keysend = disabled
   }
+  channel-types {
+    // The following parameter contains the list of all supported lightning transaction formats (order by preference).
+    // You can reorder this list or remove entries to change what types of channels can be created.
+    commitment-format = [
+      // standard lightning channels with option_static_remotekey applied (simplified funds recovery in case of data loss)
+      "static_remotekey",
+      // standard lightning channels (as defined in v1.0 of the LN specification)
+      "standard"
+    ]
+  }
   override-features = [ // optional per-node features
     #  {
     #    nodeid = "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     #    features { }
+    #    channel-types { }
     #  }
   ]
   sync-whitelist = [] // a list of public keys; if non-empty, we will only do the initial sync with those peers
@@ -321,6 +332,6 @@ akka {
       backend.min-nr-of-members = 1
       frontend.min-nr-of-members = 0
     }
-    seed-nodes = [ "akka://eclair-node@127.0.0.1:25520" ]
+    seed-nodes = ["akka://eclair-node@127.0.0.1:25520"]
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -20,7 +20,7 @@ import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin.{ByteVector32, Satoshi, Transaction}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.wire.protocol.{AnnouncementSignatures, Error, UpdateAddHtlc}
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, MilliSatoshi, UInt64}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshi, UInt64}
 
 /**
  * Created by PM on 11/04/2017.
@@ -40,6 +40,7 @@ case class InvalidChainHash                        (override val channelId: Byte
 case class InvalidFundingAmount                    (override val channelId: ByteVector32, fundingAmount: Satoshi, min: Satoshi, max: Satoshi) extends ChannelException(channelId, s"invalid funding_satoshis=$fundingAmount (min=$min max=$max)")
 case class InvalidPushAmount                       (override val channelId: ByteVector32, pushAmount: MilliSatoshi, max: MilliSatoshi) extends ChannelException(channelId, s"invalid pushAmount=$pushAmount (max=$max)")
 case class InvalidMaxAcceptedHtlcs                 (override val channelId: ByteVector32, maxAcceptedHtlcs: Int, max: Int) extends ChannelException(channelId, s"invalid max_accepted_htlcs=$maxAcceptedHtlcs (max=$max)")
+case class IncompatibleChannelTypes                (override val channelId: ByteVector32, supportedChannelTypes: Seq[Features]) extends ChannelException(channelId, s"incompatible channel types (we support ${supportedChannelTypes.map(_.toByteVector.toHex).mkString(" or ")})")
 case class DustLimitTooSmall                       (override val channelId: ByteVector32, dustLimit: Satoshi, min: Satoshi) extends ChannelException(channelId, s"dustLimit=$dustLimit is too small (min=$min)")
 case class DustLimitTooLarge                       (override val channelId: ByteVector32, dustLimit: Satoshi, max: Satoshi) extends ChannelException(channelId, s"dustLimit=$dustLimit is too large (max=$max)")
 case class DustLimitAboveOurChannelReserve         (override val channelId: ByteVector32, dustLimit: Satoshi, channelReserve: Satoshi) extends ChannelException(channelId, s"dustLimit=$dustLimit is above our channelReserve=$channelReserve")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -483,6 +483,8 @@ object ChannelFlags {
   val Empty = 0x00.toByte
 }
 
+case class ChannelType(features: Features)
+
 case class ChannelVersion(bits: BitVector) {
   import ChannelVersion._
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/ChannelTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/ChannelTlv.scala
@@ -16,9 +16,10 @@
 
 package fr.acinq.eclair.wire.protocol
 
-import fr.acinq.eclair.UInt64
-import fr.acinq.eclair.wire.protocol.TlvCodecs.tlvStream
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
+import fr.acinq.eclair.wire.protocol.LightningMessageCodecs.featuresCodec
+import fr.acinq.eclair.wire.protocol.TlvCodecs.tlvStream
+import fr.acinq.eclair.{Features, UInt64}
 import scodec.Codec
 import scodec.bits.ByteVector
 import scodec.codecs._
@@ -40,8 +41,11 @@ object OpenChannelTlv {
 
   import ChannelTlv._
 
+  case class ChannelTypes(proposed: List[Features]) extends OpenChannelTlv
+
   val openTlvCodec: Codec[TlvStream[OpenChannelTlv]] = tlvStream(discriminated[OpenChannelTlv].by(varint)
     .typecase(UInt64(0), variableSizeBytesLong(varintoverflow, bytes).as[UpfrontShutdownScript])
+    .typecase(UInt64(1), variableSizeBytesLong(varintoverflow, list(featuresCodec)).as[ChannelTypes])
   )
 
 }
@@ -50,7 +54,11 @@ object AcceptChannelTlv {
 
   import ChannelTlv._
 
+  case class ChannelType(features: Features) extends AcceptChannelTlv
+
   val acceptTlvCodec: Codec[TlvStream[AcceptChannelTlv]] = tlvStream(discriminated[AcceptChannelTlv].by(varint)
     .typecase(UInt64(0), variableSizeBytesLong(varintoverflow, bytes).as[UpfrontShutdownScript])
+    .typecase(UInt64(1), variableSizeBytesLong(varintoverflow, featuresCodec).as[ChannelType])
   )
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
@@ -87,7 +87,9 @@ case class OpenChannel(chainHash: ByteVector32,
                        htlcBasepoint: PublicKey,
                        firstPerCommitmentPoint: PublicKey,
                        channelFlags: Byte,
-                       tlvStream: TlvStream[OpenChannelTlv] = TlvStream.empty) extends ChannelMessage with HasTemporaryChannelId with HasChainHash
+                       tlvStream: TlvStream[OpenChannelTlv] = TlvStream.empty) extends ChannelMessage with HasTemporaryChannelId with HasChainHash {
+  val channelTypes: List[Features] = tlvStream.get[OpenChannelTlv.ChannelTypes].map(_.proposed).getOrElse(Nil)
+}
 
 case class AcceptChannel(temporaryChannelId: ByteVector32,
                          dustLimitSatoshis: Satoshi,
@@ -103,7 +105,9 @@ case class AcceptChannel(temporaryChannelId: ByteVector32,
                          delayedPaymentBasepoint: PublicKey,
                          htlcBasepoint: PublicKey,
                          firstPerCommitmentPoint: PublicKey,
-                         tlvStream: TlvStream[AcceptChannelTlv] = TlvStream.empty) extends ChannelMessage with HasTemporaryChannelId
+                         tlvStream: TlvStream[AcceptChannelTlv] = TlvStream.empty) extends ChannelMessage with HasTemporaryChannelId {
+  val channelType_opt: Option[Features] = tlvStream.get[AcceptChannelTlv.ChannelType].map(_.features)
+}
 
 case class FundingCreated(temporaryChannelId: ByteVector32,
                           fundingTxid: ByteVector32,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -20,7 +20,7 @@ import fr.acinq.bitcoin.{Block, ByteVector32, Satoshi, SatoshiLong, Script}
 import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
 import fr.acinq.eclair.Features._
 import fr.acinq.eclair.blockchain.fee.{FeeEstimator, FeeTargets, FeeratesPerKw, OnChainFeeConf, _}
-import fr.acinq.eclair.channel.LocalParams
+import fr.acinq.eclair.channel.{ChannelType, LocalParams}
 import fr.acinq.eclair.crypto.keymanager.{LocalChannelKeyManager, LocalNodeKeyManager}
 import fr.acinq.eclair.io.{Peer, PeerConnection}
 import fr.acinq.eclair.router.Router.RouterConf
@@ -93,6 +93,7 @@ object TestConstants {
         ),
         Set(UnknownFeature(TestFeature.optional))
       ),
+      channelTypes = List(ChannelType(Features.empty)),
       pluginParams = List(pluginParams),
       overrideFeatures = Map.empty,
       syncWhitelist = Set.empty,
@@ -199,6 +200,7 @@ object TestConstants {
         PaymentSecret -> Mandatory,
         BasicMultiPartPayment -> Optional
       ),
+      channelTypes = List(ChannelType(Features.empty)),
       pluginParams = Nil,
       overrideFeatures = Map.empty,
       syncWhitelist = Set.empty,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenChannelStateSpec.scala
@@ -22,8 +22,8 @@ import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.states.{StateTestsBase, StateTestsTags}
-import fr.acinq.eclair.wire.protocol.{AcceptChannel, ChannelTlv, Error, Init, OpenChannel, TlvStream}
-import fr.acinq.eclair.{CltvExpiryDelta, MilliSatoshiLong, TestConstants, TestKitBaseClass, ToMilliSatoshiConversion}
+import fr.acinq.eclair.wire.protocol.{AcceptChannel, ChannelTlv, Error, Init, OpenChannel}
+import fr.acinq.eclair.{CltvExpiryDelta, Features, MilliSatoshiLong, TestConstants, TestKitBaseClass, ToMilliSatoshiConversion}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.{Outcome, Tag}
 import scodec.bits.ByteVector
@@ -63,7 +63,8 @@ class WaitForOpenChannelStateSpec extends TestKitBaseClass with FixtureAnyFunSui
     import f._
     val open = alice2bob.expectMsgType[OpenChannel]
     // Since https://github.com/lightningnetwork/lightning-rfc/pull/714 we must include an empty upfront_shutdown_script.
-    assert(open.tlvStream === TlvStream(ChannelTlv.UpfrontShutdownScript(ByteVector.empty)))
+    assert(open.tlvStream.get[ChannelTlv.UpfrontShutdownScript] === Some(ChannelTlv.UpfrontShutdownScript(ByteVector.empty)))
+    assert(open.channelTypes === List(Features.empty))
     alice2bob.forward(bob)
     awaitCond(bob.stateName == WAIT_FOR_FUNDING_CREATED)
   }


### PR DESCRIPTION
This PR implements https://github.com/lightningnetwork/lightning-rfc/pull/880

Now that we have multiple types of channels ("standard" channels, static remote key, anchor outputs and anchor outputs with 0-fee htlc txs), we need a mechanism to choose which one we want to use when a new channel is opened. Up until now, this choice was made based only on feature bits (from the `init` message) and considering that the newest channel type was always better.

That deterministic behavior is quite limiting: what if we want to experiment with anchor outputs (or another commitment type) by opening a few channels that we carefully control and monitor, while keeping a reduced exposure to it? You must activate the feature, which means that any node that also has the feature and sends you an `open_channel` message will be able to create an anchor outputs channel - and you can say goodbye to your limited exposure.

In order to fix this, we introduce an explicit negotiation of what channel type to use.
In `open_channel`, the funder sends the list of channel types it supports, ordered by preference.
The fundee chooses one that he likes and sends its response in `accept_channel`.
If the fundee doesn't want any of these channel types, it can reject the channel open.

That unblocks the scenario described above. A node that wants to experiment with anchor outputs can activate the feature without putting it into its list of supported channel types. It will safely reject all `open_channel` that use anchor outputs, and can manually open some anchor output channels by overriding the default list of channel types through the `open` API.

While it sounds simple, it raises a few issues. First of all, I don't like our current `ChannelVersion`. This is not a channel "version" and it contains two very different things: a set of channel features (standard vs static_remotekey vs anchor_outputs) and a set of internal configurations (a key derivation scheme). I'd like to rename it to a `ChannelInternalConfig` that currently only contains `USE_PUBKEY_KEYPATH` (and maybe later contains others choices of key derivation based on user preference). And we should store separately the `channel_type` (which is in fact the set of Bolt 9 features that govern the channel's behavior). This will become even more true as we add more channel features to the spec that are orthogonal to the commitment format (such as `option_simplified_commitment`, which would change the rules of who can send what messages when). The issue is that this requires a migration on the channels codec, which is a bit overkill for just this small change. But since https://github.com/ACINQ/eclair/pull/1846 requires a channel codec change, we could bundle these two changes together.

Second, what do we do with peers that *don't* support explicit channel type negotiation (which isn't advertised via a feature bit)? When we're fundee, it's simple: when we receive `open_channel` we can decide whether we want to accept the channel or not. But when we're funder it's more tricky: we will discover if they support it only when we receive `accept_channel`, and then it's too late, if they didn't support channel type negotiation we have to configure the channel based on feature bits only. It means that if we have activated anchor outputs, but send a `channel_open` *without* anchor outputs in it (because we're still experimenting with it only on a limited set of channels) and the fundee doesn't support negotiation, we should open an anchor outputs channel. Currently that's the behavior I've kept, but we could change it to fail the channel when we receive `accept_channel`. I think it would be the right thing to do, otherwise node operators may be surprised by the resulting channel.

Thoughts?