### PR TITLE
Retry local channel failures in trampoline payments

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -175,7 +175,7 @@ class PaymentInitiator(nodeParams: NodeParams, outgoingPaymentFactory: PaymentIn
     val trampolineSecret = randomBytes32()
     val (trampolineAmount, trampolineExpiry, trampolineOnion) = buildTrampolinePayment(r, trampolineFees, trampolineExpiryDelta)
     val fsm = outgoingPaymentFactory.spawnOutgoingMultiPartPayment(context, paymentCfg)
-    fsm ! SendMultiPartPayment(self, trampolineSecret, r.trampolineNodeId, trampolineAmount, trampolineExpiry, 1, r.paymentRequest.routingInfo, r.routeParams, Seq(OnionTlv.TrampolineOnion(trampolineOnion)))
+    fsm ! SendMultiPartPayment(self, trampolineSecret, r.trampolineNodeId, trampolineAmount, trampolineExpiry, nodeParams.maxPaymentAttempts, r.paymentRequest.routingInfo, r.routeParams, Seq(OnionTlv.TrampolineOnion(trampolineOnion)))
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -192,6 +192,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(msg.targetExpiry.toLong === currentBlockCount + 9 + 12 + 1)
     assert(msg.totalAmount === finalAmount + trampolineFees)
     assert(msg.additionalTlvs.head.isInstanceOf[OnionTlv.TrampolineOnion])
+    assert(msg.maxAttempts === nodeParams.maxPaymentAttempts)
 
     // Verify that the trampoline node can correctly peel the trampoline onion.
     val trampolineOnion = msg.additionalTlvs.head.asInstanceOf[OnionTlv.TrampolineOnion].packet


### PR DESCRIPTION
When using trampoline, we previously made a single payment attempt per trampoline fee.
That doesn't work when our best channel has a local failure (such as `remote cannot afford increased commit tx fees`), because:

- we instantly failed the `MultiPartPaymentLifecycle` (because `maxAttempts` was set to `1`)
- we retried with a higher trampoline fee (from the `PaymentInitiator`) but since the channel selection is deterministic for the first attempt, we selected the same channel and the local failure was still there regardless of how much trampoline fees we were ready to pay

We usually only need one attempt, but there's no reason to always limit it to `1`, so we now use the node's configuration for `max-payment-attempts`. Since the `MultiPartPaymentLifecycle` aborts when it receives an error from the trampoline node, this will not cause us to waste attempts when the trampoline fee is too low.
