### PR TITLE
Extend `ChannelRestored` event

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -232,7 +232,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
 
     case Event(INPUT_RESTORED(data), _) =>
       log.info("restoring channel")
-      context.system.eventStream.publish(ChannelRestored(self, data.channelId, peer, remoteNodeId, data))
+      context.system.eventStream.publish(ChannelRestored(self, data.channelId, peer, remoteNodeId, Left(data)))
       txPublisher ! SetChannelId(remoteNodeId, data.channelId)
       data match {
         // NB: order matters!

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -32,7 +32,7 @@ trait ChannelEvent
 
 case class ChannelCreated(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, isFunder: Boolean, temporaryChannelId: ByteVector32, initialFeeratePerKw: FeeratePerKw, fundingTxFeeratePerKw: Option[FeeratePerKw]) extends ChannelEvent
 
-case class ChannelRestored(channel: ActorRef, channelId: ByteVector32, peer: ActorRef, remoteNodeId: PublicKey, data: HasCommitments) extends ChannelEvent
+case class ChannelRestored(channel: ActorRef, channelId: ByteVector32, peer: ActorRef, remoteNodeId: PublicKey, data: Either[HasCommitments, AbstractCommitments]) extends ChannelEvent
 
 case class ChannelIdAssigned(channel: ActorRef, remoteNodeId: PublicKey, temporaryChannelId: ByteVector32, channelId: ByteVector32) extends ChannelEvent
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/balance/ChannelsListenerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/balance/ChannelsListenerSpec.scala
@@ -24,9 +24,9 @@ class ChannelsListenerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load(
     }
 
     val channel1 = TestProbe[Any]()
-    system.eventStream ! EventStream.Publish(ChannelRestored(channel1.ref.toClassic, randomBytes32(), null, randomKey().publicKey, ChannelCodecsSpec.normal))
+    system.eventStream ! EventStream.Publish(ChannelRestored(channel1.ref.toClassic, randomBytes32(), null, randomKey().publicKey, Left(ChannelCodecsSpec.normal)))
     val channel2 = TestProbe[Any]()
-    system.eventStream ! EventStream.Publish(ChannelRestored(channel2.ref.toClassic, randomBytes32(), null, randomKey().publicKey, ChannelCodecsSpec.normal))
+    system.eventStream ! EventStream.Publish(ChannelRestored(channel2.ref.toClassic, randomBytes32(), null, randomKey().publicKey, Left(ChannelCodecsSpec.normal)))
 
     val probe = TestProbe[GetChannelsResponse]()
 

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -78,7 +78,7 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
       runInGuiThread(() => mainController.channelBox.getChildren.addAll(root))
       context.become(main(m + (channel -> channelPaneController)))
 
-    case ChannelRestored(channel, channelId, peer, remoteNodeId, currentData) => // We are specifically interested in normal Commitments with funding txid here
+    case ChannelRestored(channel, channelId, peer, remoteNodeId, Left(currentData)) => // We are specifically interested in normal Commitments with funding txid here
       context.watch(channel)
       val (channelPaneController, root) = createChannelPanel(channel, peer, remoteNodeId, currentData.commitments.localParams.isFunder, channelId)
       channelPaneController.updateBalance(currentData.commitments)


### PR DESCRIPTION
Previosuly `ChannelRestored` event had `commitments: AbstractCommitments` field, since https://github.com/ACINQ/eclair/pull/1737/files#diff-4dac524d45d2e6f5b4c59d0a105f689ae1dfc8459eafdadf4d6d79cd4d46165bR35 it was replaced with `data: HasCommitments` which breaks compatibility with hosted channels plugin since it uses this event, but can't use `HasCommitments` by design.

What's proposed here is to extend that field to `data: Either[HasCommitments, AbstractCommitments]`. Currently `data` is mostly used by `ChannelsListener` to calculate global balance and this change enables to take non-standard channel balances into account in future (they are omitted for now).