### PR TITLE
Move path-finding examples to documentation

### DIFF
--- a/docs/Configure.md
+++ b/docs/Configure.md
@@ -3,35 +3,46 @@
 ---
 
 * [Configuration file](#configuration-file)
-* [Change your node's configuration](#change-your-nodes-configuration)
+  * [Changing the data directory](#changing-the-data-directory)
+  * [Splitting the configuration](#splitting-the-configuration)
 * [Options reference](#options-reference)
 * [Customize features](#customize-features)
 * [Customize feerate tolerance](#customize-feerate-tolerance)
 * [Examples](#examples)
-    * [Basic configuration](#basic-configuration)
-    * [Regtest mode](#regtest-mode)
-    * [Public node](#public-node)
-    * [AB-testing for path-finding](#ab-testing-for-path-finding)
+  * [Basic configuration](#basic-configuration)
+  * [Regtest mode](#regtest-mode)
+  * [Public node](#public-node)
+  * [AB-testing for path-finding](#ab-testing-for-path-finding)
 
 ---
 
 ## Configuration file
 
-The configuration file for Eclair is named `eclair.conf`. It is located in the data directory, which is `~/.eclair` by default.
-You can change the data directory with the `eclair.datadir` parameter:
+The configuration file for eclair is named `eclair.conf`. It is located in the data directory, which is `~/.eclair` by
+default. Note that eclair won't create a configuration file by itself: if you want to change eclair's configuration, you
+need to **actually create the configuration file first**. The encoding must be UTF-8.
 
+```sh
+# this is the default data directory, it will be created at eclair first startup
+mkdir ~/.eclair 
+vi ~/.eclair/eclair.conf
+```
+
+Options are set as key-value pairs and follow the [HOCON syntax](https://github.com/lightbend/config/blob/master/HOCON.md).
+Values do not need to be surrounded by quotes, except if they contain special characters.
+
+### Changing the data directory
+
+You can change the data directory with the `eclair.datadir` parameter:
 ```sh
 eclair-node.sh -Declair.datadir="/path/to/custom/eclair/data/folder"
 ```
 
-## Change your node's configuration
+### Splitting the configuration
 
-The first step is to **actually create the configuration file**.
-Go to `eclair.datadir` and create a file named `eclair.conf`.
-The encoding should be UTF-8.
-
-Options are set as key-value pairs and follow the [HOCON syntax](https://github.com/lightbend/config/blob/master/HOCON.md).
-Values do not need to be surrounded by quotes, except if they contain special characters.
+Note that HOCON allows you to have files include other files. This allows you to split your configuration file into
+several logical files, for easier management. For example, you could defined a file `routing.conf` file with parameters
+related to routing configuration, and include it from `eclair.conf`. 
 
 ## Options reference
 

--- a/docs/Configure.md
+++ b/docs/Configure.md
@@ -41,7 +41,7 @@ eclair-node.sh -Declair.datadir="/path/to/custom/eclair/data/folder"
 ### Splitting the configuration
 
 Note that HOCON allows you to have files include other files. This allows you to split your configuration file into
-several logical files, for easier management. For example, you could defined a file `routing.conf` file with parameters
+several logical files, for easier management. For example, you could define a file `routing.conf` file with parameters
 related to routing configuration, and include it from `eclair.conf`. 
 
 ## Options reference

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -93,7 +93,8 @@ eclair {
   max-block-processing-delay = 30 seconds // we add a random delay before processing blocks, capped at this value, to prevent herd effect
   max-tx-publish-retry-delay = 60 seconds // we add a random delay before retrying failed transaction publication
 
-  relay.fees {
+  relay {
+    fees {
       // Fees for public channels
       public-channels {
         fee-base-msat = 1000
@@ -109,7 +110,8 @@ eclair {
         fee-base-msat = 1000
         fee-proportional-millionths = 100
       }
-   }
+    }
+  }
 
   on-chain-fees {
     min-feerate = 1 // minimum feerate in satoshis per byte
@@ -194,7 +196,6 @@ eclair {
       channel-query-chunk-size = 100 // max number of short_channel_ids in query_short_channel_ids *do not change this unless you know what you are doing*
     }
 
-    // The values below will be used to perform route searching
     path-finding {
       default {
         randomize-route-selection = true // when computing a route for a payment we randomize the final selection
@@ -207,6 +208,7 @@ eclair {
           max-fee-proportional-percent = 3 // that's 3%
         }
 
+        use-ratios = true // if false, will use failure-cost
         // channel 'weight' is computed with the following formula: (channelFee + hop-cost) * (ratio-base + cltvDelta * ratio-cltv + channelAge * ratio-channel-age + channelCapacity * ratio-channel-capacity)
         // the following parameters can be used to ask the router to use heuristics to find i.e: 'cltv-optimized' routes, **the sum of the four ratios must be 1**
         ratios {
@@ -215,11 +217,15 @@ eclair {
           channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
           channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
         }
-        use-ratios = true
-
-        // Virtual fee for additional hops
-        // Corresponds to how much you are willing to pay to get one less hop in the payment path
+        locked-funds-risk = 1e-8 // msat per msat locked per block. It should be your expected interest rate per block multiplied by the probability that something goes wrong and your funds stay locked.
+                                 // 1e-8 corresponds to an interest rate of ~5% per year (1e-6 per block) and a probability of 1% that the channel will fail and our funds will be locked.
+        // virtual fee for failed payments: how much you are willing to pay to get one less failed payment attempt
+        failure-cost {
+          fee-base-msat = 2000
+          fee-proportional-millionths = 500
+        }
         hop-cost {
+          // virtual fee for additional hops: how much you are willing to pay to get one less hop in the payment path
           fee-base-msat = 500
           fee-proportional-millionths = 200
         }
@@ -228,93 +234,19 @@ eclair {
           min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs
           max-parts = 5 // maximum number of HTLCs sent per payment: increasing this value will impact performance
         }
-
-        percentage = 0 // set all experiments to 0% of the traffic by default
       }
 
-      // One section per experiment
-      // The percentages of the traffic for different experiments must sum to 100.
-      // After starting an experiment, if you want to modify it you should give it a new name. If you don't, then you'll
-      // end up with metrics for different sets of parameters under the same name.
+      // The path-finding algo uses one or more sets of parameters named experiments. Each experiment has a percentage
+      // assigned, allowing AB-testing. By default, there is a single 'control' experiment with a percentage of 100 %.
+      //
+      // To enable AB-testing, you need to define experiments below. Note that:
+      // - each experiment must have a unique name, may override the default parameters, and must provide a percentage
+      // - the percentages for all experiments must sum to 100
+      // - experiments should be immutable; if you alter parameters of an experiment, you should also rename it
+      // - for a complete example, refer to the documentation.
       experiments {
         control = ${eclair.router.path-finding.default} {
           percentage = 100 // 100% of the traffic use the default configuration
-        }
-
-        // alternative routing heuristics (replaces ratios)
-        test-failure-cost = ${eclair.router.path-finding.default} {
-          use-ratios = false
-
-          locked-funds-risk = 1e-8 // msat per msat locked per block. It should be your expected interest rate per block multiplied by the probability that something goes wrong and your funds stay locked.
-          // 1e-8 corresponds to an interest rate of ~5% per year (1e-6 per block) and a probability of 1% that the channel will fail and our funds will be locked.
-
-          // Virtual fee for failed payments
-          // Corresponds to how much you are willing to pay to get one less failed payment attempt
-          failure-cost {
-            fee-base-msat = 2000
-            fee-proportional-millionths = 500
-          }
-        }
-
-        // Examples of other configs as 0% experiments:
-
-        // To optimize for fees only:
-        test-fees-only = ${eclair.router.path-finding.default} {
-          ratios {
-            base = 1
-            cltv = 0
-            channel-age = 0
-            channel-capacity = 0
-          }
-          hop-cost {
-            fee-base-msat = 0
-            fee-proportional-millionths = 0
-          }
-        }
-
-        // To optimize for shorter paths:
-        test-short-paths = ${eclair.router.path-finding.default} {
-          ratios {
-            base = 1
-            cltv = 0
-            channel-age = 0
-            channel-capacity = 0
-          }
-          hop-cost {
-            // High hop cost penalizes strongly longer paths
-            fee-base-msat = 10000
-            fee-proportional-millionths = 10000
-          }
-        }
-
-        // To optimize for successful payments:
-        test-pay-safe = ${eclair.router.path-finding.default} {
-          ratios {
-            base = 0
-            cltv = 0
-            channel-age = 0.5 // Old channels should have less risk of failures
-            channel-capacity = 0.5 // High capacity channels are more likely to have enough liquidity to relay our payment
-          }
-          hop-cost {
-            // Less hops means less chances of failures
-            fee-base-msat = 1000
-            fee-proportional-millionths = 1000
-          }
-        }
-
-        // To optimize for fast payments:
-        test-pay-fast = ${eclair.router.path-finding.default} {
-          ratios {
-            base = 0.2
-            cltv = 0.5 // In case of failure we want our funds back as fast as possible
-            channel-age = 0.3 // Older channels are more likely to run smoothly
-            channel-capacity = 0
-          }
-          hop-cost {
-            // Shorter paths should be faster
-            fee-base-msat = 10000
-            fee-proportional-millionths = 10000
-          }
         }
       }
     }


### PR DESCRIPTION
Having basic documentation in-place by providing examples in
`eclair.conf` is great and very convenient, but in the case of
path-finding, defining experiments take so much space that it makes
the whole configuration file actually more complicated to understand.
And since we don't want to enable experiments by default, the user still
has to figure out what to change to actually enable AB-testing.

I believe a better trade-off is to move examples to the docs.