### PR TITLE
Front: stop the jvm after coordinated shutdown

### DIFF
--- a/eclair-front/src/main/resources/application.conf
+++ b/eclair-front/src/main/resources/application.conf
@@ -39,6 +39,7 @@ akka {
     roles = [frontend]
     seed-nodes = ["akka://eclair-node@"${eclair.front.backend.ip}":25520"]
   }
+  coordinated-shutdown.exit-jvm = on
   //It is recommended to load the extension when the actor system is started by defining it in akka.extensions
   //configuration property. Otherwise it will be activated when first used and then it takes a while for it to be populated.
   extensions = ["akka.cluster.pubsub.DistributedPubSub"]

--- a/eclair-front/src/test/resources/application.conf
+++ b/eclair-front/src/test/resources/application.conf
@@ -8,5 +8,6 @@ kamon.environment.host = "auto"
 akka {
   actor.provider = local
   cluster.seed-nodes = []
+  coordinated-shutdown.exit-jvm = off
   extensions = []
 }


### PR DESCRIPTION
The app must stop when connection to the backend fails. It will be
gracefully restarted on Beanstalk instead of just hanging.

Fixes a regression introduced by #1912.