### PR TITLE
Implement cookie authentication for eclair json-rpc api

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ name                         | description                                      
 -----------------------------|---------------------------------------------------------------------------------------|--------------
  eclair.chain                | Which blockchain to use: *regtest*, *testnet* or *mainnet*                            | mainnet
  eclair.server.port          | Lightning TCP port                                                                    | 9735
- eclair.api.enabled          | Enable/disable the API                                                                | false. By default the API is disabled. If you want to enable it, you must set a password.
+ eclair.api.enabled          | Enable/disable the API                                                                | false. By default the API is disabled.
  eclair.api.port             | API HTTP port                                                                         | 8080
- eclair.api.password         | API password (BASIC)                                                                  | "" (must be set if the API is enabled)
+ eclair.api.password         | API password (BASIC)                                                                  | "" (change to something else if you want to enable password authentication)
+ eclair.api.cookie-enabled   | API cookie authentication                                                             | true
  eclair.bitcoind.rpcuser     | Bitcoin Core RPC user                                                                 | foo
  eclair.bitcoind.rpcpassword | Bitcoin Core RPC password                                                             | bar
  eclair.bitcoind.zmqblock    | Bitcoin Core ZMQ block address                                                        | "tcp://127.0.0.1:29000"

--- a/docs/Configure.md
+++ b/docs/Configure.md
@@ -12,6 +12,7 @@
   * [Basic configuration](#basic-configuration)
   * [Regtest mode](#regtest-mode)
   * [Public node](#public-node)
+  * [Bitcoin Core cookie authentication](#Bitcoin-Core-cookie-authentication)
   * [AB-testing for path-finding](#ab-testing-for-path-finding)
 
 ---
@@ -55,6 +56,7 @@ name                         | description                                      
  eclair.api.port             | API HTTP port                                                      | 8080
  eclair.api.enabled          | Enables the JSON API                                               | false
  eclair.api.password         | Password protecting the API (BASIC auth)                           | _no default_
+ eclair.api.cookie-enabled   | API cookie authentication                                          | true
  eclair.bitcoind.auth        | Bitcoin Core RPC authentication method: *password* or *safecookie* | password
  eclair.bitcoind.rpcuser     | Bitcoin Core RPC user                                              | foo
  eclair.bitcoind.rpcpassword | Bitcoin Core RPC password                                          | bar

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -80,6 +80,7 @@ now grouped with outgoing htlcs amounts and the field has been renamed from `htl
 ### Miscellaneous improvements and bug fixes
 
 - Eclair now supports cookie authentication for Bitcoin Core RPC (#1986)
+- The Eclair JSON API now supports cookie authentication (#2040)
 
 ## Verifying signatures
 

--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -5,7 +5,7 @@ api_url='http://localhost:8080'
 # uncomment the line below if you don't want to provide a password each time you call eclair-cli
 # api_password='your_api_password'
 # uncomment the line below if you want to use cookie authentication when you call eclair-cli
-# cookie_file="${HOME}/.eclair/.cookie"
+# api_cookie="${HOME}/.eclair/.cookie"
 # for some commands the json output can be shortened for better readability
 short=false
 
@@ -25,6 +25,7 @@ Usage
 where OPTIONS can be:
   -p <password>         API's password
   -a <address>          Override the API URL with <address>
+  -f <cookie-file>      API cookie file
   -h                    Show this help
   -s                    Some commands can print a trimmed JSON
 
@@ -103,10 +104,11 @@ command -v jq >/dev/null 2>&1 || { echo -e "This tool requires jq.\nFor installa
 command -v curl >/dev/null 2>&1 || { echo -e "This tool requires curl.\n\nAborting..."; exit 1; }
 
 # extract script options
-while getopts ':cu:su:p:a:hu:' flag; do
+while getopts ':cu:su:p:a:f:hu:' flag; do
   case "${flag}" in
     p) api_password="${OPTARG}" ;;
     a) api_url="${OPTARG}" ;;
+    f) api_cookie="${OPTARG}" ;;
     h) usage ;;
     s) short=true ;;
     *) ;;
@@ -149,9 +151,9 @@ fi
 
 jq_filter="$jq_filter end";
 
-# if cookie_file is set and exist, use cookie authentication
-if [ ! -z $cookie_file ] && [ -f $cookie_file ]; then
-  auth=$(<$cookie_file)
+# if api_cookie is set and exist, use cookie authentication
+if [ ! -z $api_cookie ] && [ -f $api_cookie ]; then
+  auth=$(<$api_cookie)
 fi
 
 # if no password is provided, auth should only contain user login so that curl prompts for the api password

--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -4,6 +4,8 @@
 api_url='http://localhost:8080'
 # uncomment the line below if you don't want to provide a password each time you call eclair-cli
 # api_password='your_api_password'
+# uncomment the line below if you want to use cookie authentication when you call eclair-cli
+# cookie_file="${HOME}/.eclair/.cookie"
 # for some commands the json output can be shortened for better readability
 short=false
 
@@ -147,11 +149,18 @@ fi
 
 jq_filter="$jq_filter end";
 
+# if cookie_file is set and exist, use cookie authentication
+if [ ! -z $cookie_file ] && [ -f $cookie_file ]; then
+  auth=$(<$cookie_file)
+fi
+
 # if no password is provided, auth should only contain user login so that curl prompts for the api password
-if [ -z $api_password ]; then
-  auth="eclair-cli";
-else
-  auth="eclair-cli:$api_password";
+if [ -z $auth ]; then
+  if [ -z $api_password ]; then
+    auth="eclair-cli";
+  else
+    auth="eclair-cli:$api_password";
+  fi
 fi
 
 # we're now ready to execute the API call

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -13,8 +13,9 @@ eclair {
     enabled = false // disabled by default for security reasons
     binding-ip = "127.0.0.1"
     port = 8080
-    password = "" // password for basic auth, must be non empty if json-rpc api is enabled
+    password = "" // password for basic auth, must be non empty to enable password authentication
     cookie-enabled = true
+    cookie-group-readable = false
     cookie-path =   ${eclair.datadir}"/.cookie"
   }
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -16,7 +16,7 @@ eclair {
     password = "" // password for basic auth, must be non empty to enable password authentication
     cookie-enabled = true
     cookie-group-readable = false
-    cookie-path =   ${eclair.datadir}"/.cookie"
+    cookie-path = ${eclair.datadir}"/.cookie"
   }
 
   watch-spent-window = 1 minute // at startup watches will be put back within that window to reduce herd effect; must be > 0s

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -14,6 +14,8 @@ eclair {
     binding-ip = "127.0.0.1"
     port = 8080
     password = "" // password for basic auth, must be non empty if json-rpc api is enabled
+    cookie-enabled = true
+    cookie-path =   ${eclair.datadir}"/.cookie"
   }
 
   watch-spent-window = 1 minute // at startup watches will be put back within that window to reduce herd effect; must be > 0s

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -401,8 +401,6 @@ case class BitcoinRPCConnectionException(e: Throwable) extends RuntimeException(
 
 case class BitcoinWalletDisabledException(e: Throwable) extends RuntimeException("bitcoind wallet not available", e)
 
-case object EmptyAPIPasswordException extends RuntimeException("must set a password for the json-rpc api")
-
 case object IncompatibleDBException extends RuntimeException("database is not compatible with this version of eclair")
 
 case object IncompatibleNetworkDBException extends RuntimeException("network database is not compatible with this version of eclair")

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -134,7 +134,7 @@ object Boot extends App with Logging {
       aclView.setAcl(List(entry).asJava)
     })
 
-    Files.writeString(path, s"__COOKIE__:$hexPassword", StandardCharsets.UTF_8)
+    Files.writeString(path, s"${Service.CookieUserName}:$hexPassword", StandardCharsets.UTF_8)
     hexPassword
   }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -81,7 +81,7 @@ object Boot extends App with Logging {
         None
       }
       if (apiPassword.isEmpty && apiCookiePassword.isEmpty) {
-        throw new RuntimeException("neither password nor cookie is enabled")
+        throw new RuntimeException("json-rpc api requires that either password or cookie is enabled")
       }
       val service: Service = new Service {
         override val actorSystem: ActorSystem = system

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -103,7 +103,7 @@ object Boot extends App with Logging {
   def generateCookie(pathString: String): String = {
     val bytes = new Array[Byte](32)
     SecureRandom.getInstanceStrong.nextBytes(bytes)
-    val hexPassword = bytes.map("%02X" format _).mkString // convert the bytes to an hex string
+    val hexPassword = bytes.map("%02X".format(_)).mkString // convert the bytes to an hex string
 
     val path = Path.of(pathString)
     Files.deleteIfExists(path)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -112,9 +112,9 @@ object Boot extends App with Logging {
     if (posixView != null) {
       // Change permissions for the .cookie file on Linux/Mac OS
       if (groupReadable) {
-        posixView.setPermissions(PosixFilePermissions.fromString("rw-------"))
-      } else {
         posixView.setPermissions(PosixFilePermissions.fromString("rw-r-----"))
+      } else {
+        posixView.setPermissions(PosixFilePermissions.fromString("rw-------"))
       }
     } else if (aclView != null) {
       // Change permissions for the .cookie file on Windows
@@ -124,7 +124,7 @@ object Boot extends App with Logging {
         .setType(AclEntryType.ALLOW)
         .build()
       // setAcl() replaces all acl entries for the file.
-      // That means setting acl with an list containing only an entry that gives access to the owner, every one else loses access to the file.
+      // That means setting acl with an list containing only an entry that gives access to the owner, everyone else lose access to the file.
       aclView.setAcl(List(aclEntry).asJava)
       if (groupReadable) {
         logger.warn("could not make the .cookie file group readable")

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -28,7 +28,12 @@ trait Service extends EclairDirectives with WebSocket with Node with Channel wit
   /**
    * Allows router access to the API password as configured in eclair.conf
    */
-  def password: String
+  def password: Option[String]
+
+  /**
+   * password for cookie authentication if enabled in eclair.conf
+   */
+  def cookiePassword: Option[String]
 
   /**
    * The API of Eclair core.

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -55,3 +55,6 @@ trait Service extends EclairDirectives with WebSocket with Node with Channel wit
     extraRouteProviders.map(_.route(this)).foldLeft(baseRoutes)(_ ~ _)
   }
 }
+object Service{
+  val CookieUserName = "__COOKIE__"
+}

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.api.directives
 import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.server.directives.Credentials
 import fr.acinq.eclair.api.Service
+import fr.acinq.eclair.api.Service.CookieUserName
 
 import scala.concurrent.Future
 import scala.concurrent.duration.DurationInt
@@ -35,7 +36,7 @@ trait AuthDirective {
   def authenticated: Directive0 = authenticateBasicAsync(realm = "Access restricted", userPassAuthenticator).tflatMap { _ => pass }
 
   private def userPassAuthenticator(credentials: Credentials): Future[Option[String]] = credentials match {
-    case p@Credentials.Provided(id@"__COOKIE__") if cookiePassword.exists(password => p.verify(password)) => Future.successful(Some(id))
+    case p@Credentials.Provided(id@CookieUserName) if cookiePassword.exists(password => p.verify(password)) => Future.successful(Some(id))
     case p@Credentials.Provided(id) if password.exists(password => p.verify(password)) => Future.successful(Some(id))
     case _ => akka.pattern.after(1 second, using = actorSystem.scheduler)(Future.successful(None))(actorSystem.dispatcher) // force a 1 sec pause to deter brute force
   }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
@@ -35,7 +35,8 @@ trait AuthDirective {
   def authenticated: Directive0 = authenticateBasicAsync(realm = "Access restricted", userPassAuthenticator).tflatMap { _ => pass }
 
   private def userPassAuthenticator(credentials: Credentials): Future[Option[String]] = credentials match {
-    case p@Credentials.Provided(id) if p.verify(password) => Future.successful(Some(id))
+    case p@Credentials.Provided(id@"__COOKIE__") if cookiePassword.exists(password => p.verify(password)) => Future.successful(Some(id))
+    case p@Credentials.Provided(id) if password.exists(password => p.verify(password)) => Future.successful(Some(id))
     case _ => akka.pattern.after(1 second, using = actorSystem.scheduler)(Future.successful(None))(actorSystem.dispatcher) // force a 1 sec pause to deter brute force
   }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
@@ -36,8 +36,8 @@ trait AuthDirective {
   def authenticated: Directive0 = authenticateBasicAsync(realm = "Access restricted", userPassAuthenticator).tflatMap { _ => pass }
 
   private def userPassAuthenticator(credentials: Credentials): Future[Option[String]] = credentials match {
-    case p@Credentials.Provided(id@CookieUserName) if cookiePassword.exists(password => p.verify(password)) => Future.successful(Some(id))
-    case p@Credentials.Provided(id) if password.exists(password => p.verify(password)) => Future.successful(Some(id))
+    case p@Credentials.Provided(id@CookieUserName) if cookiePassword.exists(p.verify) => Future.successful(Some(id))
+    case p@Credentials.Provided(id) if password.exists(p.verify) => Future.successful(Some(id))
     case _ => akka.pattern.after(1 second, using = actorSystem.scheduler)(Future.successful(None))(actorSystem.dispatcher) // force a 1 sec pause to deter brute force
   }
 

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -138,7 +138,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
   }
 
 
-  test("API returns unauthorized with cookie password and without __COOKIE__ id") {
+  test("API returns unauthorized with cookie password and without the cookie username id") {
     Post("/getinfo") ~>
       addCredentials(BasicHttpCredentials("", mockApi().cookiePassword.get)) ~>
       Route.seal(mockApi().route) ~>
@@ -176,7 +176,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
     val mockService = mockApi(eclair)
     eclair.getInfo()(any[Timeout]) returns Future.successful(null)
     Post("/getinfo") ~>
-      addCredentials(BasicHttpCredentials("__COOKIE__", mockApi().cookiePassword.get)) ~>
+      addCredentials(BasicHttpCredentials(Service.CookieUserName, mockApi().cookiePassword.get)) ~>
       Route.seal(mockService.getInfo) ~>
       check {
         assert(handled)


### PR DESCRIPTION
fixes #1437 

This PR add cookie authentication for eclair API. It is enabled by default when the API is enabled and the default cookie file is `.cookie` in the datadir.
It is possible to have both cookie and password authentication enabled at the same time and the API can be enabled without password. I used a separate configuration option for flag because I don't like how it is done in bitcoind where cookie depends on if an rpcpassword is set.

It is also possible to to use `eclair.api.cookie-group-readable` to make the generated cookie file group readable on Linux.