### PR TITLE
Fix flaky transaction published event test

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -38,7 +38,7 @@ import scala.concurrent.duration._
 
 class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ChannelStateTestsBase {
 
-  case class FixtureParam(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe)
+  case class FixtureParam(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, listener: TestProbe)
 
   override def withFixture(test: OneArgTest): Outcome = {
 
@@ -50,6 +50,8 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     val aliceInit = Init(aliceParams.initFeatures)
     val bobInit = Init(bobParams.initFeatures)
     within(30 seconds) {
+      val listener = TestProbe()
+      system.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
       alice ! INPUT_INIT_FUNDER(ByteVector32.Zeroes, TestConstants.fundingSatoshis, TestConstants.pushMsat, TestConstants.feeratePerKw, TestConstants.feeratePerKw, aliceParams, alice2bob.ref, bobInit, ChannelFlags.Empty, channelConfig, channelType)
       alice2blockchain.expectMsgType[TxPublisher.SetChannelId]
       bob ! INPUT_INIT_FUNDEE(ByteVector32.Zeroes, bobParams, bob2alice.ref, aliceInit, channelConfig, channelType)
@@ -65,13 +67,15 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
       alice2blockchain.expectMsgType[TxPublisher.SetChannelId]
       alice2blockchain.expectMsgType[WatchFundingSpent]
       alice2blockchain.expectMsgType[WatchFundingConfirmed]
+      listener.expectMsgType[TransactionPublished] // alice has published the funding transaction
       awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
-      withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain)))
+      withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain, listener)))
     }
   }
 
   test("recv FundingLocked") { f =>
     import f._
+    // we create a new listener that registers after alice has published the funding tx
     val listener = TestProbe()
     system.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
     system.eventStream.subscribe(listener.ref, classOf[TransactionConfirmed])
@@ -90,6 +94,7 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
 
   test("recv WatchFundingConfirmedTriggered") { f =>
     import f._
+    // we create a new listener that registers after alice has published the funding tx
     val listener = TestProbe()
     system.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
     system.eventStream.subscribe(listener.ref, classOf[TransactionConfirmed])


### PR DESCRIPTION
On slow CI machines, the `recv WatchFundingConfirmedTriggered` test was flaky because there was a race between the publication of Alice's `TransactionPublished` event before going to the `WaitForFundingLocked` state and the tests registering event listeners (after going to the `WaitForFundingLocked` state).

This is fixed by waiting for this first event to be delivered before starting the actual tests.