### PR TITLE
Refactor db migration

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -105,24 +105,20 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE INDEX channel_updates_cid_idx ON audit.channel_updates(channel_id)")
           statement.executeUpdate("CREATE INDEX channel_updates_nid_idx ON audit.channel_updates(node_id)")
           statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON audit.channel_updates(timestamp)")
-        case Some(v@4) =>
+        case Some(v@(4 | 5 | 6 | 7)) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration45(statement)
-          migration56(statement)
-          migration67(statement)
-          migration78(statement)
-        case Some(v@5) =>
-          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration56(statement)
-          migration67(statement)
-          migration78(statement)
-        case Some(v@6) =>
-          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration67(statement)
-          migration78(statement)
-        case Some(v@7) =>
-          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration78(statement)
+          if (v < 5) {
+            migration45(statement)
+          }
+          if (v < 6) {
+            migration56(statement)
+          }
+          if (v < 7) {
+            migration67(statement)
+          }
+          if (v < 8) {
+            migration78(statement)
+          }
         case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -34,13 +34,16 @@ import java.time.Instant
 import java.util.UUID
 import javax.sql.DataSource
 
+object PgAuditDb {
+  val DB_NAME = "audit"
+  val CURRENT_VERSION = 8
+}
+
 class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
 
   import PgUtils._
   import ExtendedResultSet._
-
-  val DB_NAME = "audit"
-  val CURRENT_VERSION = 8
+  import PgAuditDb._
 
   case class RelayedPart(channelId: ByteVector32, amount: MilliSatoshi, direction: String, relayType: String, timestamp: Long)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
@@ -106,31 +106,23 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
           statement.executeUpdate("CREATE INDEX local_channels_type_idx ON local.channels ((json->>'type'))")
           statement.executeUpdate("CREATE INDEX local_channels_remote_node_id_idx ON local.channels ((json->'commitments'->'remoteParams'->>'nodeId'))")
           statement.executeUpdate("CREATE INDEX htlc_infos_idx ON local.htlc_infos(channel_id, commitment_number)")
-        case Some(v@2) =>
+        case Some(v@(2 | 3 | 4 | 5 | 6)) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration23(statement)
-          migration34(statement)
-          migration45(statement)
-          migration56(statement)
-          migration67()
-        case Some(v@3) =>
-          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration34(statement)
-          migration45(statement)
-          migration56(statement)
-          migration67()
-        case Some(v@4) =>
-          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration45(statement)
-          migration56(statement)
-          migration67()
-        case Some(v@5) =>
-          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration56(statement)
-          migration67()
-        case Some(v@6) =>
-          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration67()
+          if (v < 3) {
+            migration23(statement)
+          }
+          if (v < 4) {
+            migration34(statement)
+          }
+          if (v < 5) {
+            migration45(statement)
+          }
+          if (v < 6) {
+            migration56(statement)
+          }
+          if (v < 7) {
+            migration67()
+          }
         case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
@@ -33,15 +33,18 @@ import java.sql.{Connection, Statement, Timestamp}
 import java.time.Instant
 import javax.sql.DataSource
 
+object PgChannelsDb {
+  val DB_NAME = "channels"
+  val CURRENT_VERSION = 7
+}
+
 class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb with Logging {
 
+  import PgChannelsDb._
   import PgUtils.ExtendedResultSet._
   import PgUtils._
   import fr.acinq.eclair.json.JsonSerializers.{formats, serialization}
   import lock._
-
-  val DB_NAME = "channels"
-  val CURRENT_VERSION = 7
 
   inTransaction { pg =>
     using(pg.createStatement()) { statement =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
@@ -31,14 +31,17 @@ import java.sql.{Connection, Statement}
 import javax.sql.DataSource
 import scala.collection.immutable.SortedMap
 
+object PgNetworkDb {
+  val DB_NAME = "network"
+  val CURRENT_VERSION = 4
+}
+
 class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
 
+  import PgNetworkDb._
   import PgUtils.ExtendedResultSet._
   import PgUtils._
   import fr.acinq.eclair.json.JsonSerializers.{formats, serialization}
-
-  val DB_NAME = "network"
-  val CURRENT_VERSION = 4
 
   inTransaction { pg =>
     using(pg.createStatement()) { statement =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
@@ -68,13 +68,14 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
           statement.executeUpdate("CREATE TABLE network.nodes (node_id TEXT NOT NULL PRIMARY KEY, data BYTEA NOT NULL, json JSONB NOT NULL)")
           statement.executeUpdate("CREATE TABLE network.public_channels (short_channel_id BIGINT NOT NULL PRIMARY KEY, txid TEXT NOT NULL, channel_announcement BYTEA NOT NULL, capacity_sat BIGINT NOT NULL, channel_update_1 BYTEA NULL, channel_update_2 BYTEA NULL, channel_announcement_json JSONB NOT NULL, channel_update_1_json JSONB NULL, channel_update_2_json JSONB NULL)")
           statement.executeUpdate("CREATE TABLE network.pruned_channels (short_channel_id BIGINT NOT NULL PRIMARY KEY)")
-        case Some(v@2) =>
+        case Some(v@(2 | 3)) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration23(statement)
-          migration34(statement)
-        case Some(v@3) =>
-          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration34(statement)
+          if (v < 3) {
+            migration23(statement)
+          }
+          if (v < 4) {
+            migration34(statement)
+          }
         case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPaymentsDb.scala
@@ -35,14 +35,17 @@ import java.time.Instant
 import java.util.UUID
 import javax.sql.DataSource
 
+object PgPaymentsDb {
+  val DB_NAME = "payments"
+  val CURRENT_VERSION = 6
+}
+
 class PgPaymentsDb(implicit ds: DataSource, lock: PgLock) extends PaymentsDb with Logging {
 
+  import PgPaymentsDb._
   import PgUtils.ExtendedResultSet._
   import PgUtils._
   import lock._
-
-  val DB_NAME = "payments"
-  val CURRENT_VERSION = 6
 
   private val hopSummaryCodec = (("node_id" | CommonCodecs.publicKey) :: ("next_node_id" | CommonCodecs.publicKey) :: ("short_channel_id" | optional(bool, CommonCodecs.shortchannelid))).as[HopSummary]
   private val paymentRouteCodec = discriminated[List[HopSummary]].by(byte)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPaymentsDb.scala
@@ -82,13 +82,14 @@ class PgPaymentsDb(implicit ds: DataSource, lock: PgLock) extends PaymentsDb wit
           statement.executeUpdate("CREATE INDEX sent_payment_hash_idx ON payments.sent(payment_hash)")
           statement.executeUpdate("CREATE INDEX sent_created_idx ON payments.sent(created_at)")
           statement.executeUpdate("CREATE INDEX received_created_idx ON payments.received(created_at)")
-        case Some(v@4) =>
+        case Some(v@(4 | 5)) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration45(statement)
-          migration56(statement)
-        case Some(v@5) =>
-          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-          migration56(statement)
+          if (v < 5) {
+            migration45(statement)
+          }
+          if (v < 6) {
+            migration56(statement)
+          }
         case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPeersDb.scala
@@ -31,14 +31,17 @@ import scodec.bits.BitVector
 import java.sql.Statement
 import javax.sql.DataSource
 
+object PgPeersDb {
+  val DB_NAME = "peers"
+  val CURRENT_VERSION = 3
+}
+
 class PgPeersDb(implicit ds: DataSource, lock: PgLock) extends PeersDb with Logging {
 
+  import PgPeersDb._
   import PgUtils.ExtendedResultSet._
   import PgUtils._
   import lock._
-
-  val DB_NAME = "peers"
-  val CURRENT_VERSION = 3
 
   inTransaction { pg =>
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPendingCommandsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPendingCommandsDb.scala
@@ -29,14 +29,17 @@ import grizzled.slf4j.Logging
 import java.sql.Statement
 import javax.sql.DataSource
 
+object PgPendingCommandsDb {
+  val DB_NAME = "pending_relay"
+  val CURRENT_VERSION = 3
+}
+
 class PgPendingCommandsDb(implicit ds: DataSource, lock: PgLock) extends PendingCommandsDb with Logging {
 
+  import PgPendingCommandsDb._
   import PgUtils.ExtendedResultSet._
   import PgUtils._
   import lock._
-
-  val DB_NAME = "pending_relay"
-  val CURRENT_VERSION = 3
 
   inTransaction { pg =>
     using(pg.createStatement()) { statement =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -32,13 +32,16 @@ import grizzled.slf4j.Logging
 import java.sql.{Connection, Statement}
 import java.util.UUID
 
+object SqliteAuditDb {
+  val DB_NAME = "audit"
+  val CURRENT_VERSION = 6
+}
+
 class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
 
   import SqliteUtils._
   import ExtendedResultSet._
-
-  val DB_NAME = "audit"
-  val CURRENT_VERSION = 6
+  import SqliteAuditDb._
 
   case class RelayedPart(channelId: ByteVector32, amount: MilliSatoshi, direction: String, relayType: String, timestamp: Long)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -111,31 +111,23 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.executeUpdate("CREATE INDEX channel_updates_cid_idx ON channel_updates(channel_id)")
         statement.executeUpdate("CREATE INDEX channel_updates_nid_idx ON channel_updates(node_id)")
         statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON channel_updates(timestamp)")
-      case Some(v@1)=>
+      case Some(v@(1 | 2 | 3 | 4 | 5)) =>
         logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-        migration12(statement)
-        migration23(statement)
-        migration34(statement)
-        migration45(statement)
-        migration56(statement)
-      case Some(v@2) =>
-        logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-        migration23(statement)
-        migration34(statement)
-        migration45(statement)
-        migration56(statement)
-      case Some(v@3) =>
-        logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-        migration34(statement)
-        migration45(statement)
-        migration56(statement)
-      case Some(v@4) =>
-        logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-        migration45(statement)
-        migration56(statement)
-      case Some(v@5) =>
-        logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-        migration56(statement)
+        if (v < 2) {
+          migration12(statement)
+        }
+        if (v < 3) {
+          migration23(statement)
+        }
+        if (v < 4) {
+          migration34(statement)
+        }
+        if (v < 5) {
+          migration45(statement)
+        }
+        if (v < 6) {
+          migration56(statement)
+        }
       case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
       case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -29,13 +29,16 @@ import scodec.bits.BitVector
 
 import java.sql.{Connection, Statement}
 
-class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
-
-  import SqliteUtils.ExtendedResultSet._
-  import SqliteUtils._
-
+object SqliteChannelsDb {
   val DB_NAME = "channels"
   val CURRENT_VERSION = 4
+}
+
+class SqliteChannelsDb(sqlite: Connection) extends ChannelsDb with Logging {
+
+  import SqliteChannelsDb._
+  import SqliteUtils.ExtendedResultSet._
+  import SqliteUtils._
 
   /**
    * The SQLite documentation states that "It is not possible to enable or disable foreign key constraints in the middle

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteFeeratesDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteFeeratesDb.scala
@@ -23,13 +23,16 @@ import grizzled.slf4j.Logging
 
 import java.sql.{Connection, Statement}
 
-class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb with Logging {
-
-  import SqliteUtils.ExtendedResultSet._
-  import SqliteUtils._
-
+object SqliteFeeratesDb {
   val DB_NAME = "feerates"
   val CURRENT_VERSION = 2
+}
+
+class SqliteFeeratesDb(sqlite: Connection) extends FeeratesDb with Logging {
+
+  import SqliteFeeratesDb._
+  import SqliteUtils.ExtendedResultSet._
+  import SqliteUtils._
 
   using(sqlite.createStatement(), inTransaction = true) { statement =>
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -29,13 +29,16 @@ import grizzled.slf4j.Logging
 import java.sql.{Connection, Statement}
 import scala.collection.immutable.SortedMap
 
+object SqliteNetworkDb {
+  val CURRENT_VERSION = 2
+  val DB_NAME = "network"
+}
+
 class SqliteNetworkDb(sqlite: Connection) extends NetworkDb with Logging {
 
+  import SqliteNetworkDb._
   import SqliteUtils.ExtendedResultSet._
   import SqliteUtils._
-
-  val DB_NAME = "network"
-  val CURRENT_VERSION = 2
 
   using(sqlite.createStatement(), inTransaction = true) { statement =>
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -39,9 +39,6 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
   import SqlitePaymentsDb._
   import SqliteUtils.ExtendedResultSet._
 
-  val DB_NAME = "payments"
-  val CURRENT_VERSION = 4
-
   using(sqlite.createStatement(), inTransaction = true) { statement =>
 
     def migration12(statement: Statement): Unit = {
@@ -399,6 +396,8 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
 }
 
 object SqlitePaymentsDb {
+  val DB_NAME = "payments"
+  val CURRENT_VERSION = 4
 
   private val hopSummaryCodec = (("node_id" | CommonCodecs.publicKey) :: ("next_node_id" | CommonCodecs.publicKey) :: ("short_channel_id" | optional(bool, CommonCodecs.shortchannelid))).as[HopSummary]
   val paymentRouteCodec = discriminated[List[HopSummary]].by(byte)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -106,18 +106,17 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
         statement.executeUpdate("CREATE INDEX sent_payment_hash_idx ON sent_payments(payment_hash)")
         statement.executeUpdate("CREATE INDEX sent_created_idx ON sent_payments(created_at)")
         statement.executeUpdate("CREATE INDEX received_created_idx ON received_payments(created_at)")
-      case Some(v@1) =>
+      case Some(v@(1 | 2 | 3)) =>
         logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-        migration12(statement)
-        migration23(statement)
-        migration34(statement)
-      case Some(v@2) =>
-        logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-        migration23(statement)
-        migration34(statement)
-      case Some(v@3) =>
-        logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
-        migration34(statement)
+        if (v < 2) {
+          migration12(statement)
+        }
+        if (v < 3) {
+          migration23(statement)
+        }
+        if (v < 4) {
+          migration34(statement)
+        }
       case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
       case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePeersDb.scala
@@ -30,12 +30,15 @@ import scodec.bits.BitVector
 
 import java.sql.{Connection, Statement}
 
-class SqlitePeersDb(sqlite: Connection) extends PeersDb with Logging {
-
-  import SqliteUtils.ExtendedResultSet._
-
+object SqlitePeersDb {
   val DB_NAME = "peers"
   val CURRENT_VERSION = 2
+}
+
+class SqlitePeersDb(sqlite: Connection) extends PeersDb with Logging {
+
+  import SqlitePeersDb._
+  import SqliteUtils.ExtendedResultSet._
 
   using(sqlite.createStatement(), inTransaction = true) { statement =>
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingCommandsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingCommandsDb.scala
@@ -26,13 +26,16 @@ import grizzled.slf4j.Logging
 
 import java.sql.{Connection, Statement}
 
-class SqlitePendingCommandsDb(sqlite: Connection) extends PendingCommandsDb with Logging {
-
-  import SqliteUtils.ExtendedResultSet._
-  import SqliteUtils._
-
+object SqlitePendingCommandsDb {
   val DB_NAME = "pending_relay"
   val CURRENT_VERSION = 2
+}
+
+class SqlitePendingCommandsDb(sqlite: Connection) extends PendingCommandsDb with Logging {
+
+  import SqlitePendingCommandsDb._
+  import SqliteUtils.ExtendedResultSet._
+  import SqliteUtils._
 
   using(sqlite.createStatement(), inTransaction = true) { statement =>
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -228,7 +228,7 @@ class AuditDbSpec extends AnyFunSuite {
           statement.executeUpdate()
         }
       },
-      dbName = "audit",
+      dbName = SqliteAuditDb.DB_NAME,
       targetVersion = SqliteAuditDb.CURRENT_VERSION,
       postCheck = connection => {
         // existing rows in the 'sent' table will use id=00000000-0000-0000-0000-000000000000 as default
@@ -279,7 +279,7 @@ class AuditDbSpec extends AnyFunSuite {
           setVersion(statement, "audit", 2)
         }
       },
-      dbName = "audit",
+      dbName = SqliteAuditDb.DB_NAME,
       targetVersion = SqliteAuditDb.CURRENT_VERSION,
       postCheck = connection => {
         val migratedDb = dbs.audit
@@ -357,7 +357,7 @@ class AuditDbSpec extends AnyFunSuite {
           }
         }
       },
-      dbName = "audit",
+      dbName = SqliteAuditDb.DB_NAME,
       targetVersion = SqliteAuditDb.CURRENT_VERSION,
       postCheck = connection => {
         val migratedDb = dbs.audit
@@ -458,7 +458,7 @@ class AuditDbSpec extends AnyFunSuite {
               }
             }
           },
-          dbName = "audit",
+          dbName = PgAuditDb.DB_NAME,
           targetVersion = PgAuditDb.CURRENT_VERSION,
           postCheck = connection => {
             val migratedDb = dbs.audit
@@ -539,7 +539,7 @@ class AuditDbSpec extends AnyFunSuite {
               }
             }
           },
-          dbName = "audit",
+          dbName = SqliteAuditDb.DB_NAME,
           targetVersion = SqliteAuditDb.CURRENT_VERSION,
           postCheck = connection => {
             val migratedDb = dbs.audit

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -184,7 +184,7 @@ class AuditDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migrate sqlite audit database v1 -> v6") {
+  test("migrate sqlite audit database v1 -> current") {
 
     val dbs = TestSqliteDatabases()
 
@@ -229,7 +229,7 @@ class AuditDbSpec extends AnyFunSuite {
         }
       },
       dbName = "audit",
-      targetVersion = 6,
+      targetVersion = SqliteAuditDb.CURRENT_VERSION,
       postCheck = connection => {
         // existing rows in the 'sent' table will use id=00000000-0000-0000-0000-000000000000 as default
         assert(dbs.audit.listSent(0, (System.currentTimeMillis.milliseconds + 1.minute).toMillis) === Seq(ps.copy(id = ZERO_UUID, parts = Seq(ps.parts.head.copy(id = ZERO_UUID)))))
@@ -251,7 +251,7 @@ class AuditDbSpec extends AnyFunSuite {
     )
   }
 
-  test("migrate sqlite audit database v2 -> v6") {
+  test("migrate sqlite audit database v2 -> current") {
     val dbs = TestSqliteDatabases()
 
     val e1 = ChannelErrorOccurred(null, randomBytes32(), randomKey().publicKey, null, LocalError(new RuntimeException("oops")), isFatal = true)
@@ -280,7 +280,7 @@ class AuditDbSpec extends AnyFunSuite {
         }
       },
       dbName = "audit",
-      targetVersion = 6,
+      targetVersion = SqliteAuditDb.CURRENT_VERSION,
       postCheck = connection => {
         val migratedDb = dbs.audit
         using(connection.createStatement()) { statement =>
@@ -297,7 +297,7 @@ class AuditDbSpec extends AnyFunSuite {
     )
   }
 
-  test("migrate sqlite audit database v3 -> v6") {
+  test("migrate sqlite audit database v3 -> current") {
 
     val dbs = TestSqliteDatabases()
 
@@ -358,7 +358,7 @@ class AuditDbSpec extends AnyFunSuite {
         }
       },
       dbName = "audit",
-      targetVersion = 6,
+      targetVersion = SqliteAuditDb.CURRENT_VERSION,
       postCheck = connection => {
         val migratedDb = dbs.audit
         using(connection.createStatement()) { statement =>
@@ -387,7 +387,7 @@ class AuditDbSpec extends AnyFunSuite {
     )
   }
 
-  test("migrate audit database v4 -> v6/v8") {
+  test("migrate audit database v4 -> current") {
 
     val relayed1 = ChannelPaymentRelayed(600 msat, 500 msat, randomBytes32(), randomBytes32(), randomBytes32(), 105)
     val relayed2 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(300 msat, randomBytes32()), PaymentRelayed.Part(350 msat, randomBytes32())), Seq(PaymentRelayed.Part(600 msat, randomBytes32())), PlaceHolderPubKey, 0 msat, 110)
@@ -459,7 +459,7 @@ class AuditDbSpec extends AnyFunSuite {
             }
           },
           dbName = "audit",
-          targetVersion = 8,
+          targetVersion = PgAuditDb.CURRENT_VERSION,
           postCheck = connection => {
             val migratedDb = dbs.audit
 
@@ -540,7 +540,7 @@ class AuditDbSpec extends AnyFunSuite {
             }
           },
           dbName = "audit",
-          targetVersion = 6,
+          targetVersion = SqliteAuditDb.CURRENT_VERSION,
           postCheck = connection => {
             val migratedDb = dbs.audit
             using(connection.createStatement()) { statement =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
@@ -242,7 +242,7 @@ class ChannelsDbSpec extends AnyFunSuite {
               }
             }
           },
-          dbName = "channels",
+          dbName = PgChannelsDb.DB_NAME,
           targetVersion = PgChannelsDb.CURRENT_VERSION,
           postCheck = _ => postCheck(dbs.channels)
         )
@@ -277,7 +277,7 @@ class ChannelsDbSpec extends AnyFunSuite {
               }
             }
           },
-          dbName = "channels",
+          dbName = SqliteChannelsDb.DB_NAME,
           targetVersion = SqliteChannelsDb.CURRENT_VERSION,
           postCheck = _ => postCheck(dbs.channels)
         )
@@ -312,7 +312,7 @@ class ChannelsDbSpec extends AnyFunSuite {
           }
         }
       },
-      dbName = "channels",
+      dbName = PgChannelsDb.DB_NAME,
       targetVersion = PgChannelsDb.CURRENT_VERSION,
       postCheck = connection => {
         assert(dbs.channels.listLocalChannels().size === testCases.filterNot(_.isClosed).size)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
@@ -151,7 +151,7 @@ class ChannelsDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migrate channel database v1 -> v4 (sqlite)") {
+  test("migrate sqlite channel database v1 -> current") {
     forAllDbs {
       case _: TestPgDatabases => // no migration
       case dbs: TestSqliteDatabases =>
@@ -185,9 +185,10 @@ class ChannelsDbSpec extends AnyFunSuite {
         }
 
         // check that db migration works
+        val targetVersion = SqliteChannelsDb.CURRENT_VERSION
         val db = new SqliteChannelsDb(sqlite)
         using(sqlite.createStatement()) { statement =>
-          assert(getVersion(statement, "channels").contains(4))
+          assert(getVersion(statement, "channels").contains(targetVersion))
         }
         assert(db.listLocalChannels().size === testCases.size)
         for (testCase <- testCases) {
@@ -199,7 +200,7 @@ class ChannelsDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migrate channel database v2 -> v4/v7") {
+  test("migrate channel database v2 -> current") {
     def postCheck(channelsDb: ChannelsDb): Unit = {
       assert(channelsDb.listLocalChannels().size === testCases.filterNot(_.isClosed).size)
       for (testCase <- testCases.filterNot(_.isClosed)) {
@@ -242,7 +243,7 @@ class ChannelsDbSpec extends AnyFunSuite {
             }
           },
           dbName = "channels",
-          targetVersion = 7,
+          targetVersion = PgChannelsDb.CURRENT_VERSION,
           postCheck = _ => postCheck(dbs.channels)
         )
       case dbs: TestSqliteDatabases =>
@@ -277,13 +278,13 @@ class ChannelsDbSpec extends AnyFunSuite {
             }
           },
           dbName = "channels",
-          targetVersion = 4,
+          targetVersion = SqliteChannelsDb.CURRENT_VERSION,
           postCheck = _ => postCheck(dbs.channels)
         )
     }
   }
 
-  test("migrate pg channel database v3->v6") {
+  test("migrate pg channel database v3 -> current") {
     val dbs = TestPgDatabases()
 
     migrationCheck(
@@ -312,7 +313,7 @@ class ChannelsDbSpec extends AnyFunSuite {
         }
       },
       dbName = "channels",
-      targetVersion = 7,
+      targetVersion = PgChannelsDb.CURRENT_VERSION,
       postCheck = connection => {
         assert(dbs.channels.listLocalChannels().size === testCases.filterNot(_.isClosed).size)
         testCases.foreach { testCase =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/NetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/NetworkDbSpec.scala
@@ -229,7 +229,7 @@ class NetworkDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migration test 1->2 (sqlite)") {
+  test("migration sqlite v1 -> current") {
     val dbs = TestSqliteDatabases()
     migrationCheck(
       dbs = dbs,
@@ -277,7 +277,7 @@ class NetworkDbSpec extends AnyFunSuite {
         }
       },
       dbName = "network",
-      targetVersion = 2,
+      targetVersion = SqliteNetworkDb.CURRENT_VERSION,
       postCheck = _ => {
         assert(dbs.network.listNodes().toSet === nodeTestCases.map(_.node).toSet)
         // NB: channel updates are not migrated
@@ -286,7 +286,7 @@ class NetworkDbSpec extends AnyFunSuite {
     )
   }
 
-  test("migration test 2->4 (postgres)") {
+  test("migration postgres v2 -> current") {
     val dbs = TestPgDatabases()
     migrationCheck(
       dbs = dbs,
@@ -317,7 +317,7 @@ class NetworkDbSpec extends AnyFunSuite {
         }
       },
       dbName = "network",
-      targetVersion = 4,
+      targetVersion = PgNetworkDb.CURRENT_VERSION,
       postCheck = _ => {
         assert(dbs.network.listNodes().toSet === nodeTestCases.map(_.node).toSet)
         // NB: channel updates are not migrated

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/NetworkDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/NetworkDbSpec.scala
@@ -276,7 +276,7 @@ class NetworkDbSpec extends AnyFunSuite {
           }
         }
       },
-      dbName = "network",
+      dbName = SqliteNetworkDb.DB_NAME,
       targetVersion = SqliteNetworkDb.CURRENT_VERSION,
       postCheck = _ => {
         assert(dbs.network.listNodes().toSet === nodeTestCases.map(_.node).toSet)
@@ -316,7 +316,7 @@ class NetworkDbSpec extends AnyFunSuite {
           }
         }
       },
-      dbName = "network",
+      dbName = PgNetworkDb.DB_NAME,
       targetVersion = PgNetworkDb.CURRENT_VERSION,
       postCheck = _ => {
         assert(dbs.network.listNodes().toSet === nodeTestCases.map(_.node).toSet)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PaymentsDbSpec.scala
@@ -48,7 +48,7 @@ class PaymentsDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migrate sqlite payments db v1 -> v4") {
+  test("migrate sqlite payments db v1 -> current") {
     val dbs = TestSqliteDatabases()
 
     migrationCheck(
@@ -70,7 +70,7 @@ class PaymentsDbSpec extends AnyFunSuite {
         }
       },
       dbName = "payments",
-      targetVersion = 4,
+      targetVersion = SqlitePaymentsDb.CURRENT_VERSION,
       postCheck = _ => {
         val db = dbs.db.payments
         // the existing received payment can NOT be queried anymore
@@ -92,7 +92,7 @@ class PaymentsDbSpec extends AnyFunSuite {
     )
   }
 
-  test("migrate sqlite payments db v2 -> v4") {
+  test("migrate sqlite payments db v2 -> current") {
     val dbs = TestSqliteDatabases()
 
     // Test data
@@ -180,7 +180,7 @@ class PaymentsDbSpec extends AnyFunSuite {
         }
       },
       dbName = "payments",
-      targetVersion = 4,
+      targetVersion = SqlitePaymentsDb.CURRENT_VERSION,
       postCheck = _ => {
         val db = dbs.db.payments
 
@@ -207,7 +207,7 @@ class PaymentsDbSpec extends AnyFunSuite {
       })
   }
 
-  test("migrate sqlite payments db v3 -> v4") {
+  test("migrate sqlite payments db v3 -> current") {
     val dbs = TestSqliteDatabases()
 
     // Test data
@@ -281,7 +281,7 @@ class PaymentsDbSpec extends AnyFunSuite {
         //  - re-ordered columns
       },
       dbName = "payments",
-      targetVersion = 4,
+      targetVersion = SqlitePaymentsDb.CURRENT_VERSION,
       postCheck = _ => {
         val db = dbs.db.payments
         assert(db.getOutgoingPayment(id1) === Some(ps1))
@@ -290,7 +290,7 @@ class PaymentsDbSpec extends AnyFunSuite {
     )
   }
 
-  test("migrate postgres payments db v4 -> v6") {
+  test("migrate postgres payments db v4 -> current") {
     val dbs = TestPgDatabases()
 
     // Test data
@@ -374,7 +374,7 @@ class PaymentsDbSpec extends AnyFunSuite {
 
       },
       dbName = "payments",
-      targetVersion = 6,
+      targetVersion = PgPaymentsDb.CURRENT_VERSION,
       postCheck = _ => {
         val db = dbs.db.payments
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PaymentsDbSpec.scala
@@ -373,7 +373,7 @@ class PaymentsDbSpec extends AnyFunSuite {
         assert(connection.createStatement().executeQuery("SELECT * FROM received_payments").map(rs => rs.getString("payment_hash")).toSeq.size > 0)
 
       },
-      dbName = "payments",
+      dbName = PgPaymentsDb.DB_NAME,
       targetVersion = PgPaymentsDb.CURRENT_VERSION,
       postCheck = _ => {
         val db = dbs.db.payments

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PendingCommandsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PendingCommandsDbSpec.scala
@@ -95,7 +95,7 @@ class PendingCommandsDbSpec extends AnyFunSuite {
               }
             }
           },
-          dbName = "pending_relay",
+          dbName = PgPendingCommandsDb.DB_NAME,
           targetVersion = PgPendingCommandsDb.CURRENT_VERSION,
           postCheck = _ =>
             assert(dbs.pendingCommands.listSettlementCommands().toSet === testCases.map(tc => tc.channelId -> tc.cmd))
@@ -117,7 +117,7 @@ class PendingCommandsDbSpec extends AnyFunSuite {
               }
             }
           },
-          dbName = "pending_relay",
+          dbName = SqlitePendingCommandsDb.DB_NAME,
           targetVersion = SqlitePendingCommandsDb.CURRENT_VERSION,
           postCheck = _ =>
             assert(dbs.pendingCommands.listSettlementCommands().toSet === testCases.map(tc => tc.channelId -> tc.cmd))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PendingCommandsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PendingCommandsDbSpec.scala
@@ -76,7 +76,7 @@ class PendingCommandsDbSpec extends AnyFunSuite {
     }
   }
 
-  test("migrate database v1->v2/v3") {
+  test("migrate database v1 -> current") {
     forAllDbs {
       case dbs: TestPgDatabases =>
         migrationCheck(
@@ -96,7 +96,7 @@ class PendingCommandsDbSpec extends AnyFunSuite {
             }
           },
           dbName = "pending_relay",
-          targetVersion = 3,
+          targetVersion = PgPendingCommandsDb.CURRENT_VERSION,
           postCheck = _ =>
             assert(dbs.pendingCommands.listSettlementCommands().toSet === testCases.map(tc => tc.channelId -> tc.cmd))
         )
@@ -118,7 +118,7 @@ class PendingCommandsDbSpec extends AnyFunSuite {
             }
           },
           dbName = "pending_relay",
-          targetVersion = 2,
+          targetVersion = SqlitePendingCommandsDb.CURRENT_VERSION,
           postCheck = _ =>
             assert(dbs.pendingCommands.listSettlementCommands().toSet === testCases.map(tc => tc.channelId -> tc.cmd))
         )

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteFeeratesDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/SqliteFeeratesDbSpec.scala
@@ -51,7 +51,7 @@ class SqliteFeeratesDbSpec extends AnyFunSuite {
     assert(db.getFeerates().get == feerate)
   }
 
-  test("migration 1->2") {
+  test("migration v1 -> current") {
     val sqlite = TestDatabases.sqliteInMemory()
 
     using(sqlite.createStatement()) { statement =>
@@ -82,7 +82,7 @@ class SqliteFeeratesDbSpec extends AnyFunSuite {
 
     val migratedDb = new SqliteFeeratesDb(sqlite)
     using(sqlite.createStatement()) { statement =>
-      assert(getVersion(statement, "feerates").contains(2))
+      assert(getVersion(statement, "feerates").contains(SqliteFeeratesDb.CURRENT_VERSION))
     }
 
     // When migrating, we simply copy the estimate for blocks 144 to blocks 1008.


### PR DESCRIPTION
Simplify the migration by not duplicating code. Should be less error-prone when adding new migration.