### PR TITLE
Retry local channel failures in trampoline payments

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -171,7 +171,7 @@ class PaymentInitiator(nodeParams: NodeParams, router: ActorRef, register: Actor
     // We generate a random secret for this payment to avoid leaking the invoice secret to the first trampoline node.
     val trampolineSecret = randomBytes32
     val (trampolineAmount, trampolineExpiry, trampolineOnion) = buildTrampolinePayment(r, trampolineFees, trampolineExpiryDelta)
-    spawnMultiPartPaymentFsm(paymentCfg) ! SendMultiPartPayment(trampolineSecret, r.trampolineNodeId, trampolineAmount, trampolineExpiry, 1, r.paymentRequest.routingInfo, r.routeParams, Seq(OnionTlv.TrampolineOnion(trampolineOnion)))
+    spawnMultiPartPaymentFsm(paymentCfg) ! SendMultiPartPayment(trampolineSecret, r.trampolineNodeId, trampolineAmount, trampolineExpiry, nodeParams.maxPaymentAttempts, r.paymentRequest.routingInfo, r.routeParams, Seq(OnionTlv.TrampolineOnion(trampolineOnion)))
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -186,6 +186,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(msg.targetExpiry.toLong === currentBlockCount + 9 + 12 + 1)
     assert(msg.totalAmount === finalAmount + trampolineFees)
     assert(msg.additionalTlvs.head.isInstanceOf[OnionTlv.TrampolineOnion])
+    assert(msg.maxAttempts === nodeParams.maxPaymentAttempts)
 
     // Verify that the trampoline node can correctly peel the trampoline onion.
     val trampolineOnion = msg.additionalTlvs.head.asInstanceOf[OnionTlv.TrampolineOnion].packet


### PR DESCRIPTION
We previously made a single payment attempt per trampoline fee.
Since our channel selection for the first attempt is deterministic, if we encountered a local failure with that channel, the retries with higher trampoline fees were hitting the exact same error, whereas we should instead try a different channel.

NB: this is a PR to the `android-phoenix` branch.