### PR TITLE
Use schemas in Postgres

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
@@ -41,7 +41,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
   import lock._
 
   val DB_NAME = "channels"
-  val CURRENT_VERSION = 5
+  val CURRENT_VERSION = 6
 
   inTransaction { pg =>
     using(pg.createStatement()) { statement =>
@@ -66,32 +66,47 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
 
       def migration45(statement: Statement): Unit = {
         statement.executeUpdate("ALTER TABLE local_channels ADD COLUMN json JSONB")
-        resetJsonColumns(pg)
+        resetJsonColumns(pg, oldTableName = true)
         statement.executeUpdate("ALTER TABLE local_channels ALTER COLUMN json SET NOT NULL")
         statement.executeUpdate("CREATE INDEX local_channels_type_idx ON local_channels ((json->>'type'))")
         statement.executeUpdate("CREATE INDEX local_channels_remote_node_id_idx ON local_channels ((json->'commitments'->'remoteParams'->>'nodeId'))")
       }
 
+      def migration56(statement: Statement): Unit = {
+        statement.executeUpdate("CREATE SCHEMA IF NOT EXISTS local")
+        statement.executeUpdate("ALTER TABLE local_channels SET SCHEMA local")
+        statement.executeUpdate("ALTER TABLE local.local_channels RENAME TO channels")
+        statement.executeUpdate("ALTER TABLE htlc_infos SET SCHEMA local")
+      }
+
       getVersion(statement, DB_NAME) match {
         case None =>
-          statement.executeUpdate("CREATE TABLE local_channels (channel_id TEXT NOT NULL PRIMARY KEY, data BYTEA NOT NULL, json JSONB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT FALSE, created_timestamp TIMESTAMP WITH TIME ZONE, last_payment_sent_timestamp TIMESTAMP WITH TIME ZONE, last_payment_received_timestamp TIMESTAMP WITH TIME ZONE, last_connected_timestamp TIMESTAMP WITH TIME ZONE, closed_timestamp TIMESTAMP WITH TIME ZONE)")
-          statement.executeUpdate("CREATE TABLE htlc_infos (channel_id TEXT NOT NULL, commitment_number BIGINT NOT NULL, payment_hash TEXT NOT NULL, cltv_expiry BIGINT NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
+          statement.executeUpdate("CREATE SCHEMA IF NOT EXISTS local")
 
-          statement.executeUpdate("CREATE INDEX local_channels_type_idx ON local_channels ((json->>'type'))")
-          statement.executeUpdate("CREATE INDEX local_channels_remote_node_id_idx ON local_channels ((json->'commitments'->'remoteParams'->>'nodeId'))")
-          statement.executeUpdate("CREATE INDEX htlc_infos_idx ON htlc_infos(channel_id, commitment_number)")
+          statement.executeUpdate("CREATE TABLE local.channels (channel_id TEXT NOT NULL PRIMARY KEY, data BYTEA NOT NULL, json JSONB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT FALSE, created_timestamp TIMESTAMP WITH TIME ZONE, last_payment_sent_timestamp TIMESTAMP WITH TIME ZONE, last_payment_received_timestamp TIMESTAMP WITH TIME ZONE, last_connected_timestamp TIMESTAMP WITH TIME ZONE, closed_timestamp TIMESTAMP WITH TIME ZONE)")
+          statement.executeUpdate("CREATE TABLE local.htlc_infos (channel_id TEXT NOT NULL, commitment_number BIGINT NOT NULL, payment_hash TEXT NOT NULL, cltv_expiry BIGINT NOT NULL, FOREIGN KEY(channel_id) REFERENCES local.channels(channel_id))")
+
+          statement.executeUpdate("CREATE INDEX local_channels_type_idx ON local.channels ((json->>'type'))")
+          statement.executeUpdate("CREATE INDEX local_channels_remote_node_id_idx ON local.channels ((json->'commitments'->'remoteParams'->>'nodeId'))")
+          statement.executeUpdate("CREATE INDEX htlc_infos_idx ON local.htlc_infos(channel_id, commitment_number)")
         case Some(v@2) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
           migration23(statement)
           migration34(statement)
           migration45(statement)
+          migration56(statement)
         case Some(v@3) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
           migration34(statement)
           migration45(statement)
+          migration56(statement)
         case Some(v@4) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
           migration45(statement)
+          migration56(statement)
+        case Some(v@5) =>
+          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
+          migration56(statement)
         case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
       }
@@ -100,10 +115,11 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
   }
 
   /** Sometimes we may want to do a full reset when we update the json format */
-  def resetJsonColumns(connection: Connection): Unit = {
+  def resetJsonColumns(connection: Connection, oldTableName: Boolean = false): Unit = {
+    val table = if (oldTableName) "local_channels" else "local.channels"
     migrateTable(connection, connection,
-      "local_channels",
-      "UPDATE local_channels SET json=?::JSONB WHERE channel_id=?",
+      table,
+      s"UPDATE $table SET json=?::JSONB WHERE channel_id=?",
       (rs, statement) => {
         val state = stateDataCodec.decode(BitVector(rs.getBytes("data"))).require.value
         val json = serialization.writePretty(state)
@@ -118,7 +134,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
       val data = stateDataCodec.encode(state).require.toByteArray
       using(pg.prepareStatement(
         """
-          | INSERT INTO local_channels (channel_id, data, json, is_closed)
+          | INSERT INTO local.channels (channel_id, data, json, is_closed)
           | VALUES (?, ?, ?::JSONB, FALSE)
           | ON CONFLICT (channel_id)
           | DO UPDATE SET data = EXCLUDED.data, json = EXCLUDED.json ;
@@ -136,7 +152,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
    */
   private def updateChannelMetaTimestampColumn(channelId: ByteVector32, columnName: String): Unit = {
     inTransaction(IsolationLevel.TRANSACTION_READ_UNCOMMITTED) { pg =>
-      using(pg.prepareStatement(s"UPDATE local_channels SET $columnName=? WHERE channel_id=?")) { statement =>
+      using(pg.prepareStatement(s"UPDATE local.channels SET $columnName=? WHERE channel_id=?")) { statement =>
         statement.setTimestamp(1, Timestamp.from(Instant.now()))
         statement.setString(2, channelId.toHex)
         statement.executeUpdate()
@@ -158,17 +174,17 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
 
   override def removeChannel(channelId: ByteVector32): Unit = withMetrics("channels/remove-channel", DbBackends.Postgres) {
     withLock { pg =>
-      using(pg.prepareStatement("DELETE FROM pending_settlement_commands WHERE channel_id=?")) { statement =>
+      using(pg.prepareStatement("DELETE FROM local.pending_settlement_commands WHERE channel_id=?")) { statement =>
         statement.setString(1, channelId.toHex)
         statement.executeUpdate()
       }
 
-      using(pg.prepareStatement("DELETE FROM htlc_infos WHERE channel_id=?")) { statement =>
+      using(pg.prepareStatement("DELETE FROM local.htlc_infos WHERE channel_id=?")) { statement =>
         statement.setString(1, channelId.toHex)
         statement.executeUpdate()
       }
 
-      using(pg.prepareStatement("UPDATE local_channels SET is_closed=TRUE WHERE channel_id=?")) { statement =>
+      using(pg.prepareStatement("UPDATE local.channels SET is_closed=TRUE WHERE channel_id=?")) { statement =>
         statement.setString(1, channelId.toHex)
         statement.executeUpdate()
       }
@@ -178,7 +194,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
   override def listLocalChannels(): Seq[HasCommitments] = withMetrics("channels/list-local-channels", DbBackends.Postgres) {
     withLock { pg =>
       using(pg.createStatement) { statement =>
-        statement.executeQuery("SELECT data FROM local_channels WHERE is_closed=FALSE")
+        statement.executeQuery("SELECT data FROM local.channels WHERE is_closed=FALSE")
           .mapCodec(stateDataCodec).toSeq
       }
     }
@@ -186,7 +202,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
 
   override def addHtlcInfo(channelId: ByteVector32, commitmentNumber: Long, paymentHash: ByteVector32, cltvExpiry: CltvExpiry): Unit = withMetrics("channels/add-htlc-info", DbBackends.Postgres) {
     withLock { pg =>
-      using(pg.prepareStatement("INSERT INTO htlc_infos VALUES (?, ?, ?, ?)")) { statement =>
+      using(pg.prepareStatement("INSERT INTO local.htlc_infos VALUES (?, ?, ?, ?)")) { statement =>
         statement.setString(1, channelId.toHex)
         statement.setLong(2, commitmentNumber)
         statement.setString(3, paymentHash.toHex)
@@ -198,7 +214,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
 
   override def listHtlcInfos(channelId: ByteVector32, commitmentNumber: Long): Seq[(ByteVector32, CltvExpiry)] = withMetrics("channels/list-htlc-infos", DbBackends.Postgres) {
     withLock { pg =>
-      using(pg.prepareStatement("SELECT payment_hash, cltv_expiry FROM htlc_infos WHERE channel_id=? AND commitment_number=?")) { statement =>
+      using(pg.prepareStatement("SELECT payment_hash, cltv_expiry FROM local.htlc_infos WHERE channel_id=? AND commitment_number=?")) { statement =>
         statement.setString(1, channelId.toHex)
         statement.setLong(2, commitmentNumber)
         statement.executeQuery

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
@@ -38,7 +38,7 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
   import fr.acinq.eclair.json.JsonSerializers.{formats, serialization}
 
   val DB_NAME = "network"
-  val CURRENT_VERSION = 3
+  val CURRENT_VERSION = 4
 
   inTransaction { pg =>
     using(pg.createStatement()) { statement =>
@@ -48,19 +48,33 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
         statement.executeUpdate("ALTER TABLE channels ADD COLUMN channel_announcement_json JSONB")
         statement.executeUpdate("ALTER TABLE channels ADD COLUMN channel_update_1_json JSONB")
         statement.executeUpdate("ALTER TABLE channels ADD COLUMN channel_update_2_json JSONB")
-        resetJsonColumns(pg)
+        resetJsonColumns(pg, oldTableName = true)
         statement.executeUpdate("ALTER TABLE nodes ALTER COLUMN json SET NOT NULL")
         statement.executeUpdate("ALTER TABLE channels ALTER COLUMN channel_announcement_json SET NOT NULL")
       }
 
+      def migration34(statement: Statement): Unit = {
+        statement.executeUpdate("CREATE SCHEMA network")
+        statement.executeUpdate("ALTER TABLE nodes SET SCHEMA network")
+        statement.executeUpdate("ALTER TABLE channels RENAME TO public_channels")
+        statement.executeUpdate("ALTER TABLE public_channels SET SCHEMA network")
+        statement.executeUpdate("ALTER TABLE pruned RENAME TO pruned_channels")
+        statement.executeUpdate("ALTER TABLE pruned_channels SET SCHEMA network")
+      }
+
       getVersion(statement, DB_NAME) match {
         case None =>
-          statement.executeUpdate("CREATE TABLE nodes (node_id TEXT NOT NULL PRIMARY KEY, data BYTEA NOT NULL, json JSONB NOT NULL)")
-          statement.executeUpdate("CREATE TABLE channels (short_channel_id BIGINT NOT NULL PRIMARY KEY, txid TEXT NOT NULL, channel_announcement BYTEA NOT NULL, capacity_sat BIGINT NOT NULL, channel_update_1 BYTEA NULL, channel_update_2 BYTEA NULL, channel_announcement_json JSONB NOT NULL, channel_update_1_json JSONB NULL, channel_update_2_json JSONB NULL)")
-          statement.executeUpdate("CREATE TABLE pruned (short_channel_id BIGINT NOT NULL PRIMARY KEY)")
+          statement.executeUpdate("CREATE SCHEMA network")
+          statement.executeUpdate("CREATE TABLE network.nodes (node_id TEXT NOT NULL PRIMARY KEY, data BYTEA NOT NULL, json JSONB NOT NULL)")
+          statement.executeUpdate("CREATE TABLE network.public_channels (short_channel_id BIGINT NOT NULL PRIMARY KEY, txid TEXT NOT NULL, channel_announcement BYTEA NOT NULL, capacity_sat BIGINT NOT NULL, channel_update_1 BYTEA NULL, channel_update_2 BYTEA NULL, channel_announcement_json JSONB NOT NULL, channel_update_1_json JSONB NULL, channel_update_2_json JSONB NULL)")
+          statement.executeUpdate("CREATE TABLE network.pruned_channels (short_channel_id BIGINT NOT NULL PRIMARY KEY)")
         case Some(v@2) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
           migration23(statement)
+          migration34(statement)
+        case Some(v@3) =>
+          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
+          migration34(statement)
         case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
       }
@@ -69,10 +83,12 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
   }
 
   /** Sometimes we may want to do a full reset when we update the json format */
-  def resetJsonColumns(connection: Connection): Unit = {
+  def resetJsonColumns(connection: Connection, oldTableName: Boolean = false): Unit = {
+    val nodesTable = if (oldTableName) "nodes" else "network.nodes"
+    val channelsTable = if (oldTableName) "channels" else "network.public_channels"
     migrateTable(connection, connection,
-      "nodes",
-      "UPDATE nodes SET json=?::JSON WHERE node_id=?",
+      nodesTable,
+      s"UPDATE $nodesTable SET json=?::JSON WHERE node_id=?",
       (rs, statement) => {
         val node = nodeAnnouncementCodec.decode(BitVector(rs.getBytes("data"))).require.value
         val json = serialization.writePretty(node)
@@ -81,8 +97,8 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
       }
     )(logger)
     migrateTable(connection, connection,
-      "channels",
-      "UPDATE channels SET channel_announcement_json=?::JSON, channel_update_1_json=?::JSON, channel_update_2_json=?::JSON WHERE short_channel_id=?",
+      channelsTable,
+      s"UPDATE $channelsTable SET channel_announcement_json=?::JSON, channel_update_1_json=?::JSON, channel_update_2_json=?::JSON WHERE short_channel_id=?",
       (rs, statement) => {
         val ann = channelAnnouncementCodec.decode(rs.getBitVectorOpt("channel_announcement").get).require.value
         val channel_update_1_opt = rs.getBitVectorOpt("channel_update_1").map(channelUpdateCodec.decode(_).require.value)
@@ -100,29 +116,31 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
 
   override def addNode(n: NodeAnnouncement): Unit = withMetrics("network/add-node", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("INSERT INTO nodes (node_id, data, json) VALUES (?, ?, ?::JSONB) ON CONFLICT DO NOTHING")) { statement =>
-        statement.setString(1, n.nodeId.value.toHex)
-        statement.setBytes(2, nodeAnnouncementCodec.encode(n).require.toByteArray)
-        statement.setString(3, serialization.writePretty(n))
-        statement.executeUpdate()
+      using(pg.prepareStatement("INSERT INTO network.nodes (node_id, data, json) VALUES (?, ?, ?::JSONB) ON CONFLICT DO NOTHING")) {
+        statement =>
+          statement.setString(1, n.nodeId.value.toHex)
+          statement.setBytes(2, nodeAnnouncementCodec.encode(n).require.toByteArray)
+          statement.setString(3, serialization.writePretty(n))
+          statement.executeUpdate()
       }
     }
   }
 
   override def updateNode(n: NodeAnnouncement): Unit = withMetrics("network/update-node", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("UPDATE nodes SET data=?, json=?::JSONB WHERE node_id=?")) { statement =>
-        statement.setBytes(1, nodeAnnouncementCodec.encode(n).require.toByteArray)
-        statement.setString(2, serialization.writePretty(n))
-        statement.setString(3, n.nodeId.value.toHex)
-        statement.executeUpdate()
+      using(pg.prepareStatement("UPDATE network.nodes SET data=?, json=?::JSONB WHERE node_id=?")) {
+        statement =>
+          statement.setBytes(1, nodeAnnouncementCodec.encode(n).require.toByteArray)
+          statement.setString(2, serialization.writePretty(n))
+          statement.setString(3, n.nodeId.value.toHex)
+          statement.executeUpdate()
       }
     }
   }
 
   override def getNode(nodeId: Crypto.PublicKey): Option[NodeAnnouncement] = withMetrics("network/get-node", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("SELECT data FROM nodes WHERE node_id=?")) { statement =>
+      using(pg.prepareStatement("SELECT data FROM network.nodes WHERE node_id=?")) { statement =>
         statement.setString(1, nodeId.value.toHex)
         statement.executeQuery()
           .mapCodec(nodeAnnouncementCodec)
@@ -133,7 +151,7 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
 
   override def removeNode(nodeId: Crypto.PublicKey): Unit = withMetrics("network/remove-node", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("DELETE FROM nodes WHERE node_id=?")) {
+      using(pg.prepareStatement("DELETE FROM network.nodes WHERE node_id=?")) {
         statement =>
           statement.setString(1, nodeId.value.toHex)
           statement.executeUpdate()
@@ -144,7 +162,7 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
   override def listNodes(): Seq[NodeAnnouncement] = withMetrics("network/list-nodes", DbBackends.Postgres) {
     inTransaction { pg =>
       using(pg.createStatement()) { statement =>
-        statement.executeQuery("SELECT data FROM nodes")
+        statement.executeQuery("SELECT data FROM network.nodes")
           .mapCodec(nodeAnnouncementCodec).toSeq
       }
     }
@@ -152,13 +170,14 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
 
   override def addChannel(c: ChannelAnnouncement, txid: ByteVector32, capacity: Satoshi): Unit = withMetrics("network/add-channel", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("INSERT INTO channels(short_channel_id, txid, channel_announcement, capacity_sat, channel_announcement_json) VALUES (?, ?, ?, ?, ?::JSONB) ON CONFLICT DO NOTHING")) { statement =>
-        statement.setLong(1, c.shortChannelId.toLong)
-        statement.setString(2, txid.toHex)
-        statement.setBytes(3, channelAnnouncementCodec.encode(c).require.toByteArray)
-        statement.setLong(4, capacity.toLong)
-        statement.setString(5, serialization.writePretty(c))
-        statement.executeUpdate()
+      using(pg.prepareStatement("INSERT INTO network.public_channels (short_channel_id, txid, channel_announcement, capacity_sat, channel_announcement_json) VALUES (?, ?, ?, ?, ?::JSONB) ON CONFLICT DO NOTHING")) {
+        statement =>
+          statement.setLong(1, c.shortChannelId.toLong)
+          statement.setString(2, txid.toHex)
+          statement.setBytes(3, channelAnnouncementCodec.encode(c).require.toByteArray)
+          statement.setLong(4, capacity.toLong)
+          statement.setString(5, serialization.writePretty(c))
+          statement.executeUpdate()
       }
     }
   }
@@ -166,11 +185,12 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
   override def updateChannel(u: ChannelUpdate): Unit = withMetrics("network/update-channel", DbBackends.Postgres) {
     val column = if (u.isNode1) "channel_update_1" else "channel_update_2"
     inTransaction { pg =>
-      using(pg.prepareStatement(s"UPDATE channels SET $column=?, ${column}_json=?::JSONB WHERE short_channel_id=?")) { statement =>
-        statement.setBytes(1, channelUpdateCodec.encode(u).require.toByteArray)
-        statement.setString(2, serialization.writePretty(u))
-        statement.setLong(3, u.shortChannelId.toLong)
-        statement.executeUpdate()
+      using(pg.prepareStatement(s"UPDATE network.public_channels SET $column=?, ${column}_json=?::JSONB WHERE short_channel_id=?")) {
+        statement =>
+          statement.setBytes(1, channelUpdateCodec.encode(u).require.toByteArray)
+          statement.setString(2, serialization.writePretty(u))
+          statement.setLong(3, u.shortChannelId.toLong)
+          statement.executeUpdate()
       }
     }
   }
@@ -178,7 +198,7 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
   override def listChannels(): SortedMap[ShortChannelId, PublicChannel] = withMetrics("network/list-channels", DbBackends.Postgres) {
     inTransaction { pg =>
       using(pg.createStatement()) { statement =>
-        statement.executeQuery("SELECT channel_announcement, txid, capacity_sat, channel_update_1, channel_update_2 FROM channels")
+        statement.executeQuery("SELECT channel_announcement, txid, capacity_sat, channel_update_1, channel_update_2 FROM network.public_channels")
           .foldLeft(SortedMap.empty[ShortChannelId, PublicChannel]) { (m, rs) =>
             val ann = channelAnnouncementCodec.decode(rs.getBitVectorOpt("channel_announcement").get).require.value
             val txId = ByteVector32.fromValidHex(rs.getString("txid"))
@@ -194,7 +214,7 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
   override def removeChannels(shortChannelIds: Iterable[ShortChannelId]): Unit = withMetrics("network/remove-channels", DbBackends.Postgres) {
     val batchSize = 100
     inTransaction { pg =>
-      using(pg.prepareStatement(s"DELETE FROM channels WHERE short_channel_id IN (${
+      using(pg.prepareStatement(s"DELETE FROM network.public_channels WHERE short_channel_id IN (${
         List.fill(batchSize)("?").mkString(",")
       })")) {
         statement =>
@@ -214,7 +234,7 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
 
   override def addToPruned(shortChannelIds: Iterable[ShortChannelId]): Unit = withMetrics("network/add-to-pruned", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("INSERT INTO pruned VALUES (?) ON CONFLICT DO NOTHING")) {
+      using(pg.prepareStatement("INSERT INTO network.pruned_channels VALUES (?) ON CONFLICT DO NOTHING")) {
         statement =>
           shortChannelIds.foreach(shortChannelId => {
             statement.setLong(1, shortChannelId.toLong)
@@ -227,7 +247,7 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
 
   override def removeFromPruned(shortChannelId: ShortChannelId): Unit = withMetrics("network/remove-from-pruned", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement(s"DELETE FROM pruned WHERE short_channel_id=?")) {
+      using(pg.prepareStatement(s"DELETE FROM network.pruned_channels WHERE short_channel_id=?")) {
         statement =>
           statement.setLong(1, shortChannelId.toLong)
           statement.executeUpdate()
@@ -237,7 +257,7 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
 
   override def isPruned(shortChannelId: ShortChannelId): Boolean = withMetrics("network/is-pruned", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("SELECT short_channel_id from pruned WHERE short_channel_id=?")) { statement =>
+      using(pg.prepareStatement("SELECT short_channel_id from network.pruned_channels WHERE short_channel_id=?")) { statement =>
         statement.setLong(1, shortChannelId.toLong)
         statement.executeQuery().nonEmpty
       }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
@@ -7,6 +7,7 @@ import fr.acinq.eclair.db._
 import fr.acinq.eclair.db.pg.PgUtils.PgLock.LockFailureHandler
 import fr.acinq.eclair.db.pg.PgUtils.{PgLock, getVersion, using}
 import org.postgresql.jdbc.PgConnection
+import org.scalatest.Assertions.convertToEqualizer
 import org.sqlite.SQLiteConnection
 
 import java.io.File
@@ -91,7 +92,7 @@ object TestDatabases {
     val _ = dbs.db
     // check that db version was updated
     using(connection.createStatement()) { statement =>
-      assert(getVersion(statement, dbName).contains(targetVersion))
+      assert(getVersion(statement, dbName).contains(targetVersion), "unexpected version post-migration")
     }
     // post-migration checks
     postCheck(connection)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
@@ -199,7 +199,7 @@ class ChannelsDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migrate channel database v2 -> v3/v5") {
+  test("migrate channel database v2 -> v3/v6") {
     def postCheck(channelsDb: ChannelsDb): Unit = {
       assert(channelsDb.listLocalChannels().size === testCases.filterNot(_.isClosed).size)
       for (testCase <- testCases.filterNot(_.isClosed)) {
@@ -242,7 +242,7 @@ class ChannelsDbSpec extends AnyFunSuite {
             }
           },
           dbName = "channels",
-          targetVersion = 5,
+          targetVersion = 6,
           postCheck = _ => postCheck(dbs.channels)
         )
       case dbs: TestSqliteDatabases =>
@@ -283,7 +283,7 @@ class ChannelsDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migrate pg channel database v3->v5") {
+  test("migrate pg channel database v3->v6") {
     val dbs = TestPgDatabases()
 
     migrationCheck(
@@ -312,7 +312,7 @@ class ChannelsDbSpec extends AnyFunSuite {
         }
       },
       dbName = "channels",
-      targetVersion = 5,
+      targetVersion = 6,
       postCheck = connection => {
         assert(dbs.channels.listLocalChannels().size === testCases.filterNot(_.isClosed).size)
         testCases.foreach { testCase =>
@@ -331,10 +331,10 @@ class ChannelsDbSpec extends AnyFunSuite {
     val db = dbs.channels
     val channel = ChannelCodecsSpec.normal
     db.addOrUpdateChannel(channel)
-    dbs.connection.execSQLUpdate("UPDATE local_channels SET json='{}'")
+    dbs.connection.execSQLUpdate("UPDATE local.channels SET json='{}'")
     db.asInstanceOf[PgChannelsDb].resetJsonColumns(dbs.connection)
     assert({
-      val res = dbs.connection.execSQLQuery("SELECT * FROM local_channels")
+      val res = dbs.connection.execSQLQuery("SELECT * FROM local.channels")
       res.next()
       res.getString("json").length > 100
     })
@@ -387,7 +387,7 @@ object ChannelsDbSpec {
   }
 
   def getPgTimestamp(connection: Connection, channelId: ByteVector32, columnName: String): Option[Long] = {
-    using(connection.prepareStatement(s"SELECT $columnName FROM local_channels WHERE channel_id=?")) { statement =>
+    using(connection.prepareStatement(s"SELECT $columnName FROM local.channels WHERE channel_id=?")) { statement =>
       statement.setString(1, channelId.toHex)
       val rs = statement.executeQuery()
       rs.next()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/NetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/NetworkDbSpec.scala
@@ -286,7 +286,7 @@ class NetworkDbSpec extends AnyFunSuite {
     )
   }
 
-  test("migration test 2->3 (postgres)") {
+  test("migration test 2->4 (postgres)") {
     val dbs = TestPgDatabases()
     migrationCheck(
       dbs = dbs,
@@ -317,7 +317,7 @@ class NetworkDbSpec extends AnyFunSuite {
         }
       },
       dbName = "network",
-      targetVersion = 3,
+      targetVersion = 4,
       postCheck = _ => {
         assert(dbs.network.listNodes().toSet === nodeTestCases.map(_.node).toSet)
         // NB: channel updates are not migrated
@@ -335,16 +335,16 @@ class NetworkDbSpec extends AnyFunSuite {
       t.update_1_opt.foreach(db.updateChannel)
       t.update_2_opt.foreach(db.updateChannel)
     }
-    dbs.connection.execSQLUpdate("UPDATE nodes SET json='{}'")
-    dbs.connection.execSQLUpdate("UPDATE channels SET channel_announcement_json='{}',channel_update_1_json=NULL,channel_update_2_json=NULL")
+    dbs.connection.execSQLUpdate("UPDATE network.nodes SET json='{}'")
+    dbs.connection.execSQLUpdate("UPDATE network.public_channels SET channel_announcement_json='{}',channel_update_1_json=NULL,channel_update_2_json=NULL")
     db.asInstanceOf[PgNetworkDb].resetJsonColumns(dbs.connection)
     assert({
-      val res = dbs.connection.execSQLQuery("SELECT * FROM nodes")
+      val res = dbs.connection.execSQLQuery("SELECT * FROM network.nodes")
       res.next()
       res.getString("json").length > 100
     })
     assert({
-      val res = dbs.connection.execSQLQuery("SELECT * FROM channels WHERE channel_update_1_json IS NOT NULL")
+      val res = dbs.connection.execSQLQuery("SELECT * FROM network.public_channels WHERE channel_update_1_json IS NOT NULL")
       res.next()
       res.getString("channel_announcement_json").length > 100
       res.getString("channel_update_1_json").length > 100

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PendingCommandsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PendingCommandsDbSpec.scala
@@ -76,7 +76,7 @@ class PendingCommandsDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migrate database v1->v2") {
+  test("migrate database v1->v2/v3") {
     forAllDbs {
       case dbs: TestPgDatabases =>
         migrationCheck(
@@ -96,7 +96,7 @@ class PendingCommandsDbSpec extends AnyFunSuite {
             }
           },
           dbName = "pending_relay",
-          targetVersion = 2,
+          targetVersion = 3,
           postCheck = _ =>
             assert(dbs.pendingCommands.listSettlementCommands().toSet === testCases.map(tc => tc.channelId -> tc.cmd))
         )


### PR DESCRIPTION
Instead of having a flat organization under the default `public` schema, we classify tables in schemas. There is roughly one schema per database type.

The new hierarchy is:
- `local`
  - `channels`
  - `htlc_infos`
  - `pending_settlement_commands`
  - `peers`
- `network`
  - `nodes`
  - `public_channels`
  - `pruned_channels`
- `payments`
  - `received`
  - `sent`
- `audit`
  - (all the audit db tables)
- `public`
  - `lease`
  - `versions`

Note in particular, the change in naming for local channels vs external channels:
- `local_channels` -> `local.channels`
- `channels` -> `network.public_channels`

The two internal tables `lease` and `versions` stay in the `public`
schema, because we have no meta way of migrating them.