### PR TITLE
Send remote address in init

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/TransportHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/TransportHandler.scala
@@ -58,7 +58,7 @@ class TransportHandler[T: ClassTag](keyPair: KeyPair, rs: Option[ByteVector], co
 
   val wireLog = new BusLogging(context.system.eventStream, "", classOf[Diagnostics], context.system.asInstanceOf[ExtendedActorSystem].logFilter) with DiagnosticLoggingAdapter
 
-  def diag(message: T, direction: String) = {
+  def diag(message: T, direction: String): Unit = {
     require(direction == "IN" || direction == "OUT")
     val channelId_opt = Logs.channelId(message)
     wireLog.mdc(Logs.mdc(LogCategory(message), remoteNodeId_opt, channelId_opt))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -104,7 +104,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
       d.transport ! TransportHandler.Listener(self)
       Metrics.PeerConnectionsConnecting.withTag(Tags.ConnectionState, Tags.ConnectionStates.Initializing).increment()
       log.info(s"using features=$localFeatures")
-      val localInit = NodeAddress.extractIPAddress(d.pendingAuth.address) match {
+      val localInit = IPAddress(d.pendingAuth.address.getAddress, d.pendingAuth.address.getPort) match {
         case Some(remoteAddress) if !d.pendingAuth.outgoing && NodeAddress.isPublicIPAddress(remoteAddress) => protocol.Init(localFeatures, TlvStream(InitTlv.Networks(chainHash :: Nil), InitTlv.RemoteAddress(remoteAddress)))
         case _ => protocol.Init(localFeatures, TlvStream(InitTlv.Networks(chainHash :: Nil)))
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -104,7 +104,10 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
       d.transport ! TransportHandler.Listener(self)
       Metrics.PeerConnectionsConnecting.withTag(Tags.ConnectionState, Tags.ConnectionStates.Initializing).increment()
       log.info(s"using features=$localFeatures")
-      val localInit = protocol.Init(localFeatures, TlvStream(InitTlv.Networks(chainHash :: Nil)))
+      val localInit = NodeAddress.extractIPAddress(d.pendingAuth.address) match {
+        case Some(remoteAddress) if !d.pendingAuth.outgoing && NodeAddress.isPublicIPAddress(remoteAddress) => protocol.Init(localFeatures, TlvStream(InitTlv.Networks(chainHash :: Nil), InitTlv.RemoteAddress(remoteAddress)))
+        case _ => protocol.Init(localFeatures, TlvStream(InitTlv.Networks(chainHash :: Nil)))
+      }
       d.transport ! localInit
       startSingleTimer(INIT_TIMER, InitTimeout, conf.initTimeout)
       goto(INITIALIZING) using InitializingData(chainHash, d.pendingAuth, d.remoteNodeId, d.transport, peer, localInit, doSync, d.isPersistent)
@@ -117,6 +120,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
         d.transport ! TransportHandler.ReadAck(remoteInit)
 
         log.info(s"peer is using features=${remoteInit.features}, networks=${remoteInit.networks.mkString(",")}")
+        remoteInit.remoteAddress_opt.foreach(address => log.info("peer reports that our IP address is {} (public={})", address.socketAddress.toString, NodeAddress.isPublicIPAddress(address)))
 
         val featureGraphErr_opt = Features.validateFeatureGraph(remoteInit.features)
         if (remoteInit.networks.nonEmpty && remoteInit.networks.intersect(d.localInit.networks).isEmpty) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
@@ -49,6 +49,7 @@ sealed trait HtlcSettlementMessage extends UpdateMessage { def id: Long } // <- 
 
 case class Init(features: Features, tlvStream: TlvStream[InitTlv] = TlvStream.empty) extends SetupMessage {
   val networks = tlvStream.get[InitTlv.Networks].map(_.chainHashes).getOrElse(Nil)
+  val remoteAddress_opt = tlvStream.get[InitTlv.RemoteAddress].map(_.address)
 }
 
 case class Warning(channelId: ByteVector32, data: ByteVector, tlvStream: TlvStream[WarningTlv] = TlvStream.empty) extends SetupMessage with HasChannelId {
@@ -215,28 +216,52 @@ case class Color(r: Byte, g: Byte, b: Byte) {
 // @formatter:off
 sealed trait NodeAddress { def socketAddress: InetSocketAddress }
 sealed trait OnionAddress extends NodeAddress
+sealed trait IPAddress extends NodeAddress
+// @formatter:on
+
 object NodeAddress {
   /**
-    * Creates a NodeAddress from a host and port.
-    *
-    * Note that non-onion hosts will be resolved.
-    *
-    * We don't attempt to resolve onion addresses (it will be done by the tor proxy), so we just recognize them based on
-    * the .onion TLD and rely on their length to separate v2/v3.
-    */
+   * Creates a NodeAddress from a host and port.
+   *
+   * Note that non-onion hosts will be resolved.
+   *
+   * We don't attempt to resolve onion addresses (it will be done by the tor proxy), so we just recognize them based on
+   * the .onion TLD and rely on their length to separate v2/v3.
+   */
   def fromParts(host: String, port: Int): Try[NodeAddress] = Try {
     host match {
       case _ if host.endsWith(".onion") && host.length == 22 => Tor2(host.dropRight(6), port)
       case _ if host.endsWith(".onion") && host.length == 62 => Tor3(host.dropRight(6), port)
-      case _  => InetAddress.getByName(host) match {
+      case _ => InetAddress.getByName(host) match {
         case a: Inet4Address => IPv4(a, port)
         case a: Inet6Address => IPv6(a, port)
       }
     }
   }
+
+  def extractIPAddress(socketAddress: InetSocketAddress): Option[IPAddress] = {
+    val address = socketAddress.getAddress
+    address match {
+      case address: Inet4Address => Some(IPv4(address, socketAddress.getPort))
+      case address: Inet6Address => Some(IPv6(address, socketAddress.getPort))
+      case _ => None
+    }
+  }
+
+  private def isPrivate(address: InetAddress): Boolean = address.isAnyLocalAddress || address.isLoopbackAddress || address.isLinkLocalAddress || address.isSiteLocalAddress
+
+  def isPublicIPAddress(address: NodeAddress): Boolean = {
+    address match {
+      case IPv4(ipv4, _) if !isPrivate(ipv4) => true
+      case IPv6(ipv6, _) if !isPrivate(ipv6) => true
+      case _ => false
+    }
+  }
 }
-case class IPv4(ipv4: Inet4Address, port: Int) extends NodeAddress { override def socketAddress = new InetSocketAddress(ipv4, port) }
-case class IPv6(ipv6: Inet6Address, port: Int) extends NodeAddress { override def socketAddress = new InetSocketAddress(ipv6, port) }
+
+// @formatter:off
+case class IPv4(ipv4: Inet4Address, port: Int) extends IPAddress { override def socketAddress = new InetSocketAddress(ipv4, port) }
+case class IPv6(ipv6: Inet6Address, port: Int) extends IPAddress { override def socketAddress = new InetSocketAddress(ipv6, port) }
 case class Tor2(tor2: String, port: Int) extends OnionAddress { override def socketAddress = InetSocketAddress.createUnresolved(tor2 + ".onion", port) }
 case class Tor3(tor3: String, port: Int) extends OnionAddress { override def socketAddress = InetSocketAddress.createUnresolved(tor3 + ".onion", port) }
 // @formatter:on

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
@@ -232,19 +232,7 @@ object NodeAddress {
     host match {
       case _ if host.endsWith(".onion") && host.length == 22 => Tor2(host.dropRight(6), port)
       case _ if host.endsWith(".onion") && host.length == 62 => Tor3(host.dropRight(6), port)
-      case _ => InetAddress.getByName(host) match {
-        case a: Inet4Address => IPv4(a, port)
-        case a: Inet6Address => IPv6(a, port)
-      }
-    }
-  }
-
-  def extractIPAddress(socketAddress: InetSocketAddress): Option[IPAddress] = {
-    val address = socketAddress.getAddress
-    address match {
-      case address: Inet4Address => Some(IPv4(address, socketAddress.getPort))
-      case address: Inet6Address => Some(IPv6(address, socketAddress.getPort))
-      case _ => None
+      case _ => IPAddress(InetAddress.getByName(host), port).get
     }
   }
 
@@ -256,6 +244,14 @@ object NodeAddress {
       case IPv6(ipv6, _) if !isPrivate(ipv6) => true
       case _ => false
     }
+  }
+}
+
+object IPAddress {
+  def apply(inetAddress: InetAddress, port: Int): Option[IPAddress] = inetAddress match {
+    case address: Inet4Address => Some(IPv4(address, port))
+    case address: Inet6Address => Some(IPv6(address, port))
+    case _ => None
   }
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/SetupAndControlTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/SetupAndControlTlv.scala
@@ -35,6 +35,12 @@ object InitTlv {
   /** The chains the node is interested in. */
   case class Networks(chainHashes: List[ByteVector32]) extends InitTlv
 
+  /**
+   * When receiving an incoming connection, we can send back the public address our peer is connecting from.
+   * This lets our peer discover if its public IP has changed from within its local network.
+   */
+  case class RemoteAddress(address: NodeAddress) extends InitTlv
+
 }
 
 object InitTlvCodecs {
@@ -42,9 +48,11 @@ object InitTlvCodecs {
   import InitTlv._
 
   private val networks: Codec[Networks] = variableSizeBytesLong(varintoverflow, list(bytes32)).as[Networks]
+  private val remoteAddress: Codec[RemoteAddress] = variableSizeBytesLong(varintoverflow, nodeaddress).as[RemoteAddress]
 
   val initTlvCodec = tlvStream(discriminated[InitTlv].by(varint)
     .typecase(UInt64(1), networks)
+    .typecase(UInt64(3), remoteAddress)
   )
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -486,8 +486,8 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
       NodeAddress.fromParts("iq7zhmhck54vcax2vlrdcavq2m32wao7ekh6jyeglmnuuvv3js57r4id.onion", 9735).get -> false,
     )
     for ((address, expected) <- testCases) {
-      val isPublic = NodeAddress.isPublicIPAddress(address)
-      assert(isPublic === expected)
+      val isPublicIP = NodeAddress.isPublicIPAddress(address)
+      assert(isPublicIP === expected)
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -93,6 +93,20 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
   }
 
+  test("send incoming connection's remote address in init") { f =>
+    import f._
+    val probe = TestProbe()
+    val incomingConnection = PeerConnection.PendingAuth(connection.ref, None, fakeIPAddress.socketAddress, origin_opt = None, transport_opt = Some(transport.ref), isPersistent = true)
+    assert(!incomingConnection.outgoing)
+    probe.send(peerConnection, incomingConnection)
+    transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
+    switchboard.expectMsg(PeerConnection.Authenticated(peerConnection, remoteNodeId))
+    probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref, nodeParams.chainHash, nodeParams.features, doSync = false))
+    transport.expectMsgType[TransportHandler.Listener]
+    val localInit = transport.expectMsgType[protocol.Init]
+    assert(localInit.remoteAddress_opt === Some(fakeIPAddress))
+  }
+
   test("handle connection closed during authentication") { f =>
     import f._
     val probe = TestProbe()
@@ -459,5 +473,23 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     peer.send(peerConnection, message)
     transport.expectMsg(message)
   }
+
+  test("filter private IP addresses") { _ =>
+    val testCases = Seq(
+      NodeAddress.fromParts("127.0.0.1", 9735).get -> false,
+      NodeAddress.fromParts("0.0.0.0", 9735).get -> false,
+      NodeAddress.fromParts("192.168.0.1", 9735).get -> false,
+      NodeAddress.fromParts("140.82.121.3", 9735).get -> true,
+      NodeAddress.fromParts("0000:0000:0000:0000:0000:0000:0000:0001", 9735).get -> false,
+      NodeAddress.fromParts("b643:8bb1:c1f9:0556:487c:0acb:2ba3:3cc2", 9735).get -> true,
+      NodeAddress.fromParts("hsmithsxurybd7uh.onion", 9735).get -> false,
+      NodeAddress.fromParts("iq7zhmhck54vcax2vlrdcavq2m32wao7ekh6jyeglmnuuvv3js57r4id.onion", 9735).get -> false,
+    )
+    for ((address, expected) <- testCases) {
+      val isPublic = NodeAddress.isPublicIPAddress(address)
+      assert(isPublic === expected)
+    }
+  }
+
 }
 


### PR DESCRIPTION
This adds the option to report a remote IP address back to a connecting peer using the `init` message.
A node can decide to use that information to discover a potential update to its public IP address (NAT) and use that for a `node_announcement` update message containing the new address.

See https://github.com/lightningnetwork/lightning-rfc/pull/917

I have successfully tested cross-compatibility with c-lightning https://github.com/ElementsProject/lightning/pull/4864