### PR TITLE
Store published txs in AuditDb

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -118,8 +118,8 @@ See the [spec discussions](https://github.com/lightningnetwork/lightning-rfc/pul
 
 ### Audit trail for published transactions
 
-Eclair now records every transaction it publishes in the `audit` database, in a new `transaction-published` table.
-It also stores confirmed transactions that have an impact on existing channels (including transactions made by your peer) in a new `transaction-confirmed` table.
+Eclair now records every transaction it publishes in the `audit` database, in a new `transactions_published` table.
+It also stores confirmed transactions that have an impact on existing channels (including transactions made by your peer) in a new `transactions_confirmed` table.
 
 This lets you audit the complete on-chain footprint of your channels and the on-chain fees paid.
 This information is exposed through the `networkfees` API (which was already available in previous versions).

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -116,6 +116,16 @@ We still support receiving non-segwit remote scripts, but will force-close if th
 
 See the [spec discussions](https://github.com/lightningnetwork/lightning-rfc/pull/894) for more details.
 
+### Audit trail for published transactions
+
+Eclair now records every transaction it publishes in the `audit` database, in a new `transaction-published` table.
+It also stores confirmed transactions that have an impact on existing channels (including transactions made by your peer) in a new `transaction-confirmed` table.
+
+This lets you audit the complete on-chain footprint of your channels and the on-chain fees paid.
+This information is exposed through the `networkfees` API (which was already available in previous versions).
+
+We removed the previous `network_fees` table which achieved the same result but contained less details.
+
 ### Sample GUI removed
 
 We previously included code for a sample GUI: `eclair-node-gui`.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -248,6 +248,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
           log.info("we have nothing at stake, going straight to CLOSED")
           goto(CLOSED) using closing
         case closing: DATA_CLOSING =>
+          val isFunder = closing.commitments.localParams.isFunder
           // we don't put back the WatchSpent if the commitment tx has already been published and the spending tx already reached mindepth
           val closingType_opt = Closing.isClosingTypeAlreadyKnown(closing)
           log.info(s"channel is closing (closingType=${closingType_opt.map(c => EventType.Closed(c).label).getOrElse("UnknownYet")})")
@@ -256,7 +257,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
           // - there is no need to attempt to publish transactions for other type of closes
           closingType_opt match {
             case Some(c: Closing.MutualClose) =>
-              doPublish(c.tx)
+              doPublish(c.tx, isFunder)
             case Some(c: Closing.LocalClose) =>
               doPublish(c.localCommitPublished, closing.commitments)
             case Some(c: Closing.RemoteClose) =>
@@ -268,7 +269,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
             case None =>
               // in all other cases we need to be ready for any type of closing
               watchFundingTx(data.commitments, closing.spendingTxs.map(_.txid).toSet)
-              closing.mutualClosePublished.foreach(doPublish)
+              closing.mutualClosePublished.foreach(mcp => doPublish(mcp, isFunder))
               closing.localCommitPublished.foreach(lcp => doPublish(lcp, closing.commitments))
               closing.remoteCommitPublished.foreach(doPublish)
               closing.nextRemoteCommitPublished.foreach(doPublish)
@@ -560,8 +561,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
           def publishFundingTx(): Unit = {
             wallet.commit(fundingTx).onComplete {
               case Success(true) =>
-                // NB: funding tx isn't confirmed at this point, so technically we didn't really pay the network fee yet, so this is a (fair) approximation
-                feePaid(fundingTxFee, fundingTx, "funding", commitments.channelId)
+                context.system.eventStream.publish(TransactionPublished(commitments.channelId, remoteNodeId, fundingTx, fundingTxFee, "funding"))
                 channelOpenReplyToUser(Right(ChannelOpenResponse.ChannelOpened(channelId)))
               case Success(false) =>
                 channelOpenReplyToUser(Left(LocalError(new RuntimeException("couldn't publish funding tx"))))
@@ -610,6 +610,8 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
         case Success(_) =>
           log.info(s"channelId=${commitments.channelId} was confirmed at blockHeight=$blockHeight txIndex=$txIndex")
           blockchain ! WatchFundingLost(self, commitments.commitInput.outPoint.txid, nodeParams.minDepthBlocks)
+          if (!d.commitments.localParams.isFunder) context.system.eventStream.publish(TransactionPublished(commitments.channelId, remoteNodeId, fundingTx, 0 sat, "funding"))
+          context.system.eventStream.publish(TransactionConfirmed(commitments.channelId, remoteNodeId, fundingTx))
           val channelKeyPath = keyManager.keyPath(d.commitments.localParams, commitments.channelConfig)
           val nextPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 1)
           val fundingLocked = FundingLocked(commitments.channelId, nextPerCommitmentPoint)
@@ -1450,7 +1452,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
       // we can then use these preimages to fulfill origin htlcs
       log.info(s"processing bitcoin output spent by txid=${tx.txid} tx=$tx")
       val extracted = Closing.extractPreimages(d.commitments.localCommit, tx)
-      extracted foreach { case (htlc, preimage) =>
+      extracted.foreach { case (htlc, preimage) =>
         d.commitments.originChannels.get(htlc.id) match {
           case Some(origin) =>
             log.info(s"fulfilling htlc #${htlc.id} paymentHash=${htlc.paymentHash} origin=$origin")
@@ -1463,7 +1465,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
       }
       val revokedCommitPublished1 = d.revokedCommitPublished.map { rev =>
         val (rev1, penaltyTxs) = Closing.claimRevokedHtlcTxOutputs(keyManager, d.commitments, rev, tx, nodeParams.onChainFeeConf.feeEstimator)
-        penaltyTxs.foreach(claimTx => txPublisher ! PublishRawTx(claimTx, None))
+        penaltyTxs.foreach(claimTx => txPublisher ! PublishRawTx(claimTx, claimTx.fee, None))
         penaltyTxs.foreach(claimTx => blockchain ! WatchOutputSpent(self, tx.txid, claimTx.input.outPoint.index.toInt, hints = Set(claimTx.tx.txid)))
         rev1
       }
@@ -1471,13 +1473,14 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
 
     case Event(WatchTxConfirmedTriggered(blockHeight, _, tx), d: DATA_CLOSING) =>
       log.info(s"txid=${tx.txid} has reached mindepth, updating closing state")
+      context.system.eventStream.publish(TransactionConfirmed(d.channelId, remoteNodeId, tx))
       // first we check if this tx belongs to one of the current local/remote commits, update it and update the channel data
       val d1 = d.copy(
         localCommitPublished = d.localCommitPublished.map(localCommitPublished => {
           // If the tx is one of our HTLC txs, we now publish a 3rd-stage claim-htlc-tx that claims its output.
           val (localCommitPublished1, claimHtlcTx_opt) = Closing.claimLocalCommitHtlcTxOutput(localCommitPublished, keyManager, d.commitments, tx, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets)
           claimHtlcTx_opt.foreach(claimHtlcTx => {
-            txPublisher ! PublishRawTx(claimHtlcTx, None)
+            txPublisher ! PublishRawTx(claimHtlcTx, claimHtlcTx.fee, None)
             blockchain ! WatchTxConfirmed(self, claimHtlcTx.tx.txid, nodeParams.minDepthBlocks)
           })
           Closing.updateLocalCommitPublished(localCommitPublished1, tx)
@@ -1495,7 +1498,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
       val timedOutHtlcs = Closing.isClosingTypeAlreadyKnown(d1) match {
         case Some(c: Closing.LocalClose) => Closing.timedOutHtlcs(d.commitments.commitmentFormat, c.localCommit, c.localCommitPublished, d.commitments.localParams.dustLimit, tx)
         case Some(c: Closing.RemoteClose) => Closing.timedOutHtlcs(d.commitments.commitmentFormat, c.remoteCommit, c.remoteCommitPublished, d.commitments.remoteParams.dustLimit, tx)
-        case _ => Set.empty[UpdateAddHtlc] // we lose htlc outputs in dataloss protection scenarii (future remote commit)
+        case _ => Set.empty[UpdateAddHtlc] // we lose htlc outputs in dataloss protection scenarios (future remote commit)
       }
       timedOutHtlcs.foreach { add =>
         d.commitments.originChannels.get(add.id) match {
@@ -1504,7 +1507,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
             relayer ! RES_ADD_SETTLED(origin, add, HtlcResult.OnChainFail(HtlcsTimedoutDownstream(d.channelId, Set(add))))
           case None =>
             // same as for fulfilling the htlc (no big deal)
-            log.info(s"cannot fail timedout htlc #${add.id} paymentHash=${add.paymentHash} (origin not found)")
+            log.info(s"cannot fail timed out htlc #${add.id} paymentHash=${add.paymentHash} (origin not found)")
         }
       }
       // we also need to fail outgoing htlcs that we know will never reach the blockchain
@@ -1523,9 +1526,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
         .onChainOutgoingHtlcs(d.commitments.localCommit, d.commitments.remoteCommit, d.commitments.remoteNextCommitInfo.left.toOption.map(_.nextRemoteCommit), tx)
         .map(add => (add, d.commitments.originChannels.get(add.id).collect { case o: Origin.Local => o.id })) // we resolve the payment id if this was a local payment
         .collect { case (add, Some(id)) => context.system.eventStream.publish(PaymentSettlingOnChain(id, amount = add.amountMsat, add.paymentHash)) }
-      // and we also send events related to fee
-      Closing.networkFeePaid(tx, d1) foreach { case (fee, desc) => feePaid(fee, tx, desc, d.channelId) }
-      // then let's see if any of the possible close scenarii can be considered done
+      // then let's see if any of the possible close scenarios can be considered done
       val closingType_opt = Closing.isClosed(d1, Some(tx))
       // finally, if one of the unilateral closes is done, we move to CLOSED state, otherwise we stay() (note that we don't store the state)
       closingType_opt match {
@@ -2143,11 +2144,11 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
       case Some(_) => () // the funding tx exists, nothing to do
       case None =>
         fundingTx_opt match {
-          // ORDER MATTERS!!
           case Some(fundingTx) =>
             // if we are funder, we never give up
+            // we cannot correctly set the fee, but it was correctly set when we initially published the transaction
             log.info(s"republishing the funding tx...")
-            txPublisher ! PublishRawTx(fundingTx, fundingTx.txIn.head.outPoint, "funding-tx", None)
+            txPublisher ! PublishRawTx(fundingTx, fundingTx.txIn.head.outPoint, "funding", 0 sat, None)
             // we also check if the funding tx has been double-spent
             checkDoubleSpent(fundingTx)
             context.system.scheduler.scheduleOnce(1 day, blockchain.toClassic, GetTxWithMeta(self, txid))
@@ -2315,11 +2316,13 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
       case Left(negotiating) => DATA_CLOSING(negotiating.commitments, fundingTx = None, waitingSinceBlock = nodeParams.currentBlockHeight, negotiating.closingTxProposed.flatten.map(_.unsignedTx), mutualClosePublished = closingTx :: Nil)
       case Right(closing) => closing.copy(mutualClosePublished = closing.mutualClosePublished :+ closingTx)
     }
-    goto(CLOSING) using nextData storing() calling doPublish(closingTx)
+    goto(CLOSING) using nextData storing() calling doPublish(closingTx, nextData.commitments.localParams.isFunder)
   }
 
-  private def doPublish(closingTx: ClosingTx): Unit = {
-    txPublisher ! PublishRawTx(closingTx, None)
+  private def doPublish(closingTx: ClosingTx, isFunder: Boolean): Unit = {
+    // the funder pays the fee
+    val fee = if (isFunder) closingTx.fee else 0.sat
+    txPublisher ! PublishRawTx(closingTx, fee, None)
     blockchain ! WatchTxConfirmed(self, closingTx.tx.txid, nodeParams.minDepthBlocks)
   }
 
@@ -2382,14 +2385,15 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
     import localCommitPublished._
 
     val commitInput = commitments.commitInput.outPoint
+    val isFunder = commitments.localParams.isFunder
     val publishQueue = commitments.commitmentFormat match {
       case Transactions.DefaultCommitmentFormat =>
-        val redeemableHtlcTxs = htlcTxs.values.flatten.map(tx => PublishRawTx(tx, Some(commitTx.txid)))
-        List(PublishRawTx(commitTx, commitInput, "commit-tx", None)) ++ (claimMainDelayedOutputTx.map(tx => PublishRawTx(tx, None)) ++ redeemableHtlcTxs ++ claimHtlcDelayedTxs.map(tx => PublishRawTx(tx, None)))
+        val redeemableHtlcTxs = htlcTxs.values.flatten.map(tx => PublishRawTx(tx, tx.fee, Some(commitTx.txid)))
+        List(PublishRawTx(commitTx, commitInput, "commit-tx", Closing.commitTxFee(commitments.commitInput, commitTx, isFunder), None)) ++ (claimMainDelayedOutputTx.map(tx => PublishRawTx(tx, tx.fee, None)) ++ redeemableHtlcTxs ++ claimHtlcDelayedTxs.map(tx => PublishRawTx(tx, tx.fee, None)))
       case _: Transactions.AnchorOutputsCommitmentFormat =>
         val claimLocalAnchor = claimAnchorTxs.collect { case tx: Transactions.ClaimLocalAnchorOutputTx => PublishReplaceableTx(tx, commitments) }
         val redeemableHtlcTxs = htlcTxs.values.collect { case Some(tx) => PublishReplaceableTx(tx, commitments) }
-        List(PublishRawTx(commitTx, commitInput, "commit-tx", None)) ++ claimLocalAnchor ++ claimMainDelayedOutputTx.map(tx => PublishRawTx(tx, None)) ++ redeemableHtlcTxs ++ claimHtlcDelayedTxs.map(tx => PublishRawTx(tx, None))
+        List(PublishRawTx(commitTx, commitInput, "commit-tx", Closing.commitTxFee(commitments.commitInput, commitTx, isFunder), None)) ++ claimLocalAnchor ++ claimMainDelayedOutputTx.map(tx => PublishRawTx(tx, tx.fee, None)) ++ redeemableHtlcTxs ++ claimHtlcDelayedTxs.map(tx => PublishRawTx(tx, tx.fee, None))
     }
     publishIfNeeded(publishQueue, irrevocablySpent)
 
@@ -2400,7 +2404,9 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
     watchConfirmedIfNeeded(watchConfirmedQueue, irrevocablySpent)
 
     // we watch outputs of the commitment tx that both parties may spend
-    val watchSpentQueue = htlcTxs.keys
+    // we also watch our local anchor: this ensures that we will correctly detect when it's confirmed and count its fees
+    // in the audit DB, even if we restart before confirmation
+    val watchSpentQueue = htlcTxs.keys ++ claimAnchorTxs.collect { case tx: Transactions.ClaimLocalAnchorOutputTx => tx.input.outPoint }
     watchSpentIfNeeded(commitTx, watchSpentQueue, irrevocablySpent)
   }
 
@@ -2408,6 +2414,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
     log.warning(s"they published their current commit in txid=${commitTx.txid}")
     require(commitTx.txid == d.commitments.remoteCommit.txid, "txid mismatch")
 
+    context.system.eventStream.publish(TransactionPublished(d.channelId, remoteNodeId, commitTx, Closing.commitTxFee(d.commitments.commitInput, commitTx, d.commitments.localParams.isFunder), "remote-commit"))
     val remoteCommitPublished = Helpers.Closing.claimRemoteCommitTxOutputs(keyManager, d.commitments, d.commitments.remoteCommit, commitTx, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets)
     val nextData = d match {
       case closing: DATA_CLOSING => closing.copy(remoteCommitPublished = Some(remoteCommitPublished))
@@ -2420,6 +2427,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
 
   private def handleRemoteSpentFuture(commitTx: Transaction, d: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) = {
     log.warning(s"they published their future commit (because we asked them to) in txid=${commitTx.txid}")
+    context.system.eventStream.publish(TransactionPublished(d.channelId, remoteNodeId, commitTx, Closing.commitTxFee(d.commitments.commitInput, commitTx, d.commitments.localParams.isFunder), "future-remote-commit"))
     d.commitments.channelFeatures match {
       case ct if ct.paysDirectlyToWallet =>
         val remoteCommitPublished = RemoteCommitPublished(commitTx, None, Map.empty, List.empty, Map.empty)
@@ -2440,6 +2448,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
     val remoteCommit = waitingForRevocation.nextRemoteCommit
     require(commitTx.txid == remoteCommit.txid, "txid mismatch")
 
+    context.system.eventStream.publish(TransactionPublished(d.channelId, remoteNodeId, commitTx, Closing.commitTxFee(d.commitments.commitInput, commitTx, d.commitments.localParams.isFunder), "next-remote-commit"))
     val remoteCommitPublished = Helpers.Closing.claimRemoteCommitTxOutputs(keyManager, d.commitments, remoteCommit, commitTx, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets)
     val nextData = d match {
       case closing: DATA_CLOSING => closing.copy(nextRemoteCommitPublished = Some(remoteCommitPublished))
@@ -2453,7 +2462,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
   private def doPublish(remoteCommitPublished: RemoteCommitPublished): Unit = {
     import remoteCommitPublished._
 
-    val publishQueue = (claimMainOutputTx ++ claimHtlcTxs.values.flatten).map(tx => PublishRawTx(tx, None))
+    val publishQueue = (claimMainOutputTx ++ claimHtlcTxs.values.flatten).map(tx => PublishRawTx(tx, tx.fee, None))
     publishIfNeeded(publishQueue, irrevocablySpent)
 
     // we watch:
@@ -2472,6 +2481,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
     Helpers.Closing.claimRevokedRemoteCommitTxOutputs(keyManager, d.commitments, tx, nodeParams.db.channels, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets) match {
       case Some(revokedCommitPublished) =>
         log.warning(s"txid=${tx.txid} was a revoked commitment, publishing the penalty tx")
+        context.system.eventStream.publish(TransactionPublished(d.channelId, remoteNodeId, tx, Closing.commitTxFee(d.commitments.commitInput, tx, d.commitments.localParams.isFunder), "revoked-commit"))
         val exc = FundingTxSpent(d.channelId, tx)
         val error = Error(d.channelId, exc.getMessage)
 
@@ -2492,7 +2502,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
   private def doPublish(revokedCommitPublished: RevokedCommitPublished): Unit = {
     import revokedCommitPublished._
 
-    val publishQueue = (claimMainOutputTx ++ mainPenaltyTx ++ htlcPenaltyTxs ++ claimHtlcDelayedPenaltyTxs).map(tx => PublishRawTx(tx, None))
+    val publishQueue = (claimMainOutputTx ++ mainPenaltyTx ++ htlcPenaltyTxs ++ claimHtlcDelayedPenaltyTxs).map(tx => PublishRawTx(tx, tx.fee, None))
     publishIfNeeded(publishQueue, irrevocablySpent)
 
     // we watch:
@@ -2607,11 +2617,6 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
           sys.exit(-2)
         case t: Throwable => handleLocalError(t, event.stateData, None)
       }
-  }
-
-  private def feePaid(fee: Satoshi, tx: Transaction, desc: String, channelId: ByteVector32): Unit = Try { // this may fail with an NPE in tests because context has been cleaned up, but it's not a big deal
-    log.info(s"paid feeSatoshi=${fee.toLong} for txid=${tx.txid} desc=$desc")
-    context.system.eventStream.publish(NetworkFeePaid(self, remoteNodeId, channelId, tx, fee, desc))
   }
 
   implicit private def state2mystate(state: FSM.State[ChannelState, ChannelData]): MyState = MyState(state)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -61,7 +61,7 @@ case class ChannelSignatureReceived(channel: ActorRef, commitments: Commitments)
 case class ChannelErrorOccurred(channel: ActorRef, channelId: ByteVector32, remoteNodeId: PublicKey, data: ChannelData, error: ChannelOpenError, isFatal: Boolean) extends ChannelEvent
 
 // NB: the fee should be set to 0 when we're not paying it.
-case class TransactionPublished(channelId: ByteVector32, remoteNodeId: PublicKey, tx: Transaction, fee: Satoshi, desc: String) extends ChannelEvent
+case class TransactionPublished(channelId: ByteVector32, remoteNodeId: PublicKey, tx: Transaction, miningFee: Satoshi, desc: String) extends ChannelEvent
 
 case class TransactionConfirmed(channelId: ByteVector32, remoteNodeId: PublicKey, tx: Transaction) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -60,9 +60,12 @@ case class ChannelSignatureReceived(channel: ActorRef, commitments: Commitments)
 
 case class ChannelErrorOccurred(channel: ActorRef, channelId: ByteVector32, remoteNodeId: PublicKey, data: ChannelData, error: ChannelOpenError, isFatal: Boolean) extends ChannelEvent
 
-case class NetworkFeePaid(channel: ActorRef, remoteNodeId: PublicKey, channelId: ByteVector32, tx: Transaction, fee: Satoshi, txType: String) extends ChannelEvent
+// NB: the fee should be set to 0 when we're not paying it.
+case class TransactionPublished(channelId: ByteVector32, remoteNodeId: PublicKey, tx: Transaction, fee: Satoshi, desc: String) extends ChannelEvent
 
-// NB: this event is only sent when the channel is available
+case class TransactionConfirmed(channelId: ByteVector32, remoteNodeId: PublicKey, tx: Transaction) extends ChannelEvent
+
+// NB: this event is only sent when the channel is available.
 case class AvailableBalanceChanged(channel: ActorRef, channelId: ByteVector32, shortChannelId: ShortChannelId, commitments: AbstractCommitments) extends ChannelEvent
 
 case class ChannelPersisted(channel: ActorRef, remoteNodeId: PublicKey, channelId: ByteVector32, data: HasCommitments) extends ChannelEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -36,8 +36,8 @@ import fr.acinq.eclair.transactions._
 import fr.acinq.eclair.wire.protocol._
 import scodec.bits.ByteVector
 
-import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -565,6 +565,13 @@ object Helpers {
       }
     }
 
+    /** Compute the fee paid by a commitment transaction. */
+    def commitTxFee(commitInput: InputInfo, commitTx: Transaction, isFunder: Boolean): Satoshi = {
+      require(commitTx.txIn.size == 1, "transaction must have only one input")
+      require(commitTx.txIn.exists(txIn => txIn.outPoint == commitInput.outPoint), "transaction must spend the funding output")
+      if (isFunder) commitInput.txOut.amount - commitTx.txOut.map(_.amount).sum else 0 sat
+    }
+
     /**
      * Claim all the HTLCs that we've received from our current commit tx. This will be done using 2nd stage HTLC transactions.
      *
@@ -668,18 +675,17 @@ object Helpers {
      * @return a list of transactions (one per output of the commit tx that we can claim)
      */
     def claimRemoteCommitTxOutputs(keyManager: ChannelKeyManager, commitments: Commitments, remoteCommit: RemoteCommit, tx: Transaction, feeEstimator: FeeEstimator, feeTargets: FeeTargets)(implicit log: LoggingAdapter): RemoteCommitPublished = {
-      import commitments.{channelConfig, channelFeatures, commitInput, localParams, remoteParams}
       require(remoteCommit.txid == tx.txid, "txid mismatch, provided tx is not the current remote commit tx")
-      val (remoteCommitTx, _) = Commitments.makeRemoteTxs(keyManager, channelConfig, channelFeatures, remoteCommit.index, localParams, remoteParams, commitInput, remoteCommit.remotePerCommitmentPoint, remoteCommit.spec)
+      val (remoteCommitTx, _) = Commitments.makeRemoteTxs(keyManager, commitments.channelConfig, commitments.channelFeatures, remoteCommit.index, commitments.localParams, commitments.remoteParams, commitments.commitInput, remoteCommit.remotePerCommitmentPoint, remoteCommit.spec)
       require(remoteCommitTx.tx.txid == tx.txid, "txid mismatch, cannot recompute the current remote commit tx")
-      val channelKeyPath = keyManager.keyPath(localParams, channelConfig)
-      val localFundingPubkey = keyManager.fundingPublicKey(localParams.fundingKeyPath).publicKey
+      val channelKeyPath = keyManager.keyPath(commitments.localParams, commitments.channelConfig)
+      val localFundingPubkey = keyManager.fundingPublicKey(commitments.localParams.fundingKeyPath).publicKey
       val localHtlcPubkey = Generators.derivePubKey(keyManager.htlcPoint(channelKeyPath).publicKey, remoteCommit.remotePerCommitmentPoint)
-      val remoteHtlcPubkey = Generators.derivePubKey(remoteParams.htlcBasepoint, remoteCommit.remotePerCommitmentPoint)
+      val remoteHtlcPubkey = Generators.derivePubKey(commitments.remoteParams.htlcBasepoint, remoteCommit.remotePerCommitmentPoint)
       val remoteRevocationPubkey = Generators.revocationPubKey(keyManager.revocationPoint(channelKeyPath).publicKey, remoteCommit.remotePerCommitmentPoint)
-      val remoteDelayedPaymentPubkey = Generators.derivePubKey(remoteParams.delayedPaymentBasepoint, remoteCommit.remotePerCommitmentPoint)
+      val remoteDelayedPaymentPubkey = Generators.derivePubKey(commitments.remoteParams.delayedPaymentBasepoint, remoteCommit.remotePerCommitmentPoint)
       val localPaymentPubkey = Generators.derivePubKey(keyManager.paymentPoint(channelKeyPath).publicKey, remoteCommit.remotePerCommitmentPoint)
-      val outputs = makeCommitTxOutputs(!localParams.isFunder, remoteParams.dustLimit, remoteRevocationPubkey, localParams.toSelfDelay, remoteDelayedPaymentPubkey, localPaymentPubkey, remoteHtlcPubkey, localHtlcPubkey, remoteParams.fundingPubKey, localFundingPubkey, remoteCommit.spec, commitments.commitmentFormat)
+      val outputs = makeCommitTxOutputs(!commitments.localParams.isFunder, commitments.remoteParams.dustLimit, remoteRevocationPubkey, commitments.localParams.toSelfDelay, remoteDelayedPaymentPubkey, localPaymentPubkey, remoteHtlcPubkey, localHtlcPubkey, commitments.remoteParams.fundingPubKey, localFundingPubkey, remoteCommit.spec, commitments.commitmentFormat)
 
       // we need to use a rather high fee for htlc-claim because we compete with the counterparty
       val feeratePerKwHtlc = feeEstimator.getFeeratePerKw(target = 2)
@@ -691,7 +697,7 @@ object Helpers {
       val htlcTxs: Map[OutPoint, Option[ClaimHtlcTx]] = remoteCommit.spec.htlcs.collect {
         case OutgoingHtlc(add: UpdateAddHtlc) =>
           generateTx("claim-htlc-success") {
-            Transactions.makeClaimHtlcSuccessTx(remoteCommitTx.tx, outputs, localParams.dustLimit, localHtlcPubkey, remoteHtlcPubkey, remoteRevocationPubkey, localParams.defaultFinalScriptPubKey, add, feeratePerKwHtlc, commitments.commitmentFormat)
+            Transactions.makeClaimHtlcSuccessTx(remoteCommitTx.tx, outputs, commitments.localParams.dustLimit, localHtlcPubkey, remoteHtlcPubkey, remoteRevocationPubkey, commitments.localParams.defaultFinalScriptPubKey, add, feeratePerKwHtlc, commitments.commitmentFormat)
           }.map(claimHtlcTx => {
             if (preimages.contains(add.paymentHash)) {
               // incoming htlc for which we have the preimage: we can spend it immediately
@@ -708,7 +714,7 @@ object Helpers {
         case IncomingHtlc(add: UpdateAddHtlc) =>
           // outgoing htlc: they may or may not have the preimage, the only thing to do is try to get back our funds after timeout
           generateTx("claim-htlc-timeout") {
-            Transactions.makeClaimHtlcTimeoutTx(remoteCommitTx.tx, outputs, localParams.dustLimit, localHtlcPubkey, remoteHtlcPubkey, remoteRevocationPubkey, localParams.defaultFinalScriptPubKey, add, feeratePerKwHtlc, commitments.commitmentFormat)
+            Transactions.makeClaimHtlcTimeoutTx(remoteCommitTx.tx, outputs, commitments.localParams.dustLimit, localHtlcPubkey, remoteHtlcPubkey, remoteRevocationPubkey, commitments.localParams.defaultFinalScriptPubKey, add, feeratePerKwHtlc, commitments.commitmentFormat)
           }.map(claimHtlcTx => {
             claimHtlcTx.input.outPoint -> generateTx("claim-htlc-timeout") {
               val sig = keyManager.sign(claimHtlcTx, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint, TxOwner.Local, commitments.commitmentFormat)
@@ -726,7 +732,7 @@ object Helpers {
         }
       ).flatten
 
-      if (channelFeatures.paysDirectlyToWallet) {
+      if (commitments.channelFeatures.paysDirectlyToWallet) {
         RemoteCommitPublished(
           commitTx = tx,
           claimMainOutputTx = None,
@@ -1255,64 +1261,6 @@ object Helpers {
       irrevocablySpent.contains(input)
     }
 
-    /**
-     * This helper function returns the fee paid by the given transaction.
-     * It relies on the current channel data to find the parent tx and compute the fee, and also provides a description.
-     *
-     * @param tx a tx for which we want to compute the fee
-     * @param d  current channel data
-     * @return if the parent tx is found, a tuple (fee, description)
-     */
-    def networkFeePaid(tx: Transaction, d: DATA_CLOSING): Option[(Satoshi, String)] = {
-      val isCommitTx = tx.txIn.map(_.outPoint).contains(d.commitments.commitInput.outPoint)
-      // only the funder pays the fee for the commit tx, but 2nd-stage and 3rd-stage tx fees are paid by their recipients
-      // we can compute the fees only for transactions with a single parent for which we know the output amount
-      if (tx.txIn.size == 1 && (d.commitments.localParams.isFunder || !isCommitTx)) {
-        // we build a map with all known txs (that's not particularly efficient, but it doesn't really matter)
-        val txs: Map[ByteVector32, (Transaction, String)] = (
-          d.mutualClosePublished.map(_.tx -> "mutual") ++
-            d.localCommitPublished.map(_.commitTx).map(_ -> "local-commit").toSeq ++
-            d.localCommitPublished.flatMap(_.claimMainDelayedOutputTx).map(_.tx -> "local-main-delayed") ++
-            d.localCommitPublished.toSeq.flatMap(_.htlcTxs.values).flatten.map {
-              case htlcTx: HtlcSuccessTx => htlcTx.tx -> "local-htlc-success"
-              case htlcTx: HtlcTimeoutTx => htlcTx.tx -> "local-htlc-timeout"
-            } ++
-            d.localCommitPublished.toSeq.flatMap(_.claimHtlcDelayedTxs).map(_.tx -> "local-htlc-delayed") ++
-            d.remoteCommitPublished.map(_.commitTx).map(_ -> "remote-commit") ++
-            d.remoteCommitPublished.toSeq.flatMap(_.claimMainOutputTx).map(_.tx -> "remote-main") ++
-            d.remoteCommitPublished.toSeq.flatMap(_.claimHtlcTxs.values).flatten.map {
-              case htlcTx: ClaimHtlcSuccessTx => htlcTx.tx -> "remote-htlc-success"
-              case htlcTx: ClaimHtlcTimeoutTx => htlcTx.tx -> "remote-htlc-timeout"
-            } ++
-            d.nextRemoteCommitPublished.map(_.commitTx).map(_ -> "remote-commit") ++
-            d.nextRemoteCommitPublished.toSeq.flatMap(_.claimMainOutputTx).map(_.tx -> "remote-main") ++
-            d.nextRemoteCommitPublished.toSeq.flatMap(_.claimHtlcTxs.values).flatten.map {
-              case htlcTx: ClaimHtlcSuccessTx => htlcTx.tx -> "remote-htlc-success"
-              case htlcTx: ClaimHtlcTimeoutTx => htlcTx.tx -> "remote-htlc-timeout"
-            } ++
-            d.revokedCommitPublished.map(_.commitTx).map(_ -> "revoked-commit") ++
-            d.revokedCommitPublished.flatMap(_.claimMainOutputTx).map(_.tx -> "revoked-main") ++
-            d.revokedCommitPublished.flatMap(_.mainPenaltyTx).map(_.tx -> "revoked-main-penalty") ++
-            d.revokedCommitPublished.flatMap(_.htlcPenaltyTxs).map(_.tx -> "revoked-htlc-penalty") ++
-            d.revokedCommitPublished.flatMap(_.claimHtlcDelayedPenaltyTxs).map(_.tx -> "revoked-htlc-penalty-delayed")
-          )
-          .map { case (tx, desc) => tx.txid -> (tx, desc) } // will allow easy lookup of parent transaction
-          .toMap
-
-        txs.get(tx.txid).flatMap {
-          case (_, desc) =>
-            val parentTxOut_opt = if (isCommitTx) {
-              Some(d.commitments.commitInput.txOut)
-            } else {
-              val outPoint = tx.txIn.head.outPoint
-              txs.get(outPoint.txid).map { case (parent, _) => parent.txOut(outPoint.index.toInt) }
-            }
-            parentTxOut_opt.map(parentTxOut => parentTxOut.amount - tx.txOut.map(_.amount).sum).map(_ -> desc)
-        }
-      } else {
-        None
-      }
-    }
   }
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/RawTxPublisher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/RawTxPublisher.scala
@@ -119,7 +119,7 @@ private class RawTxPublisher(nodeParams: NodeParams,
 
   def publish(replyTo: ActorRef[TxPublisher.PublishTxResult], cmd: TxPublisher.PublishRawTx): Behavior[Command] = {
     val txMonitor = context.spawn(MempoolTxMonitor(nodeParams, bitcoinClient, loggingInfo), "mempool-tx-monitor")
-    txMonitor ! MempoolTxMonitor.Publish(context.messageAdapter[MempoolTxMonitor.TxResult](WrappedTxResult), cmd.tx, cmd.input)
+    txMonitor ! MempoolTxMonitor.Publish(context.messageAdapter[MempoolTxMonitor.TxResult](WrappedTxResult), cmd.tx, cmd.input, cmd.desc, cmd.fee)
     Behaviors.receiveMessagePartial {
       case WrappedTxResult(MempoolTxMonitor.TxConfirmed) => sendResult(replyTo, TxPublisher.TxConfirmed(cmd, cmd.tx))
       case WrappedTxResult(MempoolTxMonitor.TxRejected(reason)) => sendResult(replyTo, TxPublisher.TxRejected(loggingInfo.id, cmd, reason))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/TxPublisher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/TxPublisher.scala
@@ -20,7 +20,7 @@ import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
 import akka.actor.typed.{ActorRef, Behavior}
 import fr.acinq.bitcoin.Crypto.PublicKey
-import fr.acinq.bitcoin.{ByteVector32, OutPoint, Transaction}
+import fr.acinq.bitcoin.{ByteVector32, OutPoint, Satoshi, Transaction}
 import fr.acinq.eclair.blockchain.CurrentBlockCount
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
@@ -81,9 +81,9 @@ object TxPublisher {
    * NB: the parent tx should only be provided when it's being concurrently published, it's unnecessary when it is
    * confirmed or when the tx has a relative delay.
    */
-  case class PublishRawTx(tx: Transaction, input: OutPoint, desc: String, parentTx_opt: Option[ByteVector32]) extends PublishTx
+  case class PublishRawTx(tx: Transaction, input: OutPoint, desc: String, fee: Satoshi, parentTx_opt: Option[ByteVector32]) extends PublishTx
   object PublishRawTx {
-    def apply(txInfo: TransactionWithInputInfo, parentTx_opt: Option[ByteVector32]): PublishRawTx = PublishRawTx(txInfo.tx, txInfo.input.outPoint, txInfo.desc, parentTx_opt)
+    def apply(txInfo: TransactionWithInputInfo, fee: Satoshi, parentTx_opt: Option[ByteVector32]): PublishRawTx = PublishRawTx(txInfo.tx, txInfo.input.outPoint, txInfo.desc, fee, parentTx_opt)
   }
   /** Publish an unsigned transaction that can be RBF-ed. */
   case class PublishReplaceableTx(txInfo: ReplaceableTransactionWithInputInfo, commitments: Commitments) extends PublishTx {
@@ -91,9 +91,7 @@ object TxPublisher {
     override def desc: String = txInfo.desc
   }
 
-  sealed trait PublishTxResult extends Command {
-    def cmd: PublishTx
-  }
+  sealed trait PublishTxResult extends Command { def cmd: PublishTx }
   /**
    * The requested transaction has been confirmed.
    *

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -35,7 +35,9 @@ trait AuditDb extends Closeable {
 
   def add(paymentRelayed: PaymentRelayed): Unit
 
-  def add(networkFeePaid: NetworkFeePaid): Unit
+  def add(txPublished: TransactionPublished): Unit
+
+  def add(txConfirmed: TransactionConfirmed): Unit
 
   def add(channelErrorOccurred: ChannelErrorOccurred): Unit
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DbEventHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DbEventHandler.scala
@@ -85,7 +85,7 @@ class DbEventHandler(nodeParams: NodeParams) extends Actor with DiagnosticActorL
       auditDb.add(e)
 
     case e: TransactionPublished =>
-      log.info(s"paying fee=${e.fee} for txid=${e.tx.txid} desc=${e.desc}")
+      log.info(s"paying mining fee=${e.miningFee} for txid=${e.tx.txid} desc=${e.desc}")
       auditDb.add(e)
 
     case e: TransactionConfirmed => auditDb.add(e)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DualDatabases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DualDatabases.scala
@@ -151,9 +151,14 @@ case class DualAuditDb(sqlite: SqliteAuditDb, postgres: PgAuditDb) extends Audit
     sqlite.add(paymentRelayed)
   }
 
-  override def add(networkFeePaid: NetworkFeePaid): Unit = {
-    runAsync(postgres.add(networkFeePaid))
-    sqlite.add(networkFeePaid)
+  override def add(txPublished: TransactionPublished): Unit = {
+    runAsync(postgres.add(txPublished))
+    sqlite.add(txPublished)
+  }
+
+  override def add(txConfirmed: TransactionConfirmed): Unit = {
+    runAsync(postgres.add(txConfirmed))
+    sqlite.add(txConfirmed)
   }
 
   override def add(channelErrorOccurred: ChannelErrorOccurred): Unit = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -92,13 +92,13 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
       }
 
       def migration910(statement: Statement): Unit = {
-        statement.executeUpdate("CREATE TABLE audit.transaction_published (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
-        statement.executeUpdate("CREATE TABLE audit.transaction_confirmed (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
-        statement.executeUpdate("CREATE INDEX transaction_published_timestamp_idx ON audit.transaction_published(timestamp)")
-        statement.executeUpdate("CREATE INDEX transaction_confirmed_timestamp_idx ON audit.transaction_confirmed(timestamp)")
+        statement.executeUpdate("CREATE TABLE audit.transactions_published (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+        statement.executeUpdate("CREATE TABLE audit.transactions_confirmed (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+        statement.executeUpdate("CREATE INDEX transactions_published_timestamp_idx ON audit.transactions_published(timestamp)")
+        statement.executeUpdate("CREATE INDEX transactions_confirmed_timestamp_idx ON audit.transactions_confirmed(timestamp)")
         // Migrate data from the network_fees table (which only stored data about confirmed transactions).
-        statement.executeUpdate("INSERT INTO audit.transaction_published (tx_id, channel_id, node_id, fee_sat, tx_type, timestamp) SELECT tx_id, channel_id, node_id, fee_sat, tx_type, timestamp FROM audit.network_fees ON CONFLICT DO NOTHING")
-        statement.executeUpdate("INSERT INTO audit.transaction_confirmed (tx_id, channel_id, node_id, timestamp) SELECT tx_id, channel_id, node_id, timestamp FROM audit.network_fees ON CONFLICT DO NOTHING")
+        statement.executeUpdate("INSERT INTO audit.transactions_published (tx_id, channel_id, node_id, fee_sat, tx_type, timestamp) SELECT tx_id, channel_id, node_id, fee_sat, tx_type, timestamp FROM audit.network_fees ON CONFLICT DO NOTHING")
+        statement.executeUpdate("INSERT INTO audit.transactions_confirmed (tx_id, channel_id, node_id, timestamp) SELECT tx_id, channel_id, node_id, timestamp FROM audit.network_fees ON CONFLICT DO NOTHING")
         statement.executeUpdate("DROP TABLE audit.network_fees")
       }
 
@@ -113,8 +113,8 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE TABLE audit.channel_events (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, capacity_sat BIGINT NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_updates (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_base_msat BIGINT NOT NULL, fee_proportional_millionths BIGINT NOT NULL, cltv_expiry_delta BIGINT NOT NULL, htlc_minimum_msat BIGINT NOT NULL, htlc_maximum_msat BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, status TEXT NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, is_mpp BOOLEAN NOT NULL, experiment_name TEXT NOT NULL, recipient_node_id TEXT NOT NULL)")
-          statement.executeUpdate("CREATE TABLE audit.transaction_published (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
-          statement.executeUpdate("CREATE TABLE audit.transaction_confirmed (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+          statement.executeUpdate("CREATE TABLE audit.transactions_published (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+          statement.executeUpdate("CREATE TABLE audit.transactions_confirmed (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
 
           statement.executeUpdate("CREATE TABLE audit.channel_errors (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal BOOLEAN NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON audit.sent(timestamp)")
@@ -132,8 +132,8 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.path_finding_metrics(timestamp)")
           statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON audit.path_finding_metrics(is_mpp)")
           statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
-          statement.executeUpdate("CREATE INDEX transaction_published_timestamp_idx ON audit.transaction_published(timestamp)")
-          statement.executeUpdate("CREATE INDEX transaction_confirmed_timestamp_idx ON audit.transaction_confirmed(timestamp)")
+          statement.executeUpdate("CREATE INDEX transactions_published_timestamp_idx ON audit.transactions_published(timestamp)")
+          statement.executeUpdate("CREATE INDEX transactions_confirmed_timestamp_idx ON audit.transactions_confirmed(timestamp)")
         case Some(v@(4 | 5 | 6 | 7 | 8 | 9)) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
           if (v < 5) {
@@ -245,7 +245,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
 
   override def add(e: TransactionPublished): Unit = withMetrics("audit/add-transaction-published", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("INSERT INTO audit.transaction_published VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING")) { statement =>
+      using(pg.prepareStatement("INSERT INTO audit.transactions_published VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING")) { statement =>
         statement.setString(1, e.tx.txid.toHex)
         statement.setString(2, e.channelId.toHex)
         statement.setString(3, e.remoteNodeId.value.toHex)
@@ -259,7 +259,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
 
   override def add(e: TransactionConfirmed): Unit = withMetrics("audit/add-transaction-confirmed", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("INSERT INTO audit.transaction_confirmed VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING")) { statement =>
+      using(pg.prepareStatement("INSERT INTO audit.transactions_confirmed VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING")) { statement =>
         statement.setString(1, e.tx.txid.toHex)
         statement.setString(2, e.channelId.toHex)
         statement.setString(3, e.remoteNodeId.value.toHex)
@@ -418,7 +418,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
 
   override def listNetworkFees(from: Long, to: Long): Seq[NetworkFee] =
     inTransaction { pg =>
-      using(pg.prepareStatement("SELECT * FROM audit.transaction_confirmed INNER JOIN audit.transaction_published ON audit.transaction_published.tx_id = audit.transaction_confirmed.tx_id  WHERE audit.transaction_confirmed.timestamp BETWEEN ? and ? ORDER BY audit.transaction_confirmed.timestamp")) { statement =>
+      using(pg.prepareStatement("SELECT * FROM audit.transactions_confirmed INNER JOIN audit.transactions_published ON audit.transactions_published.tx_id = audit.transactions_confirmed.tx_id  WHERE audit.transactions_confirmed.timestamp BETWEEN ? and ? ORDER BY audit.transactions_confirmed.timestamp")) { statement =>
         statement.setTimestamp(1, Timestamp.from(Instant.ofEpochMilli(from)))
         statement.setTimestamp(2, Timestamp.from(Instant.ofEpochMilli(to)))
         statement.executeQuery().map { rs =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgAuditDb.scala
@@ -28,7 +28,6 @@ import fr.acinq.eclair.payment._
 import fr.acinq.eclair.transactions.Transactions.PlaceHolderPubKey
 import fr.acinq.eclair.{MilliSatoshi, MilliSatoshiLong}
 import grizzled.slf4j.Logging
-import org.postgresql.util.PGInterval
 
 import java.sql.{Statement, Timestamp}
 import java.time.Instant
@@ -37,7 +36,7 @@ import javax.sql.DataSource
 
 object PgAuditDb {
   val DB_NAME = "audit"
-  val CURRENT_VERSION = 9
+  val CURRENT_VERSION = 10
 }
 
 class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
@@ -92,6 +91,13 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
         statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
       }
 
+      def migration910(statement: Statement): Unit = {
+        statement.executeUpdate("CREATE TABLE audit.transaction_published (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+        statement.executeUpdate("CREATE TABLE audit.transaction_confirmed (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+        statement.executeUpdate("CREATE INDEX transaction_published_timestamp_idx ON audit.transaction_published(timestamp)")
+        statement.executeUpdate("CREATE INDEX transaction_confirmed_timestamp_idx ON audit.transaction_confirmed(timestamp)")
+      }
+
       getVersion(statement, DB_NAME) match {
         case None =>
           statement.executeUpdate("CREATE SCHEMA audit")
@@ -100,10 +106,11 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE TABLE audit.received (amount_msat BIGINT NOT NULL, payment_hash TEXT NOT NULL, from_channel_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.relayed (payment_hash TEXT NOT NULL, amount_msat BIGINT NOT NULL, channel_id TEXT NOT NULL, direction TEXT NOT NULL, relay_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.relayed_trampoline (payment_hash TEXT NOT NULL, amount_msat BIGINT NOT NULL, next_node_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
-          statement.executeUpdate("CREATE TABLE audit.network_fees (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, tx_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_events (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, capacity_sat BIGINT NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.channel_updates (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_base_msat BIGINT NOT NULL, fee_proportional_millionths BIGINT NOT NULL, cltv_expiry_delta BIGINT NOT NULL, htlc_minimum_msat BIGINT NOT NULL, htlc_maximum_msat BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, status TEXT NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, is_mpp BOOLEAN NOT NULL, experiment_name TEXT NOT NULL, recipient_node_id TEXT NOT NULL)")
+          statement.executeUpdate("CREATE TABLE audit.transaction_published (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+          statement.executeUpdate("CREATE TABLE audit.transaction_confirmed (tx_id TEXT NOT NULL PRIMARY KEY, channel_id TEXT NOT NULL, node_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
 
           statement.executeUpdate("CREATE TABLE audit.channel_errors (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal BOOLEAN NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
           statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON audit.sent(timestamp)")
@@ -112,7 +119,6 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE INDEX relayed_payment_hash_idx ON audit.relayed(payment_hash)")
           statement.executeUpdate("CREATE INDEX relayed_trampoline_timestamp_idx ON audit.relayed_trampoline(timestamp)")
           statement.executeUpdate("CREATE INDEX relayed_trampoline_payment_hash_idx ON audit.relayed_trampoline(payment_hash)")
-          statement.executeUpdate("CREATE INDEX network_fees_timestamp_idx ON audit.network_fees(timestamp)")
           statement.executeUpdate("CREATE INDEX channel_events_timestamp_idx ON audit.channel_events(timestamp)")
           statement.executeUpdate("CREATE INDEX channel_errors_timestamp_idx ON audit.channel_errors(timestamp)")
           statement.executeUpdate("CREATE INDEX channel_updates_cid_idx ON audit.channel_updates(channel_id)")
@@ -122,7 +128,9 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.path_finding_metrics(timestamp)")
           statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON audit.path_finding_metrics(is_mpp)")
           statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
-        case Some(v@(4 | 5 | 6 | 7 | 8)) =>
+          statement.executeUpdate("CREATE INDEX transaction_published_timestamp_idx ON audit.transaction_published(timestamp)")
+          statement.executeUpdate("CREATE INDEX transaction_confirmed_timestamp_idx ON audit.transaction_confirmed(timestamp)")
+        case Some(v@(4 | 5 | 6 | 7 | 8 | 9)) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
           if (v < 5) {
             migration45(statement)
@@ -138,6 +146,9 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
           }
           if (v < 9) {
             migration89(statement)
+          }
+          if (v < 10) {
+            migration910(statement)
           }
         case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
@@ -228,15 +239,27 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
     }
   }
 
-  override def add(e: NetworkFeePaid): Unit = withMetrics("audit/add-network-fee", DbBackends.Postgres) {
+  override def add(e: TransactionPublished): Unit = withMetrics("audit/add-transaction-published", DbBackends.Postgres) {
     inTransaction { pg =>
-      using(pg.prepareStatement("INSERT INTO audit.network_fees VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
-        statement.setString(1, e.channelId.toHex)
-        statement.setString(2, e.remoteNodeId.value.toHex)
-        statement.setString(3, e.tx.txid.toHex)
+      using(pg.prepareStatement("INSERT INTO audit.transaction_published VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING")) { statement =>
+        statement.setString(1, e.tx.txid.toHex)
+        statement.setString(2, e.channelId.toHex)
+        statement.setString(3, e.remoteNodeId.value.toHex)
         statement.setLong(4, e.fee.toLong)
-        statement.setString(5, e.txType)
+        statement.setString(5, e.desc)
         statement.setTimestamp(6, Timestamp.from(Instant.now()))
+        statement.executeUpdate()
+      }
+    }
+  }
+
+  override def add(e: TransactionConfirmed): Unit = withMetrics("audit/add-transaction-confirmed", DbBackends.Postgres) {
+    inTransaction { pg =>
+      using(pg.prepareStatement("INSERT INTO audit.transaction_confirmed VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING")) { statement =>
+        statement.setString(1, e.tx.txid.toHex)
+        statement.setString(2, e.channelId.toHex)
+        statement.setString(3, e.remoteNodeId.value.toHex)
+        statement.setTimestamp(4, Timestamp.from(Instant.now()))
         statement.executeUpdate()
       }
     }
@@ -391,7 +414,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
 
   override def listNetworkFees(from: Long, to: Long): Seq[NetworkFee] =
     inTransaction { pg =>
-      using(pg.prepareStatement("SELECT * FROM audit.network_fees WHERE timestamp BETWEEN ? and ? ORDER BY timestamp")) { statement =>
+      using(pg.prepareStatement("SELECT * FROM audit.transaction_confirmed INNER JOIN audit.transaction_published ON audit.transaction_published.tx_id = audit.transaction_confirmed.tx_id  WHERE audit.transaction_confirmed.timestamp BETWEEN ? and ? ORDER BY audit.transaction_confirmed.timestamp")) { statement =>
         statement.setTimestamp(1, Timestamp.from(Instant.ofEpochMilli(from)))
         statement.setTimestamp(2, Timestamp.from(Instant.ofEpochMilli(to)))
         statement.executeQuery().map { rs =>
@@ -430,7 +453,7 @@ class PgAuditDb(implicit ds: DataSource) extends AuditDb with Logging {
       }
       previous ++ current
     }
-    // Channels opened by our peers won't have any entry in the network_fees table, but we still want to compute stats for them.
+    // Channels opened by our peers won't have any network fees paid by us, but we still want to compute stats for them.
     val allChannels = networkFees.keySet ++ relayed.keySet
     allChannels.toSeq.flatMap(channelId => {
       val networkFee = networkFees.getOrElse(channelId, 0 sat)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -104,6 +104,10 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
       statement.executeUpdate("CREATE TABLE transaction_confirmed (tx_id BLOB NOT NULL PRIMARY KEY, channel_id BLOB NOT NULL, node_id BLOB NOT NULL, timestamp INTEGER NOT NULL)")
       statement.executeUpdate("CREATE INDEX transaction_published_timestamp_idx ON transaction_published(timestamp)")
       statement.executeUpdate("CREATE INDEX transaction_confirmed_timestamp_idx ON transaction_confirmed(timestamp)")
+      // Migrate data from the network_fees table (which only stored data about confirmed transactions).
+      statement.executeUpdate("INSERT OR IGNORE INTO transaction_published (tx_id, channel_id, node_id, fee_sat, tx_type, timestamp) SELECT tx_id, channel_id, node_id, fee_sat, tx_type, timestamp FROM network_fees")
+      statement.executeUpdate("INSERT OR IGNORE INTO transaction_confirmed (tx_id, channel_id, node_id, timestamp) SELECT tx_id, channel_id, node_id, timestamp FROM network_fees")
+      statement.executeUpdate("DROP TABLE network_fees")
     }
 
     getVersion(statement, DB_NAME) match {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitorSpec.scala
@@ -249,7 +249,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     waitTxInMempool(bitcoinClient, tx.txid, probe)
     val txPublished = eventListener.expectMsgType[TransactionPublished]
     assert(txPublished.tx === tx)
-    assert(txPublished.fee === 15.sat)
+    assert(txPublished.miningFee === 15.sat)
     assert(txPublished.desc === "test-tx")
 
     generateBlocks(TestConstants.Alice.nodeParams.minDepthBlocks)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitorSpec.scala
@@ -29,6 +29,7 @@ import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
 import fr.acinq.eclair.channel.publish.MempoolTxMonitor.{Publish, Stop, TxConfirmed, TxRejected}
 import fr.acinq.eclair.channel.publish.TxPublisher.TxPublishLogContext
 import fr.acinq.eclair.channel.publish.TxPublisher.TxRejectedReason._
+import fr.acinq.eclair.channel.{TransactionConfirmed, TransactionPublished}
 import fr.acinq.eclair.{TestConstants, TestKitBaseClass, randomBytes32, randomKey}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuiteLike
@@ -78,7 +79,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     generateBlocks(1)
 
     val tx = createSpendP2WPKH(parentTx, priv, priv.publicKey, 1_000 sat, 0, 0)
-    monitor ! Publish(probe.ref, tx, tx.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, tx, tx.txIn.head.outPoint, "test-tx", 50 sat)
     waitTxInMempool(bitcoinClient, tx.txid, probe)
 
     assert(TestConstants.Alice.nodeParams.minDepthBlocks > 1)
@@ -100,7 +101,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     probe.expectMsg(tx1.txid)
 
     val tx2 = createSpendP2WPKH(parentTx, priv, priv.publicKey, 10_000 sat, 0, 0)
-    monitor ! Publish(probe.ref, tx2, tx2.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, tx2, tx2.txIn.head.outPoint, "test-tx", 10 sat)
     waitTxInMempool(bitcoinClient, tx2.txid, probe)
 
     generateBlocks(TestConstants.Alice.nodeParams.minDepthBlocks)
@@ -117,7 +118,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     probe.expectMsg(tx1.txid)
 
     val tx2 = createSpendP2WPKH(parentTx, priv, priv.publicKey, 7_500 sat, 0, 0)
-    monitor ! Publish(probe.ref, tx2, tx2.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, tx2, tx2.txIn.head.outPoint, "test-tx", 25 sat)
     probe.expectMsg(TxRejected(ConflictingTxUnconfirmed))
   }
 
@@ -131,7 +132,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     generateBlocks(1)
 
     val tx2 = createSpendP2WPKH(parentTx, priv, priv.publicKey, 15_000 sat, 0, 0)
-    monitor ! Publish(probe.ref, tx2, tx2.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, tx2, tx2.txIn.head.outPoint, "test-tx", 10 sat)
     probe.expectMsg(TxRejected(ConflictingTxConfirmed))
   }
 
@@ -141,7 +142,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
 
     val tx = createSpendP2WPKH(parentTx, priv, priv.publicKey, 5_000 sat, 0, 0)
     val txUnknownInput = tx.copy(txIn = tx.txIn ++ Seq(TxIn(OutPoint(randomBytes32(), 13), Nil, 0)))
-    monitor ! Publish(probe.ref, txUnknownInput, txUnknownInput.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, txUnknownInput, txUnknownInput.txIn.head.outPoint, "test-tx", 10 sat)
     probe.expectMsg(TxRejected(WalletInputGone))
   }
 
@@ -154,7 +155,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
 
     val tx = createSpendP2WPKH(parentTx, priv, priv.publicKey, 5_000 sat, 0, 0)
     val txUnknownInput = tx.copy(txIn = tx.txIn ++ Seq(TxIn(OutPoint(randomBytes32(), 13), Nil, 0)))
-    monitor ! Publish(probe.ref, txUnknownInput, txUnknownInput.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, txUnknownInput, txUnknownInput.txIn.head.outPoint, "test-tx", 10 sat)
     probe.expectMsg(TxRejected(WalletInputGone))
   }
 
@@ -169,7 +170,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     generateBlocks(1) // we ensure the wallet input is already spent by a confirmed transaction
 
     val tx = createSpendManyP2WPKH(Seq(parentTx, walletTx), priv, priv.publicKey, 5_000 sat, 0, 0)
-    monitor ! Publish(probe.ref, tx, tx.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, tx, tx.txIn.head.outPoint, "test-tx", 10 sat)
     probe.expectMsg(TxRejected(WalletInputGone))
   }
 
@@ -178,7 +179,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     import f._
 
     val tx1 = createSpendP2WPKH(parentTx, priv, priv.publicKey, 5_000 sat, 0, 0)
-    monitor ! Publish(probe.ref, tx1, tx1.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, tx1, tx1.txIn.head.outPoint, "test-tx", 0 sat)
     waitTxInMempool(bitcoinClient, tx1.txid, probe)
 
     val tx2 = createSpendP2WPKH(parentTx, priv, priv.publicKey, 15_000 sat, 0, 0)
@@ -195,7 +196,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     import f._
 
     val tx1 = createSpendP2WPKH(parentTx, priv, priv.publicKey, 5_000 sat, 0, 0)
-    monitor ! Publish(probe.ref, tx1, tx1.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, tx1, tx1.txIn.head.outPoint, "test-tx", 10 sat)
     waitTxInMempool(bitcoinClient, tx1.txid, probe)
 
     val tx2 = createSpendP2WPKH(parentTx, priv, priv.publicKey, 15_000 sat, 0, 0)
@@ -218,7 +219,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     probe.expectMsg(walletTx.txid)
 
     val tx = createSpendManyP2WPKH(Seq(parentTx, walletTx), priv, priv.publicKey, 1_000 sat, 0, 0)
-    monitor ! Publish(probe.ref, tx, tx.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, tx, tx.txIn.head.outPoint, "test-tx", 10 sat)
     waitTxInMempool(bitcoinClient, tx.txid, probe)
 
     // A transaction replaces our unconfirmed wallet input.
@@ -232,12 +233,36 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     probe.expectMsg(TxRejected(WalletInputGone))
   }
 
+  test("emit transaction events") {
+    val f = createFixture()
+    import f._
+
+    val eventListener = TestProbe()
+    system.eventStream.subscribe(eventListener.ref, classOf[TransactionPublished])
+    system.eventStream.subscribe(eventListener.ref, classOf[TransactionConfirmed])
+
+    // Ensure parent tx is confirmed.
+    generateBlocks(1)
+
+    val tx = createSpendP2WPKH(parentTx, priv, priv.publicKey, 1_000 sat, 0, 0)
+    monitor ! Publish(probe.ref, tx, tx.txIn.head.outPoint, "test-tx", 15 sat)
+    waitTxInMempool(bitcoinClient, tx.txid, probe)
+    val txPublished = eventListener.expectMsgType[TransactionPublished]
+    assert(txPublished.tx === tx)
+    assert(txPublished.fee === 15.sat)
+    assert(txPublished.desc === "test-tx")
+
+    generateBlocks(TestConstants.Alice.nodeParams.minDepthBlocks)
+    system.eventStream.publish(CurrentBlockCount(currentBlockHeight(probe)))
+    eventListener.expectMsg(TransactionConfirmed(txPublished.channelId, txPublished.remoteNodeId, tx))
+  }
+
   test("stop actor before transaction confirms") {
     val f = createFixture()
     import f._
 
     val tx = createSpendP2WPKH(parentTx, priv, priv.publicKey, 1_000 sat, 0, 0)
-    monitor ! Publish(probe.ref, tx, tx.txIn.head.outPoint)
+    monitor ! Publish(probe.ref, tx, tx.txIn.head.outPoint, "test-tx", 10 sat)
     waitTxInMempool(bitcoinClient, tx.txid, probe)
 
     probe.watch(monitor.toClassic)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/RawTxPublisherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/RawTxPublisherSpec.scala
@@ -80,7 +80,7 @@ class RawTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitc
     val priv = dumpPrivateKey(address)
     val parentTx = sendToAddress(address, 125_000 sat, probe)
     val tx = createSpendP2WPKH(parentTx, priv, priv.publicKey, 2_500 sat, sequence = 5, lockTime = 0)
-    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "tx-time-locks", None)
+    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "tx-time-locks", 0 sat, None)
     publisher ! Publish(probe.ref, cmd)
 
     val w = watcher.expectMsgType[WatchParentTxConfirmed]
@@ -111,7 +111,7 @@ class RawTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitc
     val ancestorTx = sendToAddress(address, 125_000 sat, probe)
     val parentTx = createSpendP2WPKH(ancestorTx, priv, priv.publicKey, 2_500 sat, 0, 0)
     val tx = createSpendP2WPKH(parentTx, priv, priv.publicKey, 2_000 sat, 0, 0)
-    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "tx-with-parent", Some(parentTx.txid))
+    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "tx-with-parent", 10 sat, Some(parentTx.txid))
     publisher ! Publish(probe.ref, cmd)
 
     // Since the parent is not published yet, we can't publish the child tx either:
@@ -135,7 +135,7 @@ class RawTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitc
     val priv = dumpPrivateKey(address)
     val parentTx = sendToAddress(address, 125_000 sat, probe)
     val tx1 = createSpendP2WPKH(parentTx, priv, priv.publicKey, 2_500 sat, 0, 0)
-    val cmd = PublishRawTx(tx1, tx1.txIn.head.outPoint, "tx-time-locks", None)
+    val cmd = PublishRawTx(tx1, tx1.txIn.head.outPoint, "tx-time-locks", 10 sat, None)
     publisher ! Publish(probe.ref, cmd)
     waitTxInMempool(bitcoinClient, tx1.txid, probe)
 
@@ -160,7 +160,7 @@ class RawTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitc
     import f._
 
     val tx = sendToAddress(getNewAddress(probe), 125_000 sat, probe)
-    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "raw-tx", None)
+    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "raw-tx", 10 sat, None)
     publisher ! Publish(probe.ref, cmd)
 
     probe.watch(publisher.toClassic)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/TxPublisherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/TxPublisherSpec.scala
@@ -78,7 +78,7 @@ class TxPublisherSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     import f._
 
     val tx = Transaction(2, TxIn(OutPoint(randomBytes32(), 1), Nil, 0) :: Nil, Nil, 0)
-    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "raw-tx", None)
+    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "raw-tx", 5 sat, None)
     txPublisher ! cmd
     val child = factory.expectMsgType[RawTxPublisherSpawned].actor
     assert(child.expectMsgType[RawTxPublisher.Publish].cmd === cmd)
@@ -89,7 +89,7 @@ class TxPublisherSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
 
     val input = OutPoint(randomBytes32(), 1)
     val tx1 = Transaction(2, TxIn(input, Nil, 0) :: Nil, Nil, 0)
-    val cmd1 = PublishRawTx(tx1, input, "raw-tx", None)
+    val cmd1 = PublishRawTx(tx1, input, "raw-tx", 10 sat, None)
     txPublisher ! cmd1
     factory.expectMsgType[RawTxPublisherSpawned]
 
@@ -99,7 +99,7 @@ class TxPublisherSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
 
     // But a different tx spending the same main input is allowed:
     val tx2 = tx1.copy(txIn = tx1.txIn ++ Seq(TxIn(OutPoint(randomBytes32(), 0), Nil, 0)))
-    val cmd2 = PublishRawTx(tx2, input, "another-raw-tx", None)
+    val cmd2 = PublishRawTx(tx2, input, "another-raw-tx", 0 sat, None)
     txPublisher ! cmd2
     factory.expectMsgType[RawTxPublisherSpawned]
   }
@@ -148,13 +148,13 @@ class TxPublisherSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
 
     val input = OutPoint(randomBytes32(), 3)
     val tx1 = Transaction(2, TxIn(input, Nil, 0) :: Nil, Nil, 0)
-    val cmd1 = PublishRawTx(tx1, input, "raw-tx-1", None)
+    val cmd1 = PublishRawTx(tx1, input, "raw-tx-1", 5 sat, None)
     txPublisher ! cmd1
     val attempt1 = factory.expectMsgType[RawTxPublisherSpawned].actor
     attempt1.expectMsgType[RawTxPublisher.Publish]
 
     val tx2 = Transaction(2, TxIn(input, Nil, 0) :: TxIn(OutPoint(randomBytes32(), 0), Nil, 3) :: Nil, Nil, 0)
-    val cmd2 = PublishRawTx(tx2, input, "raw-tx-2", None)
+    val cmd2 = PublishRawTx(tx2, input, "raw-tx-2", 15 sat, None)
     txPublisher ! cmd2
     val attempt2 = factory.expectMsgType[RawTxPublisherSpawned].actor
     attempt2.expectMsgType[RawTxPublisher.Publish]
@@ -176,7 +176,7 @@ class TxPublisherSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
 
     val input = OutPoint(randomBytes32(), 3)
     val tx1 = Transaction(2, TxIn(input, Nil, 0) :: Nil, Nil, 0)
-    val cmd1 = PublishRawTx(tx1, input, "raw-tx-1", None)
+    val cmd1 = PublishRawTx(tx1, input, "raw-tx-1", 0 sat, None)
     txPublisher ! cmd1
     val attempt1 = factory.expectMsgType[RawTxPublisherSpawned]
     attempt1.actor.expectMsgType[RawTxPublisher.Publish]
@@ -227,13 +227,13 @@ class TxPublisherSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     import f._
 
     val tx1 = Transaction(2, TxIn(OutPoint(randomBytes32(), 1), Nil, 0) :: Nil, Nil, 0)
-    val cmd1 = PublishRawTx(tx1, tx1.txIn.head.outPoint, "raw-tx-1", None)
+    val cmd1 = PublishRawTx(tx1, tx1.txIn.head.outPoint, "raw-tx-1", 0 sat, None)
     txPublisher ! cmd1
     val attempt1 = factory.expectMsgType[RawTxPublisherSpawned]
     attempt1.actor.expectMsgType[RawTxPublisher.Publish]
 
     val tx2 = Transaction(2, TxIn(OutPoint(randomBytes32(), 0), Nil, 0) :: Nil, Nil, 0)
-    val cmd2 = PublishRawTx(tx2, tx2.txIn.head.outPoint, "raw-tx-2", None)
+    val cmd2 = PublishRawTx(tx2, tx2.txIn.head.outPoint, "raw-tx-2", 5 sat, None)
     txPublisher ! cmd2
     val attempt2 = factory.expectMsgType[RawTxPublisherSpawned]
     attempt2.actor.expectMsgType[RawTxPublisher.Publish]
@@ -254,7 +254,7 @@ class TxPublisherSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     import f._
 
     val tx = Transaction(2, TxIn(OutPoint(randomBytes32(), 1), Nil, 0) :: Nil, Nil, 0)
-    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "raw-tx", None)
+    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "raw-tx", 5 sat, None)
     txPublisher ! cmd
     val attempt = factory.expectMsgType[RawTxPublisherSpawned]
     attempt.actor.expectMsgType[RawTxPublisher.Publish]
@@ -271,7 +271,7 @@ class TxPublisherSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     import f._
 
     val tx = Transaction(2, TxIn(OutPoint(randomBytes32(), 1), Nil, 0) :: Nil, Nil, 0)
-    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "raw-tx", None)
+    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "raw-tx", 5 sat, None)
     txPublisher ! cmd
     val attempt = factory.expectMsgType[RawTxPublisherSpawned]
     attempt.actor.expectMsgType[RawTxPublisher.Publish]
@@ -288,7 +288,7 @@ class TxPublisherSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike {
     import f._
 
     val tx = Transaction(2, TxIn(OutPoint(randomBytes32(), 1), Nil, 0) :: Nil, Nil, 0)
-    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "raw-tx", None)
+    val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "raw-tx", 5 sat, None)
     txPublisher ! cmd
     val attempt = factory.expectMsgType[RawTxPublisherSpawned]
     attempt.actor.expectMsgType[RawTxPublisher.Publish]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
@@ -336,11 +336,11 @@ trait ChannelStateTestsHelperMethods extends TestKitBase {
       assert(s2blockchain.expectMsgType[TxPublisher.PublishReplaceableTx].txInfo.isInstanceOf[ClaimLocalAnchorOutputTx])
     }
     // if s has a main output in the commit tx (when it has a non-dust balance), it should be claimed
-    localCommitPublished.claimMainDelayedOutputTx.foreach(tx => s2blockchain.expectMsg(TxPublisher.PublishRawTx(tx, None)))
+    localCommitPublished.claimMainDelayedOutputTx.foreach(tx => s2blockchain.expectMsg(TxPublisher.PublishRawTx(tx, tx.fee, None)))
     closingState.commitments.commitmentFormat match {
       case Transactions.DefaultCommitmentFormat =>
         // all htlcs success/timeout should be published as-is, without claiming their outputs
-        s2blockchain.expectMsgAllOf(localCommitPublished.htlcTxs.values.toSeq.collect { case Some(tx) => TxPublisher.PublishRawTx(tx, Some(commitTx.txid)) }: _*)
+        s2blockchain.expectMsgAllOf(localCommitPublished.htlcTxs.values.toSeq.collect { case Some(tx) => TxPublisher.PublishRawTx(tx, tx.fee, Some(commitTx.txid)) }: _*)
         assert(localCommitPublished.claimHtlcDelayedTxs.isEmpty)
       case _: Transactions.AnchorOutputsCommitmentFormat =>
         // all htlcs success/timeout should be published as replaceable txs, without claiming their outputs
@@ -354,11 +354,11 @@ trait ChannelStateTestsHelperMethods extends TestKitBase {
     assert(s2blockchain.expectMsgType[WatchTxConfirmed].txId === commitTx.txid)
     localCommitPublished.claimMainDelayedOutputTx.foreach(claimMain => assert(s2blockchain.expectMsgType[WatchTxConfirmed].txId === claimMain.tx.txid))
 
-    // we watch outputs of the commitment tx that both parties may spend
-    val htlcOutputIndexes = localCommitPublished.htlcTxs.keySet.map(_.index)
-    val spentWatches = htlcOutputIndexes.map(_ => s2blockchain.expectMsgType[WatchOutputSpent])
+    // we watch outputs of the commitment tx that both parties may spend and anchor outputs
+    val watchedOutputIndexes = localCommitPublished.htlcTxs.keySet.map(_.index) ++ localCommitPublished.claimAnchorTxs.collect { case tx: ClaimLocalAnchorOutputTx => tx.input.outPoint.index }
+    val spentWatches = watchedOutputIndexes.map(_ => s2blockchain.expectMsgType[WatchOutputSpent])
     spentWatches.foreach(ws => assert(ws.txId == commitTx.txid))
-    assert(spentWatches.map(_.outputIndex) == htlcOutputIndexes)
+    assert(spentWatches.map(_.outputIndex) == watchedOutputIndexes)
     s2blockchain.expectNoMessage(1 second)
 
     // s is now in CLOSING state with txs pending for confirmation before going in CLOSED state
@@ -378,12 +378,12 @@ trait ChannelStateTestsHelperMethods extends TestKitBase {
     // if s has a main output in the commit tx (when it has a non-dust balance), it should be claimed
     remoteCommitPublished.claimMainOutputTx.foreach(claimMain => {
       Transaction.correctlySpends(claimMain.tx, rCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-      s2blockchain.expectMsg(TxPublisher.PublishRawTx(claimMain, None))
+      s2blockchain.expectMsg(TxPublisher.PublishRawTx(claimMain, claimMain.fee, None))
     })
     // all htlcs success/timeout should be claimed
     val claimHtlcTxs = remoteCommitPublished.claimHtlcTxs.values.collect { case Some(tx: ClaimHtlcTx) => tx }.toSeq
     claimHtlcTxs.foreach(claimHtlc => Transaction.correctlySpends(claimHtlc.tx, rCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS))
-    s2blockchain.expectMsgAllOf(claimHtlcTxs.map(claimHtlc => TxPublisher.PublishRawTx(claimHtlc, None)): _*)
+    s2blockchain.expectMsgAllOf(claimHtlcTxs.map(claimHtlc => TxPublisher.PublishRawTx(claimHtlc, claimHtlc.fee, None)): _*)
 
     // we watch the confirmation of the "final" transactions that send funds to our wallets (main delayed output and 2nd stage htlc transactions)
     assert(s2blockchain.expectMsgType[WatchTxConfirmed].txId === rCommitTx.txid)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -87,7 +87,7 @@ class WaitForFundingSignedStateSpec extends TestKitBaseClass with FixtureAnyFunS
     val fundingTxId = alice2blockchain.expectMsgType[WatchFundingSpent].txId
     val txPublished = listener.expectMsgType[TransactionPublished]
     assert(txPublished.tx.txid === fundingTxId)
-    assert(txPublished.fee > 0.sat)
+    assert(txPublished.miningFee > 0.sat)
     val watchConfirmed = alice2blockchain.expectMsgType[WatchFundingConfirmed]
     assert(watchConfirmed.minDepth === Alice.nodeParams.minDepthBlocks)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.channel.states.b
 
 import akka.testkit.{TestFSMRef, TestProbe}
-import fr.acinq.bitcoin.{Btc, ByteVector32, ByteVector64}
+import fr.acinq.bitcoin.{Btc, ByteVector32, ByteVector64, SatoshiLong}
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair.blockchain.DummyOnChainWallet
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
@@ -79,10 +79,15 @@ class WaitForFundingSignedStateSpec extends TestKitBaseClass with FixtureAnyFunS
 
   test("recv FundingSigned with valid signature") { f =>
     import f._
+    val listener = TestProbe()
+    system.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
     bob2alice.expectMsgType[FundingSigned]
     bob2alice.forward(alice)
     awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
-    alice2blockchain.expectMsgType[WatchFundingSpent]
+    val fundingTxId = alice2blockchain.expectMsgType[WatchFundingSpent].txId
+    val txPublished = listener.expectMsgType[TransactionPublished]
+    assert(txPublished.tx.txid === fundingTxId)
+    assert(txPublished.fee > 0.sat)
     val watchConfirmed = alice2blockchain.expectMsgType[WatchFundingConfirmed]
     assert(watchConfirmed.minDepth === Alice.nodeParams.minDepthBlocks)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -80,7 +80,7 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     bob ! WatchFundingConfirmedTriggered(42000, 42, fundingTx)
     val txPublished = listener.expectMsgType[TransactionPublished]
     assert(txPublished.tx === fundingTx)
-    assert(txPublished.fee === 0.sat) // bob is fundee
+    assert(txPublished.miningFee === 0.sat) // bob is fundee
     assert(listener.expectMsgType[TransactionConfirmed].tx === fundingTx)
     val msg = bob2alice.expectMsgType[FundingLocked]
     bob2alice.forward(alice)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -636,7 +636,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     assert(alice.stateData.asInstanceOf[DATA_CLOSING].copy(remoteCommitPublished = None) == initialState)
     val txPublished = txListener.expectMsgType[TransactionPublished]
     assert(txPublished.tx === bobCommitTx)
-    assert(txPublished.fee > 0.sat) // alice is funder, she pays the fee for the remote commit
+    assert(txPublished.miningFee > 0.sat) // alice is funder, she pays the fee for the remote commit
   }
 
   test("recv WatchTxConfirmedTriggered (remote commit)") { f =>
@@ -857,7 +857,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val (bobCommitTx, closingState, htlcs) = testNextRemoteCommitTxConfirmed(f, ChannelFeatures())
     val txPublished = txListener.expectMsgType[TransactionPublished]
     assert(txPublished.tx === bobCommitTx)
-    assert(txPublished.fee > 0.sat) // alice is funder, she pays the fee for the remote commit
+    assert(txPublished.miningFee > 0.sat) // alice is funder, she pays the fee for the remote commit
     val claimHtlcTimeoutTxs = getClaimHtlcTimeoutTxs(closingState).map(_.tx)
     alice ! WatchTxConfirmedTriggered(42, 0, bobCommitTx)
     assert(txListener.expectMsgType[TransactionConfirmed].tx === bobCommitTx)
@@ -1039,7 +1039,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val bobCommitTx = testFutureRemoteCommitTxConfirmed(f, ChannelFeatures())
     val txPublished = txListener.expectMsgType[TransactionPublished]
     assert(txPublished.tx === bobCommitTx)
-    assert(txPublished.fee > 0.sat) // alice is funder, she pays the fee for the remote commit
+    assert(txPublished.miningFee > 0.sat) // alice is funder, she pays the fee for the remote commit
     // alice is able to claim its main output
     val claimMainTx = alice2blockchain.expectMsgType[PublishRawTx].tx
     Transaction.correctlySpends(claimMainTx, bobCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
@@ -1225,7 +1225,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val (bobRevokedTx, rvk) = setupFundingSpentRevokedTx(f, channelFeatures)
     val txPublished = txListener.expectMsgType[TransactionPublished]
     assert(txPublished.tx === bobRevokedTx)
-    assert(txPublished.fee > 0.sat) // alice is funder, she pays the fee for the revoked commit
+    assert(txPublished.miningFee > 0.sat) // alice is funder, she pays the fee for the revoked commit
 
     // once all txs are confirmed, alice can move to the closed state
     alice ! WatchTxConfirmedTriggered(100, 3, bobRevokedTx)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -22,7 +22,7 @@ import fr.acinq.eclair.TestDatabases.{TestPgDatabases, TestSqliteDatabases, migr
 import fr.acinq.eclair._
 import fr.acinq.eclair.channel.Helpers.Closing.MutualClose
 import fr.acinq.eclair.channel._
-import fr.acinq.eclair.db.AuditDb.Stats
+import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.db.jdbc.JdbcUtils.using
 import fr.acinq.eclair.db.pg.PgAuditDb
@@ -571,6 +571,134 @@ class AuditDbSpec extends AnyFunSuite {
             val relayed3 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(450 msat, randomBytes32()), PaymentRelayed.Part(500 msat, randomBytes32())), Seq(PaymentRelayed.Part(800 msat, randomBytes32())), randomKey().publicKey, 700 msat, 150)
             postMigrationDb.add(relayed3)
             assert(postMigrationDb.listRelayed(100, 160) === Seq(relayed1, relayed2, relayed3))
+          }
+        )
+    }
+  }
+
+  test("migrate audit database v7 -> current") {
+    val networkFees = Seq(
+      NetworkFee(randomKey().publicKey, randomBytes32(), randomBytes32(), 50 sat, "test-tx-1", 500),
+      NetworkFee(randomKey().publicKey, randomBytes32(), randomBytes32(), 0 sat, "test-tx-2", 600),
+    )
+
+    forAllDbs {
+      case dbs: TestPgDatabases =>
+        migrationCheck(
+          dbs = dbs,
+          initializeTables = connection => {
+            // simulate existing previous version db
+            using(connection.createStatement()) { statement =>
+              statement.executeUpdate("CREATE SCHEMA audit")
+
+              statement.executeUpdate("CREATE TABLE audit.sent (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, recipient_amount_msat BIGINT NOT NULL, payment_id TEXT NOT NULL, parent_payment_id TEXT NOT NULL, payment_hash TEXT NOT NULL, payment_preimage TEXT NOT NULL, recipient_node_id TEXT NOT NULL, to_channel_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+              statement.executeUpdate("CREATE TABLE audit.received (amount_msat BIGINT NOT NULL, payment_hash TEXT NOT NULL, from_channel_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+              statement.executeUpdate("CREATE TABLE audit.relayed (payment_hash TEXT NOT NULL, amount_msat BIGINT NOT NULL, channel_id TEXT NOT NULL, direction TEXT NOT NULL, relay_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+              statement.executeUpdate("CREATE TABLE audit.relayed_trampoline (payment_hash TEXT NOT NULL, amount_msat BIGINT NOT NULL, next_node_id TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+              statement.executeUpdate("CREATE TABLE audit.network_fees (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, tx_id TEXT NOT NULL, fee_sat BIGINT NOT NULL, tx_type TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+              statement.executeUpdate("CREATE TABLE audit.channel_events (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, capacity_sat BIGINT NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+              statement.executeUpdate("CREATE TABLE audit.channel_updates (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, fee_base_msat BIGINT NOT NULL, fee_proportional_millionths BIGINT NOT NULL, cltv_expiry_delta BIGINT NOT NULL, htlc_minimum_msat BIGINT NOT NULL, htlc_maximum_msat BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+              statement.executeUpdate("CREATE TABLE audit.path_finding_metrics (amount_msat BIGINT NOT NULL, fees_msat BIGINT NOT NULL, status TEXT NOT NULL, duration_ms BIGINT NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL, is_mpp BOOLEAN NOT NULL, experiment_name TEXT NOT NULL, recipient_node_id TEXT NOT NULL)")
+
+              statement.executeUpdate("CREATE TABLE audit.channel_errors (channel_id TEXT NOT NULL, node_id TEXT NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal BOOLEAN NOT NULL, timestamp TIMESTAMP WITH TIME ZONE NOT NULL)")
+              statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON audit.sent(timestamp)")
+              statement.executeUpdate("CREATE INDEX received_timestamp_idx ON audit.received(timestamp)")
+              statement.executeUpdate("CREATE INDEX relayed_timestamp_idx ON audit.relayed(timestamp)")
+              statement.executeUpdate("CREATE INDEX relayed_payment_hash_idx ON audit.relayed(payment_hash)")
+              statement.executeUpdate("CREATE INDEX relayed_trampoline_timestamp_idx ON audit.relayed_trampoline(timestamp)")
+              statement.executeUpdate("CREATE INDEX relayed_trampoline_payment_hash_idx ON audit.relayed_trampoline(payment_hash)")
+              statement.executeUpdate("CREATE INDEX network_fees_timestamp_idx ON audit.network_fees(timestamp)")
+              statement.executeUpdate("CREATE INDEX channel_events_timestamp_idx ON audit.channel_events(timestamp)")
+              statement.executeUpdate("CREATE INDEX channel_errors_timestamp_idx ON audit.channel_errors(timestamp)")
+              statement.executeUpdate("CREATE INDEX channel_updates_cid_idx ON audit.channel_updates(channel_id)")
+              statement.executeUpdate("CREATE INDEX channel_updates_nid_idx ON audit.channel_updates(node_id)")
+              statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON audit.channel_updates(timestamp)")
+              statement.executeUpdate("CREATE INDEX metrics_status_idx ON audit.path_finding_metrics(status)")
+              statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON audit.path_finding_metrics(timestamp)")
+              statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON audit.path_finding_metrics(is_mpp)")
+              statement.executeUpdate("CREATE INDEX metrics_name_idx ON audit.path_finding_metrics(experiment_name)")
+
+              setVersion(statement, "audit", 9)
+            }
+
+            // We insert some transactions in the table.
+            // NB: the first transaction is explicitly duplicated to test the primary key addition.
+            for (tx <- networkFees.head +: networkFees) {
+              using(connection.prepareStatement("INSERT INTO audit.network_fees VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
+                statement.setString(1, tx.channelId.toHex)
+                statement.setString(2, tx.remoteNodeId.value.toHex)
+                statement.setString(3, tx.txId.toHex)
+                statement.setLong(4, tx.fee.toLong)
+                statement.setString(5, tx.txType)
+                statement.setTimestamp(6, Timestamp.from(Instant.ofEpochMilli(tx.timestamp)))
+                statement.executeUpdate()
+              }
+            }
+          },
+          dbName = PgAuditDb.DB_NAME,
+          targetVersion = PgAuditDb.CURRENT_VERSION,
+          postCheck = connection => {
+            val migratedDb = dbs.audit
+            using(connection.createStatement()) { statement => assert(getVersion(statement, "audit").contains(PgAuditDb.CURRENT_VERSION)) }
+            assert(migratedDb.listNetworkFees(0, 700) === networkFees)
+          }
+        )
+      case dbs: TestSqliteDatabases =>
+        migrationCheck(
+          dbs = dbs,
+          initializeTables = connection => {
+            // simulate existing previous version db
+            using(connection.createStatement()) { statement =>
+              statement.executeUpdate("CREATE TABLE sent (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, recipient_amount_msat INTEGER NOT NULL, payment_id TEXT NOT NULL, parent_payment_id TEXT NOT NULL, payment_hash BLOB NOT NULL, payment_preimage BLOB NOT NULL, recipient_node_id BLOB NOT NULL, to_channel_id BLOB NOT NULL, timestamp INTEGER NOT NULL)")
+              statement.executeUpdate("CREATE TABLE received (amount_msat INTEGER NOT NULL, payment_hash BLOB NOT NULL, from_channel_id BLOB NOT NULL, timestamp INTEGER NOT NULL)")
+              statement.executeUpdate("CREATE TABLE relayed (payment_hash BLOB NOT NULL, amount_msat INTEGER NOT NULL, channel_id BLOB NOT NULL, direction TEXT NOT NULL, relay_type TEXT NOT NULL, timestamp INTEGER NOT NULL)")
+              statement.executeUpdate("CREATE TABLE relayed_trampoline (payment_hash BLOB NOT NULL, amount_msat INTEGER NOT NULL, next_node_id BLOB NOT NULL, timestamp INTEGER NOT NULL)")
+              statement.executeUpdate("CREATE TABLE network_fees (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, tx_id BLOB NOT NULL, fee_sat INTEGER NOT NULL, tx_type TEXT NOT NULL, timestamp INTEGER NOT NULL)")
+              statement.executeUpdate("CREATE TABLE channel_events (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, capacity_sat INTEGER NOT NULL, is_funder BOOLEAN NOT NULL, is_private BOOLEAN NOT NULL, event TEXT NOT NULL, timestamp INTEGER NOT NULL)")
+              statement.executeUpdate("CREATE TABLE channel_errors (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, error_name TEXT NOT NULL, error_message TEXT NOT NULL, is_fatal INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
+              statement.executeUpdate("CREATE TABLE channel_updates (channel_id BLOB NOT NULL, node_id BLOB NOT NULL, fee_base_msat INTEGER NOT NULL, fee_proportional_millionths INTEGER NOT NULL, cltv_expiry_delta INTEGER NOT NULL, htlc_minimum_msat INTEGER NOT NULL, htlc_maximum_msat INTEGER NOT NULL, timestamp INTEGER NOT NULL)")
+              statement.executeUpdate("CREATE TABLE path_finding_metrics (amount_msat INTEGER NOT NULL, fees_msat INTEGER NOT NULL, status TEXT NOT NULL, duration_ms INTEGER NOT NULL, timestamp INTEGER NOT NULL, is_mpp INTEGER NOT NULL, experiment_name TEXT NOT NULL, recipient_node_id BLOB NOT NULL)")
+
+              statement.executeUpdate("CREATE INDEX sent_timestamp_idx ON sent(timestamp)")
+              statement.executeUpdate("CREATE INDEX received_timestamp_idx ON received(timestamp)")
+              statement.executeUpdate("CREATE INDEX relayed_timestamp_idx ON relayed(timestamp)")
+              statement.executeUpdate("CREATE INDEX relayed_payment_hash_idx ON relayed(payment_hash)")
+              statement.executeUpdate("CREATE INDEX relayed_trampoline_timestamp_idx ON relayed_trampoline(timestamp)")
+              statement.executeUpdate("CREATE INDEX relayed_trampoline_payment_hash_idx ON relayed_trampoline(payment_hash)")
+              statement.executeUpdate("CREATE INDEX network_fees_timestamp_idx ON network_fees(timestamp)")
+              statement.executeUpdate("CREATE INDEX channel_events_timestamp_idx ON channel_events(timestamp)")
+              statement.executeUpdate("CREATE INDEX channel_errors_timestamp_idx ON channel_errors(timestamp)")
+              statement.executeUpdate("CREATE INDEX channel_updates_cid_idx ON channel_updates(channel_id)")
+              statement.executeUpdate("CREATE INDEX channel_updates_nid_idx ON channel_updates(node_id)")
+              statement.executeUpdate("CREATE INDEX channel_updates_timestamp_idx ON channel_updates(timestamp)")
+              statement.executeUpdate("CREATE INDEX metrics_status_idx ON path_finding_metrics(status)")
+              statement.executeUpdate("CREATE INDEX metrics_timestamp_idx ON path_finding_metrics(timestamp)")
+              statement.executeUpdate("CREATE INDEX metrics_mpp_idx ON path_finding_metrics(is_mpp)")
+              statement.executeUpdate("CREATE INDEX metrics_name_idx ON path_finding_metrics(experiment_name)")
+
+              setVersion(statement, "audit", 7)
+            }
+
+            // We insert some transactions in the table.
+            // NB: the first transaction is explicitly duplicated to test the primary key addition.
+            for (tx <- networkFees.head +: networkFees) {
+              using(connection.prepareStatement("INSERT INTO network_fees VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
+                statement.setBytes(1, tx.channelId.toArray)
+                statement.setBytes(2, tx.remoteNodeId.value.toArray)
+                statement.setBytes(3, tx.txId.toArray)
+                statement.setLong(4, tx.fee.toLong)
+                statement.setString(5, tx.txType)
+                statement.setLong(6, tx.timestamp)
+                statement.executeUpdate()
+              }
+            }
+          },
+          dbName = SqliteAuditDb.DB_NAME,
+          targetVersion = SqliteAuditDb.CURRENT_VERSION,
+          postCheck = connection => {
+            val migratedDb = dbs.audit
+            using(connection.createStatement()) { statement => assert(getVersion(statement, "audit").contains(SqliteAuditDb.CURRENT_VERSION)) }
+            assert(migratedDb.listNetworkFees(0, 700) === networkFees)
           }
         )
     }


### PR DESCRIPTION
We previously computed the on-chain fees paid by us after the fact, when receiving a notification that a transaction was confirmed. This worked because lightning transactions had a single input, which we stored in our channel data to allow us to compute the fee.

With anchor outputs, this mechanism doesn't work anymore. Some txs have their fees paid by a child tx, and may have more than one input.

We completely change our model to store every transaction we publish, along with the fee we're paying for this transaction. We then separately store every transaction that confirms, which lets us join these two data sets to compute how much on-chain fees we paid.

This has the added benefit that we can now audit every transaction that we tried to publish, which lets node operators audit the anchor outputs internal RBF mechanism and all the on-chain footprint of a given channel.