### PR TITLE
Update akka-http-json4s dependency

### DIFF
--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>de.heikoseeberger</groupId>
             <artifactId>akka-http-json4s_${scala.version.short}</artifactId>
-            <version>1.34.0</version>
+            <version>1.37.0</version>
         </dependency>
         <!-- metrics -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,9 @@
         <developer>
             <id>sstone</id>
         </developer>
+        <developer>
+            <id>t-bast</id>
+        </developer>
     </developers>
 
     <properties>


### PR DESCRIPTION
Fixes:

```
021-07-19 12:03:13,504 WARN  akka.util.ManifestInfo - You are using version 10.2.4 of Akka HTTP, but it appears you (perhaps indirectly) also depend on older versions of related artifacts. You can solve this by adding an explicit dependency on version 10.2.4 of the [akka-http] artifacts to your project. Here's a complete collection of detected artifacts: (10.2.0, [akka-http]), (10.2.4, [akka-http-core, akka-parsing]). See also: https://doc.akka.io/docs/akka/current/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed
```