### PR TITLE
Forward incompatibility with Bitcoin Core

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You will find detailed guides and frequently asked questions there.
 
 ### Prerequisite: Bitcoin Core
 
-:warning: Eclair requires Bitcoin Core 0.20.1 or 0.21.1. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
+:warning: Eclair requires Bitcoin Core 0.20.1 or 0.21.1. **Do not update to a newer version of Bitcoin Core software** until you have upgraded Eclair to a verstion that supports it.  If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
 
 Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You will find detailed guides and frequently asked questions there.
 
 ### Prerequisite: Bitcoin Core
 
-:warning: Eclair requires Bitcoin Core 0.20.1 or 0.21.1. **Do not update to a newer version of Bitcoin Core software** until you have upgraded Eclair to a verstion that supports it.  If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
+:warning: Eclair requires Bitcoin Core 0.20.1 or 0.21.1. (other versions of Bitcoin Core are *not* actively tested - use at your own risk).  If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
 
 Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
 


### PR DESCRIPTION
Installation instructions now make it clear that future versions of Bitcoin Core are not supported in the current version of Eclair.