### PR TITLE
Log payment failure summary (alternative)

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Timestamp.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Timestamp.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair
+
+import java.time.Instant
+import java.sql
+
+//case class TimestampSecond(private val underlying: Long) extends Ordered[TimestampSecond] {
+//  // @formatter: off
+//  def toLong: Long = underlying
+//  def toSqlTimestamp: sql.Timestamp = sql.Timestamp.from(Instant.ofEpochSecond(underlying))
+//  override def toString: String = underlying.toString
+//  override def compare(that: TimestampSecond): Int = underlying.compareTo(that.underlying)
+//  // @formatter: on
+//}
+//
+//object TimestampSecond {
+//  def now: TimestampSecond = TimestampSecond(System.currentTimeMillis() / 1000)
+//}
+
+case class TimestampMilli(private val underlying: Long) extends Ordered[TimestampMilli] {
+  // @formatter: off
+  def toLong: Long = underlying
+  def toSqlTimestamp: sql.Timestamp = sql.Timestamp.from(Instant.ofEpochMilli(underlying))
+  override def toString: String = underlying.toString
+  override def compare(that: TimestampMilli): Int = underlying.compareTo(that.underlying)
+  // @formatter: on
+}
+
+object TimestampMilli {
+  def now: TimestampMilli = TimestampMilli(System.currentTimeMillis())
+
+  def fromSqlTimestamp(sqlTs: sql.Timestamp): TimestampMilli = TimestampMilli(sqlTs.getTime)
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/WeakEntropyPool.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/WeakEntropyPool.scala
@@ -21,6 +21,7 @@ import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.Behaviors
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{ByteVector32, ByteVector64, Crypto}
+import fr.acinq.eclair.TimestampMilli
 import fr.acinq.eclair.blockchain.NewBlock
 import fr.acinq.eclair.channel.ChannelSignatureReceived
 import fr.acinq.eclair.io.PeerConnected
@@ -47,7 +48,7 @@ object WeakEntropyPool {
   sealed trait Command
   private case object FlushEntropy extends Command
   private case class WrappedNewBlock(blockHash: ByteVector32) extends Command
-  private case class WrappedPaymentRelayed(paymentHash: ByteVector32, relayedAt: Long) extends Command
+  private case class WrappedPaymentRelayed(paymentHash: ByteVector32, relayedAt: TimestampMilli) extends Command
   private case class WrappedPeerConnected(nodeId: PublicKey) extends Command
   private case class WrappedChannelSignature(wtxid: ByteVector32) extends Command
   private case class WrappedNodeUpdated(sig: ByteVector64) extends Command
@@ -80,7 +81,7 @@ object WeakEntropyPool {
 
       case WrappedNewBlock(blockHash) => collecting(collector, collect(entropy_opt, blockHash ++ ByteVector.fromLong(System.currentTimeMillis())))
 
-      case WrappedPaymentRelayed(paymentHash, relayedAt) => collecting(collector, collect(entropy_opt, paymentHash ++ ByteVector.fromLong(relayedAt)))
+      case WrappedPaymentRelayed(paymentHash, relayedAt) => collecting(collector, collect(entropy_opt, paymentHash ++ ByteVector.fromLong(relayedAt.toLong)))
 
       case WrappedPeerConnected(nodeId) => collecting(collector, collect(entropy_opt, nodeId.value ++ ByteVector.fromLong(System.currentTimeMillis())))
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -209,9 +209,9 @@ object FailureType extends Enumeration {
 
 object FailureSummary {
   def apply(f: PaymentFailure): FailureSummary = f match {
-    case LocalFailure(route, t) => FailureSummary(FailureType.LOCAL, t.getMessage, route.map(h => HopSummary(h)).toList)
-    case RemoteFailure(route, e) => FailureSummary(FailureType.REMOTE, e.failureMessage.message, route.map(h => HopSummary(h)).toList)
-    case UnreadableRemoteFailure(route) => FailureSummary(FailureType.UNREADABLE_REMOTE, "could not decrypt failure onion", route.map(h => HopSummary(h)).toList)
+    case LocalFailure(_, route, t) => FailureSummary(FailureType.LOCAL, t.getMessage, route.map(h => HopSummary(h)).toList)
+    case RemoteFailure(_, route, e) => FailureSummary(FailureType.REMOTE, e.failureMessage.message, route.map(h => HopSummary(h)).toList)
+    case UnreadableRemoteFailure(_, route) => FailureSummary(FailureType.UNREADABLE_REMOTE, "could not decrypt failure onion", route.map(h => HopSummary(h)).toList)
   }
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -26,7 +26,7 @@ import fr.acinq.eclair.db.Monitoring.Tags.DbBackends
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.transactions.Transactions.PlaceHolderPubKey
-import fr.acinq.eclair.{MilliSatoshi, MilliSatoshiLong}
+import fr.acinq.eclair.{MilliSatoshi, MilliSatoshiLong, TimestampMilli}
 import grizzled.slf4j.Logging
 
 import java.sql.{Connection, Statement}
@@ -43,7 +43,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
   import ExtendedResultSet._
   import SqliteAuditDb._
 
-  case class RelayedPart(channelId: ByteVector32, amount: MilliSatoshi, direction: String, relayType: String, timestamp: Long)
+  case class RelayedPart(channelId: ByteVector32, amount: MilliSatoshi, direction: String, relayType: String, timestamp: TimestampMilli)
 
   using(sqlite.createStatement(), inTransaction = true) { statement =>
 
@@ -178,7 +178,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.setBytes(7, e.paymentPreimage.toArray)
         statement.setBytes(8, e.recipientNodeId.value.toArray)
         statement.setBytes(9, p.toChannelId.toArray)
-        statement.setLong(10, p.timestamp)
+        statement.setLong(10, p.timestamp.toLong)
         statement.addBatch()
       })
       statement.executeBatch()
@@ -191,7 +191,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.setLong(1, p.amount.toLong)
         statement.setBytes(2, e.paymentHash.toArray)
         statement.setBytes(3, p.fromChannelId.toArray)
-        statement.setLong(4, p.timestamp)
+        statement.setLong(4, p.timestamp.toLong)
         statement.addBatch()
       })
       statement.executeBatch()
@@ -208,7 +208,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
           statement.setBytes(1, e.paymentHash.toArray)
           statement.setLong(2, nextTrampolineAmount.toLong)
           statement.setBytes(3, nextTrampolineNodeId.value.toArray)
-          statement.setLong(4, e.timestamp)
+          statement.setLong(4, e.timestamp.toLong)
           statement.executeUpdate()
         }
         // trampoline relayed payments do MPP aggregation and may have M inputs and N outputs
@@ -222,7 +222,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
         statement.setBytes(3, p.channelId.toArray)
         statement.setString(4, p.direction)
         statement.setString(5, p.relayType)
-        statement.setLong(6, e.timestamp)
+        statement.setLong(6, e.timestamp.toLong)
         statement.executeUpdate()
       }
     }
@@ -297,7 +297,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
             MilliSatoshi(rs.getLong("fees_msat")),
             rs.getByteVector32("to_channel_id"),
             None, // we don't store the route in the audit DB
-            rs.getLong("timestamp"))
+            TimestampMilli(rs.getLong("timestamp")))
           val sent = sentByParentId.get(parentId) match {
             case Some(s) => s.copy(parts = s.parts :+ part)
             case None => PaymentSent(
@@ -322,7 +322,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
           val part = PaymentReceived.PartialPayment(
             MilliSatoshi(rs.getLong("amount_msat")),
             rs.getByteVector32("from_channel_id"),
-            rs.getLong("timestamp"))
+            TimestampMilli(rs.getLong("timestamp")))
           val received = receivedByHash.get(paymentHash) match {
             case Some(r) => r.copy(parts = r.parts :+ part)
             case None => PaymentReceived(paymentHash, Seq(part))
@@ -355,7 +355,7 @@ class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
             MilliSatoshi(rs.getLong("amount_msat")),
             rs.getString("direction"),
             rs.getString("relay_type"),
-            rs.getLong("timestamp"))
+            TimestampMilli(rs.getLong("timestamp")))
           relayedByHash + (paymentHash -> (relayedByHash.getOrElse(paymentHash, Nil) :+ part))
         }
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePaymentsDb.scala
@@ -141,7 +141,7 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
   override def updateOutgoingPayment(paymentResult: PaymentSent): Unit = withMetrics("payments/update-outgoing-sent", DbBackends.Sqlite) {
     using(sqlite.prepareStatement("UPDATE sent_payments SET (completed_at, payment_preimage, fees_msat, payment_route) = (?, ?, ?, ?) WHERE id = ? AND completed_at IS NULL")) { statement =>
       paymentResult.parts.foreach(p => {
-        statement.setLong(1, p.timestamp)
+        statement.setLong(1, p.timestamp.toLong)
         statement.setBytes(2, paymentResult.paymentPreimage.toArray)
         statement.setLong(3, p.feesPaid.toLong)
         statement.setBytes(4, paymentRouteCodec.encode(p.route.getOrElse(Nil).map(h => HopSummary(h)).toList).require.toByteArray)
@@ -154,7 +154,7 @@ class SqlitePaymentsDb(sqlite: Connection) extends PaymentsDb with Logging {
 
   override def updateOutgoingPayment(paymentResult: PaymentFailed): Unit = withMetrics("payments/update-outgoing-failed", DbBackends.Sqlite) {
     using(sqlite.prepareStatement("UPDATE sent_payments SET (completed_at, failures) = (?, ?) WHERE id = ? AND completed_at IS NULL")) { statement =>
-      statement.setLong(1, paymentResult.timestamp)
+      statement.setLong(1, paymentResult.timestamp.toLong)
       statement.setBytes(2, paymentFailuresCodec.encode(paymentResult.failures.map(f => FailureSummary(f)).toList).require.toByteArray)
       statement.setString(3, paymentResult.id.toString)
       if (statement.executeUpdate() == 0) throw new IllegalArgumentException(s"Tried to mark an outgoing payment as failed but already in final status (id=${paymentResult.id})")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Monitoring.scala
@@ -121,9 +121,9 @@ object Monitoring {
       }
 
       def apply(pf: PaymentFailure): String = pf match {
-        case LocalFailure(_, t) => t.getClass.getSimpleName
-        case RemoteFailure(_, e) => e.failureMessage.getClass.getSimpleName
-        case UnreadableRemoteFailure(_) => "UnreadableRemoteFailure"
+        case LocalFailure(_, _, t) => t.getClass.getSimpleName
+        case RemoteFailure(_, _, e) => e.failureMessage.getClass.getSimpleName
+        case UnreadableRemoteFailure(_, _) => "UnreadableRemoteFailure"
       }
     }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -164,7 +164,7 @@ object PaymentFailure {
         case RemoteFailure(_, _, Sphinx.DecryptedFailurePacket(origin, failureMessage)) => s"$origin returned: ${failureMessage.message}"
         case _: UnreadableRemoteFailure => "unreadable remote failure"
       }
-      val route = JArray(failure.route.map(r => JString(r.nextNodeId.value.toHex)).toList)
+      val route = JArray((failure.route.map(_.nodeId) ++ failure.route.lastOption.map(_.nextNodeId)).map(n => JString(n.value.toHex)).toList)
       JObject(
         JField("amount", JString(failure.amount.toString)),
         JField("route", route),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -114,17 +114,20 @@ object PaymentReceived {
 case class PaymentSettlingOnChain(id: UUID, amount: MilliSatoshi, paymentHash: ByteVector32, timestamp: Long = System.currentTimeMillis) extends PaymentEvent
 
 sealed trait PaymentFailure {
+  // @formatter:off
+  def amount: MilliSatoshi
   def route: Seq[Hop]
+  // @formatter:on
 }
 
 /** A failure happened locally, preventing the payment from being sent (e.g. no route found). */
-case class LocalFailure(route: Seq[Hop], t: Throwable) extends PaymentFailure
+case class LocalFailure(amount: MilliSatoshi, route: Seq[Hop], t: Throwable) extends PaymentFailure
 
 /** A remote node failed the payment and we were able to decrypt the onion failure packet. */
-case class RemoteFailure(route: Seq[Hop], e: Sphinx.DecryptedFailurePacket) extends PaymentFailure
+case class RemoteFailure(amount: MilliSatoshi, route: Seq[Hop], e: Sphinx.DecryptedFailurePacket) extends PaymentFailure
 
 /** A remote node failed the payment but we couldn't decrypt the failure (e.g. a malicious node tampered with the message). */
-case class UnreadableRemoteFailure(route: Seq[Hop]) extends PaymentFailure
+case class UnreadableRemoteFailure(amount: MilliSatoshi, route: Seq[Hop]) extends PaymentFailure
 
 object PaymentFailure {
 
@@ -144,8 +147,25 @@ object PaymentFailure {
    */
   def transformForUser(failures: Seq[PaymentFailure]): Seq[PaymentFailure] = {
     failures match {
-      case previousFailures :+ LocalFailure(_, RouteNotFound) if previousFailures.nonEmpty => previousFailures
+      case previousFailures :+ LocalFailure(_, _, RouteNotFound) if previousFailures.nonEmpty => previousFailures
       case other => other
+    }
+  }
+
+  /**
+   * Print a friendly summary of the payment failure.
+   */
+  def print(failure: PaymentFailure): String = {
+    val route = failure.route.map(_.nextNodeId).mkString("->")
+    val details = failure match {
+      case LocalFailure(_, _, t) => t.getMessage
+      case RemoteFailure(_, _, Sphinx.DecryptedFailurePacket(origin, failureMessage)) => s"$origin returned: ${failureMessage.message}"
+      case _: UnreadableRemoteFailure => "unreadable remote failure"
+    }
+    if (failure.route.isEmpty) {
+      s"sending ${failure.amount} failed: $details"
+    } else {
+      s"sending ${failure.amount} to $route failed: $details"
     }
   }
 
@@ -155,7 +175,7 @@ object PaymentFailure {
    */
   def hasAlreadyFailedOnce(nodeId: PublicKey, failures: Seq[PaymentFailure]): Boolean =
     failures
-      .collectFirst { case RemoteFailure(_, Sphinx.DecryptedFailurePacket(origin, u: Update)) if origin == nodeId => u.update }
+      .collectFirst { case RemoteFailure(_, _, Sphinx.DecryptedFailurePacket(origin, u: Update)) if origin == nodeId => u.update }
       .isDefined
 
   /** Ignore the channel outgoing from the given nodeId in the given route. */
@@ -170,12 +190,12 @@ object PaymentFailure {
 
   /** Update the set of nodes and channels to ignore in retries depending on the failure we received. */
   def updateIgnored(failure: PaymentFailure, ignore: Ignore): Ignore = failure match {
-    case RemoteFailure(hops, Sphinx.DecryptedFailurePacket(nodeId, _)) if nodeId == hops.last.nextNodeId =>
+    case RemoteFailure(_, hops, Sphinx.DecryptedFailurePacket(nodeId, _)) if nodeId == hops.last.nextNodeId =>
       // The failure came from the final recipient: the payment should be aborted without penalizing anyone in the route.
       ignore
-    case RemoteFailure(_, Sphinx.DecryptedFailurePacket(nodeId, _: Node)) =>
+    case RemoteFailure(_, _, Sphinx.DecryptedFailurePacket(nodeId, _: Node)) =>
       ignore + nodeId
-    case RemoteFailure(hops, Sphinx.DecryptedFailurePacket(nodeId, failureMessage: Update)) =>
+    case RemoteFailure(_, hops, Sphinx.DecryptedFailurePacket(nodeId, failureMessage: Update)) =>
       if (Announcements.checkSig(failureMessage.update, nodeId)) {
         val shouldIgnore = failureMessage match {
           case _: TemporaryChannelFailure => true
@@ -192,13 +212,13 @@ object PaymentFailure {
         // This node is fishy, it gave us a bad signature, so let's filter it out.
         ignore + nodeId
       }
-    case RemoteFailure(hops, Sphinx.DecryptedFailurePacket(nodeId, _)) =>
+    case RemoteFailure(_, hops, Sphinx.DecryptedFailurePacket(nodeId, _)) =>
       ignoreNodeOutgoingChannel(nodeId, hops, ignore)
-    case UnreadableRemoteFailure(hops) =>
+    case UnreadableRemoteFailure(_, hops) =>
       // We don't know which node is sending garbage, let's blacklist all nodes except the one we are directly connected to and the final recipient.
       val blacklist = hops.map(_.nextNodeId).drop(1).dropRight(1).toSet
       ignore ++ blacklist
-    case LocalFailure(hops, _) => hops.headOption match {
+    case LocalFailure(_, hops, _) => hops.headOption match {
       case Some(hop: ChannelHop) =>
         val faultyChannel = ChannelDesc(hop.lastUpdate.shortChannelId, hop.nodeId, hop.nextNodeId)
         ignore + faultyChannel
@@ -216,7 +236,7 @@ object PaymentFailure {
     // We're only interested in the last channel update received per channel.
     val updates = failures.foldLeft(Map.empty[ShortChannelId, ChannelUpdate]) {
       case (current, failure) => failure match {
-        case RemoteFailure(_, Sphinx.DecryptedFailurePacket(_, f: Update)) => current.updated(f.update.shortChannelId, f.update)
+        case RemoteFailure(_, _, Sphinx.DecryptedFailurePacket(_, f: Update)) => current.updated(f.update.shortChannelId, f.update)
         case _ => current
       }
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
@@ -138,7 +138,7 @@ class MultiPartHandler(nodeParams: NodeParams, register: ActorRef, db: IncomingP
             case p: MultiPartPaymentFSM.HtlcPart => db.getIncomingPayment(paymentHash).foreach(record => {
               PendingCommandsDb.safeSend(register, nodeParams.db.pendingCommands, p.htlc.channelId, CMD_FULFILL_HTLC(p.htlc.id, record.paymentPreimage, commit = true))
               val received = PaymentReceived(paymentHash, PaymentReceived.PartialPayment(p.amount, p.htlc.channelId) :: Nil)
-              db.receiveIncomingPayment(paymentHash, p.amount, received.timestamp)
+              db.receiveIncomingPayment(paymentHash, p.amount, received.timestamp.toLong)
               ctx.system.eventStream.publish(received)
             })
           }
@@ -151,7 +151,7 @@ class MultiPartHandler(nodeParams: NodeParams, register: ActorRef, db: IncomingP
         val received = PaymentReceived(paymentHash, parts.map {
           case p: MultiPartPaymentFSM.HtlcPart => PaymentReceived.PartialPayment(p.amount, p.htlc.channelId)
         })
-        db.receiveIncomingPayment(paymentHash, received.amount, received.timestamp)
+        db.receiveIncomingPayment(paymentHash, received.amount, received.timestamp.toLong)
         parts.collect {
           case p: MultiPartPaymentFSM.HtlcPart => PendingCommandsDb.safeSend(register, nodeParams.db.pendingCommands, p.htlc.channelId, CMD_FULFILL_HTLC(p.htlc.id, preimage, commit = true))
         }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.payment.Monitoring.Tags
 import fr.acinq.eclair.payment.{ChannelPaymentRelayed, IncomingPacket, PaymentFailed, PaymentSent}
 import fr.acinq.eclair.transactions.DirectedHtlc.outgoing
 import fr.acinq.eclair.wire.protocol.{FailureMessage, TemporaryNodeFailure, UpdateAddHtlc}
-import fr.acinq.eclair.{CustomCommitmentsPlugin, MilliSatoshiLong, NodeParams}
+import fr.acinq.eclair.{CustomCommitmentsPlugin, MilliSatoshiLong, NodeParams, TimestampMilli}
 
 import scala.concurrent.Promise
 import scala.util.Try
@@ -151,7 +151,7 @@ class PostRestartHtlcCleaner(nodeParams: NodeParams, register: ActorRef, initial
               if (!payments.exists(p => p.status == OutgoingPaymentStatus.Pending)) {
                 val succeeded = payments.collect {
                   case OutgoingPayment(id, _, _, _, _, amount, _, _, _, _, OutgoingPaymentStatus.Succeeded(_, feesPaid, _, completedAt)) =>
-                    PaymentSent.PartialPayment(id, amount, feesPaid, ByteVector32.Zeroes, None, completedAt)
+                    PaymentSent.PartialPayment(id, amount, feesPaid, ByteVector32.Zeroes, None, TimestampMilli(completedAt))
                 }
                 val sent = PaymentSent(p.parentId, fulfilledHtlc.paymentHash, paymentPreimage, p.recipientAmount, p.recipientNodeId, succeeded)
                 log.info(s"payment id=${sent.id} paymentHash=${sent.paymentHash} successfully sent (amount=${sent.recipientAmount})")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Autoprobe.scala
@@ -20,8 +20,7 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.crypto.Sphinx.DecryptedFailurePacket
 import fr.acinq.eclair.payment.{PaymentEvent, PaymentFailed, PaymentRequest, RemoteFailure}
-import fr.acinq.eclair.router.Router.RouteParams
-import fr.acinq.eclair.router.{Announcements, RouteCalculation, Router}
+import fr.acinq.eclair.router.Router
 import fr.acinq.eclair.wire.protocol.IncorrectOrUnknownPaymentDetails
 import fr.acinq.eclair.{MilliSatoshiLong, NodeParams, randomBytes32, randomLong}
 import scodec.bits.ByteVector
@@ -74,7 +73,7 @@ class Autoprobe(nodeParams: NodeParams, router: ActorRef, paymentInitiator: Acto
 
     case paymentResult: PaymentEvent =>
       paymentResult match {
-        case PaymentFailed(_, _, _ :+ RemoteFailure(_, DecryptedFailurePacket(targetNodeId, IncorrectOrUnknownPaymentDetails(_, _))), _) =>
+        case PaymentFailed(_, _, _ :+ RemoteFailure(_, _, DecryptedFailurePacket(targetNodeId, IncorrectOrUnknownPaymentDetails(_, _))), _) =>
           log.info(s"payment probe successful to node=$targetNodeId")
         case _ =>
           log.info(s"payment probe failed with paymentResult=$paymentResult")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -230,7 +230,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
     event match {
       case Left(paymentFailed) =>
         log.warning("multi-part payment failed")
-        log.info(s"failed payment attempts details:\n    + ${paymentFailed.failures.map(f => PaymentFailure.print(f)).mkString("\n    + ")}")
+        log.info(s"failed payment attempts details: ${PaymentFailure.summary(paymentFailed)}")
         reply(request.replyTo, paymentFailed)
       case Right(paymentSent) =>
         log.info("multi-part payment succeeded")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -16,9 +16,6 @@
 
 package fr.acinq.eclair.payment.send
 
-import java.util.UUID
-import java.util.concurrent.TimeUnit
-
 import akka.actor.{ActorRef, FSM, Props, Status}
 import akka.event.Logging.MDC
 import fr.acinq.bitcoin.ByteVector32
@@ -35,6 +32,9 @@ import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPaymentToRoute
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.wire.protocol._
 import fr.acinq.eclair.{CltvExpiry, FSMDiagnosticActorLogging, Logs, MilliSatoshi, MilliSatoshiLong, NodeParams}
+
+import java.util.UUID
+import java.util.concurrent.TimeUnit
 
 /**
  * Created by t-bast on 18/07/2019.
@@ -71,7 +71,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
     case Event(RouteResponse(routes), d: PaymentProgress) =>
       log.info("{} routes found (attempt={}/{})", routes.length, d.request.maxAttempts - d.remainingAttempts + 1, d.request.maxAttempts)
       // We may have already succeeded sending parts of the payment and only need to take care of the rest.
-      val (toSend, maxFee) = remainingToSend(nodeParams, d.request, d.pending.values)
+      val (toSend, maxFee) = remainingToSend(d.request, d.pending.values)
       if (routes.map(_.amount).sum == toSend) {
         val childPayments = routes.map(route => (UUID.randomUUID(), route)).toMap
         childPayments.foreach { case (childId, route) => spawnChildPaymentFsm(childId) ! createChildPayment(self, route, d.request) }
@@ -92,7 +92,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
         // Channels are mostly ignored for temporary reasons, likely because they didn't have enough balance to forward
         // the payment. When we're retrying an MPP split, it may make sense to retry those ignored channels because with
         // a different split, they may have enough balance to forward the payment.
-        val (toSend, maxFee) = remainingToSend(nodeParams, d.request, d.pending.values)
+        val (toSend, maxFee) = remainingToSend(d.request, d.pending.values)
         log.debug("retry sending {} with maximum fee {} without ignoring channels ({})", toSend, maxFee, d.ignore.channels.map(_.shortChannelId).mkString(","))
         val routeParams = d.request.routeParams.copy(randomize = true) // we randomize route selection when we retry
         router ! createRouteRequest(nodeParams, toSend, maxFee, routeParams, d, cfg).copy(ignore = d.ignore.emptyChannels())
@@ -140,7 +140,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
         val ignore1 = PaymentFailure.updateIgnored(pf.failures, d.ignore)
         val assistedRoutes1 = PaymentFailure.updateRoutingHints(pf.failures, d.request.assistedRoutes)
         val stillPending = d.pending - pf.id
-        val (toSend, maxFee) = remainingToSend(nodeParams, d.request, stillPending.values)
+        val (toSend, maxFee) = remainingToSend(d.request, stillPending.values)
         log.debug("child payment failed, retry sending {} with maximum fee {}", toSend, maxFee)
         val routeParams = d.request.routeParams.copy(randomize = true) // we randomize route selection when we retry
         val d1 = d.copy(pending = stillPending, ignore = ignore1, failures = d.failures ++ pf.failures, request = d.request.copy(assistedRoutes = assistedRoutes1))
@@ -230,13 +230,14 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
     event match {
       case Left(paymentFailed) =>
         log.warning("multi-part payment failed")
+        // TODO: print failure summary
         reply(request.replyTo, paymentFailed)
       case Right(paymentSent) =>
         log.info("multi-part payment succeeded")
         reply(request.replyTo, paymentSent)
     }
     val status = event match {
-      case Right(s: PaymentSent) => "SUCCESS"
+      case Right(_: PaymentSent) => "SUCCESS"
       case Left(f: PaymentFailed) =>
         if (f.failures.exists({ case r: RemoteFailure => r.e.originNode == cfg.recipientNodeId case _ => false })) {
           "RECIPIENT_FAILURE"
@@ -265,7 +266,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
     }
     Metrics.SentPaymentDuration
       .withTag(Tags.MultiPart, Tags.MultiPartType.Parent)
-      .withTag(Tags.Success, value = (status == "SUCCESS"))
+      .withTag(Tags.Success, value = status == "SUCCESS")
       .record(duration, TimeUnit.MILLISECONDS)
     if (retriedFailedChannels) {
       Metrics.RetryFailedChannelsResult.withTag(Tags.Success, event.isRight).increment()
@@ -411,7 +412,7 @@ object MultiPartPaymentLifecycle {
     case _ => false
   }
 
-  private def remainingToSend(nodeParams: NodeParams, request: SendMultiPartPayment, pending: Iterable[Route]): (MilliSatoshi, MilliSatoshi) = {
+  private def remainingToSend(request: SendMultiPartPayment, pending: Iterable[Route]): (MilliSatoshi, MilliSatoshi) = {
     val sentAmount = pending.map(_.amount).sum
     val sentFees = pending.map(_.fee).sum
     (request.totalAmount - sentAmount, request.routeParams.copy(randomize = false).getMaxFee(request.totalAmount) - sentFees)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -99,7 +99,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
         retriedFailedChannels = true
         stay() using d.copy(remainingAttempts = (d.remainingAttempts - 1).max(0), ignore = d.ignore.emptyChannels())
       } else {
-        val failure = LocalFailure(Nil, t)
+        val failure = LocalFailure(d.request.totalAmount - d.pending.values.map(_.amount).sum, Nil, t)
         Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(failure)).increment()
         if (cfg.storeInDb && d.pending.isEmpty && d.failures.isEmpty) {
           // In cases where we fail early (router error during the first attempt), the DB won't have an entry for that
@@ -133,7 +133,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
       if (abortPayment(pf, d)) {
         gotoAbortedOrStop(PaymentAborted(d.request, d.failures ++ pf.failures, d.pending.keySet - pf.id))
       } else if (d.remainingAttempts == 0) {
-        val failure = LocalFailure(Nil, PaymentError.RetryExhausted)
+        val failure = LocalFailure(d.request.totalAmount, Nil, PaymentError.RetryExhausted)
         Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(failure)).increment()
         gotoAbortedOrStop(PaymentAborted(d.request, d.failures ++ pf.failures :+ failure, d.pending.keySet - pf.id))
       } else {
@@ -230,7 +230,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
     event match {
       case Left(paymentFailed) =>
         log.warning("multi-part payment failed")
-        // TODO: print failure summary
+        log.info(s"failed payment attempts details:\n    + ${paymentFailed.failures.map(f => PaymentFailure.print(f)).mkString("\n    + ")}")
         reply(request.replyTo, paymentFailed)
       case Right(paymentSent) =>
         log.info("multi-part payment succeeded")
@@ -406,9 +406,9 @@ object MultiPartPaymentLifecycle {
   /** When we receive an error from the final recipient or payment gets settled on chain, we should fail the whole payment, it's useless to retry. */
   private def abortPayment(pf: PaymentFailed, d: PaymentProgress): Boolean = pf.failures.exists {
     case f: RemoteFailure => f.e.originNode == d.request.targetNodeId
-    case LocalFailure(_, _: HtlcOverriddenByLocalCommit) => true
-    case LocalFailure(_, _: HtlcsWillTimeoutUpstream) => true
-    case LocalFailure(_, _: HtlcsTimedoutDownstream) => true
+    case LocalFailure(_, _, _: HtlcOverriddenByLocalCommit) => true
+    case LocalFailure(_, _, _: HtlcsWillTimeoutUpstream) => true
+    case LocalFailure(_, _, _: HtlcsTimedoutDownstream) => true
     case _ => false
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/MultiPartPaymentLifecycle.scala
@@ -249,7 +249,7 @@ class MultiPartPaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, 
     if (cfg.recordPathFindingMetrics) {
       val fees = event match {
         case Left(paymentFailed) =>
-          log.info(s"failed payment attempts details: ${PaymentFailure.summary(paymentFailed)}")
+          log.info(s"failed payment attempts details: ${PaymentFailure.jsonSummary(paymentFailed)}")
           request.routeParams.getMaxFee(cfg.recipientAmount)
         case Right(paymentSent) =>
           val localFees = cfg.upstream match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentError.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentError.scala
@@ -25,24 +25,24 @@ object PaymentError {
   // @formatter:off
   sealed trait InvalidInvoice extends PaymentError
   /** The invoice contains a feature we don't support. */
-  case class UnsupportedFeatures(features: Features) extends InvalidInvoice
+  case class UnsupportedFeatures(features: Features) extends InvalidInvoice { override def getMessage: String = s"unsupported invoice features: ${features.toByteVector.toHex}" }
   /** The invoice is missing a payment secret. */
-  case object PaymentSecretMissing extends InvalidInvoice
+  case object PaymentSecretMissing extends InvalidInvoice { override def getMessage: String = "invalid invoice: payment secret is missing" }
   // @formatter:on
 
   // @formatter:off
   sealed trait InvalidTrampolineArguments extends PaymentError
   /** Trampoline fees or cltv expiry delta is missing. */
-  case object TrampolineFeesMissing extends InvalidTrampolineArguments
+  case object TrampolineFeesMissing extends InvalidTrampolineArguments { override def getMessage: String = "cannot send payment: trampoline fees missing" }
   /** 0-value invoice should not be paid via trampoline-to-legacy (trampoline may steal funds). */
-  case object TrampolineLegacyAmountLessInvoice extends InvalidTrampolineArguments
+  case object TrampolineLegacyAmountLessInvoice extends InvalidTrampolineArguments { override def getMessage: String = "cannot send payment: unsafe trampoline-to-legacy amount-less invoice" }
   /** Only a single trampoline node is currently supported. */
-  case object TrampolineMultiNodeNotSupported extends InvalidTrampolineArguments
+  case object TrampolineMultiNodeNotSupported extends InvalidTrampolineArguments { override def getMessage: String = "cannot send payment: multiple trampoline hops not supported" }
   // @formatter:on
 
   // @formatter:off
   /** Payment attempts exhausted without success. */
-  case object RetryExhausted extends PaymentError
+  case object RetryExhausted extends PaymentError { override def getMessage: String = "payment attempts exhausted without success" }
   // @formatter:on
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -318,7 +318,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
           }
           paymentSent.feesPaid + localFees
         case Left(paymentFailed) =>
-          log.info(s"failed payment attempts details: ${PaymentFailure.summary(paymentFailed)}")
+          log.info(s"failed payment attempts details: ${PaymentFailure.jsonSummary(paymentFailed)}")
           request match {
             case s: SendPaymentToNode => s.routeParams.getMaxFee(cfg.recipientAmount)
             case _: SendPaymentToRoute => 0 msat

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -82,8 +82,8 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
 
     case Event(Status.Failure(t), WaitingForRoute(c, failures, _)) =>
       log.warning("router error: {}", t.getMessage)
-      Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(Nil, t))).increment()
-      myStop(c, Left(PaymentFailed(id, paymentHash, failures :+ LocalFailure(Nil, t))))
+      Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(c.finalPayload.amount, Nil, t))).increment()
+      myStop(c, Left(PaymentFailed(id, paymentHash, failures :+ LocalFailure(c.finalPayload.amount, Nil, t))))
   }
 
   when(WAITING_FOR_PAYMENT_COMPLETE) {
@@ -145,11 +145,11 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
   private def handleLocalFail(d: WaitingForComplete, t: Throwable, isFatal: Boolean) = {
     t match {
       case UpdateMalformedException => Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType.Malformed).increment()
-      case _ => Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(cfg.fullRoute(d.route), t))).increment()
+      case _ => Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(d.c.finalPayload.amount, cfg.fullRoute(d.route), t))).increment()
     }
     // we only retry if the error isn't fatal, and we haven't exhausted the max number of retried
     val doRetry = !isFatal && (d.failures.size + 1 < d.c.maxAttempts)
-    val localFailure = LocalFailure(cfg.fullRoute(d.route), t)
+    val localFailure = LocalFailure(d.c.finalPayload.amount, cfg.fullRoute(d.route), t)
     if (doRetry) {
       log.info(s"received an error message from local, trying to use a different channel (failure=${t.getMessage})")
       retry(localFailure, d)
@@ -162,16 +162,16 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
     import d._
     (Sphinx.FailurePacket.decrypt(fail.reason, sharedSecrets) match {
       case success@Success(e) =>
-        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(RemoteFailure(Nil, e))).increment()
+        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(RemoteFailure(d.c.finalPayload.amount, Nil, e))).increment()
         success
       case failure@Failure(_) =>
-        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(UnreadableRemoteFailure(Nil))).increment()
+        Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(UnreadableRemoteFailure(d.c.finalPayload.amount, Nil))).increment()
         failure
     }) match {
       case Success(e@Sphinx.DecryptedFailurePacket(nodeId, failureMessage)) if nodeId == c.targetNodeId =>
         // if destination node returns an error, we fail the payment immediately
         log.warning(s"received an error message from target nodeId=$nodeId, failing the payment (failure=$failureMessage)")
-        myStop(c, Left(PaymentFailed(id, paymentHash, failures :+ RemoteFailure(cfg.fullRoute(route), e))))
+        myStop(c, Left(PaymentFailed(id, paymentHash, failures :+ RemoteFailure(d.c.finalPayload.amount, cfg.fullRoute(route), e))))
       case res if failures.size + 1 >= c.maxAttempts =>
         // otherwise we never try more than maxAttempts, no matter the kind of error returned
         val failure = res match {
@@ -181,24 +181,24 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
               case failureMessage: Update => handleUpdate(nodeId, failureMessage, d)
               case _ =>
             }
-            RemoteFailure(cfg.fullRoute(route), e)
+            RemoteFailure(d.c.finalPayload.amount, cfg.fullRoute(route), e)
           case Failure(t) =>
             log.warning(s"cannot parse returned error ${fail.reason.toHex} with sharedSecrets=$sharedSecrets: ${t.getMessage}")
-            UnreadableRemoteFailure(cfg.fullRoute(route))
+            UnreadableRemoteFailure(d.c.finalPayload.amount, cfg.fullRoute(route))
         }
         log.warning(s"too many failed attempts, failing the payment")
         myStop(c, Left(PaymentFailed(id, paymentHash, failures :+ failure)))
       case Failure(t) =>
         log.warning(s"cannot parse returned error: ${t.getMessage}, route=${route.printNodes()}")
-        val failure = UnreadableRemoteFailure(cfg.fullRoute(route))
+        val failure = UnreadableRemoteFailure(d.c.finalPayload.amount, cfg.fullRoute(route))
         retry(failure, d)
       case Success(e@Sphinx.DecryptedFailurePacket(nodeId, failureMessage: Node)) =>
         log.info(s"received 'Node' type error message from nodeId=$nodeId, trying to route around it (failure=$failureMessage)")
-        val failure = RemoteFailure(cfg.fullRoute(route), e)
+        val failure = RemoteFailure(d.c.finalPayload.amount, cfg.fullRoute(route), e)
         retry(failure, d)
       case Success(e@Sphinx.DecryptedFailurePacket(nodeId, failureMessage: Update)) =>
         log.info(s"received 'Update' type error message from nodeId=$nodeId, retrying payment (failure=$failureMessage)")
-        val failure = RemoteFailure(cfg.fullRoute(route), e)
+        val failure = RemoteFailure(d.c.finalPayload.amount, cfg.fullRoute(route), e)
         if (Announcements.checkSig(failureMessage.update, nodeId)) {
           val assistedRoutes1 = handleUpdate(nodeId, failureMessage, d)
           val ignore1 = PaymentFailure.updateIgnored(failure, ignore)
@@ -225,7 +225,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
         }
       case Success(e@Sphinx.DecryptedFailurePacket(nodeId, failureMessage)) =>
         log.info(s"received an error message from nodeId=$nodeId, trying to use a different channel (failure=$failureMessage)")
-        val failure = RemoteFailure(cfg.fullRoute(route), e)
+        val failure = RemoteFailure(d.c.finalPayload.amount, cfg.fullRoute(route), e)
         retry(failure, d)
     }
   }
@@ -347,15 +347,13 @@ object PaymentLifecycle {
   def props(nodeParams: NodeParams, cfg: SendPaymentConfig, router: ActorRef, register: ActorRef) = Props(new PaymentLifecycle(nodeParams, cfg, router, register))
 
   sealed trait SendPayment {
+    // @formatter:off
     def replyTo: ActorRef
-
     def finalPayload: FinalPayload
-
     def assistedRoutes: Seq[Seq[ExtraHop]]
-
     def targetNodeId: PublicKey
-
     def maxAttempts: Int
+    // @formatter:on
   }
 
   /**
@@ -416,7 +414,7 @@ object PaymentLifecycle {
 
   /** custom exceptions to handle corner cases */
   case object UpdateMalformedException extends RuntimeException("first hop returned an UpdateFailMalformedHtlc message")
-  case object ChannelFailureException extends RuntimeException("a channel failure occured with the first hop")
+  case object ChannelFailureException extends RuntimeException("a channel failure occurred with the first hop")
   case object DisconnectedException extends RuntimeException("a disconnection occurred with the first hop")
   // @formatter:on
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -317,10 +317,12 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
               }.sum
           }
           paymentSent.feesPaid + localFees
-        case Left(_) => request match {
-          case s: SendPaymentToNode => s.routeParams.getMaxFee(cfg.recipientAmount)
-          case _: SendPaymentToRoute => 0 msat
-        }
+        case Left(paymentFailed) =>
+          log.info(s"failed payment attempts details: ${PaymentFailure.summary(paymentFailed)}")
+          request match {
+            case s: SendPaymentToNode => s.routeParams.getMaxFee(cfg.recipientAmount)
+            case _: SendPaymentToRoute => 0 msat
+          }
       }
       request match {
         case SendPaymentToNode(_, _, _, _, _, routeParams) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -68,17 +68,17 @@ class AuditDbSpec extends AnyFunSuite {
       val e2 = PaymentReceived(randomBytes32(), pp2a :: pp2b :: Nil)
       val e3 = ChannelPaymentRelayed(42000 msat, 1000 msat, randomBytes32(), randomBytes32(), randomBytes32())
       val e4 = NetworkFeePaid(null, randomKey().publicKey, randomBytes32(), Transaction(0, Seq.empty, Seq.empty, 0), 42 sat, "mutual")
-      val pp5a = PaymentSent.PartialPayment(UUID.randomUUID(), 42000 msat, 1000 msat, randomBytes32(), None, timestamp = 0)
-      val pp5b = PaymentSent.PartialPayment(UUID.randomUUID(), 42100 msat, 900 msat, randomBytes32(), None, timestamp = 1)
+      val pp5a = PaymentSent.PartialPayment(UUID.randomUUID(), 42000 msat, 1000 msat, randomBytes32(), None, timestamp = TimestampMilli(0))
+      val pp5b = PaymentSent.PartialPayment(UUID.randomUUID(), 42100 msat, 900 msat, randomBytes32(), None, timestamp = TimestampMilli(1))
       val e5 = PaymentSent(UUID.randomUUID(), randomBytes32(), randomBytes32(), 84100 msat, randomKey().publicKey, pp5a :: pp5b :: Nil)
-      val pp6 = PaymentSent.PartialPayment(UUID.randomUUID(), 42000 msat, 1000 msat, randomBytes32(), None, timestamp = (System.currentTimeMillis.milliseconds + 10.minutes).toMillis)
+      val pp6 = PaymentSent.PartialPayment(UUID.randomUUID(), 42000 msat, 1000 msat, randomBytes32(), None, timestamp = TimestampMilli((System.currentTimeMillis.milliseconds + 10.minutes).toMillis))
       val e6 = PaymentSent(UUID.randomUUID(), randomBytes32(), randomBytes32(), 42000 msat, randomKey().publicKey, pp6 :: Nil)
       val e7 = ChannelEvent(randomBytes32(), randomKey().publicKey, 456123000 sat, isFunder = true, isPrivate = false, ChannelEvent.EventType.Closed(MutualClose(null)))
       val e8 = ChannelErrorOccurred(null, randomBytes32(), randomKey().publicKey, null, LocalError(new RuntimeException("oops")), isFatal = true)
       val e9 = ChannelErrorOccurred(null, randomBytes32(), randomKey().publicKey, null, RemoteError(Error(randomBytes32(), "remote oops")), isFatal = true)
       val e10 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(20000 msat, randomBytes32()), PaymentRelayed.Part(22000 msat, randomBytes32())), Seq(PaymentRelayed.Part(10000 msat, randomBytes32()), PaymentRelayed.Part(12000 msat, randomBytes32()), PaymentRelayed.Part(15000 msat, randomBytes32())), randomKey().publicKey, 30000 msat)
       val multiPartPaymentHash = randomBytes32()
-      val now = System.currentTimeMillis
+      val now = TimestampMilli.now
       val e11 = ChannelPaymentRelayed(13000 msat, 11000 msat, multiPartPaymentHash, randomBytes32(), randomBytes32(), now)
       val e12 = ChannelPaymentRelayed(15000 msat, 12500 msat, multiPartPaymentHash, randomBytes32(), randomBytes32(), now)
 
@@ -224,7 +224,7 @@ class AuditDbSpec extends AnyFunSuite {
           statement.setBytes(3, ps.paymentHash.toArray)
           statement.setBytes(4, ps.paymentPreimage.toArray)
           statement.setBytes(5, ps.parts.head.toChannelId.toArray)
-          statement.setLong(6, ps.timestamp)
+          statement.setLong(6, ps.timestamp.toLong)
           statement.executeUpdate()
         }
       },
@@ -301,12 +301,12 @@ class AuditDbSpec extends AnyFunSuite {
 
     val dbs = TestSqliteDatabases()
 
-    val pp1 = PaymentSent.PartialPayment(UUID.randomUUID(), 500 msat, 10 msat, randomBytes32(), None, 100)
-    val pp2 = PaymentSent.PartialPayment(UUID.randomUUID(), 600 msat, 5 msat, randomBytes32(), None, 110)
+    val pp1 = PaymentSent.PartialPayment(UUID.randomUUID(), 500 msat, 10 msat, randomBytes32(), None, TimestampMilli(100))
+    val pp2 = PaymentSent.PartialPayment(UUID.randomUUID(), 600 msat, 5 msat, randomBytes32(), None, TimestampMilli(110))
     val ps1 = PaymentSent(UUID.randomUUID(), randomBytes32(), randomBytes32(), 1100 msat, PrivateKey(ByteVector32.One).publicKey, pp1 :: pp2 :: Nil)
 
-    val relayed1 = ChannelPaymentRelayed(600 msat, 500 msat, randomBytes32(), randomBytes32(), randomBytes32(), 105)
-    val relayed2 = ChannelPaymentRelayed(650 msat, 500 msat, randomBytes32(), randomBytes32(), randomBytes32(), 115)
+    val relayed1 = ChannelPaymentRelayed(600 msat, 500 msat, randomBytes32(), randomBytes32(), randomBytes32(), TimestampMilli(105))
+    val relayed2 = ChannelPaymentRelayed(650 msat, 500 msat, randomBytes32(), randomBytes32(), randomBytes32(), TimestampMilli(115))
 
     migrationCheck(
       dbs = dbs,
@@ -339,7 +339,7 @@ class AuditDbSpec extends AnyFunSuite {
             statement.setBytes(3, ps1.paymentHash.toArray)
             statement.setBytes(4, ps1.paymentPreimage.toArray)
             statement.setBytes(5, pp.toChannelId.toArray)
-            statement.setLong(6, pp.timestamp)
+            statement.setLong(6, pp.timestamp.toLong)
             statement.setBytes(7, pp.id.toString.getBytes)
             statement.executeUpdate()
           }
@@ -352,7 +352,7 @@ class AuditDbSpec extends AnyFunSuite {
             statement.setBytes(3, relayed.paymentHash.toArray)
             statement.setBytes(4, relayed.fromChannelId.toArray)
             statement.setBytes(5, relayed.toChannelId.toArray)
-            statement.setLong(6, relayed.timestamp)
+            statement.setLong(6, relayed.timestamp.toLong)
             statement.executeUpdate()
           }
         }
@@ -375,10 +375,10 @@ class AuditDbSpec extends AnyFunSuite {
           assert(getVersion(statement, "audit").contains(SqliteAuditDb.CURRENT_VERSION))
         }
         val ps2 = PaymentSent(UUID.randomUUID(), randomBytes32(), randomBytes32(), 1100 msat, randomKey().publicKey, Seq(
-          PaymentSent.PartialPayment(UUID.randomUUID(), 500 msat, 10 msat, randomBytes32(), None, 160),
-          PaymentSent.PartialPayment(UUID.randomUUID(), 600 msat, 5 msat, randomBytes32(), None, 165)
+          PaymentSent.PartialPayment(UUID.randomUUID(), 500 msat, 10 msat, randomBytes32(), None, TimestampMilli(160)),
+          PaymentSent.PartialPayment(UUID.randomUUID(), 600 msat, 5 msat, randomBytes32(), None, TimestampMilli(165))
         ))
-        val relayed3 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(450 msat, randomBytes32()), PaymentRelayed.Part(500 msat, randomBytes32())), Seq(PaymentRelayed.Part(800 msat, randomBytes32())), randomKey().publicKey, 700 msat, 150)
+        val relayed3 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(450 msat, randomBytes32()), PaymentRelayed.Part(500 msat, randomBytes32())), Seq(PaymentRelayed.Part(800 msat, randomBytes32())), randomKey().publicKey, 700 msat, TimestampMilli(150))
         postMigrationDb.add(ps2)
         assert(postMigrationDb.listSent(155, 200) === Seq(ps2))
         postMigrationDb.add(relayed3)
@@ -389,8 +389,8 @@ class AuditDbSpec extends AnyFunSuite {
 
   test("migrate audit database v4 -> current") {
 
-    val relayed1 = ChannelPaymentRelayed(600 msat, 500 msat, randomBytes32(), randomBytes32(), randomBytes32(), 105)
-    val relayed2 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(300 msat, randomBytes32()), PaymentRelayed.Part(350 msat, randomBytes32())), Seq(PaymentRelayed.Part(600 msat, randomBytes32())), PlaceHolderPubKey, 0 msat, 110)
+    val relayed1 = ChannelPaymentRelayed(600 msat, 500 msat, randomBytes32(), randomBytes32(), randomBytes32(), TimestampMilli(105))
+    val relayed2 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(300 msat, randomBytes32()), PaymentRelayed.Part(350 msat, randomBytes32())), Seq(PaymentRelayed.Part(600 msat, randomBytes32())), PlaceHolderPubKey, 0 msat, TimestampMilli(110))
 
     forAllDbs {
       case dbs: TestPgDatabases =>
@@ -423,7 +423,7 @@ class AuditDbSpec extends AnyFunSuite {
               statement.setString(3, relayed1.fromChannelId.toHex)
               statement.setString(4, "IN")
               statement.setString(5, "channel")
-              statement.setLong(6, relayed1.timestamp)
+              statement.setLong(6, relayed1.timestamp.toLong)
               statement.executeUpdate()
             }
             using(connection.prepareStatement("INSERT INTO relayed VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
@@ -432,7 +432,7 @@ class AuditDbSpec extends AnyFunSuite {
               statement.setString(3, relayed1.toChannelId.toHex)
               statement.setString(4, "OUT")
               statement.setString(5, "channel")
-              statement.setLong(6, relayed1.timestamp)
+              statement.setLong(6, relayed1.timestamp.toLong)
               statement.executeUpdate()
             }
             for (incoming <- relayed2.incoming) {
@@ -442,7 +442,7 @@ class AuditDbSpec extends AnyFunSuite {
                 statement.setString(3, incoming.channelId.toHex)
                 statement.setString(4, "IN")
                 statement.setString(5, "trampoline")
-                statement.setLong(6, relayed2.timestamp)
+                statement.setLong(6, relayed2.timestamp.toLong)
                 statement.executeUpdate()
               }
             }
@@ -453,7 +453,7 @@ class AuditDbSpec extends AnyFunSuite {
                 statement.setString(3, outgoing.channelId.toHex)
                 statement.setString(4, "OUT")
                 statement.setString(5, "trampoline")
-                statement.setLong(6, relayed2.timestamp)
+                statement.setLong(6, relayed2.timestamp.toLong)
                 statement.executeUpdate()
               }
             }
@@ -469,7 +469,7 @@ class AuditDbSpec extends AnyFunSuite {
             using(connection.createStatement()) { statement =>
               assert(getVersion(statement, "audit").contains(PgAuditDb.CURRENT_VERSION))
             }
-            val relayed3 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(450 msat, randomBytes32()), PaymentRelayed.Part(500 msat, randomBytes32())), Seq(PaymentRelayed.Part(800 msat, randomBytes32())), randomKey().publicKey, 700 msat, 150)
+            val relayed3 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(450 msat, randomBytes32()), PaymentRelayed.Part(500 msat, randomBytes32())), Seq(PaymentRelayed.Part(800 msat, randomBytes32())), randomKey().publicKey, 700 msat, TimestampMilli(150))
             postMigrationDb.add(relayed3)
             assert(postMigrationDb.listRelayed(100, 160) === Seq(relayed1, relayed2, relayed3))
           }
@@ -504,7 +504,7 @@ class AuditDbSpec extends AnyFunSuite {
               statement.setBytes(3, relayed1.fromChannelId.toArray)
               statement.setString(4, "IN")
               statement.setString(5, "channel")
-              statement.setLong(6, relayed1.timestamp)
+              statement.setLong(6, relayed1.timestamp.toLong)
               statement.executeUpdate()
             }
             using(connection.prepareStatement("INSERT INTO relayed VALUES (?, ?, ?, ?, ?, ?)")) { statement =>
@@ -513,7 +513,7 @@ class AuditDbSpec extends AnyFunSuite {
               statement.setBytes(3, relayed1.toChannelId.toArray)
               statement.setString(4, "OUT")
               statement.setString(5, "channel")
-              statement.setLong(6, relayed1.timestamp)
+              statement.setLong(6, relayed1.timestamp.toLong)
               statement.executeUpdate()
             }
             for (incoming <- relayed2.incoming) {
@@ -523,7 +523,7 @@ class AuditDbSpec extends AnyFunSuite {
                 statement.setBytes(3, incoming.channelId.toArray)
                 statement.setString(4, "IN")
                 statement.setString(5, "trampoline")
-                statement.setLong(6, relayed2.timestamp)
+                statement.setLong(6, relayed2.timestamp.toLong)
                 statement.executeUpdate()
               }
             }
@@ -534,7 +534,7 @@ class AuditDbSpec extends AnyFunSuite {
                 statement.setBytes(3, outgoing.channelId.toArray)
                 statement.setString(4, "OUT")
                 statement.setString(5, "trampoline")
-                statement.setLong(6, relayed2.timestamp)
+                statement.setLong(6, relayed2.timestamp.toLong)
                 statement.executeUpdate()
               }
             }
@@ -552,7 +552,7 @@ class AuditDbSpec extends AnyFunSuite {
             using(connection.createStatement()) { statement =>
               assert(getVersion(statement, "audit").contains(SqliteAuditDb.CURRENT_VERSION))
             }
-            val relayed3 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(450 msat, randomBytes32()), PaymentRelayed.Part(500 msat, randomBytes32())), Seq(PaymentRelayed.Part(800 msat, randomBytes32())), randomKey().publicKey, 700 msat, 150)
+            val relayed3 = TrampolinePaymentRelayed(randomBytes32(), Seq(PaymentRelayed.Part(450 msat, randomBytes32()), PaymentRelayed.Part(500 msat, randomBytes32())), Seq(PaymentRelayed.Part(800 msat, randomBytes32())), randomKey().publicKey, 700 msat, TimestampMilli(150))
             postMigrationDb.add(relayed3)
             assert(postMigrationDb.listRelayed(100, 160) === Seq(relayed1, relayed2, relayed3))
           }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PaymentsDbSpec.scala
@@ -481,7 +481,7 @@ class PaymentsDbSpec extends AnyFunSuite {
       db.updateOutgoingPayment(PaymentFailed(s3.id, s3.paymentHash, Nil, 310))
       val ss3 = s3.copy(status = OutgoingPaymentStatus.Failed(Nil, 310))
       assert(db.getOutgoingPayment(s3.id) === Some(ss3))
-      db.updateOutgoingPayment(PaymentFailed(s4.id, s4.paymentHash, Seq(LocalFailure(500 msat, Seq(hop_ab), new RuntimeException("woops")), RemoteFailure(400 msat, Seq(hop_ab, hop_bc), Sphinx.DecryptedFailurePacket(carol, UnknownNextPeer))), 320))
+      db.updateOutgoingPayment(PaymentFailed(s4.id, s4.paymentHash, Seq(LocalFailure(s4.amount, Seq(hop_ab), new RuntimeException("woops")), RemoteFailure(s4.amount, Seq(hop_ab, hop_bc), Sphinx.DecryptedFailurePacket(carol, UnknownNextPeer))), 320))
       val ss4 = s4.copy(status = OutgoingPaymentStatus.Failed(Seq(FailureSummary(FailureType.LOCAL, "woops", List(HopSummary(alice, bob, Some(ShortChannelId(42))))), FailureSummary(FailureType.REMOTE, "processing node does not know the next peer in the route", List(HopSummary(alice, bob, Some(ShortChannelId(42))), HopSummary(bob, carol, None)))), 320))
       assert(db.getOutgoingPayment(s4.id) === Some(ss4))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PaymentsDbSpec.scala
@@ -370,7 +370,7 @@ class PaymentsDbSpec extends AnyFunSuite {
         }
 
         import fr.acinq.eclair.db.jdbc.JdbcUtils.ExtendedResultSet._
-        assert(connection.createStatement().executeQuery("SELECT * FROM received_payments").map(rs => rs.getString("payment_hash")).toSeq.size > 0)
+        assert(connection.createStatement().executeQuery("SELECT * FROM received_payments").map(rs => rs.getString("payment_hash")).toSeq.nonEmpty)
 
       },
       dbName = PgPaymentsDb.DB_NAME,
@@ -481,7 +481,7 @@ class PaymentsDbSpec extends AnyFunSuite {
       db.updateOutgoingPayment(PaymentFailed(s3.id, s3.paymentHash, Nil, 310))
       val ss3 = s3.copy(status = OutgoingPaymentStatus.Failed(Nil, 310))
       assert(db.getOutgoingPayment(s3.id) === Some(ss3))
-      db.updateOutgoingPayment(PaymentFailed(s4.id, s4.paymentHash, Seq(LocalFailure(Seq(hop_ab), new RuntimeException("woops")), RemoteFailure(Seq(hop_ab, hop_bc), Sphinx.DecryptedFailurePacket(carol, UnknownNextPeer))), 320))
+      db.updateOutgoingPayment(PaymentFailed(s4.id, s4.paymentHash, Seq(LocalFailure(500 msat, Seq(hop_ab), new RuntimeException("woops")), RemoteFailure(400 msat, Seq(hop_ab, hop_bc), Sphinx.DecryptedFailurePacket(carol, UnknownNextPeer))), 320))
       val ss4 = s4.copy(status = OutgoingPaymentStatus.Failed(Seq(FailureSummary(FailureType.LOCAL, "woops", List(HopSummary(alice, bob, Some(ShortChannelId(42))))), FailureSummary(FailureType.REMOTE, "processing node does not know the next peer in the route", List(HopSummary(alice, bob, Some(ShortChannelId(42))), HopSummary(bob, carol, None)))), 320))
       assert(db.getOutgoingPayment(s4.id) === Some(ss4))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
@@ -27,6 +27,7 @@ import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.transactions.{IncomingHtlc, OutgoingHtlc}
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecs
 import fr.acinq.eclair.wire.protocol._
+import org.json4s.DefaultFormats
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import scodec.bits._
@@ -240,6 +241,19 @@ class JsonSerializersSpec extends AnyFunSuite with Matchers {
     assert(JsonSerializers.serialization.write(ChannelCodecs.stateDataCodec.decode(dataNegotiating.bits).require.value)(JsonSerializers.formats).contains(""""type":"DATA_NEGOTIATING""""))
     assert(JsonSerializers.serialization.write(ChannelCodecs.stateDataCodec.decode(dataClosingLocal.bits).require.value)(JsonSerializers.formats).contains(""""type":"DATA_CLOSING""""))
 
+  }
+
+  test("map serializer") {
+    val formats = DefaultFormats + new PublicKeyKeySerializer
+    val m = Map(randomKey().publicKey -> "foo", randomKey().publicKey -> "bar", randomKey().publicKey -> "baz").toList.toMap
+    println(JsonSerializers.serialization.writePretty(m)(formats))
+  }
+  case class Foo(a: (String, ByteVector32))
+  case class FooJson(a: String, b: ByteVector32)
+  test("test serializer") {
+    val formats = DefaultFormats + new ByteVector32Serializer + new ConvertClassSerializer[Foo](o => FooJson(o.a._1, o.a._2))
+    val o = Foo(("foo", randomBytes32()))
+    println(JsonSerializers.serialization.writePretty(o)(formats))
   }
 
   /** utility method that strips line breaks in the expected json */

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
@@ -32,7 +32,7 @@ import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM.HtlcPart
 import fr.acinq.eclair.payment.receive.{MultiPartPaymentFSM, PaymentHandler}
 import fr.acinq.eclair.wire.protocol.Onion.FinalTlvPayload
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshiLong, NodeParams, ShortChannelId, TestConstants, TestKitBaseClass, randomBytes32, randomKey}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshiLong, NodeParams, ShortChannelId, TestConstants, TestKitBaseClass, TimestampMilli, randomBytes32, randomKey}
 import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 
@@ -96,7 +96,7 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
       register.expectMsgType[Register.Forward[CMD_FULFILL_HTLC]]
 
       val paymentReceived = eventListener.expectMsgType[PaymentReceived]
-      assert(paymentReceived.copy(parts = paymentReceived.parts.map(_.copy(timestamp = 0))) === PaymentReceived(add.paymentHash, PartialPayment(amountMsat, add.channelId, timestamp = 0) :: Nil))
+      assert(paymentReceived.copy(parts = paymentReceived.parts.map(_.copy(timestamp = TimestampMilli(0)))) === PaymentReceived(add.paymentHash, PartialPayment(amountMsat, add.channelId, timestamp = TimestampMilli(0)) :: Nil))
       val received = nodeParams.db.payments.getIncomingPayment(pr.paymentHash)
       assert(received.isDefined && received.get.status.isInstanceOf[IncomingPaymentStatus.Received])
       assert(received.get.status.asInstanceOf[IncomingPaymentStatus.Received].copy(receivedAt = 0) === IncomingPaymentStatus.Received(amountMsat, 0))
@@ -115,7 +115,7 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
       register.expectMsgType[Register.Forward[CMD_FULFILL_HTLC]]
 
       val paymentReceived = eventListener.expectMsgType[PaymentReceived]
-      assert(paymentReceived.copy(parts = paymentReceived.parts.map(_.copy(timestamp = 0))) === PaymentReceived(add.paymentHash, PartialPayment(amountMsat, add.channelId, timestamp = 0) :: Nil))
+      assert(paymentReceived.copy(parts = paymentReceived.parts.map(_.copy(timestamp = TimestampMilli(0)))) === PaymentReceived(add.paymentHash, PartialPayment(amountMsat, add.channelId, timestamp = TimestampMilli(0)) :: Nil))
       val received = nodeParams.db.payments.getIncomingPayment(pr.paymentHash)
       assert(received.isDefined && received.get.status.isInstanceOf[IncomingPaymentStatus.Received])
       assert(received.get.status.asInstanceOf[IncomingPaymentStatus.Received].copy(receivedAt = 0) === IncomingPaymentStatus.Received(amountMsat, 0))
@@ -414,7 +414,7 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     )
 
     val paymentReceived = f.eventListener.expectMsgType[PaymentReceived]
-    assert(paymentReceived.parts.map(_.copy(timestamp = 0)).toSet === Set(PartialPayment(800 msat, ByteVector32.One, 0), PartialPayment(200 msat, ByteVector32.Zeroes, 0)))
+    assert(paymentReceived.parts.map(_.copy(timestamp = TimestampMilli(0))).toSet === Set(PartialPayment(800 msat, ByteVector32.One, TimestampMilli(0)), PartialPayment(200 msat, ByteVector32.Zeroes, TimestampMilli(0))))
     val received = nodeParams.db.payments.getIncomingPayment(pr.paymentHash)
     assert(received.isDefined && received.get.status.isInstanceOf[IncomingPaymentStatus.Received])
     assert(received.get.status.asInstanceOf[IncomingPaymentStatus.Received].amount === 1000.msat)
@@ -465,7 +465,7 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
 
     val paymentReceived = f.eventListener.expectMsgType[PaymentReceived]
     assert(paymentReceived.paymentHash === pr.paymentHash)
-    assert(paymentReceived.parts.map(_.copy(timestamp = 0)).toSet === Set(PartialPayment(300 msat, ByteVector32.One, 0), PartialPayment(700 msat, ByteVector32.Zeroes, 0)))
+    assert(paymentReceived.parts.map(_.copy(timestamp = TimestampMilli(0))).toSet === Set(PartialPayment(300 msat, ByteVector32.One, TimestampMilli(0)), PartialPayment(700 msat, ByteVector32.Zeroes, TimestampMilli(0))))
     val received = nodeParams.db.payments.getIncomingPayment(pr.paymentHash)
     assert(received.isDefined && received.get.status.isInstanceOf[IncomingPaymentStatus.Received])
     assert(received.get.status.asInstanceOf[IncomingPaymentStatus.Received].amount === 1000.msat)
@@ -491,7 +491,7 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     register.expectMsgType[Register.Forward[CMD_FULFILL_HTLC]]
 
     val paymentReceived = eventListener.expectMsgType[PaymentReceived]
-    assert(paymentReceived.copy(parts = paymentReceived.parts.map(_.copy(timestamp = 0))) === PaymentReceived(add.paymentHash, PartialPayment(amountMsat, add.channelId, timestamp = 0) :: Nil))
+    assert(paymentReceived.copy(parts = paymentReceived.parts.map(_.copy(timestamp = TimestampMilli(0)))) === PaymentReceived(add.paymentHash, PartialPayment(amountMsat, add.channelId, timestamp = TimestampMilli(0)) :: Nil))
     val received = nodeParams.db.payments.getIncomingPayment(paymentHash)
     assert(received.isDefined && received.get.status.isInstanceOf[IncomingPaymentStatus.Received])
     assert(received.get.status.asInstanceOf[IncomingPaymentStatus.Received].copy(receivedAt = 0) === IncomingPaymentStatus.Received(amountMsat, 0))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -217,7 +217,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status === OutgoingPaymentStatus.Pending))
 
     routerForwarder.forward(routerFixture.router, routeRequest)
-    assert(sender.expectMsgType[PaymentFailed].failures === LocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === LocalFailure(defaultAmountMsat, Nil, RouteNotFound) :: Nil)
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
@@ -247,7 +247,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val Transition(_, WAITING_FOR_REQUEST, WAITING_FOR_ROUTE) = monitor.expectMsgClass(classOf[Transition[_]])
 
     routerForwarder.forward(routerFixture.router, routeRequest)
-    val Seq(LocalFailure(Nil, RouteNotFound)) = sender.expectMsgType[PaymentFailed].failures
+    val Seq(LocalFailure(_, Nil, RouteNotFound)) = sender.expectMsgType[PaymentFailed].failures
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
@@ -290,7 +290,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.send(paymentFSM, addCompleted(HtlcResult.RemoteFail(UpdateFailHtlc(ByteVector32.Zeroes, 0, defaultPaymentHash)))) // unparsable message
 
     // we allow 2 tries, so we send a 2nd request to the router
-    assert(sender.expectMsgType[PaymentFailed].failures === UnreadableRemoteFailure(route.hops) :: UnreadableRemoteFailure(route.hops) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === UnreadableRemoteFailure(route.amount, route.hops) :: UnreadableRemoteFailure(route.amount, route.hops) :: Nil)
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed])) // after last attempt the payment is failed
 
     val metrics = metricsListener.expectMsgType[PathFindingExperimentMetrics]
@@ -438,7 +438,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.expectMsg(defaultRouteRequest(a, d, cfg).copy(ignore = Ignore(Set.empty, Set(ChannelDesc(update_bc.shortChannelId, b, c)))))
     routerForwarder.forward(routerFixture.router)
     // we allow 2 tries, so we send a 2nd request to the router
-    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route.amount, route.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: LocalFailure(defaultAmountMsat, Nil, RouteNotFound) :: Nil)
   }
 
   test("payment failed (Update)") { routerFixture =>
@@ -490,7 +490,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.forward(routerFixture.router)
 
     // this time the router can't find a route: game over
-    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route1.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: RemoteFailure(route2.hops, Sphinx.DecryptedFailurePacket(b, failure2)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route1.amount, route1.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: RemoteFailure(route2.amount, route2.hops, Sphinx.DecryptedFailurePacket(b, failure2)) :: LocalFailure(defaultAmountMsat, Nil, RouteNotFound) :: Nil)
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
   }
 
@@ -613,7 +613,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     routerForwarder.forward(router)
     // we allow 2 tries, so we send a 2nd request to the router, which won't find another route
 
-    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route1.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: LocalFailure(Nil, RouteNotFound) :: Nil)
+    assert(sender.expectMsgType[PaymentFailed].failures === RemoteFailure(route1.amount, route1.hops, Sphinx.DecryptedFailurePacket(b, failure)) :: LocalFailure(defaultAmountMsat, Nil, RouteNotFound) :: Nil)
     awaitCond(nodeParams.db.payments.getOutgoingPayment(id).exists(_.status.isInstanceOf[OutgoingPaymentStatus.Failed]))
   }
 
@@ -715,16 +715,16 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
 
   test("filter errors properly") { _ =>
     val failures = Seq(
-      LocalFailure(Nil, RouteNotFound),
-      RemoteFailure(ChannelHop(a, b, update_ab) :: Nil, Sphinx.DecryptedFailurePacket(a, TemporaryNodeFailure)),
-      LocalFailure(ChannelHop(a, b, update_ab) :: Nil, ChannelUnavailable(ByteVector32.Zeroes)),
-      LocalFailure(Nil, RouteNotFound)
+      LocalFailure(defaultAmountMsat, Nil, RouteNotFound),
+      RemoteFailure(defaultAmountMsat, ChannelHop(a, b, update_ab) :: Nil, Sphinx.DecryptedFailurePacket(a, TemporaryNodeFailure)),
+      LocalFailure(defaultAmountMsat, ChannelHop(a, b, update_ab) :: Nil, ChannelUnavailable(ByteVector32.Zeroes)),
+      LocalFailure(defaultAmountMsat, Nil, RouteNotFound)
     )
     val filtered = PaymentFailure.transformForUser(failures)
     val expected = Seq(
-      LocalFailure(Nil, RouteNotFound),
-      RemoteFailure(ChannelHop(a, b, update_ab) :: Nil, Sphinx.DecryptedFailurePacket(a, TemporaryNodeFailure)),
-      LocalFailure(ChannelHop(a, b, update_ab) :: Nil, ChannelUnavailable(ByteVector32.Zeroes))
+      LocalFailure(defaultAmountMsat, Nil, RouteNotFound),
+      RemoteFailure(defaultAmountMsat, ChannelHop(a, b, update_ab) :: Nil, Sphinx.DecryptedFailurePacket(a, TemporaryNodeFailure)),
+      LocalFailure(defaultAmountMsat, ChannelHop(a, b, update_ab) :: Nil, ChannelUnavailable(ByteVector32.Zeroes))
     )
     assert(filtered === expected)
   }
@@ -733,20 +733,20 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     val route_abcd = ChannelHop(a, b, update_ab) :: ChannelHop(b, c, update_bc) :: ChannelHop(c, d, update_cd) :: Nil
     val testCases = Seq(
       // local failures -> ignore first channel if there is one
-      (LocalFailure(Nil, RouteNotFound), Set.empty, Set.empty),
-      (LocalFailure(NodeHop(a, b, CltvExpiryDelta(144), 0 msat) :: NodeHop(b, c, CltvExpiryDelta(144), 0 msat) :: Nil, RouteNotFound), Set.empty, Set.empty),
-      (LocalFailure(route_abcd, new RuntimeException("fatal")), Set.empty, Set(ChannelDesc(channelId_ab, a, b))),
+      (LocalFailure(defaultAmountMsat, Nil, RouteNotFound), Set.empty, Set.empty),
+      (LocalFailure(defaultAmountMsat, NodeHop(a, b, CltvExpiryDelta(144), 0 msat) :: NodeHop(b, c, CltvExpiryDelta(144), 0 msat) :: Nil, RouteNotFound), Set.empty, Set.empty),
+      (LocalFailure(defaultAmountMsat, route_abcd, new RuntimeException("fatal")), Set.empty, Set(ChannelDesc(channelId_ab, a, b))),
       // remote failure from final recipient -> all intermediate nodes behaved correctly
-      (RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(d, IncorrectOrUnknownPaymentDetails(100 msat, 42))), Set.empty, Set.empty),
+      (RemoteFailure(defaultAmountMsat, route_abcd, Sphinx.DecryptedFailurePacket(d, IncorrectOrUnknownPaymentDetails(100 msat, 42))), Set.empty, Set.empty),
       // remote failures from intermediate nodes -> depending on the failure, ignore either the failing node or its outgoing channel
-      (RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(b, PermanentNodeFailure)), Set(b), Set.empty),
-      (RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(c, TemporaryNodeFailure)), Set(c), Set.empty),
-      (RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(b, PermanentChannelFailure)), Set.empty, Set(ChannelDesc(channelId_bc, b, c))),
-      (RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(c, UnknownNextPeer)), Set.empty, Set(ChannelDesc(channelId_cd, c, d))),
-      (RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(b, FeeInsufficient(100 msat, update_bc))), Set.empty, Set.empty),
+      (RemoteFailure(defaultAmountMsat, route_abcd, Sphinx.DecryptedFailurePacket(b, PermanentNodeFailure)), Set(b), Set.empty),
+      (RemoteFailure(defaultAmountMsat, route_abcd, Sphinx.DecryptedFailurePacket(c, TemporaryNodeFailure)), Set(c), Set.empty),
+      (RemoteFailure(defaultAmountMsat, route_abcd, Sphinx.DecryptedFailurePacket(b, PermanentChannelFailure)), Set.empty, Set(ChannelDesc(channelId_bc, b, c))),
+      (RemoteFailure(defaultAmountMsat, route_abcd, Sphinx.DecryptedFailurePacket(c, UnknownNextPeer)), Set.empty, Set(ChannelDesc(channelId_cd, c, d))),
+      (RemoteFailure(defaultAmountMsat, route_abcd, Sphinx.DecryptedFailurePacket(b, FeeInsufficient(100 msat, update_bc))), Set.empty, Set.empty),
       // unreadable remote failures -> blacklist all nodes except our direct peer and the final recipient
-      (UnreadableRemoteFailure(ChannelHop(a, b, update_ab) :: Nil), Set.empty, Set.empty),
-      (UnreadableRemoteFailure(ChannelHop(a, b, update_ab) :: ChannelHop(b, c, update_bc) :: ChannelHop(c, d, update_cd) :: ChannelHop(d, e, null) :: Nil), Set(c, d), Set.empty)
+      (UnreadableRemoteFailure(defaultAmountMsat, ChannelHop(a, b, update_ab) :: Nil), Set.empty, Set.empty),
+      (UnreadableRemoteFailure(defaultAmountMsat, ChannelHop(a, b, update_ab) :: ChannelHop(b, c, update_bc) :: ChannelHop(c, d, update_cd) :: ChannelHop(d, e, null) :: Nil), Set(c, d), Set.empty)
     )
 
     for ((failure, expectedNodes, expectedChannels) <- testCases) {
@@ -756,9 +756,9 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     }
 
     val failures = Seq(
-      RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(c, TemporaryNodeFailure)),
-      RemoteFailure(route_abcd, Sphinx.DecryptedFailurePacket(b, UnknownNextPeer)),
-      LocalFailure(route_abcd, new RuntimeException("fatal"))
+      RemoteFailure(defaultAmountMsat, route_abcd, Sphinx.DecryptedFailurePacket(c, TemporaryNodeFailure)),
+      RemoteFailure(defaultAmountMsat, route_abcd, Sphinx.DecryptedFailurePacket(b, UnknownNextPeer)),
+      LocalFailure(defaultAmountMsat, route_abcd, new RuntimeException("fatal"))
     )
     val ignore = PaymentFailure.updateIgnored(failures, Ignore.empty)
     assert(ignore.nodes === Set(c))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/ChannelRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/ChannelRelayerSpec.scala
@@ -407,7 +407,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       assert(fwd2.message.r === paymentPreimage)
 
       val paymentRelayed = eventListener.expectMessageType[ChannelPaymentRelayed]
-      assert(paymentRelayed.copy(timestamp = 0) === ChannelPaymentRelayed(r.add.amountMsat, r.payload.amountToForward, r.add.paymentHash, r.add.channelId, channelId1, timestamp = 0))
+      assert(paymentRelayed.copy(timestamp = TimestampMilli(0)) === ChannelPaymentRelayed(r.add.amountMsat, r.payload.amountToForward, r.add.paymentHash, r.add.channelId, channelId1, timestamp = TimestampMilli(0)))
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -37,7 +37,7 @@ import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPaymentToNode
 import fr.acinq.eclair.router.Router.RouteRequest
 import fr.acinq.eclair.router.{BalanceTooLow, RouteNotFound}
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, MilliSatoshi, MilliSatoshiLong, NodeParams, ShortChannelId, TestConstants, UInt64, nodeFee, randomBytes, randomBytes32, randomKey}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, MilliSatoshi, MilliSatoshiLong, NodeParams, ShortChannelId, TestConstants, UInt64, randomBytes, randomBytes32, randomKey}
 import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import scodec.bits.HexStringSyntax
@@ -398,7 +398,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     val nodeRelayerAdapters = mockPayFSM.expectMessageType[SendMultiPartPayment].replyTo
 
     // The proposed fees are low, so we ask the sender to raise them.
-    nodeRelayerAdapters ! PaymentFailed(relayId, paymentHash, LocalFailure(Nil, BalanceTooLow) :: Nil)
+    nodeRelayerAdapters ! PaymentFailed(relayId, paymentHash, LocalFailure(outgoingAmount, Nil, BalanceTooLow) :: Nil)
     incomingMultiPart.foreach { p =>
       val fwd = register.expectMessageType[Register.Forward[CMD_FAIL_HTLC]]
       assert(fwd.channelId === p.add.channelId)
@@ -444,7 +444,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     router.expectMessageType[RouteRequest]
 
     // If we're having a hard time finding routes, raising the fee/cltv will likely help.
-    val failures = LocalFailure(Nil, RouteNotFound) :: RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, PermanentNodeFailure)) :: LocalFailure(Nil, RouteNotFound) :: Nil
+    val failures = LocalFailure(outgoingAmount, Nil, RouteNotFound) :: RemoteFailure(outgoingAmount, Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, PermanentNodeFailure)) :: LocalFailure(outgoingAmount, Nil, RouteNotFound) :: Nil
     payFSM ! PaymentFailed(relayId, incomingMultiPart.head.add.paymentHash, failures)
 
     incomingMultiPart.foreach { p =>
@@ -466,7 +466,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     val payFSM = mockPayFSM.expectMessageType[akka.actor.ActorRef]
     router.expectMessageType[RouteRequest]
 
-    val failures = RemoteFailure(Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, FinalIncorrectHtlcAmount(42 msat))) :: UnreadableRemoteFailure(Nil) :: Nil
+    val failures = RemoteFailure(outgoingAmount, Nil, Sphinx.DecryptedFailurePacket(outgoingNodeId, FinalIncorrectHtlcAmount(42 msat))) :: UnreadableRemoteFailure(outgoingAmount, Nil) :: Nil
     payFSM ! PaymentFailed(relayId, incomingMultiPart.head.add.paymentHash, failures)
 
     incomingMultiPart.foreach { p =>

--- a/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
+++ b/eclair-node-gui/src/main/scala/fr/acinq/eclair/gui/GUIUpdater.scala
@@ -200,8 +200,8 @@ class GUIUpdater(mainController: MainController) extends Actor with ActorLogging
       val distilledFailures = PaymentFailure.transformForUser(p.failures)
       val message = s"${distilledFailures.size} attempts:\n${
         distilledFailures.map {
-          case LocalFailure(_, t) => s"- (local) ${t.getMessage}"
-          case RemoteFailure(_, e) => s"- (remote) ${e.failureMessage.message}"
+          case LocalFailure(_, _, t) => s"- (local) ${t.getMessage}"
+          case RemoteFailure(_, _, e) => s"- (remote) ${e.failureMessage.message}"
           case _ => "- Unknown error"
         }.mkString("\n")
       }"


### PR DESCRIPTION
This build upon #1966 and is best reviewed commit-by-commit.

Changes in json serializers and timestamp formats were rabbit-holey, so I only did the minimum as a proof of concept that should be generalized in a separate PR.

NB: the new timestamp serialization breaks API backwards compatibility, requires API doc update and an addition to the release note.