### PR TITLE
Add firstHopChannel/lastHopChannel parameters to findroute* API calls

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -122,7 +122,7 @@ trait Eclair {
 
   def sendOnChain(address: String, amount: Satoshi, confirmationTarget: Long): Future[ByteVector32]
 
-  def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId: Option[ShortChannelId], lastHopChannelId: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse]
+  def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId_opt: Option[ShortChannelId], lastHopChannelId_opt: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse]
 
   def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId: Option[ShortChannelId], lastHopChannelId: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse]
 
@@ -279,8 +279,8 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
   }
 
-  override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId: Option[ShortChannelId], lastHopChannelId: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse] =
-    findRouteBetween(appKit.nodeParams.nodeId, targetNodeId, amount, pathFindingExperimentName_opt, assistedRoutes, firstHopChannelId, lastHopChannelId)
+  override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId_opt: Option[ShortChannelId], lastHopChannelId_opt: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse] =
+    findRouteBetween(appKit.nodeParams.nodeId, targetNodeId, amount, pathFindingExperimentName_opt, assistedRoutes, firstHopChannelId_opt, lastHopChannelId_opt)
 
   private def getRouteParams(pathFindingExperimentName_opt: Option[String]): Option[RouteParams] = {
     pathFindingExperimentName_opt match {
@@ -289,11 +289,11 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
   }
 
-  override def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId: Option[ShortChannelId], lastHopChannelId: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse] = {
+  override def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId_opt: Option[ShortChannelId], lastHopChannelId_opt: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse] = {
     getRouteParams(pathFindingExperimentName_opt) match {
       case Some(routeParams) =>
         val maxFee = routeParams.getMaxFee(amount)
-        (appKit.router ? RouteRequest(sourceNodeId, targetNodeId, amount, maxFee, assistedRoutes, routeParams = routeParams, firstHopChannelId = firstHopChannelId, lastHopChannelId = lastHopChannelId)).mapTo[RouteResponse]
+        (appKit.router ? RouteRequest(sourceNodeId, targetNodeId, amount, maxFee, assistedRoutes, routeParams = routeParams, firstHopChannelId = firstHopChannelId_opt, lastHopChannelId = lastHopChannelId_opt)).mapTo[RouteResponse]
       case None => Future.failed(new IllegalArgumentException(s"Path-finding experiment ${pathFindingExperimentName_opt.get} does not exist."))
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -122,9 +122,9 @@ trait Eclair {
 
   def sendOnChain(address: String, amount: Satoshi, confirmationTarget: Long): Future[ByteVector32]
 
-  def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse]
+  def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId: Option[ShortChannelId], lastHopChannelId: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse]
 
-  def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse]
+  def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId: Option[ShortChannelId], lastHopChannelId: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse]
 
   def sendToRoute(amount: MilliSatoshi, recipientAmount_opt: Option[MilliSatoshi], externalId_opt: Option[String], parentId_opt: Option[UUID], invoice: PaymentRequest, finalCltvExpiryDelta: CltvExpiryDelta, route: PredefinedRoute, trampolineSecret_opt: Option[ByteVector32] = None, trampolineFees_opt: Option[MilliSatoshi] = None, trampolineExpiryDelta_opt: Option[CltvExpiryDelta] = None, trampolineNodes_opt: Seq[PublicKey] = Nil)(implicit timeout: Timeout): Future[SendPaymentToRouteResponse]
 
@@ -279,8 +279,8 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
   }
 
-  override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] =
-    findRouteBetween(appKit.nodeParams.nodeId, targetNodeId, amount, pathFindingExperimentName_opt, assistedRoutes)
+  override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId: Option[ShortChannelId], lastHopChannelId: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse] =
+    findRouteBetween(appKit.nodeParams.nodeId, targetNodeId, amount, pathFindingExperimentName_opt, assistedRoutes, firstHopChannelId, lastHopChannelId)
 
   private def getRouteParams(pathFindingExperimentName_opt: Option[String]): Option[RouteParams] = {
     pathFindingExperimentName_opt match {
@@ -289,11 +289,11 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
   }
 
-  override def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty)(implicit timeout: Timeout): Future[RouteResponse] = {
+  override def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, firstHopChannelId: Option[ShortChannelId], lastHopChannelId: Option[ShortChannelId])(implicit timeout: Timeout): Future[RouteResponse] = {
     getRouteParams(pathFindingExperimentName_opt) match {
       case Some(routeParams) =>
         val maxFee = routeParams.getMaxFee(amount)
-        (appKit.router ? RouteRequest(sourceNodeId, targetNodeId, amount, maxFee, assistedRoutes, routeParams = routeParams)).mapTo[RouteResponse]
+        (appKit.router ? RouteRequest(sourceNodeId, targetNodeId, amount, maxFee, assistedRoutes, routeParams = routeParams, firstHopChannelId = firstHopChannelId, lastHopChannelId = lastHopChannelId)).mapTo[RouteResponse]
       case None => Future.failed(new IllegalArgumentException(s"Path-finding experiment ${pathFindingExperimentName_opt.get} does not exist."))
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -484,7 +484,9 @@ object Router {
                           routeParams: RouteParams,
                           allowMultiPart: Boolean = false,
                           pendingPayments: Seq[Route] = Nil,
-                          paymentContext: Option[PaymentContext] = None)
+                          paymentContext: Option[PaymentContext] = None,
+                          firstHopChannelId: Option[ShortChannelId] = None,
+                          lastHopChannelId: Option[ShortChannelId] = None)
 
   case class FinalizeRoute(amount: MilliSatoshi,
                            route: PredefinedRoute,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -162,7 +162,6 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     //      10000 msat |         | 10000 msat
     //                 +--> D <--+
 
-    //    val amount = 8750 msat
     val amount = 10000 msat
     val (ab, ae, bc, cd, df, fd) = (
       makeEdge(1L, a, b, feeBase = 1 msat, feeProportionalMillionth = 200, minHtlc = 0 msat),
@@ -186,15 +185,6 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     {
       // a route via F: A->E->F->D
       val Success(route :: Nil) = findRoute(graph, a, d, amount, maxFee = 10 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000, firstHopChannelId = Some(ae.desc.shortChannelId))
-      val weightedPath = Graph.pathWeight(a, route2Edges(route), amount, 0, NO_WEIGHT_RATIOS, false)
-      assert(route2Ids(route) === 4 :: 5 :: 6 :: Nil)
-      assert(weightedPath.length === 3)
-      assert(weightedPath.cost === 10007.msat)
-    }
-
-    {
-      // no last hop nodeId provided, find the shortest path which is A->E->F->D
-      val Success(route :: Nil) = findRoute(graph, a, d, amount, maxFee = 10 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000, firstHopChannelId = None)
       val weightedPath = Graph.pathWeight(a, route2Edges(route), amount, 0, NO_WEIGHT_RATIOS, false)
       assert(route2Ids(route) === 4 :: 5 :: 6 :: Nil)
       assert(weightedPath.length === 3)
@@ -257,15 +247,6 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     {
       // a route via F: A->E->F->D
       val Success(route :: Nil) = findRoute(graph, a, d, amount, maxFee = 10 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000, lastHopChannelId = Some(fd.desc.shortChannelId))
-      val weightedPath = Graph.pathWeight(a, route2Edges(route), amount, 0, NO_WEIGHT_RATIOS, false)
-      assert(route2Ids(route) === 4 :: 5 :: 6 :: Nil)
-      assert(weightedPath.length === 3)
-      assert(weightedPath.cost === 10007.msat)
-    }
-
-    {
-      // no last hop nodeId provided, find the shortest path which is A->E->F->D
-      val Success(route :: Nil) = findRoute(graph, a, d, amount, maxFee = 10 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = 400000, lastHopChannelId = None)
       val weightedPath = Graph.pathWeight(a, route2Edges(route), amount, 0, NO_WEIGHT_RATIOS, false)
       assert(route2Ids(route) === 4 :: 5 :: 6 :: Nil)
       assert(weightedPath.length === 3)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
@@ -47,6 +47,8 @@ trait ExtraDirectives extends Directives {
   val amountMsatFormParam: NameReceptacle[MilliSatoshi] = "amountMsat".as[MilliSatoshi]
   val invoiceFormParam: NameReceptacle[PaymentRequest] = "invoice".as[PaymentRequest]
   val routeFormat: NameUnmarshallerReceptacle[RouteFormat] = "format".as[RouteFormat](routeFormatUnmarshaller)
+  val firstHopChannelIdParam: NameUnmarshallerReceptacle[ShortChannelId] = "firstHopChannel".as[ShortChannelId](shortChannelIdUnmarshaller)
+  val lastHopChannelIdParam: NameUnmarshallerReceptacle[ShortChannelId] = "lastHopChannel".as[ShortChannelId](shortChannelIdUnmarshaller)
 
   // custom directive to fail with HTTP 404 (and JSON response) if the element was not found
   def completeOrNotFound[T](fut: Future[Option[T]])(implicit marshaller: ToResponseMarshaller[T]): Route = onComplete(fut) {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
@@ -33,11 +33,11 @@ trait PathFinding {
   private implicit def ec: ExecutionContext = actorSystem.dispatcher
 
   val findRoute: Route = postRequest("findroute") { implicit t =>
-    formFields(invoiceFormParam, amountMsatFormParam.?, "pathFindingExperimentName".?, routeFormat.?) {
-      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, pathFindingExperimentName_opt, routeFormat) =>
-        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, invoice.routingInfo).map(r => RouteFormat.format(r, routeFormat)))
-      case (invoice, Some(overrideAmount), pathFindingExperimentName_opt, routeFormat) =>
-        complete(eclairApi.findRoute(invoice.nodeId, overrideAmount, pathFindingExperimentName_opt, invoice.routingInfo).map(r => RouteFormat.format(r, routeFormat)))
+    formFields(invoiceFormParam, amountMsatFormParam.?, "pathFindingExperimentName".?, routeFormat.?, firstHopChannelIdParam.?, lastHopChannelIdParam.?) {
+      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, pathFindingExperimentName_opt, routeFormat, firstHopChannel_opt, lastHopChannel_opt) =>
+        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, invoice.routingInfo, firstHopChannel_opt, lastHopChannel_opt).map(r => RouteFormat.format(r, routeFormat)))
+      case (invoice, Some(overrideAmount), pathFindingExperimentName_opt, routeFormat, firstHopChannel_opt, lastHopChannel_opt) =>
+        complete(eclairApi.findRoute(invoice.nodeId, overrideAmount, pathFindingExperimentName_opt, invoice.routingInfo, firstHopChannel_opt, lastHopChannel_opt).map(r => RouteFormat.format(r, routeFormat)))
       case _ => reject(MalformedFormFieldRejection(
         "invoice", "The invoice must have an amount or you need to specify one using 'amountMsat'"
       ))
@@ -45,14 +45,16 @@ trait PathFinding {
   }
 
   val findRouteToNode: Route = postRequest("findroutetonode") { implicit t =>
-    formFields(nodeIdFormParam, amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?) { (nodeId, amount, pathFindingExperimentName_opt, routeFormat) =>
-      complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt).map(r => RouteFormat.format(r, routeFormat)))
+    formFields(nodeIdFormParam, amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?, firstHopChannelIdParam.?, lastHopChannelIdParam.?) {
+      (nodeId, amount, pathFindingExperimentName_opt, routeFormat, firstHopChannel_opt, lastHopChannel_opt) =>
+        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, firstHopChannelId = firstHopChannel_opt, lastHopChannelId = lastHopChannel_opt).map(r => RouteFormat.format(r, routeFormat)))
     }
   }
 
   val findRouteBetweenNodes: Route = postRequest("findroutebetweennodes") { implicit t =>
-    formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?) { (sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt, routeFormat) =>
-      complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt).map(r => RouteFormat.format(r, routeFormat)))
+    formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?, firstHopChannelIdParam.?, lastHopChannelIdParam.?) {
+      (sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt, routeFormat, firstHopChannel_opt, lastHopChannel_opt) =>
+        complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt, firstHopChannelId = firstHopChannel_opt, lastHopChannelId = lastHopChannel_opt).map(r => RouteFormat.format(r, routeFormat)))
     }
   }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
@@ -47,7 +47,7 @@ trait PathFinding {
   val findRouteToNode: Route = postRequest("findroutetonode") { implicit t =>
     formFields(nodeIdFormParam, amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?, firstHopChannelIdParam.?, lastHopChannelIdParam.?) {
       (nodeId, amount, pathFindingExperimentName_opt, routeFormat, firstHopChannel_opt, lastHopChannel_opt) =>
-        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, firstHopChannelId = firstHopChannel_opt, lastHopChannelId = lastHopChannel_opt).map(r => RouteFormat.format(r, routeFormat)))
+        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, firstHopChannelId_opt = firstHopChannel_opt, lastHopChannelId_opt = lastHopChannel_opt).map(r => RouteFormat.format(r, routeFormat)))
     }
   }
 

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -979,7 +979,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
 
     val eclair = mock[Eclair]
     val mockService = new MockService(eclair)
-    eclair.findRoute(any, any, any, any)(any[Timeout]) returns Future.successful(Router.RouteResponse(Seq(Router.Route(456.msat, mockHops))))
+    eclair.findRoute(any, any, any, any, any, any)(any[Timeout]) returns Future.successful(Router.RouteResponse(Seq(Router.Route(456.msat, mockHops))))
 
     // invalid format
     Post("/findroute", FormData("format"-> "invalid-output-format", "invoice" -> invoice, "amountMsat" -> "456")) ~>
@@ -989,7 +989,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       check {
         assert(handled)
         assert(status == BadRequest)
-        eclair.findRoute(PublicKey.fromBin(ByteVector.fromValidHex("036ded9bb8175d0c9fd3fad145965cf5005ec599570f35c682e710dc6001ff605e")), 456.msat, any, any)(any[Timeout]).wasNever(called)
+        eclair.findRoute(PublicKey.fromBin(ByteVector.fromValidHex("036ded9bb8175d0c9fd3fad145965cf5005ec599570f35c682e710dc6001ff605e")), 456.msat, any, any, any, any)(any[Timeout]).wasNever(called)
       }
 
     // default format
@@ -1006,7 +1006,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
           JString(mockHop3.nodeId.toString()),
           JString(mockHop3.nextNodeId.toString())
         )))
-        eclair.findRoute(PublicKey.fromBin(ByteVector.fromValidHex("036ded9bb8175d0c9fd3fad145965cf5005ec599570f35c682e710dc6001ff605e")), 456.msat, any, any)(any[Timeout]).wasCalled(once)
+        eclair.findRoute(PublicKey.fromBin(ByteVector.fromValidHex("036ded9bb8175d0c9fd3fad145965cf5005ec599570f35c682e710dc6001ff605e")), 456.msat, any, any, any, any)(any[Timeout]).wasCalled(once)
       }
 
     Post("/findroute", FormData("format" -> "nodeId", "invoice" -> invoice, "amountMsat" -> "456")) ~>
@@ -1022,7 +1022,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
           JString(mockHop3.nodeId.toString()),
           JString(mockHop3.nextNodeId.toString())
         )))
-        eclair.findRoute(PublicKey.fromBin(ByteVector.fromValidHex("036ded9bb8175d0c9fd3fad145965cf5005ec599570f35c682e710dc6001ff605e")), 456.msat, any, any)(any[Timeout]).wasCalled(twice)
+        eclair.findRoute(PublicKey.fromBin(ByteVector.fromValidHex("036ded9bb8175d0c9fd3fad145965cf5005ec599570f35c682e710dc6001ff605e")), 456.msat, any, any, any, any)(any[Timeout]).wasCalled(twice)
       }
 
     Post("/findroute", FormData("format" -> "shortChannelId", "invoice" -> invoice, "amountMsat" -> "456")) ~>
@@ -1037,7 +1037,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
           JString(mockHop2.lastUpdate.shortChannelId.toString()),
           JString(mockHop3.lastUpdate.shortChannelId.toString())
         )))
-        eclair.findRoute(PublicKey.fromBin(ByteVector.fromValidHex("036ded9bb8175d0c9fd3fad145965cf5005ec599570f35c682e710dc6001ff605e")), 456.msat, any, any)(any[Timeout]).wasCalled(threeTimes)
+        eclair.findRoute(PublicKey.fromBin(ByteVector.fromValidHex("036ded9bb8175d0c9fd3fad145965cf5005ec599570f35c682e710dc6001ff605e")), 456.msat, any, any, any, any)(any[Timeout]).wasCalled(threeTimes)
       }
   }
 


### PR DESCRIPTION
The rationale behind this PR is repurposing https://github.com/C-Otto/rebalance-lnd for Eclair to allow the Eclair’s users to automatically re-balance their channels.

This PR allows the users to specify which channels exactly they want to re-balance by providing their short channel ID's using `firstHopChannel` and/or `lastHopChannel` parameters. 

This is one PR in the upcoming series of PR's changing the router. Since the router is a one of the most critical parts, I’d like to keep them rather small.