### PR TITLE
Different default relay fees for announced and unannounced channels

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -90,8 +90,23 @@ eclair {
   max-block-processing-delay = 30 seconds // we add a random delay before processing blocks, capped at this value, to prevent herd effect
   max-tx-publish-retry-delay = 60 seconds // we add a random delay before retrying failed transaction publication
 
-  fee-base-msat = 1000
-  fee-proportional-millionths = 100 // fee charged per transferred satoshi in millionths of a satoshi (100 = 0.01%)
+  relay.fees {
+      // Fees for public channels
+      public-channels {
+        fee-base-msat = 1000
+        fee-proportional-millionths = 200 // fee charged per transferred satoshi in millionths of a satoshi (200 = 0.02%)
+      }
+      // Fees for private channels
+      private-channels {
+        fee-base-msat = 1000
+        fee-proportional-millionths = 100
+      }
+      // Minimum fees for trampoline relays
+      min-trampoline {
+        fee-base-msat = 1000
+        fee-proportional-millionths = 100
+      }
+   }
 
   on-chain-fees {
     min-feerate = 1 // minimum feerate in satoshis per byte

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -353,9 +353,9 @@ object NodeParams extends Logging {
       maxToLocalDelay = CltvExpiryDelta(config.getInt("max-to-local-delay-blocks")),
       minDepthBlocks = config.getInt("mindepth-blocks"),
       relayParams = RelayParams(
-        getRelayFees(config.getConfig("relay.fees.public-channels")),
-        getRelayFees(config.getConfig("relay.fees.private-channels")),
-        getRelayFees(config.getConfig("relay.fees.min-trampoline")),
+        publicChannelFees = getRelayFees(config.getConfig("relay.fees.public-channels")),
+        privateChannelFees = getRelayFees(config.getConfig("relay.fees.private-channels")),
+        minTrampolineFees = getRelayFees(config.getConfig("relay.fees.min-trampoline")),
       ),
       reserveToFundingRatio = config.getDouble("reserve-to-funding-ratio"),
       maxReserveToFundingRatio = config.getDouble("max-reserve-to-funding-ratio"),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -102,7 +102,7 @@ object NodeRelay {
     }
 
   def validateRelay(nodeParams: NodeParams, upstream: Upstream.Trampoline, payloadOut: Onion.NodeRelayPayload): Option[FailureMessage] = {
-    val fee = nodeFee(nodeParams.feeBase, nodeParams.feeProportionalMillionth, payloadOut.amountToForward)
+    val fee = nodeFee(nodeParams.relayParams.minTrampolineFees.feeBase, nodeParams.relayParams.minTrampolineFees.feeProportionalMillionth, payloadOut.amountToForward)
     if (upstream.amountIn - payloadOut.amountToForward < fee) {
       Some(TrampolineFeeInsufficient)
     } else if (upstream.expiryIn - payloadOut.outgoingCltv < nodeParams.expiryDelta) {
@@ -136,7 +136,7 @@ object NodeRelay {
    */
   def translateError(nodeParams: NodeParams, failures: Seq[PaymentFailure], upstream: Upstream.Trampoline, nextPayload: Onion.NodeRelayPayload): Option[FailureMessage] = {
     val routeNotFound = failures.collectFirst { case f@LocalFailure(_, RouteNotFound) => f }.nonEmpty
-    val routingFeeHigh = upstream.amountIn - nextPayload.amountToForward >= nodeFee(nodeParams.feeBase, nodeParams.feeProportionalMillionth, nextPayload.amountToForward) * 5
+    val routingFeeHigh = upstream.amountIn - nextPayload.amountToForward >= nodeFee(nodeParams.relayParams.minTrampolineFees.feeBase, nodeParams.relayParams.minTrampolineFees.feeProportionalMillionth, nextPayload.amountToForward) * 5
     failures match {
       case Nil => None
       case LocalFailure(_, BalanceTooLow) :: Nil if routingFeeHigh =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -112,6 +112,11 @@ object Relayer extends Logging {
     Props(new Relayer(nodeParams, router, register, paymentHandler, initialized))
 
   // @formatter:off
+  case class RelayFees(feeBase: MilliSatoshi, feeProportionalMillionth: Int)
+  case class RelayParams(publicChannelFees: RelayFees,
+                         privateChannelFees: RelayFees,
+                         minTrampolineFees: RelayFees)
+
   case class RelayForward(add: UpdateAddHtlc)
   case class UsableBalance(remoteNodeId: PublicKey, shortChannelId: ShortChannelId, canSend: MilliSatoshi, canReceive: MilliSatoshi, isPublic: Boolean)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -20,9 +20,10 @@ import fr.acinq.bitcoin.{Block, ByteVector32, Satoshi, SatoshiLong, Script}
 import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
 import fr.acinq.eclair.Features._
 import fr.acinq.eclair.blockchain.fee.{FeeEstimator, FeeTargets, FeeratesPerKw, OnChainFeeConf, _}
-import fr.acinq.eclair.channel.{ChannelFeatures, LocalParams}
+import fr.acinq.eclair.channel.LocalParams
 import fr.acinq.eclair.crypto.keymanager.{LocalChannelKeyManager, LocalNodeKeyManager}
 import fr.acinq.eclair.io.{Peer, PeerConnection}
+import fr.acinq.eclair.payment.relay.Relayer.{RelayFees, RelayParams}
 import fr.acinq.eclair.router.Router.RouterConf
 import fr.acinq.eclair.wire.protocol.{Color, EncodingType, NodeAddress, OnionRoutingPacket}
 import org.scalatest.Tag
@@ -117,8 +118,16 @@ object TestConstants {
       minDepthBlocks = 3,
       toRemoteDelay = CltvExpiryDelta(144),
       maxToLocalDelay = CltvExpiryDelta(1000),
-      feeBase = 546000 msat,
-      feeProportionalMillionth = 10,
+      relayParams = RelayParams(
+         publicChannelFees = RelayFees(
+          feeBase = 546000 msat,
+          feeProportionalMillionth = 10),
+        privateChannelFees = RelayFees(
+          feeBase = 547000 msat,
+          feeProportionalMillionth = 20),
+        minTrampolineFees = RelayFees(
+          feeBase = 548000 msat,
+          feeProportionalMillionth = 30)),
       reserveToFundingRatio = 0.01, // note: not used (overridden below)
       maxReserveToFundingRatio = 0.05,
       db = TestDatabases.inMemoryDb(),
@@ -224,8 +233,16 @@ object TestConstants {
       minDepthBlocks = 3,
       toRemoteDelay = CltvExpiryDelta(144),
       maxToLocalDelay = CltvExpiryDelta(1000),
-      feeBase = 546000 msat,
-      feeProportionalMillionth = 10,
+      relayParams = RelayParams(
+        publicChannelFees = RelayFees(
+          feeBase = 546000 msat,
+          feeProportionalMillionth = 10),
+        privateChannelFees = RelayFees(
+          feeBase = 547000 msat,
+          feeProportionalMillionth = 20),
+        minTrampolineFees = RelayFees(
+          feeBase = 548000 msat,
+          feeProportionalMillionth = 30)),
       reserveToFundingRatio = 0.01, // note: not used (overridden below)
       maxReserveToFundingRatio = 0.05,
       db = TestDatabases.inMemoryDb(),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -1780,8 +1780,8 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("recv CMD_UPDATE_RELAY_FEE ") { f =>
     import f._
     val sender = TestProbe()
-    val newFeeBaseMsat = TestConstants.Alice.nodeParams.feeBase * 2
-    val newFeeProportionalMillionth = TestConstants.Alice.nodeParams.feeProportionalMillionth * 2
+    val newFeeBaseMsat = TestConstants.Alice.nodeParams.relayParams.publicChannelFees.feeBase * 2
+    val newFeeProportionalMillionth = TestConstants.Alice.nodeParams.relayParams.publicChannelFees.feeProportionalMillionth * 2
     sender.send(alice, CMD_UPDATE_RELAY_FEE(ActorRef.noSender, newFeeBaseMsat, newFeeProportionalMillionth))
     sender.expectMsgType[RES_SUCCESS[CMD_UPDATE_RELAY_FEE]]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -596,8 +596,8 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
   test("recv CMD_UPDATE_RELAY_FEE ") { f =>
     import f._
     val sender = TestProbe()
-    val newFeeBaseMsat = TestConstants.Alice.nodeParams.feeBase * 2
-    val newFeeProportionalMillionth = TestConstants.Alice.nodeParams.feeProportionalMillionth * 2
+    val newFeeBaseMsat = TestConstants.Alice.nodeParams.relayParams.publicChannelFees.feeBase * 2
+    val newFeeProportionalMillionth = TestConstants.Alice.nodeParams.relayParams.publicChannelFees.feeProportionalMillionth * 2
     alice ! CMD_UPDATE_RELAY_FEE(sender.ref, newFeeBaseMsat, newFeeProportionalMillionth)
     sender.expectMsgType[RES_FAILURE[CMD_UPDATE_RELAY_FEE, _]]
     relayerA.expectNoMessage(1 seconds)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
@@ -177,7 +177,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     nodes("B").register ! Register.ForwardShortId(sender.ref, shortIdBC, CMD_GETINFO(ActorRef.noSender))
     val commitmentBC = sender.expectMsgType[RES_GETINFO].data.asInstanceOf[DATA_NORMAL].commitments
     // we then forge a new channel_update for B-C...
-    val channelUpdateBC = Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, nodes("B").nodeParams.privateKey, nodes("C").nodeParams.nodeId, shortIdBC, nodes("B").nodeParams.expiryDelta + 1, nodes("C").nodeParams.htlcMinimum, nodes("B").nodeParams.feeBase, nodes("B").nodeParams.feeProportionalMillionth, 500000000 msat)
+    val channelUpdateBC = Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, nodes("B").nodeParams.privateKey, nodes("C").nodeParams.nodeId, shortIdBC, nodes("B").nodeParams.expiryDelta + 1, nodes("C").nodeParams.htlcMinimum, nodes("B").nodeParams.relayParams.publicChannelFees.feeBase, nodes("B").nodeParams.relayParams.publicChannelFees.feeProportionalMillionth, 500000000 msat)
     // ...and notify B's relayer
     nodes("B").system.eventStream.publish(LocalChannelUpdate(system.deadLetters, commitmentBC.channelId, shortIdBC, commitmentBC.remoteParams.nodeId, None, channelUpdateBC, commitmentBC))
     // we retrieve a payment hash from D

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/AnnouncementsSpec.scala
@@ -80,7 +80,7 @@ class AnnouncementsSpec extends AnyFunSuite {
   }
 
   test("create valid signed channel update announcement") {
-    val ann = makeChannelUpdate(Block.RegtestGenesisBlock.hash, Alice.nodeParams.privateKey, randomKey().publicKey, ShortChannelId(45561L), Alice.nodeParams.expiryDelta, Alice.nodeParams.htlcMinimum, Alice.nodeParams.feeBase, Alice.nodeParams.feeProportionalMillionth, 500000000 msat)
+    val ann = makeChannelUpdate(Block.RegtestGenesisBlock.hash, Alice.nodeParams.privateKey, randomKey().publicKey, ShortChannelId(45561L), Alice.nodeParams.expiryDelta, Alice.nodeParams.htlcMinimum, Alice.nodeParams.relayParams.publicChannelFees.feeBase, Alice.nodeParams.relayParams.publicChannelFees.feeProportionalMillionth, 500000000 msat)
     assert(checkSig(ann, Alice.nodeParams.nodeId))
     assert(checkSig(ann, randomKey().publicKey) === false)
   }


### PR DESCRIPTION
Split the settings for the default relay fee in two:
- fees for announced channels
- fees for unannounced channels
- minimum fee for trampoline relays (we don't even try to relay trampoline payments with lower fees)