### PR TITLE
Fixing API substream materialization issues

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/EclairDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/EclairDirectives.scala
@@ -29,7 +29,7 @@ trait EclairDirectives extends Directives with TimeoutDirective with ErrorDirect
    * Prepares inner routes to be exposed as public API with default headers, basic authentication and error handling.
    * Must be applied *after* aggregating all the inner routes.
    */
-  def securedHandler: Directive0 = eclairHeaders & handled & authenticated
+  def securedHandler: Directive0 = toStrictEntity(5 seconds) & eclairHeaders & handled & authenticated
 
   /**
    * Provides a Timeout to the inner route either from request param or the default.


### PR DESCRIPTION
According to https://github.com/akka/akka-http/issues/745#issuecomment-271571342, we should use `toStrictEntity` to wrap all underlying operations if we want to avoid hitting the `Substream Source(EntitySource) cannot be materialized more than once` error.

This has been tested by @engenegr who confirmed that it does fix the issue on his side.

Fixes #1855