### PR TITLE
Fix default file backup config

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -236,14 +236,14 @@ eclair {
       }
     }
   }
-}
 
-file-backup {
-  enabled = true // enable the automatic sqlite db backup; do not change this unless you know what you are doing
-  interval = 10 seconds // interval between two backups
-  target-file = "eclair.sqlite.bak" // name of the target backup file; will be placed under the chain directory
-  // override this with a script/exe that will be called everytime a new database backup has been created
-  # notify-script = "/absolute/path/to/script.sh"
+  file-backup {
+    enabled = true // enable the automatic sqlite db backup; do not change this unless you know what you are doing
+    interval = 10 seconds // interval between two backups
+    target-file = "eclair.sqlite.bak" // name of the target backup file; will be placed under the chain directory
+    // override this with a script/exe that will be called everytime a new database backup has been created
+    # notify-script = "/absolute/path/to/script.sh"
+  }
 }
 
 akka {


### PR DESCRIPTION
The `file-backup` section should be inside `eclair`, otherwise startup fails.