### PR TITLE
Gracefully release Postgres lock on shutdown

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -368,6 +368,10 @@ akka {
     }
   }
 
+  // we rely on coordinated shutdown to gracefully release the postgres lock
+  coordinated-shutdown.terminate-actor-system = on
+  coordinated-shutdown.exit-jvm = on
+
   cluster {
     role {
       backend.min-nr-of-members = 1

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
@@ -120,7 +120,7 @@ object Databases extends Logging {
               logger.info("cancelling the pg lock renew task...")
               leaseLockTask.cancel()
               logger.info("releasing the curent pg lock...")
-              l.releaseExclusiveLock
+              l.releaseExclusiveLock(ds)
               logger.info("closing the connection pool...")
               ds.close()
               Done

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
@@ -16,7 +16,8 @@
 
 package fr.acinq.eclair.db
 
-import akka.actor.ActorSystem
+import akka.Done
+import akka.actor.{ActorSystem, CoordinatedShutdown}
 import com.typesafe.config.Config
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import fr.acinq.eclair.db.pg.PgUtils.PgLock.LockFailureHandler
@@ -29,6 +30,7 @@ import java.io.File
 import java.nio.file._
 import java.sql.Connection
 import java.util.UUID
+import scala.concurrent.Future
 import scala.concurrent.duration._
 
 trait Databases {
@@ -111,7 +113,19 @@ object Databases extends Logging {
           l.obtainExclusiveLock(ds)
           // ...and renew the lease regularly
           import system.dispatcher
-          system.scheduler.scheduleWithFixedDelay(l.leaseRenewInterval, l.leaseRenewInterval)(() => l.obtainExclusiveLock(ds))
+          val leaseLockTask = system.scheduler.scheduleWithFixedDelay(l.leaseRenewInterval, l.leaseRenewInterval)(() => l.obtainExclusiveLock(ds))
+
+          CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseActorSystemTerminate, "release-postgres-lock") { () =>
+            Future {
+              logger.info("cancelling the pg lock renew task...")
+              leaseLockTask.cancel()
+              logger.info("releasing the curent pg lock...")
+              l.releaseExclusiveLock
+              logger.info("closing the connection pool...")
+              ds.close()
+              Done
+            }
+          }
       }
 
       val databases = PostgresDatabases(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgUtils.scala
@@ -38,6 +38,8 @@ object PgUtils extends JdbcUtils {
   sealed trait PgLock {
     def obtainExclusiveLock(implicit ds: DataSource): Unit
 
+    def releaseExclusiveLock(implicit ds: DataSource): Unit
+
     def withLock[T](f: Connection => T)(implicit ds: DataSource): T
   }
 
@@ -91,6 +93,8 @@ object PgUtils extends JdbcUtils {
     case object NoLock extends PgLock {
       override def obtainExclusiveLock(implicit ds: DataSource): Unit = ()
 
+      override def releaseExclusiveLock(implicit ds: DataSource): Unit = ()
+
       override def withLock[T](f: Connection => T)(implicit ds: DataSource): T =
         inTransaction(f)
     }
@@ -114,6 +118,14 @@ object PgUtils extends JdbcUtils {
 
       override def obtainExclusiveLock(implicit ds: DataSource): Unit = {
         obtainDatabaseLease(instanceId, leaseDuration) match {
+          case Right(_) => ()
+          case Left(ex) => lockFailureHandler(ex)
+        }
+      }
+
+      override def releaseExclusiveLock(implicit ds: DataSource): Unit = {
+        // put a new lease that expires right away: same as releasing the lock
+        obtainDatabaseLease(instanceId, 1 millisecond) match {
           case Right(_) => ()
           case Left(ex) => lockFailureHandler(ex)
         }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PgUtilsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PgUtilsSpec.scala
@@ -102,21 +102,21 @@ class PgUtilsSpec extends TestKitBaseClass with AnyFunSuiteLike with Eventually 
 
   test("lock release utility method") {
     val pg = EmbeddedPostgres.start()
-    implicit val ds: DataSource = pg.getPostgresDatabase
+    val ds: DataSource = pg.getPostgresDatabase
 
     val lock1 = LeaseLock(UUID.randomUUID(), 2 minutes, 1 minute, LockFailureHandler.logAndThrow)
     val lock2 = LeaseLock(UUID.randomUUID(), 2 minutes, 1 minute, LockFailureHandler.logAndThrow)
 
-    lock1.obtainExclusiveLock
+    lock1.obtainExclusiveLock(ds)
     intercept[LockFailureHandler.LockException] {
-      lock2.obtainExclusiveLock
+      lock2.obtainExclusiveLock(ds)
     }
 
-    lock1.releaseExclusiveLock
+    lock1.releaseExclusiveLock(ds)
     Thread.sleep(5)
-    lock2.obtainExclusiveLock
+    lock2.obtainExclusiveLock(ds)
     intercept[LockFailureHandler.LockException] {
-      lock1.obtainExclusiveLock
+      lock1.obtainExclusiveLock(ds)
     }
 
     pg.close()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PgUtilsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PgUtilsSpec.scala
@@ -3,7 +3,7 @@ package fr.acinq.eclair.db
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import com.typesafe.config.{Config, ConfigFactory}
 import fr.acinq.eclair.db.pg.PgUtils.ExtendedResultSet._
-import fr.acinq.eclair.db.pg.PgUtils.PgLock.{LockFailure, LockFailureHandler}
+import fr.acinq.eclair.db.pg.PgUtils.PgLock.{LeaseLock, LockFailure, LockFailureHandler}
 import fr.acinq.eclair.db.pg.PgUtils.{JdbcUrlChanged, migrateTable, using}
 import fr.acinq.eclair.{TestKitBaseClass, TestUtils}
 import grizzled.slf4j.{Logger, Logging}
@@ -15,6 +15,7 @@ import org.scalatest.funsuite.AnyFunSuiteLike
 import java.io.File
 import java.util.UUID
 import javax.sql.DataSource
+import scala.concurrent.duration.DurationInt
 
 class PgUtilsSpec extends TestKitBaseClass with AnyFunSuiteLike with Eventually {
 
@@ -25,7 +26,7 @@ class PgUtilsSpec extends TestKitBaseClass with AnyFunSuiteLike with Eventually 
     datadir.mkdirs()
     val instanceId1 = UUID.randomUUID()
     // this will lock the database for this instance id
-    val db = Databases.postgres(config, instanceId1, datadir, LockFailureHandler.logAndThrow)
+    val db1 = Databases.postgres(config, instanceId1, datadir, LockFailureHandler.logAndThrow)
 
     assert(
       intercept[LockFailureHandler.LockException] {
@@ -34,7 +35,7 @@ class PgUtilsSpec extends TestKitBaseClass with AnyFunSuiteLike with Eventually 
       }.lockFailure === LockFailure.AlreadyLocked(instanceId1))
 
     // we can renew the lease at will
-    db.obtainExclusiveLock()
+    db1.obtainExclusiveLock()
 
     // we wait significantly longer than the lease interval, and make sure that the lock is still there
     Thread.sleep(10_000)
@@ -45,18 +46,18 @@ class PgUtilsSpec extends TestKitBaseClass with AnyFunSuiteLike with Eventually 
       }.lockFailure === LockFailure.AlreadyLocked(instanceId1))
 
     // we close the first connection
-    db.dataSource.close()
-    eventually(assert(db.dataSource.isClosed))
+    db1.dataSource.close()
+    eventually(assert(db1.dataSource.isClosed))
     // we wait just a bit longer than the lease interval
     Thread.sleep(6_000)
 
     // now we can put a lock with a different instance id
     val instanceId2 = UUID.randomUUID()
-    Databases.postgres(config, instanceId2, datadir, LockFailureHandler.logAndThrow)
+    val db2 = Databases.postgres(config, instanceId2, datadir, LockFailureHandler.logAndThrow)
 
     // we close the second connection
-    db.dataSource.close()
-    eventually(assert(db.dataSource.isClosed))
+    db2.dataSource.close()
+    eventually(assert(db2.dataSource.isClosed))
 
     // but we don't wait for the previous lease to expire, so we can't take over right now
     assert(intercept[LockFailureHandler.LockException] {
@@ -94,6 +95,28 @@ class PgUtilsSpec extends TestKitBaseClass with AnyFunSuiteLike with Eventually 
             statement.executeUpdate()
         }
       }
+    }
+
+    pg.close()
+  }
+
+  test("lock release utility method") {
+    val pg = EmbeddedPostgres.start()
+    implicit val ds: DataSource = pg.getPostgresDatabase
+
+    val lock1 = LeaseLock(UUID.randomUUID(), 2 minutes, 1 minute, LockFailureHandler.logAndThrow)
+    val lock2 = LeaseLock(UUID.randomUUID(), 2 minutes, 1 minute, LockFailureHandler.logAndThrow)
+
+    lock1.obtainExclusiveLock
+    intercept[LockFailureHandler.LockException] {
+      lock2.obtainExclusiveLock
+    }
+
+    lock1.releaseExclusiveLock
+    Thread.sleep(5)
+    lock2.obtainExclusiveLock
+    intercept[LockFailureHandler.LockException] {
+      lock1.obtainExclusiveLock
     }
 
     pg.close()

--- a/eclair-front/src/main/resources/application.conf
+++ b/eclair-front/src/main/resources/application.conf
@@ -39,8 +39,6 @@ akka {
     roles = [frontend]
     seed-nodes = ["akka://eclair-node@"${eclair.front.backend.ip}":25520"]
   }
-  coordinated-shutdown.terminate-actor-system = on
-  coordinated-shutdown.exit-jvm = on
   //It is recommended to load the extension when the actor system is started by defining it in akka.extensions
   //configuration property. Otherwise it will be activated when first used and then it takes a while for it to be populated.
   extensions = ["akka.cluster.pubsub.DistributedPubSub"]

--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -25,8 +25,6 @@ akka {
     }
   }
   cluster.roles = [backend]
-  coordinated-shutdown.terminate-actor-system = on
-  coordinated-shutdown.exit-jvm = on
   // It is recommended to load the extension when the actor system is started by defining it in akka.extensions
   // configuration property. Otherwise it will be activated when first used and then it takes a while for it to be populated.
   // Uncomment the line below in cluster mode


### PR DESCRIPTION
This allows instant restart of eclair when using Postgres backend.

Fixes #1896.