### PR TITLE
Add success probabilities in path finding

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -127,6 +127,7 @@ This release contains many API updates:
 - `payinvoice`, `sendtonode`, `findroute`, `findroutetonode` and `findroutebetweennodes` let you specify `--pathFindingExperimentName` when using path-finding A/B testing (#1930)
 - the `--maxFeePct` parameter used in `payinvoice` and `sendtonode` must now be an integer between 0 and 100: it was previously a value between 0 and 1, which was misleading for a percentage (#1930)
 - `findroute`, `findroutetonode` and `findroutebetweennodes` let you choose the format of the route returned with the `--routeFormat` parameter (supported values are `nodeId` and `shortChannelId`) (#1943)
+- `findroute`, `findroutetonode` and `findroutebetweennodes` now accept `--includeLocalChannelCost` to specify if you want to count the fees from your node like trampoline payments do (#1942) 
 
 Have a look at our [API documentation](https://acinq.github.io/eclair) for more details.
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -215,6 +215,7 @@ eclair {
           channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
           channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
         }
+        use-ratios = true
 
         // Virtual fee for additional hops
         // Corresponds to how much you are willing to pay to get one less hop in the payment path
@@ -238,6 +239,20 @@ eclair {
       experiments {
         control = ${eclair.router.path-finding.default} {
           percentage = 100 // 100% of the traffic use the default configuration
+        }
+
+        // alternative routing heuristics (replaces ratios)
+        test-failure-cost = ${eclair.router.path-finding.default} {
+          use-ratios = false
+
+          locked-funds-risk = 1e-15 // msat per msat locked per block. It should be your expected interest rate per block multiplied by the probability that something goes wrong and your funds stay locked.
+
+          // Virtual fee for failed payments
+          // Corresponds to how much you are willing to pay to get one less failed payment attempt
+          failure-cost {
+            fee-base-msat = 2000
+            fee-proportional-millionths = 500
+          }
         }
 
         // Examples of other configs as 0% experiments:

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -245,7 +245,7 @@ eclair {
         test-failure-cost = ${eclair.router.path-finding.default} {
           use-ratios = false
 
-          locked-funds-risk = 1e-15 // msat per msat locked per block. It should be your expected interest rate per block multiplied by the probability that something goes wrong and your funds stay locked.
+          locked-funds-risk = 1e-10 // msat per msat locked per block. It should be your expected interest rate per block multiplied by the probability that something goes wrong and your funds stay locked.
 
           // Virtual fee for failed payments
           // Corresponds to how much you are willing to pay to get one less failed payment attempt

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -245,7 +245,8 @@ eclair {
         test-failure-cost = ${eclair.router.path-finding.default} {
           use-ratios = false
 
-          locked-funds-risk = 1e-10 // msat per msat locked per block. It should be your expected interest rate per block multiplied by the probability that something goes wrong and your funds stay locked.
+          locked-funds-risk = 1e-8 // msat per msat locked per block. It should be your expected interest rate per block multiplied by the probability that something goes wrong and your funds stay locked.
+          // 1e-8 corresponds to an interest rate of ~5% per year (1e-6 per block) and a probability of 1% that the channel will fail and our funds will be locked.
 
           // Virtual fee for failed payments
           // Corresponds to how much you are willing to pay to get one less failed payment attempt

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -24,8 +24,8 @@ import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.io.Switchboard.RouterPeerConf
 import fr.acinq.eclair.io.{ClientSpawner, Peer, PeerConnection, Switchboard}
 import fr.acinq.eclair.payment.relay.Relayer.RelayFees
-import fr.acinq.eclair.router.Graph.WeightRatios
-import fr.acinq.eclair.router.Router.{GossipDecision, MultiPartParams, PathFindingConf, RouteParams, RouterConf, SearchBoundaries, SendChannelQuery}
+import fr.acinq.eclair.router.Graph.{HeuristicsConstants, WeightRatios}
+import fr.acinq.eclair.router.Router.{GossipDecision, MultiPartParams, PathFindingConf, RouterConf, SearchBoundaries, SendChannelQuery}
 import fr.acinq.eclair.router._
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
 import fr.acinq.eclair.wire.protocol.LightningMessageCodecs._
@@ -50,9 +50,9 @@ object EclairInternalsSerializer {
 
   val searchBoundariesCodec: Codec[SearchBoundaries] = (
     ("maxFee" | millisatoshi) ::
-    ("maxFeeProportional" | double) ::
-    ("maxRouteLength" | int32) ::
-    ("maxCltv" | int32.as[CltvExpiryDelta])).as[SearchBoundaries]
+      ("maxFeeProportional" | double) ::
+      ("maxRouteLength" | int32) ::
+      ("maxCltv" | int32.as[CltvExpiryDelta])).as[SearchBoundaries]
 
   val relayFeesCodec: Codec[RelayFees] = (
     ("feeBase" | millisatoshi) ::
@@ -65,6 +65,11 @@ object EclairInternalsSerializer {
       ("capacityFactor" | double) ::
       ("hopCost" | relayFeesCodec)).as[WeightRatios]
 
+  val heuristicsConstantsCodec: Codec[HeuristicsConstants] = (
+    ("lockedFundsRisk" | double) ::
+      ("failureCost" | relayFeesCodec) ::
+      ("hopCost" | relayFeesCodec)).as[HeuristicsConstants]
+
   val multiPartParamsCodec: Codec[MultiPartParams] = (
     ("minPartAmount" | millisatoshi) ::
       ("maxParts" | int32)).as[MultiPartParams]
@@ -72,7 +77,7 @@ object EclairInternalsSerializer {
   val pathFindingConfCodec: Codec[PathFindingConf] = (
     ("randomize" | bool(8)) ::
       ("boundaries" | searchBoundariesCodec) ::
-      ("ratios" | weightRatiosCodec) ::
+      ("heuristicsParams" | either(bool(8), weightRatiosCodec, heuristicsConstantsCodec)) ::
       ("mpp" | multiPartParamsCodec) ::
       ("experimentName" | utf8_32) ::
       ("experimentPercentage" | int32)).as[PathFindingConf]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.router
 
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{Btc, MilliBtc, Satoshi, SatoshiLong}
+import fr.acinq.bitcoin.{Btc, ByteVector32, MilliBtc, Satoshi, SatoshiLong}
 import fr.acinq.eclair._
 import fr.acinq.eclair.payment.relay.Relayer.RelayFees
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
@@ -30,18 +30,20 @@ import scala.collection.mutable
 
 object Graph {
 
-  // @formatter:off
   /**
    * The cumulative weight of a set of edges (path in the graph).
    *
-   * @param cost   amount to send to the recipient + each edge's fees
-   * @param length number of edges in the path
-   * @param cltv   sum of each edge's cltv
-   * @param weight cost multiplied by a factor based on heuristics (see [[WeightRatios]]).
+   * @param amount             amount to send to the recipient + each edge's fees
+   * @param length             number of edges in the path
+   * @param cltv               sum of each edge's cltv
+   * @param successProbability estimate of the probability that the payment would succeed using this path
+   * @param fees               total fees of the path
+   * @param weight             cost multiplied by a factor based on heuristics (see [[WeightRatios]]).
    */
-  case class RichWeight(cost: MilliSatoshi, length: Int, cltv: CltvExpiryDelta, weight: Double) extends Ordered[RichWeight] {
+  case class RichWeight(amount: MilliSatoshi, length: Int, cltv: CltvExpiryDelta, successProbability: Double, fees: MilliSatoshi, weight: Double) extends Ordered[RichWeight] {
     override def compare(that: RichWeight): Int = this.weight.compareTo(that.weight)
   }
+
   /**
    * We use heuristics to calculate the weight of an edge based on channel age, cltv delta, capacity and a virtual hop cost to keep routes short.
    * We favor older channels, with bigger capacity and small cltv delta.
@@ -53,9 +55,21 @@ object Graph {
     require(ageFactor >= 0.0, "ratio-channel-age must be nonnegative")
     require(capacityFactor >= 0.0, "ratio-channel-capacity must be nonnegative")
   }
+
+  /**
+   * We use heuristics to calculate the weight of an edge.
+   * The fee for a failed attempt and the fee per hop are never actually spent, they are used to incentivize shorter
+   * paths or path with higher success probability.
+   *
+   * @param lockedFundsRisk cost of having funds locked in htlc in msat per msat per block
+   * @param failureCost     fee for a failed attempt
+   * @param hopCost         virtual fee per hop (how much we're willing to pay to make the route one hop shorter)
+   */
+  case class HeuristicsConstants(lockedFundsRisk: Double, failureCost: RelayFees, hopCost: RelayFees)
+
   case class WeightedNode(key: PublicKey, weight: RichWeight)
+
   case class WeightedPath(path: Seq[GraphEdge], weight: RichWeight)
-  // @formatter:on
 
   /**
    * This comparator must be consistent with the "equals" behavior, thus for two weighted nodes with
@@ -99,12 +113,12 @@ object Graph {
                         ignoredVertices: Set[PublicKey],
                         extraEdges: Set[GraphEdge],
                         pathsToFind: Int,
-                        wr: WeightRatios,
+                        wr: Either[WeightRatios, HeuristicsConstants],
                         currentBlockHeight: Long,
                         boundaries: RichWeight => Boolean,
                         includeLocalChannelCost: Boolean): Seq[WeightedPath] = {
     // find the shortest path (k = 0)
-    val targetWeight = RichWeight(amount, 0, CltvExpiryDelta(0), 0)
+    val targetWeight = RichWeight(amount, 0, CltvExpiryDelta(0), 1.0, 0 msat, 0.0)
     val shortestPath = dijkstraShortestPath(graph, sourceNode, targetNode, ignoredEdges, ignoredVertices, extraEdges, targetWeight, boundaries, currentBlockHeight, wr, includeLocalChannelCost)
     if (shortestPath.isEmpty) {
       return Seq.empty // if we can't even find a single path, avoid returning a Seq(Seq.empty)
@@ -191,7 +205,7 @@ object Graph {
                                    initialWeight: RichWeight,
                                    boundaries: RichWeight => Boolean,
                                    currentBlockHeight: Long,
-                                   wr: WeightRatios,
+                                   wr: Either[WeightRatios, HeuristicsConstants],
                                    includeLocalChannelCost: Boolean): Seq[GraphEdge] = {
     // the graph does not contain source/destination nodes
     val sourceNotInGraph = !g.containsVertex(sourceNode) && !extraEdges.exists(_.desc.a == sourceNode)
@@ -231,12 +245,12 @@ object Graph {
           // NB: this contains the amount (including fees) that will need to be sent to `neighbor`, but the amount that
           // will be relayed through that edge is the one in `currentWeight`.
           val neighborWeight = addEdgeWeight(sourceNode, edge, current.weight, currentBlockHeight, wr, includeLocalChannelCost)
-          val canRelayAmount = current.weight.cost <= edge.capacity &&
-            edge.balance_opt.forall(current.weight.cost <= _) &&
-            edge.update.htlcMaximumMsat.forall(current.weight.cost <= _) &&
-            current.weight.cost >= edge.update.htlcMinimumMsat
+          val canRelayAmount = current.weight.amount <= edge.capacity &&
+            edge.balance_opt.forall(current.weight.amount <= _) &&
+            edge.update.htlcMaximumMsat.forall(current.weight.amount <= _) &&
+            current.weight.amount >= edge.update.htlcMinimumMsat
           if (canRelayAmount && boundaries(neighborWeight) && !ignoredEdges.contains(edge.desc) && !ignoredVertices.contains(neighbor)) {
-            val previousNeighborWeight = bestWeights.getOrElse(neighbor, RichWeight(MilliSatoshi(Long.MaxValue), Int.MaxValue, CltvExpiryDelta(Int.MaxValue), Double.MaxValue))
+            val previousNeighborWeight = bestWeights.getOrElse(neighbor, RichWeight(MilliSatoshi(Long.MaxValue), Int.MaxValue, CltvExpiryDelta(Int.MaxValue), 0.0, MilliSatoshi(Long.MaxValue), Double.MaxValue))
             // if this path between neighbor and the target has a shorter distance than previously known, we select it
             if (neighborWeight.weight < previousNeighborWeight.weight) {
               // update the best edge for this vertex
@@ -274,28 +288,45 @@ object Graph {
    * @param weightRatios            ratios used to 'weight' edges when searching for the shortest path
    * @param includeLocalChannelCost if the path is for relaying and we need to include the cost of the local channel
    */
-  private def addEdgeWeight(sender: PublicKey, edge: GraphEdge, prev: RichWeight, currentBlockHeight: Long, weightRatios: WeightRatios, includeLocalChannelCost: Boolean): RichWeight = {
-    val totalCost = if (edge.desc.a == sender && !includeLocalChannelCost) prev.cost else addEdgeFees(edge, prev.cost)
-    val fee = totalCost - prev.cost
-    val hopCost = nodeFee(weightRatios.hopCost.feeBase, weightRatios.hopCost.feeProportionalMillionths, prev.cost)
-    val totalCltv = if (edge.desc.a == sender && !includeLocalChannelCost) prev.cltv else prev.cltv + edge.update.cltvExpiryDelta
-    import RoutingHeuristics._
+  private def addEdgeWeight(sender: PublicKey, edge: GraphEdge, prev: RichWeight, currentBlockHeight: Long, weightRatios: Either[WeightRatios, HeuristicsConstants], includeLocalChannelCost: Boolean): RichWeight = {
+    val totalAmount = if (edge.desc.a == sender && !includeLocalChannelCost) prev.amount else addEdgeFees(edge, prev.amount)
+    val fee = totalAmount - prev.amount
+    val totalFees = prev.fees + fee
+    val cltv = if (edge.desc.a == sender && !includeLocalChannelCost) CltvExpiryDelta(0) else edge.update.cltvExpiryDelta
+    val totalCltv = prev.cltv + cltv
+    weightRatios match {
+      case Left(weightRatios) =>
+        val hopCost = nodeFee(weightRatios.hopCost.feeBase, weightRatios.hopCost.feeProportionalMillionths, prev.amount)
+        import RoutingHeuristics._
 
-    // Every edge is weighted by funding block height where older blocks add less weight. The window considered is 1 year.
-    val channelBlockHeight = ShortChannelId.coordinates(edge.desc.shortChannelId).blockHeight
-    val ageFactor = normalize(channelBlockHeight, min = (currentBlockHeight - BLOCK_TIME_ONE_YEAR).toDouble, max = currentBlockHeight.toDouble)
+        // Every edge is weighted by funding block height where older blocks add less weight. The window considered is 1 year.
+        val channelBlockHeight = ShortChannelId.coordinates(edge.desc.shortChannelId).blockHeight
+        val ageFactor = normalize(channelBlockHeight, min = (currentBlockHeight - BLOCK_TIME_ONE_YEAR).toDouble, max = currentBlockHeight.toDouble)
 
-    // Every edge is weighted by channel capacity, larger channels add less weight
-    val edgeMaxCapacity = edge.capacity.toMilliSatoshi
-    val capFactor = 1 - normalize(edgeMaxCapacity.toLong.toDouble, CAPACITY_CHANNEL_LOW.toLong.toDouble, CAPACITY_CHANNEL_HIGH.toLong.toDouble)
+        // Every edge is weighted by channel capacity, larger channels add less weight
+        val edgeMaxCapacity = edge.capacity.toMilliSatoshi
+        val capFactor = 1 - normalize(edgeMaxCapacity.toLong.toDouble, CAPACITY_CHANNEL_LOW.toLong.toDouble, CAPACITY_CHANNEL_HIGH.toLong.toDouble)
 
-    // Every edge is weighted by its cltv-delta value, normalized
-    val cltvFactor = normalize(edge.update.cltvExpiryDelta.toInt, CLTV_LOW, CLTV_HIGH)
+        // Every edge is weighted by its cltv-delta value, normalized
+        val cltvFactor = normalize(edge.update.cltvExpiryDelta.toInt, CLTV_LOW, CLTV_HIGH)
 
-    // NB we're guaranteed to have weightRatios and factors > 0
-    val factor = weightRatios.baseFactor + (cltvFactor * weightRatios.cltvDeltaFactor) + (ageFactor * weightRatios.ageFactor) + (capFactor * weightRatios.capacityFactor)
-    val totalWeight = prev.weight + (fee + hopCost).toLong * factor
-    RichWeight(totalCost, prev.length + 1, totalCltv, totalWeight)
+        // NB we're guaranteed to have weightRatios and factors > 0
+        val factor = weightRatios.baseFactor + (cltvFactor * weightRatios.cltvDeltaFactor) + (ageFactor * weightRatios.ageFactor) + (capFactor * weightRatios.capacityFactor)
+        val totalWeight = prev.weight + (fee + hopCost).toLong * factor
+        RichWeight(totalAmount, prev.length + 1, totalCltv, 1.0, totalFees, totalWeight)
+      case Right(heuristicsConstants) =>
+        val hopCost = nodeFee(heuristicsConstants.hopCost.feeBase, heuristicsConstants.hopCost.feeProportionalMillionths, prev.amount)
+        val cltv = if (edge.desc.a == sender && !includeLocalChannelCost) CltvExpiryDelta(0) else edge.update.cltvExpiryDelta
+        val totalCltv = prev.cltv + cltv
+        val riskCost = totalAmount.toLong * cltv.toInt * heuristicsConstants.lockedFundsRisk
+        // If the edge was added by the invoice, it is assumed that it can route the payment.
+        // If we know the balance of the channel, then we will check separately that it can relay the payment.
+        val successProbability = if (edge.update.chainHash == ByteVector32.Zeroes || edge.balance_opt.nonEmpty) 1.0 else 1.0 - totalAmount.toLong.toDouble / (1000 * edge.capacity.toLong.toDouble)
+        val totalSuccessProbability = prev.successProbability * successProbability
+        val failureCost = nodeFee(heuristicsConstants.failureCost.feeBase, heuristicsConstants.failureCost.feeProportionalMillionths, totalAmount)
+        val weight = totalFees.toLong + hopCost.toLong + riskCost * totalCltv.toInt * totalAmount.toLong + failureCost.toLong / totalSuccessProbability
+        RichWeight(totalAmount, prev.length + 1, totalCltv, totalSuccessProbability, totalFees, weight)
+    }
   }
 
   /**
@@ -335,8 +366,8 @@ object Graph {
    * @param wr                      ratios used to 'weight' edges when searching for the shortest path
    * @param includeLocalChannelCost if the path is for relaying and we need to include the cost of the local channel
    */
-  def pathWeight(sender: PublicKey, path: Seq[GraphEdge], amount: MilliSatoshi, currentBlockHeight: Long, wr: WeightRatios, includeLocalChannelCost: Boolean): RichWeight = {
-    path.foldRight(RichWeight(amount, 0, CltvExpiryDelta(0), 0)) { (edge, prev) =>
+  def pathWeight(sender: PublicKey, path: Seq[GraphEdge], amount: MilliSatoshi, currentBlockHeight: Long, wr: Either[WeightRatios, HeuristicsConstants], includeLocalChannelCost: Boolean): RichWeight = {
+    path.foldRight(RichWeight(amount, 0, CltvExpiryDelta(0), 1.0, 0 msat, 0.0)) { (edge, prev) =>
       addEdgeWeight(sender, edge, prev, currentBlockHeight, wr, includeLocalChannelCost)
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -238,7 +238,7 @@ object RouteCalculation {
 
     def cltvOk(cltv: CltvExpiryDelta): Boolean = cltv <= routeParams.maxCltv
 
-    val boundaries: RichWeight => Boolean = { weight => feeOk(weight.cost - amount) && lengthOk(weight.length) && cltvOk(weight.cltv) }
+    val boundaries: RichWeight => Boolean = { weight => feeOk(weight.amount - amount) && lengthOk(weight.length) && cltvOk(weight.cltv) }
 
     val foundRoutes: Seq[Graph.WeightedPath] = Graph.yenKshortestPaths(g, localNodeId, targetNodeId, amount, ignoredEdges, ignoredVertices, extraEdges, numRoutes, routeParams.ratios, currentBlockHeight, boundaries, routeParams.includeLocalChannelCost)
     if (foundRoutes.nonEmpty) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -34,7 +34,7 @@ import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.payment.PaymentRequest.ExtraHop
 import fr.acinq.eclair.remote.EclairInternalsSerializer.RemoteTypes
 import fr.acinq.eclair.router.Graph.GraphStructure.DirectedGraph
-import fr.acinq.eclair.router.Graph.WeightRatios
+import fr.acinq.eclair.router.Graph.{HeuristicsConstants, WeightRatios}
 import fr.acinq.eclair.router.Monitoring.{Metrics, Tags}
 import fr.acinq.eclair.wire.protocol._
 import kamon.context.Context
@@ -304,7 +304,7 @@ object Router {
 
   case class PathFindingConf(randomize: Boolean,
                              boundaries: SearchBoundaries,
-                             ratios: WeightRatios,
+                             heuristicsParams: Either[WeightRatios, HeuristicsConstants],
                              mpp: MultiPartParams,
                              experimentName: String,
                              experimentPercentage: Int) {
@@ -315,7 +315,7 @@ object Router {
       maxRouteLength = boundaries.maxRouteLength,
       maxCltv = boundaries.maxCltv,
       includeLocalChannelCost = false,
-      ratios = ratios,
+      ratios = heuristicsParams,
       mpp = mpp,
       experimentName = experimentName,
     )
@@ -452,7 +452,7 @@ object Router {
                          maxRouteLength: Int,
                          maxCltv: CltvExpiryDelta,
                          includeLocalChannelCost: Boolean,
-                         ratios: WeightRatios,
+                         ratios: Either[WeightRatios, HeuristicsConstants],
                          mpp: MultiPartParams,
                          experimentName: String) {
     def getMaxFee(amount: MilliSatoshi): MilliSatoshi = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -176,13 +176,13 @@ object TestConstants {
             maxFeeProportional = 0.03,
             maxCltv = CltvExpiryDelta(2016),
             maxRouteLength = 20),
-          ratios = WeightRatios(
+          heuristicsParams = Left(WeightRatios(
             baseFactor = 1.0,
             cltvDeltaFactor = 0.0,
             ageFactor = 0.0,
             capacityFactor = 0.0,
             hopCost = RelayFees(0 msat, 0),
-          ),
+          )),
           mpp = MultiPartParams(
             minPartAmount = 15000000 msat,
             maxParts = 10,
@@ -302,13 +302,13 @@ object TestConstants {
             maxFeeProportional = 0.03,
             maxCltv = CltvExpiryDelta(2016),
             maxRouteLength = 20),
-          ratios = WeightRatios(
+          heuristicsParams = Left(WeightRatios(
             baseFactor = 1.0,
             cltvDeltaFactor = 0.0,
             ageFactor = 0.0,
             capacityFactor = 0.0,
             hopCost = RelayFees(0 msat, 0),
-          ),
+          )),
           mpp = MultiPartParams(
             minPartAmount = 15000000 msat,
             maxParts = 10,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/IntegrationSpec.scala
@@ -57,13 +57,13 @@ abstract class IntegrationSpec extends TestKitBaseClass with BitcoindService wit
       maxFeeProportional = 0.03,
       maxCltv = CltvExpiryDelta(Int.MaxValue),
       maxRouteLength = ROUTE_MAX_LENGTH),
-    ratios = WeightRatios(
+    heuristicsParams = Left(WeightRatios(
       baseFactor = 0,
       cltvDeltaFactor = 1,
       ageFactor = 0,
       capacityFactor = 0,
       hopCost = RelayFees(0 msat, 0),
-    ),
+    )),
     mpp = MultiPartParams(15000000 msat, 6),
     experimentName = "my-test-experiment",
     experimentPercentage = 100

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
@@ -329,7 +329,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     val pr = sender.expectMsgType[PaymentRequest]
 
     // the payment is requesting to use a capacity-optimized route which will select node G even though it's a bit more expensive
-    sender.send(nodes("A").paymentInitiator, SendPaymentToNode(amountMsat, pr, maxAttempts = 1, fallbackFinalExpiryDelta = finalCltvExpiryDelta, routeParams = integrationTestRouteParams.copy(ratios = WeightRatios(0, 0, 0, 1, RelayFees(0 msat, 0)))))
+    sender.send(nodes("A").paymentInitiator, SendPaymentToNode(amountMsat, pr, maxAttempts = 1, fallbackFinalExpiryDelta = finalCltvExpiryDelta, routeParams = integrationTestRouteParams.copy(ratios = Left(WeightRatios(0, 0, 0, 1, RelayFees(0 msat, 0))))))
     sender.expectMsgType[UUID]
     sender.expectMsgType[PreimageReceived]
     val ps = sender.expectMsgType[PaymentSent]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -661,7 +661,7 @@ object MultiPartPaymentLifecycleSpec {
       0.01,
       6,
       CltvExpiryDelta(1008)),
-    WeightRatios(1, 0, 0, 0, RelayFees(0 msat, 0)),
+    Left(WeightRatios(1, 0, 0, 0, RelayFees(0 msat, 0))),
     MultiPartParams(1000 msat, 5),
     experimentName = "my-test-experiment",
     experimentPercentage = 100).getDefaultRouteParams

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -236,7 +236,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val routeParams = PathFindingConf(
       randomize = false,
       boundaries = SearchBoundaries(100 msat, 0.0, 20, CltvExpiryDelta(2016)),
-      WeightRatios(1, 0, 0, 0, RelayFees(0 msat, 0)),
+      Left(WeightRatios(1, 0, 0, 0, RelayFees(0 msat, 0))),
       MultiPartParams(10000 msat, 5),
       "my-test-experiment",
       experimentPercentage = 100

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -1809,14 +1809,14 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     val start = randomKey().publicKey
     val g = DirectedGraph(List(
       makeEdge(0L, start, a, 0 msat, 0),
-      makeEdge(1L, a, b, 1000 msat, 1000, cltvDelta = CltvExpiryDelta(10000)),
+      makeEdge(1L, a, b, 1000 msat, 1000, cltvDelta = CltvExpiryDelta(1000)),
       makeEdge(2L, a, c, 350 msat, 350, cltvDelta = CltvExpiryDelta(10)),
       makeEdge(3L, c, d, 350 msat, 350, cltvDelta = CltvExpiryDelta(10)),
       makeEdge(4L, d, b, 350 msat, 350, cltvDelta = CltvExpiryDelta(10)),
     ))
 
     val hc = HeuristicsConstants(
-      lockedFundsRisk = 1e-10,
+      lockedFundsRisk = 1e-7,
       failureCost = RelayFees(0 msat, 0),
       hopCost = RelayFees(0 msat, 0),
     )

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -1809,14 +1809,14 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     val start = randomKey().publicKey
     val g = DirectedGraph(List(
       makeEdge(0L, start, a, 0 msat, 0),
-      makeEdge(1L, a, b, 1000 msat, 1000, cltvDelta = CltvExpiryDelta(1000)),
-      makeEdge(2L, a, c, 400 msat, 500, cltvDelta = CltvExpiryDelta(10)),
-      makeEdge(3L, c, d, 400 msat, 500, cltvDelta = CltvExpiryDelta(10)),
-      makeEdge(4L, d, b, 400 msat, 500, cltvDelta = CltvExpiryDelta(10)),
+      makeEdge(1L, a, b, 1000 msat, 1000, cltvDelta = CltvExpiryDelta(10000)),
+      makeEdge(2L, a, c, 350 msat, 350, cltvDelta = CltvExpiryDelta(10)),
+      makeEdge(3L, c, d, 350 msat, 350, cltvDelta = CltvExpiryDelta(10)),
+      makeEdge(4L, d, b, 350 msat, 350, cltvDelta = CltvExpiryDelta(10)),
     ))
 
     val hc = HeuristicsConstants(
-      lockedFundsRisk = 1e-15,
+      lockedFundsRisk = 1e-10,
       failureCost = RelayFees(0 msat, 0),
       hopCost = RelayFees(0 msat, 0),
     )

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
@@ -33,11 +33,11 @@ trait PathFinding {
   private implicit def ec: ExecutionContext = actorSystem.dispatcher
 
   val findRoute: Route = postRequest("findroute") { implicit t =>
-    formFields(invoiceFormParam, amountMsatFormParam.?, "pathFindingExperimentName".?, routeFormat.?) {
-      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, pathFindingExperimentName_opt, routeFormat) =>
-        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, invoice.routingInfo).map(r => RouteFormat.format(r, routeFormat)))
-      case (invoice, Some(overrideAmount), pathFindingExperimentName_opt, routeFormat) =>
-        complete(eclairApi.findRoute(invoice.nodeId, overrideAmount, pathFindingExperimentName_opt, invoice.routingInfo).map(r => RouteFormat.format(r, routeFormat)))
+    formFields(invoiceFormParam, amountMsatFormParam.?, "pathFindingExperimentName".?, routeFormat.?, "includeLocalChannelCost".as[Boolean].?) {
+      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, pathFindingExperimentName_opt, routeFormat, includeLocalChannelCost_opt) =>
+        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, invoice.routingInfo, includeLocalChannelCost_opt.getOrElse(false)).map(r => RouteFormat.format(r, routeFormat)))
+      case (invoice, Some(overrideAmount), pathFindingExperimentName_opt, routeFormat, includeLocalChannelCost_opt) =>
+        complete(eclairApi.findRoute(invoice.nodeId, overrideAmount, pathFindingExperimentName_opt, invoice.routingInfo, includeLocalChannelCost_opt.getOrElse(false)).map(r => RouteFormat.format(r, routeFormat)))
       case _ => reject(MalformedFormFieldRejection(
         "invoice", "The invoice must have an amount or you need to specify one using 'amountMsat'"
       ))
@@ -45,14 +45,16 @@ trait PathFinding {
   }
 
   val findRouteToNode: Route = postRequest("findroutetonode") { implicit t =>
-    formFields(nodeIdFormParam, amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?) { (nodeId, amount, pathFindingExperimentName_opt, routeFormat) =>
-      complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt).map(r => RouteFormat.format(r, routeFormat)))
+    formFields(nodeIdFormParam, amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?, "includeLocalChannelCost".as[Boolean].?) {
+      (nodeId, amount, pathFindingExperimentName_opt, routeFormat, includeLocalChannelCost_opt) =>
+        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, includeLocalChannelCost = includeLocalChannelCost_opt.getOrElse(false)).map(r => RouteFormat.format(r, routeFormat)))
     }
   }
 
   val findRouteBetweenNodes: Route = postRequest("findroutebetweennodes") { implicit t =>
-    formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?) { (sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt, routeFormat) =>
-      complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt).map(r => RouteFormat.format(r, routeFormat)))
+    formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?, "includeLocalChannelCost".as[Boolean].?) {
+      (sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt, routeFormat, includeLocalChannelCost_opt) =>
+        complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt, includeLocalChannelCost = includeLocalChannelCost_opt.getOrElse(false)).map(r => RouteFormat.format(r, routeFormat)))
     }
   }
 


### PR DESCRIPTION
Add a new way of scoring paths that estimates the success probabilities of paths and put a cost on failed payment attempts.

For now the success probabilities are estimated in a very simple way based on capacity: I assume that the balance is a random variable uniformly distributed between 0 and capacity and multiply probabilities for all the channels on the path.
The formula for estimating the probability could be changed easily, that's not the focus of this PR. The goal of this PR is to introduce a new scoring of paths that uses this probability and can be evaluated using the new AB testing framework from #1930.