### PR TITLE
Zmq resilence

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
@@ -41,6 +41,8 @@ class ZMQActor(address: String, topic: String, connected: Option[Promise[Done]] 
   subscriber.monitor("inproc://events", ZMQ.EVENT_CONNECTED | ZMQ.EVENT_DISCONNECTED)
   subscriber.setRcvHWM(0) // disable high watermark to ensure we never drop messages
   subscriber.setTCPKeepAlive(1) // enable tcp keep-alive
+  subscriber.setTCPKeepAliveIdle(300)
+  subscriber.setTCPKeepAliveInterval(300)
   subscriber.subscribe(topic.getBytes(ZMQ.CHARSET))
   subscriber.connect(address)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/zmq/ZMQActor.scala
@@ -39,9 +39,10 @@ class ZMQActor(address: String, topic: String, connected: Option[Promise[Done]] 
 
   val subscriber = ctx.createSocket(SocketType.SUB)
   subscriber.monitor("inproc://events", ZMQ.EVENT_CONNECTED | ZMQ.EVENT_DISCONNECTED)
-  subscriber.connect(address)
+  subscriber.setRcvHWM(0) // disable high watermark to ensure we never drop messages
+  subscriber.setTCPKeepAlive(1) // enable tcp keep-alive
   subscriber.subscribe(topic.getBytes(ZMQ.CHARSET))
-  subscriber.setTCPKeepAlive(1)
+  subscriber.connect(address)
 
   val monitor = ctx.createSocket(SocketType.PAIR)
   monitor.connect("inproc://events")


### PR DESCRIPTION
In addition to proposed by @t-bast ZMQ options following an example in Core Python code, I've add two more lines.

For two days Eclair is following Core without meaningful lag (before it was like 5-6 blocks). Maximum lag I observed was about 2 blocks and probably related to more frequent  blocks due to increasing hashrate.

I did little research collecting timestamps as they pop-up in Eclair logs and comparing them with block timestamps.

![zmq-blocks](https://user-images.githubusercontent.com/15425710/130088180-468609eb-4ea4-430f-a92c-becfb42fcf66.png)

![zmq-delta](https://user-images.githubusercontent.com/15425710/130088207-974a62b1-f5c7-4bcc-87b2-ee5e96978a13.png)

I'm continuing to look after node health but I hope these two little strings address the issue.
