### PR TITLE
Store blinding pubkey for introduction node

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/SphinxSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/SphinxSpec.scala
@@ -366,9 +366,10 @@ class SphinxSpec extends AnyFunSuite {
 
   test("create blinded route (reference test vector)") {
     val sessionKey = PrivateKey(hex"0101010101010101010101010101010101010101010101010101010101010101")
-    val RouteBlinding.BlindedRouteWithEphemeralKeys(blindedRoute, blindingEphemeralKeys) = RouteBlinding.create(sessionKey, publicKeys, routeBlindingPayloads)
+    val blindedRoute = RouteBlinding.create(sessionKey, publicKeys, routeBlindingPayloads)
     assert(blindedRoute.introductionNode.publicKey === publicKeys(0))
     assert(blindedRoute.introductionNode.blindedPublicKey === PublicKey(hex"02ec68ed555f5d18b12fe0e2208563c3566032967cf11dc29b20c345449f9a50a2"))
+    assert(blindedRoute.introductionNode.blindingEphemeralKey === PublicKey(hex"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"))
     assert(blindedRoute.introductionNode.encryptedPayload === hex"a245b767bd52520bdf8179b2dc681d1a36c2ededaf59429dfc4bea342fa460c9")
     assert(blindedRoute.nodeIds === Seq(
       publicKeys(0),
@@ -383,13 +384,6 @@ class SphinxSpec extends AnyFunSuite {
       PublicKey(hex"03bfddd2253b42fe12edd37f9071a3883830ed61a4bc347eeac63421629cf032b5"),
       PublicKey(hex"03a8588bc4a0a2f0d2fb8d5c0f8d062fb4d78bfba24a85d0ddeb4fd35dd3b34110"),
     ))
-    assert(blindingEphemeralKeys === Seq(
-      PublicKey(hex"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f"),
-      PublicKey(hex"035cb4c003d58e16cc9207270b3596c2be3309eca64c36b208c946bbb599bfcad0"),
-      PublicKey(hex"02e105bc01a7af07074a1b0b1d9a112a1d89c6cd87cc4e2b6ba3a824731d9508bd"),
-      PublicKey(hex"0349164db5398925ef234002e62d2834da115b8eafc73436fab98ed12266e797cc"),
-      PublicKey(hex"020a6d1951916adcac22125063f62c35b3686f36e5db2f77073f3d35b19c7a118a"),
-    ))
     assert(blindedRoute.encryptedPayloads === blindedRoute.introductionNode.encryptedPayload +: blindedRoute.blindedNodes.map(_.encryptedPayload))
     assert(blindedRoute.blindedNodes.map(_.encryptedPayload) === Seq(
       hex"38748f94ead7de2a54fc43e8bb927bfc377dda7ed5a2e36b327b739c3c82a602e43e07e378f17cd46ee32d987eb8b6d03b3403acb095bd2868f640b92ea1",
@@ -399,27 +393,27 @@ class SphinxSpec extends AnyFunSuite {
     ))
 
     // The introduction point can decrypt its encrypted payload and obtain the next ephemeral public key.
-    val Success((payload0, ephKey1)) = RouteBlinding.decryptPayload(privKeys(0), blindingEphemeralKeys(0), blindedRoute.encryptedPayloads(0))
+    val Success((payload0, ephKey1)) = RouteBlinding.decryptPayload(privKeys(0), blindedRoute.introductionNode.blindingEphemeralKey, blindedRoute.encryptedPayloads(0))
     assert(payload0 === routeBlindingPayloads(0))
-    assert(ephKey1 === blindingEphemeralKeys(1))
+    assert(ephKey1 === PublicKey(hex"035cb4c003d58e16cc9207270b3596c2be3309eca64c36b208c946bbb599bfcad0"))
 
     // The next node can derive the private key used to unwrap the onion and decrypt its encrypted payload.
     assert(RouteBlinding.derivePrivateKey(privKeys(1), ephKey1).publicKey === blindedRoute.nodeIds(1))
     val Success((payload1, ephKey2)) = RouteBlinding.decryptPayload(privKeys(1), ephKey1, blindedRoute.encryptedPayloads(1))
     assert(payload1 === routeBlindingPayloads(1))
-    assert(ephKey2 === blindingEphemeralKeys(2))
+    assert(ephKey2 === PublicKey(hex"02e105bc01a7af07074a1b0b1d9a112a1d89c6cd87cc4e2b6ba3a824731d9508bd"))
 
     // The next node can derive the private key used to unwrap the onion and decrypt its encrypted payload.
     assert(RouteBlinding.derivePrivateKey(privKeys(2), ephKey2).publicKey === blindedRoute.nodeIds(2))
     val Success((payload2, ephKey3)) = RouteBlinding.decryptPayload(privKeys(2), ephKey2, blindedRoute.encryptedPayloads(2))
     assert(payload2 === routeBlindingPayloads(2))
-    assert(ephKey3 === blindingEphemeralKeys(3))
+    assert(ephKey3 === PublicKey(hex"0349164db5398925ef234002e62d2834da115b8eafc73436fab98ed12266e797cc"))
 
     // The next node can derive the private key used to unwrap the onion and decrypt its encrypted payload.
     assert(RouteBlinding.derivePrivateKey(privKeys(3), ephKey3).publicKey === blindedRoute.nodeIds(3))
     val Success((payload3, ephKey4)) = RouteBlinding.decryptPayload(privKeys(3), ephKey3, blindedRoute.encryptedPayloads(3))
     assert(payload3 === routeBlindingPayloads(3))
-    assert(ephKey4 === blindingEphemeralKeys(4))
+    assert(ephKey4 === PublicKey(hex"020a6d1951916adcac22125063f62c35b3686f36e5db2f77073f3d35b19c7a118a"))
 
     // The last node can derive the private key used to unwrap the onion and decrypt its encrypted payload.
     assert(RouteBlinding.derivePrivateKey(privKeys(4), ephKey4).publicKey === blindedRoute.nodeIds(4))
@@ -428,7 +422,7 @@ class SphinxSpec extends AnyFunSuite {
   }
 
   test("invalid blinded route") {
-    val encryptedPayloads = RouteBlinding.create(sessionKey, publicKeys, routeBlindingPayloads).route.encryptedPayloads
+    val encryptedPayloads = RouteBlinding.create(sessionKey, publicKeys, routeBlindingPayloads).encryptedPayloads
     // Invalid node private key:
     val ephKey0 = sessionKey.publicKey
     assert(RouteBlinding.decryptPayload(privKeys(1), ephKey0, encryptedPayloads(0)).isFailure)
@@ -442,7 +436,7 @@ class SphinxSpec extends AnyFunSuite {
     // The recipient creates a blinded route containing 3 hops.
     val (blindedRoute, blindingEphemeralKey0) = {
       val recipientSessionKey = PrivateKey(hex"0101010101010101010101010101010101010101010101010101010101010101")
-      (RouteBlinding.create(recipientSessionKey, publicKeys.drop(2), routeBlindingPayloads.drop(2)).route, recipientSessionKey.publicKey)
+      (RouteBlinding.create(recipientSessionKey, publicKeys.drop(2), routeBlindingPayloads.drop(2)), recipientSessionKey.publicKey)
     }
 
     // The sender obtains this information (e.g. from a Bolt11 invoice) and prepends two normal hops to reach the introduction node.

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/EncryptedRecipientDataSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/EncryptedRecipientDataSpec.scala
@@ -23,10 +23,10 @@ class EncryptedRecipientDataSpec extends AnyFunSuiteLike {
 
     val blindedRoute = RouteBlinding.create(sessionKey, nodePrivKeys.map(_.publicKey), payloads.map(_._2))
     val blinding0 = sessionKey.publicKey
-    val Success((decryptedPayload0, blinding1)) = EncryptedRecipientDataCodecs.decode(nodePrivKeys.head, blinding0, blindedRoute.route.encryptedPayloads(0))
-    val Success((decryptedPayload1, blinding2)) = EncryptedRecipientDataCodecs.decode(nodePrivKeys(1), blinding1, blindedRoute.route.encryptedPayloads(1))
-    val Success((decryptedPayload2, blinding3)) = EncryptedRecipientDataCodecs.decode(nodePrivKeys(2), blinding2, blindedRoute.route.encryptedPayloads(2))
-    val Success((decryptedPayload3, _)) = EncryptedRecipientDataCodecs.decode(nodePrivKeys(3), blinding3, blindedRoute.route.encryptedPayloads(3))
+    val Success((decryptedPayload0, blinding1)) = EncryptedRecipientDataCodecs.decode(nodePrivKeys.head, blinding0, blindedRoute.encryptedPayloads(0))
+    val Success((decryptedPayload1, blinding2)) = EncryptedRecipientDataCodecs.decode(nodePrivKeys(1), blinding1, blindedRoute.encryptedPayloads(1))
+    val Success((decryptedPayload2, blinding3)) = EncryptedRecipientDataCodecs.decode(nodePrivKeys(2), blinding2, blindedRoute.encryptedPayloads(2))
+    val Success((decryptedPayload3, _)) = EncryptedRecipientDataCodecs.decode(nodePrivKeys(3), blinding3, blindedRoute.encryptedPayloads(3))
     assert(Seq(decryptedPayload0, decryptedPayload1, decryptedPayload2, decryptedPayload3) === payloads.map(_._1))
   }
 
@@ -47,13 +47,13 @@ class EncryptedRecipientDataSpec extends AnyFunSuiteLike {
       val blindedRoute = RouteBlinding.create(blindingPrivKey, nodePrivKeys.map(_.publicKey), payloads)
       // The payload for the first node is valid.
       val blinding0 = blindingPrivKey.publicKey
-      val Success((_, blinding1)) = EncryptedRecipientDataCodecs.decode(nodePrivKeys.head, blinding0, blindedRoute.route.encryptedPayloads.head)
+      val Success((_, blinding1)) = EncryptedRecipientDataCodecs.decode(nodePrivKeys.head, blinding0, blindedRoute.encryptedPayloads.head)
       // If the first node is given invalid decryption material, it cannot decrypt recipient data.
-      assert(EncryptedRecipientDataCodecs.decode(nodePrivKeys.last, blinding0, blindedRoute.route.encryptedPayloads.head).isFailure)
-      assert(EncryptedRecipientDataCodecs.decode(nodePrivKeys.head, blinding1, blindedRoute.route.encryptedPayloads.head).isFailure)
-      assert(EncryptedRecipientDataCodecs.decode(nodePrivKeys.head, blinding0, blindedRoute.route.encryptedPayloads.last).isFailure)
+      assert(EncryptedRecipientDataCodecs.decode(nodePrivKeys.last, blinding0, blindedRoute.encryptedPayloads.head).isFailure)
+      assert(EncryptedRecipientDataCodecs.decode(nodePrivKeys.head, blinding1, blindedRoute.encryptedPayloads.head).isFailure)
+      assert(EncryptedRecipientDataCodecs.decode(nodePrivKeys.head, blinding0, blindedRoute.encryptedPayloads.last).isFailure)
       // The payload for the last node is invalid, even with valid decryption material.
-      assert(EncryptedRecipientDataCodecs.decode(nodePrivKeys.last, blinding1, blindedRoute.route.encryptedPayloads.last).isFailure)
+      assert(EncryptedRecipientDataCodecs.decode(nodePrivKeys.last, blinding1, blindedRoute.encryptedPayloads.last).isFailure)
     }
   }
 


### PR DESCRIPTION
The blinding public key of the introduction node is necessary for onion messages.
The blinding ephemeral public keys aren't necessary for now: we only need the first one that will be sent to the introduction node.
The other nodes will derive the next blinding ephemeral keys hop by hop.