### PR TITLE
Additional parameters for findroute* API calls

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -49,6 +49,7 @@ import scodec.bits.ByteVector
 
 import java.nio.charset.StandardCharsets
 import java.util.UUID
+import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.reflect.ClassTag
@@ -123,9 +124,9 @@ trait Eclair {
 
   def sendOnChain(address: String, amount: Satoshi, confirmationTarget: Long): Future[ByteVector32]
 
-  def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, includeLocalChannelCost: Boolean = false)(implicit timeout: Timeout): Future[RouteResponse]
+  def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, includeLocalChannelCost: Boolean = false, ignoredNodeIds: Seq[PublicKey] = Seq.empty, ignoredShortChannelIds: Seq[ShortChannelId] = Seq.empty, maxFee_opt: Option[MilliSatoshi] = None)(implicit timeout: Timeout): Future[RouteResponse]
 
-  def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, includeLocalChannelCost: Boolean = false)(implicit timeout: Timeout): Future[RouteResponse]
+  def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, includeLocalChannelCost: Boolean = false, ignoredNodeIds: Seq[PublicKey] = Seq.empty, ignoredShortChannelIds: Seq[ShortChannelId] = Seq.empty, maxFee_opt: Option[MilliSatoshi] = None)(implicit timeout: Timeout): Future[RouteResponse]
 
   def sendToRoute(amount: MilliSatoshi, recipientAmount_opt: Option[MilliSatoshi], externalId_opt: Option[String], parentId_opt: Option[UUID], invoice: PaymentRequest, finalCltvExpiryDelta: CltvExpiryDelta, route: PredefinedRoute, trampolineSecret_opt: Option[ByteVector32] = None, trampolineFees_opt: Option[MilliSatoshi] = None, trampolineExpiryDelta_opt: Option[CltvExpiryDelta] = None, trampolineNodes_opt: Seq[PublicKey] = Nil)(implicit timeout: Timeout): Future[SendPaymentToRouteResponse]
 
@@ -280,8 +281,8 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
   }
 
-  override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, includeLocalChannelCost: Boolean = false)(implicit timeout: Timeout): Future[RouteResponse] =
-    findRouteBetween(appKit.nodeParams.nodeId, targetNodeId, amount, pathFindingExperimentName_opt, assistedRoutes, includeLocalChannelCost)
+  override def findRoute(targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, includeLocalChannelCost: Boolean = false, ignoredNodeIds: Seq[PublicKey] = Seq.empty, ignoredShortChannelIds: Seq[ShortChannelId] = Seq.empty, maxFee_opt: Option[MilliSatoshi] = None)(implicit timeout: Timeout): Future[RouteResponse] =
+    findRouteBetween(appKit.nodeParams.nodeId, targetNodeId, amount, pathFindingExperimentName_opt, assistedRoutes, includeLocalChannelCost, ignoredNodeIds, ignoredShortChannelIds, maxFee_opt)
 
   private def getRouteParams(pathFindingExperimentName_opt: Option[String]): Either[IllegalArgumentException, RouteParams] = {
     pathFindingExperimentName_opt match {
@@ -293,11 +294,15 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
   }
 
-  override def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, includeLocalChannelCost: Boolean = false)(implicit timeout: Timeout): Future[RouteResponse] = {
+  override def findRouteBetween(sourceNodeId: PublicKey, targetNodeId: PublicKey, amount: MilliSatoshi, pathFindingExperimentName_opt: Option[String], assistedRoutes: Seq[Seq[PaymentRequest.ExtraHop]] = Seq.empty, includeLocalChannelCost: Boolean = false, ignoredNodeIds: Seq[PublicKey] = Seq.empty, ignoredShortChannelIds: Seq[ShortChannelId] = Seq.empty, maxFee_opt: Option[MilliSatoshi] = None)(implicit timeout: Timeout): Future[RouteResponse] = {
     getRouteParams(pathFindingExperimentName_opt) match {
       case Right(routeParams) =>
-        val maxFee = routeParams.getMaxFee(amount)
-        (appKit.router ? RouteRequest(sourceNodeId, targetNodeId, amount, maxFee, assistedRoutes, routeParams = routeParams.copy(includeLocalChannelCost = includeLocalChannelCost))).mapTo[RouteResponse]
+        val maxFee = maxFee_opt.getOrElse(routeParams.getMaxFee(amount))
+        for {
+          ignoredChannels <- getChannelDescs(ignoredShortChannelIds.toSet)
+          ignore = Ignore(ignoredNodeIds.toSet, ignoredChannels)
+          response <- (appKit.router ? RouteRequest(sourceNodeId, targetNodeId, amount, maxFee, assistedRoutes, ignore = ignore, routeParams = routeParams.copy(includeLocalChannelCost = includeLocalChannelCost))).mapTo[RouteResponse]
+        } yield response
       case Left(t) => Future.failed(t)
     }
   }
@@ -489,5 +494,16 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
     val pubKeyFromSignature = Crypto.recoverPublicKey(signature, signedBytes, recoveryId)
     VerifiedMessage(valid = true, pubKeyFromSignature)
+  }
+
+  private def getChannelDescs(shortChannelIds: Set[ShortChannelId])(implicit timeout: Timeout): Future[Set[ChannelDesc]] = {
+    for {
+      channelsMap <- (appKit.router ? GetChannelsMap).mapTo[SortedMap[ShortChannelId, PublicChannel]]
+    } yield {
+      shortChannelIds.map { id =>
+        val c = channelsMap.getOrElse(id, throw new IllegalArgumentException(s"unknown channel: $id"))
+        ChannelDesc(c.ann.shortChannelId, c.ann.nodeId1, c.ann.nodeId2)
+      }
+    }
   }
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
@@ -46,7 +46,10 @@ trait ExtraDirectives extends Directives {
   val toFormParam: NameReceptacle[Long] = "to".as[Long]
   val amountMsatFormParam: NameReceptacle[MilliSatoshi] = "amountMsat".as[MilliSatoshi]
   val invoiceFormParam: NameReceptacle[PaymentRequest] = "invoice".as[PaymentRequest]
-  val routeFormat: NameUnmarshallerReceptacle[RouteFormat] = "format".as[RouteFormat](routeFormatUnmarshaller)
+  val routeFormatFormParam: NameUnmarshallerReceptacle[RouteFormat] = "format".as[RouteFormat](routeFormatUnmarshaller)
+  val ignoreNodeIdsFormParam: NameUnmarshallerReceptacle[List[PublicKey]] = "ignoreNodeIds".as[List[PublicKey]](pubkeyListUnmarshaller)
+  val ignoreChannelIdsFormParam: NameUnmarshallerReceptacle[List[ShortChannelId]] = "ignoreChannelIds".as[List[ShortChannelId]](shortChannelIdsUnmarshaller)
+  val maxFeeMsatFormParam: NameReceptacle[MilliSatoshi] = "maxFeeMsat".as[MilliSatoshi]
 
   // custom directive to fail with HTTP 404 (and JSON response) if the element was not found
   def completeOrNotFound[T](fut: Future[Option[T]])(implicit marshaller: ToResponseMarshaller[T]): Route = onComplete(fut) {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/RouteFormat.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/RouteFormat.scala
@@ -16,38 +16,47 @@
 
 package fr.acinq.eclair.api.directives
 
+import akka.http.scaladsl.model.StatusCodes.OK
+import akka.http.scaladsl.model.{ContentTypes, HttpResponse}
+import fr.acinq.eclair.api.serde.JsonSupport._
 import fr.acinq.eclair.router.Router.RouteResponse
 
 // @formatter:off
 sealed trait RouteFormat
 case object NodeIdRouteFormat extends RouteFormat
 case object ShortChannelIdRouteFormat extends RouteFormat
+case object FullRouteFormat extends RouteFormat
 // @formatter:on
 
 object RouteFormat {
 
   val NODE_ID = "nodeId"
   val SHORT_CHANNEL_ID = "shortChannelId"
+  val FULL = "full"
 
   def fromString(s: String): RouteFormat = s match {
     case NODE_ID => NodeIdRouteFormat
     case SHORT_CHANNEL_ID => ShortChannelIdRouteFormat
-    case _ => throw new IllegalArgumentException(s"invalid route format, possible values are ($NODE_ID, $SHORT_CHANNEL_ID)")
+    case FULL => FullRouteFormat
+    case _ => throw new IllegalArgumentException(s"invalid route format, possible values are ($NODE_ID, $SHORT_CHANNEL_ID, $FULL)")
   }
 
-  def format(route: RouteResponse, format_opt: Option[RouteFormat]): Seq[String] = format(route, format_opt.getOrElse(NodeIdRouteFormat))
+  def format(route: RouteResponse, format_opt: Option[RouteFormat]): HttpResponse = format(route, format_opt.getOrElse(NodeIdRouteFormat))
 
-  def format(route: RouteResponse, format: RouteFormat): Seq[String] = format match {
-    case NodeIdRouteFormat =>
-      val nodeIds = route.routes.head.hops match {
-        case rest :+ last => rest.map(_.nodeId) :+ last.nodeId :+ last.nextNodeId
-        case Nil => Nil
-      }
-      nodeIds.toList.map(_.toString)
-    case ShortChannelIdRouteFormat =>
-      val shortChannelIds = route.routes.head.hops.map(_.lastUpdate.shortChannelId)
-      shortChannelIds.map(_.toString)
-  }
-
+  def format(route: RouteResponse, format: RouteFormat): HttpResponse =
+    HttpResponse(OK).withEntity(ContentTypes.`application/json`,
+      format match {
+        case NodeIdRouteFormat =>
+          val nodeIds = route.routes.head.hops match {
+            case rest :+ last => rest.map(_.nodeId) :+ last.nodeId :+ last.nextNodeId
+            case Nil => Nil
+          }
+          serialization.write(nodeIds.toList.map(_.toString))
+        case ShortChannelIdRouteFormat =>
+          val shortChannelIds = route.routes.head.hops.map(_.lastUpdate.shortChannelId)
+          serialization.write(shortChannelIds.toList.map(_.toString))
+        case FullRouteFormat =>
+          serialization.writePretty(route.routes)
+      })
 }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
@@ -33,11 +33,11 @@ trait PathFinding {
   private implicit def ec: ExecutionContext = actorSystem.dispatcher
 
   val findRoute: Route = postRequest("findroute") { implicit t =>
-    formFields(invoiceFormParam, amountMsatFormParam.?, "pathFindingExperimentName".?, routeFormat.?, "includeLocalChannelCost".as[Boolean].?) {
-      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, pathFindingExperimentName_opt, routeFormat, includeLocalChannelCost_opt) =>
-        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, invoice.routingInfo, includeLocalChannelCost_opt.getOrElse(false)).map(r => RouteFormat.format(r, routeFormat)))
-      case (invoice, Some(overrideAmount), pathFindingExperimentName_opt, routeFormat, includeLocalChannelCost_opt) =>
-        complete(eclairApi.findRoute(invoice.nodeId, overrideAmount, pathFindingExperimentName_opt, invoice.routingInfo, includeLocalChannelCost_opt.getOrElse(false)).map(r => RouteFormat.format(r, routeFormat)))
+    formFields(invoiceFormParam, amountMsatFormParam.?, "pathFindingExperimentName".?, routeFormatFormParam.?, "includeLocalChannelCost".as[Boolean].?, ignoreNodeIdsFormParam.?, ignoreChannelIdsFormParam.?, maxFeeMsatFormParam.?) {
+      case (invoice@PaymentRequest(_, Some(amount), _, nodeId, _, _), None, pathFindingExperimentName_opt, routeFormat_opt, includeLocalChannelCost_opt, ignoreNodeIds_opt, ignoreChannels_opt, maxFee_opt) =>
+        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, invoice.routingInfo, includeLocalChannelCost_opt.getOrElse(false), ignoredNodeIds = ignoreNodeIds_opt.getOrElse(Nil), ignoredShortChannelIds = ignoreChannels_opt.getOrElse(Nil), maxFee_opt = maxFee_opt).map(r => RouteFormat.format(r, routeFormat_opt)))
+      case (invoice, Some(overrideAmount), pathFindingExperimentName_opt, routeFormat_opt, includeLocalChannelCost_opt, ignoreNodeIds_opt, ignoreChannels_opt, maxFee_opt) =>
+        complete(eclairApi.findRoute(invoice.nodeId, overrideAmount, pathFindingExperimentName_opt, invoice.routingInfo, includeLocalChannelCost_opt.getOrElse(false), ignoredNodeIds = ignoreNodeIds_opt.getOrElse(Nil), ignoredShortChannelIds = ignoreChannels_opt.getOrElse(Nil), maxFee_opt = maxFee_opt).map(r => RouteFormat.format(r, routeFormat_opt)))
       case _ => reject(MalformedFormFieldRejection(
         "invoice", "The invoice must have an amount or you need to specify one using 'amountMsat'"
       ))
@@ -45,16 +45,15 @@ trait PathFinding {
   }
 
   val findRouteToNode: Route = postRequest("findroutetonode") { implicit t =>
-    formFields(nodeIdFormParam, amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?, "includeLocalChannelCost".as[Boolean].?) {
-      (nodeId, amount, pathFindingExperimentName_opt, routeFormat, includeLocalChannelCost_opt) =>
-        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, includeLocalChannelCost = includeLocalChannelCost_opt.getOrElse(false)).map(r => RouteFormat.format(r, routeFormat)))
+    formFields(nodeIdFormParam, amountMsatFormParam, "pathFindingExperimentName".?, routeFormatFormParam.?, "includeLocalChannelCost".as[Boolean].?, ignoreNodeIdsFormParam.?, ignoreChannelIdsFormParam.?, maxFeeMsatFormParam.?) {
+      (nodeId, amount, pathFindingExperimentName_opt, routeFormat_opt, includeLocalChannelCost_opt, ignoreNodeIds_opt, ignoreChannels_opt, maxFee_opt) =>
+        complete(eclairApi.findRoute(nodeId, amount, pathFindingExperimentName_opt, includeLocalChannelCost = includeLocalChannelCost_opt.getOrElse(false), ignoredNodeIds = ignoreNodeIds_opt.getOrElse(Nil), ignoredShortChannelIds = ignoreChannels_opt.getOrElse(Nil), maxFee_opt = maxFee_opt).map(r => RouteFormat.format(r, routeFormat_opt)))
     }
   }
 
   val findRouteBetweenNodes: Route = postRequest("findroutebetweennodes") { implicit t =>
-    formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam, "pathFindingExperimentName".?, routeFormat.?, "includeLocalChannelCost".as[Boolean].?) {
-      (sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt, routeFormat, includeLocalChannelCost_opt) =>
-        complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt, includeLocalChannelCost = includeLocalChannelCost_opt.getOrElse(false)).map(r => RouteFormat.format(r, routeFormat)))
+    formFields("sourceNodeId".as[PublicKey], "targetNodeId".as[PublicKey], amountMsatFormParam, "pathFindingExperimentName".?, routeFormatFormParam.?, "includeLocalChannelCost".as[Boolean].?, ignoreNodeIdsFormParam.?, ignoreChannelIdsFormParam.?, maxFeeMsatFormParam.?) { (sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt, routeFormat_opt, includeLocalChannelCost_opt, ignoreNodeIds_opt, ignoreChannels_opt, maxFee_opt) =>
+      complete(eclairApi.findRouteBetween(sourceNodeId, targetNodeId, amount, pathFindingExperimentName_opt, includeLocalChannelCost = includeLocalChannelCost_opt.getOrElse(false), ignoredNodeIds = ignoreNodeIds_opt.getOrElse(Nil), ignoredShortChannelIds = ignoreChannels_opt.getOrElse(Nil), maxFee_opt = maxFee_opt).map(r => RouteFormat.format(r, routeFormat_opt)))
     }
   }
 

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -46,7 +46,7 @@ import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentToRouteResponse
 import fr.acinq.eclair.router.Router.PredefinedNodeRoute
 import fr.acinq.eclair.router.{NetworkStats, Router, Stats}
 import fr.acinq.eclair.wire.protocol.{ChannelUpdate, Color, NodeAddress}
-import org.json4s.JsonAST.{JArray, JString}
+import org.json4s.JsonAST.{JArray, JInt, JObject, JString}
 import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -952,7 +952,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       }
   }
 
-  test("'findroute' method response should support both a node ID and channel ID formats") {
+  test("'findroute' method response should support nodeId, channelId and full formats") {
     val invoice = "lnbc12580n1pw2ywztpp554ganw404sh4yjkwnysgn3wjcxfcq7gtx53gxczkjr9nlpc3hzvqdq2wpskwctddyxqr4rqrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glc7z9rtvqqwngqqqqqqqlgqqqqqeqqjqrrt8smgjvfj7sg38dwtr9kc9gg3era9k3t2hvq3cup0jvsrtrxuplevqgfhd3rzvhulgcxj97yjuj8gdx8mllwj4wzjd8gdjhpz3lpqqvk2plh"
 
 
@@ -1038,6 +1038,27 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
           JString(mockHop3.lastUpdate.shortChannelId.toString())
         )))
         eclair.findRoute(PublicKey.fromBin(ByteVector.fromValidHex("036ded9bb8175d0c9fd3fad145965cf5005ec599570f35c682e710dc6001ff605e")), 456.msat, any, any)(any[Timeout]).wasCalled(threeTimes)
+      }
+    Post("/findroute", FormData("format" -> "full", "invoice" -> invoice, "amountMsat" -> "456")) ~>
+      addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
+      addHeader("Content-Type", "application/json") ~>
+      Route.seal(mockService.findRoute) ~>
+      check {
+        assert(handled)
+        assert(status == OK)
+        val responseArray = entityAs[JArray](Json4sSupport.unmarshaller, ClassTag(classOf[ErrorResponse]))
+        assert(responseArray.arr.size == 1)
+        assert(responseArray.arr.head.isInstanceOf[JObject])
+        val route = responseArray.arr.head.asInstanceOf[JObject]
+        assert(route.obj.head == ("amount", JInt(456)))
+        assert(route.obj.last._1 == "hops")
+        val hops = route.obj.last._2.asInstanceOf[JArray]
+        assert(hops.arr.size == 3)
+        val (hop1 :: hop2 :: hop3 :: Nil) = hops.arr
+        assert(hop1.asInstanceOf[JObject].obj.head == ("nodeId", JString(mockHop1.nodeId.toString())))
+        assert(hop2.asInstanceOf[JObject].obj.head == ("nodeId", JString(mockHop2.nodeId.toString())))
+        assert(hop3.asInstanceOf[JObject].obj.head == ("nodeId", JString(mockHop3.nodeId.toString())))
+        eclair.findRoute(PublicKey.fromBin(ByteVector.fromValidHex("036ded9bb8175d0c9fd3fad145965cf5005ec599570f35c682e710dc6001ff605e")), 456.msat, any, any)(any[Timeout]).wasCalled(fourTimes)
       }
   }
 


### PR DESCRIPTION
This PR adds new parameters for `findroute*` API calls useful automated route calculations for third-party applications:

`ignoreNodeIds` - specifies ignored nodes
`ignoreChannelIds` - specifies ignored channels 
`maxFeeMsat` - sets max fee for route calculations

Also it adds `full` format that returns all information that `Router` can provide about the found routes.
