### PR TITLE
Better handling of remote commit confirmation in TxPublisher

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/ExtendedBitcoinClient.scala
@@ -153,6 +153,15 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) extends Logging
     }
 
   /**
+   * Mark a transaction as abandoned, which will allow for its wallet inputs to be re-spent.
+   * This method can be used to replace "stuck" or evicted transactions.
+   * It only works on transactions which are not included in a block and are not currently in the mempool.
+   */
+  def abandonTransaction(txId: ByteVector32)(implicit ec: ExecutionContext): Future[Boolean] = {
+    rpcClient.invoke("abandontransaction", txId).map(_ => true).recover(_ => false)
+  }
+
+  /**
    * @param outPoints outpoints to unlock.
    * @return true if all outpoints were successfully unlocked, false otherwise.
    */
@@ -282,7 +291,7 @@ class ExtendedBitcoinClient(val rpcClient: BitcoinJsonRPCClient) extends Logging
       val JBool(safe) = utxo \ "safe"
       val JDecimal(amount) = utxo \ "amount"
       val JString(txid) = utxo \ "txid"
-      val label =  utxo \ "label" match {
+      val label = utxo \ "label" match {
         case JString(label) => Some(label)
         case _ => None
       }


### PR DESCRIPTION
This PR is split in two independent commits.

In the first commit, we fix a (harmless) issue where we kept spawning `TxPublisher` actors to spend anchor outputs even when the commit tx was confirmed if the feerate was already high enough. This was spamming the logs for no reason (and spawning actors that immediately stopped themselves), we should instead check the status of the commit tx as the first precondition to spending anchor outputs.

In the second commit, we call `bitcoind`'s `abandontransaction` when 2nd-stage txs are evicted from the mempool because their parent is replaced (e.g. the remote commit tx is confirmed instead of our local commit tx). This ensures the `bitcoind` wallet will not keep these obsolete transactions in its DB and reserve their inputs for no good reason.

Fixes #1898