### PR TITLE
Use warning messages for connection issues

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1703,18 +1703,17 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
     // we will eventually receive their channel_reestablish.
     case Event(_: FundingLocked, d) =>
       log.warning("received funding_locked before channel_reestablish (known lnd bug): disconnecting...")
-      send(Warning(d.channelId, "spec violation: you sent funding_locked before channel_reestablish"))
-      peer ! Peer.Disconnect(remoteNodeId)
-      stay
+      // NB: we use a small delay to ensure we've sent our warning before disconnecting.
+      context.system.scheduler.scheduleOnce(2 second, peer, Peer.Disconnect(remoteNodeId))
+      stay sending Warning(d.channelId, "spec violation: you sent funding_locked before channel_reestablish")
 
     // This handler is a workaround for an issue in lnd similar to the one above: they sometimes send announcement_signatures
     // before channel_reestablish, which is a minor spec violation. It doesn't halt the channel, we can simply postpone
     // that message.
     case Event(remoteAnnSigs: AnnouncementSignatures, d) =>
       log.warning("received announcement_signatures before channel_reestablish (known lnd bug): delaying...")
-      send(Warning(d.channelId, "spec violation: you sent announcement_signatures before channel_reestablish"))
       context.system.scheduler.scheduleOnce(5 seconds, self, remoteAnnSigs)
-      stay
+      stay sending Warning(d.channelId, "spec violation: you sent announcement_signatures before channel_reestablish")
 
     case Event(ProcessCurrentBlockCount(c), d: HasCommitments) => handleNewBlock(c, d)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -106,7 +106,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: EclairWa
         stay
 
       case Event(warning: Warning, _: ConnectedData) =>
-        log.warning("peer sent warning: {}", warning.channelId, warning.toAscii)
+        log.warning("peer sent warning: {}", warning.toAscii)
         // NB: we don't forward warnings to the channel actors, they shouldn't take any automatic action.
         // It's up to the node operator to decide what to do to address the warning.
         stay
@@ -318,7 +318,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: EclairWa
   }
 
   def replyUnknownChannel(peerConnection: ActorRef, unknownChannelId: ByteVector32): Unit = {
-    val msg = Error(unknownChannelId, UNKNOWN_CHANNEL_MESSAGE)
+    val msg = Warning(unknownChannelId, "unknown channel")
     logMessage(msg, "OUT")
     peerConnection ! msg
   }
@@ -361,10 +361,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: EclairWa
 
 object Peer {
 
-  // @formatter:off
   val CHANNELID_ZERO: ByteVector32 = ByteVector32.Zeroes
-  val UNKNOWN_CHANNEL_MESSAGE: ByteVector = ByteVector.view("unknown channel".getBytes())
-  // @formatter:on
 
   trait ChannelFactory {
     def spawn(context: ActorContext, remoteNodeId: PublicKey, origin_opt: Option[ActorRef]): ActorRef

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -208,8 +208,8 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
             cancelTimer(PingTimeout.toString())
           // we don't need to call scheduleNextPing here, the next ping was already scheduled when we received that pong
           case _ =>
-            log.debug(s"received unexpected pong with size=${data.length}")
-            d.transport ! Warning(s"invalid pong length (${data.length})")
+            log.debug(s"received unexpected pong with length=${data.length}")
+            d.transport ! Warning(s"invalid pong with length=${data.length}")
         }
         stay using d.copy(expectedPong_opt = None)
 


### PR DESCRIPTION
https://github.com/lightningnetwork/lightning-rfc/pull/834 recommends sending warning messages instead of connection-level errors in some cases, which avoids unnecessary channel closure.