### PR TITLE
Add `AbstractChannelRestored` event trait

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -32,14 +32,15 @@ trait ChannelEvent
 
 case class ChannelCreated(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, isFunder: Boolean, temporaryChannelId: ByteVector32, initialFeeratePerKw: FeeratePerKw, fundingTxFeeratePerKw: Option[FeeratePerKw]) extends ChannelEvent
 
-trait ChannelAvailable extends ChannelEvent {
+// This trait can be used by non-standard channels to inject themselves into Register actor and thus make them usable for routing
+trait AbstractChannelRestored extends ChannelEvent {
   val channel: ActorRef
   val channelId: ByteVector32
   val peer: ActorRef
   val remoteNodeId: PublicKey
 }
 
-case class ChannelRestored(channel: ActorRef, channelId: ByteVector32, peer: ActorRef, remoteNodeId: PublicKey, data: HasCommitments) extends ChannelAvailable
+case class ChannelRestored(channel: ActorRef, channelId: ByteVector32, peer: ActorRef, remoteNodeId: PublicKey, data: HasCommitments) extends AbstractChannelRestored
 
 case class ChannelIdAssigned(channel: ActorRef, remoteNodeId: PublicKey, temporaryChannelId: ByteVector32, channelId: ByteVector32) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -32,7 +32,14 @@ trait ChannelEvent
 
 case class ChannelCreated(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, isFunder: Boolean, temporaryChannelId: ByteVector32, initialFeeratePerKw: FeeratePerKw, fundingTxFeeratePerKw: Option[FeeratePerKw]) extends ChannelEvent
 
-case class ChannelRestored(channel: ActorRef, channelId: ByteVector32, peer: ActorRef, remoteNodeId: PublicKey, data: HasCommitments) extends ChannelEvent
+trait ChannelAvailable extends ChannelEvent {
+  val channel: ActorRef
+  val channelId: ByteVector32
+  val peer: ActorRef
+  val remoteNodeId: PublicKey
+}
+
+case class ChannelRestored(channel: ActorRef, channelId: ByteVector32, peer: ActorRef, remoteNodeId: PublicKey, data: HasCommitments) extends ChannelAvailable
 
 case class ChannelIdAssigned(channel: ActorRef, remoteNodeId: PublicKey, temporaryChannelId: ByteVector32, channelId: ByteVector32) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -29,7 +29,7 @@ import fr.acinq.eclair.channel.Register._
 class Register extends Actor with ActorLogging {
 
   context.system.eventStream.subscribe(self, classOf[ChannelCreated])
-  context.system.eventStream.subscribe(self, classOf[ChannelAvailable])
+  context.system.eventStream.subscribe(self, classOf[AbstractChannelRestored])
   context.system.eventStream.subscribe(self, classOf[ChannelIdAssigned])
   context.system.eventStream.subscribe(self, classOf[ShortChannelIdAssigned])
 
@@ -40,7 +40,7 @@ class Register extends Actor with ActorLogging {
       context.watch(channel)
       context become main(channels + (temporaryChannelId -> channel), shortIds, channelsTo + (temporaryChannelId -> remoteNodeId))
 
-    case event: ChannelAvailable =>
+    case event: AbstractChannelRestored =>
       context.watch(event.channel)
       context become main(channels + (event.channelId -> event.channel), shortIds, channelsTo + (event.channelId -> event.remoteNodeId))
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -29,7 +29,7 @@ import fr.acinq.eclair.channel.Register._
 class Register extends Actor with ActorLogging {
 
   context.system.eventStream.subscribe(self, classOf[ChannelCreated])
-  context.system.eventStream.subscribe(self, classOf[ChannelRestored])
+  context.system.eventStream.subscribe(self, classOf[ChannelAvailable])
   context.system.eventStream.subscribe(self, classOf[ChannelIdAssigned])
   context.system.eventStream.subscribe(self, classOf[ShortChannelIdAssigned])
 
@@ -40,9 +40,9 @@ class Register extends Actor with ActorLogging {
       context.watch(channel)
       context become main(channels + (temporaryChannelId -> channel), shortIds, channelsTo + (temporaryChannelId -> remoteNodeId))
 
-    case ChannelRestored(channel, channelId, _, remoteNodeId, _) =>
-      context.watch(channel)
-      context become main(channels + (channelId -> channel), shortIds, channelsTo + (channelId -> remoteNodeId))
+    case event: ChannelAvailable =>
+      context.watch(event.channel)
+      context become main(channels + (event.channelId -> event.channel), shortIds, channelsTo + (event.channelId -> event.remoteNodeId))
 
     case ChannelIdAssigned(channel, remoteNodeId, temporaryChannelId, channelId) =>
       context become main(channels + (channelId -> channel) - temporaryChannelId, shortIds, channelsTo + (channelId -> remoteNodeId) - temporaryChannelId)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/RegisterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/RegisterSpec.scala
@@ -17,7 +17,7 @@ class RegisterSpec extends AnyFunSuite {
 
   case class CustomChannelRestored(channel: ActorRef, channelId: ByteVector32, peer: ActorRef, remoteNodeId: PublicKey) extends AbstractChannelRestored
 
-  test("relay an htlc-add") {
+  test("register processes custom restored events") {
     implicit val timeout: Timeout = Timeout(3.seconds)
     implicit val system: ActorSystem = ActorSystem("test")
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/RegisterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/RegisterSpec.scala
@@ -19,6 +19,6 @@ class RegisterSpec extends TestKitBaseClass with AnyFunSuiteLike with ParallelTe
     val customRestoredEvent = CustomChannelRestored(TestProbe().ref, randomBytes32(), TestProbe().ref, randomKey().publicKey)
     registerRef ! customRestoredEvent
     sender.send(registerRef, Symbol("channels"))
-    sender.expectMsgType[Map[ByteVector32, ActorRef]] == Map(customRestoredEvent.channelId -> customRestoredEvent.channel)
+    sender.expectMsgType[Map[ByteVector32, ActorRef]] === Map(customRestoredEvent.channelId -> customRestoredEvent.channel)
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/RegisterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/RegisterSpec.scala
@@ -1,0 +1,30 @@
+package fr.acinq.eclair.channel
+
+import fr.acinq.eclair._
+
+import scala.concurrent.duration._
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.testkit.TestProbe
+import fr.acinq.bitcoin.ByteVector32
+import fr.acinq.bitcoin.Crypto.PublicKey
+import org.scalatest.funsuite.AnyFunSuite
+import akka.pattern.ask
+import akka.util.Timeout
+
+import scala.concurrent.Await
+
+class RegisterSpec extends AnyFunSuite {
+
+  case class CustomChannelRestored(channel: ActorRef, channelId: ByteVector32, peer: ActorRef, remoteNodeId: PublicKey) extends AbstractChannelRestored
+
+  test("relay an htlc-add") {
+    implicit val timeout: Timeout = Timeout(3.seconds)
+    implicit val system: ActorSystem = ActorSystem("test")
+
+    val registerRef = system.actorOf(Props(new Register))
+    val customRestoredEvent = CustomChannelRestored(TestProbe().ref, randomBytes32(), TestProbe().ref, randomKey().publicKey)
+    registerRef ! customRestoredEvent
+
+    assert(Await.result(registerRef ? Symbol("channels"), 3.seconds).asInstanceOf[Map[ByteVector32, ActorRef]].keys.head == customRestoredEvent.channelId)
+  }
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/RegisterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/RegisterSpec.scala
@@ -2,29 +2,23 @@ package fr.acinq.eclair.channel
 
 import fr.acinq.eclair._
 
-import scala.concurrent.duration._
-import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.actor.{ActorRef, Props}
 import akka.testkit.TestProbe
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
-import org.scalatest.funsuite.AnyFunSuite
-import akka.pattern.ask
-import akka.util.Timeout
+import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatest.ParallelTestExecution
 
-import scala.concurrent.Await
-
-class RegisterSpec extends AnyFunSuite {
+class RegisterSpec extends TestKitBaseClass with AnyFunSuiteLike with ParallelTestExecution {
 
   case class CustomChannelRestored(channel: ActorRef, channelId: ByteVector32, peer: ActorRef, remoteNodeId: PublicKey) extends AbstractChannelRestored
 
   test("register processes custom restored events") {
-    implicit val timeout: Timeout = Timeout(3.seconds)
-    implicit val system: ActorSystem = ActorSystem("test")
-
+    val sender = TestProbe()
     val registerRef = system.actorOf(Props(new Register))
     val customRestoredEvent = CustomChannelRestored(TestProbe().ref, randomBytes32(), TestProbe().ref, randomKey().publicKey)
     registerRef ! customRestoredEvent
-
-    assert(Await.result(registerRef ? Symbol("channels"), 3.seconds).asInstanceOf[Map[ByteVector32, ActorRef]].keys.head == customRestoredEvent.channelId)
+    sender.send(registerRef, Symbol("channels"))
+    sender.expectMsgType[Map[ByteVector32, ActorRef]] == Map(customRestoredEvent.channelId -> customRestoredEvent.channel)
   }
 }


### PR DESCRIPTION
This is an alternative and hopefully more principled solution to https://github.com/ACINQ/eclair/pull/1924. It makes `Register` in base Eclair to rely on new `ChannelAvailable` trait rather than on concrete `ChannelRestored` class so non-standard channels can be injected into `Register` without affecting other parts of system.

> https://github.com/ACINQ/eclair/pull/1924#issuecomment-908417301
> Why do you have to use ChannelRestored? Your code must be the one emitting and listening to those events, since we only emit ChannelRestored for non-virtual channels.

`ChannelRestored` connectes HC to the rest of the system by injecting it into `Register` so routings like `Normal channel -> HC`, `HC -> Normal channel`, `HC -> HC` become possible while reusing all of the existing base code. 

This is one of the few places where HC must make base system to know about itself and it was doing that by emitting `ChannelRestored` just like a normal channel would. With this change it emits a special `HostedChannelRestored extends ChannelAvailable`.

