### PR TITLE
Reject 0-value trampoline payments

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -111,6 +111,8 @@ object NodeRelay {
       Some(TrampolineExpiryTooSoon)
     } else if (payloadOut.invoiceFeatures.isDefined && payloadOut.paymentSecret.isEmpty) {
       Some(InvalidOnionPayload(UInt64(8), 0)) // payment secret field is missing
+    } else if (payloadOut.amountToForward <= MilliSatoshi(0)) {
+      Some(InvalidOnionPayload(UInt64(2), 0))
     } else {
       None
     }


### PR DESCRIPTION
It doesn't make any sense to forward empty payments.
This is also checked when adding the htlcs in the outgoing channel, but we should fail early in the node-relay actor.