### PR TITLE
AB testing

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -254,6 +254,7 @@ eclair {
       // One section per experiment
       // Each experiment must have a percentage of the traffic it affects (must sum to 100 for all experiments) and may
       // have other values that override the default ones.
+        // The control experiment is mandatory
         control {
           percentage = 98
         }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -247,8 +247,10 @@ eclair {
             channel-age = 0
             channel-capacity = 0
           }
-          hop-cost-base-msat = 0
-          hop-cost-millionths = 0
+          hop-cost {
+            fee-base-msat = 0
+            fee-proportional-millionths = 0
+          }
         }
 
         // To optimize for shorter paths:
@@ -259,8 +261,11 @@ eclair {
             channel-age = 0
             channel-capacity = 0
           }
-          hop-cost-base-msat = 10000 // High hop cost penalizes strongly longer paths
-          hop-cost-millionths = 10000
+          hop-cost {
+            // High hop cost penalizes strongly longer paths
+            fee-base-msat = 10000
+            fee-proportional-millionths = 10000
+          }
         }
 
         // To optimize for successful payments:
@@ -271,8 +276,11 @@ eclair {
             channel-age = 0.5 // Old channels should have less risk of failures
             channel-capacity = 0.5 // High capacity channels are more likely to have enough liquidity to relay our payment
           }
-          hop-cost-base-msat = 1000 // Less hops means less chances of failures
-          hop-cost-millionths = 1000
+          hop-cost {
+            // Less hops means less chances of failures
+            fee-base-msat = 1000
+            fee-proportional-millionths = 1000
+          }
         }
 
         // To optimize for fast payments:
@@ -283,8 +291,11 @@ eclair {
             channel-age = 0.3 // Older channels are more likely to run smoothly
             channel-capacity = 0
           }
-          hop-cost-base-msat = 10000 // Shorter paths should be faster
-          hop-cost-millionths = 10000
+          hop-cost {
+            // Shorter paths should be faster
+            fee-base-msat = 10000
+            fee-proportional-millionths = 10000
+          }
         }
       }
     }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -249,6 +249,29 @@ eclair {
         min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs
         max-parts = 5 // maximum number of HTLCs sent per payment: increasing this value will impact performance
       }
+
+      ab-testing {
+      // One section per experiment
+      // Each experiment must have a percentage of the traffic it affects (must sum to 100 for all experiments) and may
+      // have other values that override the default ones.
+        control {
+          percentage = 98
+        }
+        test-no-weights {
+          percentage = 1
+
+          ratio-base = 1
+          ratio-cltv = 0
+          ratio-channel-age = 0
+          ratio-channel-capacity = 0
+        }
+        test-no-hop-cost {
+          percentage = 1
+
+          hop-cost-base-msat = 0
+          hop-cost-millionths = 0
+        }
+      }
     }
   }
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -191,89 +191,86 @@ eclair {
       channel-query-chunk-size = 100 // max number of short_channel_ids in query_short_channel_ids *do not change this unless you know what you are doing*
     }
 
-    default-path-finding-params {
-      randomize-route-selection = true // when computing a route for a payment we randomize the final selection
-
-      max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
-      max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
-      fee-threshold-sat = 21       // if fee is below this value we skip the max-fee-pct check
-      max-fee-pct = 0.03           // route will be discarded if fee is above this value (in percentage relative to the total payment amount); doesn't apply if fee < fee-threshold-sat
-
-      // channel 'weight' is computed with the following formula: (channelFee + hop-cost) * (ratio-base + cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)
-      // the following parameters can be used to ask the router to use heuristics to find i.e: 'cltv-optimized' routes, **the sum of the four ratios must be 1**
-      ratio-base = 0.0
-      ratio-cltv = 0.05             // when computing the weight for a channel, consider its CLTV delta in this proportion
-      ratio-channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
-      ratio-channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
-
-      // Virtual fee for additional hops
-      // Corresponds to how much you are willing to pay to get one less hop in the payment path
-      hop-cost-base-msat = 500
-      hop-cost-millionths = 200
-
-      // Examples:
-      // To optimize for fees only:
-      // ratio-base = 1
-      // ratio-cltv = 0
-      // ratio-channel-age = 0
-      // ratio-channel-capacity = 0
-      // hop-cost-base-msat = 0
-      // hop-cost-millionths = 0
-      //
-      // To optimize for shorter paths:
-      // ratio-base = 1
-      // ratio-cltv = 0
-      // ratio-channel-age = 0
-      // ratio-channel-capacity = 0
-      // hop-cost-base-msat = 10000 // High hop cost penalizes strongly longer paths
-      // hop-cost-millionths = 10000
-      //
-      // To optimize for successful payments:
-      // ratio-base = 0
-      // ratio-cltv = 0
-      // ratio-channel-age = 0.5 // Old channels should have less risk of failures
-      // ratio-channel-capacity = 0.5 // High capacity channels are more likely to have enough liquidity to relay our payment
-      // hop-cost-base-msat = 1000 // Less hops means less chances of failures
-      // hop-cost-millionths = 1000
-      //
-      // To optimize for fast payments:
-      // ratio-base = 0.2
-      // ratio-cltv = 0.5 // In case of failure we want our funds back as fast as possible
-      // ratio-channel-age = 0.3 // Older channels are more likely to run smoothly
-      // ratio-channel-capacity = 0
-      // hop-cost-base-msat = 10000 // Shorter paths should be faster
-      // hop-cost-millionths = 10000
-
-      mpp {
-	    min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs
-	    max-parts = 5 // maximum number of HTLCs sent per payment: increasing this value will impact performance
-      }
-    }
-
     // The values below will be used to perform route searching
     // One section per experiment
     // Each experiment must have a percentage of the traffic it affects (must sum to 100 for all experiments).
     // After starting an experiment, if you want to modify it you should give it a new name. If you don't, then you'll
     // end up with metrics for different sets of parameters under the same name.
     path-finding {
-      control = ${eclair.router.default-path-finding-params} {
-        percentage = 98
-      }
+      default {
+        randomize-route-selection = true // when computing a route for a payment we randomize the final selection
 
-      test-no-weights = ${eclair.router.default-path-finding-params} {
-        percentage = 2
+        max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
+        max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
+        fee-threshold-sat = 21       // if fee is below this value we skip the max-fee-pct check
+        max-fee-pct = 0.03           // route will be discarded if fee is above this value (in percentage relative to the total payment amount); doesn't apply if fee < fee-threshold-sat
 
-        ratio-base = 1
-        ratio-cltv = 0
-        ratio-channel-age = 0
-        ratio-channel-capacity = 0
-      }
+        // channel 'weight' is computed with the following formula: (channelFee + hop-cost) * (ratio-base + cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)
+        // the following parameters can be used to ask the router to use heuristics to find i.e: 'cltv-optimized' routes, **the sum of the four ratios must be 1**
+        ratio-base = 0.0
+        ratio-cltv = 0.05             // when computing the weight for a channel, consider its CLTV delta in this proportion
+        ratio-channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
+        ratio-channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
 
-      test-no-hop-cost = ${eclair.router.default-path-finding-params} {
+        // Virtual fee for additional hops
+        // Corresponds to how much you are willing to pay to get one less hop in the payment path
+        hop-cost-base-msat = 500
+        hop-cost-millionths = 200
+
+        mpp {
+          min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs
+          max-parts = 5 // maximum number of HTLCs sent per payment: increasing this value will impact performance
+        }
+
         percentage = 0
+      }
 
-        hop-cost-base-msat = 0
-        hop-cost-millionths = 0
+      experiments {
+        control = ${eclair.router.path-finding.default} {
+          percentage = 100 // All traffic use the default configuration
+        }
+
+        // Examples of other configs as 0% experiments:
+
+        // To optimize for fees only:
+        test-fees-only = ${eclair.router.path-finding.default} {
+          ratio-base = 1
+          ratio-cltv = 0
+          ratio-channel-age = 0
+          ratio-channel-capacity = 0
+          hop-cost-base-msat = 0
+          hop-cost-millionths = 0
+        }
+
+        // To optimize for shorter paths:
+        test-short-paths = ${eclair.router.path-finding.default} {
+          ratio-base = 1
+          ratio-cltv = 0
+          ratio-channel-age = 0
+          ratio-channel-capacity = 0
+          hop-cost-base-msat = 10000 // High hop cost penalizes strongly longer paths
+          hop-cost-millionths = 10000
+        }
+
+        // To optimize for successful payments:
+        test-pay-safe = ${eclair.router.path-finding.default} {
+          ratio-base = 0
+          ratio-cltv = 0
+          ratio-channel-age = 0.5 // Old channels should have less risk of failures
+          ratio-channel-capacity = 0.5 // High capacity channels are more likely to have enough liquidity to relay our payment
+          hop-cost-base-msat = 1000 // Less hops means less chances of failures
+          hop-cost-millionths = 1000
+        }
+
+        // To optimize for fast payments:
+        test-pay-fast = ${eclair.router.path-finding.default} {
+          ratio-base = 0.2
+          ratio-cltv = 0.5 // In case of failure we want our funds back as fast as possible
+          ratio-channel-age = 0.3 // Older channels are more likely to run smoothly
+          ratio-channel-capacity = 0
+          hop-cost-base-msat = 10000 // Shorter paths should be faster
+          hop-cost-millionths = 10000
+        }
       }
     }
   }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -203,8 +203,8 @@ eclair {
         boundaries {
           max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
           max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
-          // the route must have a fee that's below max-fee-sat OR below max-fee-proportional * total-amount
-          max-fee-sat = 21
+          // the route must have a fee that's below max-fee-fixed-sat OR below max-fee-proportional * total-amount
+          max-fee-fixed-sat = 21
           max-fee-proportional = 0.03
         }
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -219,8 +219,10 @@ eclair {
 
         // Virtual fee for additional hops
         // Corresponds to how much you are willing to pay to get one less hop in the payment path
-        hop-cost-base-msat = 500
-        hop-cost-millionths = 200
+        hop-cost {
+          fee-base-msat = 500
+          fee-proportional-millionths = 200
+        }
 
         mpp {
           min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -191,87 +191,87 @@ eclair {
       channel-query-chunk-size = 100 // max number of short_channel_ids in query_short_channel_ids *do not change this unless you know what you are doing*
     }
 
-    // the values below will be used to perform route searching
+    // The values below will be used to perform route searching
+    // One section per experiment
+    // Each experiment must have a percentage of the traffic it affects (must sum to 100 for all experiments).
+    // After starting an experiment, if you want to modify it you should give it a new name. If you don't, then you'll
+    // end up with metrics for different sets of parameters under the same name.
     path-finding {
-      randomize-route-selection = true // when computing a route for a payment we randomize the final selection
+      control {
+        percentage = 98
 
-      max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
-      max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
-      fee-threshold-sat = 21       // if fee is below this value we skip the max-fee-pct check
-      max-fee-pct = 0.03           // route will be discarded if fee is above this value (in percentage relative to the total payment amount); doesn't apply if fee < fee-threshold-sat
+        randomize-route-selection = true // when computing a route for a payment we randomize the final selection
 
-      // channel 'weight' is computed with the following formula: (channelFee + hop-cost) * (ratio-base + cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)
-      // the following parameters can be used to ask the router to use heuristics to find i.e: 'cltv-optimized' routes, **the sum of the four ratios must be 1**
-      ratio-base = 0.0
-      ratio-cltv = 0.05             // when computing the weight for a channel, consider its CLTV delta in this proportion
-      ratio-channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
-      ratio-channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
+        max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
+        max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
+        fee-threshold-sat = 21       // if fee is below this value we skip the max-fee-pct check
+        max-fee-pct = 0.03           // route will be discarded if fee is above this value (in percentage relative to the total payment amount); doesn't apply if fee < fee-threshold-sat
 
-      // Virtual fee for additional hops
-      // Corresponds to how much you are willing to pay to get one less hop in the payment path
-      hop-cost-base-msat = 500
-      hop-cost-millionths = 200
+        // channel 'weight' is computed with the following formula: (channelFee + hop-cost) * (ratio-base + cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)
+        // the following parameters can be used to ask the router to use heuristics to find i.e: 'cltv-optimized' routes, **the sum of the four ratios must be 1**
+        ratio-base = 0.0
+        ratio-cltv = 0.05             // when computing the weight for a channel, consider its CLTV delta in this proportion
+        ratio-channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
+        ratio-channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
 
-      // Examples:
-      // To optimize for fees only:
-      // ratio-base = 1
-      // ratio-cltv = 0
-      // ratio-channel-age = 0
-      // ratio-channel-capacity = 0
-      // hop-cost-base-msat = 0
-      // hop-cost-millionths = 0
-      //
-      // To optimize for shorter paths:
-      // ratio-base = 1
-      // ratio-cltv = 0
-      // ratio-channel-age = 0
-      // ratio-channel-capacity = 0
-      // hop-cost-base-msat = 10000 // High hop cost penalizes strongly longer paths
-      // hop-cost-millionths = 10000
-      //
-      // To optimize for successful payments:
-      // ratio-base = 0
-      // ratio-cltv = 0
-      // ratio-channel-age = 0.5 // Old channels should have less risk of failures
-      // ratio-channel-capacity = 0.5 // High capacity channels are more likely to have enough liquidity to relay our payment
-      // hop-cost-base-msat = 1000 // Less hops means less chances of failures
-      // hop-cost-millionths = 1000
-      //
-      // To optimize for fast payments:
-      // ratio-base = 0.2
-      // ratio-cltv = 0.5 // In case of failure we want our funds back as fast as possible
-      // ratio-channel-age = 0.3 // Older channels are more likely to run smoothly
-      // ratio-channel-capacity = 0
-      // hop-cost-base-msat = 10000 // Shorter paths should be faster
-      // hop-cost-millionths = 10000
+        // Virtual fee for additional hops
+        // Corresponds to how much you are willing to pay to get one less hop in the payment path
+        hop-cost-base-msat = 500
+        hop-cost-millionths = 200
 
-      mpp {
-        min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs
-        max-parts = 5 // maximum number of HTLCs sent per payment: increasing this value will impact performance
+        // Examples:
+        // To optimize for fees only:
+        // ratio-base = 1
+        // ratio-cltv = 0
+        // ratio-channel-age = 0
+        // ratio-channel-capacity = 0
+        // hop-cost-base-msat = 0
+        // hop-cost-millionths = 0
+        //
+        // To optimize for shorter paths:
+        // ratio-base = 1
+        // ratio-cltv = 0
+        // ratio-channel-age = 0
+        // ratio-channel-capacity = 0
+        // hop-cost-base-msat = 10000 // High hop cost penalizes strongly longer paths
+        // hop-cost-millionths = 10000
+        //
+        // To optimize for successful payments:
+        // ratio-base = 0
+        // ratio-cltv = 0
+        // ratio-channel-age = 0.5 // Old channels should have less risk of failures
+        // ratio-channel-capacity = 0.5 // High capacity channels are more likely to have enough liquidity to relay our payment
+        // hop-cost-base-msat = 1000 // Less hops means less chances of failures
+        // hop-cost-millionths = 1000
+        //
+        // To optimize for fast payments:
+        // ratio-base = 0.2
+        // ratio-cltv = 0.5 // In case of failure we want our funds back as fast as possible
+        // ratio-channel-age = 0.3 // Older channels are more likely to run smoothly
+        // ratio-channel-capacity = 0
+        // hop-cost-base-msat = 10000 // Shorter paths should be faster
+        // hop-cost-millionths = 10000
+
+        mpp {
+          min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs
+          max-parts = 5 // maximum number of HTLCs sent per payment: increasing this value will impact performance
+        }
       }
 
-      ab-testing {
-      // One section per experiment
-      // Each experiment must have a percentage of the traffic it affects (must sum to 100 for all experiments) and may
-      // have other values that override the default ones.
-        // The control experiment is mandatory
-        control {
-          percentage = 98
-        }
-        test-no-weights {
-          percentage = 1
+      test-no-weights = ${eclair.router.path-finding.control} {
+        percentage = 2
 
-          ratio-base = 1
-          ratio-cltv = 0
-          ratio-channel-age = 0
-          ratio-channel-capacity = 0
-        }
-        test-no-hop-cost {
-          percentage = 1
+        ratio-base = 1
+        ratio-cltv = 0
+        ratio-channel-age = 0
+        ratio-channel-capacity = 0
+      }
 
-          hop-cost-base-msat = 0
-          hop-cost-millionths = 0
-        }
+      test-no-hop-cost = ${eclair.router.path-finding.control} {
+        percentage = 0
+
+        hop-cost-base-msat = 0
+        hop-cost-millionths = 0
       }
     }
   }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -203,9 +203,9 @@ eclair {
         boundaries {
           max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
           max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
-          // the route must have a fee that's below max-fee-fixed-sat OR below max-fee-proportional * total-amount
-          max-fee-fixed-sat = 21
-          max-fee-proportional = 0.03
+          // the route must have a fee that's below max-fee-flat-sat OR below max-fee-proportional-percent / 100 * total-amount
+          max-fee-flat-sat = 21
+          max-fee-proportional-percent = 3
         }
 
         // channel 'weight' is computed with the following formula: (channelFee + hop-cost) * (ratio-base + cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -200,17 +200,22 @@ eclair {
       default {
         randomize-route-selection = true // when computing a route for a payment we randomize the final selection
 
-        max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
-        max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
-        fee-threshold-sat = 21       // if fee is below this value we skip the max-fee-pct check
-        max-fee-pct = 0.03           // route will be discarded if fee is above this value (in percentage relative to the total payment amount); doesn't apply if fee < fee-threshold-sat
+        boundaries {
+          max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
+          max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
+          // the route must have a fee that's below max-fee-sat OR below max-fee-proportional * total-amount
+          max-fee-sat = 21
+          max-fee-proportional = 0.03
+        }
 
         // channel 'weight' is computed with the following formula: (channelFee + hop-cost) * (ratio-base + cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)
         // the following parameters can be used to ask the router to use heuristics to find i.e: 'cltv-optimized' routes, **the sum of the four ratios must be 1**
-        ratio-base = 0.0
-        ratio-cltv = 0.05             // when computing the weight for a channel, consider its CLTV delta in this proportion
-        ratio-channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
-        ratio-channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
+        ratios {
+          base = 0.0
+          cltv = 0.05             // when computing the weight for a channel, consider its CLTV delta in this proportion
+          channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
+          channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
+        }
 
         // Virtual fee for additional hops
         // Corresponds to how much you are willing to pay to get one less hop in the payment path
@@ -234,40 +239,48 @@ eclair {
 
         // To optimize for fees only:
         test-fees-only = ${eclair.router.path-finding.default} {
-          ratio-base = 1
-          ratio-cltv = 0
-          ratio-channel-age = 0
-          ratio-channel-capacity = 0
+          ratios {
+            base = 1
+            cltv = 0
+            channel-age = 0
+            channel-capacity = 0
+          }
           hop-cost-base-msat = 0
           hop-cost-millionths = 0
         }
 
         // To optimize for shorter paths:
         test-short-paths = ${eclair.router.path-finding.default} {
-          ratio-base = 1
-          ratio-cltv = 0
-          ratio-channel-age = 0
-          ratio-channel-capacity = 0
+          ratios {
+            base = 1
+            cltv = 0
+            channel-age = 0
+            channel-capacity = 0
+          }
           hop-cost-base-msat = 10000 // High hop cost penalizes strongly longer paths
           hop-cost-millionths = 10000
         }
 
         // To optimize for successful payments:
         test-pay-safe = ${eclair.router.path-finding.default} {
-          ratio-base = 0
-          ratio-cltv = 0
-          ratio-channel-age = 0.5 // Old channels should have less risk of failures
-          ratio-channel-capacity = 0.5 // High capacity channels are more likely to have enough liquidity to relay our payment
+          ratios {
+            base = 0
+            cltv = 0
+            channel-age = 0.5 // Old channels should have less risk of failures
+            channel-capacity = 0.5 // High capacity channels are more likely to have enough liquidity to relay our payment
+          }
           hop-cost-base-msat = 1000 // Less hops means less chances of failures
           hop-cost-millionths = 1000
         }
 
         // To optimize for fast payments:
         test-pay-fast = ${eclair.router.path-finding.default} {
-          ratio-base = 0.2
-          ratio-cltv = 0.5 // In case of failure we want our funds back as fast as possible
-          ratio-channel-age = 0.3 // Older channels are more likely to run smoothly
-          ratio-channel-capacity = 0
+          ratios {
+            base = 0.2
+            cltv = 0.5 // In case of failure we want our funds back as fast as possible
+            channel-age = 0.3 // Older channels are more likely to run smoothly
+            channel-capacity = 0
+          }
           hop-cost-base-msat = 10000 // Shorter paths should be faster
           hop-cost-millionths = 10000
         }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -191,74 +191,76 @@ eclair {
       channel-query-chunk-size = 100 // max number of short_channel_ids in query_short_channel_ids *do not change this unless you know what you are doing*
     }
 
+    default-path-finding-params {
+      randomize-route-selection = true // when computing a route for a payment we randomize the final selection
+
+      max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
+      max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
+      fee-threshold-sat = 21       // if fee is below this value we skip the max-fee-pct check
+      max-fee-pct = 0.03           // route will be discarded if fee is above this value (in percentage relative to the total payment amount); doesn't apply if fee < fee-threshold-sat
+
+      // channel 'weight' is computed with the following formula: (channelFee + hop-cost) * (ratio-base + cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)
+      // the following parameters can be used to ask the router to use heuristics to find i.e: 'cltv-optimized' routes, **the sum of the four ratios must be 1**
+      ratio-base = 0.0
+      ratio-cltv = 0.05             // when computing the weight for a channel, consider its CLTV delta in this proportion
+      ratio-channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
+      ratio-channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
+
+      // Virtual fee for additional hops
+      // Corresponds to how much you are willing to pay to get one less hop in the payment path
+      hop-cost-base-msat = 500
+      hop-cost-millionths = 200
+
+      // Examples:
+      // To optimize for fees only:
+      // ratio-base = 1
+      // ratio-cltv = 0
+      // ratio-channel-age = 0
+      // ratio-channel-capacity = 0
+      // hop-cost-base-msat = 0
+      // hop-cost-millionths = 0
+      //
+      // To optimize for shorter paths:
+      // ratio-base = 1
+      // ratio-cltv = 0
+      // ratio-channel-age = 0
+      // ratio-channel-capacity = 0
+      // hop-cost-base-msat = 10000 // High hop cost penalizes strongly longer paths
+      // hop-cost-millionths = 10000
+      //
+      // To optimize for successful payments:
+      // ratio-base = 0
+      // ratio-cltv = 0
+      // ratio-channel-age = 0.5 // Old channels should have less risk of failures
+      // ratio-channel-capacity = 0.5 // High capacity channels are more likely to have enough liquidity to relay our payment
+      // hop-cost-base-msat = 1000 // Less hops means less chances of failures
+      // hop-cost-millionths = 1000
+      //
+      // To optimize for fast payments:
+      // ratio-base = 0.2
+      // ratio-cltv = 0.5 // In case of failure we want our funds back as fast as possible
+      // ratio-channel-age = 0.3 // Older channels are more likely to run smoothly
+      // ratio-channel-capacity = 0
+      // hop-cost-base-msat = 10000 // Shorter paths should be faster
+      // hop-cost-millionths = 10000
+
+      mpp {
+	    min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs
+	    max-parts = 5 // maximum number of HTLCs sent per payment: increasing this value will impact performance
+      }
+    }
+
     // The values below will be used to perform route searching
     // One section per experiment
     // Each experiment must have a percentage of the traffic it affects (must sum to 100 for all experiments).
     // After starting an experiment, if you want to modify it you should give it a new name. If you don't, then you'll
     // end up with metrics for different sets of parameters under the same name.
     path-finding {
-      control {
+      control = ${eclair.router.default-path-finding-params} {
         percentage = 98
-
-        randomize-route-selection = true // when computing a route for a payment we randomize the final selection
-
-        max-route-length = 6         // max route length for the 'first pass', if none is found then a second pass is made with no limit
-        max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
-        fee-threshold-sat = 21       // if fee is below this value we skip the max-fee-pct check
-        max-fee-pct = 0.03           // route will be discarded if fee is above this value (in percentage relative to the total payment amount); doesn't apply if fee < fee-threshold-sat
-
-        // channel 'weight' is computed with the following formula: (channelFee + hop-cost) * (ratio-base + cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)
-        // the following parameters can be used to ask the router to use heuristics to find i.e: 'cltv-optimized' routes, **the sum of the four ratios must be 1**
-        ratio-base = 0.0
-        ratio-cltv = 0.05             // when computing the weight for a channel, consider its CLTV delta in this proportion
-        ratio-channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
-        ratio-channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
-
-        // Virtual fee for additional hops
-        // Corresponds to how much you are willing to pay to get one less hop in the payment path
-        hop-cost-base-msat = 500
-        hop-cost-millionths = 200
-
-        // Examples:
-        // To optimize for fees only:
-        // ratio-base = 1
-        // ratio-cltv = 0
-        // ratio-channel-age = 0
-        // ratio-channel-capacity = 0
-        // hop-cost-base-msat = 0
-        // hop-cost-millionths = 0
-        //
-        // To optimize for shorter paths:
-        // ratio-base = 1
-        // ratio-cltv = 0
-        // ratio-channel-age = 0
-        // ratio-channel-capacity = 0
-        // hop-cost-base-msat = 10000 // High hop cost penalizes strongly longer paths
-        // hop-cost-millionths = 10000
-        //
-        // To optimize for successful payments:
-        // ratio-base = 0
-        // ratio-cltv = 0
-        // ratio-channel-age = 0.5 // Old channels should have less risk of failures
-        // ratio-channel-capacity = 0.5 // High capacity channels are more likely to have enough liquidity to relay our payment
-        // hop-cost-base-msat = 1000 // Less hops means less chances of failures
-        // hop-cost-millionths = 1000
-        //
-        // To optimize for fast payments:
-        // ratio-base = 0.2
-        // ratio-cltv = 0.5 // In case of failure we want our funds back as fast as possible
-        // ratio-channel-age = 0.3 // Older channels are more likely to run smoothly
-        // ratio-channel-capacity = 0
-        // hop-cost-base-msat = 10000 // Shorter paths should be faster
-        // hop-cost-millionths = 10000
-
-        mpp {
-          min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs
-          max-parts = 5 // maximum number of HTLCs sent per payment: increasing this value will impact performance
-        }
       }
 
-      test-no-weights = ${eclair.router.path-finding.control} {
+      test-no-weights = ${eclair.router.default-path-finding-params} {
         percentage = 2
 
         ratio-base = 1
@@ -267,7 +269,7 @@ eclair {
         ratio-channel-capacity = 0
       }
 
-      test-no-hop-cost = ${eclair.router.path-finding.control} {
+      test-no-hop-cost = ${eclair.router.default-path-finding-params} {
         percentage = 0
 
         hop-cost-base-msat = 0

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -192,10 +192,6 @@ eclair {
     }
 
     // The values below will be used to perform route searching
-    // One section per experiment
-    // Each experiment must have a percentage of the traffic it affects (must sum to 100 for all experiments).
-    // After starting an experiment, if you want to modify it you should give it a new name. If you don't, then you'll
-    // end up with metrics for different sets of parameters under the same name.
     path-finding {
       default {
         randomize-route-selection = true // when computing a route for a payment we randomize the final selection
@@ -205,7 +201,7 @@ eclair {
           max-cltv = 1008              // max acceptable cltv expiry for the payment (1008 ~ 1 week)
           // the route must have a fee that's below max-fee-flat-sat OR below max-fee-proportional-percent / 100 * total-amount
           max-fee-flat-sat = 21
-          max-fee-proportional-percent = 3
+          max-fee-proportional-percent = 3 // that's 3%
         }
 
         // channel 'weight' is computed with the following formula: (channelFee + hop-cost) * (ratio-base + cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)
@@ -229,12 +225,16 @@ eclair {
           max-parts = 5 // maximum number of HTLCs sent per payment: increasing this value will impact performance
         }
 
-        percentage = 0
+        percentage = 0 // set all experiments to 0% of the traffic by default
       }
 
+      // One section per experiment
+      // The percentages of the traffic for different experiments must sum to 100.
+      // After starting an experiment, if you want to modify it you should give it a new name. If you don't, then you'll
+      // end up with metrics for different sets of parameters under the same name.
       experiments {
         control = ${eclair.router.path-finding.default} {
-          percentage = 100 // All traffic use the default configuration
+          percentage = 100 // 100% of the traffic use the default configuration
         }
 
         // Examples of other configs as 0% experiments:

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -284,8 +284,8 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
 
   private def getRouteParams(experimentName: Option[String]): Option[RouteParams] = {
     experimentName match {
-      case None => Some(RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingExperimentConf.get()))
-      case Some(name) => appKit.nodeParams.routerConf.pathFindingExperimentConf.getByName(name).map(RouteCalculation.getDefaultRouteParams)
+      case None => Some(appKit.nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+      case Some(name) => appKit.nodeParams.routerConf.pathFindingExperimentConf.getByName(name)
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -41,7 +41,7 @@ import fr.acinq.eclair.payment.relay.Relayer.{GetOutgoingChannels, OutgoingChann
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.PreimageReceived
 import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentToNode, SendPaymentToRoute, SendPaymentToRouteResponse, SendSpontaneousPayment}
 import fr.acinq.eclair.router.Router._
-import fr.acinq.eclair.router.{NetworkStats, RouteCalculation, Router}
+import fr.acinq.eclair.router.{NetworkStats, Router}
 import fr.acinq.eclair.wire.protocol._
 import grizzled.slf4j.Logging
 import scodec.bits.ByteVector
@@ -284,8 +284,8 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
 
   private def getRouteParams(experimentName: Option[String]): Option[RouteParams] = {
     experimentName match {
-      case None => Some(appKit.nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
-      case Some(name) => appKit.nodeParams.routerConf.pathFindingExperimentConf.getByName(name)
+      case None => Some(appKit.nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
+      case Some(name) => appKit.nodeParams.routerConf.pathFindingExperimentConf.getByName(name).map(_.getDefaultRouteParams)
     }
   }
 
@@ -321,8 +321,8 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     getRouteParams(experimentName) match {
       case Some(defaultRouteParams) =>
         val routeParams = defaultRouteParams.copy(
-          maxFeePct = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeePct),
-          maxFeeBase = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeBase)
+          maxFeeProportional = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeeProportional),
+          maxFee = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFee)
         )
 
         externalId_opt match {
@@ -359,8 +359,8 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     getRouteParams(experimentName) match {
       case Some(defaultRouteParams) =>
         val routeParams = defaultRouteParams.copy(
-          maxFeePct = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeePct),
-          maxFeeBase = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeBase)
+          maxFeeProportional = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeeProportional),
+          maxFee = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFee)
         )
         val sendPayment = SendSpontaneousPayment(amount, recipientNodeId, paymentPreimage, maxAttempts, externalId_opt, routeParams)
         (appKit.paymentInitiator ? sendPayment).mapTo[UUID]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -322,7 +322,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
       case Some(defaultRouteParams) =>
         val routeParams = defaultRouteParams.copy(
           maxFeeProportional = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeeProportional),
-          maxFeeFixed = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeFixed)
+          maxFeeFlat = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeFlat)
         )
 
         externalId_opt match {
@@ -360,7 +360,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
       case Some(defaultRouteParams) =>
         val routeParams = defaultRouteParams.copy(
           maxFeeProportional = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeeProportional),
-          maxFeeFixed = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeFixed)
+          maxFeeFlat = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeFlat)
         )
         val sendPayment = SendSpontaneousPayment(amount, recipientNodeId, paymentPreimage, maxAttempts, externalId_opt, routeParams)
         (appKit.paymentInitiator ? sendPayment).mapTo[UUID]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -112,19 +112,19 @@ trait Eclair {
 
   def receivedInfo(paymentHash: ByteVector32)(implicit timeout: Timeout): Future[Option[IncomingPayment]]
 
-  def send(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None)(implicit timeout: Timeout): Future[UUID]
+  def send(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None, experimentName: Option[String] = None)(implicit timeout: Timeout): Future[UUID]
 
-  def sendBlocking(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None)(implicit timeout: Timeout): Future[Either[PreimageReceived, PaymentEvent]]
+  def sendBlocking(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None, experimentName: Option[String] = None)(implicit timeout: Timeout): Future[Either[PreimageReceived, PaymentEvent]]
 
-  def sendWithPreimage(externalId_opt: Option[String], recipientNodeId: PublicKey, amount: MilliSatoshi, paymentPreimage: ByteVector32 = randomBytes32(), maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None)(implicit timeout: Timeout): Future[UUID]
+  def sendWithPreimage(externalId_opt: Option[String], recipientNodeId: PublicKey, amount: MilliSatoshi, paymentPreimage: ByteVector32 = randomBytes32(), maxAttempts_opt: Option[Int] = None, feeThresholdSat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None, experimentName: Option[String] = None)(implicit timeout: Timeout): Future[UUID]
 
   def sentInfo(id: Either[UUID, ByteVector32])(implicit timeout: Timeout): Future[Seq[OutgoingPayment]]
 
   def sendOnChain(address: String, amount: Satoshi, confirmationTarget: Long): Future[ByteVector32]
 
-  def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse]
+  def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, experimentName: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse]
 
-  def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse]
+  def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, experimentName: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse]
 
   def sendToRoute(amount: MilliSatoshi, recipientAmount_opt: Option[MilliSatoshi], externalId_opt: Option[String], parentId_opt: Option[UUID], invoice: PaymentRequest, finalCltvExpiryDelta: CltvExpiryDelta, route: PredefinedRoute, trampolineSecret_opt: Option[ByteVector32] = None, trampolineFees_opt: Option[MilliSatoshi] = None, trampolineExpiryDelta_opt: Option[CltvExpiryDelta] = None, trampolineNodes_opt: Seq[PublicKey] = Nil)(implicit timeout: Timeout): Future[SendPaymentToRouteResponse]
 
@@ -279,13 +279,23 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
   }
 
-  override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] =
-    findRouteBetween(appKit.nodeParams.nodeId, targetNodeId, amount, assistedRoutes)
+  override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, experimentName: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] =
+    findRouteBetween(appKit.nodeParams.nodeId, targetNodeId, amount, experimentName, assistedRoutes)
 
-  override def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] = {
-    val routeParams = RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingExperimentConf.get())
-    val maxFee = routeParams.getMaxFee(amount)
-    (appKit.router ? RouteRequest(sourceNodeId, targetNodeId, amount, maxFee, assistedRoutes, routeParams = routeParams)).mapTo[RouteResponse]
+  private def getRouteParams(experimentName: Option[String]): Option[RouteParams] = {
+    experimentName match {
+      case None => Some(RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingExperimentConf.get()))
+      case Some(name) => appKit.nodeParams.routerConf.pathFindingExperimentConf.getByName(name).map(RouteCalculation.getDefaultRouteParams)
+    }
+  }
+
+  override def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, experimentName: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] = {
+    getRouteParams(experimentName) match {
+      case Some(routeParams) =>
+        val maxFee = routeParams.getMaxFee(amount)
+        (appKit.router ? RouteRequest(sourceNodeId, targetNodeId, amount, maxFee, assistedRoutes, routeParams = routeParams)).mapTo[RouteResponse]
+      case None => Future.failed(new IllegalArgumentException(s"Experiment $experimentName does not exist."))
+    }
   }
 
   override def sendToRoute(amount: MilliSatoshi, recipientAmount_opt: Option[MilliSatoshi], externalId_opt: Option[String], parentId_opt: Option[UUID], invoice: PaymentRequest, finalCltvExpiryDelta: CltvExpiryDelta, route: PredefinedRoute, trampolineSecret_opt: Option[ByteVector32], trampolineFees_opt: Option[MilliSatoshi], trampolineExpiryDelta_opt: Option[CltvExpiryDelta], trampolineNodes_opt: Seq[PublicKey])(implicit timeout: Timeout): Future[SendPaymentToRouteResponse] = {
@@ -306,33 +316,36 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
   }
 
-  private def createPaymentRequest(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double]): Either[IllegalArgumentException, SendPaymentToNode] = {
+  private def createPaymentRequest(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double], experimentName: Option[String]): Either[IllegalArgumentException, SendPaymentToNode] = {
     val maxAttempts = maxAttempts_opt.getOrElse(appKit.nodeParams.maxPaymentAttempts)
-    val defaultRouteParams = RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingExperimentConf.get())
-    val routeParams = defaultRouteParams.copy(
-      maxFeePct = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeePct),
-      maxFeeBase = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeBase)
-    )
+    getRouteParams(experimentName) match {
+      case Some(defaultRouteParams) =>
+        val routeParams = defaultRouteParams.copy(
+          maxFeePct = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeePct),
+          maxFeeBase = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeBase)
+        )
 
-    externalId_opt match {
-      case Some(externalId) if externalId.length > externalIdMaxLength => Left(new IllegalArgumentException(s"externalId is too long: cannot exceed $externalIdMaxLength characters"))
-      case _ if invoice.isExpired => Left(new IllegalArgumentException("invoice has expired"))
-      case _ => invoice.minFinalCltvExpiryDelta match {
-        case Some(minFinalCltvExpiryDelta) => Right(SendPaymentToNode(amount, invoice, maxAttempts, minFinalCltvExpiryDelta, externalId_opt, assistedRoutes = invoice.routingInfo, routeParams = routeParams))
-        case None => Right(SendPaymentToNode(amount, invoice, maxAttempts, externalId = externalId_opt, assistedRoutes = invoice.routingInfo, routeParams = routeParams))
-      }
+        externalId_opt match {
+          case Some(externalId) if externalId.length > externalIdMaxLength => Left(new IllegalArgumentException(s"externalId is too long: cannot exceed $externalIdMaxLength characters"))
+          case _ if invoice.isExpired => Left(new IllegalArgumentException("invoice has expired"))
+          case _ => invoice.minFinalCltvExpiryDelta match {
+            case Some(minFinalCltvExpiryDelta) => Right(SendPaymentToNode(amount, invoice, maxAttempts, minFinalCltvExpiryDelta, externalId_opt, assistedRoutes = invoice.routingInfo, routeParams = routeParams))
+            case None => Right(SendPaymentToNode(amount, invoice, maxAttempts, externalId = externalId_opt, assistedRoutes = invoice.routingInfo, routeParams = routeParams))
+          }
+        }
+      case None => Left(new IllegalArgumentException(s"Experiment $experimentName does not exist."))
     }
   }
 
-  override def send(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double])(implicit timeout: Timeout): Future[UUID] = {
-    createPaymentRequest(externalId_opt, amount, invoice, maxAttempts_opt, feeThreshold_opt, maxFeePct_opt) match {
+  override def send(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double], experimentName: Option[String])(implicit timeout: Timeout): Future[UUID] = {
+    createPaymentRequest(externalId_opt, amount, invoice, maxAttempts_opt, feeThreshold_opt, maxFeePct_opt, experimentName) match {
       case Left(ex) => Future.failed(ex)
       case Right(req) => (appKit.paymentInitiator ? req).mapTo[UUID]
     }
   }
 
-  override def sendBlocking(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double])(implicit timeout: Timeout): Future[Either[PreimageReceived, PaymentEvent]] = {
-    createPaymentRequest(externalId_opt, amount, invoice, maxAttempts_opt, feeThreshold_opt, maxFeePct_opt) match {
+  override def sendBlocking(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double], experimentName: Option[String])(implicit timeout: Timeout): Future[Either[PreimageReceived, PaymentEvent]] = {
+    createPaymentRequest(externalId_opt, amount, invoice, maxAttempts_opt, feeThreshold_opt, maxFeePct_opt, experimentName) match {
       case Left(ex) => Future.failed(ex)
       case Right(req) => (appKit.paymentInitiator ? req.copy(blockUntilComplete = true)).map {
         case e: PreimageReceived => Left(e)
@@ -341,15 +354,18 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
   }
 
-  override def sendWithPreimage(externalId_opt: Option[String], recipientNodeId: PublicKey, amount: MilliSatoshi, paymentPreimage: ByteVector32, maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double])(implicit timeout: Timeout): Future[UUID] = {
+  override def sendWithPreimage(externalId_opt: Option[String], recipientNodeId: PublicKey, amount: MilliSatoshi, paymentPreimage: ByteVector32, maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double], experimentName: Option[String])(implicit timeout: Timeout): Future[UUID] = {
     val maxAttempts = maxAttempts_opt.getOrElse(appKit.nodeParams.maxPaymentAttempts)
-    val defaultRouteParams = RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingExperimentConf.get())
-    val routeParams = defaultRouteParams.copy(
-      maxFeePct = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeePct),
-      maxFeeBase = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeBase)
-    )
-    val sendPayment = SendSpontaneousPayment(amount, recipientNodeId, paymentPreimage, maxAttempts, externalId_opt, routeParams)
-    (appKit.paymentInitiator ? sendPayment).mapTo[UUID]
+    getRouteParams(experimentName) match {
+      case Some(defaultRouteParams) =>
+        val routeParams = defaultRouteParams.copy(
+          maxFeePct = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeePct),
+          maxFeeBase = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeBase)
+        )
+        val sendPayment = SendSpontaneousPayment(amount, recipientNodeId, paymentPreimage, maxAttempts, externalId_opt, routeParams)
+        (appKit.paymentInitiator ? sendPayment).mapTo[UUID]
+      case None => Future.failed(new IllegalArgumentException(s"Experiment $experimentName does not exist."))
+    }
   }
 
   override def sentInfo(id: Either[UUID, ByteVector32])(implicit timeout: Timeout): Future[Seq[OutgoingPayment]] = Future {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -283,7 +283,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     findRouteBetween(appKit.nodeParams.nodeId, targetNodeId, amount, assistedRoutes)
 
   override def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] = {
-    val routeParams = RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingConf)
+    val routeParams = RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingExperimentConf.get())
     val maxFee = routeParams.getMaxFee(amount)
     (appKit.router ? RouteRequest(sourceNodeId, targetNodeId, amount, maxFee, assistedRoutes, routeParams = routeParams)).mapTo[RouteResponse]
   }
@@ -308,7 +308,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
 
   private def createPaymentRequest(externalId_opt: Option[String], amount: MilliSatoshi, invoice: PaymentRequest, maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double]): Either[IllegalArgumentException, SendPaymentToNode] = {
     val maxAttempts = maxAttempts_opt.getOrElse(appKit.nodeParams.maxPaymentAttempts)
-    val defaultRouteParams = RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingConf)
+    val defaultRouteParams = RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingExperimentConf.get())
     val routeParams = defaultRouteParams.copy(
       maxFeePct = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeePct),
       maxFeeBase = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeBase)
@@ -343,7 +343,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
 
   override def sendWithPreimage(externalId_opt: Option[String], recipientNodeId: PublicKey, amount: MilliSatoshi, paymentPreimage: ByteVector32, maxAttempts_opt: Option[Int], feeThreshold_opt: Option[Satoshi], maxFeePct_opt: Option[Double])(implicit timeout: Timeout): Future[UUID] = {
     val maxAttempts = maxAttempts_opt.getOrElse(appKit.nodeParams.maxPaymentAttempts)
-    val defaultRouteParams = RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingConf)
+    val defaultRouteParams = RouteCalculation.getDefaultRouteParams(appKit.nodeParams.routerConf.pathFindingExperimentConf.get())
     val routeParams = defaultRouteParams.copy(
       maxFeePct = maxFeePct_opt.getOrElse(defaultRouteParams.maxFeePct),
       maxFeeBase = feeThreshold_opt.map(_.toMilliSatoshi).getOrElse(defaultRouteParams.maxFeeBase)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -407,7 +407,7 @@ object NodeParams extends Logging {
         encodingType = routerSyncEncodingType,
         channelRangeChunkSize = config.getInt("router.sync.channel-range-chunk-size"),
         channelQueryChunkSize = config.getInt("router.sync.channel-query-chunk-size"),
-        pathFindingConf = getPathFindingConf(config.getConfig("router.path-finding"))
+        pathFindingConf = getPathFindingConf(config.getConfig("router.path-finding.ab-testing.control").withFallback(config.getConfig("router.path-finding")))
       ),
       socksProxy_opt = socksProxy_opt,
       maxPaymentAttempts = config.getInt("max-payment-attempts"),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -201,7 +201,17 @@ object NodeParams extends Logging {
       "enable-db-backup" -> "file-backup.enabled",
       "backup-notify-script" -> "file-backup.notify-script",
       // v0.6.2
-      "router.randomize-route-selection" -> "router.path-finding.randomize-route-selection",
+      "router.randomize-route-selection" -> "router.path-finding.default.randomize-route-selection",
+      "router.path-finding.max-route-length" -> "router.path-finding.default.boundaries.max-route-length",
+      "router.path-finding.max-cltv" -> "router.path-finding.default.boundaries.max-cltv",
+      "router.path-finding.fee-threshold-sat" -> "router.path-finding.default.boundaries.max-fee-sat",
+      "router.path-finding.max-fee-pct" -> "router.path-finding.default.boundaries.max-fee-proportional",
+      "router.path-finding.ratio-base" -> "router.path-finding.default.ratios.base",
+      "router.path-finding.ratio-cltv" -> "router.path-finding.default.ratios.cltv",
+      "router.path-finding.ratio-channel-age" -> "router.path-finding.default.ratios.channel-age",
+      "router.path-finding.ratio-channel-capacity" -> "router.path-finding.default.ratios.channel-capacity",
+      "router.path-finding.hop-cost-base-msat" -> "router.path-finding.default.hop-cost-base-msat",
+      "router.path-finding.hop-cost-millionths" -> "router.path-finding.default.hop-cost-millionths",
     )
     deprecatedKeyPaths.foreach {
       case (old, new_) => require(!config.hasPath(old), s"configuration key '$old' has been replaced by '$new_'")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -422,7 +422,7 @@ object NodeParams extends Logging {
         encodingType = routerSyncEncodingType,
         channelRangeChunkSize = config.getInt("router.sync.channel-range-chunk-size"),
         channelQueryChunkSize = config.getInt("router.sync.channel-query-chunk-size"),
-        pathFindingExperimentConf = getPathFindingExperimentConf(config.getConfig("router.path-finding"))
+        pathFindingExperimentConf = getPathFindingExperimentConf(config.getConfig("router.path-finding.experiments"))
       ),
       socksProxy_opt = socksProxy_opt,
       maxPaymentAttempts = config.getInt("max-payment-attempts"),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -204,8 +204,8 @@ object NodeParams extends Logging {
       "router.randomize-route-selection" -> "router.path-finding.default.randomize-route-selection",
       "router.path-finding.max-route-length" -> "router.path-finding.default.boundaries.max-route-length",
       "router.path-finding.max-cltv" -> "router.path-finding.default.boundaries.max-cltv",
-      "router.path-finding.fee-threshold-sat" -> "router.path-finding.default.boundaries.max-fee-fixed-sat",
-      "router.path-finding.max-fee-pct" -> "router.path-finding.default.boundaries.max-fee-proportional",
+      "router.path-finding.fee-threshold-sat" -> "router.path-finding.default.boundaries.max-fee-flat-sat",
+      "router.path-finding.max-fee-pct" -> "router.path-finding.default.boundaries.max-fee-proportional-percent",
       "router.path-finding.ratio-base" -> "router.path-finding.default.ratios.base",
       "router.path-finding.ratio-cltv" -> "router.path-finding.default.ratios.cltv",
       "router.path-finding.ratio-channel-age" -> "router.path-finding.default.ratios.channel-age",
@@ -322,8 +322,8 @@ object NodeParams extends Logging {
       boundaries = SearchBoundaries(
         maxRouteLength = config.getInt("boundaries.max-route-length"),
         maxCltv = CltvExpiryDelta(config.getInt("boundaries.max-cltv")),
-        maxFeeFixed = Satoshi(config.getLong("boundaries.max-fee-fixed-sat")).toMilliSatoshi,
-        maxFeeProportional = config.getDouble("boundaries.max-fee-proportional")),
+        maxFeeFlat = Satoshi(config.getLong("boundaries.max-fee-flat-sat")).toMilliSatoshi,
+        maxFeeProportional = config.getDouble("boundaries.max-fee-proportional-percent") / 100.0),
       ratios = WeightRatios(
         baseFactor = config.getDouble("ratios.base"),
         cltvDeltaFactor = config.getDouble("ratios.cltv"),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -210,8 +210,8 @@ object NodeParams extends Logging {
       "router.path-finding.ratio-cltv" -> "router.path-finding.default.ratios.cltv",
       "router.path-finding.ratio-channel-age" -> "router.path-finding.default.ratios.channel-age",
       "router.path-finding.ratio-channel-capacity" -> "router.path-finding.default.ratios.channel-capacity",
-      "router.path-finding.hop-cost-base-msat" -> "router.path-finding.default.hop-cost-base-msat",
-      "router.path-finding.hop-cost-millionths" -> "router.path-finding.default.hop-cost-millionths",
+      "router.path-finding.hop-cost-base-msat" -> "router.path-finding.default.hop-cost.fee-base-msat",
+      "router.path-finding.hop-cost-millionths" -> "router.path-finding.default.hop-cost.fee-proportional-millionths",
     )
     deprecatedKeyPaths.foreach {
       case (old, new_) => require(!config.hasPath(old), s"configuration key '$old' has been replaced by '$new_'")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -204,7 +204,7 @@ object NodeParams extends Logging {
       "router.randomize-route-selection" -> "router.path-finding.default.randomize-route-selection",
       "router.path-finding.max-route-length" -> "router.path-finding.default.boundaries.max-route-length",
       "router.path-finding.max-cltv" -> "router.path-finding.default.boundaries.max-cltv",
-      "router.path-finding.fee-threshold-sat" -> "router.path-finding.default.boundaries.max-fee-sat",
+      "router.path-finding.fee-threshold-sat" -> "router.path-finding.default.boundaries.max-fee-fixed-sat",
       "router.path-finding.max-fee-pct" -> "router.path-finding.default.boundaries.max-fee-proportional",
       "router.path-finding.ratio-base" -> "router.path-finding.default.ratios.base",
       "router.path-finding.ratio-cltv" -> "router.path-finding.default.ratios.cltv",
@@ -322,7 +322,7 @@ object NodeParams extends Logging {
       boundaries = SearchBoundaries(
         maxRouteLength = config.getInt("boundaries.max-route-length"),
         maxCltv = CltvExpiryDelta(config.getInt("boundaries.max-cltv")),
-        maxFee = Satoshi(config.getLong("boundaries.max-fee-sat")).toMilliSatoshi,
+        maxFeeFixed = Satoshi(config.getLong("boundaries.max-fee-fixed-sat")).toMilliSatoshi,
         maxFeeProportional = config.getDouble("boundaries.max-fee-proportional")),
       ratios = WeightRatios(
         baseFactor = config.getDouble("ratios.base"),
@@ -340,10 +340,7 @@ object NodeParams extends Logging {
 
 
     def getPathFindingExperimentConf(config: Config): PathFindingExperimentConf = {
-      val experiments = for ((name -> _) <- config.root.asScala;
-                             experimentConfig = config.getConfig(name))
-      yield (name -> getPathFindingConf(experimentConfig, name))
-
+      val experiments = config.root.asScala.keys.map(name => name -> getPathFindingConf(config.getConfig(name), name))
       PathFindingExperimentConf(experiments.toMap)
     }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -329,8 +329,7 @@ object NodeParams extends Logging {
         cltvDeltaFactor = config.getDouble("ratios.cltv"),
         ageFactor = config.getDouble("ratios.channel-age"),
         capacityFactor = config.getDouble("ratios.channel-capacity"),
-        hopCostBase = MilliSatoshi(config.getLong("hop-cost-base-msat")),
-        hopCostMillionths = config.getLong("hop-cost-millionths")
+        hopCost = getRelayFees(config.getConfig("hop-cost")),
       ),
       mpp = MultiPartParams(
         Satoshi(config.getLong("mpp.min-amount-satoshis")).toMilliSatoshi,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -21,7 +21,7 @@ import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
-import fr.acinq.eclair.payment.{ExperimentMetrics, PaymentReceived, PaymentRelayed, PaymentSent}
+import fr.acinq.eclair.payment.{PathFindingExperimentMetrics, PaymentReceived, PaymentRelayed, PaymentSent}
 
 import java.io.Closeable
 
@@ -41,7 +41,7 @@ trait AuditDb extends Closeable {
 
   def addChannelUpdate(channelUpdateParametersChanged: ChannelUpdateParametersChanged): Unit
 
-  def addExperimentMetrics(metrics: ExperimentMetrics): Unit
+  def addPathFindingExperimentMetrics(metrics: PathFindingExperimentMetrics): Unit
 
   def listSent(from: Long, to: Long): Seq[PaymentSent]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -21,7 +21,7 @@ import fr.acinq.bitcoin.{ByteVector32, Satoshi}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
-import fr.acinq.eclair.payment.{PaymentReceived, PaymentRelayed, PaymentSent}
+import fr.acinq.eclair.payment.{ExperimentMetrics, PaymentReceived, PaymentRelayed, PaymentSent}
 
 import java.io.Closeable
 
@@ -40,6 +40,8 @@ trait AuditDb extends Closeable {
   def add(channelErrorOccurred: ChannelErrorOccurred): Unit
 
   def addChannelUpdate(channelUpdateParametersChanged: ChannelUpdateParametersChanged): Unit
+
+  def addExperimentMetrics(metrics: ExperimentMetrics): Unit
 
   def listSent(from: Long, to: Long): Seq[PaymentSent]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbEventHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbEventHandler.scala
@@ -41,6 +41,7 @@ class DbEventHandler(nodeParams: NodeParams) extends Actor with ActorLogging {
   context.system.eventStream.subscribe(self, classOf[ChannelStateChanged])
   context.system.eventStream.subscribe(self, classOf[ChannelClosed])
   context.system.eventStream.subscribe(self, classOf[ChannelUpdateParametersChanged])
+  context.system.eventStream.subscribe(self, classOf[ExperimentMetrics])
 
   override def receive: Receive = {
 
@@ -119,6 +120,9 @@ class DbEventHandler(nodeParams: NodeParams) extends Actor with ActorLogging {
 
     case u: ChannelUpdateParametersChanged =>
       auditDb.addChannelUpdate(u)
+
+    case m: ExperimentMetrics =>
+      auditDb.addExperimentMetrics(m)
 
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbEventHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbEventHandler.scala
@@ -41,7 +41,7 @@ class DbEventHandler(nodeParams: NodeParams) extends Actor with ActorLogging {
   context.system.eventStream.subscribe(self, classOf[ChannelStateChanged])
   context.system.eventStream.subscribe(self, classOf[ChannelClosed])
   context.system.eventStream.subscribe(self, classOf[ChannelUpdateParametersChanged])
-  context.system.eventStream.subscribe(self, classOf[ExperimentMetrics])
+  context.system.eventStream.subscribe(self, classOf[PathFindingExperimentMetrics])
 
   override def receive: Receive = {
 
@@ -121,8 +121,8 @@ class DbEventHandler(nodeParams: NodeParams) extends Actor with ActorLogging {
     case u: ChannelUpdateParametersChanged =>
       auditDb.addChannelUpdate(u)
 
-    case m: ExperimentMetrics =>
-      auditDb.addExperimentMetrics(m)
+    case m: PathFindingExperimentMetrics =>
+      auditDb.addPathFindingExperimentMetrics(m)
 
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DualDatabases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DualDatabases.scala
@@ -166,9 +166,9 @@ case class DualAuditDb(sqlite: SqliteAuditDb, postgres: PgAuditDb) extends Audit
     sqlite.addChannelUpdate(channelUpdateParametersChanged)
   }
 
-  override def addExperimentMetrics(metrics: ExperimentMetrics): Unit = {
-    runAsync(postgres.addExperimentMetrics(metrics))
-    sqlite.addExperimentMetrics(metrics)
+  override def addPathFindingExperimentMetrics(metrics: PathFindingExperimentMetrics): Unit = {
+    runAsync(postgres.addPathFindingExperimentMetrics(metrics))
+    sqlite.addPathFindingExperimentMetrics(metrics)
   }
 
   override def listSent(from: Long, to: Long): Seq[PaymentSent] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DualDatabases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DualDatabases.scala
@@ -166,6 +166,11 @@ case class DualAuditDb(sqlite: SqliteAuditDb, postgres: PgAuditDb) extends Audit
     sqlite.addChannelUpdate(channelUpdateParametersChanged)
   }
 
+  override def addExperimentMetrics(metrics: ExperimentMetrics): Unit = {
+    runAsync(postgres.addExperimentMetrics(metrics))
+    sqlite.addExperimentMetrics(metrics)
+  }
+
   override def listSent(from: Long, to: Long): Seq[PaymentSent] = {
     runAsync(postgres.listSent(from, to))
     sqlite.listSent(from, to)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -85,7 +85,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
       }
 
       def migration89(statement: Statement): Unit = {
-        statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration INTERVAL NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
+        statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
         statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.path_finding_metrics(success)")
         statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.path_finding_metrics(timestamp)")
         statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
@@ -102,7 +102,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE TABLE audit.network_fees (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, tx_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_events (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, capacity_sat BIGINT NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_updates (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_base_msat BIGINT NOT NULL, fee_proportional_millionths BIGINT NOT NULL, cltv_expiry_delta BIGINT NOT NULL, htlc_minimum_msat BIGINT NOT NULL, htlc_maximum_msat BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
-          statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration INTERVAL NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
+          statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
 
           statement.executeUpdate("CREATE TABLE audit.channel_errors (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal BOOLEAN NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON audit.sent(timestamp)")
@@ -280,7 +280,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
         statement.setLong(1, m.amount.toLong)
         statement.setLong(2, m.fees.toLong)
         statement.setBoolean(3, m.success)
-        statement.setObject(4, new PGInterval(0, 0, 0, 0, 0, m.duration.toDouble / 1000.0))
+        statement.setLong(4, m.duration)
         statement.setTimestamp(5, new Timestamp(m.timestamp))
         statement.setString(6, m.experimentName)
         statement.executeUpdate()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -84,7 +84,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
       }
 
       def migration89(statement: Statement): Unit = {
-        statement.executeUpdate("CREATE TABLE audit.metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration INTERVAL NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
+        statement.executeUpdate("CREATE TABLE audit.metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
         statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.metrics(success)")
         statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.metrics(timestamp)")
         statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.metrics(experiment_name)")
@@ -101,7 +101,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE TABLE audit.network_fees (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, tx_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_events (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, capacity_sat BIGINT NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_updates (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_base_msat BIGINT NOT NULL, fee_proportional_millionths BIGINT NOT NULL, cltv_expiry_delta BIGINT NOT NULL, htlc_minimum_msat BIGINT NOT NULL, htlc_maximum_msat BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
-          statement.executeUpdate("CREATE TABLE audit.metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration INTERVAL NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
+          statement.executeUpdate("CREATE TABLE audit.metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
 
           statement.executeUpdate("CREATE TABLE audit.channel_errors (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal BOOLEAN NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON audit.sent(timestamp)")
@@ -275,7 +275,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
 
   override def addExperimentMetrics(m: ExperimentMetrics): Unit = withMetrics("audit/add-experiment-metrics", DbBackends.Postgres) {
     inTransaction { pg =>
-    using(pg.prepareStatement("INSERT INTO audit.metrics VALUES (?, ?, ?, INTERVAL '? millisecond', ?, ?)")) { statement =>
+    using(pg.prepareStatement("INSERT INTO audit.metrics VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
       statement.setLong(1, m.amount.toLong)
       statement.setLong(2, m.fees.toLong)
       statement.setBoolean(3, m.success)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -28,6 +28,7 @@ import fr.acinq.eclair.payment._
 import fr.acinq.eclair.transactions.Transactions.PlaceHolderPubKey
 import fr.acinq.eclair.{MilliSatoshi, MilliSatoshiLong}
 import grizzled.slf4j.Logging
+import org.postgresql.util.PGInterval
 
 import java.sql.{Statement, Timestamp}
 import java.time.Instant
@@ -84,10 +85,10 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
       }
 
       def migration89(statement: Statement): Unit = {
-        statement.executeUpdate("CREATE TABLE audit.metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
-        statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.metrics(success)")
-        statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.metrics(timestamp)")
-        statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.metrics(experiment_name)")
+        statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration INTERVAL NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
+        statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.path_finding_metrics(success)")
+        statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.path_finding_metrics(timestamp)")
+        statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
       }
 
       getVersion(statement, DB_NAME) match {
@@ -101,7 +102,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE TABLE audit.network_fees (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, tx_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_events (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, capacity_sat BIGINT NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_updates (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_base_msat BIGINT NOT NULL, fee_proportional_millionths BIGINT NOT NULL, cltv_expiry_delta BIGINT NOT NULL, htlc_minimum_msat BIGINT NOT NULL, htlc_maximum_msat BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
-          statement.executeUpdate("CREATE TABLE audit.metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
+          statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration INTERVAL NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
 
           statement.executeUpdate("CREATE TABLE audit.channel_errors (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal BOOLEAN NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON audit.sent(timestamp)")
@@ -116,9 +117,9 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE INDEX channel_updates_cid_idx ON audit.channel_updates(channel_id)")
           statement.executeUpdate("CREATE INDEX channel_updates_nid_idx ON audit.channel_updates(node_id)")
           statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON audit.channel_updates(timestamp)")
-          statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.metrics(success)")
-          statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.metrics(timestamp)")
-          statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.metrics(experiment_name)")
+          statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.path_finding_metrics(success)")
+          statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.path_finding_metrics(timestamp)")
+          statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
         case Some(v@(4 | 5 | 6 | 7 | 8)) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
           if (v < 5) {
@@ -273,17 +274,18 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
     }
   }
 
-  override def addExperimentMetrics(m: ExperimentMetrics): Unit = withMetrics("audit/add-experiment-metrics", DbBackends.Postgres) {
+  override def addPathFindingExperimentMetrics(m: PathFindingExperimentMetrics): Unit = withMetrics("audit/add-experiment-metrics", DbBackends.Postgres) {
     inTransaction { pg =>
-    using(pg.prepareStatement("INSERT INTO audit.metrics VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
-      statement.setLong(1, m.amount.toLong)
-      statement.setLong(2, m.fees.toLong)
-      statement.setBoolean(3, m.success)
-      statement.setLong(4, m.duration)
-      statement.setTimestamp(5, new Timestamp(m.timestamp))
-      statement.setString(6, m.experimentName)
-      statement.executeUpdate()
-    }}
+      using(pg.prepareStatement("INSERT INTO audit.path_finding_metrics VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
+        statement.setLong(1, m.amount.toLong)
+        statement.setLong(2, m.fees.toLong)
+        statement.setBoolean(3, m.success)
+        statement.setObject(4, new PGInterval(0, 0, 0, 0, 0, m.duration.toDouble / 1000.0))
+        statement.setTimestamp(5, new Timestamp(m.timestamp))
+        statement.setString(6, m.experimentName)
+        statement.executeUpdate()
+      }
+    }
   }
 
   override def listSent(from: Long, to: Long): Seq[PaymentSent] =

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -85,8 +85,8 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
       }
 
       def migration89(statement: Statement): Unit = {
-        statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, is_mpp BOOLEAN NOT NULL, experiment_name TEXT NOT NULL)")
-        statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.path_finding_metrics(success)")
+        statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, status TEXT NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, is_mpp BOOLEAN NOT NULL, experiment_name TEXT NOT NULL, recipient_node_id TEXT NOT NULL)")
+        statement.executeUpdate("CREATE INDEX metrics_status_idx ON audit.path_finding_metrics(status)")
         statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.path_finding_metrics(timestamp)")
         statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON audit.path_finding_metrics(is_mpp)")
         statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
@@ -103,7 +103,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE TABLE audit.network_fees (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, tx_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_events (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, capacity_sat BIGINT NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_updates (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_base_msat BIGINT NOT NULL, fee_proportional_millionths BIGINT NOT NULL, cltv_expiry_delta BIGINT NOT NULL, htlc_minimum_msat BIGINT NOT NULL, htlc_maximum_msat BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
-          statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, is_mpp BOOLEAN NOT NULL, experiment_name TEXT NOT NULL)")
+          statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, status TEXT NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, is_mpp BOOLEAN NOT NULL, experiment_name TEXT NOT NULL, recipient_node_id TEXT NOT NULL)")
 
           statement.executeUpdate("CREATE TABLE audit.channel_errors (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal BOOLEAN NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON audit.sent(timestamp)")
@@ -118,7 +118,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE INDEX channel_updates_cid_idx ON audit.channel_updates(channel_id)")
           statement.executeUpdate("CREATE INDEX channel_updates_nid_idx ON audit.channel_updates(node_id)")
           statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON audit.channel_updates(timestamp)")
-          statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.path_finding_metrics(success)")
+          statement.executeUpdate("CREATE INDEX metrics_status_idx ON audit.path_finding_metrics(status)")
           statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.path_finding_metrics(timestamp)")
           statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON audit.path_finding_metrics(is_mpp)")
           statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
@@ -278,14 +278,15 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
 
   override def addPathFindingExperimentMetrics(m: PathFindingExperimentMetrics): Unit = withMetrics("audit/add-experiment-metrics", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("INSERT INTO audit.path_finding_metrics VALUES (?, ?, ?, ?, ?, ?, ?)")) { statement =>
+      using(pg.prepareStatement("INSERT INTO audit.path_finding_metrics VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) { statement =>
         statement.setLong(1, m.amount.toLong)
         statement.setLong(2, m.fees.toLong)
-        statement.setBoolean(3, m.success)
+        statement.setString(3, m.status)
         statement.setLong(4, m.duration)
         statement.setTimestamp(5, new Timestamp(m.timestamp))
         statement.setBoolean(6, m.isMultiPart)
         statement.setString(7, m.experimentName)
+        statement.setString(8, m.recipientNodeId.value.toHex)
         statement.executeUpdate()
       }
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -36,7 +36,7 @@ import javax.sql.DataSource
 
 object PgAuditDb {
   val DB_NAME = "audit"
-  val CURRENT_VERSION = 8
+  val CURRENT_VERSION = 9
 }
 
 class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
@@ -83,6 +83,13 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
         statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON audit.channel_updates(timestamp)")
       }
 
+      def migration89(statement: Statement): Unit = {
+        statement.executeUpdate("CREATE TABLE audit.metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration INTERVAL NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
+        statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.metrics(success)")
+        statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.metrics(timestamp)")
+        statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.metrics(experiment_name)")
+      }
+
       getVersion(statement, DB_NAME) match {
         case None =>
           statement.executeUpdate("CREATE SCHEMA audit")
@@ -94,6 +101,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE TABLE audit.network_fees (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, tx_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_events (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, capacity_sat BIGINT NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_updates (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_base_msat BIGINT NOT NULL, fee_proportional_millionths BIGINT NOT NULL, cltv_expiry_delta BIGINT NOT NULL, htlc_minimum_msat BIGINT NOT NULL, htlc_maximum_msat BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+          statement.executeUpdate("CREATE TABLE audit.metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration INTERVAL NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
 
           statement.executeUpdate("CREATE TABLE audit.channel_errors (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal BOOLEAN NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON audit.sent(timestamp)")
@@ -108,7 +116,10 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE INDEX channel_updates_cid_idx ON audit.channel_updates(channel_id)")
           statement.executeUpdate("CREATE INDEX channel_updates_nid_idx ON audit.channel_updates(node_id)")
           statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON audit.channel_updates(timestamp)")
-        case Some(v@(4 | 5 | 6 | 7)) =>
+          statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.metrics(success)")
+          statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.metrics(timestamp)")
+          statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.metrics(experiment_name)")
+        case Some(v@(4 | 5 | 6 | 7 | 8)) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
           if (v < 5) {
             migration45(statement)
@@ -121,6 +132,9 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           }
           if (v < 8) {
             migration78(statement)
+          }
+          if (v < 9) {
+            migration89(statement)
           }
         case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
@@ -257,6 +271,19 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
         statement.executeUpdate()
       }
     }
+  }
+
+  override def addExperimentMetrics(m: ExperimentMetrics): Unit = withMetrics("audit/add-experiment-metrics", DbBackends.Postgres) {
+    inTransaction { pg =>
+    using(pg.prepareStatement("INSERT INTO audit.metrics VALUES (?, ?, ?, INTERVAL '? millisecond', ?, ?)")) { statement =>
+      statement.setLong(1, m.amount.toLong)
+      statement.setLong(2, m.fees.toLong)
+      statement.setBoolean(3, m.success)
+      statement.setLong(4, m.duration)
+      statement.setTimestamp(5, new Timestamp(m.timestamp))
+      statement.setString(6, m.experimentName)
+      statement.executeUpdate()
+    }}
   }
 
   override def listSent(from: Long, to: Long): Seq[PaymentSent] =

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -85,9 +85,10 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
       }
 
       def migration89(statement: Statement): Unit = {
-        statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
+        statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, is_mpp BOOLEAN NOT NULL, experiment_name TEXT NOT NULL)")
         statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.path_finding_metrics(success)")
         statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.path_finding_metrics(timestamp)")
+        statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON audit.path_finding_metrics(is_mpp)")
         statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
       }
 
@@ -102,7 +103,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE TABLE audit.network_fees (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, tx_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_events (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, capacity_sat BIGINT NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_updates (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_base_msat BIGINT NOT NULL, fee_proportional_millionths BIGINT NOT NULL, cltv_expiry_delta BIGINT NOT NULL, htlc_minimum_msat BIGINT NOT NULL, htlc_maximum_msat BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
-          statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, experiment_name TEXT NOT NULL)")
+          statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, success BOOLEAN NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, is_mpp BOOLEAN NOT NULL, experiment_name TEXT NOT NULL)")
 
           statement.executeUpdate("CREATE TABLE audit.channel_errors (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal BOOLEAN NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON audit.sent(timestamp)")
@@ -119,6 +120,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON audit.channel_updates(timestamp)")
           statement.executeUpdate("CREATE INDEX metrics_success_idx ON audit.path_finding_metrics(success)")
           statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.path_finding_metrics(timestamp)")
+          statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON audit.path_finding_metrics(is_mpp)")
           statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
         case Some(v@(4 | 5 | 6 | 7 | 8)) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
@@ -276,13 +278,14 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
 
   override def addPathFindingExperimentMetrics(m: PathFindingExperimentMetrics): Unit = withMetrics("audit/add-experiment-metrics", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("INSERT INTO audit.path_finding_metrics VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
+      using(pg.prepareStatement("INSERT INTO audit.path_finding_metrics VALUES (?, ?, ?, ?, ?, ?, ?)")) { statement =>
         statement.setLong(1, m.amount.toLong)
         statement.setLong(2, m.fees.toLong)
         statement.setBoolean(3, m.success)
         statement.setLong(4, m.duration)
         statement.setTimestamp(5, new Timestamp(m.timestamp))
-        statement.setString(6, m.experimentName)
+        statement.setBoolean(6, m.isMultiPart)
+        statement.setString(7, m.experimentName)
         statement.executeUpdate()
       }
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -92,7 +92,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
     }
 
     def migration67(statement: Statement): Unit = {
-      statement.executeUpdate("CREATE TABLE metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration INTEGER NOT NULL, timestamp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
+      statement.executeUpdate("CREATE TABLE metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
       statement.executeUpdate("CREATE INDEX metrics_success_idx ON metrics(success)")
       statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON metrics(timestamp)")
       statement.executeUpdate("CREATE INDEX metrics_name_idx ON metrics(experiment_name)")
@@ -108,7 +108,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.executeUpdate("CREATE TABLE channel_events (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, capacity_sat INTEGER NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp INTEGER NOT NULL)")
         statement.executeUpdate("CREATE TABLE channel_errors (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
         statement.executeUpdate("CREATE TABLE channel_updates (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, fee_base_msat INTEGER NOT NULL, fee_proportional_millionths INTEGER NOT NULL, cltv_expiry_delta INTEGER NOT NULL, htlc_minimum_msat INTEGER NOT NULL, htlc_maximum_msat INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
-        statement.executeUpdate("CREATE TABLE metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration INTEGER NOT NULL, timestamp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
+        statement.executeUpdate("CREATE TABLE metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
 
         statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON sent(timestamp)")
         statement.executeUpdate("CREATE INDEX received_timestamp_idx ON received(timestamp)")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -92,10 +92,10 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
     }
 
     def migration67(statement: Statement): Unit = {
-      statement.executeUpdate("CREATE TABLE metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
-      statement.executeUpdate("CREATE INDEX metrics_success_idx ON metrics(success)")
-      statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON metrics(timestamp)")
-      statement.executeUpdate("CREATE INDEX metrics_name_idx ON metrics(experiment_name)")
+      statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
+      statement.executeUpdate("CREATE INDEX metrics_success_idx ON path_finding_metrics(success)")
+      statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON path_finding_metrics(timestamp)")
+      statement.executeUpdate("CREATE INDEX metrics_name_idx ON path_finding_metrics(experiment_name)")
     }
 
     getVersion(statement, DB_NAME) match {
@@ -108,7 +108,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.executeUpdate("CREATE TABLE channel_events (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, capacity_sat INTEGER NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp INTEGER NOT NULL)")
         statement.executeUpdate("CREATE TABLE channel_errors (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
         statement.executeUpdate("CREATE TABLE channel_updates (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, fee_base_msat INTEGER NOT NULL, fee_proportional_millionths INTEGER NOT NULL, cltv_expiry_delta INTEGER NOT NULL, htlc_minimum_msat INTEGER NOT NULL, htlc_maximum_msat INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
-        statement.executeUpdate("CREATE TABLE metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
+        statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
 
         statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON sent(timestamp)")
         statement.executeUpdate("CREATE INDEX received_timestamp_idx ON received(timestamp)")
@@ -122,9 +122,9 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.executeUpdate("CREATE INDEX channel_updates_cid_idx ON channel_updates(channel_id)")
         statement.executeUpdate("CREATE INDEX channel_updates_nid_idx ON channel_updates(node_id)")
         statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON channel_updates(timestamp)")
-        statement.executeUpdate("CREATE INDEX metrics_success_idx ON metrics(success)")
-        statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON metrics(timestamp)")
-        statement.executeUpdate("CREATE INDEX metrics_name_idx ON metrics(experiment_name)")
+        statement.executeUpdate("CREATE INDEX metrics_success_idx ON path_finding_metrics(success)")
+        statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON path_finding_metrics(timestamp)")
+        statement.executeUpdate("CREATE INDEX metrics_name_idx ON path_finding_metrics(experiment_name)")
       case Some(v@(1 | 2 | 3 | 4 | 5 | 6)) =>
         logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
         if (v < 2) {
@@ -268,8 +268,8 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
     }
   }
 
-  override def addExperimentMetrics(m: ExperimentMetrics): Unit = {
-    using(sqlite.prepareStatement("INSERT INTO metrics VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
+  override def addPathFindingExperimentMetrics(m: PathFindingExperimentMetrics): Unit = {
+    using(sqlite.prepareStatement("INSERT INTO path_finding_metrics VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
       statement.setLong(1, m.amount.toLong)
       statement.setLong(2, m.fees.toLong)
       statement.setBoolean(3, m.success)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -92,8 +92,8 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
     }
 
     def migration67(statement: Statement): Unit = {
-      statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, is_mpp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
-      statement.executeUpdate("CREATE INDEX metrics_success_idx ON path_finding_metrics(success)")
+      statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, status TEXT NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, is_mpp INTEGER NOT NULL, experiment_name TEXT NOT NULL, recipient_node_id BLOB NOT NULL)")
+      statement.executeUpdate("CREATE INDEX metrics_status_idx ON path_finding_metrics(status)")
       statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON path_finding_metrics(timestamp)")
       statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON path_finding_metrics(is_mpp)")
       statement.executeUpdate("CREATE INDEX metrics_name_idx ON path_finding_metrics(experiment_name)")
@@ -109,7 +109,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.executeUpdate("CREATE TABLE channel_events (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, capacity_sat INTEGER NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp INTEGER NOT NULL)")
         statement.executeUpdate("CREATE TABLE channel_errors (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
         statement.executeUpdate("CREATE TABLE channel_updates (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, fee_base_msat INTEGER NOT NULL, fee_proportional_millionths INTEGER NOT NULL, cltv_expiry_delta INTEGER NOT NULL, htlc_minimum_msat INTEGER NOT NULL, htlc_maximum_msat INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
-        statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, is_mpp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
+        statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, status TEXT NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, is_mpp INTEGER NOT NULL, experiment_name TEXT NOT NULL, recipient_node_id BLOB NOT NULL)")
 
         statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON sent(timestamp)")
         statement.executeUpdate("CREATE INDEX received_timestamp_idx ON received(timestamp)")
@@ -123,7 +123,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.executeUpdate("CREATE INDEX channel_updates_cid_idx ON channel_updates(channel_id)")
         statement.executeUpdate("CREATE INDEX channel_updates_nid_idx ON channel_updates(node_id)")
         statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON channel_updates(timestamp)")
-        statement.executeUpdate("CREATE INDEX metrics_success_idx ON path_finding_metrics(success)")
+        statement.executeUpdate("CREATE INDEX metrics_status_idx ON path_finding_metrics(status)")
         statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON path_finding_metrics(timestamp)")
         statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON path_finding_metrics(is_mpp)")
         statement.executeUpdate("CREATE INDEX metrics_name_idx ON path_finding_metrics(experiment_name)")
@@ -271,14 +271,15 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
   }
 
   override def addPathFindingExperimentMetrics(m: PathFindingExperimentMetrics): Unit = {
-    using(sqlite.prepareStatement("INSERT INTO path_finding_metrics VALUES (?, ?, ?, ?, ?, ?, ?)")) { statement =>
+    using(sqlite.prepareStatement("INSERT INTO path_finding_metrics VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) { statement =>
       statement.setLong(1, m.amount.toLong)
       statement.setLong(2, m.fees.toLong)
-      statement.setBoolean(3, m.success)
+      statement.setString(3, m.status)
       statement.setLong(4, m.duration)
       statement.setLong(5, m.timestamp)
       statement.setBoolean(6, m.isMultiPart)
       statement.setString(7, m.experimentName)
+      statement.setBytes(8, m.recipientNodeId.value.toArray)
       statement.executeUpdate()
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -92,9 +92,10 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
     }
 
     def migration67(statement: Statement): Unit = {
-      statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
+      statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, is_mpp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
       statement.executeUpdate("CREATE INDEX metrics_success_idx ON path_finding_metrics(success)")
       statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON path_finding_metrics(timestamp)")
+      statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON path_finding_metrics(is_mpp)")
       statement.executeUpdate("CREATE INDEX metrics_name_idx ON path_finding_metrics(experiment_name)")
     }
 
@@ -108,7 +109,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.executeUpdate("CREATE TABLE channel_events (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, capacity_sat INTEGER NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp INTEGER NOT NULL)")
         statement.executeUpdate("CREATE TABLE channel_errors (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
         statement.executeUpdate("CREATE TABLE channel_updates (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, fee_base_msat INTEGER NOT NULL, fee_proportional_millionths INTEGER NOT NULL, cltv_expiry_delta INTEGER NOT NULL, htlc_minimum_msat INTEGER NOT NULL, htlc_maximum_msat INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
-        statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
+        statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, success INTEGER NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, is_mpp INTEGER NOT NULL, experiment_name TEXT NOT NULL)")
 
         statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON sent(timestamp)")
         statement.executeUpdate("CREATE INDEX received_timestamp_idx ON received(timestamp)")
@@ -124,6 +125,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON channel_updates(timestamp)")
         statement.executeUpdate("CREATE INDEX metrics_success_idx ON path_finding_metrics(success)")
         statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON path_finding_metrics(timestamp)")
+        statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON path_finding_metrics(is_mpp)")
         statement.executeUpdate("CREATE INDEX metrics_name_idx ON path_finding_metrics(experiment_name)")
       case Some(v@(1 | 2 | 3 | 4 | 5 | 6)) =>
         logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
@@ -269,13 +271,14 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
   }
 
   override def addPathFindingExperimentMetrics(m: PathFindingExperimentMetrics): Unit = {
-    using(sqlite.prepareStatement("INSERT INTO path_finding_metrics VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
+    using(sqlite.prepareStatement("INSERT INTO path_finding_metrics VALUES (?, ?, ?, ?, ?, ?, ?)")) { statement =>
       statement.setLong(1, m.amount.toLong)
       statement.setLong(2, m.fees.toLong)
       statement.setBoolean(3, m.success)
       statement.setLong(4, m.duration)
       statement.setLong(5, m.timestamp)
-      statement.setString(6, m.experimentName)
+      statement.setBoolean(6, m.isMultiPart)
+      statement.setString(7, m.experimentName)
       statement.executeUpdate()
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -232,4 +232,4 @@ object PaymentFailure {
 
 }
 
-case class PathFindingExperimentMetrics(amount: MilliSatoshi, fees: MilliSatoshi, success: Boolean, duration: Long, timestamp: Long, experimentName: String)
+case class PathFindingExperimentMetrics(amount: MilliSatoshi, fees: MilliSatoshi, success: Boolean, duration: Long, timestamp: Long, isMultiPart: Boolean, experimentName: String)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -231,3 +231,5 @@ object PaymentFailure {
   }
 
 }
+
+case class ExperimentMetrics(amount: MilliSatoshi, fees: MilliSatoshi, success: Boolean, duration: Long, timestamp: Long, experimentName: String)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -232,4 +232,11 @@ object PaymentFailure {
 
 }
 
-case class PathFindingExperimentMetrics(amount: MilliSatoshi, fees: MilliSatoshi, success: Boolean, duration: Long, timestamp: Long, isMultiPart: Boolean, experimentName: String)
+case class PathFindingExperimentMetrics(amount: MilliSatoshi,
+                                        fees: MilliSatoshi,
+                                        status: String,
+                                        duration: Long,
+                                        timestamp: Long,
+                                        isMultiPart: Boolean,
+                                        experimentName: String,
+                                        recipientNodeId: PublicKey)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -232,4 +232,4 @@ object PaymentFailure {
 
 }
 
-case class ExperimentMetrics(amount: MilliSatoshi, fees: MilliSatoshi, success: Boolean, duration: Long, timestamp: Long, experimentName: String)
+case class PathFindingExperimentMetrics(amount: MilliSatoshi, fees: MilliSatoshi, success: Boolean, duration: Long, timestamp: Long, experimentName: String)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -123,7 +123,7 @@ object NodeRelay {
     val routeMaxCltv = expiryIn - expiryOut
     val routeMaxFee = amountIn - amountOut
     nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams.copy(
-      maxFee = routeMaxFee,
+      maxFeeFixed = routeMaxFee,
       maxCltv = routeMaxCltv,
       maxFeeProportional = 0, // we disable percent-based max fee calculation, we're only interested in collecting our node fee
       includeLocalChannelCost = true)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -122,7 +122,7 @@ object NodeRelay {
   def computeRouteParams(nodeParams: NodeParams, amountIn: MilliSatoshi, expiryIn: CltvExpiry, amountOut: MilliSatoshi, expiryOut: CltvExpiry): RouteParams = {
     val routeMaxCltv = expiryIn - expiryOut
     val routeMaxFee = amountIn - amountOut
-    RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf).copy(
+    RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()).copy(
       maxFeeBase = routeMaxFee,
       routeMaxCltv = routeMaxCltv,
       maxFeePct = 0, // we disable percent-based max fee calculation, we're only interested in collecting our node fee

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -123,7 +123,7 @@ object NodeRelay {
     val routeMaxCltv = expiryIn - expiryOut
     val routeMaxFee = amountIn - amountOut
     nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams.copy(
-      maxFeeFixed = routeMaxFee,
+      maxFeeFlat = routeMaxFee,
       maxCltv = routeMaxCltv,
       maxFeeProportional = 0, // we disable percent-based max fee calculation, we're only interested in collecting our node fee
       includeLocalChannelCost = true)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -122,7 +122,7 @@ object NodeRelay {
   def computeRouteParams(nodeParams: NodeParams, amountIn: MilliSatoshi, expiryIn: CltvExpiry, amountOut: MilliSatoshi, expiryOut: CltvExpiry): RouteParams = {
     val routeMaxCltv = expiryIn - expiryOut
     val routeMaxFee = amountIn - amountOut
-    RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()).copy(
+    nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().copy(
       maxFeeBase = routeMaxFee,
       routeMaxCltv = routeMaxCltv,
       maxFeePct = 0, // we disable percent-based max fee calculation, we're only interested in collecting our node fee

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -264,7 +264,7 @@ class NodeRelay private(nodeParams: NodeParams,
   }.toClassic
 
   private def relay(upstream: Upstream.Trampoline, payloadOut: Onion.NodeRelayPayload, packetOut: OnionRoutingPacket): ActorRef = {
-    val paymentCfg = SendPaymentConfig(relayId, relayId, None, paymentHash, payloadOut.amountToForward, payloadOut.outgoingNodeId, upstream, None, storeInDb = false, publishEvent = false, Nil)
+    val paymentCfg = SendPaymentConfig(relayId, relayId, None, paymentHash, payloadOut.amountToForward, payloadOut.outgoingNodeId, upstream, None, storeInDb = false, publishEvent = false, recordMetrics = true, Nil)
     val routeParams = computeRouteParams(nodeParams, upstream.amountIn, upstream.expiryIn, payloadOut.amountToForward, payloadOut.outgoingCltv)
     // If invoice features are provided in the onion, the sender is asking us to relay to a non-trampoline recipient.
     val payFSM = payloadOut.invoiceFeatures match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -122,12 +122,11 @@ object NodeRelay {
   def computeRouteParams(nodeParams: NodeParams, amountIn: MilliSatoshi, expiryIn: CltvExpiry, amountOut: MilliSatoshi, expiryOut: CltvExpiry): RouteParams = {
     val routeMaxCltv = expiryIn - expiryOut
     val routeMaxFee = amountIn - amountOut
-    nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().copy(
-      maxFeeBase = routeMaxFee,
-      routeMaxCltv = routeMaxCltv,
-      maxFeePct = 0, // we disable percent-based max fee calculation, we're only interested in collecting our node fee
-      includeLocalChannelCost = true,
-    )
+    nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams.copy(
+      maxFee = routeMaxFee,
+      maxCltv = routeMaxCltv,
+      maxFeeProportional = 0, // we disable percent-based max fee calculation, we're only interested in collecting our node fee
+      includeLocalChannelCost = true)
   }
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -112,7 +112,10 @@ object Relayer extends Logging {
     Props(new Relayer(nodeParams, router, register, paymentHandler, initialized))
 
   // @formatter:off
-  case class RelayFees(feeBase: MilliSatoshi, feeProportionalMillionths: Long)
+  case class RelayFees(feeBase: MilliSatoshi, feeProportionalMillionths: Long) {
+    require(feeBase.toLong >= 0.0, "feeBase must be nonnegative")
+    require(feeProportionalMillionths >= 0.0, "feeProportionalMillionths must be nonnegative")
+  }
 
   case class RelayParams(publicChannelFees: RelayFees,
                          privateChannelFees: RelayFees,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
@@ -64,7 +64,7 @@ class Autoprobe(nodeParams: NodeParams, router: ActorRef, paymentInitiator: Acto
             ),
             ByteVector.empty)
           log.info(s"sending payment probe to node=$targetNodeId payment_hash=${fakeInvoice.paymentHash}")
-          val routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf)
+          val routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get())
           paymentInitiator ! PaymentInitiator.SendPaymentToNode(PAYMENT_AMOUNT_MSAT, fakeInvoice, maxAttempts = 1, routeParams = routeParams)
         case None =>
           log.info(s"could not find a destination, re-scheduling")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
@@ -20,6 +20,7 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.crypto.Sphinx.DecryptedFailurePacket
 import fr.acinq.eclair.payment.{PaymentEvent, PaymentFailed, PaymentRequest, RemoteFailure}
+import fr.acinq.eclair.router.Router.RouteParams
 import fr.acinq.eclair.router.{Announcements, RouteCalculation, Router}
 import fr.acinq.eclair.wire.protocol.IncorrectOrUnknownPaymentDetails
 import fr.acinq.eclair.{MilliSatoshiLong, NodeParams, randomBytes32, randomLong}
@@ -64,7 +65,7 @@ class Autoprobe(nodeParams: NodeParams, router: ActorRef, paymentInitiator: Acto
             ),
             ByteVector.empty)
           log.info(s"sending payment probe to node=$targetNodeId payment_hash=${fakeInvoice.paymentHash}")
-          val routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf()
+          val routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams
           paymentInitiator ! PaymentInitiator.SendPaymentToNode(PAYMENT_AMOUNT_MSAT, fakeInvoice, maxAttempts = 1, routeParams = routeParams)
         case None =>
           log.info(s"could not find a destination, re-scheduling")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
@@ -64,7 +64,7 @@ class Autoprobe(nodeParams: NodeParams, router: ActorRef, paymentInitiator: Acto
             ),
             ByteVector.empty)
           log.info(s"sending payment probe to node=$targetNodeId payment_hash=${fakeInvoice.paymentHash}")
-          val routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get())
+          val routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf()
           paymentInitiator ! PaymentInitiator.SendPaymentToNode(PAYMENT_AMOUNT_MSAT, fakeInvoice, maxAttempts = 1, routeParams = routeParams)
         case None =>
           log.info(s"could not find a destination, re-scheduling")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -243,7 +243,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
       val success = event.isRight
       val now = System.currentTimeMillis
       val duration = now - start
-      context.system.eventStream.publish(ExperimentMetrics(cfg.recipientAmount, fees, success, duration, now, request.routeParams.experimentName))
+      context.system.eventStream.publish(PathFindingExperimentMetrics(cfg.recipientAmount, fees, success, duration, now, request.routeParams.experimentName))
       Metrics.SentPaymentDuration
         .withTag(Tags.MultiPart, Tags.MultiPartType.Parent)
         .withTag(Tags.Success, value = success)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -243,7 +243,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
       val success = event.isRight
       val now = System.currentTimeMillis
       val duration = now - start
-      context.system.eventStream.publish(ExperimentMetrics(request.totalAmount, fees, success, duration, now, request.routeParams.experimentName))
+      context.system.eventStream.publish(ExperimentMetrics(cfg.recipientAmount, fees, success, duration, now, request.routeParams.experimentName))
       Metrics.SentPaymentDuration
         .withTag(Tags.MultiPart, Tags.MultiPartType.Parent)
         .withTag(Tags.Success, value = success)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -349,6 +349,7 @@ object PaymentInitiator {
    *                        don't want to store in the DB).
    * @param publishEvent    whether to publish a [[fr.acinq.eclair.payment.PaymentEvent]] on success/failure (e.g. for
    *                        multi-part child payments, we don't want to emit events for each child, only for the whole payment).
+   * @param recordMetrics   We don't record metrics for payments that don't use path finding or that are a part of a bigger payment.
    * @param additionalHops  additional hops that the payment state machine isn't aware of (e.g. when using trampoline, hops
    *                        that occur after the first trampoline node).
    */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -301,7 +301,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
         case SendPaymentToNode(_, _, _, _, _, routeParams) => routeParams.experimentName
         case SendPaymentToRoute(_, _, _, _) => ""
       }
-      context.system.eventStream.publish(ExperimentMetrics(request.finalPayload.amount, fees, success, duration, now, experimentName))
+      context.system.eventStream.publish(PathFindingExperimentMetrics(request.finalPayload.amount, fees, success, duration, now, experimentName))
       Metrics.SentPaymentDuration
         .withTag(Tags.MultiPart, if (cfg.id != cfg.parentId) Tags.MultiPartType.Child else Tags.MultiPartType.Disabled)
         .withTag(Tags.Success, value = success)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -297,11 +297,11 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
       val success = result.isInstanceOf[PaymentSent]
       val now = System.currentTimeMillis
       val duration = now - start
-      val experimentName = request match {
-        case SendPaymentToNode(_, _, _, _, _, routeParams) => routeParams.experimentName
-        case SendPaymentToRoute(_, _, _, _) => ""
+      request match {
+        case SendPaymentToNode(_, _, _, _, _, routeParams) =>
+          context.system.eventStream.publish(PathFindingExperimentMetrics(request.finalPayload.amount, fees, success, duration, now, routeParams.experimentName))
+        case SendPaymentToRoute(_, _, _, _) => ()
       }
-      context.system.eventStream.publish(PathFindingExperimentMetrics(request.finalPayload.amount, fees, success, duration, now, experimentName))
       Metrics.SentPaymentDuration
         .withTag(Tags.MultiPart, if (cfg.id != cfg.parentId) Tags.MultiPartType.Child else Tags.MultiPartType.Disabled)
         .withTag(Tags.Success, value = success)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -59,7 +59,13 @@ object EclairInternalsSerializer {
       ("searchHopCostBase" | millisatoshi) ::
       ("searchHopCostMillionths" | int64) ::
       ("mppMinPartAmount" | millisatoshi) ::
-      ("mppMaxParts" | int32)).as[PathFindingConf]
+      ("mppMaxParts" | int32) ::
+      ("experimentName" | utf8_32) ::
+      ("experimentPercentage" | int32)).as[PathFindingConf]
+
+  val pathFindingExperimentConfCodec: Codec[PathFindingExperimentConf] = (
+    ("experiments" | listOfN(int32, pathFindingConfCodec))
+    ).as[PathFindingExperimentConf]
 
   val routerConfCodec: Codec[RouterConf] = (
     ("channelExcludeDuration" | finiteDurationCodec) ::
@@ -71,7 +77,7 @@ object EclairInternalsSerializer {
         .typecase(1, provide(EncodingType.COMPRESSED_ZLIB))) ::
       ("channelRangeChunkSize" | int32) ::
       ("channelQueryChunkSize" | int32) ::
-      ("pathFindingConf" | pathFindingConfCodec)).as[RouterConf]
+      ("pathFindingExperimentConf" | pathFindingExperimentConfCodec)).as[RouterConf]
 
   val overrideFeaturesListCodec: Codec[List[(PublicKey, Features)]] = listOfN(uint16, publicKey ~ variableSizeBytes(uint16, featuresCodec))
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -23,6 +23,7 @@ import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.io.Switchboard.RouterPeerConf
 import fr.acinq.eclair.io.{ClientSpawner, Peer, PeerConnection, Switchboard}
+import fr.acinq.eclair.payment.relay.Relayer.RelayFees
 import fr.acinq.eclair.router.Graph.WeightRatios
 import fr.acinq.eclair.router.Router.{GossipDecision, MultiPartParams, PathFindingConf, RouteParams, RouterConf, SearchBoundaries, SendChannelQuery}
 import fr.acinq.eclair.router._
@@ -53,13 +54,16 @@ object EclairInternalsSerializer {
     ("maxRouteLength" | int32) ::
     ("maxCltv" | int32.as[CltvExpiryDelta])).as[SearchBoundaries]
 
+  val relayFeesCodec: Codec[RelayFees] = (
+    ("feeBase" | millisatoshi) ::
+      ("feeProportionalMillionths" | int64)).as[RelayFees]
+
   val weightRatiosCodec: Codec[WeightRatios] = (
     ("baseFactor" | double) ::
       ("cltvDeltaFactor" | double) ::
       ("ageFactor" | double) ::
       ("capacityFactor" | double) ::
-      ("hopCostBase" | millisatoshi) ::
-      ("hopCostMillionths" | int64)).as[WeightRatios]
+      ("hopCost" | relayFeesCodec)).as[WeightRatios]
 
   val multiPartParamsCodec: Codec[MultiPartParams] = (
     ("minPartAmount" | millisatoshi) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.router
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{Btc, MilliBtc, Satoshi, SatoshiLong}
 import fr.acinq.eclair._
+import fr.acinq.eclair.payment.relay.Relayer.RelayFees
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.wire.protocol.ChannelUpdate
@@ -45,14 +46,12 @@ object Graph {
    * We use heuristics to calculate the weight of an edge based on channel age, cltv delta, capacity and a virtual hop cost to keep routes short.
    * We favor older channels, with bigger capacity and small cltv delta.
    */
-  case class WeightRatios(baseFactor: Double, cltvDeltaFactor: Double, ageFactor: Double, capacityFactor: Double, hopCostBase: MilliSatoshi, hopCostMillionths: Long) {
+  case class WeightRatios(baseFactor: Double, cltvDeltaFactor: Double, ageFactor: Double, capacityFactor: Double, hopCost: RelayFees) {
     require(baseFactor + cltvDeltaFactor + ageFactor + capacityFactor == 1, "The sum of heuristics ratios must be 1")
     require(baseFactor >= 0.0, "ratio-base must be nonnegative")
     require(cltvDeltaFactor >= 0.0, "ratio-cltv must be nonnegative")
     require(ageFactor >= 0.0, "ratio-channel-age must be nonnegative")
     require(capacityFactor >= 0.0, "ratio-channel-capacity must be nonnegative")
-    require(hopCostBase.toLong >= 0.0, "hop-cost-base-msat must be nonnegative")
-    require(hopCostMillionths >= 0.0, "hop-cost-millionths must be nonnegative")
   }
   case class WeightedNode(key: PublicKey, weight: RichWeight)
   case class WeightedPath(path: Seq[GraphEdge], weight: RichWeight)
@@ -278,7 +277,7 @@ object Graph {
   private def addEdgeWeight(sender: PublicKey, edge: GraphEdge, prev: RichWeight, currentBlockHeight: Long, weightRatios: WeightRatios, includeLocalChannelCost: Boolean): RichWeight = {
     val totalCost = if (edge.desc.a == sender && !includeLocalChannelCost) prev.cost else addEdgeFees(edge, prev.cost)
     val fee = totalCost - prev.cost
-    val hopCost = nodeFee(weightRatios.hopCostBase, weightRatios.hopCostMillionths, prev.cost)
+    val hopCost = nodeFee(weightRatios.hopCost.feeBase, weightRatios.hopCost.feeProportionalMillionths, prev.cost)
     val totalCltv = if (edge.desc.a == sender && !includeLocalChannelCost) prev.cltv else prev.cltv + edge.update.cltvExpiryDelta
     import RoutingHeuristics._
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -47,6 +47,12 @@ object Graph {
    */
   case class WeightRatios(baseFactor: Double, cltvDeltaFactor: Double, ageFactor: Double, capacityFactor: Double, hopCostBase: MilliSatoshi, hopCostMillionths: Long) {
     require(baseFactor + cltvDeltaFactor + ageFactor + capacityFactor == 1, "The sum of heuristics ratios must be 1")
+    require(baseFactor >= 0.0, "ratio-base must be nonnegative")
+    require(cltvDeltaFactor >= 0.0, "ratio-cltv must be nonnegative")
+    require(ageFactor >= 0.0, "ratio-channel-age must be nonnegative")
+    require(capacityFactor >= 0.0, "ratio-channel-capacity must be nonnegative")
+    require(hopCostBase.toLong >= 0.0, "hop-cost-base-msat must be nonnegative")
+    require(hopCostMillionths >= 0.0, "hop-cost-millionths must be nonnegative")
   }
   case class WeightedNode(key: PublicKey, weight: RichWeight)
   case class WeightedPath(path: Seq[GraphEdge], weight: RichWeight)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/PathFindingExperimentConf.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/PathFindingExperimentConf.scala
@@ -1,35 +1,21 @@
 package fr.acinq.eclair.router
 
-import fr.acinq.eclair.router.Router.PathFindingConf
+import fr.acinq.eclair.router.Router.RouteParams
 
 import scala.util.Random
 
-case class PathFindingExperimentConf(experiments: List[PathFindingConf]) {
-  private val confByPercentile: Array[PathFindingConf] = new Array[PathFindingConf](100)
+case class PathFindingExperimentConf(experiments: Map[String, RouteParams]) {
+  private val confByPercentile: Array[RouteParams] = experiments.values.flatMap(e => Array.fill(e.experimentPercentage)(e)).toArray
 
-  {
-    var i = 0
-    for (conf <- experiments) {
-      for (j <- 0 until conf.experimentPercentage) {
-        confByPercentile(i + j) = conf
-      }
-      i += conf.experimentPercentage
-    }
-    require(i == 100, "All experiments percentages must sum to 100.")
-  }
+  require(confByPercentile.length == 100, "All experiments percentages must sum to 100.")
 
   private val rng = new Random()
 
-  def get(): PathFindingConf = {
+  def getRandomConf(): RouteParams = {
     confByPercentile(rng.nextInt(100))
   }
 
-  def getByName(name: String): Option[PathFindingConf] = {
-    for (conf <- experiments) {
-      if(conf.experimentName == name) {
-        return Some(conf)
-      }
-    }
-    None
+  def getByName(name: String): Option[RouteParams] = {
+    experiments.get(name)
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/PathFindingExperimentConf.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/PathFindingExperimentConf.scala
@@ -23,4 +23,13 @@ case class PathFindingExperimentConf(experiments: List[PathFindingConf]) {
   def get(): PathFindingConf = {
     confByPercentile(rng.nextInt(100))
   }
+
+  def getByName(name: String): Option[PathFindingConf] = {
+    for (conf <- experiments) {
+      if(conf.experimentName == name) {
+        return Some(conf)
+      }
+    }
+    None
+  }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/PathFindingExperimentConf.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/PathFindingExperimentConf.scala
@@ -1,0 +1,26 @@
+package fr.acinq.eclair.router
+
+import fr.acinq.eclair.router.Router.PathFindingConf
+
+import scala.util.Random
+
+case class PathFindingExperimentConf(experiments: List[PathFindingConf]) {
+  private val confByPercentile: Array[PathFindingConf] = new Array[PathFindingConf](100)
+
+  {
+    var i = 0
+    for (conf <- experiments) {
+      for (j <- 0 until conf.experimentPercentage) {
+        confByPercentile(i + j) = conf
+      }
+      i += conf.experimentPercentage
+    }
+    require(i == 100, "All experiments percentages must sum to 100.")
+  }
+
+  private val rng = new Random()
+
+  def get(): PathFindingConf = {
+    confByPercentile(rng.nextInt(100))
+  }
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/PathFindingExperimentConf.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/PathFindingExperimentConf.scala
@@ -1,21 +1,21 @@
 package fr.acinq.eclair.router
 
-import fr.acinq.eclair.router.Router.RouteParams
+import fr.acinq.eclair.router.Router.PathFindingConf
 
 import scala.util.Random
 
-case class PathFindingExperimentConf(experiments: Map[String, RouteParams]) {
-  private val confByPercentile: Array[RouteParams] = experiments.values.flatMap(e => Array.fill(e.experimentPercentage)(e)).toArray
+case class PathFindingExperimentConf(experiments: Map[String, PathFindingConf]) {
+  private val confByPercentile: Array[PathFindingConf] = experiments.values.flatMap(e => Array.fill(e.experimentPercentage)(e)).toArray
 
   require(confByPercentile.length == 100, "All experiments percentages must sum to 100.")
 
   private val rng = new Random()
 
-  def getRandomConf(): RouteParams = {
+  def getRandomConf(): PathFindingConf = {
     confByPercentile(rng.nextInt(100))
   }
 
-  def getByName(name: String): Option[RouteParams] = {
+  def getByName(name: String): Option[PathFindingConf] = {
     experiments.get(name)
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -183,25 +183,6 @@ object RouteCalculation {
   /** The default number of routes we'll search for when findRoute is called with randomize = true */
   val DEFAULT_ROUTES_COUNT = 3
 
-  def getDefaultRouteParams(pathFindingConf: PathFindingConf): RouteParams = RouteParams(
-    randomize = pathFindingConf.randomizeRouteSelection,
-    maxFeeBase = pathFindingConf.searchMaxFeeBase.toMilliSatoshi,
-    maxFeePct = pathFindingConf.searchMaxFeePct,
-    routeMaxLength = pathFindingConf.searchMaxRouteLength,
-    routeMaxCltv = pathFindingConf.searchMaxCltv,
-    ratios = WeightRatios(
-      baseFactor = pathFindingConf.searchRatioBase,
-      cltvDeltaFactor = pathFindingConf.searchRatioCltv,
-      ageFactor = pathFindingConf.searchRatioChannelAge,
-      capacityFactor = pathFindingConf.searchRatioChannelCapacity,
-      hopCostBase = pathFindingConf.searchHopCostBase,
-      hopCostMillionths = pathFindingConf.searchHopCostMillionths
-    ),
-    mpp = MultiPartParams(pathFindingConf.mppMinPartAmount, pathFindingConf.mppMaxParts),
-    includeLocalChannelCost = false,
-    experimentName = pathFindingConf.experimentName,
-  )
-
   /**
    * Find a route in the graph between localNodeId and targetNodeId, returns the route.
    * Will perform a k-shortest path selection given the @param numRoutes and randomly select one of the result.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -25,7 +25,7 @@ import fr.acinq.eclair._
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.router.Graph.GraphStructure.DirectedGraph.graphEdgeToHop
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
-import fr.acinq.eclair.router.Graph.{RichWeight, RoutingHeuristics, WeightRatios}
+import fr.acinq.eclair.router.Graph.{RichWeight, RoutingHeuristics}
 import fr.acinq.eclair.router.Monitoring.{Metrics, Tags}
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.wire.protocol.ChannelUpdate
@@ -234,9 +234,9 @@ object RouteCalculation {
 
     def feeOk(fee: MilliSatoshi): Boolean = fee <= maxFee
 
-    def lengthOk(length: Int): Boolean = length <= routeParams.routeMaxLength && length <= ROUTE_MAX_LENGTH
+    def lengthOk(length: Int): Boolean = length <= routeParams.maxRouteLength && length <= ROUTE_MAX_LENGTH
 
-    def cltvOk(cltv: CltvExpiryDelta): Boolean = cltv <= routeParams.routeMaxCltv
+    def cltvOk(cltv: CltvExpiryDelta): Boolean = cltv <= routeParams.maxCltv
 
     val boundaries: RichWeight => Boolean = { weight => feeOk(weight.cost - amount) && lengthOk(weight.length) && cltvOk(weight.cltv) }
 
@@ -249,9 +249,9 @@ object RouteCalculation {
         directRoutes ++ indirectRoutes
       }
       Right(routes)
-    } else if (routeParams.routeMaxLength < ROUTE_MAX_LENGTH) {
+    } else if (routeParams.maxRouteLength < ROUTE_MAX_LENGTH) {
       // if not found within the constraints we relax and repeat the search
-      val relaxedRouteParams = routeParams.copy(routeMaxLength = ROUTE_MAX_LENGTH, routeMaxCltv = DEFAULT_ROUTE_MAX_CLTV)
+      val relaxedRouteParams = routeParams.copy(maxRouteLength = ROUTE_MAX_LENGTH, maxCltv = DEFAULT_ROUTE_MAX_CLTV)
       findRouteInternal(g, localNodeId, targetNodeId, amount, maxFee, numRoutes, extraEdges, ignoredEdges, ignoredVertices, relaxedRouteParams, currentBlockHeight)
     } else {
       Left(RouteNotFound)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -199,6 +199,7 @@ object RouteCalculation {
     ),
     mpp = MultiPartParams(pathFindingConf.mppMinPartAmount, pathFindingConf.mppMaxParts),
     includeLocalChannelCost = false,
+    experimentName = pathFindingConf.experimentName,
   )
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -446,7 +446,7 @@ object Router {
 
   case class MultiPartParams(minPartAmount: MilliSatoshi, maxParts: Int)
 
-  case class RouteParams(randomize: Boolean, maxFeeBase: MilliSatoshi, maxFeePct: Double, routeMaxLength: Int, routeMaxCltv: CltvExpiryDelta, ratios: WeightRatios, mpp: MultiPartParams, includeLocalChannelCost: Boolean) {
+  case class RouteParams(randomize: Boolean, maxFeeBase: MilliSatoshi, maxFeePct: Double, routeMaxLength: Int, routeMaxCltv: CltvExpiryDelta, ratios: WeightRatios, mpp: MultiPartParams, includeLocalChannelCost: Boolean, experimentName: String) {
     def getMaxFee(amount: MilliSatoshi): MilliSatoshi = {
       // The payment fee must satisfy either the flat fee or the percentage fee, not necessarily both.
       maxFeeBase.max(amount * maxFeePct)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -309,7 +309,9 @@ object Router {
                              searchHopCostBase: MilliSatoshi,
                              searchHopCostMillionths: Long,
                              mppMinPartAmount: MilliSatoshi,
-                             mppMaxParts: Int) {
+                             mppMaxParts: Int,
+                             experimentName: String,
+                             experimentPercentage: Int) {
     require(searchRatioBase >= 0.0, "ratio-base must be nonnegative")
     require(searchRatioCltv >= 0.0, "ratio-cltv must be nonnegative")
     require(searchRatioChannelAge >= 0.0, "ratio-channel-age must be nonnegative")
@@ -326,7 +328,7 @@ object Router {
                         encodingType: EncodingType,
                         channelRangeChunkSize: Int,
                         channelQueryChunkSize: Int,
-                        pathFindingConf: PathFindingConf)
+                        pathFindingExperimentConf: PathFindingExperimentConf)
 
   // @formatter:off
   case class ChannelDesc(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -297,7 +297,7 @@ object Router {
 
   def props(nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Command], initialized: Option[Promise[Done]] = None) = Props(new Router(nodeParams, watcher, initialized))
 
-  case class SearchBoundaries(maxFeeFixed: MilliSatoshi,
+  case class SearchBoundaries(maxFeeFlat: MilliSatoshi,
                               maxFeeProportional: Double,
                               maxRouteLength: Int,
                               maxCltv: CltvExpiryDelta)
@@ -310,7 +310,7 @@ object Router {
                              experimentPercentage: Int) {
     def getDefaultRouteParams: RouteParams = RouteParams(
       randomize = randomize,
-      maxFeeFixed = boundaries.maxFeeFixed,
+      maxFeeFlat = boundaries.maxFeeFlat,
       maxFeeProportional = boundaries.maxFeeProportional,
       maxRouteLength = boundaries.maxRouteLength,
       maxCltv = boundaries.maxCltv,
@@ -447,7 +447,7 @@ object Router {
   case class MultiPartParams(minPartAmount: MilliSatoshi, maxParts: Int)
 
   case class RouteParams(randomize: Boolean,
-                         maxFeeFixed: MilliSatoshi,
+                         maxFeeFlat: MilliSatoshi,
                          maxFeeProportional: Double,
                          maxRouteLength: Int,
                          maxCltv: CltvExpiryDelta,
@@ -456,8 +456,8 @@ object Router {
                          mpp: MultiPartParams,
                          experimentName: String) {
     def getMaxFee(amount: MilliSatoshi): MilliSatoshi = {
-      // The payment fee must satisfy either the flat fee or the percentage fee, not necessarily both.
-      maxFeeFixed.max(amount * maxFeeProportional)
+      // The payment fee must satisfy either the flat fee or the proportional fee, not necessarily both.
+      maxFeeFlat.max(amount * maxFeeProportional)
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -297,7 +297,7 @@ object Router {
 
   def props(nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Command], initialized: Option[Promise[Done]] = None) = Props(new Router(nodeParams, watcher, initialized))
 
-  case class SearchBoundaries(maxFee: MilliSatoshi,
+  case class SearchBoundaries(maxFeeFixed: MilliSatoshi,
                               maxFeeProportional: Double,
                               maxRouteLength: Int,
                               maxCltv: CltvExpiryDelta)
@@ -310,7 +310,7 @@ object Router {
                              experimentPercentage: Int) {
     def getDefaultRouteParams: RouteParams = RouteParams(
       randomize = randomize,
-      maxFee = boundaries.maxFee,
+      maxFeeFixed = boundaries.maxFeeFixed,
       maxFeeProportional = boundaries.maxFeeProportional,
       maxRouteLength = boundaries.maxRouteLength,
       maxCltv = boundaries.maxCltv,
@@ -447,7 +447,7 @@ object Router {
   case class MultiPartParams(minPartAmount: MilliSatoshi, maxParts: Int)
 
   case class RouteParams(randomize: Boolean,
-                         maxFee: MilliSatoshi,
+                         maxFeeFixed: MilliSatoshi,
                          maxFeeProportional: Double,
                          maxRouteLength: Int,
                          maxCltv: CltvExpiryDelta,
@@ -457,14 +457,13 @@ object Router {
                          experimentName: String) {
     def getMaxFee(amount: MilliSatoshi): MilliSatoshi = {
       // The payment fee must satisfy either the flat fee or the percentage fee, not necessarily both.
-      maxFee.max(amount * maxFeeProportional)
+      maxFeeFixed.max(amount * maxFeeProportional)
     }
   }
 
   case class Ignore(nodes: Set[PublicKey], channels: Set[ChannelDesc]) {
     // @formatter:off
     def +(ignoreNode: PublicKey): Ignore = copy(nodes = nodes + ignoreNode)
-
     def ++(ignoreNodes: Set[PublicKey]): Ignore = copy(nodes = nodes ++ ignoreNodes)
     def +(ignoreChannel: ChannelDesc): Ignore = copy(channels = channels + ignoreChannel)
     def emptyNodes(): Ignore = copy(nodes = Set.empty)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -297,30 +297,6 @@ object Router {
 
   def props(nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Command], initialized: Option[Promise[Done]] = None) = Props(new Router(nodeParams, watcher, initialized))
 
-  case class PathFindingConf(randomizeRouteSelection: Boolean,
-                             searchMaxFeeBase: Satoshi,
-                             searchMaxFeePct: Double,
-                             searchMaxRouteLength: Int,
-                             searchMaxCltv: CltvExpiryDelta,
-                             searchRatioBase: Double,
-                             searchRatioCltv: Double,
-                             searchRatioChannelAge: Double,
-                             searchRatioChannelCapacity: Double,
-                             searchHopCostBase: MilliSatoshi,
-                             searchHopCostMillionths: Long,
-                             mppMinPartAmount: MilliSatoshi,
-                             mppMaxParts: Int,
-                             experimentName: String,
-                             experimentPercentage: Int) {
-    require(searchRatioBase >= 0.0, "ratio-base must be nonnegative")
-    require(searchRatioCltv >= 0.0, "ratio-cltv must be nonnegative")
-    require(searchRatioChannelAge >= 0.0, "ratio-channel-age must be nonnegative")
-    require(searchRatioChannelCapacity >= 0.0, "ratio-channel-capacity must be nonnegative")
-    require(searchRatioBase + searchRatioCltv + searchRatioChannelAge + searchRatioChannelCapacity == 1, "The sum of heuristics ratios must be 1")
-    require(searchHopCostBase.toLong >= 0.0, "hop-cost-base-msat must be nonnegative")
-    require(searchHopCostMillionths >= 0.0, "hop-cost-millionths must be nonnegative")
-  }
-
   case class RouterConf(channelExcludeDuration: FiniteDuration,
                         routerBroadcastInterval: FiniteDuration,
                         networkStatsRefreshInterval: FiniteDuration,
@@ -446,7 +422,16 @@ object Router {
 
   case class MultiPartParams(minPartAmount: MilliSatoshi, maxParts: Int)
 
-  case class RouteParams(randomize: Boolean, maxFeeBase: MilliSatoshi, maxFeePct: Double, routeMaxLength: Int, routeMaxCltv: CltvExpiryDelta, ratios: WeightRatios, mpp: MultiPartParams, includeLocalChannelCost: Boolean, experimentName: String) {
+  case class RouteParams(randomize: Boolean,
+                         maxFeeBase: MilliSatoshi,
+                         maxFeePct: Double,
+                         routeMaxLength: Int,
+                         routeMaxCltv: CltvExpiryDelta,
+                         ratios: WeightRatios,
+                         mpp: MultiPartParams,
+                         includeLocalChannelCost: Boolean,
+                         experimentName: String,
+                         experimentPercentage: Int) {
     def getMaxFee(amount: MilliSatoshi): MilliSatoshi = {
       // The payment fee must satisfy either the flat fee or the percentage fee, not necessarily both.
       maxFeeBase.max(amount * maxFeePct)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -149,7 +149,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     assert(send3.recipientNodeId === nodePrivKey.publicKey)
     assert(send3.recipientAmount === 123.msat)
     assert(send3.paymentHash === ByteVector32.Zeroes)
-    assert(send3.routeParams.maxFeeFixed === 123000.msat) // conversion sat -> msat
+    assert(send3.routeParams.maxFeeFlat === 123000.msat) // conversion sat -> msat
     assert(send3.routeParams.maxFeeProportional === 4.20)
 
     val invalidExternalId = "Robert'); DROP TABLE received_payments; DROP TABLE sent_payments; DROP TABLE payments;"

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -149,7 +149,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     assert(send3.recipientNodeId === nodePrivKey.publicKey)
     assert(send3.recipientAmount === 123.msat)
     assert(send3.paymentHash === ByteVector32.Zeroes)
-    assert(send3.routeParams.maxFee === 123000.msat) // conversion sat -> msat
+    assert(send3.routeParams.maxFeeFixed === 123000.msat) // conversion sat -> msat
     assert(send3.routeParams.maxFeeProportional === 4.20)
 
     val invalidExternalId = "Robert'); DROP TABLE received_payments; DROP TABLE sent_payments; DROP TABLE payments;"

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -149,8 +149,8 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     assert(send3.recipientNodeId === nodePrivKey.publicKey)
     assert(send3.recipientAmount === 123.msat)
     assert(send3.paymentHash === ByteVector32.Zeroes)
-    assert(send3.routeParams.maxFeeBase === 123000.msat) // conversion sat -> msat
-    assert(send3.routeParams.maxFeePct === 4.20)
+    assert(send3.routeParams.maxFee === 123000.msat) // conversion sat -> msat
+    assert(send3.routeParams.maxFeeProportional === 4.20)
 
     val invalidExternalId = "Robert'); DROP TABLE received_payments; DROP TABLE sent_payments; DROP TABLE payments;"
     assertThrows[IllegalArgumentException](Await.result(eclair.send(Some(invalidExternalId), 123 msat, invoice0), 50 millis))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -143,14 +143,14 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     assert(send2.fallbackFinalExpiryDelta === CltvExpiryDelta(96))
 
     // with custom route fees parameters
-    eclair.send(None, 123 msat, invoice0, feeThreshold_opt = Some(123 sat), maxFeePct_opt = Some(4.20))
+    eclair.send(None, 123 msat, invoice0, maxFeeFlat_opt = Some(123 sat), maxFeePct_opt = Some(4.20))
     val send3 = paymentInitiator.expectMsgType[SendPaymentToNode]
     assert(send3.externalId === None)
     assert(send3.recipientNodeId === nodePrivKey.publicKey)
     assert(send3.recipientAmount === 123.msat)
     assert(send3.paymentHash === ByteVector32.Zeroes)
     assert(send3.routeParams.maxFeeFlat === 123000.msat) // conversion sat -> msat
-    assert(send3.routeParams.maxFeeProportional === 4.20)
+    assert(send3.routeParams.maxFeeProportional === 0.042)
 
     val invalidExternalId = "Robert'); DROP TABLE received_payments; DROP TABLE sent_payments; DROP TABLE payments;"
     assertThrows[IllegalArgumentException](Await.result(eclair.send(Some(invalidExternalId), 123 msat, invoice0), 50 millis))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -33,7 +33,7 @@ import scala.util.Try
 
 class StartupSpec extends AnyFunSuite {
 
-  val defaultConf = ConfigFactory.parseResources("reference.conf").resolve(ConfigResolveOptions.defaults().setAllowUnresolved(true)).getConfig("eclair")
+  val defaultConf = ConfigFactory.load("reference.conf").getConfig("eclair")
 
   def makeNodeParamsWithDefaults(conf: Config): NodeParams = {
     val blockCount = new AtomicLong(0)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -16,7 +16,7 @@
 
 package fr.acinq.eclair
 
-import com.typesafe.config.{Config, ConfigFactory}
+import com.typesafe.config.{Config, ConfigFactory, ConfigResolveOptions}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{Block, SatoshiLong}
 import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
@@ -33,7 +33,7 @@ import scala.util.Try
 
 class StartupSpec extends AnyFunSuite {
 
-  val defaultConf = ConfigFactory.parseResources("reference.conf").getConfig("eclair")
+  val defaultConf = ConfigFactory.parseResources("reference.conf").resolve(ConfigResolveOptions.defaults().setAllowUnresolved(true)).getConfig("eclair")
 
   def makeNodeParamsWithDefaults(conf: Config): NodeParams = {
     val blockCount = new AtomicLong(0)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -24,6 +24,7 @@ import fr.acinq.eclair.channel.LocalParams
 import fr.acinq.eclair.crypto.keymanager.{LocalChannelKeyManager, LocalNodeKeyManager}
 import fr.acinq.eclair.io.{Peer, PeerConnection}
 import fr.acinq.eclair.payment.relay.Relayer.{RelayFees, RelayParams}
+import fr.acinq.eclair.router.PathFindingExperimentConf
 import fr.acinq.eclair.router.Router.{PathFindingConf, RouterConf}
 import fr.acinq.eclair.wire.protocol.{Color, EncodingType, NodeAddress, OnionRoutingPacket}
 import org.scalatest.Tag
@@ -166,7 +167,7 @@ object TestConstants {
         encodingType = EncodingType.COMPRESSED_ZLIB,
         channelRangeChunkSize = 20,
         channelQueryChunkSize = 5,
-        pathFindingConf = PathFindingConf(
+        pathFindingExperimentConf = PathFindingExperimentConf(List(PathFindingConf(
           randomizeRouteSelection = false,
           searchMaxFeeBase = 21 sat,
           searchMaxFeePct = 0.03,
@@ -179,7 +180,9 @@ object TestConstants {
           searchHopCostBase = 0 msat,
           searchHopCostMillionths = 0,
           mppMinPartAmount = 15000000 msat,
-          mppMaxParts = 10)
+          mppMaxParts = 10,
+          experimentName = "",
+          experimentPercentage = 100)))
       ),
       socksProxy_opt = None,
       maxPaymentAttempts = 5,
@@ -285,7 +288,7 @@ object TestConstants {
         encodingType = EncodingType.UNCOMPRESSED,
         channelRangeChunkSize = 20,
         channelQueryChunkSize = 5,
-        pathFindingConf = PathFindingConf(
+        pathFindingExperimentConf = PathFindingExperimentConf(List(PathFindingConf(
           randomizeRouteSelection = false,
           searchMaxFeeBase = 21 sat,
           searchMaxFeePct = 0.03,
@@ -298,7 +301,9 @@ object TestConstants {
           searchHopCostBase = 0 msat,
           searchHopCostMillionths = 0,
           mppMinPartAmount = 15000000 msat,
-          mppMaxParts = 10)
+          mppMaxParts = 10,
+          experimentName = "",
+          experimentPercentage = 100)))
       ),
       socksProxy_opt = None,
       maxPaymentAttempts = 5,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -24,8 +24,9 @@ import fr.acinq.eclair.channel.LocalParams
 import fr.acinq.eclair.crypto.keymanager.{LocalChannelKeyManager, LocalNodeKeyManager}
 import fr.acinq.eclair.io.{Peer, PeerConnection}
 import fr.acinq.eclair.payment.relay.Relayer.{RelayFees, RelayParams}
+import fr.acinq.eclair.router.Graph.WeightRatios
 import fr.acinq.eclair.router.PathFindingExperimentConf
-import fr.acinq.eclair.router.Router.{PathFindingConf, RouterConf}
+import fr.acinq.eclair.router.Router.{MultiPartParams, RouteParams, RouterConf}
 import fr.acinq.eclair.wire.protocol.{Color, EncodingType, NodeAddress, OnionRoutingPacket}
 import org.scalatest.Tag
 import scodec.bits.ByteVector
@@ -167,22 +168,27 @@ object TestConstants {
         encodingType = EncodingType.COMPRESSED_ZLIB,
         channelRangeChunkSize = 20,
         channelQueryChunkSize = 5,
-        pathFindingExperimentConf = PathFindingExperimentConf(List(PathFindingConf(
-          randomizeRouteSelection = false,
-          searchMaxFeeBase = 21 sat,
-          searchMaxFeePct = 0.03,
-          searchMaxCltv = CltvExpiryDelta(2016),
-          searchMaxRouteLength = 20,
-          searchRatioBase = 1.0,
-          searchRatioCltv = 0.0,
-          searchRatioChannelAge = 0.0,
-          searchRatioChannelCapacity = 0.0,
-          searchHopCostBase = 0 msat,
-          searchHopCostMillionths = 0,
-          mppMinPartAmount = 15000000 msat,
-          mppMaxParts = 10,
+        pathFindingExperimentConf = PathFindingExperimentConf(Map(("alice-test-experiment" -> RouteParams(
+          randomize = false,
+          maxFeeBase = (21 sat).toMilliSatoshi,
+          maxFeePct = 0.03,
+          routeMaxCltv = CltvExpiryDelta(2016),
+          routeMaxLength = 20,
+          ratios = WeightRatios(
+            baseFactor = 1.0,
+            cltvDeltaFactor = 0.0,
+            ageFactor = 0.0,
+            capacityFactor = 0.0,
+            hopCostBase = 0 msat,
+            hopCostMillionths = 0,
+          ),
+          mpp = MultiPartParams(
+            minPartAmount = 15000000 msat,
+            maxParts = 10,
+          ),
+          includeLocalChannelCost = false,
           experimentName = "alice-test-experiment",
-          experimentPercentage = 100)))
+          experimentPercentage = 100))))
       ),
       socksProxy_opt = None,
       maxPaymentAttempts = 5,
@@ -288,22 +294,27 @@ object TestConstants {
         encodingType = EncodingType.UNCOMPRESSED,
         channelRangeChunkSize = 20,
         channelQueryChunkSize = 5,
-        pathFindingExperimentConf = PathFindingExperimentConf(List(PathFindingConf(
-          randomizeRouteSelection = false,
-          searchMaxFeeBase = 21 sat,
-          searchMaxFeePct = 0.03,
-          searchMaxCltv = CltvExpiryDelta(2016),
-          searchMaxRouteLength = 20,
-          searchRatioBase = 1.0,
-          searchRatioCltv = 0.0,
-          searchRatioChannelAge = 0.0,
-          searchRatioChannelCapacity = 0.0,
-          searchHopCostBase = 0 msat,
-          searchHopCostMillionths = 0,
-          mppMinPartAmount = 15000000 msat,
-          mppMaxParts = 10,
+        pathFindingExperimentConf = PathFindingExperimentConf(Map(("bob-test-experiment" -> RouteParams(
+          randomize = false,
+          maxFeeBase = (21 sat).toMilliSatoshi,
+          maxFeePct = 0.03,
+          routeMaxCltv = CltvExpiryDelta(2016),
+          routeMaxLength = 20,
+          ratios = WeightRatios(
+            baseFactor = 1.0,
+            cltvDeltaFactor = 0.0,
+            ageFactor = 0.0,
+            capacityFactor = 0.0,
+            hopCostBase = 0 msat,
+            hopCostMillionths = 0,
+          ),
+          mpp = MultiPartParams(
+            minPartAmount = 15000000 msat,
+            maxParts = 10,
+          ),
+          includeLocalChannelCost = false,
           experimentName = "bob-test-experiment",
-          experimentPercentage = 100)))
+          experimentPercentage = 100))))
       ),
       socksProxy_opt = None,
       maxPaymentAttempts = 5,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -26,7 +26,7 @@ import fr.acinq.eclair.io.{Peer, PeerConnection}
 import fr.acinq.eclair.payment.relay.Relayer.{RelayFees, RelayParams}
 import fr.acinq.eclair.router.Graph.WeightRatios
 import fr.acinq.eclair.router.PathFindingExperimentConf
-import fr.acinq.eclair.router.Router.{MultiPartParams, RouteParams, RouterConf}
+import fr.acinq.eclair.router.Router.{MultiPartParams, PathFindingConf, RouterConf, SearchBoundaries}
 import fr.acinq.eclair.wire.protocol.{Color, EncodingType, NodeAddress, OnionRoutingPacket}
 import org.scalatest.Tag
 import scodec.bits.ByteVector
@@ -168,12 +168,13 @@ object TestConstants {
         encodingType = EncodingType.COMPRESSED_ZLIB,
         channelRangeChunkSize = 20,
         channelQueryChunkSize = 5,
-        pathFindingExperimentConf = PathFindingExperimentConf(Map(("alice-test-experiment" -> RouteParams(
+        pathFindingExperimentConf = PathFindingExperimentConf(Map(("alice-test-experiment" -> PathFindingConf(
           randomize = false,
-          maxFeeBase = (21 sat).toMilliSatoshi,
-          maxFeePct = 0.03,
-          routeMaxCltv = CltvExpiryDelta(2016),
-          routeMaxLength = 20,
+          boundaries = SearchBoundaries(
+            maxFee = (21 sat).toMilliSatoshi,
+            maxFeeProportional = 0.03,
+            maxCltv = CltvExpiryDelta(2016),
+            maxRouteLength = 20),
           ratios = WeightRatios(
             baseFactor = 1.0,
             cltvDeltaFactor = 0.0,
@@ -186,7 +187,6 @@ object TestConstants {
             minPartAmount = 15000000 msat,
             maxParts = 10,
           ),
-          includeLocalChannelCost = false,
           experimentName = "alice-test-experiment",
           experimentPercentage = 100))))
       ),
@@ -294,12 +294,13 @@ object TestConstants {
         encodingType = EncodingType.UNCOMPRESSED,
         channelRangeChunkSize = 20,
         channelQueryChunkSize = 5,
-        pathFindingExperimentConf = PathFindingExperimentConf(Map(("bob-test-experiment" -> RouteParams(
+        pathFindingExperimentConf = PathFindingExperimentConf(Map(("bob-test-experiment" -> PathFindingConf(
           randomize = false,
-          maxFeeBase = (21 sat).toMilliSatoshi,
-          maxFeePct = 0.03,
-          routeMaxCltv = CltvExpiryDelta(2016),
-          routeMaxLength = 20,
+          boundaries = SearchBoundaries(
+            maxFee = (21 sat).toMilliSatoshi,
+            maxFeeProportional = 0.03,
+            maxCltv = CltvExpiryDelta(2016),
+            maxRouteLength = 20),
           ratios = WeightRatios(
             baseFactor = 1.0,
             cltvDeltaFactor = 0.0,
@@ -312,7 +313,6 @@ object TestConstants {
             minPartAmount = 15000000 msat,
             maxParts = 10,
           ),
-          includeLocalChannelCost = false,
           experimentName = "bob-test-experiment",
           experimentPercentage = 100))))
       ),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -171,7 +171,7 @@ object TestConstants {
         pathFindingExperimentConf = PathFindingExperimentConf(Map(("alice-test-experiment" -> PathFindingConf(
           randomize = false,
           boundaries = SearchBoundaries(
-            maxFee = (21 sat).toMilliSatoshi,
+            maxFeeFixed = (21 sat).toMilliSatoshi,
             maxFeeProportional = 0.03,
             maxCltv = CltvExpiryDelta(2016),
             maxRouteLength = 20),
@@ -297,7 +297,7 @@ object TestConstants {
         pathFindingExperimentConf = PathFindingExperimentConf(Map(("bob-test-experiment" -> PathFindingConf(
           randomize = false,
           boundaries = SearchBoundaries(
-            maxFee = (21 sat).toMilliSatoshi,
+            maxFeeFixed = (21 sat).toMilliSatoshi,
             maxFeeProportional = 0.03,
             maxCltv = CltvExpiryDelta(2016),
             maxRouteLength = 20),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -171,7 +171,7 @@ object TestConstants {
         pathFindingExperimentConf = PathFindingExperimentConf(Map(("alice-test-experiment" -> PathFindingConf(
           randomize = false,
           boundaries = SearchBoundaries(
-            maxFeeFixed = (21 sat).toMilliSatoshi,
+            maxFeeFlat = (21 sat).toMilliSatoshi,
             maxFeeProportional = 0.03,
             maxCltv = CltvExpiryDelta(2016),
             maxRouteLength = 20),
@@ -296,7 +296,7 @@ object TestConstants {
         pathFindingExperimentConf = PathFindingExperimentConf(Map(("bob-test-experiment" -> PathFindingConf(
           randomize = false,
           boundaries = SearchBoundaries(
-            maxFeeFixed = (21 sat).toMilliSatoshi,
+            maxFeeFlat = (21 sat).toMilliSatoshi,
             maxFeeProportional = 0.03,
             maxCltv = CltvExpiryDelta(2016),
             maxRouteLength = 20),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -181,7 +181,7 @@ object TestConstants {
           searchHopCostMillionths = 0,
           mppMinPartAmount = 15000000 msat,
           mppMaxParts = 10,
-          experimentName = "",
+          experimentName = "alice-test-experiment",
           experimentPercentage = 100)))
       ),
       socksProxy_opt = None,
@@ -302,7 +302,7 @@ object TestConstants {
           searchHopCostMillionths = 0,
           mppMinPartAmount = 15000000 msat,
           mppMaxParts = 10,
-          experimentName = "",
+          experimentName = "bob-test-experiment",
           experimentPercentage = 100)))
       ),
       socksProxy_opt = None,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -180,8 +180,7 @@ object TestConstants {
             cltvDeltaFactor = 0.0,
             ageFactor = 0.0,
             capacityFactor = 0.0,
-            hopCostBase = 0 msat,
-            hopCostMillionths = 0,
+            hopCost = RelayFees(0 msat, 0),
           ),
           mpp = MultiPartParams(
             minPartAmount = 15000000 msat,
@@ -306,8 +305,7 @@ object TestConstants {
             cltvDeltaFactor = 0.0,
             ageFactor = 0.0,
             capacityFactor = 0.0,
-            hopCostBase = 0 msat,
-            hopCostMillionths = 0,
+            hopCost = RelayFees(0 msat, 0),
           ),
           mpp = MultiPartParams(
             minPartAmount = 15000000 msat,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -616,7 +616,7 @@ class AuditDbSpec extends AnyFunSuite {
 
   test("add experiment metrics") {
     forAllDbs { dbs =>
-      dbs.audit.addPathFindingExperimentMetrics(PathFindingExperimentMetrics(100000000 msat, 3000 msat, success = true, 37, System.currentTimeMillis, "my-test-experiment"))
+      dbs.audit.addPathFindingExperimentMetrics(PathFindingExperimentMetrics(100000000 msat, 3000 msat, success = true, 37, System.currentTimeMillis, isMultiPart = false, "my-test-experiment"))
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -616,7 +616,7 @@ class AuditDbSpec extends AnyFunSuite {
 
   test("add experiment metrics") {
     forAllDbs { dbs =>
-      dbs.audit.addExperimentMetrics(ExperimentMetrics(100000000 msat, 3000 msat, success = true, 37, System.currentTimeMillis, "my-test-experiment"))
+      dbs.audit.addPathFindingExperimentMetrics(PathFindingExperimentMetrics(100000000 msat, 3000 msat, success = true, 37, System.currentTimeMillis, "my-test-experiment"))
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -616,7 +616,7 @@ class AuditDbSpec extends AnyFunSuite {
 
   test("add experiment metrics") {
     forAllDbs { dbs =>
-      dbs.audit.addPathFindingExperimentMetrics(PathFindingExperimentMetrics(100000000 msat, 3000 msat, success = true, 37, System.currentTimeMillis, isMultiPart = false, "my-test-experiment"))
+      dbs.audit.addPathFindingExperimentMetrics(PathFindingExperimentMetrics(100000000 msat, 3000 msat, status = "SUCCESS", 37, System.currentTimeMillis, isMultiPart = false, "my-test-experiment", randomKey().publicKey))
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -237,7 +237,7 @@ class AuditDbSpec extends AnyFunSuite {
         val postMigrationDb = new SqliteAuditDb(connection)
 
         using(connection.createStatement()) { statement =>
-          assert(getVersion(statement, "audit").contains(6))
+          assert(getVersion(statement, "audit").contains(SqliteAuditDb.CURRENT_VERSION))
         }
 
         postMigrationDb.add(ps1)
@@ -284,13 +284,13 @@ class AuditDbSpec extends AnyFunSuite {
       postCheck = connection => {
         val migratedDb = dbs.audit
         using(connection.createStatement()) { statement =>
-          assert(getVersion(statement, "audit").contains(6))
+          assert(getVersion(statement, "audit").contains(SqliteAuditDb.CURRENT_VERSION))
         }
         migratedDb.add(e1)
 
         val postMigrationDb = new SqliteAuditDb(connection)
         using(connection.createStatement()) { statement =>
-          assert(getVersion(statement, "audit").contains(6))
+          assert(getVersion(statement, "audit").contains(SqliteAuditDb.CURRENT_VERSION))
         }
         postMigrationDb.add(e2)
       }
@@ -362,7 +362,7 @@ class AuditDbSpec extends AnyFunSuite {
       postCheck = connection => {
         val migratedDb = dbs.audit
         using(connection.createStatement()) { statement =>
-          assert(getVersion(statement, "audit").contains(6))
+          assert(getVersion(statement, "audit").contains(SqliteAuditDb.CURRENT_VERSION))
         }
         assert(migratedDb.listSent(50, 150).toSet === Set(
           ps1.copy(id = pp1.id, recipientAmount = pp1.amount, parts = pp1 :: Nil),
@@ -372,7 +372,7 @@ class AuditDbSpec extends AnyFunSuite {
 
         val postMigrationDb = new SqliteAuditDb(connection)
         using(connection.createStatement()) { statement =>
-          assert(getVersion(statement, "audit").contains(6))
+          assert(getVersion(statement, "audit").contains(SqliteAuditDb.CURRENT_VERSION))
         }
         val ps2 = PaymentSent(UUID.randomUUID(), randomBytes32(), randomBytes32(), 1100 msat, randomKey().publicKey, Seq(
           PaymentSent.PartialPayment(UUID.randomUUID(), 500 msat, 10 msat, randomBytes32(), None, 160),
@@ -467,7 +467,7 @@ class AuditDbSpec extends AnyFunSuite {
 
             val postMigrationDb = new PgAuditDb()(dbs.datasource)
             using(connection.createStatement()) { statement =>
-              assert(getVersion(statement, "audit").contains(8))
+              assert(getVersion(statement, "audit").contains(PgAuditDb.CURRENT_VERSION))
             }
             val relayed3 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(450 msat, randomBytes32()), PaymentRelayed.Part(500 msat, randomBytes32())), Seq(PaymentRelayed.Part(800 msat, randomBytes32())), randomKey().publicKey, 700 msat, 150)
             postMigrationDb.add(relayed3)
@@ -544,13 +544,13 @@ class AuditDbSpec extends AnyFunSuite {
           postCheck = connection => {
             val migratedDb = dbs.audit
             using(connection.createStatement()) { statement =>
-              assert(getVersion(statement, "audit").contains(6))
+              assert(getVersion(statement, "audit").contains(SqliteAuditDb.CURRENT_VERSION))
             }
             assert(migratedDb.listRelayed(100, 120) === Seq(relayed1, relayed2))
 
             val postMigrationDb = new SqliteAuditDb(connection)
             using(connection.createStatement()) { statement =>
-              assert(getVersion(statement, "audit").contains(6))
+              assert(getVersion(statement, "audit").contains(SqliteAuditDb.CURRENT_VERSION))
             }
             val relayed3 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(450 msat, randomBytes32()), PaymentRelayed.Part(500 msat, randomBytes32())), Seq(PaymentRelayed.Part(800 msat, randomBytes32())), randomKey().publicKey, 700 msat, 150)
             postMigrationDb.add(relayed3)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -614,4 +614,10 @@ class AuditDbSpec extends AnyFunSuite {
     }
   }
 
+  test("add experiment metrics") {
+    forAllDbs { dbs =>
+      dbs.audit.addExperimentMetrics(ExperimentMetrics(100000000 msat, 3000 msat, success = true, 37, System.currentTimeMillis, "my-test-experiment"))
+    }
+  }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -65,6 +65,7 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
     ),
     mpp = MultiPartParams(15000000 msat, 6),
     includeLocalChannelCost = false,
+    experimentName = "",
   )
 
   // we need to provide a value higher than every node's fulfill-safety-before-timeout

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -52,7 +52,7 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
   val integrationTestRouteParams = PathFindingConf(
     randomize = false,
     boundaries = SearchBoundaries(
-      maxFee = 21000 msat,
+      maxFeeFixed = 21000 msat,
       maxFeeProportional = 0.03,
       maxCltv = CltvExpiryDelta(Int.MaxValue),
       maxRouteLength = ROUTE_MAX_LENGTH),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -65,7 +65,7 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
     ),
     mpp = MultiPartParams(15000000 msat, 6),
     includeLocalChannelCost = false,
-    experimentName = "",
+    experimentName = "my-test-experiment",
   )
 
   // we need to provide a value higher than every node's fulfill-safety-before-timeout

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -53,7 +53,7 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
   val integrationTestRouteParams = PathFindingConf(
     randomize = false,
     boundaries = SearchBoundaries(
-      maxFeeFixed = 21000 msat,
+      maxFeeFlat = 21000 msat,
       maxFeeProportional = 0.03,
       maxCltv = CltvExpiryDelta(Int.MaxValue),
       maxRouteLength = ROUTE_MAX_LENGTH),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.io.{Peer, PeerConnection}
 import fr.acinq.eclair.router.Graph.WeightRatios
 import fr.acinq.eclair.router.RouteCalculation.ROUTE_MAX_LENGTH
-import fr.acinq.eclair.router.Router.{MultiPartParams, RouteParams, NORMAL => _, State => _}
+import fr.acinq.eclair.router.Router.{MultiPartParams, PathFindingConf, SearchBoundaries, NORMAL => _, State => _}
 import fr.acinq.eclair.{CltvExpiryDelta, Kit, MilliSatoshi, MilliSatoshiLong, Setup, TestKitBaseClass}
 import grizzled.slf4j.Logging
 import org.json4s.{DefaultFormats, Formats}
@@ -49,12 +49,13 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
   var nodes: Map[String, Kit] = Map()
 
   // we override the default because these test were designed to use cost-optimized routes
-  val integrationTestRouteParams = RouteParams(
+  val integrationTestRouteParams = PathFindingConf(
     randomize = false,
-    maxFeeBase = 21000 msat,
-    maxFeePct = 0.03,
-    routeMaxCltv = CltvExpiryDelta(Int.MaxValue),
-    routeMaxLength = ROUTE_MAX_LENGTH,
+    boundaries = SearchBoundaries(
+      maxFee = 21000 msat,
+      maxFeeProportional = 0.03,
+      maxCltv = CltvExpiryDelta(Int.MaxValue),
+      maxRouteLength = ROUTE_MAX_LENGTH),
     ratios = WeightRatios(
       baseFactor = 0,
       cltvDeltaFactor = 1,
@@ -64,10 +65,9 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
       hopCostMillionths = 0
     ),
     mpp = MultiPartParams(15000000 msat, 6),
-    includeLocalChannelCost = false,
     experimentName = "my-test-experiment",
     experimentPercentage = 100
-  )
+  ).getDefaultRouteParams
 
   // we need to provide a value higher than every node's fulfill-safety-before-timeout
   val finalCltvExpiryDelta = CltvExpiryDelta(36)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -25,6 +25,7 @@ import fr.acinq.eclair.Features._
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.io.{Peer, PeerConnection}
+import fr.acinq.eclair.payment.relay.Relayer.RelayFees
 import fr.acinq.eclair.router.Graph.WeightRatios
 import fr.acinq.eclair.router.RouteCalculation.ROUTE_MAX_LENGTH
 import fr.acinq.eclair.router.Router.{MultiPartParams, PathFindingConf, SearchBoundaries, NORMAL => _, State => _}
@@ -61,8 +62,7 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
       cltvDeltaFactor = 1,
       ageFactor = 0,
       capacityFactor = 0,
-      hopCostBase = 0 msat,
-      hopCostMillionths = 0
+      hopCost = RelayFees(0 msat, 0),
     ),
     mpp = MultiPartParams(15000000 msat, 6),
     experimentName = "my-test-experiment",

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -66,6 +66,7 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
     mpp = MultiPartParams(15000000 msat, 6),
     includeLocalChannelCost = false,
     experimentName = "my-test-experiment",
+    experimentPercentage = 100
   )
 
   // we need to provide a value higher than every node's fulfill-safety-before-timeout

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
@@ -36,6 +36,7 @@ import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceivePayment
 import fr.acinq.eclair.payment.relay.Relayer
+import fr.acinq.eclair.payment.relay.Relayer.RelayFees
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.PreimageReceived
 import fr.acinq.eclair.payment.send.PaymentInitiator.{SendPaymentToNode, SendTrampolinePayment}
 import fr.acinq.eclair.router.Graph.WeightRatios
@@ -328,7 +329,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     val pr = sender.expectMsgType[PaymentRequest]
 
     // the payment is requesting to use a capacity-optimized route which will select node G even though it's a bit more expensive
-    sender.send(nodes("A").paymentInitiator, SendPaymentToNode(amountMsat, pr, maxAttempts = 1, fallbackFinalExpiryDelta = finalCltvExpiryDelta, routeParams = integrationTestRouteParams.copy(ratios = WeightRatios(0, 0, 0, 1, 0 msat, 0))))
+    sender.send(nodes("A").paymentInitiator, SendPaymentToNode(amountMsat, pr, maxAttempts = 1, fallbackFinalExpiryDelta = finalCltvExpiryDelta, routeParams = integrationTestRouteParams.copy(ratios = WeightRatios(0, 0, 0, 1, RelayFees(0 msat, 0)))))
     sender.expectMsgType[UUID]
     sender.expectMsgType[PreimageReceived]
     val ps = sender.expectMsgType[PaymentSent]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -55,7 +55,8 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
                           router: TestProbe,
                           sender: TestProbe,
                           childPayFsm: TestProbe,
-                          eventListener: TestProbe)
+                          eventListener: TestProbe,
+                          metricsListener: TestProbe)
 
   case class FakePaymentFactory(childPayFsm: TestProbe) extends PaymentInitiator.PaymentFactory {
     override def spawnOutgoingPayment(context: ActorContext, cfg: SendPaymentConfig): ActorRef = childPayFsm.ref
@@ -65,10 +66,11 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     val id = UUID.randomUUID()
     val cfg = SendPaymentConfig(id, id, Some("42"), paymentHash, finalAmount, finalRecipient, Upstream.Local(id), None, storeInDb = true, publishEvent = true, recordMetrics = true, Nil)
     val nodeParams = TestConstants.Alice.nodeParams
-    val (childPayFsm, router, sender, eventListener) = (TestProbe(), TestProbe(), TestProbe(), TestProbe())
+    val (childPayFsm, router, sender, eventListener, metricsListener) = (TestProbe(), TestProbe(), TestProbe(), TestProbe(), TestProbe())
     val paymentHandler = TestFSMRef(new MultiPartPaymentLifecycle(nodeParams, cfg, router.ref, FakePaymentFactory(childPayFsm)))
     system.eventStream.subscribe(eventListener.ref, classOf[PaymentEvent])
-    withFixture(test.toNoArgTest(FixtureParam(cfg, nodeParams, paymentHandler, router, sender, childPayFsm, eventListener)))
+    system.eventStream.subscribe(metricsListener.ref, classOf[ExperimentMetrics])
+    withFixture(test.toNoArgTest(FixtureParam(cfg, nodeParams, paymentHandler, router, sender, childPayFsm, eventListener, metricsListener)))
   }
 
   test("successful first attempt (single part)") { f =>
@@ -95,6 +97,13 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.amountWithFees === finalAmount + 100.msat)
     assert(result.trampolineFees === 0.msat)
     assert(result.nonTrampolineFees === 100.msat)
+
+    val metrics = metricsListener.expectMsgType[ExperimentMetrics]
+    assert(metrics.success)
+    assert(metrics.experimentName == "my-test-experiment")
+    assert(metrics.amount == finalAmount)
+    assert(metrics.fees == 100.msat)
+    metricsListener.expectNoMessage()
   }
 
   test("successful first attempt (multiple parts)") { f =>
@@ -124,6 +133,13 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.amountWithFees === 1200200.msat)
     assert(result.trampolineFees === 200000.msat)
     assert(result.nonTrampolineFees === 200.msat)
+
+    val metrics = metricsListener.expectMsgType[ExperimentMetrics]
+    assert(metrics.success)
+    assert(metrics.experimentName == "my-test-experiment")
+    assert(metrics.amount == finalAmount)
+    assert(metrics.fees == 200200.msat)
+    metricsListener.expectNoMessage()
   }
 
   test("send custom tlv records") { f =>
@@ -144,6 +160,13 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
 
     val result = fulfillPendingPayments(f, 2)
     assert(result.trampolineFees === 1000.msat)
+
+    val metrics = metricsListener.expectMsgType[ExperimentMetrics]
+    assert(metrics.success)
+    assert(metrics.experimentName == "my-test-experiment")
+    assert(metrics.amount == finalAmount)
+    assert(metrics.fees == 1200.msat)
+    metricsListener.expectNoMessage()
   }
 
   test("successful retry") { f =>
@@ -170,6 +193,13 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.amountWithFees === 1000200.msat)
     assert(result.trampolineFees === 0.msat)
     assert(result.nonTrampolineFees === 200.msat)
+
+    val metrics = metricsListener.expectMsgType[ExperimentMetrics]
+    assert(metrics.success)
+    assert(metrics.experimentName == "my-test-experiment")
+    assert(metrics.amount == finalAmount)
+    assert(metrics.fees == 200.msat)
+    metricsListener.expectNoMessage()
   }
 
   test("retry failures while waiting for routes") { f =>
@@ -205,6 +235,13 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     val result = fulfillPendingPayments(f, 2)
     assert(result.amountWithFees === 1000200.msat)
     assert(result.nonTrampolineFees === 200.msat)
+
+    val metrics = metricsListener.expectMsgType[ExperimentMetrics]
+    assert(metrics.success)
+    assert(metrics.experimentName == "my-test-experiment")
+    assert(metrics.amount == finalAmount)
+    assert(metrics.fees == 200.msat)
+    metricsListener.expectNoMessage()
   }
 
   test("retry local channel failures") { f =>
@@ -265,6 +302,13 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
 
     val result = fulfillPendingPayments(f, 2)
     assert(result.amountWithFees === 1000200.msat)
+
+    val metrics = metricsListener.expectMsgType[ExperimentMetrics]
+    assert(metrics.success)
+    assert(metrics.experimentName == "my-test-experiment")
+    assert(metrics.amount == finalAmount)
+    assert(metrics.fees == 200.msat)
+    metricsListener.expectNoMessage()
   }
 
   test("retry with updated routing hints") { f =>
@@ -370,6 +414,12 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     val result = abortAfterFailure(f, PaymentFailed(failedId2, paymentHash, Seq(UnreadableRemoteFailure(failedRoute2.hops))))
     assert(result.failures.length >= 3)
     assert(result.failures.contains(LocalFailure(Nil, RetryExhausted)))
+
+    val metrics = metricsListener.expectMsgType[ExperimentMetrics]
+    assert(!metrics.success)
+    assert(metrics.experimentName == "my-test-experiment")
+    assert(metrics.amount == finalAmount)
+    metricsListener.expectNoMessage()
   }
 
   test("abort if no routes found") { f =>
@@ -394,6 +444,12 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     sender.expectNoMessage(100 millis)
     router.expectNoMessage(100 millis)
     childPayFsm.expectNoMessage(100 millis)
+
+    val metrics = metricsListener.expectMsgType[ExperimentMetrics]
+    assert(!metrics.success)
+    assert(metrics.experimentName == "my-test-experiment")
+    assert(metrics.amount == finalAmount)
+    metricsListener.expectNoMessage()
   }
 
   test("abort if recipient sends error") { f =>
@@ -408,6 +464,12 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     val (failedId, failedRoute) = payFsm.stateData.asInstanceOf[PaymentProgress].pending.head
     val result = abortAfterFailure(f, PaymentFailed(failedId, paymentHash, Seq(RemoteFailure(failedRoute.hops, Sphinx.DecryptedFailurePacket(e, IncorrectOrUnknownPaymentDetails(600000 msat, 0))))))
     assert(result.failures.length === 1)
+
+    val metrics = metricsListener.expectMsgType[ExperimentMetrics]
+    assert(!metrics.success)
+    assert(metrics.experimentName == "my-test-experiment")
+    assert(metrics.amount == finalAmount)
+    metricsListener.expectNoMessage()
   }
 
   test("abort if payment gets settled on chain") { f =>
@@ -588,7 +650,7 @@ object MultiPartPaymentLifecycleSpec {
   val expiry = CltvExpiry(1105)
   val finalAmount = 1000000 msat
   val finalRecipient = randomKey().publicKey
-  val routeParams = RouteParams(randomize = false, 15000 msat, 0.01, 6, CltvExpiryDelta(1008), WeightRatios(1, 0, 0, 0, 0 msat, 0), MultiPartParams(1000 msat, 5), includeLocalChannelCost = false, experimentName = "")
+  val routeParams = RouteParams(randomize = false, 15000 msat, 0.01, 6, CltvExpiryDelta(1008), WeightRatios(1, 0, 0, 0, 0 msat, 0), MultiPartParams(1000 msat, 5), includeLocalChannelCost = false, experimentName = "my-test-experiment")
   val maxFee = 15000 msat // max fee for the defaultAmount
 
   /**

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -100,7 +100,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.nonTrampolineFees === 100.msat)
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(metrics.success)
+    assert(metrics.status == "SUCCESS")
     assert(metrics.experimentName == "my-test-experiment")
     assert(metrics.amount == finalAmount)
     assert(metrics.fees == 100.msat)
@@ -136,7 +136,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.nonTrampolineFees === 200.msat)
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(metrics.success)
+    assert(metrics.status == "SUCCESS")
     assert(metrics.experimentName == "my-test-experiment")
     assert(metrics.amount == finalAmount)
     assert(metrics.fees == 200200.msat)
@@ -163,7 +163,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.trampolineFees === 1000.msat)
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(metrics.success)
+    assert(metrics.status == "SUCCESS")
     assert(metrics.experimentName == "my-test-experiment")
     assert(metrics.amount == finalAmount)
     assert(metrics.fees == 1200.msat)
@@ -196,7 +196,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.nonTrampolineFees === 200.msat)
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(metrics.success)
+    assert(metrics.status == "SUCCESS")
     assert(metrics.experimentName == "my-test-experiment")
     assert(metrics.amount == finalAmount)
     assert(metrics.fees == 200.msat)
@@ -238,7 +238,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.nonTrampolineFees === 200.msat)
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(metrics.success)
+    assert(metrics.status == "SUCCESS")
     assert(metrics.experimentName == "my-test-experiment")
     assert(metrics.amount == finalAmount)
     assert(metrics.fees == 200.msat)
@@ -305,7 +305,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.amountWithFees === 1000200.msat)
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(metrics.success)
+    assert(metrics.status == "SUCCESS")
     assert(metrics.experimentName == "my-test-experiment")
     assert(metrics.amount == finalAmount)
     assert(metrics.fees == 200.msat)
@@ -417,9 +417,10 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.failures.contains(LocalFailure(Nil, RetryExhausted)))
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(!metrics.success)
+    assert(metrics.status == "FAILURE")
     assert(metrics.experimentName == "my-test-experiment")
     assert(metrics.amount == finalAmount)
+    assert(metrics.fees == 15000.msat)
     metricsListener.expectNoMessage()
   }
 
@@ -447,9 +448,10 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     childPayFsm.expectNoMessage(100 millis)
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(!metrics.success)
+    assert(metrics.status == "FAILURE")
     assert(metrics.experimentName == "my-test-experiment")
     assert(metrics.amount == finalAmount)
+    assert(metrics.fees == 15000.msat)
     metricsListener.expectNoMessage()
   }
 
@@ -467,9 +469,10 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(result.failures.length === 1)
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(!metrics.success)
+    assert(metrics.status == "FAILURE")
     assert(metrics.experimentName == "my-test-experiment")
     assert(metrics.amount == finalAmount)
+    assert(metrics.fees == 15000.msat)
     metricsListener.expectNoMessage()
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -63,7 +63,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
 
   override def withFixture(test: OneArgTest): Outcome = {
     val id = UUID.randomUUID()
-    val cfg = SendPaymentConfig(id, id, Some("42"), paymentHash, finalAmount, finalRecipient, Upstream.Local(id), None, storeInDb = true, publishEvent = true, Nil)
+    val cfg = SendPaymentConfig(id, id, Some("42"), paymentHash, finalAmount, finalRecipient, Upstream.Local(id), None, storeInDb = true, publishEvent = true, recordMetrics = true, Nil)
     val nodeParams = TestConstants.Alice.nodeParams
     val (childPayFsm, router, sender, eventListener) = (TestProbe(), TestProbe(), TestProbe(), TestProbe())
     val paymentHandler = TestFSMRef(new MultiPartPaymentLifecycle(nodeParams, cfg, router.ref, FakePaymentFactory(childPayFsm)))
@@ -588,7 +588,7 @@ object MultiPartPaymentLifecycleSpec {
   val expiry = CltvExpiry(1105)
   val finalAmount = 1000000 msat
   val finalRecipient = randomKey().publicKey
-  val routeParams = RouteParams(randomize = false, 15000 msat, 0.01, 6, CltvExpiryDelta(1008), WeightRatios(1, 0, 0, 0, 0 msat, 0), MultiPartParams(1000 msat, 5), includeLocalChannelCost = false)
+  val routeParams = RouteParams(randomize = false, 15000 msat, 0.01, 6, CltvExpiryDelta(1008), WeightRatios(1, 0, 0, 0, 0 msat, 0), MultiPartParams(1000 msat, 5), includeLocalChannelCost = false, experimentName = "")
   val maxFee = 15000 msat // max fee for the defaultAmount
 
   /**

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -650,7 +650,17 @@ object MultiPartPaymentLifecycleSpec {
   val expiry = CltvExpiry(1105)
   val finalAmount = 1000000 msat
   val finalRecipient = randomKey().publicKey
-  val routeParams = RouteParams(randomize = false, 15000 msat, 0.01, 6, CltvExpiryDelta(1008), WeightRatios(1, 0, 0, 0, 0 msat, 0), MultiPartParams(1000 msat, 5), includeLocalChannelCost = false, experimentName = "my-test-experiment", experimentPercentage = 100)
+  val routeParams = PathFindingConf(
+    randomize = false,
+    boundaries = SearchBoundaries(
+      15000 msat,
+      0.01,
+      6,
+      CltvExpiryDelta(1008)),
+    WeightRatios(1, 0, 0, 0, 0 msat, 0),
+    MultiPartParams(1000 msat, 5),
+    experimentName = "my-test-experiment",
+    experimentPercentage = 100).getDefaultRouteParams
   val maxFee = 15000 msat // max fee for the defaultAmount
 
   /**

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -25,6 +25,7 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.db.{FailureSummary, FailureType, OutgoingPaymentStatus}
 import fr.acinq.eclair.payment.OutgoingPacket.Upstream
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
+import fr.acinq.eclair.payment.relay.Relayer.RelayFees
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle._
 import fr.acinq.eclair.payment.send.PaymentError.RetryExhausted
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentConfig
@@ -657,7 +658,7 @@ object MultiPartPaymentLifecycleSpec {
       0.01,
       6,
       CltvExpiryDelta(1008)),
-    WeightRatios(1, 0, 0, 0, 0 msat, 0),
+    WeightRatios(1, 0, 0, 0, RelayFees(0 msat, 0)),
     MultiPartParams(1000 msat, 5),
     experimentName = "my-test-experiment",
     experimentPercentage = 100).getDefaultRouteParams

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -89,7 +89,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val customRecords = Seq(GenericTlv(500L, hex"01020304"), GenericTlv(501L, hex"d34db33f"))
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, None, paymentHash, priv_c.privateKey, Left("test"), Channel.MIN_CLTV_EXPIRY_DELTA)
-    val req = SendPaymentToNode(finalAmount, pr, 1, Channel.MIN_CLTV_EXPIRY_DELTA, userCustomTlvs = customRecords, routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendPaymentToNode(finalAmount, pr, 1, Channel.MIN_CLTV_EXPIRY_DELTA, userCustomTlvs = customRecords, routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     payFsm.expectMsgType[SendPaymentConfig]
@@ -101,7 +101,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
 
   test("forward keysend payment") { f =>
     import f._
-    val req = SendSpontaneousPayment(finalAmount, c, paymentPreimage, 1, routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendSpontaneousPayment(finalAmount, c, paymentPreimage, 1, routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     payFsm.expectMsgType[SendPaymentConfig]
@@ -116,7 +116,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val unknownFeature = 42
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, randomKey(), Left("Some invoice"), CltvExpiryDelta(18), features = PaymentRequestFeatures(Features.VariableLengthOnion.mandatory, Features.PaymentSecret.mandatory, unknownFeature))
-    val req = SendPaymentToNode(finalAmount + 100.msat, pr, 1, CltvExpiryDelta(42), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendPaymentToNode(finalAmount + 100.msat, pr, 1, CltvExpiryDelta(42), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
@@ -141,22 +141,22 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val finalExpiryDelta = CltvExpiryDelta(24)
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some MPP invoice"), finalExpiryDelta, features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional))
-    val req = SendPaymentToNode(finalAmount, pr, 1, /* ignored since the invoice provides it */ CltvExpiryDelta(12), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendPaymentToNode(finalAmount, pr, 1, /* ignored since the invoice provides it */ CltvExpiryDelta(12), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     assert(req.finalExpiry(nodeParams.currentBlockHeight) === (finalExpiryDelta + 1).toCltvExpiry(nodeParams.currentBlockHeight))
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     payFsm.expectMsg(SendPaymentConfig(id, id, None, paymentHash, finalAmount, c, Upstream.Local(id), Some(pr), storeInDb = true, publishEvent = true, Nil))
-    payFsm.expectMsg(PaymentLifecycle.SendPaymentToNode(sender.ref, c, FinalTlvPayload(TlvStream(OnionTlv.AmountToForward(finalAmount), OnionTlv.OutgoingCltv(req.finalExpiry(nodeParams.currentBlockHeight)), OnionTlv.PaymentData(pr.paymentSecret.get, finalAmount))), 1, routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf)))
+    payFsm.expectMsg(PaymentLifecycle.SendPaymentToNode(sender.ref, c, FinalTlvPayload(TlvStream(OnionTlv.AmountToForward(finalAmount), OnionTlv.OutgoingCltv(req.finalExpiry(nodeParams.currentBlockHeight)), OnionTlv.PaymentData(pr.paymentSecret.get, finalAmount))), 1, routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get())))
   }
 
   test("forward multi-part payment") { f =>
     import f._
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some invoice"), CltvExpiryDelta(18), features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional))
-    val req = SendPaymentToNode(finalAmount + 100.msat, pr, 1, CltvExpiryDelta(42), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendPaymentToNode(finalAmount + 100.msat, pr, 1, CltvExpiryDelta(42), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     multiPartPayFsm.expectMsg(SendPaymentConfig(id, id, None, paymentHash, finalAmount + 100.msat, c, Upstream.Local(id), Some(pr), storeInDb = true, publishEvent = true, Nil))
-    multiPartPayFsm.expectMsg(SendMultiPartPayment(sender.ref, pr.paymentSecret.get, c, finalAmount + 100.msat, req.finalExpiry(nodeParams.currentBlockHeight), 1, routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf)))
+    multiPartPayFsm.expectMsg(SendMultiPartPayment(sender.ref, pr.paymentSecret.get, c, finalAmount + 100.msat, req.finalExpiry(nodeParams.currentBlockHeight), 1, routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get())))
   }
 
   test("forward multi-part payment with pre-defined route") { f =>
@@ -181,7 +181,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val ignoredRoutingHints = List(List(ExtraHop(b, channelUpdate_bc.shortChannelId, feeBase = 10 msat, feeProportionalMillionths = 1, cltvExpiryDelta = CltvExpiryDelta(12))))
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(9), features = features, extraHops = ignoredRoutingHints)
     val trampolineFees = 21000 msat
-    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), /* ignored since the invoice provides it */ CltvExpiryDelta(18), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), /* ignored since the invoice provides it */ CltvExpiryDelta(18), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -221,7 +221,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some eclair-mobile invoice"), CltvExpiryDelta(9))
     val trampolineFees = 21000 msat
-    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -253,7 +253,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional)
     val pr = PaymentRequest(Block.RegtestGenesisBlock.hash, None, paymentHash, priv_a.privateKey, Left("#abittooreckless"), CltvExpiryDelta(18), None, None, routingHints, features = features)
     val trampolineFees = 21000 msat
-    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), CltvExpiryDelta(9), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), CltvExpiryDelta(9), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
@@ -269,7 +269,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional, TrampolinePayment.optional)
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(18), features = features)
     val trampolineAttempts = (21000 msat, CltvExpiryDelta(12)) :: (25000 msat, CltvExpiryDelta(24)) :: Nil
-    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     val cfg = multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -299,7 +299,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional, TrampolinePayment.optional)
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(18), features = features)
     val trampolineAttempts = (21000 msat, CltvExpiryDelta(12)) :: (25000 msat, CltvExpiryDelta(24)) :: Nil
-    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     val cfg = multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -329,7 +329,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional, TrampolinePayment.optional)
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(18), features = features)
     val trampolineAttempts = (21000 msat, CltvExpiryDelta(12)) :: (25000 msat, CltvExpiryDelta(24)) :: Nil
-    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingConf))
+    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = RouteCalculation.getDefaultRouteParams(nodeParams.routerConf.pathFindingExperimentConf.get()))
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -89,7 +89,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val customRecords = Seq(GenericTlv(500L, hex"01020304"), GenericTlv(501L, hex"d34db33f"))
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, None, paymentHash, priv_c.privateKey, Left("test"), Channel.MIN_CLTV_EXPIRY_DELTA)
-    val req = SendPaymentToNode(finalAmount, pr, 1, Channel.MIN_CLTV_EXPIRY_DELTA, userCustomTlvs = customRecords, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendPaymentToNode(finalAmount, pr, 1, Channel.MIN_CLTV_EXPIRY_DELTA, userCustomTlvs = customRecords, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     payFsm.expectMsgType[SendPaymentConfig]
@@ -101,7 +101,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
 
   test("forward keysend payment") { f =>
     import f._
-    val req = SendSpontaneousPayment(finalAmount, c, paymentPreimage, 1, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendSpontaneousPayment(finalAmount, c, paymentPreimage, 1, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     payFsm.expectMsgType[SendPaymentConfig]
@@ -116,7 +116,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val unknownFeature = 42
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, randomKey(), Left("Some invoice"), CltvExpiryDelta(18), features = PaymentRequestFeatures(Features.VariableLengthOnion.mandatory, Features.PaymentSecret.mandatory, unknownFeature))
-    val req = SendPaymentToNode(finalAmount + 100.msat, pr, 1, CltvExpiryDelta(42), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendPaymentToNode(finalAmount + 100.msat, pr, 1, CltvExpiryDelta(42), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
@@ -141,22 +141,22 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val finalExpiryDelta = CltvExpiryDelta(24)
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some MPP invoice"), finalExpiryDelta, features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional))
-    val req = SendPaymentToNode(finalAmount, pr, 1, /* ignored since the invoice provides it */ CltvExpiryDelta(12), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendPaymentToNode(finalAmount, pr, 1, /* ignored since the invoice provides it */ CltvExpiryDelta(12), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     assert(req.finalExpiry(nodeParams.currentBlockHeight) === (finalExpiryDelta + 1).toCltvExpiry(nodeParams.currentBlockHeight))
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     payFsm.expectMsg(SendPaymentConfig(id, id, None, paymentHash, finalAmount, c, Upstream.Local(id), Some(pr), storeInDb = true, publishEvent = true, recordMetrics = true, Nil))
-    payFsm.expectMsg(PaymentLifecycle.SendPaymentToNode(sender.ref, c, FinalTlvPayload(TlvStream(OnionTlv.AmountToForward(finalAmount), OnionTlv.OutgoingCltv(req.finalExpiry(nodeParams.currentBlockHeight)), OnionTlv.PaymentData(pr.paymentSecret.get, finalAmount))), 1, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf()))
+    payFsm.expectMsg(PaymentLifecycle.SendPaymentToNode(sender.ref, c, FinalTlvPayload(TlvStream(OnionTlv.AmountToForward(finalAmount), OnionTlv.OutgoingCltv(req.finalExpiry(nodeParams.currentBlockHeight)), OnionTlv.PaymentData(pr.paymentSecret.get, finalAmount))), 1, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams))
   }
 
   test("forward multi-part payment") { f =>
     import f._
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some invoice"), CltvExpiryDelta(18), features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional))
-    val req = SendPaymentToNode(finalAmount + 100.msat, pr, 1, CltvExpiryDelta(42), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendPaymentToNode(finalAmount + 100.msat, pr, 1, CltvExpiryDelta(42), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     multiPartPayFsm.expectMsg(SendPaymentConfig(id, id, None, paymentHash, finalAmount + 100.msat, c, Upstream.Local(id), Some(pr), storeInDb = true, publishEvent = true, recordMetrics = true, Nil))
-    multiPartPayFsm.expectMsg(SendMultiPartPayment(sender.ref, pr.paymentSecret.get, c, finalAmount + 100.msat, req.finalExpiry(nodeParams.currentBlockHeight), 1, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf()))
+    multiPartPayFsm.expectMsg(SendMultiPartPayment(sender.ref, pr.paymentSecret.get, c, finalAmount + 100.msat, req.finalExpiry(nodeParams.currentBlockHeight), 1, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams))
   }
 
   test("forward multi-part payment with pre-defined route") { f =>
@@ -181,7 +181,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val ignoredRoutingHints = List(List(ExtraHop(b, channelUpdate_bc.shortChannelId, feeBase = 10 msat, feeProportionalMillionths = 1, cltvExpiryDelta = CltvExpiryDelta(12))))
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(9), features = features, extraHops = ignoredRoutingHints)
     val trampolineFees = 21000 msat
-    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), /* ignored since the invoice provides it */ CltvExpiryDelta(18), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), /* ignored since the invoice provides it */ CltvExpiryDelta(18), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -221,7 +221,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some eclair-mobile invoice"), CltvExpiryDelta(9))
     val trampolineFees = 21000 msat
-    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -253,7 +253,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional)
     val pr = PaymentRequest(Block.RegtestGenesisBlock.hash, None, paymentHash, priv_a.privateKey, Left("#abittooreckless"), CltvExpiryDelta(18), None, None, routingHints, features = features)
     val trampolineFees = 21000 msat
-    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), CltvExpiryDelta(9), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendTrampolinePayment(finalAmount, pr, b, Seq((trampolineFees, CltvExpiryDelta(12))), CltvExpiryDelta(9), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
@@ -269,7 +269,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional, TrampolinePayment.optional)
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(18), features = features)
     val trampolineAttempts = (21000 msat, CltvExpiryDelta(12)) :: (25000 msat, CltvExpiryDelta(24)) :: Nil
-    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     val cfg = multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -299,7 +299,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional, TrampolinePayment.optional)
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(18), features = features)
     val trampolineAttempts = (21000 msat, CltvExpiryDelta(12)) :: (25000 msat, CltvExpiryDelta(24)) :: Nil
-    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     val cfg = multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -329,7 +329,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val features = PaymentRequestFeatures(VariableLengthOnion.mandatory, PaymentSecret.mandatory, BasicMultiPartPayment.optional, TrampolinePayment.optional)
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(18), features = features)
     val trampolineAttempts = (21000 msat, CltvExpiryDelta(12)) :: (25000 msat, CltvExpiryDelta(24)) :: Nil
-    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf())
+    val req = SendTrampolinePayment(finalAmount, pr, b, trampolineAttempts, CltvExpiryDelta(9), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -73,10 +73,10 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
                             monitor: TestProbe,
                             eventListener: TestProbe)
 
-  def createPaymentLifecycle(storeInDb: Boolean = true, publishEvent: Boolean = true): PaymentFixture = {
+  def createPaymentLifecycle(storeInDb: Boolean = true, publishEvent: Boolean = true, recordMetrics: Boolean = true): PaymentFixture = {
     val (id, parentId) = (UUID.randomUUID(), UUID.randomUUID())
     val nodeParams = TestConstants.Alice.nodeParams.copy(nodeKeyManager = testNodeKeyManager, channelKeyManager = testChannelKeyManager)
-    val cfg = SendPaymentConfig(id, parentId, Some(defaultExternalId), defaultPaymentHash, defaultAmountMsat, d, Upstream.Local(id), Some(defaultInvoice), storeInDb, publishEvent, Nil)
+    val cfg = SendPaymentConfig(id, parentId, Some(defaultExternalId), defaultPaymentHash, defaultAmountMsat, d, Upstream.Local(id), Some(defaultInvoice), storeInDb, publishEvent, recordMetrics, Nil)
     val (routerForwarder, register, sender, monitor, eventListener) = (TestProbe(), TestProbe(), TestProbe(), TestProbe(), TestProbe())
     val paymentFSM = TestFSMRef(new PaymentLifecycle(nodeParams, cfg, routerForwarder.ref, register.ref))
     paymentFSM ! SubscribeTransitionCallBack(monitor.ref)
@@ -213,7 +213,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     import payFixture._
     import cfg._
 
-    val request = SendPaymentToNode(sender.ref, d, Onion.createSinglePartPayload(defaultAmountMsat, defaultExpiry, defaultInvoice.paymentSecret.get), 5, routeParams = RouteParams(randomize = false, 100 msat, 0.0, 20, CltvExpiryDelta(2016), WeightRatios(1, 0, 0, 0, 0 msat, 0), MultiPartParams(10000 msat, 5), false))
+    val request = SendPaymentToNode(sender.ref, d, Onion.createSinglePartPayload(defaultAmountMsat, defaultExpiry, defaultInvoice.paymentSecret.get), 5, routeParams = RouteParams(randomize = false, 100 msat, 0.0, 20, CltvExpiryDelta(2016), WeightRatios(1, 0, 0, 0, 0 msat, 0), MultiPartParams(10000 msat, 5), false, ""))
     sender.send(paymentFSM, request)
     val routeRequest = routerForwarder.expectMsgType[RouteRequest]
     val Transition(_, WAITING_FOR_REQUEST, WAITING_FOR_ROUTE) = monitor.expectMsgClass(classOf[Transition[_]])
@@ -710,7 +710,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
   }
 
   test("disable database and events") { routerFixture =>
-    val payFixture = createPaymentLifecycle(storeInDb = false, publishEvent = false)
+    val payFixture = createPaymentLifecycle(storeInDb = false, publishEvent = false, recordMetrics = false)
     import payFixture._
     import cfg._
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -32,6 +32,7 @@ import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.payment.OutgoingPacket.Upstream
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.payment.PaymentSent.PartialPayment
+import fr.acinq.eclair.payment.relay.Relayer.RelayFees
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentConfig
 import fr.acinq.eclair.payment.send.PaymentLifecycle
 import fr.acinq.eclair.payment.send.PaymentLifecycle._
@@ -234,7 +235,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val routeParams = PathFindingConf(
       randomize = false,
       boundaries = SearchBoundaries(100 msat, 0.0, 20, CltvExpiryDelta(2016)),
-      WeightRatios(1, 0, 0, 0, 0 msat, 0),
+      WeightRatios(1, 0, 0, 0, RelayFees(0 msat, 0)),
       MultiPartParams(10000 msat, 5),
       "my-test-experiment",
       experimentPercentage = 100

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -60,7 +60,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
   val defaultOrigin = Origin.LocalCold(UUID.randomUUID())
   val defaultExternalId = UUID.randomUUID().toString
   val defaultInvoice = PaymentRequest(Block.RegtestGenesisBlock.hash, None, defaultPaymentHash, priv_d, Left("test"), Channel.MIN_CLTV_EXPIRY_DELTA)
-  val defaultRouteParams = RouteCalculation.getDefaultRouteParams(TestConstants.Alice.nodeParams.routerConf.pathFindingConf)
+  val defaultRouteParams = RouteCalculation.getDefaultRouteParams(TestConstants.Alice.nodeParams.routerConf.pathFindingExperimentConf.get())
 
   def defaultRouteRequest(source: PublicKey, target: PublicKey, cfg: SendPaymentConfig): RouteRequest = RouteRequest(source, target, defaultAmountMsat, defaultMaxFee, paymentContext = Some(cfg.paymentContext), routeParams = defaultRouteParams)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -221,9 +221,10 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(!metrics.success)
+    assert(metrics.status == "FAILURE")
     assert(metrics.experimentName == "alice-test-experiment")
     assert(metrics.amount == defaultAmountMsat)
+    assert(metrics.fees == 4260000.msat)
     metricsListener.expectNoMessage()
   }
 
@@ -250,9 +251,10 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(!metrics.success)
+    assert(metrics.status == "FAILURE")
     assert(metrics.experimentName == "my-test-experiment")
     assert(metrics.amount == defaultAmountMsat)
+    assert(metrics.fees == 100.msat)
     metricsListener.expectNoMessage()
   }
 
@@ -292,9 +294,10 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed])) // after last attempt the payment is failed
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(!metrics.success)
+    assert(metrics.status == "FAILURE")
     assert(metrics.experimentName == "alice-test-experiment")
     assert(metrics.amount == defaultAmountMsat)
+    assert(metrics.fees == 4260000.msat)
     metricsListener.expectNoMessage()
   }
 
@@ -650,7 +653,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Succeeded]))
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(metrics.success)
+    assert(metrics.status == "SUCCESS")
     assert(metrics.experimentName == "alice-test-experiment")
     assert(metrics.amount == defaultAmountMsat)
     assert(metrics.fees == 730.msat)
@@ -703,7 +706,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     assert(paymentOK.recipientAmount === request.finalPayload.amount)
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
-    assert(metrics.success)
+    assert(metrics.status == "SUCCESS")
     assert(metrics.experimentName == "alice-test-experiment")
     assert(metrics.amount == defaultAmountMsat)
     assert(metrics.fees == 0.msat)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -488,7 +488,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     val routeRequest = router.expectMessageType[RouteRequest]
     val routeParams = routeRequest.routeParams
     assert(routeParams.maxFeeProportional === 0) // should be disabled
-    assert(routeParams.maxFeeFixed === incomingAmount - outgoingAmount)
+    assert(routeParams.maxFeeFlat === incomingAmount - outgoingAmount)
     assert(routeParams.maxCltv === incomingSinglePart.add.cltvExpiry - outgoingExpiry)
     assert(routeParams.includeLocalChannelCost)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -487,9 +487,9 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
 
     val routeRequest = router.expectMessageType[RouteRequest]
     val routeParams = routeRequest.routeParams
-    assert(routeParams.maxFeePct === 0) // should be disabled
-    assert(routeParams.maxFeeBase === incomingAmount - outgoingAmount)
-    assert(routeParams.routeMaxCltv === incomingSinglePart.add.cltvExpiry - outgoingExpiry)
+    assert(routeParams.maxFeeProportional === 0) // should be disabled
+    assert(routeParams.maxFee === incomingAmount - outgoingAmount)
+    assert(routeParams.maxCltv === incomingSinglePart.add.cltvExpiry - outgoingExpiry)
     assert(routeParams.includeLocalChannelCost)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -488,7 +488,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     val routeRequest = router.expectMessageType[RouteRequest]
     val routeParams = routeRequest.routeParams
     assert(routeParams.maxFeeProportional === 0) // should be disabled
-    assert(routeParams.maxFee === incomingAmount - outgoingAmount)
+    assert(routeParams.maxFeeFixed === incomingAmount - outgoingAmount)
     assert(routeParams.maxCltv === incomingSinglePart.add.cltvExpiry - outgoingExpiry)
     assert(routeParams.includeLocalChannelCost)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -65,7 +65,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     // here we have a maximum fee base of 1 msat, and all our updates have a base fee of 10 msat
     // so our fee will always be above the base fee, and we will always check that it is below our maximum percentage
     // of the amount being paid
-    val routeParams = DEFAULT_ROUTE_PARAMS.copy(maxFeeFixed = 1 msat)
+    val routeParams = DEFAULT_ROUTE_PARAMS.copy(maxFeeFlat = 1 msat)
     val maxFee = routeParams.getMaxFee(DEFAULT_AMOUNT_MSAT)
 
     val g = DirectedGraph(List(
@@ -772,7 +772,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
   }
 
   test("select a random route below the requested fee") {
-    val strictFeeParams = DEFAULT_ROUTE_PARAMS.copy(maxFeeFixed = 7 msat, maxFeeProportional = 0, randomize = true)
+    val strictFeeParams = DEFAULT_ROUTE_PARAMS.copy(maxFeeFlat = 7 msat, maxFeeProportional = 0, randomize = true)
     val strictFee = strictFeeParams.getMaxFee(DEFAULT_AMOUNT_MSAT)
     assert(strictFee === 7.msat)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -1789,7 +1789,7 @@ object RouteCalculationSpec {
   val DEFAULT_CAPACITY = 100000 sat
 
   val NO_WEIGHT_RATIOS: WeightRatios = WeightRatios(1, 0, 0, 0, 0 msat, 0)
-  val DEFAULT_ROUTE_PARAMS = RouteParams(randomize = false, 21000 msat, 0.03, 6, CltvExpiryDelta(2016), NO_WEIGHT_RATIOS, MultiPartParams(1000 msat, 10), includeLocalChannelCost = false, experimentName = "")
+  val DEFAULT_ROUTE_PARAMS = RouteParams(randomize = false, 21000 msat, 0.03, 6, CltvExpiryDelta(2016), NO_WEIGHT_RATIOS, MultiPartParams(1000 msat, 10), includeLocalChannelCost = false, experimentName = "my-test-experiment", experimentPercentage = 100)
 
   val DUMMY_SIG = Transactions.PlaceHolderSig
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -64,7 +64,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     // here we have a maximum fee base of 1 msat, and all our updates have a base fee of 10 msat
     // so our fee will always be above the base fee, and we will always check that it is below our maximum percentage
     // of the amount being paid
-    val routeParams = DEFAULT_ROUTE_PARAMS.copy(maxFee = 1 msat)
+    val routeParams = DEFAULT_ROUTE_PARAMS.copy(maxFeeFixed = 1 msat)
     val maxFee = routeParams.getMaxFee(DEFAULT_AMOUNT_MSAT)
 
     val g = DirectedGraph(List(
@@ -771,7 +771,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
   }
 
   test("select a random route below the requested fee") {
-    val strictFeeParams = DEFAULT_ROUTE_PARAMS.copy(maxFee = 7 msat, maxFeeProportional = 0, randomize = true)
+    val strictFeeParams = DEFAULT_ROUTE_PARAMS.copy(maxFeeFixed = 7 msat, maxFeeProportional = 0, randomize = true)
     val strictFee = strictFeeParams.getMaxFee(DEFAULT_AMOUNT_MSAT)
     assert(strictFee === 7.msat)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.router
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{Block, ByteVector32, ByteVector64, Satoshi, SatoshiLong}
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
+import fr.acinq.eclair.payment.relay.Relayer.RelayFees
 import fr.acinq.eclair.router.Graph.GraphStructure.DirectedGraph.graphEdgeToHop
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
 import fr.acinq.eclair.router.Graph.{RichWeight, WeightRatios}
@@ -824,8 +825,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       cltvDeltaFactor = 1,
       ageFactor = 0,
       capacityFactor = 0,
-      hopCostBase = 0 msat,
-      hopCostMillionths = 0
+      hopCost = RelayFees(0 msat, 0),
     )), currentBlockHeight = 400000)
     assert(route2Nodes(routeCltvOptimized) === (a, e) :: (e, f) :: (f, d) :: Nil)
 
@@ -834,8 +834,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       cltvDeltaFactor = 0,
       ageFactor = 0,
       capacityFactor = 1,
-      hopCostBase = 0 msat,
-      hopCostMillionths = 0
+      hopCost = RelayFees(0 msat, 0),
     )), currentBlockHeight = 400000)
     assert(route2Nodes(routeCapacityOptimized) === (a, e) :: (e, c) :: (c, d) :: Nil)
   }
@@ -857,8 +856,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       ageFactor = 0.33,
       cltvDeltaFactor = 0.33,
       capacityFactor = 0.33,
-      hopCostBase = 0 msat,
-      hopCostMillionths = 0
+      hopCost = RelayFees(0 msat, 0),
     )), currentBlockHeight = currentBlockHeight)
 
     assert(route2Nodes(routeScoreOptimized) === (a, b) :: (b, c) :: (c, d) :: Nil)
@@ -879,8 +877,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       ageFactor = 0.33,
       cltvDeltaFactor = 0.33,
       capacityFactor = 0.33,
-      hopCostBase = 0 msat,
-      hopCostMillionths = 0
+      hopCost = RelayFees(0 msat, 0),
     )), currentBlockHeight = 400000)
 
     assert(route2Nodes(routeScoreOptimized) === (a, b) :: (b, c) :: (c, d) :: Nil)
@@ -903,8 +900,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       ageFactor = 0.33,
       cltvDeltaFactor = 0.33,
       capacityFactor = 0.33,
-      hopCostBase = 0 msat,
-      hopCostMillionths = 0
+      hopCost = RelayFees(0 msat, 0),
     )), currentBlockHeight = 400000)
 
     assert(route2Nodes(routeScoreOptimized) === (a, e) :: (e, f) :: (f, d) :: Nil)
@@ -943,7 +939,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     val g = DirectedGraph.makeGraph(updates)
     val params = DEFAULT_ROUTE_PARAMS.copy(
       maxCltv = CltvExpiryDelta(1008),
-      ratios = WeightRatios(baseFactor = 0, cltvDeltaFactor = 0.15, ageFactor = 0.35, capacityFactor = 0.5, hopCostBase = 0 msat, hopCostMillionths = 0),
+      ratios = WeightRatios(baseFactor = 0, cltvDeltaFactor = 0.15, ageFactor = 0.35, capacityFactor = 0.5, hopCost = RelayFees(0 msat, 0)),
     )
     val thisNode = PublicKey(hex"036d65409c41ab7380a43448f257809e7496b52bf92057c09c4f300cbd61c50d96")
     val targetNode = PublicKey(hex"024655b768ef40951b20053a5c4b951606d4d86085d51238f2c67c7dec29c792ca")
@@ -1766,13 +1762,13 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       assert(route2Ids(route) === 0 :: 2 :: 5 :: 6 :: 7 :: 4 :: Nil)
     }
     { // small base hop cost
-      val Success(routes) = findRoute(g, start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(ratios = WeightRatios(1, 0, 0, 0, 100 msat, 0)), currentBlockHeight = 400000)
+      val Success(routes) = findRoute(g, start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(ratios = WeightRatios(1, 0, 0, 0, RelayFees(100 msat, 0))), currentBlockHeight = 400000)
       assert(routes.distinct.length == 1)
       val route :: Nil = routes
       assert(route2Ids(route) === 0 :: 2 :: 3 :: 4 :: Nil)
     }
     { // large proportional hop cost
-      val Success(routes) = findRoute(g, start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(ratios = WeightRatios(1, 0, 0, 0, 0 msat, 200)), currentBlockHeight = 400000)
+      val Success(routes) = findRoute(g, start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(ratios = WeightRatios(1, 0, 0, 0, RelayFees(0 msat, 200))), currentBlockHeight = 400000)
       assert(routes.distinct.length == 1)
       val route :: Nil = routes
       assert(route2Ids(route) === 0 :: 1 :: Nil)
@@ -1788,7 +1784,7 @@ object RouteCalculationSpec {
   val DEFAULT_MAX_FEE = 100000 msat
   val DEFAULT_CAPACITY = 100000 sat
 
-  val NO_WEIGHT_RATIOS: WeightRatios = WeightRatios(1, 0, 0, 0, 0 msat, 0)
+  val NO_WEIGHT_RATIOS: WeightRatios = WeightRatios(1, 0, 0, 0, RelayFees(0 msat, 0))
   val DEFAULT_ROUTE_PARAMS = PathFindingConf(
     randomize = false,
     boundaries = SearchBoundaries(21000 msat, 0.03, 6, CltvExpiryDelta(2016)),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -1789,7 +1789,7 @@ object RouteCalculationSpec {
   val DEFAULT_CAPACITY = 100000 sat
 
   val NO_WEIGHT_RATIOS: WeightRatios = WeightRatios(1, 0, 0, 0, 0 msat, 0)
-  val DEFAULT_ROUTE_PARAMS = RouteParams(randomize = false, 21000 msat, 0.03, 6, CltvExpiryDelta(2016), NO_WEIGHT_RATIOS, MultiPartParams(1000 msat, 10), includeLocalChannelCost = false)
+  val DEFAULT_ROUTE_PARAMS = RouteParams(randomize = false, 21000 msat, 0.03, 6, CltvExpiryDelta(2016), NO_WEIGHT_RATIOS, MultiPartParams(1000 msat, 10), includeLocalChannelCost = false, experimentName = "")
 
   val DUMMY_SIG = Transactions.PlaceHolderSig
 

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
@@ -85,7 +85,7 @@ class Handlers(fKit: Future[Kit])(implicit ec: ExecutionContext = ExecutionConte
     logger.info(s"sending $amountMsat to ${req.paymentHash} @ ${req.nodeId}")
     (for {
       kit <- fKit
-      routeParams = RouteCalculation.getDefaultRouteParams(kit.nodeParams.routerConf.pathFindingConf)
+      routeParams = RouteCalculation.getDefaultRouteParams(kit.nodeParams.routerConf.pathFindingExperimentConf.get())
       sendPayment = req.minFinalCltvExpiryDelta match {
         case None => SendPaymentToNode(MilliSatoshi(amountMsat), req, kit.nodeParams.maxPaymentAttempts, assistedRoutes = req.routingInfo, routeParams = routeParams)
         case Some(minFinalCltvExpiry) => SendPaymentToNode(MilliSatoshi(amountMsat), req, kit.nodeParams.maxPaymentAttempts, assistedRoutes = req.routingInfo, fallbackFinalExpiryDelta = minFinalCltvExpiry, routeParams = routeParams)

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
@@ -85,7 +85,7 @@ class Handlers(fKit: Future[Kit])(implicit ec: ExecutionContext = ExecutionConte
     logger.info(s"sending $amountMsat to ${req.paymentHash} @ ${req.nodeId}")
     (for {
       kit <- fKit
-      routeParams = kit.nodeParams.routerConf.pathFindingExperimentConf.getRandomConf()
+      routeParams = kit.nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams
       sendPayment = req.minFinalCltvExpiryDelta match {
         case None => SendPaymentToNode(MilliSatoshi(amountMsat), req, kit.nodeParams.maxPaymentAttempts, assistedRoutes = req.routingInfo, routeParams = routeParams)
         case Some(minFinalCltvExpiry) => SendPaymentToNode(MilliSatoshi(amountMsat), req, kit.nodeParams.maxPaymentAttempts, assistedRoutes = req.routingInfo, fallbackFinalExpiryDelta = minFinalCltvExpiry, routeParams = routeParams)

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/Handlers.scala
@@ -85,7 +85,7 @@ class Handlers(fKit: Future[Kit])(implicit ec: ExecutionContext = ExecutionConte
     logger.info(s"sending $amountMsat to ${req.paymentHash} @ ${req.nodeId}")
     (for {
       kit <- fKit
-      routeParams = RouteCalculation.getDefaultRouteParams(kit.nodeParams.routerConf.pathFindingExperimentConf.get())
+      routeParams = kit.nodeParams.routerConf.pathFindingExperimentConf.getRandomConf()
       sendPayment = req.minFinalCltvExpiryDelta match {
         case None => SendPaymentToNode(MilliSatoshi(amountMsat), req, kit.nodeParams.maxPaymentAttempts, assistedRoutes = req.routingInfo, routeParams = routeParams)
         case Some(minFinalCltvExpiry) => SendPaymentToNode(MilliSatoshi(amountMsat), req, kit.nodeParams.maxPaymentAttempts, assistedRoutes = req.routingInfo, fallbackFinalExpiryDelta = minFinalCltvExpiry, routeParams = routeParams)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
@@ -29,11 +29,11 @@ trait PathFinding {
   import fr.acinq.eclair.api.serde.JsonSupport.{formats, marshaller, serialization}
 
   val findRoute: Route = postRequest("findroute") { implicit t =>
-    formFields(invoiceFormParam, amountMsatFormParam.?, "experimentName".as[String].?) {
-      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, experimentName) =>
-        complete(eclairApi.findRoute(nodeId, amount, experimentName, invoice.routingInfo))
-      case (invoice, Some(overrideAmount), experimentName) =>
-        complete(eclairApi.findRoute(invoice.nodeId, overrideAmount, experimentName, invoice.routingInfo))
+    formFields(invoiceFormParam, amountMsatFormParam.?, "pathFindingExperimentName".?) {
+      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, pathFindingExperimentName_opt) =>
+        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, invoice.routingInfo))
+      case (invoice, Some(overrideAmount), pathFindingExperimentName_opt) =>
+        complete(eclairApi.findRoute(invoice.nodeId, overrideAmount, pathFindingExperimentName_opt, invoice.routingInfo))
       case _ => reject(MalformedFormFieldRejection(
         "invoice", "The invoice must have an amount or you need to specify one using 'amountMsat'"
       ))
@@ -41,14 +41,14 @@ trait PathFinding {
   }
 
   val findRouteToNode: Route = postRequest("findroutetonode") { implicit t =>
-    formFields(nodeIdFormParam, amountMsatFormParam, "experimentName".as[String].?) { (nodeId, amount, experimentName) =>
-      complete(eclairApi.findRoute(nodeId, amount, experimentName))
+    formFields(nodeIdFormParam, amountMsatFormParam, "pathFindingExperimentName".?) { (nodeId, amount, pathFindingExperimentName_opt) =>
+      complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt))
     }
   }
 
   val findRouteBetweenNodes: Route = postRequest("findroutebetweennodes") { implicit t =>
-    formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam, "experimentName".as[String].?) { (sourceNodeId, targetNodeId, amount, experimentName) =>
-      complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount, experimentName))
+    formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam, "pathFindingExperimentName".?) { (sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt) =>
+      complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt))
     }
   }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
@@ -29,11 +29,11 @@ trait PathFinding {
   import fr.acinq.eclair.api.serde.JsonSupport.{formats, marshaller, serialization}
 
   val findRoute: Route = postRequest("findroute") { implicit t =>
-    formFields(invoiceFormParam, amountMsatFormParam.?) {
-      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None) =>
-        complete(eclairApi.findRoute(nodeId, amount, invoice.routingInfo))
-      case (invoice, Some(overrideAmount)) =>
-        complete(eclairApi.findRoute(invoice.nodeId, overrideAmount, invoice.routingInfo))
+    formFields(invoiceFormParam, amountMsatFormParam.?, "experimentName".as[String].?) {
+      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, experimentName) =>
+        complete(eclairApi.findRoute(nodeId, amount, experimentName, invoice.routingInfo))
+      case (invoice, Some(overrideAmount), experimentName) =>
+        complete(eclairApi.findRoute(invoice.nodeId, overrideAmount, experimentName, invoice.routingInfo))
       case _ => reject(MalformedFormFieldRejection(
         "invoice", "The invoice must have an amount or you need to specify one using 'amountMsat'"
       ))
@@ -41,14 +41,14 @@ trait PathFinding {
   }
 
   val findRouteToNode: Route = postRequest("findroutetonode") { implicit t =>
-    formFields(nodeIdFormParam, amountMsatFormParam) { (nodeId, amount) =>
-      complete(eclairApi.findRoute(nodeId, amount))
+    formFields(nodeIdFormParam, amountMsatFormParam, "experimentName".as[String].?) { (nodeId, amount, experimentName) =>
+      complete(eclairApi.findRoute(nodeId, amount, experimentName))
     }
   }
 
   val findRouteBetweenNodes: Route = postRequest("findroutebetweennodes") { implicit t =>
-    formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam) { (sourceNodeId, targetNodeId, amount) =>
-      complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount))
+    formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam, "experimentName".as[String].?) { (sourceNodeId, targetNodeId, amount, experimentName) =>
+      complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount, experimentName))
     }
   }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Payment.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Payment.scala
@@ -38,16 +38,16 @@ trait Payment {
   }
 
   val payInvoice: Route = postRequest("payinvoice") { implicit t =>
-    formFields(invoiceFormParam, amountMsatFormParam.?, "maxAttempts".as[Int].?, "feeThresholdSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?, "blocking".as[Boolean].?, "experimentName".as[String].?) {
-      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, blocking_opt, experimentName) =>
+    formFields(invoiceFormParam, amountMsatFormParam.?, "maxAttempts".as[Int].?, "feeThresholdSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?, "blocking".as[Boolean].?, "pathFindingExperimentName".?) {
+      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, blocking_opt, pathFindingExperimentName_opt) =>
         blocking_opt match {
-          case Some(true) => complete(eclairApi.sendBlocking(externalId_opt, amount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, experimentName))
-          case _ => complete(eclairApi.send(externalId_opt, amount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, experimentName))
+          case Some(true) => complete(eclairApi.sendBlocking(externalId_opt, amount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, pathFindingExperimentName_opt))
+          case _ => complete(eclairApi.send(externalId_opt, amount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, pathFindingExperimentName_opt))
         }
-      case (invoice, Some(overrideAmount), maxAttempts, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, blocking_opt, experimentName) =>
+      case (invoice, Some(overrideAmount), maxAttempts, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, blocking_opt, pathFindingExperimentName_opt) =>
         blocking_opt match {
-          case Some(true) => complete(eclairApi.sendBlocking(externalId_opt, overrideAmount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, experimentName))
-          case _ => complete(eclairApi.send(externalId_opt, overrideAmount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, experimentName))
+          case Some(true) => complete(eclairApi.sendBlocking(externalId_opt, overrideAmount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, pathFindingExperimentName_opt))
+          case _ => complete(eclairApi.send(externalId_opt, overrideAmount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, pathFindingExperimentName_opt))
         }
       case _ => reject(MalformedFormFieldRejection("invoice", "The invoice must have an amount or you need to specify one using the field 'amountMsat'"))
     }
@@ -72,9 +72,9 @@ trait Payment {
   }
 
   val sendToNode: Route = postRequest("sendtonode") { implicit t =>
-    formFields(amountMsatFormParam, nodeIdFormParam, "maxAttempts".as[Int].?, "feeThresholdSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?, "experimentName".as[String].?) {
-      case (amountMsat, nodeId, maxAttempts_opt, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, experimentName) =>
-        complete(eclairApi.sendWithPreimage(externalId_opt, nodeId, amountMsat, randomBytes32(), maxAttempts_opt, feeThresholdSat_opt, maxFeePct_opt, experimentName))
+    formFields(amountMsatFormParam, nodeIdFormParam, "maxAttempts".as[Int].?, "feeThresholdSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?, "pathFindingExperimentName".?) {
+      case (amountMsat, nodeId, maxAttempts_opt, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, pathFindingExperimentName_opt) =>
+        complete(eclairApi.sendWithPreimage(externalId_opt, nodeId, amountMsat, randomBytes32(), maxAttempts_opt, feeThresholdSat_opt, maxFeePct_opt, pathFindingExperimentName_opt))
     }
   }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Payment.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Payment.scala
@@ -38,16 +38,16 @@ trait Payment {
   }
 
   val payInvoice: Route = postRequest("payinvoice") { implicit t =>
-    formFields(invoiceFormParam, amountMsatFormParam.?, "maxAttempts".as[Int].?, "feeThresholdSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?, "blocking".as[Boolean].?) {
-      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, blocking_opt) =>
+    formFields(invoiceFormParam, amountMsatFormParam.?, "maxAttempts".as[Int].?, "feeThresholdSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?, "blocking".as[Boolean].?, "experimentName".as[String].?) {
+      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, blocking_opt, experimentName) =>
         blocking_opt match {
-          case Some(true) => complete(eclairApi.sendBlocking(externalId_opt, amount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt))
-          case _ => complete(eclairApi.send(externalId_opt, amount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt))
+          case Some(true) => complete(eclairApi.sendBlocking(externalId_opt, amount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, experimentName))
+          case _ => complete(eclairApi.send(externalId_opt, amount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, experimentName))
         }
-      case (invoice, Some(overrideAmount), maxAttempts, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, blocking_opt) =>
+      case (invoice, Some(overrideAmount), maxAttempts, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, blocking_opt, experimentName) =>
         blocking_opt match {
-          case Some(true) => complete(eclairApi.sendBlocking(externalId_opt, overrideAmount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt))
-          case _ => complete(eclairApi.send(externalId_opt, overrideAmount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt))
+          case Some(true) => complete(eclairApi.sendBlocking(externalId_opt, overrideAmount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, experimentName))
+          case _ => complete(eclairApi.send(externalId_opt, overrideAmount, invoice, maxAttempts, feeThresholdSat_opt, maxFeePct_opt, experimentName))
         }
       case _ => reject(MalformedFormFieldRejection("invoice", "The invoice must have an amount or you need to specify one using the field 'amountMsat'"))
     }
@@ -72,9 +72,9 @@ trait Payment {
   }
 
   val sendToNode: Route = postRequest("sendtonode") { implicit t =>
-    formFields(amountMsatFormParam, nodeIdFormParam, "maxAttempts".as[Int].?, "feeThresholdSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?) {
-      case (amountMsat, nodeId, maxAttempts_opt, feeThresholdSat_opt, maxFeePct_opt, externalId_opt) =>
-        complete(eclairApi.sendWithPreimage(externalId_opt, nodeId, amountMsat, randomBytes32(), maxAttempts_opt, feeThresholdSat_opt, maxFeePct_opt))
+    formFields(amountMsatFormParam, nodeIdFormParam, "maxAttempts".as[Int].?, "feeThresholdSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?, "experimentName".as[String].?) {
+      case (amountMsat, nodeId, maxAttempts_opt, feeThresholdSat_opt, maxFeePct_opt, externalId_opt, experimentName) =>
+        complete(eclairApi.sendWithPreimage(externalId_opt, nodeId, amountMsat, randomBytes32(), maxAttempts_opt, feeThresholdSat_opt, maxFeePct_opt, experimentName))
     }
   }
 

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -263,6 +263,14 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(entityAs[String] == "\"created channel 56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e\"")
         eclair.open(nodeId, 100002 sat, None, None, None, None, None)(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'open' channels with bad channelType") {
+    val nodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
+    val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
+
+    val eclair = mock[Eclair]
+    val mockService = new MockService(eclair)
 
     Post("/open", FormData("nodeId" -> nodeId.toString(), "fundingSatoshis" -> "100000", "channelType" -> "super_dope_channel").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -272,6 +280,15 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == BadRequest)
       }
+  }
+
+  test("'open' channels with standard channelType") {
+    val nodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
+    val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
+
+    val eclair = mock[Eclair]
+    eclair.open(any, any, any, any, any, any, any)(any[Timeout]) returns Future.successful(ChannelOpened(channelId))
+    val mockService = new MockService(eclair)
 
     Post("/open", FormData("nodeId" -> nodeId.toString(), "fundingSatoshis" -> "25000", "channelType" -> "standard").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -283,6 +300,15 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(entityAs[String] == "\"created channel 56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e\"")
         eclair.open(nodeId, 25000 sat, None, Some(ChannelTypes.Standard), None, None, None)(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'open' channels with static_remotekey channelType") {
+    val nodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
+    val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
+
+    val eclair = mock[Eclair]
+    eclair.open(any, any, any, any, any, any, any)(any[Timeout]) returns Future.successful(ChannelOpened(channelId))
+    val mockService = new MockService(eclair)
 
     Post("/open", FormData("nodeId" -> nodeId.toString(), "fundingSatoshis" -> "25000", "channelType" -> "static_remotekey").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -294,6 +320,15 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(entityAs[String] == "\"created channel 56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e\"")
         eclair.open(nodeId, 25000 sat, None, Some(ChannelTypes.StaticRemoteKey), None, None, None)(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'open' channels with anchor_outputs channelType") {
+    val nodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
+    val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
+
+    val eclair = mock[Eclair]
+    eclair.open(any, any, any, any, any, any, any)(any[Timeout]) returns Future.successful(ChannelOpened(channelId))
+    val mockService = new MockService(eclair)
 
     Post("/open", FormData("nodeId" -> nodeId.toString(), "fundingSatoshis" -> "25000", "channelType" -> "anchor_outputs").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -307,7 +342,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       }
   }
 
-  test("'close' method should accept channelIds and shortChannelIds") {
+  test("'close' method should accept shortChannelIds") {
     val shortChannelIdSerialized = "42000x27x3"
     val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
     val channelIdSerialized = channelId.toHex
@@ -332,6 +367,21 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         eclair.close(Right(ShortChannelId(shortChannelIdSerialized)) :: Nil, None, None)(any[Timeout]).wasCalled(once)
         matchTestJson("close", resp)
       }
+  }
+
+  test("'close' method should accept channelIds") {
+    val shortChannelIdSerialized = "42000x27x3"
+    val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
+    val channelIdSerialized = channelId.toHex
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+      Left(channelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), channelId)),
+      Left(channelId.reverse) -> Left(new RuntimeException("channel not found")),
+      Right(ShortChannelId(shortChannelIdSerialized)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
+    )
+
+    val eclair = mock[Eclair]
+    eclair.close(any, any, any)(any[Timeout]) returns Future.successful(response)
+    val mockService = new MockService(eclair)
 
     Post("/close", FormData("channelId" -> channelIdSerialized).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -344,6 +394,21 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         eclair.close(Left(channelId) :: Nil, None, None)(any[Timeout]).wasCalled(once)
         matchTestJson("close", resp)
       }
+  }
+
+  test("'close' method should accept channelIds and shortChannelIds") {
+    val shortChannelIdSerialized = "42000x27x3"
+    val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
+    val channelIdSerialized = channelId.toHex
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+      Left(channelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), channelId)),
+      Left(channelId.reverse) -> Left(new RuntimeException("channel not found")),
+      Right(ShortChannelId(shortChannelIdSerialized)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
+    )
+
+    val eclair = mock[Eclair]
+    eclair.close(any, any, any)(any[Timeout]) returns Future.successful(response)
+    val mockService = new MockService(eclair)
 
     Post("/close", FormData("channelIds" -> channelIdSerialized, "shortChannelIds" -> "42000x27x3,42000x561x1").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -358,7 +423,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       }
   }
 
-  test("'close' accepts custom closing feerates") {
+  test("'close' accepts custom closing feerates 1") {
     val shortChannelId = "1701x42x3"
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
       Right(ShortChannelId(shortChannelId)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
@@ -378,6 +443,17 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         val expectedFeerates = ClosingFeerates(FeeratePerKw(2500 sat), FeeratePerKw(500 sat), FeeratePerKw(12500 sat))
         eclair.close(Right(ShortChannelId(shortChannelId)) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'close' accepts custom closing feerates 2") {
+    val shortChannelId = "1701x42x3"
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+      Right(ShortChannelId(shortChannelId)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
+    )
+
+    val eclair = mock[Eclair]
+    eclair.close(any, any, any)(any[Timeout]) returns Future.successful(response)
+    val mockService = new MockService(eclair)
 
     Post("/close", FormData("shortChannelId" -> shortChannelId, "preferredFeerateSatByte" -> "10").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -389,6 +465,17 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         val expectedFeerates = ClosingFeerates(FeeratePerKw(2500 sat), FeeratePerKw(1250 sat), FeeratePerKw(5000 sat))
         eclair.close(Right(ShortChannelId(shortChannelId)) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'close' accepts custom closing feerates 3") {
+    val shortChannelId = "1701x42x3"
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+      Right(ShortChannelId(shortChannelId)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
+    )
+
+    val eclair = mock[Eclair]
+    eclair.close(any, any, any)(any[Timeout]) returns Future.successful(response)
+    val mockService = new MockService(eclair)
 
     Post("/close", FormData("shortChannelId" -> shortChannelId, "preferredFeerateSatByte" -> "10", "minFeerateSatByte" -> "2").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -400,6 +487,17 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         val expectedFeerates = ClosingFeerates(FeeratePerKw(2500 sat), FeeratePerKw(500 sat), FeeratePerKw(5000 sat))
         eclair.close(Right(ShortChannelId(shortChannelId)) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'close' accepts custom closing feerates 4") {
+    val shortChannelId = "1701x42x3"
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+      Right(ShortChannelId(shortChannelId)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
+    )
+
+    val eclair = mock[Eclair]
+    eclair.close(any, any, any)(any[Timeout]) returns Future.successful(response)
+    val mockService = new MockService(eclair)
 
     Post("/close", FormData("shortChannelId" -> shortChannelId, "preferredFeerateSatByte" -> "10", "maxFeerateSatByte" -> "50").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -413,9 +511,8 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       }
   }
 
-  test("'connect' method should accept an URI and a triple with nodeId/host/port") {
+  test("'connect' method should accept a nodeId") {
     val remoteNodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
-    val remoteUri = NodeURI.parse("030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87@93.137.102.239:9735")
 
     val eclair = mock[Eclair]
     eclair.connect(any[Either[NodeURI, PublicKey]])(any[Timeout]) returns Future.successful("connected")
@@ -430,6 +527,14 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(entityAs[String] == "\"connected\"")
         eclair.connect(Right(remoteNodeId))(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'connect' method should accept an URI") {
+    val remoteUri = NodeURI.parse("030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87@93.137.102.239:9735")
+
+    val eclair = mock[Eclair]
+    eclair.connect(any[Either[NodeURI, PublicKey]])(any[Timeout]) returns Future.successful("connected")
+    val mockService = new MockService(eclair)
 
     Post("/connect", FormData("uri" -> remoteUri.toString).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -441,6 +546,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         eclair.connect(Left(remoteUri))(any[Timeout]).wasCalled(once) // must account for the previous, identical, invocation
       }
   }
+
 
   test("'send' method should handle payment failures") {
     val eclair = mock[Eclair]
@@ -506,7 +612,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       }
   }
 
-  test("'send' method should correctly forward amount parameters to EclairImpl") {
+  test("'send' method should correctly forward amount parameters to EclairImpl 1") {
     val invoice = "lnbc12580n1pw2ywztpp554ganw404sh4yjkwnysgn3wjcxfcq7gtx53gxczkjr9nlpc3hzvqdq2wpskwctddyxqr4rqrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glc7z9rtvqqwngqqqqqqqlgqqqqqeqqjqrrt8smgjvfj7sg38dwtr9kc9gg3era9k3t2hvq3cup0jvsrtrxuplevqgfhd3rzvhulgcxj97yjuj8gdx8mllwj4wzjd8gdjhpz3lpqqvk2plh"
 
     val eclair = mock[Eclair]
@@ -521,6 +627,14 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(status == OK)
         eclair.send(None, 1258000 msat, any, any, any, any)(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'send' method should correctly forward amount parameters to EclairImpl 2") {
+    val invoice = "lnbc12580n1pw2ywztpp554ganw404sh4yjkwnysgn3wjcxfcq7gtx53gxczkjr9nlpc3hzvqdq2wpskwctddyxqr4rqrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glc7z9rtvqqwngqqqqqqqlgqqqqqeqqjqrrt8smgjvfj7sg38dwtr9kc9gg3era9k3t2hvq3cup0jvsrtrxuplevqgfhd3rzvhulgcxj97yjuj8gdx8mllwj4wzjd8gdjhpz3lpqqvk2plh"
+
+    val eclair = mock[Eclair]
+    eclair.send(any, any, any, any, any, any)(any[Timeout]) returns Future.successful(UUID.randomUUID())
+    val mockService = new MockService(eclair)
 
     Post("/payinvoice", FormData("invoice" -> invoice, "amountMsat" -> "123", "feeThresholdSat" -> "112233", "maxFeePct" -> "2.34", "externalId" -> "42").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -530,6 +644,14 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(status == OK)
         eclair.send(Some("42"), 123 msat, any, any, Some(112233 sat), Some(2.34))(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'send' method should correctly forward amount parameters to EclairImpl 3") {
+    val invoice = "lnbc12580n1pw2ywztpp554ganw404sh4yjkwnysgn3wjcxfcq7gtx53gxczkjr9nlpc3hzvqdq2wpskwctddyxqr4rqrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glc7z9rtvqqwngqqqqqqqlgqqqqqeqqjqrrt8smgjvfj7sg38dwtr9kc9gg3era9k3t2hvq3cup0jvsrtrxuplevqgfhd3rzvhulgcxj97yjuj8gdx8mllwj4wzjd8gdjhpz3lpqqvk2plh"
+
+    val eclair = mock[Eclair]
+    eclair.send(any, any, any, any, any, any)(any[Timeout]) returns Future.successful(UUID.randomUUID())
+    val mockService = new MockService(eclair)
 
     Post("/payinvoice", FormData("invoice" -> invoice, "amountMsat" -> "456", "feeThresholdSat" -> "10", "maxFeePct" -> "0.5").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -541,11 +663,26 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       }
   }
 
-  test("'sendtonode'") {
+  test("'send' method should correctly forward amount parameters to EclairImpl 4") {
+    val invoice = "lnbc12580n1pw2ywztpp554ganw404sh4yjkwnysgn3wjcxfcq7gtx53gxczkjr9nlpc3hzvqdq2wpskwctddyxqr4rqrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glc7z9rtvqqwngqqqqqqqlgqqqqqeqqjqrrt8smgjvfj7sg38dwtr9kc9gg3era9k3t2hvq3cup0jvsrtrxuplevqgfhd3rzvhulgcxj97yjuj8gdx8mllwj4wzjd8gdjhpz3lpqqvk2plh"
+
     val eclair = mock[Eclair]
-    eclair.sendWithPreimage(any, any, any, any, any, any, any)(any[Timeout]) returns Future.successful(UUID.randomUUID())
+    eclair.send(any, any, any, any, any, any, any)(any[Timeout]) returns Future.successful(UUID.randomUUID())
     val mockService = new MockService(eclair)
-    val remoteNodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
+
+    Post("/payinvoice", FormData("invoice" -> invoice, "amountMsat" -> "456", "feeThresholdSat" -> "10", "maxFeePct" -> "0.5", "pathFindingExperimentName" -> "my-test-experiment").toEntity) ~>
+      addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
+      Route.seal(mockService.route) ~>
+      check {
+        assert(handled)
+        assert(status == OK)
+        eclair.send(None, 456 msat, any, any, Some(10 sat), Some(0.5), Some("my-test-experiment"))(any[Timeout]).wasCalled(once)
+      }
+  }
+
+  test("'sendtonode' 1") {
+    val eclair = mock[Eclair]
+    val mockService = new MockService(eclair)
 
     Post("/sendtonode", FormData("amountMsat" -> "123").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -554,6 +691,11 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == BadRequest)
       }
+  }
+
+  test("'sendtonode' 2") {
+    val eclair = mock[Eclair]
+    val mockService = new MockService(eclair)
 
     Post("/sendtonode", FormData("nodeId" -> "030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -562,6 +704,13 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == BadRequest)
       }
+  }
+
+  test("'sendtonode' 3") {
+    val eclair = mock[Eclair]
+    eclair.sendWithPreimage(any, any, any, any, any, any, any, any)(any[Timeout]) returns Future.successful(UUID.randomUUID())
+    val mockService = new MockService(eclair)
+    val remoteNodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
 
     Post("/sendtonode", FormData("amountMsat" -> "123", "nodeId" -> "030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -569,8 +718,15 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       check {
         assert(handled)
         assert(status == OK)
-        eclair.sendWithPreimage(None, remoteNodeId, 123 msat, any, None, None, None)(any[Timeout]).wasCalled(once)
+        eclair.sendWithPreimage(None, remoteNodeId, 123 msat, any, None, None, None, None)(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'sendtonode' 4") {
+    val eclair = mock[Eclair]
+    eclair.sendWithPreimage(any, any, any, any, any, any, any, any)(any[Timeout]) returns Future.successful(UUID.randomUUID())
+    val mockService = new MockService(eclair)
+    val remoteNodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
 
     Post("/sendtonode", FormData("amountMsat" -> "123", "nodeId" -> "030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87", "feeThresholdSat" -> "10000", "maxFeePct" -> "2.5", "externalId" -> "42").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -578,22 +734,32 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       check {
         assert(handled)
         assert(status == OK)
-        eclair.sendWithPreimage(Some("42"), remoteNodeId, 123 msat, any, any, Some(10000 sat), Some(2.5))(any[Timeout]).wasCalled(once)
+        eclair.sendWithPreimage(Some("42"), remoteNodeId, 123 msat, any, any, Some(10000 sat), Some(2.5), None)(any[Timeout]).wasCalled(once)
       }
   }
 
-  test("'getreceivedinfo'") {
+  test("'sendtonode' 5") {
+    val eclair = mock[Eclair]
+    eclair.sendWithPreimage(any, any, any, any, any, any, any, any)(any[Timeout]) returns Future.successful(UUID.randomUUID())
+    val mockService = new MockService(eclair)
+    val remoteNodeId = PublicKey(hex"030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87")
+
+    Post("/sendtonode", FormData("amountMsat" -> "123", "nodeId" -> "030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87", "pathFindingExperimentName" -> "my-test-experiment").toEntity) ~>
+      addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
+      Route.seal(mockService.sendToNode) ~>
+      check {
+        assert(handled)
+        assert(status == OK)
+        eclair.sendWithPreimage(None, remoteNodeId, 123 msat, any, None, None, None, Some("my-test-experiment"))(any[Timeout]).wasCalled(once)
+      }
+  }
+
+  test("'getreceivedinfo' 1") {
     val invoice = "lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp"
     val defaultPayment = IncomingPayment(PaymentRequest.read(invoice), ByteVector32.One, PaymentType.Standard, 42, IncomingPaymentStatus.Pending)
     val eclair = mock[Eclair]
     val notFound = randomBytes32()
     eclair.receivedInfo(notFound)(any) returns Future.successful(None)
-    val pending = randomBytes32()
-    eclair.receivedInfo(pending)(any) returns Future.successful(Some(defaultPayment))
-    val expired = randomBytes32()
-    eclair.receivedInfo(expired)(any) returns Future.successful(Some(defaultPayment.copy(status = IncomingPaymentStatus.Expired)))
-    val received = randomBytes32()
-    eclair.receivedInfo(received)(any) returns Future.successful(Some(defaultPayment.copy(status = IncomingPaymentStatus.Received(42 msat, 45))))
     val mockService = new MockService(eclair)
 
     Post("/getreceivedinfo", FormData("paymentHash" -> notFound.toHex).toEntity) ~>
@@ -606,6 +772,15 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(resp == ErrorResponse("Not found"))
         eclair.receivedInfo(notFound)(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'getreceivedinfo' 2") {
+    val invoice = "lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp"
+    val defaultPayment = IncomingPayment(PaymentRequest.read(invoice), ByteVector32.One, PaymentType.Standard, 42, IncomingPaymentStatus.Pending)
+    val eclair = mock[Eclair]
+    val pending = randomBytes32()
+    eclair.receivedInfo(pending)(any) returns Future.successful(Some(defaultPayment))
+    val mockService = new MockService(eclair)
 
     Post("/getreceivedinfo", FormData("paymentHash" -> pending.toHex).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -617,6 +792,15 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         matchTestJson("received-pending", response)
         eclair.receivedInfo(pending)(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'getreceivedinfo' 3") {
+    val invoice = "lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp"
+    val defaultPayment = IncomingPayment(PaymentRequest.read(invoice), ByteVector32.One, PaymentType.Standard, 42, IncomingPaymentStatus.Pending)
+    val eclair = mock[Eclair]
+    val expired = randomBytes32()
+    eclair.receivedInfo(expired)(any) returns Future.successful(Some(defaultPayment.copy(status = IncomingPaymentStatus.Expired)))
+    val mockService = new MockService(eclair)
 
     Post("/getreceivedinfo", FormData("paymentHash" -> expired.toHex).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -628,6 +812,15 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         matchTestJson("received-expired", response)
         eclair.receivedInfo(expired)(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'getreceivedinfo' 4") {
+    val invoice = "lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp"
+    val defaultPayment = IncomingPayment(PaymentRequest.read(invoice), ByteVector32.One, PaymentType.Standard, 42, IncomingPaymentStatus.Pending)
+    val eclair = mock[Eclair]
+    val received = randomBytes32()
+    eclair.receivedInfo(received)(any) returns Future.successful(Some(defaultPayment.copy(status = IncomingPaymentStatus.Received(42 msat, 45))))
+    val mockService = new MockService(eclair)
 
     Post("/getreceivedinfo", FormData("paymentHash" -> received.toHex).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -641,15 +834,11 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       }
   }
 
-  test("'getsentinfo'") {
+  test("'getsentinfo' 1") {
     val defaultPayment = OutgoingPayment(UUID.fromString("00000000-0000-0000-0000-000000000000"), UUID.fromString("11111111-1111-1111-1111-111111111111"), None, ByteVector32.Zeroes, PaymentType.Standard, 42 msat, 50 msat, aliceNodeId, 1, None, OutgoingPaymentStatus.Pending)
     val eclair = mock[Eclair]
     val pending = UUID.randomUUID()
     eclair.sentInfo(Left(pending))(any) returns Future.successful(Seq(defaultPayment))
-    val failed = UUID.randomUUID()
-    eclair.sentInfo(Left(failed))(any) returns Future.successful(Seq(defaultPayment.copy(status = OutgoingPaymentStatus.Failed(Nil, 2))))
-    val sent = UUID.randomUUID()
-    eclair.sentInfo(Left(sent))(any) returns Future.successful(Seq(defaultPayment.copy(status = OutgoingPaymentStatus.Succeeded(ByteVector32.One, 5 msat, Nil, 3))))
     val mockService = new MockService(eclair)
 
     Post("/getsentinfo", FormData("id" -> pending.toString).toEntity) ~>
@@ -662,6 +851,14 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         matchTestJson("sent-pending", response)
         eclair.sentInfo(Left(pending))(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'getsentinfo' 2") {
+    val defaultPayment = OutgoingPayment(UUID.fromString("00000000-0000-0000-0000-000000000000"), UUID.fromString("11111111-1111-1111-1111-111111111111"), None, ByteVector32.Zeroes, PaymentType.Standard, 42 msat, 50 msat, aliceNodeId, 1, None, OutgoingPaymentStatus.Pending)
+    val eclair = mock[Eclair]
+    val failed = UUID.randomUUID()
+    eclair.sentInfo(Left(failed))(any) returns Future.successful(Seq(defaultPayment.copy(status = OutgoingPaymentStatus.Failed(Nil, 2))))
+    val mockService = new MockService(eclair)
 
     Post("/getsentinfo", FormData("id" -> failed.toString).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -673,6 +870,14 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         matchTestJson("sent-failed", response)
         eclair.sentInfo(Left(failed))(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'getsentinfo' 3") {
+    val defaultPayment = OutgoingPayment(UUID.fromString("00000000-0000-0000-0000-000000000000"), UUID.fromString("11111111-1111-1111-1111-111111111111"), None, ByteVector32.Zeroes, PaymentType.Standard, 42 msat, 50 msat, aliceNodeId, 1, None, OutgoingPaymentStatus.Pending)
+    val eclair = mock[Eclair]
+    val sent = UUID.randomUUID()
+    eclair.sentInfo(Left(sent))(any) returns Future.successful(Seq(defaultPayment.copy(status = OutgoingPaymentStatus.Succeeded(ByteVector32.One, 5 msat, Nil, 3))))
+    val mockService = new MockService(eclair)
 
     Post("/getsentinfo", FormData("id" -> sent.toString).toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
@@ -686,13 +891,12 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       }
   }
 
-  test("'sendtoroute' method should accept a both a json-encoded AND comma separated list of pubkeys") {
+  test("'sendtoroute' method should accept a json-encoded") {
     val payment = SendPaymentToRouteResponse(UUID.fromString("487da196-a4dc-4b1e-92b4-3e5e905e9f3f"), UUID.fromString("2ad8c6d7-99cb-4238-8f67-89024b8eed0d"), None)
     val expected = """{"paymentId":"487da196-a4dc-4b1e-92b4-3e5e905e9f3f","parentId":"2ad8c6d7-99cb-4238-8f67-89024b8eed0d"}"""
     val externalId = UUID.randomUUID().toString
     val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(1234 msat), ByteVector32.Zeroes, randomKey(), Left("Some invoice"), CltvExpiryDelta(24))
     val expectedRoute = PredefinedNodeRoute(Seq(PublicKey(hex"0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9"), PublicKey(hex"0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3"), PublicKey(hex"026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28")))
-    val csvNodes = "0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9, 0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3, 026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28"
     val jsonNodes = serialization.write(expectedRoute.nodes)
 
     val eclair = mock[Eclair]
@@ -709,6 +913,18 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(entityAs[String] == expected)
         eclair.sendToRoute(1234 msat, None, Some(externalId), None, pr, CltvExpiryDelta(190), expectedRoute, None, None, None, Nil)(any[Timeout]).wasCalled(once)
       }
+  }
+
+  test("'sendtoroute' method should accept a comma separated list of pubkeys") {
+    val payment = SendPaymentToRouteResponse(UUID.fromString("487da196-a4dc-4b1e-92b4-3e5e905e9f3f"), UUID.fromString("2ad8c6d7-99cb-4238-8f67-89024b8eed0d"), None)
+    val expected = """{"paymentId":"487da196-a4dc-4b1e-92b4-3e5e905e9f3f","parentId":"2ad8c6d7-99cb-4238-8f67-89024b8eed0d"}"""
+    val pr = PaymentRequest(Block.LivenetGenesisBlock.hash, Some(1234 msat), ByteVector32.Zeroes, randomKey(), Left("Some invoice"), CltvExpiryDelta(24))
+    val expectedRoute = PredefinedNodeRoute(Seq(PublicKey(hex"0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9"), PublicKey(hex"0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3"), PublicKey(hex"026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28")))
+    val csvNodes = "0217eb8243c95f5a3b7d4c5682d10de354b7007eb59b6807ae407823963c7547a9, 0242a4ae0c5bef18048fbecf995094b74bfb0f7391418d71ed394784373f41e4f3, 026ac9fcd64fb1aa1c491fc490634dc33da41d4a17b554e0adf1b32fee88ee9f28"
+
+    val eclair = mock[Eclair]
+    eclair.sendToRoute(any[MilliSatoshi], any[Option[MilliSatoshi]], any[Option[String]], any[Option[UUID]], any[PaymentRequest], any[CltvExpiryDelta], any[PredefinedNodeRoute], any[Option[ByteVector32]], any[Option[MilliSatoshi]], any[Option[CltvExpiryDelta]], any[List[PublicKey]])(any[Timeout]) returns Future.successful(payment)
+    val mockService = new MockService(eclair)
 
     // this test uses CSV encoded route
     Post("/sendtoroute", FormData("nodeIds" -> csvNodes, "amountMsat" -> "1234", "finalCltvExpiry" -> "190", "invoice" -> PaymentRequest.write(pr)).toEntity) ~>


### PR DESCRIPTION
Enable doing AB testing to find the best path finding parameters.

When a new payment needs to use path finding, it will be assigned randomly an experiment (which may be the control experiment) and use its set of parameters. When the payment finishes (either with a success or failure), we record metrics such as the fee we paid and the time the payment took.
After sending enough payments we can compute the success rate, average fee and average duration of payments for a given set of parameters and choose the best one.

Each experiments is assigned some percentage of the traffic. It is advised to start low with new experiments in case the new parameters are terrible but should then be increased to collect enough data timely. Experiments can be at 0% in which case they will never be used by live relay traffic but can still be used manually using the API.