### PR TITLE
Use Github discussions instead of Gitter

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,14 @@
 <!-- This issue tracker is only for technical issues related to Eclair.
 
-Please do not open issues for support requests or questions about Lightning or Eclair: use our gitter at https://gitter.im/ACINQ/eclair instead.
+Please do not open issues for support requests or questions about Lightning or Eclair: use Github discussions instead (https://github.com/ACINQ/eclair/discussions).
+
 Please check that there is not already a similar issue before opening a new one.
 -->
 
 <!-- Describe the issue -->
 <!-- What behaviour did you expect? -->
 
-<!-- What was the actual behaviour (provide screenshots if the issue is GUI-related)? -->
+<!-- What was the actual behaviour? -->
 
 <!-- How reliably can you reproduce the issue, what are the steps to do so? -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ This will help you understand the different parts of the codebase and how they w
 
 ## Communicating
 
-We recommend using our Gitter [developers channel](https://gitter.im/ACINQ/developers).
+We recommend using the [developers channel](https://github.com/ACINQ/eclair/discussions/categories/developers).
 Introducing yourself and explaining what you'd like to work on is always a good idea: you will get
 some pointers and feedback from experienced contributors. It will also ensure that you're not
 duplicating work that someone else is doing.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://github.com/ACINQ/eclair/workflows/Build%20&%20Test/badge.svg)](https://github.com/ACINQ/eclair/actions?query=workflow%3A%22Build+%26+Test%22)
 [![codecov](https://codecov.io/gh/acinq/eclair/branch/master/graph/badge.svg)](https://codecov.io/gh/acinq/eclair)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Gitter chat](https://img.shields.io/badge/chat-on%20gitter-red.svg)](https://gitter.im/ACINQ/eclair)
 
 **Eclair** (French for Lightning) is a Scala implementation of the Lightning Network.
 


### PR DESCRIPTION
Remove references to Gitter, so that newcomers use Github discussions instead.