### PR TITLE
Make backward compatibility code for `waitingSince` work on testnet

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -288,7 +288,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
               }
           }
           // no need to go OFFLINE, we can directly switch to CLOSING
-          if (closing.waitingSinceBlock > 1500000) {
+          if (closing.waitingSinceBlock > 1_500_000_000) {
             // we were using timestamps instead of block heights when the channel was created: we reset it *and* we use block heights
             goto(CLOSING) using closing.copy(waitingSinceBlock = nodeParams.currentBlockHeight) storing()
           } else {
@@ -318,7 +318,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
           watchFundingTx(funding.commitments)
           // we make sure that the funding tx has been published
           blockchain ! GetTxWithMeta(self, funding.commitments.commitInput.outPoint.txid)
-          if (funding.waitingSinceBlock > 1500000) {
+          if (funding.waitingSinceBlock > 1_500_000_000) {
             // we were using timestamps instead of block heights when the channel was created: we reset it *and* we use block heights
             goto(OFFLINE) using funding.copy(waitingSinceBlock = nodeParams.currentBlockHeight) storing()
           } else {


### PR DESCRIPTION
We used to store UNIX timestamps in the `waitingSince` field before moving to block count. In order to ensure backward compatibility, we converted from timestamps to blockheight based on the value. Anything over 1 500 000 was considered a timestamp. But this value is much too low: on testnet the blockheight is already greater than 2 000 000.

We can use 1 500 000 000 instead, which is somewhere in 2017.

Another way to deal with this would be to simply remove this compatibility code.