### PR TITLE
Refactor sphinx payment packet

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Sphinx.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Sphinx.scala
@@ -19,7 +19,6 @@ package fr.acinq.eclair.crypto
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.{ByteVector32, Crypto}
 import fr.acinq.eclair.crypto.Monitoring.{Metrics, Tags}
-import fr.acinq.eclair.wire.protocol
 import fr.acinq.eclair.wire.protocol._
 import grizzled.slf4j.Logging
 import scodec.Attempt
@@ -33,6 +32,12 @@ import scala.util.{Failure, Success, Try}
  * see https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md
  */
 object Sphinx extends Logging {
+
+  /**
+   * Supported packet version. Note that since this value is outside of the onion encrypted payload, intermediate
+   * nodes may or may not use this value when forwarding the packet to the next node.
+   */
+  val Version = 0
 
   // We use HMAC-SHA256 which returns 32-bytes message authentication codes.
   val MacLength = 32
@@ -107,10 +112,8 @@ object Sphinx extends Logging {
    * @param nextPacket   packet for the next node.
    * @param sharedSecret shared secret for the sending node, which we will need to return failure messages.
    */
-  case class DecryptedPacket(payload: ByteVector, nextPacket: protocol.OnionRoutingPacket, sharedSecret: ByteVector32) {
-
+  case class DecryptedPacket(payload: ByteVector, nextPacket: OnionRoutingPacket, sharedSecret: ByteVector32) {
     val isLastPacket: Boolean = nextPacket.hmac == ByteVector32.Zeroes
-
   }
 
   /**
@@ -120,176 +123,151 @@ object Sphinx extends Logging {
    * @param sharedSecrets shared secrets (one per node in the route). Known (and needed) only if you're creating the
    *                      packet. Empty if you're just forwarding the packet to the next node.
    */
-  case class PacketAndSecrets(packet: protocol.OnionRoutingPacket, sharedSecrets: Seq[(ByteVector32, PublicKey)])
+  case class PacketAndSecrets(packet: OnionRoutingPacket, sharedSecrets: Seq[(ByteVector32, PublicKey)])
 
-  sealed trait OnionRoutingPacket[T <: PaymentOnion.PacketType] {
+  /**
+   * Generate a deterministic filler to prevent intermediate nodes from knowing their position in the route.
+   * See https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#filler-generation
+   *
+   * @param keyType             type of key used (depends on the onion we're building).
+   * @param packetPayloadLength length of the packet's encrypted onion payload (e.g. 1300 for standard payment onions).
+   * @param sharedSecrets       shared secrets for all the hops.
+   * @param payloads            payloads for all the hops.
+   * @return filler bytes.
+   */
+  def generateFiller(keyType: String, packetPayloadLength: Int, sharedSecrets: Seq[ByteVector32], payloads: Seq[ByteVector]): ByteVector = {
+    require(sharedSecrets.length == payloads.length, "the number of secrets should equal the number of payloads")
 
-    /**
-     * Supported packet version. Note that since this value is outside of the onion encrypted payload, intermediate
-     * nodes may or may not use this value when forwarding the packet to the next node.
-     */
-    def Version = 0
+    (sharedSecrets zip payloads).foldLeft(ByteVector.empty)((padding, secretAndPayload) => {
+      val (secret, perHopPayload) = secretAndPayload
+      val perHopPayloadLength = peekPayloadLength(perHopPayload)
+      require(perHopPayloadLength == perHopPayload.length + MacLength, s"invalid payload: length isn't correctly encoded: $perHopPayload")
+      val key = generateKey(keyType, secret)
+      val padding1 = padding ++ ByteVector.fill(perHopPayloadLength)(0)
+      val stream = generateStream(key, packetPayloadLength + perHopPayloadLength).takeRight(padding1.length)
+      padding1.xor(stream)
+    })
+  }
 
-    /**
-     * Length of the encrypted onion payload.
-     */
-    def PayloadLength: Int
+  /**
+   * Decrypt the incoming packet, extract the per-hop payload and build the packet for the next node.
+   *
+   * @param privateKey     this node's private key.
+   * @param associatedData associated data.
+   * @param packet         packet received by this node.
+   * @return a DecryptedPacket(payload, packet, shared secret) object where:
+   *         - payload is the per-hop payload for this node.
+   *         - packet is the next packet, to be forwarded using the info that is given in the payload.
+   *         - shared secret is the secret we share with the node that sent the packet. We need it to propagate
+   *           failure messages upstream.
+   *           or a BadOnion error containing the hash of the invalid onion.
+   */
+  def peel(privateKey: PrivateKey, associatedData: ByteVector, packet: OnionRoutingPacket): Either[BadOnion, DecryptedPacket] = packet.version match {
+    case 0 => Try(PublicKey(packet.publicKey, checkValid = true)) match {
+      case Success(packetEphKey) =>
+        val sharedSecret = computeSharedSecret(packetEphKey, privateKey)
+        val mu = generateKey("mu", sharedSecret)
+        val check = mac(mu, packet.payload ++ associatedData)
+        if (check == packet.hmac) {
+          val rho = generateKey("rho", sharedSecret)
+          // Since we don't know the length of the per-hop payload (we will learn it once we decode the first bytes),
+          // we have to pessimistically generate a long cipher stream.
+          val stream = generateStream(rho, 2 * packet.payload.length.toInt)
+          val bin = (packet.payload ++ ByteVector.fill(packet.payload.length)(0)) xor stream
 
-    /**
-     * Generate a deterministic filler to prevent intermediate nodes from knowing their position in the route.
-     * See https://github.com/lightningnetwork/lightning-rfc/blob/master/04-onion-routing.md#filler-generation
-     *
-     * @param keyType       type of key used (depends on the onion we're building).
-     * @param sharedSecrets shared secrets for all the hops.
-     * @param payloads      payloads for all the hops.
-     * @return filler bytes.
-     */
-    def generateFiller(keyType: String, sharedSecrets: Seq[ByteVector32], payloads: Seq[ByteVector]): ByteVector = {
-      require(sharedSecrets.length == payloads.length, "the number of secrets should equal the number of payloads")
+          val perHopPayloadLength = peekPayloadLength(bin)
+          val perHopPayload = bin.take(perHopPayloadLength - MacLength)
 
-      (sharedSecrets zip payloads).foldLeft(ByteVector.empty)((padding, secretAndPayload) => {
-        val (secret, perHopPayload) = secretAndPayload
-        val perHopPayloadLength = peekPayloadLength(perHopPayload)
-        require(perHopPayloadLength == perHopPayload.length + MacLength, s"invalid payload: length isn't correctly encoded: $perHopPayload")
-        val key = generateKey(keyType, secret)
-        val padding1 = padding ++ ByteVector.fill(perHopPayloadLength)(0)
-        val stream = generateStream(key, PayloadLength + perHopPayloadLength).takeRight(padding1.length)
-        padding1.xor(stream)
-      })
-    }
+          val hmac = ByteVector32(bin.slice(perHopPayloadLength - MacLength, perHopPayloadLength))
+          val nextOnionPayload = bin.drop(perHopPayloadLength).take(packet.payload.length)
+          val nextPubKey = blind(packetEphKey, computeBlindingFactor(packetEphKey, sharedSecret))
 
-    /**
-     * Decrypt the incoming packet, extract the per-hop payload and build the packet for the next node.
-     *
-     * @param privateKey     this node's private key.
-     * @param associatedData associated data.
-     * @param packet         packet received by this node.
-     * @return a DecryptedPacket(payload, packet, shared secret) object where:
-     *         - payload is the per-hop payload for this node.
-     *         - packet is the next packet, to be forwarded using the info that is given in the payload.
-     *         - shared secret is the secret we share with the node that sent the packet. We need it to propagate
-     *           failure messages upstream.
-     *           or a BadOnion error containing the hash of the invalid onion.
-     */
-    def peel(privateKey: PrivateKey, associatedData: ByteVector, packet: protocol.OnionRoutingPacket): Either[BadOnion, DecryptedPacket] = packet.version match {
-      case 0 => Try(PublicKey(packet.publicKey, checkValid = true)) match {
-        case Success(packetEphKey) =>
-          val sharedSecret = computeSharedSecret(packetEphKey, privateKey)
-          val mu = generateKey("mu", sharedSecret)
-          val check = mac(mu, packet.payload ++ associatedData)
-          if (check == packet.hmac) {
-            val rho = generateKey("rho", sharedSecret)
-            // Since we don't know the length of the per-hop payload (we will learn it once we decode the first bytes),
-            // we have to pessimistically generate a long cipher stream.
-            val stream = generateStream(rho, 2 * PayloadLength)
-            val bin = (packet.payload ++ ByteVector.fill(PayloadLength)(0)) xor stream
-
-            val perHopPayloadLength = peekPayloadLength(bin)
-            val perHopPayload = bin.take(perHopPayloadLength - MacLength)
-
-            val hmac = ByteVector32(bin.slice(perHopPayloadLength - MacLength, perHopPayloadLength))
-            val nextOnionPayload = bin.drop(perHopPayloadLength).take(PayloadLength)
-            val nextPubKey = blind(packetEphKey, computeBlindingFactor(packetEphKey, sharedSecret))
-
-            Right(DecryptedPacket(perHopPayload, protocol.OnionRoutingPacket(Version, nextPubKey.value, nextOnionPayload, hmac), sharedSecret))
-          } else {
-            Left(InvalidOnionHmac(hash(packet)))
-          }
-        case Failure(_) => Left(InvalidOnionKey(hash(packet)))
-      }
-      case _ => Left(InvalidOnionVersion(hash(packet)))
-    }
-
-    /**
-     * Wrap the given packet in an additional layer of onion encryption, adding an encrypted payload for a specific
-     * node.
-     *
-     * Packets are constructed in reverse order:
-     * - you first create the packet for the final recipient
-     * - then you call wrap(...) until you've built the final onion packet that will be sent to the first node in the
-     * route
-     *
-     * @param payload            per-hop payload for the target node.
-     * @param associatedData     associated data.
-     * @param ephemeralPublicKey ephemeral key shared with the target node.
-     * @param sharedSecret       shared secret with this hop.
-     * @param packet             current packet or random bytes if the packet hasn't been initialized.
-     * @param onionPayloadFiller optional onion payload filler, needed only when you're constructing the last packet.
-     * @return the next packet.
-     */
-    def wrap(payload: ByteVector, associatedData: ByteVector32, ephemeralPublicKey: PublicKey, sharedSecret: ByteVector32, packet: Either[ByteVector, protocol.OnionRoutingPacket], onionPayloadFiller: ByteVector = ByteVector.empty): protocol.OnionRoutingPacket = {
-      require(payload.length <= PayloadLength - MacLength, s"packet payload cannot exceed ${PayloadLength - MacLength} bytes")
-
-      val (currentMac, currentPayload): (ByteVector32, ByteVector) = packet match {
-        // Packet construction starts with an empty mac and random payload.
-        case Left(startingBytes) =>
-          require(startingBytes.length == PayloadLength, "invalid initial random bytes length")
-          (ByteVector32.Zeroes, startingBytes)
-        case Right(p) => (p.hmac, p.payload)
-      }
-      val nextOnionPayload = {
-        val onionPayload1 = payload ++ currentMac ++ currentPayload.dropRight(payload.length + MacLength)
-        val onionPayload2 = onionPayload1 xor generateStream(generateKey("rho", sharedSecret), PayloadLength)
-        onionPayload2.dropRight(onionPayloadFiller.length) ++ onionPayloadFiller
-      }
-
-      val nextHmac = mac(generateKey("mu", sharedSecret), nextOnionPayload ++ associatedData)
-      val nextPacket = protocol.OnionRoutingPacket(Version, ephemeralPublicKey.value, nextOnionPayload, nextHmac)
-      nextPacket
-    }
-
-    /**
-     * Create an encrypted onion packet that contains payloads for all nodes in the list.
-     *
-     * @param sessionKey     session key.
-     * @param publicKeys     node public keys (one per node).
-     * @param payloads       payloads (one per node).
-     * @param associatedData associated data.
-     * @return An onion packet with all shared secrets. The onion packet can be sent to the first node in the list, and
-     *         the shared secrets (one per node) can be used to parse returned failure messages if needed.
-     */
-    def create(sessionKey: PrivateKey, publicKeys: Seq[PublicKey], payloads: Seq[ByteVector], associatedData: ByteVector32): PacketAndSecrets = {
-      val (ephemeralPublicKeys, sharedsecrets) = computeEphemeralPublicKeysAndSharedSecrets(sessionKey, publicKeys)
-      val filler = generateFiller("rho", sharedsecrets.dropRight(1), payloads.dropRight(1))
-
-      // We deterministically-derive the initial payload bytes: see https://github.com/lightningnetwork/lightning-rfc/pull/697
-      val startingBytes = generateStream(generateKey("pad", sessionKey.value), PayloadLength)
-      val lastPacket = wrap(payloads.last, associatedData, ephemeralPublicKeys.last, sharedsecrets.last, Left(startingBytes), filler)
-
-      @tailrec
-      def loop(hopPayloads: Seq[ByteVector], ephKeys: Seq[PublicKey], sharedSecrets: Seq[ByteVector32], packet: protocol.OnionRoutingPacket): protocol.OnionRoutingPacket = {
-        if (hopPayloads.isEmpty) packet else {
-          val nextPacket = wrap(hopPayloads.last, associatedData, ephKeys.last, sharedSecrets.last, Right(packet))
-          loop(hopPayloads.dropRight(1), ephKeys.dropRight(1), sharedSecrets.dropRight(1), nextPacket)
+          Right(DecryptedPacket(perHopPayload, OnionRoutingPacket(Version, nextPubKey.value, nextOnionPayload, hmac), sharedSecret))
+        } else {
+          Left(InvalidOnionHmac(hash(packet)))
         }
-      }
+      case Failure(_) => Left(InvalidOnionKey(hash(packet)))
+    }
+    case _ => Left(InvalidOnionVersion(hash(packet)))
+  }
 
-      val packet = loop(payloads.dropRight(1), ephemeralPublicKeys.dropRight(1), sharedsecrets.dropRight(1), lastPacket)
-      PacketAndSecrets(packet, sharedsecrets.zip(publicKeys))
+  /**
+   * Wrap the given packet in an additional layer of onion encryption, adding an encrypted payload for a specific
+   * node.
+   *
+   * Packets are constructed in reverse order:
+   * - you first create the packet for the final recipient
+   * - then you call wrap(...) until you've built the final onion packet that will be sent to the first node in the
+   * route
+   *
+   * @param payload            per-hop payload for the target node.
+   * @param associatedData     associated data.
+   * @param ephemeralPublicKey ephemeral key shared with the target node.
+   * @param sharedSecret       shared secret with this hop.
+   * @param packet             current packet or random bytes if the packet hasn't been initialized.
+   * @param onionPayloadFiller optional onion payload filler, needed only when you're constructing the last packet.
+   * @return the next packet.
+   */
+  def wrap(payload: ByteVector, associatedData: ByteVector32, ephemeralPublicKey: PublicKey, sharedSecret: ByteVector32, packet: Either[ByteVector, OnionRoutingPacket], onionPayloadFiller: ByteVector = ByteVector.empty): OnionRoutingPacket = {
+    val packetPayloadLength = packet match {
+      case Left(startingBytes) => startingBytes.length.toInt
+      case Right(p) => p.payload.length.toInt
+    }
+    require(payload.length <= packetPayloadLength - MacLength, s"packet per-hop payload cannot exceed ${packetPayloadLength - MacLength} bytes")
+
+    val (currentMac, currentPayload): (ByteVector32, ByteVector) = packet match {
+      // Packet construction starts with an empty mac and random payload.
+      case Left(startingBytes) => (ByteVector32.Zeroes, startingBytes)
+      case Right(p) => (p.hmac, p.payload)
+    }
+    val nextOnionPayload = {
+      val onionPayload1 = payload ++ currentMac ++ currentPayload.dropRight(payload.length + MacLength)
+      val onionPayload2 = onionPayload1 xor generateStream(generateKey("rho", sharedSecret), packetPayloadLength)
+      onionPayload2.dropRight(onionPayloadFiller.length) ++ onionPayloadFiller
     }
 
-    /**
-     * When an invalid onion is received, its hash should be included in the failure message.
-     */
-    def hash(onion: protocol.OnionRoutingPacket): ByteVector32 =
-      Crypto.sha256(OnionRoutingCodecs.onionRoutingPacketCodec(onion.payload.length.toInt).encode(onion).require.toByteVector)
-
+    val nextHmac = mac(generateKey("mu", sharedSecret), nextOnionPayload ++ associatedData)
+    val nextPacket = OnionRoutingPacket(Version, ephemeralPublicKey.value, nextOnionPayload, nextHmac)
+    nextPacket
   }
 
   /**
-   * A payment onion packet is used when offering an HTLC to a remote node.
+   * Create an encrypted onion packet that contains payloads for all nodes in the list.
+   *
+   * @param sessionKey          session key.
+   * @param packetPayloadLength length of the packet's encrypted onion payload (e.g. 1300 for standard payment onions).
+   * @param publicKeys          node public keys (one per node).
+   * @param payloads            payloads (one per node).
+   * @param associatedData      associated data.
+   * @return An onion packet with all shared secrets. The onion packet can be sent to the first node in the list, and
+   *         the shared secrets (one per node) can be used to parse returned failure messages if needed.
    */
-  object PaymentPacket extends OnionRoutingPacket[PaymentOnion.PaymentPacket] {
-    override val PayloadLength = 1300
+  def create(sessionKey: PrivateKey, packetPayloadLength: Int, publicKeys: Seq[PublicKey], payloads: Seq[ByteVector], associatedData: ByteVector32): PacketAndSecrets = {
+    require(payloads.map(_.length + MacLength).sum <= packetPayloadLength, s"packet per-hop payloads cannot exceed $packetPayloadLength bytes")
+    val (ephemeralPublicKeys, sharedsecrets) = computeEphemeralPublicKeysAndSharedSecrets(sessionKey, publicKeys)
+    val filler = generateFiller("rho", packetPayloadLength, sharedsecrets.dropRight(1), payloads.dropRight(1))
+
+    // We deterministically-derive the initial payload bytes: see https://github.com/lightningnetwork/lightning-rfc/pull/697
+    val startingBytes = generateStream(generateKey("pad", sessionKey.value), packetPayloadLength)
+    val lastPacket = wrap(payloads.last, associatedData, ephemeralPublicKeys.last, sharedsecrets.last, Left(startingBytes), filler)
+
+    @tailrec
+    def loop(hopPayloads: Seq[ByteVector], ephKeys: Seq[PublicKey], sharedSecrets: Seq[ByteVector32], packet: OnionRoutingPacket): OnionRoutingPacket = {
+      if (hopPayloads.isEmpty) packet else {
+        val nextPacket = wrap(hopPayloads.last, associatedData, ephKeys.last, sharedSecrets.last, Right(packet))
+        loop(hopPayloads.dropRight(1), ephKeys.dropRight(1), sharedSecrets.dropRight(1), nextPacket)
+      }
+    }
+
+    val packet = loop(payloads.dropRight(1), ephemeralPublicKeys.dropRight(1), sharedsecrets.dropRight(1), lastPacket)
+    PacketAndSecrets(packet, sharedsecrets.zip(publicKeys))
   }
 
   /**
-   * A trampoline onion packet is used to defer route construction to trampoline nodes.
-   * It is usually embedded inside a payment onion packet in the final node's payload.
+   * When an invalid onion is received, its hash should be included in the failure message.
    */
-  object TrampolinePacket extends OnionRoutingPacket[PaymentOnion.TrampolinePacket] {
-    override val PayloadLength = 400
-  }
+  def hash(onion: OnionRoutingPacket): ByteVector32 =
+    Crypto.sha256(OnionRoutingCodecs.onionRoutingPacketCodec(onion.payload.length.toInt).encode(onion).require.toByteVector)
 
   /**
    * A properly decrypted failure from a node in the route.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -162,7 +162,7 @@ class PaymentInitiator(nodeParams: NodeParams, outgoingPaymentFactory: PaymentIn
     }
     // We assume that the trampoline node supports multi-part payments (it should).
     val (trampolineAmount, trampolineExpiry, trampolineOnion) = if (r.paymentRequest.features.allowTrampoline) {
-      OutgoingPaymentPacket.buildPacket(Sphinx.TrampolinePacket)(r.paymentHash, trampolineRoute, finalPayload)
+      OutgoingPaymentPacket.buildTrampolinePacket(r.paymentHash, trampolineRoute, finalPayload)
     } else {
       OutgoingPaymentPacket.buildTrampolineToLegacyPacket(r.paymentRequest, trampolineRoute, finalPayload)
     }
@@ -260,13 +260,13 @@ object PaymentInitiator {
                                blockUntilComplete: Boolean = false) extends SendRequestedPayment
 
   /**
-   * @param recipientAmount amount that should be received by the final recipient.
-   * @param recipientNodeId id of the final recipient.
-   * @param paymentPreimage payment preimage.
-   * @param maxAttempts     maximum number of retries.
-   * @param externalId      (optional) externally-controlled identifier (to reconcile between application DB and eclair DB).
-   * @param routeParams     (optional) parameters to fine-tune the routing algorithm.
-   * @param userCustomTlvs  (optional) user-defined custom tlvs that will be added to the onion sent to the target node.
+   * @param recipientAmount          amount that should be received by the final recipient.
+   * @param recipientNodeId          id of the final recipient.
+   * @param paymentPreimage          payment preimage.
+   * @param maxAttempts              maximum number of retries.
+   * @param externalId               (optional) externally-controlled identifier (to reconcile between application DB and eclair DB).
+   * @param routeParams              (optional) parameters to fine-tune the routing algorithm.
+   * @param userCustomTlvs           (optional) user-defined custom tlvs that will be added to the onion sent to the target node.
    * @param recordPathFindingMetrics will be used to build [[SendPaymentConfig]].
    */
   case class SendSpontaneousPayment(recipientAmount: MilliSatoshi,
@@ -339,22 +339,22 @@ object PaymentInitiator {
   /**
    * Configuration for an instance of a payment state machine.
    *
-   * @param id              id of the outgoing payment (mapped to a single outgoing HTLC).
-   * @param parentId        id of the whole payment (if using multi-part, there will be N associated child payments,
-   *                        each with a different id).
-   * @param externalId      externally-controlled identifier (to reconcile between application DB and eclair DB).
-   * @param paymentHash     payment hash.
-   * @param recipientAmount amount that should be received by the final recipient (usually from a Bolt 11 invoice).
-   * @param recipientNodeId id of the final recipient.
-   * @param upstream        information about the payment origin (to link upstream to downstream when relaying a payment).
-   * @param paymentRequest  Bolt 11 invoice.
-   * @param storeInDb       whether to store data in the payments DB (e.g. when we're relaying a trampoline payment, we
-   *                        don't want to store in the DB).
-   * @param publishEvent    whether to publish a [[fr.acinq.eclair.payment.PaymentEvent]] on success/failure (e.g. for
-   *                        multi-part child payments, we don't want to emit events for each child, only for the whole payment).
-   * @param recordPathFindingMetrics   We don't record metrics for payments that don't use path finding or that are a part of a bigger payment.
-   * @param additionalHops  additional hops that the payment state machine isn't aware of (e.g. when using trampoline, hops
-   *                        that occur after the first trampoline node).
+   * @param id                       id of the outgoing payment (mapped to a single outgoing HTLC).
+   * @param parentId                 id of the whole payment (if using multi-part, there will be N associated child payments,
+   *                                 each with a different id).
+   * @param externalId               externally-controlled identifier (to reconcile between application DB and eclair DB).
+   * @param paymentHash              payment hash.
+   * @param recipientAmount          amount that should be received by the final recipient (usually from a Bolt 11 invoice).
+   * @param recipientNodeId          id of the final recipient.
+   * @param upstream                 information about the payment origin (to link upstream to downstream when relaying a payment).
+   * @param paymentRequest           Bolt 11 invoice.
+   * @param storeInDb                whether to store data in the payments DB (e.g. when we're relaying a trampoline payment, we
+   *                                 don't want to store in the DB).
+   * @param publishEvent             whether to publish a [[fr.acinq.eclair.payment.PaymentEvent]] on success/failure (e.g. for
+   *                                 multi-part child payments, we don't want to emit events for each child, only for the whole payment).
+   * @param recordPathFindingMetrics We don't record metrics for payments that don't use path finding or that are a part of a bigger payment.
+   * @param additionalHops           additional hops that the payment state machine isn't aware of (e.g. when using trampoline, hops
+   *                                 that occur after the first trampoline node).
    */
   case class SendPaymentConfig(id: UUID,
                                parentId: UUID,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -1420,7 +1420,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     import f._
     val (_, htlc) = addHtlc(150000000 msat, alice, bob, alice2bob, bob2alice)
     crossSign(alice, bob, alice2bob, bob2alice)
-    bob ! CMD_FAIL_MALFORMED_HTLC(htlc.id, Sphinx.PaymentPacket.hash(htlc.onionRoutingPacket), FailureMessageCodecs.BADONION)
+    bob ! CMD_FAIL_MALFORMED_HTLC(htlc.id, Sphinx.hash(htlc.onionRoutingPacket), FailureMessageCodecs.BADONION)
     val fail = bob2alice.expectMsgType[UpdateFailMalformedHtlc]
     bob2alice.forward(alice)
     bob ! CMD_SIGN()
@@ -1755,7 +1755,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
 
     // actual test begins
     val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
-    bob ! CMD_FAIL_MALFORMED_HTLC(htlc.id, Sphinx.PaymentPacket.hash(htlc.onionRoutingPacket), FailureMessageCodecs.BADONION)
+    bob ! CMD_FAIL_MALFORMED_HTLC(htlc.id, Sphinx.hash(htlc.onionRoutingPacket), FailureMessageCodecs.BADONION)
     val fail = bob2alice.expectMsgType[UpdateFailMalformedHtlc]
     awaitCond(bob.stateData == initialState.copy(
       commitments = initialState.commitments.copy(
@@ -1834,7 +1834,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     crossSign(alice, bob, alice2bob, bob2alice)
     // Bob fails the HTLC because he cannot parse it
     val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
-    bob ! CMD_FAIL_MALFORMED_HTLC(htlc.id, Sphinx.PaymentPacket.hash(htlc.onionRoutingPacket), FailureMessageCodecs.BADONION)
+    bob ! CMD_FAIL_MALFORMED_HTLC(htlc.id, Sphinx.hash(htlc.onionRoutingPacket), FailureMessageCodecs.BADONION)
     val fail = bob2alice.expectMsgType[UpdateFailMalformedHtlc]
     bob2alice.forward(alice)
 
@@ -1860,7 +1860,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
 
     // actual test begins
     val tx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.commitTxAndRemoteSig.commitTx.tx
-    val fail = UpdateFailMalformedHtlc(ByteVector32.Zeroes, htlc.id, Sphinx.PaymentPacket.hash(htlc.onionRoutingPacket), 42)
+    val fail = UpdateFailMalformedHtlc(ByteVector32.Zeroes, htlc.id, Sphinx.hash(htlc.onionRoutingPacket), 42)
     alice ! fail
     val error = alice2bob.expectMsgType[Error]
     assert(new String(error.data.toArray) === InvalidFailureCode(ByteVector32.Zeroes).getMessage)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/SphinxSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/SphinxSpec.scala
@@ -71,13 +71,13 @@ class SphinxSpec extends AnyFunSuite {
 
   test("generate filler with fixed-size payloads (reference test vector)") {
     val (_, sharedsecrets) = computeEphemeralPublicKeysAndSharedSecrets(sessionKey, publicKeys)
-    val filler = PaymentPacket.generateFiller("rho", sharedsecrets.dropRight(1), referenceFixedSizePaymentPayloads.dropRight(1))
+    val filler = generateFiller("rho", 1300, sharedsecrets.dropRight(1), referenceFixedSizePaymentPayloads.dropRight(1))
     assert(filler == hex"c6b008cf6414ed6e4c42c291eb505e9f22f5fe7d0ecdd15a833f4d016ac974d33adc6ea3293e20859e87ebfb937ba406abd025d14af692b12e9c9c2adbe307a679779259676211c071e614fdb386d1ff02db223a5b2fae03df68d321c7b29f7c7240edd3fa1b7cb6903f89dc01abf41b2eb0b49b6b8d73bb0774b58204c0d0e96d3cce45ad75406be0bc009e327b3e712a4bd178609c00b41da2daf8a4b0e1319f07a492ab4efb056f0f599f75e6dc7e0d10ce1cf59088ab6e873de377343880f7a24f0e36731a0b72092f8d5bc8cd346762e93b2bf203d00264e4bc136fc142de8f7b69154deb05854ea88e2d7506222c95ba1aab065c8a851391377d3406a35a9af3ac")
   }
 
   test("generate filler with variable-size payloads") {
     val (_, sharedsecrets) = computeEphemeralPublicKeysAndSharedSecrets(sessionKey, publicKeys)
-    val filler = PaymentPacket.generateFiller("rho", sharedsecrets.dropRight(1), referenceVariableSizePaymentPayloads.dropRight(1))
+    val filler = generateFiller("rho", 1300, sharedsecrets.dropRight(1), referenceVariableSizePaymentPayloads.dropRight(1))
     assert(filler == hex"b77d99c935d3f32469844f7e09340a91ded147557bdd0456c369f7e449587c0f5666faab58040146db49024db88553729bce12b860391c29c1779f022ae48a9cb314ca35d73fc91addc92632bcf7ba6fd9f38e6fd30fabcedbd5407b6648073c38331ee7ab0332f41f550c180e1601f8c25809ed75b3a1e78635a2ef1b828e92c9658e76e49f995d72cf9781eec0c838901d0bdde3ac21c13b4979ac9e738a1c4d0b9741d58e777ad1aed01263ad1390d36a18a6b92f4f799dcf75edbb43b7515e8d72cb4f827a9af0e7b9338d07b1a24e0305b5535f5b851b1144bad6238b9d9482b5ba6413f1aafac3cdde5067966ed8b78f7c1c5f916a05f874d5f17a2b7d0ae75d66a5f1bb6ff932570dc5a0cf3ce04eb5d26bc55c2057af1f8326e20a7d6f0ae644f09d00fac80de60f20aceee85be41a074d3e1dda017db79d0070b99f54736396f206ee3777abd4c00a4bb95c871750409261e3b01e59a3793a9c20159aae4988c68397a1443be6370fd9614e46108291e615691729faea58537209fa668a172d066d0efff9bc77c2bd34bd77870ad79effd80140990e36731a0b72092f8d5bc8cd346762e93b2bf203d00264e4bc136fc142de8f7b69154deb05854ea88e2d7506222c95ba1aab065c8a")
   }
 
@@ -127,20 +127,20 @@ class SphinxSpec extends AnyFunSuite {
     )
 
     for ((packet, expected) <- badOnions zip expected) {
-      val Left(onionErr) = PaymentPacket.peel(privKeys.head, associatedData, packet)
+      val Left(onionErr) = peel(privKeys.head, associatedData, packet)
       assert(onionErr === expected)
     }
   }
 
   test("create payment packet with fixed-size payloads (reference test vector)") {
-    val PacketAndSecrets(onion, sharedSecrets) = PaymentPacket.create(sessionKey, publicKeys, referenceFixedSizePaymentPayloads, associatedData)
+    val PacketAndSecrets(onion, sharedSecrets) = create(sessionKey, 1300, publicKeys, referenceFixedSizePaymentPayloads, associatedData)
     assert(serializePaymentOnion(onion) == hex"0002eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619e5f14350c2a76fc232b5e46d421e9615471ab9e0bc887beff8c95fdb878f7b3a71e87f9aab8f6378c6ff744c1f34b393ad28d065b535c1a8668d85d3b34a1b3befd10f7d61ab590531cf08000178a333a347f8b4072e216400406bdf3bf038659793a1f9e7abc789266cc861cabd95818c0fc8efbdfdc14e3f7c2bc7eb8d6a79ef75ce721caad69320c3a469a202f3e468c67eaf7a7cda226d0fd32f7b48084dca885d014698cf05d742557763d9cb743faeae65dcc79dddaecf27fe5942be5380d15e9a1ec866abe044a9ad635778ba61fc0776dc832b39451bd5d35072d2269cf9b040a2a2fba158a0d8085926dc2e44f0c88bf487da56e13ef2d5e676a8589881b4869ed4c7f0218ff8c6c7dd7221d189c65b3b9aaa71a01484b122846c7c7b57e02e679ea8469b70e14fe4f70fee4d87b910cf144be6fe48eef24da475c0b0bcc6565a9f99728426ce2380a9580e2a9442481ceae7679906c30b1a0e21a10f26150e0645ab6edfdab1ce8f8bea7b1dee511c5fd38ac0e702c1c15bb86b52bca1b71e15b96982d262a442024c33ceb7dd8f949063c2e5e613e873250e2f8708bd4e1924abd45f65c2fa5617bfb10ee9e4a42d6b5811acc8029c16274f937dac9e8817c7e579fdb767ffe277f26d413ced06b620ede8362081da21cf67c2ca9d6f15fe5bc05f82f5bb93f8916bad3d63338ca824f3bbc11b57ce94a5fa1bc239533679903d6fec92a8c792fd86e2960188c14f21e399cfd72a50c620e10aefc6249360b463df9a89bf6836f4f26359207b765578e5ed76ae9f31b1cc48324be576e3d8e44d217445dba466f9b6293fdf05448584eb64f61e02903f834518622b7d4732471c6e0e22e22d1f45e31f0509eab39cdea5980a492a1da2aaac55a98a01216cd4bfe7abaa682af0fbff2dfed030ba28f1285df750e4d3477190dd193f8643b61d8ac1c427d590badb1f61a05d480908fbdc7c6f0502dd0c4abb51d725e92f95da2a8facb79881a844e2026911adcc659d1fb20a2fce63787c8bb0d9f6789c4b231c76da81c3f0718eb7156565a081d2be6b4170c0e0bcebddd459f53db2590c974bca0d705c055dee8c629bf854a5d58edc85228499ec6dde80cce4c8910b81b1e9e8b0f43bd39c8d69c3a80672729b7dc952dd9448688b6bd06afc2d2819cda80b66c57b52ccf7ac1a86601410d18d0c732f69de792e0894a9541684ef174de766fd4ce55efea8f53812867be6a391ac865802dbc26d93959df327ec2667c7256aa5a1d3c45a69a6158f285d6c97c3b8eedb09527848500517995a9eae4cd911df531544c77f5a9a2f22313e3eb72ca7a07dba243476bc926992e0d1e58b4a2fc8c7b01e0cad726237933ea319bad7537d39f3ed635d1e6c1d29e97b3d2160a09e30ee2b65ac5bce00996a73c008bcf351cecb97b6833b6d121dcf4644260b2946ea204732ac9954b228f0beaa15071930fd9583dfc466d12b5f0eeeba6dcf23d5ce8ae62ee5796359d97a4a15955c778d868d0ef9991d9f2833b5bb66119c5f8b396fd108baed7906cbb3cc376d13551caed97fece6f42a4c908ee279f1127fda1dd3ee77d8de0a6f3c135fa3f1cffe38591b6738dc97b55f0acc52be9753ce53e64d7e497bb00ca6123758df3b68fad99e35c04389f7514a8e36039f541598a417275e77869989782325a15b5342ac5011ff07af698584b476b35d941a4981eac590a07a092bb50342da5d3341f901aa07964a8d02b623c7b106dd0ae50bfa007a22d46c8772fa55558176602946cb1d11ea5460db7586fb89c6d3bcd3ab6dd20df4a4db63d2e7d52380800ad812b8640887e027e946df96488b47fbc4a4fadaa8beda4abe446fafea5403fae2ef")
 
-    val Right(DecryptedPacket(payload0, nextPacket0, sharedSecret0)) = PaymentPacket.peel(privKeys(0), associatedData, onion)
-    val Right(DecryptedPacket(payload1, nextPacket1, sharedSecret1)) = PaymentPacket.peel(privKeys(1), associatedData, nextPacket0)
-    val Right(DecryptedPacket(payload2, nextPacket2, sharedSecret2)) = PaymentPacket.peel(privKeys(2), associatedData, nextPacket1)
-    val Right(DecryptedPacket(payload3, nextPacket3, sharedSecret3)) = PaymentPacket.peel(privKeys(3), associatedData, nextPacket2)
-    val Right(DecryptedPacket(payload4, nextPacket4, sharedSecret4)) = PaymentPacket.peel(privKeys(4), associatedData, nextPacket3)
+    val Right(DecryptedPacket(payload0, nextPacket0, sharedSecret0)) = peel(privKeys(0), associatedData, onion)
+    val Right(DecryptedPacket(payload1, nextPacket1, sharedSecret1)) = peel(privKeys(1), associatedData, nextPacket0)
+    val Right(DecryptedPacket(payload2, nextPacket2, sharedSecret2)) = peel(privKeys(2), associatedData, nextPacket1)
+    val Right(DecryptedPacket(payload3, nextPacket3, sharedSecret3)) = peel(privKeys(3), associatedData, nextPacket2)
+    val Right(DecryptedPacket(payload4, nextPacket4, sharedSecret4)) = peel(privKeys(4), associatedData, nextPacket3)
     assert(Seq(payload0, payload1, payload2, payload3, payload4) == referenceFixedSizePaymentPayloads)
     assert(Seq(sharedSecret0, sharedSecret1, sharedSecret2, sharedSecret3, sharedSecret4) == sharedSecrets.map(_._1))
 
@@ -154,14 +154,14 @@ class SphinxSpec extends AnyFunSuite {
   }
 
   test("create payment packet with variable-size payloads (reference test vector)") {
-    val PacketAndSecrets(onion, sharedSecrets) = PaymentPacket.create(sessionKey, publicKeys, referenceVariableSizePaymentPayloads, associatedData)
+    val PacketAndSecrets(onion, sharedSecrets) = create(sessionKey, 1300, publicKeys, referenceVariableSizePaymentPayloads, associatedData)
     assert(serializePaymentOnion(onion) == hex"0002eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619e5f14350c2a76fc232b5e46d421e9615471ab9e0bc887beff8c95fdb878f7b3a710f8eaf9ccc768f66bb5dec1f7827f33c43fe2ddd05614c8283aa78e9e7573f87c50f7d61ab590531cf08000178a333a347f8b4072e1cea42da7552402b10765adae3f581408f35ff0a71a34b78b1d8ecae77df96c6404bae9a8e8d7178977d7094a1ae549f89338c0777551f874159eb42d3a59fb9285ad4e24883f27de23942ec966611e99bee1cee503455be9e8e642cef6cef7b9864130f692283f8a973d47a8f1c1726b6e59969385975c766e35737c8d76388b64f748ee7943ffb0e2ee45c57a1abc40762ae598723d21bd184e2b338f68ebff47219357bd19cd7e01e2337b806ef4d717888e129e59cd3dc31e6201ccb2fd6d7499836f37a993262468bcb3a4dcd03a22818aca49c6b7b9b8e9e870045631d8e039b066ff86e0d1b7291f71cefa7264c70404a8e538b566c17ccc5feab231401e6c08a01bd5edfc1aa8e3e533b96e82d1f91118d508924b923531929aea889fcdf057f5995d9731c4bf796fb0e41c885d488dcbc68eb742e27f44310b276edc6f652658149e7e9ced4edde5d38c9b8f92e16f6b4ab13d710ee5c193921909bdd75db331cd9d7581a39fca50814ed8d9d402b86e7f8f6ac2f3bca8e6fe47eb45fbdd3be21a8a8d200797eae3c9a0497132f92410d804977408494dff49dd3d8bce248e0b74fd9e6f0f7102c25ddfa02bd9ad9f746abbfa3379834bc2380d58e9d23237821475a1874484783a15d68f47d3dc339f38d9bf925655d5c946778680fd6d1f062f84128895aff09d35d6c92cca63d3f95a9ee8f2a84f383b4d6a087533e65de12fc8dcaf85777736a2088ff4b22462265028695b37e70963c10df8ef2458756c73007dc3e544340927f9e9f5ea4816a9fd9832c311d122e9512739a6b4714bba590e31caa143ce83cb84b36c738c60c3190ff70cd9ac286a9fd2ab619399b68f1f7447be376ce884b5913c8496d01cbf7a44a60b6e6747513f69dc538f340bc1388e0fde5d0c1db50a4dcb9cc0576e0e2474e4853af9623212578d502757ffb2e0e749695ed70f61c116560d0d4154b64dcf3cbf3c91d89fb6dd004dc19588e3479fcc63c394a4f9e8a3b8b961fce8a532304f1337f1a697a1bb14b94d2953f39b73b6a3125d24f27fcd4f60437881185370bde68a5454d816e7a70d4cea582effab9a4f1b730437e35f7a5c4b769c7b72f0346887c1e63576b2f1e2b3706142586883f8cf3a23595cc8e35a52ad290afd8d2f8bcd5b4c1b891583a4159af7110ecde092079209c6ec46d2bda60b04c519bb8bc6dffb5c87f310814ef2f3003671b3c90ddf5d0173a70504c2280d31f17c061f4bb12a978122c8a2a618bb7d1edcf14f84bf0fa181798b826a254fca8b6d7c81e0beb01bd77f6461be3c8647301d02b04753b0771105986aa0cbc13f7718d64e1b3437e8eef1d319359914a7932548c91570ef3ea741083ca5be5ff43c6d9444d29df06f76ec3dc936e3d180f4b6d0fbc495487c7d44d7c8fe4a70d5ff1461d0d9593f3f898c919c363fa18341ce9dae54f898ccf3fe792136682272941563387263c51b2a2f32363b804672cc158c9230472b554090a661aa81525d11876eefdcc45442249e61e07284592f1606491de5c0324d3af4be035d7ede75b957e879e9770cdde2e1bbc1ef75d45fe555f1ff6ac296a2f648eeee59c7c08260226ea333c285bcf37a9bbfa57ba2ab8083c4be6fc2ebe279537d22da96a07392908cf22b233337a74fe5c603b51712b43c3ee55010ee3d44dd9ba82bba3145ec358f863e04bbfa53799a7a9216718fd5859da2f0deb77b8e315ad6868fdec9400f45a48e6dc8ddbaeb3")
 
-    val Right(DecryptedPacket(payload0, nextPacket0, sharedSecret0)) = PaymentPacket.peel(privKeys(0), associatedData, onion)
-    val Right(DecryptedPacket(payload1, nextPacket1, sharedSecret1)) = PaymentPacket.peel(privKeys(1), associatedData, nextPacket0)
-    val Right(DecryptedPacket(payload2, nextPacket2, sharedSecret2)) = PaymentPacket.peel(privKeys(2), associatedData, nextPacket1)
-    val Right(DecryptedPacket(payload3, nextPacket3, sharedSecret3)) = PaymentPacket.peel(privKeys(3), associatedData, nextPacket2)
-    val Right(DecryptedPacket(payload4, nextPacket4, sharedSecret4)) = PaymentPacket.peel(privKeys(4), associatedData, nextPacket3)
+    val Right(DecryptedPacket(payload0, nextPacket0, sharedSecret0)) = peel(privKeys(0), associatedData, onion)
+    val Right(DecryptedPacket(payload1, nextPacket1, sharedSecret1)) = peel(privKeys(1), associatedData, nextPacket0)
+    val Right(DecryptedPacket(payload2, nextPacket2, sharedSecret2)) = peel(privKeys(2), associatedData, nextPacket1)
+    val Right(DecryptedPacket(payload3, nextPacket3, sharedSecret3)) = peel(privKeys(3), associatedData, nextPacket2)
+    val Right(DecryptedPacket(payload4, nextPacket4, sharedSecret4)) = peel(privKeys(4), associatedData, nextPacket3)
     assert(Seq(payload0, payload1, payload2, payload3, payload4) == referenceVariableSizePaymentPayloads)
     assert(Seq(sharedSecret0, sharedSecret1, sharedSecret2, sharedSecret3, sharedSecret4) == sharedSecrets.map(_._1))
 
@@ -174,14 +174,14 @@ class SphinxSpec extends AnyFunSuite {
   }
 
   test("create payment packet with variable-size payloads filling the onion") {
-    val PacketAndSecrets(onion, sharedSecrets) = PaymentPacket.create(sessionKey, publicKeys, variableSizePaymentPayloadsFull, associatedData)
+    val PacketAndSecrets(onion, sharedSecrets) = create(sessionKey, 1300, publicKeys, variableSizePaymentPayloadsFull, associatedData)
     assert(serializePaymentOnion(onion) == hex"0002eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f2836866196ef84350c2a76fc232b5d46d421e9615471ab9e0bc887beff8c95fdb878f7b3a7141453e5f8d22b6101810ae541ce499a09b4a9d9f80d1845c8960c85fc6d1a87bf74b2ce49922898e9353fa268086c00ae8b7f718405b72ad3829dbb38c85e02a00427eb4bdbda8fcd42b44708a9efde49cf776b75ebb389bf84d0bfbf58590e510e034572a01e409c309396778760423a8d8754c52e9a01a8f0e271cba5068bab5ee5bd0b5cd98276b0e04d60ba6a0f6bafd75ff41903ab352a1f47586eae3c6c8e437d4308766f71052b46ba2efbd87c0a781e8b3f456300fc7efbefc78ab515338666aed2070e674143c30b520b9cc1782ba8b46454db0d4ce72589cfc2eafb2db452ec98573ad08496483741de5376bfc7357fc6ea629e31236ba6ba7703014959129141a1719788ec83884f2e9151a680e2a96d2bcc67a8a2935aa11acee1f9d04812045b4ae5491220313756b5b9a0a6f867f2a95be1fab14870f04eeab694d9594620632b14ec4b424b495914f3dc587f75cd4582c113bb61e34a0fa7f79f97463be4e3c6fb99516889ed020acee419bb173d38e5ba18a00065e11fd733cf9ae46505dbb4ef70ef2f502601f4f6ee1fdb9d17435e15080e962f24760843f35bac1ac079b694ff7c347c1ed6a87f02b0758fbf00917764716c68ed7d6e6c0e75ccdb6dc7fa59554784b3ad906127ea77a6cdd814662ee7d57a939e28d77b3da47efc072436a3fd7f9c40515af8c4903764301e62b57153a5ca03ff5bb49c7dc8d3b2858100fb4aa5df7a94a271b73a76129445a3ea180d84d19029c003c164db926ed6983e5219028721a294f145e3fcc20915b8a2147efc8b5d508339f64970feee3e2da9b9c9348c1a0a4df7527d0ae3f8ae507a5beb5c73c2016ecf387a3cd8b79df80a8e9412e707cb9c761a0809a84c606a779567f9f0edf685b38c98877e90d02aedd096ed841e50abf2114ce01efbff04788fb280f870eca20c7ec353d5c381903e7d08fc57695fd79c27d43e7bd603a876068d3f1c7f45af99003e5eec7e8d8c91e395320f1fc421ef3552ea033129429383304b760c8f93de342417c3223c2112a623c3514480cdfae8ec15a99abfca71b03a8396f19edc3d5000bcfb77b5544813476b1b521345f4da396db09e783870b97bc2034bd11611db30ed2514438b046f1eb7093eceddfb1e73880786cd7b540a3896eaadd0a0692e4b19439815b5f2ec855ec8ececce889442a64037e956452a3f7b86cb3780b3e316c8dde464bc74a60a85b613f849eb0b29daf81892877bd4be9ba5997fc35544d3c2a00e5e1f45dc925607d952c6a89721bd0b6f6aec03314d667166a5b8b18471403be7018b2479aaef6c7c6c554a50a98b717dff06d50be39fb36dc03e678e0a52fc615be46b223e3bee83fa0c7c47a1f29fb94f1e9eebf6c9ecf8fc79ae847df2effb60d07aba301fc536546ec4899eedb4fec9a9bed79e3a83c4b32757745778e977e485c67c0f12bbc82c0b3bb0f4df0bd13d046fed4446f54cd85bfce55ef781a80e5f63d289d08de001237928c2a4e0c8694d0c1e68cc23f2409f30009019085e831a928e7bc5b00a1f29d25482f7fd0b6dad30e6ef8edc68ddf7db404ea7d11540fc2cee74863d64af4c945457e04b7bea0a5fb8636edadb1e1d6f2630d61062b781c1821f46eddadf269ea1fada829547590081b16bc116e074cae0224a375f2d9ce16e836687c89cd285e3b40f1e59ce2caa3d1d8cf37ee4d5e3abe7ef0afd6ffeb4fd6905677b950894863c828ab8d93519566f69fa3c2129da763bf58d9c4d2837d4d9e13821258f7e7098b34f695a589bd9eb568ba51ee3014b2d3ba1d4cf9ebaed0231ed57ecea7bd918216")
 
-    val Right(DecryptedPacket(payload0, nextPacket0, sharedSecret0)) = PaymentPacket.peel(privKeys(0), associatedData, onion)
-    val Right(DecryptedPacket(payload1, nextPacket1, sharedSecret1)) = PaymentPacket.peel(privKeys(1), associatedData, nextPacket0)
-    val Right(DecryptedPacket(payload2, nextPacket2, sharedSecret2)) = PaymentPacket.peel(privKeys(2), associatedData, nextPacket1)
-    val Right(DecryptedPacket(payload3, nextPacket3, sharedSecret3)) = PaymentPacket.peel(privKeys(3), associatedData, nextPacket2)
-    val Right(DecryptedPacket(payload4, nextPacket4, sharedSecret4)) = PaymentPacket.peel(privKeys(4), associatedData, nextPacket3)
+    val Right(DecryptedPacket(payload0, nextPacket0, sharedSecret0)) = peel(privKeys(0), associatedData, onion)
+    val Right(DecryptedPacket(payload1, nextPacket1, sharedSecret1)) = peel(privKeys(1), associatedData, nextPacket0)
+    val Right(DecryptedPacket(payload2, nextPacket2, sharedSecret2)) = peel(privKeys(2), associatedData, nextPacket1)
+    val Right(DecryptedPacket(payload3, nextPacket3, sharedSecret3)) = peel(privKeys(3), associatedData, nextPacket2)
+    val Right(DecryptedPacket(payload4, nextPacket4, sharedSecret4)) = peel(privKeys(4), associatedData, nextPacket3)
     assert(Seq(payload0, payload1, payload2, payload3, payload4) == variableSizePaymentPayloadsFull)
     assert(Seq(sharedSecret0, sharedSecret1, sharedSecret2, sharedSecret3, sharedSecret4) == sharedSecrets.map(_._1))
 
@@ -194,23 +194,23 @@ class SphinxSpec extends AnyFunSuite {
   }
 
   test("create payment packet with single variable-size payload filling the onion") {
-    val PacketAndSecrets(onion, _) = PaymentPacket.create(sessionKey, publicKeys.take(1), variableSizeOneHopPaymentPayload, associatedData)
+    val PacketAndSecrets(onion, _) = create(sessionKey, 1300, publicKeys.take(1), variableSizeOneHopPaymentPayload, associatedData)
     assert(serializePaymentOnion(onion) == hex"0002eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f28368661918f5b235c2a76fc232b5e46d421e9615471ab9e0bc887beff8c95fdb878f7b3a7141453e5f8d22b6351810ae541ce499a09b4a9d9f80d1845c8960c85fc6d1a87bd24b2cc49922898e9353fa268086c00ae8b7f718405b72ad380cdbb38c85e02a00427eb4bdbda8fcd42b44708a9efde49cf753b75ebb389bf84d0bfbf58590e510e034572a01e409c30939e2e4a090ecc89c371820af54e06e4ad5495d4e58718385cca5414552e078fedf284fdc2cc5c070cba21a6a8d4b77525ddbc9a9fca9b2f29aac5783ee8badd709f81c73ff60556cf2ee623af073b5a84799acc1ca46b764f74b97068c7826cc0579794a540d7a55e49eac26a6930340132e946a983240b0cd1b732e305c1042f580c4b26f140fc1cab3ee6f620958e0979f85eddf586c410ce42e93a4d7c803ead45fc47cf4396d284632314d789e73cf3f534126c63fe244069d9e8a7c4f98e7e530fc588e648ef4e641364981b5377542d5e7a4aaab6d35f6df7d3a9d7ca715213599ee02c4dbea4dc78860febe1d29259c64b59b3333ffdaebbaff4e7b31c27a3791f6bf848a58df7c69bb2b1852d2ad357b9919ffdae570b27dc709fba087273d3a4de9e6a6be66db647fb6a8d1a503b3f481befb96745abf5cc4a6bba0f780d5c7759b9e303a2a6b17eb05b6e660f4c474959db183e1cae060e1639227ee0bca03978a238dc4352ed764da7d4f3ed5337f6d0376dff72615beeeeaaeef79ab93e4bcbf18cd8424eb2b6ad7f33d2b4ffd5ea08372e6ed1d984152df17e04c6f73540988d7dd979e020424a163c271151a255966be7edef42167b8facca633649739bab97572b485658cde409e5d4a0f653f1a5911141634e3d2b6079b19347df66f9820755fd517092dae62fb278b0bafcc7ad682f7921b3a455e0c6369988779e26f0458b31bffd7e4e5bfb31944e80f100b2553c3b616e75be18328dc430f6618d55cd7d0962bb916d26ed4b117c46fa29e0a112c02c36020b34a96762db628fa3490828ec2079962ad816ef20ea0bca78fb2b7f7aedd4c47e375e64294d151ff03083730336dea64934003a27730cc1c7dec5049ddba8188123dd191aa71390d43a49fb792a3da7082efa6cced73f00eccea18145fbc84925349f7b552314ab8ed4c491e392aed3b1f03eb79474c294b42e2eba1528da26450aa592cba7ea22e965c54dff0fd6fdfd6b52b9a0f5f762e27fb0e6c3cd326a1ca1c5973de9be881439f702830affeb0c034c18ac8d5c2f135c964bf69de50d6e99bde88e90321ba843d9753c8f83666105d25fafb1a11ea22d62ef6f1fc34ca4e60c35d69773a104d9a44728c08c20b6314327301a2c400a71e1424c12628cf9f4a67990ade8a2203b0edb96c6082d4673b7309cd52c4b32b02951db2f66c6c72bd6c7eac2b50b83830c75cdfc3d6e9c2b592c45ed5fa5f6ec0da85710b7e1562aea363e28665835791dc574d9a70b2e5e2b9973ab590d45b94d244fc4256926c5a55b01cd0aca21fe5f9c907691fb026d0c56788b03ca3f08db0abb9f901098dde2ec4003568bc3ca27475ff86a7cb0aabd9e5136c5de064d16774584b252024109bb02004dba1fabf9e8277de097a0ab0dc8f6e26fcd4a28fb9d27cd4a2f6b13e276ed259a39e1c7e60f3c32c5cc4c4f96bd981edcb5e2c76a517cdc285aa2ca571d1e3d463ecd7614ae227df17af7445305bd7c661cf7dba658b0adcf36b0084b74a5fa408e272f703770ac5351334709112c5d4e4fe987e0c27b670412696f52b33245c229775da550729938268ee4e7a282e4a60b25dbb28ea8877a5069f819e5d1d31d9140bbc627ff3df267d22e5f0e151db066577845d71b7cd4484089f3f59194963c8f02bd7a637")
 
-    val Right(DecryptedPacket(payload, nextPacket, _)) = PaymentPacket.peel(privKeys(0), associatedData, onion)
+    val Right(DecryptedPacket(payload, nextPacket, _)) = peel(privKeys(0), associatedData, onion)
     assert(payload == variableSizeOneHopPaymentPayload.head)
     assert(nextPacket.hmac == ByteVector32(hex"0000000000000000000000000000000000000000000000000000000000000000"))
   }
 
   test("create trampoline payment packet") {
-    val PacketAndSecrets(onion, sharedSecrets) = TrampolinePacket.create(sessionKey, publicKeys, trampolinePaymentPayloads, associatedData)
+    val PacketAndSecrets(onion, sharedSecrets) = create(sessionKey, 400, publicKeys, trampolinePaymentPayloads, associatedData)
     assert(serializeTrampolineOnion(onion) == hex"0002eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619cff34152f3a36e52ca94e74927203a560392b9cc7ce3c45809c6be52166c24a595716880f95f178bf5b30ca5f01f7d8f9e2d26348fa73a0cf0e01efaeb4a6ff69f0e8ca2cb7f180d97b5becc99e303f3706509aa43ba7c8a88cba175fccf9a8f5016ef06d3b935dbb15196d7ce16dc1a7157845566901d7b2197e52cab4ce487019d8f59df4c61e85b3c678636701ea8bb55b8bdbd8724d8d39ee47087a648501329db7c5f7eafaa166578c720619561dd14b3277db557ec7dcdb793771aef0f2f667cfdbe148be176e089e1ae07192472031bcdaf47ab6334b98e5b6fcd26b3b47982842019517d7e2ea8c5391cf17d0fe30c80913ed887234ccb48808f7ef9425bcd815c3b9604b5119fbc40ae57b5921bb333f5dd9de0b2638d44bc5e1a863715f96589f3e77eecb277229b4b682322371c0a1dbfcd723a991993df8cc1f2696b84b055b40a1792a29f710295a18fbd351b0f3ff34cd13941131b8278ba79303c89117120eea69173fd2cf5e044e97bcd4060d1ab6da116bdb4136f4d37eb832845b64366dfcbe8729df1dda5708c1c89cd880b0f7c82318bcfe8a27f9e857b1dc453eb555c428c412a1056005319")
 
-    val Right(DecryptedPacket(payload0, nextPacket0, sharedSecret0)) = TrampolinePacket.peel(privKeys(0), associatedData, onion)
-    val Right(DecryptedPacket(payload1, nextPacket1, sharedSecret1)) = TrampolinePacket.peel(privKeys(1), associatedData, nextPacket0)
-    val Right(DecryptedPacket(payload2, nextPacket2, sharedSecret2)) = TrampolinePacket.peel(privKeys(2), associatedData, nextPacket1)
-    val Right(DecryptedPacket(payload3, nextPacket3, sharedSecret3)) = TrampolinePacket.peel(privKeys(3), associatedData, nextPacket2)
-    val Right(DecryptedPacket(payload4, _, sharedSecret4)) = TrampolinePacket.peel(privKeys(4), associatedData, nextPacket3)
+    val Right(DecryptedPacket(payload0, nextPacket0, sharedSecret0)) = peel(privKeys(0), associatedData, onion)
+    val Right(DecryptedPacket(payload1, nextPacket1, sharedSecret1)) = peel(privKeys(1), associatedData, nextPacket0)
+    val Right(DecryptedPacket(payload2, nextPacket2, sharedSecret2)) = peel(privKeys(2), associatedData, nextPacket1)
+    val Right(DecryptedPacket(payload3, nextPacket3, sharedSecret3)) = peel(privKeys(3), associatedData, nextPacket2)
+    val Right(DecryptedPacket(payload4, _, sharedSecret4)) = peel(privKeys(4), associatedData, nextPacket3)
     assert(Seq(payload0, payload1, payload2, payload3, payload4) == trampolinePaymentPayloads)
     assert(Seq(sharedSecret0, sharedSecret1, sharedSecret2, sharedSecret3, sharedSecret4) == sharedSecrets.map(_._1))
   }
@@ -223,7 +223,7 @@ class SphinxSpec extends AnyFunSuite {
       hex"000000000000000000000000000000000000000000000000000000000000000000"
     )
 
-    assertThrows[IllegalArgumentException](PaymentPacket.create(sessionKey, publicKeys.take(2), incorrectVarint, associatedData))
+    assertThrows[IllegalArgumentException](create(sessionKey, 1300, publicKeys.take(2), incorrectVarint, associatedData))
   }
 
   test("decrypt failure message") {
@@ -271,27 +271,27 @@ class SphinxSpec extends AnyFunSuite {
   }
 
   test("last node replies with a failure message (reference test vector)") {
-    for ((payloads, packetType) <- Seq(
-      (referenceFixedSizePaymentPayloads, PaymentPacket),
-      (referenceVariableSizePaymentPayloads, PaymentPacket),
-      (variableSizePaymentPayloadsFull, PaymentPacket),
-      (trampolinePaymentPayloads, TrampolinePacket))) {
+    for ((payloads, packetPayloadLength) <- Seq(
+      (referenceFixedSizePaymentPayloads, 1300),
+      (referenceVariableSizePaymentPayloads, 1300),
+      (variableSizePaymentPayloadsFull, 1300),
+      (trampolinePaymentPayloads, 400))) {
       // route: origin -> node #0 -> node #1 -> node #2 -> node #3 -> node #4
 
       // origin build the onion packet
-      val PacketAndSecrets(packet, sharedSecrets) = packetType.create(sessionKey, publicKeys, payloads, associatedData)
+      val PacketAndSecrets(packet, sharedSecrets) = create(sessionKey, packetPayloadLength, publicKeys, payloads, associatedData)
 
       // each node parses and forwards the packet
       // node #0
-      val Right(DecryptedPacket(_, packet1, sharedSecret0)) = packetType.peel(privKeys(0), associatedData, packet)
+      val Right(DecryptedPacket(_, packet1, sharedSecret0)) = peel(privKeys(0), associatedData, packet)
       // node #1
-      val Right(DecryptedPacket(_, packet2, sharedSecret1)) = packetType.peel(privKeys(1), associatedData, packet1)
+      val Right(DecryptedPacket(_, packet2, sharedSecret1)) = peel(privKeys(1), associatedData, packet1)
       // node #2
-      val Right(DecryptedPacket(_, packet3, sharedSecret2)) = packetType.peel(privKeys(2), associatedData, packet2)
+      val Right(DecryptedPacket(_, packet3, sharedSecret2)) = peel(privKeys(2), associatedData, packet2)
       // node #3
-      val Right(DecryptedPacket(_, packet4, sharedSecret3)) = packetType.peel(privKeys(3), associatedData, packet3)
+      val Right(DecryptedPacket(_, packet4, sharedSecret3)) = peel(privKeys(3), associatedData, packet3)
       // node #4
-      val Right(lastPacket@DecryptedPacket(_, _, sharedSecret4)) = packetType.peel(privKeys(4), associatedData, packet4)
+      val Right(lastPacket@DecryptedPacket(_, _, sharedSecret4)) = peel(privKeys(4), associatedData, packet4)
       assert(lastPacket.isLastPacket)
 
       // node #4 want to reply with an error message
@@ -332,23 +332,23 @@ class SphinxSpec extends AnyFunSuite {
   }
 
   test("intermediate node replies with a failure message (reference test vector)") {
-    for ((payloads, packetType) <- Seq(
-      (referenceFixedSizePaymentPayloads, PaymentPacket),
-      (referenceVariableSizePaymentPayloads, PaymentPacket),
-      (variableSizePaymentPayloadsFull, PaymentPacket),
-      (trampolinePaymentPayloads, TrampolinePacket))) {
+    for ((payloads, packetPayloadLength) <- Seq(
+      (referenceFixedSizePaymentPayloads, 1300),
+      (referenceVariableSizePaymentPayloads, 1300),
+      (variableSizePaymentPayloadsFull, 1300),
+      (trampolinePaymentPayloads, 400))) {
       // route: origin -> node #0 -> node #1 -> node #2 -> node #3 -> node #4
 
       // origin build the onion packet
-      val PacketAndSecrets(packet, sharedSecrets) = packetType.create(sessionKey, publicKeys, payloads, associatedData)
+      val PacketAndSecrets(packet, sharedSecrets) = create(sessionKey, packetPayloadLength, publicKeys, payloads, associatedData)
 
       // each node parses and forwards the packet
       // node #0
-      val Right(DecryptedPacket(_, packet1, sharedSecret0)) = packetType.peel(privKeys(0), associatedData, packet)
+      val Right(DecryptedPacket(_, packet1, sharedSecret0)) = peel(privKeys(0), associatedData, packet)
       // node #1
-      val Right(DecryptedPacket(_, packet2, sharedSecret1)) = packetType.peel(privKeys(1), associatedData, packet1)
+      val Right(DecryptedPacket(_, packet2, sharedSecret1)) = peel(privKeys(1), associatedData, packet1)
       // node #2
-      val Right(DecryptedPacket(_, _, sharedSecret2)) = packetType.peel(privKeys(2), associatedData, packet2)
+      val Right(DecryptedPacket(_, _, sharedSecret2)) = peel(privKeys(2), associatedData, packet2)
 
       // node #2 want to reply with an error message
       val error = FailurePacket.create(sharedSecret2, InvalidRealm)
@@ -458,17 +458,17 @@ class SphinxSpec extends AnyFunSuite {
     ).map(tlvs => PaymentOnionCodecs.tlvPerHopPayloadCodec.encode(tlvs).require.bytes)
 
     val senderSessionKey = PrivateKey(hex"0202020202020202020202020202020202020202020202020202020202020202")
-    val PacketAndSecrets(onion, sharedSecrets) = PaymentPacket.create(senderSessionKey, nodeIds, payloads, associatedData)
+    val PacketAndSecrets(onion, sharedSecrets) = create(senderSessionKey, 1300, nodeIds, payloads, associatedData)
     assert(serializePaymentOnion(onion) == hex"00024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d07666a78b866fda75eb6a991f9815c47624f46324b3e437bb0bd12c29a779d62b7912677b490268f80b9e05044c726b1744e50d20777aa103ebb2a5f054f3d9271e7bf2f0cbe7c4d0bf1e53e911040a52c78dd545aa034b026618ac8ea390ae606baddfd5b82f1fc2ad3a99be0f16ac186e5d6e02d98d4f60f2e505831aa8563d86a7f37f10c133df59201f2d288347a64e4a11a61bc524372ee73179179a51809330e01dc38bb5eee8e7de92885b52423493a326f8bf4c4827760a0af90ac6c4e2f91c3ef9e079523c0262ddc052aefa4154f6aaa814ee8b44b17e9d30650a61076c1a4742fe755694923c78c50b3fbb5549aa7876c797f0f48c929c5ce3742db691d66d101e31426128ee1600b3e0c500c9f955d2ae07710842c23c1e1b7ebb6ed428605f35062fed12f868ef735d1d9d6eee61fc722c5797d886b663400e0fd868898a21fbea928c7382ae82a4016e31fe83e3276b9ab95016d32c6318c7fcf859cf1fd9f02c0b2622dd83c961051eb56f10225297154c5b3c535951749402ea57ca8f6daa5cfaec1e08a15badb4cbae156de04d5ba2ce5212699c5fb11ba3307aafab4028963b41a245b9831035bab359ead24ef15e4d50573d40d66fbdedb1ca652488b96e78266f4d4679af93d685ab9519b1565e822d88a69af3e9f3cadb94619e03ce9828d4c28633b992434d23930e2ee943df0229c57276d9c6a977090137544ea48637eba7d6eca4c5fc7bf827658a6a1944a3d9320e549430dea871bd449d6e971cceca7bf48fe855d1b84f63f7cccf3db81ff4c1626f76084b37c95575cd5aa484d34d9129bbd70dcdbc43a7eda6cef758919bbeee00ff16dff45c7d156c3dc3f928949399398a6eb7fa72ac1610b603cbe73d47c7514d28aeca457678b2748c473e043bc1505df8a8e5836b6c8585be7d18ebb24962311e2f46336abff9db3153c56ab2a5af3722ee4128455ba18fe1bfec545a9b0d043a8cf1d5e36cf7419045aed571c1caab08c8f31c773b1a4fd3bb4eee634a9a9de27a2199d4d90fd9ddc6a89d8a3c27b3229653cb076d8a1e867d4ddb02983464797157736e7e635b234a11a0e5f89ae968b2dc6ca39d62d67274a2bf4b86fdfc249b76bd462185703ee5a0edc5d1662a9cc2d2e7a0badace2b4c3b716c6cae7ab5b976ceec3f15ff3f1af849dc22de2a67d73204b21738e74897bd983526bab2edc4825efbbd060675e1858d866606a79634456b2ff89d07166d4b656684db9dbbfa0cb9a85d2a693e1555f05d923768925c8beb67ecbcb4bdaa0028100a84e67e73de06e3fab255d0b1b87822503b17872a5c14502b87d0281d7830e4989659135735677683d8e9f5555a42a6ab8d22347115f254266332a4e54594052ca1afd0475e47dc8ba6bf6c2a381585722949e7ef102bcd68e181965322c5780f66570528b408f00af716c89b8d82bc359f007dfe7c32ce7e44a760a08b97efe9353a1902ba38058f87b90af99bc88ae488d0ad31ffda18c789854dd1e5bf57726b1eb691b4a4b664d33dc225d1242405361d23b3e5d9b6ad5ce3611f276b29a7bf3307326f5f3016f522d513a0d6e0b10280f846e7f14bb365680fd1be66495f49c7d0dc5c36d7c7d845e1c7ddc36a4d54b0733ba9ba3c881f84ed56acf38104eba5ca0a1078c9ee6ba2580f24ac33334cb7e46b9e66925ba5b7066354bae63bb5b79ecedd25a0ec439ec9246fdad77aa1b159741a34579cd7aa237a83f3bbf9663b668024314c6d707a0e25b01808410a3b75c4fc5e2ce04f4dd87e0e8fc317199cbc4b32ba1256ae6138a61936becc4fa9761515b3c2c86372d30949f2d5f89e89bbb6ca708ea9568b58a98d04e219ac69261c3c3dadbb7457d")
 
     // The first two hops can decrypt the onion as usual.
-    val Right(DecryptedPacket(payload0, nextPacket0, sharedSecret0)) = PaymentPacket.peel(privKeys(0), associatedData, onion)
-    val Right(DecryptedPacket(payload1, nextPacket1, sharedSecret1)) = PaymentPacket.peel(privKeys(1), associatedData, nextPacket0)
+    val Right(DecryptedPacket(payload0, nextPacket0, sharedSecret0)) = peel(privKeys(0), associatedData, onion)
+    val Right(DecryptedPacket(payload1, nextPacket1, sharedSecret1)) = peel(privKeys(1), associatedData, nextPacket0)
 
     // The third hop is the introduction node.
     // It can decrypt the onion as usual, but the payload doesn't contain a shortChannelId or a nodeId to forward to.
     // However it contains a blinding point and encrypted data, which it can decrypt to discover the next node.
-    val Right(DecryptedPacket(payload2, nextPacket2, sharedSecret2)) = PaymentPacket.peel(privKeys(2), associatedData, nextPacket1)
+    val Right(DecryptedPacket(payload2, nextPacket2, sharedSecret2)) = peel(privKeys(2), associatedData, nextPacket1)
     val tlvs2 = PaymentOnionCodecs.tlvPerHopPayloadCodec.decode(payload2.bits).require.value
     assert(tlvs2.get[OnionPaymentPayloadTlv.BlindingPoint].map(_.publicKey) === Some(blindingEphemeralKey0))
     assert(tlvs2.get[OnionPaymentPayloadTlv.EncryptedRecipientData].nonEmpty)
@@ -481,7 +481,7 @@ class SphinxSpec extends AnyFunSuite {
     // derive the private key corresponding to its blinded node ID and decrypt the onion.
     // The payload doesn't contain a shortChannelId or a nodeId to forward to, but the encrypted data does.
     val blindedPrivKey3 = RouteBlinding.derivePrivateKey(privKeys(3), blindingEphemeralKey1)
-    val Right(DecryptedPacket(payload3, nextPacket3, sharedSecret3)) = PaymentPacket.peel(blindedPrivKey3, associatedData, nextPacket2)
+    val Right(DecryptedPacket(payload3, nextPacket3, sharedSecret3)) = peel(blindedPrivKey3, associatedData, nextPacket2)
     val tlvs3 = PaymentOnionCodecs.tlvPerHopPayloadCodec.decode(payload3.bits).require.value
     assert(tlvs3.get[OnionPaymentPayloadTlv.EncryptedRecipientData].nonEmpty)
     val Success((recipientTlvs3, blindingEphemeralKey2)) = EncryptedRecipientDataCodecs.decode(privKeys(3), blindingEphemeralKey1, tlvs3.get[OnionPaymentPayloadTlv.EncryptedRecipientData].get.data)
@@ -491,7 +491,7 @@ class SphinxSpec extends AnyFunSuite {
     // It receives the blinding key from the previous node (e.g. in a tlv field in update_add_htlc) which it can use to
     // derive the private key corresponding to its blinded node ID and decrypt the onion.
     val blindedPrivKey4 = RouteBlinding.derivePrivateKey(privKeys(4), blindingEphemeralKey2)
-    val Right(DecryptedPacket(payload4, nextPacket4, sharedSecret4)) = PaymentPacket.peel(blindedPrivKey4, associatedData, nextPacket3)
+    val Right(DecryptedPacket(payload4, nextPacket4, sharedSecret4)) = peel(blindedPrivKey4, associatedData, nextPacket3)
     val tlvs4 = PaymentOnionCodecs.tlvPerHopPayloadCodec.decode(payload4.bits).require.value
     assert(tlvs4.get[OnionPaymentPayloadTlv.EncryptedRecipientData].nonEmpty)
     val Success((recipientTlvs4, _)) = EncryptedRecipientDataCodecs.decode(privKeys(4), blindingEphemeralKey2, tlvs4.get[OnionPaymentPayloadTlv.EncryptedRecipientData].get.data)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -32,8 +32,8 @@ import fr.acinq.eclair.payment.send.PaymentInitiator._
 import fr.acinq.eclair.payment.send.{PaymentError, PaymentInitiator, PaymentLifecycle}
 import fr.acinq.eclair.router.RouteNotFound
 import fr.acinq.eclair.router.Router._
-import fr.acinq.eclair.wire.protocol.PaymentOnion.FinalTlvPayload
 import fr.acinq.eclair.wire.protocol.OnionPaymentPayloadTlv.{AmountToForward, KeySend, OutgoingCltv}
+import fr.acinq.eclair.wire.protocol.PaymentOnion.FinalTlvPayload
 import fr.acinq.eclair.wire.protocol._
 import fr.acinq.eclair.{CltvExpiryDelta, Features, MilliSatoshiLong, NodeParams, TestConstants, TestKitBaseClass, randomBytes32, randomKey}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
@@ -196,7 +196,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
 
     // Verify that the trampoline node can correctly peel the trampoline onion.
     val trampolineOnion = msg.additionalTlvs.head.asInstanceOf[OnionPaymentPayloadTlv.TrampolineOnion].packet
-    val Right(decrypted) = Sphinx.TrampolinePacket.peel(priv_b.privateKey, pr.paymentHash, trampolineOnion)
+    val Right(decrypted) = Sphinx.peel(priv_b.privateKey, pr.paymentHash, trampolineOnion)
     assert(!decrypted.isLastPacket)
     val trampolinePayload = PaymentOnionCodecs.nodeRelayPerHopPayloadCodec.decode(decrypted.payload.bits).require.value
     assert(trampolinePayload.amountToForward === finalAmount)
@@ -208,7 +208,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(trampolinePayload.invoiceFeatures === None)
 
     // Verify that the recipient can correctly peel the trampoline onion.
-    val Right(decrypted1) = Sphinx.TrampolinePacket.peel(priv_c.privateKey, pr.paymentHash, decrypted.nextPacket)
+    val Right(decrypted1) = Sphinx.peel(priv_c.privateKey, pr.paymentHash, decrypted.nextPacket)
     assert(decrypted1.isLastPacket)
     val finalPayload = PaymentOnionCodecs.finalPerHopPayloadCodec.decode(decrypted1.payload.bits).require.value
     assert(finalPayload.amount === finalAmount)
@@ -235,7 +235,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
 
     // Verify that the trampoline node can correctly peel the trampoline onion.
     val trampolineOnion = msg.additionalTlvs.head.asInstanceOf[OnionPaymentPayloadTlv.TrampolineOnion].packet
-    val Right(decrypted) = Sphinx.TrampolinePacket.peel(priv_b.privateKey, pr.paymentHash, trampolineOnion)
+    val Right(decrypted) = Sphinx.peel(priv_b.privateKey, pr.paymentHash, trampolineOnion)
     assert(!decrypted.isLastPacket)
     val trampolinePayload = PaymentOnionCodecs.nodeRelayPerHopPayloadCodec.decode(decrypted.payload.bits).require.value
     assert(trampolinePayload.amountToForward === finalAmount)
@@ -372,7 +372,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(trampolineOnion.nonEmpty)
 
     // Verify that the trampoline node can correctly peel the trampoline onion.
-    val Right(decrypted) = Sphinx.TrampolinePacket.peel(priv_b.privateKey, pr.paymentHash, trampolineOnion.get.packet)
+    val Right(decrypted) = Sphinx.peel(priv_b.privateKey, pr.paymentHash, trampolineOnion.get.packet)
     assert(!decrypted.isLastPacket)
     val trampolinePayload = PaymentOnionCodecs.nodeRelayPerHopPayloadCodec.decode(decrypted.payload.bits).require.value
     assert(trampolinePayload.amountToForward === finalAmount)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
@@ -28,10 +28,10 @@ import fr.acinq.eclair.payment.OutgoingPaymentPacket._
 import fr.acinq.eclair.payment.PaymentRequest.PaymentRequestFeatures
 import fr.acinq.eclair.router.Router.{ChannelHop, NodeHop}
 import fr.acinq.eclair.transactions.Transactions.InputInfo
-import fr.acinq.eclair.wire.protocol.PaymentOnion.{ChannelRelayTlvPayload, FinalTlvPayload}
 import fr.acinq.eclair.wire.protocol.OnionPaymentPayloadTlv.{AmountToForward, OutgoingCltv, PaymentData}
+import fr.acinq.eclair.wire.protocol.PaymentOnion.{ChannelRelayTlvPayload, FinalTlvPayload}
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, MilliSatoshi, MilliSatoshiLong, ShortChannelId, TestConstants, TimestampSecond, TimestampSecondLong, nodeFee, randomBytes32, randomKey}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, MilliSatoshi, MilliSatoshiLong, ShortChannelId, TestConstants, TimestampSecondLong, nodeFee, randomBytes32, randomKey}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.Attempt
@@ -61,10 +61,10 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
 
   def testBuildOnion(): Unit = {
     val finalPayload = FinalTlvPayload(TlvStream(AmountToForward(finalAmount), OutgoingCltv(finalExpiry), PaymentData(paymentSecret, 0 msat)))
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, hops, finalPayload)
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, hops, finalPayload)
     assert(firstAmount === amount_ab)
     assert(firstExpiry === expiry_ab)
-    assert(onion.packet.payload.length === Sphinx.PaymentPacket.PayloadLength)
+    assert(onion.packet.payload.length === PaymentOnionCodecs.paymentOnionPayloadLength)
 
     // let's peel the onion
     testPeelOnion(onion.packet)
@@ -74,7 +74,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     val add_b = UpdateAddHtlc(randomBytes32(), 0, amount_ab, paymentHash, expiry_ab, packet_b)
     val Right(relay_b@ChannelRelayPacket(add_b2, payload_b, packet_c)) = decrypt(add_b, priv_b.privateKey)
     assert(add_b2 === add_b)
-    assert(packet_c.payload.length === Sphinx.PaymentPacket.PayloadLength)
+    assert(packet_c.payload.length === PaymentOnionCodecs.paymentOnionPayloadLength)
     assert(payload_b.amountToForward === amount_bc)
     assert(payload_b.outgoingCltv === expiry_bc)
     assert(payload_b.outgoingChannelId === channelUpdate_bc.shortChannelId)
@@ -84,7 +84,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     val add_c = UpdateAddHtlc(randomBytes32(), 1, amount_bc, paymentHash, expiry_bc, packet_c)
     val Right(relay_c@ChannelRelayPacket(add_c2, payload_c, packet_d)) = decrypt(add_c, priv_c.privateKey)
     assert(add_c2 === add_c)
-    assert(packet_d.payload.length === Sphinx.PaymentPacket.PayloadLength)
+    assert(packet_d.payload.length === PaymentOnionCodecs.paymentOnionPayloadLength)
     assert(payload_c.amountToForward === amount_cd)
     assert(payload_c.outgoingCltv === expiry_cd)
     assert(payload_c.outgoingChannelId === channelUpdate_cd.shortChannelId)
@@ -94,7 +94,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     val add_d = UpdateAddHtlc(randomBytes32(), 2, amount_cd, paymentHash, expiry_cd, packet_d)
     val Right(relay_d@ChannelRelayPacket(add_d2, payload_d, packet_e)) = decrypt(add_d, priv_d.privateKey)
     assert(add_d2 === add_d)
-    assert(packet_e.payload.length === Sphinx.PaymentPacket.PayloadLength)
+    assert(packet_e.payload.length === PaymentOnionCodecs.paymentOnionPayloadLength)
     assert(payload_d.amountToForward === amount_de)
     assert(payload_d.outgoingCltv === expiry_de)
     assert(payload_d.outgoingChannelId === channelUpdate_de.shortChannelId)
@@ -119,7 +119,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     assert(add.amount > finalAmount)
     assert(add.cltvExpiry === finalExpiry + channelUpdate_de.cltvExpiryDelta + channelUpdate_cd.cltvExpiryDelta + channelUpdate_bc.cltvExpiryDelta)
     assert(add.paymentHash === paymentHash)
-    assert(add.onion.payload.length === Sphinx.PaymentPacket.PayloadLength)
+    assert(add.onion.payload.length === PaymentOnionCodecs.paymentOnionPayloadLength)
 
     // let's peel the onion
     testPeelOnion(add.onion)
@@ -130,7 +130,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     assert(add.amount === finalAmount)
     assert(add.cltvExpiry === finalExpiry)
     assert(add.paymentHash === paymentHash)
-    assert(add.onion.payload.length === Sphinx.PaymentPacket.PayloadLength)
+    assert(add.onion.payload.length === PaymentOnionCodecs.paymentOnionPayloadLength)
 
     // let's peel the onion
     val add_b = UpdateAddHtlc(randomBytes32(), 0, finalAmount, paymentHash, finalExpiry, add.onion)
@@ -148,11 +148,11 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     //            /    \ /    \
     // a -> b -> c      d      e
 
-    val (amount_ac, expiry_ac, trampolineOnion) = buildPacket(Sphinx.TrampolinePacket)(paymentHash, trampolineHops, PaymentOnion.createMultiPartPayload(finalAmount, finalAmount * 3, finalExpiry, paymentSecret))
+    val (amount_ac, expiry_ac, trampolineOnion) = buildTrampolinePacket(paymentHash, trampolineHops, PaymentOnion.createMultiPartPayload(finalAmount, finalAmount * 3, finalExpiry, paymentSecret))
     assert(amount_ac === amount_bc)
     assert(expiry_ac === expiry_bc)
 
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
     assert(firstAmount === amount_ab)
     assert(firstExpiry === expiry_ab)
 
@@ -175,7 +175,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     assert(inner_c.paymentSecret === None)
 
     // c forwards the trampoline payment to d.
-    val (amount_d, expiry_d, onion_d) = buildPacket(Sphinx.PaymentPacket)(paymentHash, ChannelHop(c, d, channelUpdate_cd) :: Nil, PaymentOnion.createTrampolinePayload(amount_cd, amount_cd, expiry_cd, randomBytes32(), packet_d))
+    val (amount_d, expiry_d, onion_d) = buildPaymentPacket(paymentHash, ChannelHop(c, d, channelUpdate_cd) :: Nil, PaymentOnion.createTrampolinePayload(amount_cd, amount_cd, expiry_cd, randomBytes32(), packet_d))
     assert(amount_d === amount_cd)
     assert(expiry_d === expiry_cd)
     val add_d = UpdateAddHtlc(randomBytes32(), 3, amount_d, paymentHash, expiry_d, onion_d.packet)
@@ -192,7 +192,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     assert(inner_d.paymentSecret === None)
 
     // d forwards the trampoline payment to e.
-    val (amount_e, expiry_e, onion_e) = buildPacket(Sphinx.PaymentPacket)(paymentHash, ChannelHop(d, e, channelUpdate_de) :: Nil, PaymentOnion.createTrampolinePayload(amount_de, amount_de, expiry_de, randomBytes32(), packet_e))
+    val (amount_e, expiry_e, onion_e) = buildPaymentPacket(paymentHash, ChannelHop(d, e, channelUpdate_de) :: Nil, PaymentOnion.createTrampolinePayload(amount_de, amount_de, expiry_de, randomBytes32(), packet_e))
     assert(amount_e === amount_de)
     assert(expiry_e === expiry_de)
     val add_e = UpdateAddHtlc(randomBytes32(), 4, amount_e, paymentHash, expiry_e, onion_e.packet)
@@ -214,7 +214,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     assert(amount_ac === amount_bc)
     assert(expiry_ac === expiry_bc)
 
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
     assert(firstAmount === amount_ab)
     assert(firstExpiry === expiry_ab)
 
@@ -235,7 +235,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     assert(inner_c.paymentSecret === None)
 
     // c forwards the trampoline payment to d.
-    val (amount_d, expiry_d, onion_d) = buildPacket(Sphinx.PaymentPacket)(paymentHash, ChannelHop(c, d, channelUpdate_cd) :: Nil, PaymentOnion.createTrampolinePayload(amount_cd, amount_cd, expiry_cd, randomBytes32(), packet_d))
+    val (amount_d, expiry_d, onion_d) = buildPaymentPacket(paymentHash, ChannelHop(c, d, channelUpdate_cd) :: Nil, PaymentOnion.createTrampolinePayload(amount_cd, amount_cd, expiry_cd, randomBytes32(), packet_d))
     assert(amount_d === amount_cd)
     assert(expiry_d === expiry_cd)
     val add_d = UpdateAddHtlc(randomBytes32(), 3, amount_d, paymentHash, expiry_d, onion_d.packet)
@@ -262,15 +262,15 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   test("fail to decrypt when the onion is invalid") {
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, hops, PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, hops, PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
     val add = UpdateAddHtlc(randomBytes32(), 1, firstAmount, paymentHash, firstExpiry, onion.packet.copy(payload = onion.packet.payload.reverse))
     val Left(failure) = decrypt(add, priv_b.privateKey)
     assert(failure.isInstanceOf[InvalidOnionHmac])
   }
 
   test("fail to decrypt when the trampoline onion is invalid") {
-    val (amount_ac, expiry_ac, trampolineOnion) = buildPacket(Sphinx.TrampolinePacket)(paymentHash, trampolineHops, PaymentOnion.createMultiPartPayload(finalAmount, finalAmount * 2, finalExpiry, paymentSecret))
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet.copy(payload = trampolineOnion.packet.payload.reverse)))
+    val (amount_ac, expiry_ac, trampolineOnion) = buildTrampolinePacket(paymentHash, trampolineHops, PaymentOnion.createMultiPartPayload(finalAmount, finalAmount * 2, finalExpiry, paymentSecret))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet.copy(payload = trampolineOnion.packet.payload.reverse)))
     val add_b = UpdateAddHtlc(randomBytes32(), 1, firstAmount, paymentHash, firstExpiry, onion.packet)
     val Right(ChannelRelayPacket(_, _, packet_c)) = decrypt(add_b, priv_b.privateKey)
     val add_c = UpdateAddHtlc(randomBytes32(), 2, amount_bc, paymentHash, expiry_bc, packet_c)
@@ -279,59 +279,59 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   test("fail to decrypt when payment hash doesn't match associated data") {
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash.reverse, hops, PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash.reverse, hops, PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
     val add = UpdateAddHtlc(randomBytes32(), 1, firstAmount, paymentHash, firstExpiry, onion.packet)
     val Left(failure) = decrypt(add, priv_b.privateKey)
     assert(failure.isInstanceOf[InvalidOnionHmac])
   }
 
   test("fail to decrypt at the final node when amount has been modified by next-to-last node") {
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, hops.take(1), PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, hops.take(1), PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
     val add = UpdateAddHtlc(randomBytes32(), 1, firstAmount - 100.msat, paymentHash, firstExpiry, onion.packet)
     val Left(failure) = decrypt(add, priv_b.privateKey)
     assert(failure === FinalIncorrectHtlcAmount(firstAmount - 100.msat))
   }
 
   test("fail to decrypt at the final node when expiry has been modified by next-to-last node") {
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, hops.take(1), PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, hops.take(1), PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
     val add = UpdateAddHtlc(randomBytes32(), 1, firstAmount, paymentHash, firstExpiry - CltvExpiryDelta(12), onion.packet)
     val Left(failure) = decrypt(add, priv_b.privateKey)
     assert(failure === FinalIncorrectCltvExpiry(firstExpiry - CltvExpiryDelta(12)))
   }
 
   test("fail to decrypt at the final trampoline node when amount has been modified by next-to-last trampoline") {
-    val (amount_ac, expiry_ac, trampolineOnion) = buildPacket(Sphinx.TrampolinePacket)(paymentHash, trampolineHops, PaymentOnion.createMultiPartPayload(finalAmount, finalAmount, finalExpiry, paymentSecret))
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
+    val (amount_ac, expiry_ac, trampolineOnion) = buildTrampolinePacket(paymentHash, trampolineHops, PaymentOnion.createMultiPartPayload(finalAmount, finalAmount, finalExpiry, paymentSecret))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
     val Right(ChannelRelayPacket(_, _, packet_c)) = decrypt(UpdateAddHtlc(randomBytes32(), 1, firstAmount, paymentHash, firstExpiry, onion.packet), priv_b.privateKey)
     val Right(NodeRelayPacket(_, _, _, packet_d)) = decrypt(UpdateAddHtlc(randomBytes32(), 2, amount_bc, paymentHash, expiry_bc, packet_c), priv_c.privateKey)
     // c forwards the trampoline payment to d.
-    val (amount_d, expiry_d, onion_d) = buildPacket(Sphinx.PaymentPacket)(paymentHash, ChannelHop(c, d, channelUpdate_cd) :: Nil, PaymentOnion.createTrampolinePayload(amount_cd, amount_cd, expiry_cd, randomBytes32(), packet_d))
+    val (amount_d, expiry_d, onion_d) = buildPaymentPacket(paymentHash, ChannelHop(c, d, channelUpdate_cd) :: Nil, PaymentOnion.createTrampolinePayload(amount_cd, amount_cd, expiry_cd, randomBytes32(), packet_d))
     val Right(NodeRelayPacket(_, _, _, packet_e)) = decrypt(UpdateAddHtlc(randomBytes32(), 3, amount_d, paymentHash, expiry_d, onion_d.packet), priv_d.privateKey)
     // d forwards an invalid amount to e (the outer total amount doesn't match the inner amount).
     val invalidTotalAmount = amount_de + 100.msat
-    val (amount_e, expiry_e, onion_e) = buildPacket(Sphinx.PaymentPacket)(paymentHash, ChannelHop(d, e, channelUpdate_de) :: Nil, PaymentOnion.createTrampolinePayload(amount_de, invalidTotalAmount, expiry_de, randomBytes32(), packet_e))
+    val (amount_e, expiry_e, onion_e) = buildPaymentPacket(paymentHash, ChannelHop(d, e, channelUpdate_de) :: Nil, PaymentOnion.createTrampolinePayload(amount_de, invalidTotalAmount, expiry_de, randomBytes32(), packet_e))
     val Left(failure) = decrypt(UpdateAddHtlc(randomBytes32(), 4, amount_e, paymentHash, expiry_e, onion_e.packet), priv_e.privateKey)
     assert(failure === FinalIncorrectHtlcAmount(invalidTotalAmount))
   }
 
   test("fail to decrypt at the final trampoline node when expiry has been modified by next-to-last trampoline") {
-    val (amount_ac, expiry_ac, trampolineOnion) = buildPacket(Sphinx.TrampolinePacket)(paymentHash, trampolineHops, PaymentOnion.createMultiPartPayload(finalAmount, finalAmount, finalExpiry, paymentSecret))
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
+    val (amount_ac, expiry_ac, trampolineOnion) = buildTrampolinePacket(paymentHash, trampolineHops, PaymentOnion.createMultiPartPayload(finalAmount, finalAmount, finalExpiry, paymentSecret))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
     val Right(ChannelRelayPacket(_, _, packet_c)) = decrypt(UpdateAddHtlc(randomBytes32(), 1, firstAmount, paymentHash, firstExpiry, onion.packet), priv_b.privateKey)
     val Right(NodeRelayPacket(_, _, _, packet_d)) = decrypt(UpdateAddHtlc(randomBytes32(), 2, amount_bc, paymentHash, expiry_bc, packet_c), priv_c.privateKey)
     // c forwards the trampoline payment to d.
-    val (amount_d, expiry_d, onion_d) = buildPacket(Sphinx.PaymentPacket)(paymentHash, ChannelHop(c, d, channelUpdate_cd) :: Nil, PaymentOnion.createTrampolinePayload(amount_cd, amount_cd, expiry_cd, randomBytes32(), packet_d))
+    val (amount_d, expiry_d, onion_d) = buildPaymentPacket(paymentHash, ChannelHop(c, d, channelUpdate_cd) :: Nil, PaymentOnion.createTrampolinePayload(amount_cd, amount_cd, expiry_cd, randomBytes32(), packet_d))
     val Right(NodeRelayPacket(_, _, _, packet_e)) = decrypt(UpdateAddHtlc(randomBytes32(), 3, amount_d, paymentHash, expiry_d, onion_d.packet), priv_d.privateKey)
     // d forwards an invalid expiry to e (the outer expiry doesn't match the inner expiry).
     val invalidExpiry = expiry_de - CltvExpiryDelta(12)
-    val (amount_e, expiry_e, onion_e) = buildPacket(Sphinx.PaymentPacket)(paymentHash, ChannelHop(d, e, channelUpdate_de) :: Nil, PaymentOnion.createTrampolinePayload(amount_de, amount_de, invalidExpiry, randomBytes32(), packet_e))
+    val (amount_e, expiry_e, onion_e) = buildPaymentPacket(paymentHash, ChannelHop(d, e, channelUpdate_de) :: Nil, PaymentOnion.createTrampolinePayload(amount_de, amount_de, invalidExpiry, randomBytes32(), packet_e))
     val Left(failure) = decrypt(UpdateAddHtlc(randomBytes32(), 4, amount_e, paymentHash, expiry_e, onion_e.packet), priv_e.privateKey)
     assert(failure === FinalIncorrectCltvExpiry(invalidExpiry))
   }
 
   test("fail to decrypt at intermediate trampoline node when amount is invalid") {
-    val (amount_ac, expiry_ac, trampolineOnion) = buildPacket(Sphinx.TrampolinePacket)(paymentHash, trampolineHops, PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
+    val (amount_ac, expiry_ac, trampolineOnion) = buildTrampolinePacket(paymentHash, trampolineHops, PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
     val Right(ChannelRelayPacket(_, _, packet_c)) = decrypt(UpdateAddHtlc(randomBytes32(), 1, firstAmount, paymentHash, firstExpiry, onion.packet), priv_b.privateKey)
     // A trampoline relay is very similar to a final node: it can validate that the HTLC amount matches the onion outer amount.
     val Left(failure) = decrypt(UpdateAddHtlc(randomBytes32(), 2, amount_bc - 100.msat, paymentHash, expiry_bc, packet_c), priv_c.privateKey)
@@ -339,8 +339,8 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   test("fail to decrypt at intermediate trampoline node when expiry is invalid") {
-    val (amount_ac, expiry_ac, trampolineOnion) = buildPacket(Sphinx.TrampolinePacket)(paymentHash, trampolineHops, PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
-    val (firstAmount, firstExpiry, onion) = buildPacket(Sphinx.PaymentPacket)(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
+    val (amount_ac, expiry_ac, trampolineOnion) = buildTrampolinePacket(paymentHash, trampolineHops, PaymentOnion.createSinglePartPayload(finalAmount, finalExpiry, paymentSecret))
+    val (firstAmount, firstExpiry, onion) = buildPaymentPacket(paymentHash, trampolineChannelHops, PaymentOnion.createTrampolinePayload(amount_ac, amount_ac, expiry_ac, randomBytes32(), trampolineOnion.packet))
     val Right(ChannelRelayPacket(_, _, packet_c)) = decrypt(UpdateAddHtlc(randomBytes32(), 1, firstAmount, paymentHash, firstExpiry, onion.packet), priv_b.privateKey)
     // A trampoline relay is very similar to a final node: it can validate that the HTLC expiry matches the onion outer expiry.
     val Left(failure) = decrypt(UpdateAddHtlc(randomBytes32(), 2, amount_bc, paymentHash, expiry_bc - CltvExpiryDelta(12), packet_c), priv_c.privateKey)
@@ -352,7 +352,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
 object PaymentPacketSpec {
 
   /** Build onion from arbitrary tlv stream (potentially invalid). */
-  def buildTlvOnion[T <: PaymentOnion.PacketType](packetType: Sphinx.OnionRoutingPacket[T])(nodes: Seq[PublicKey], payloads: Seq[TlvStream[OnionPaymentPayloadTlv]], associatedData: ByteVector32): OnionRoutingPacket = {
+  def buildTlvOnion(packetPayloadLength: Int, nodes: Seq[PublicKey], payloads: Seq[TlvStream[OnionPaymentPayloadTlv]], associatedData: ByteVector32): OnionRoutingPacket = {
     require(nodes.size == payloads.size)
     val sessionKey = randomKey()
     val payloadsBin: Seq[ByteVector] = payloads.map(PaymentOnionCodecs.tlvPerHopPayloadCodec.encode)
@@ -360,7 +360,7 @@ object PaymentPacketSpec {
         case Attempt.Successful(bitVector) => bitVector.bytes
         case Attempt.Failure(cause) => throw new RuntimeException(s"serialization error: $cause")
       }
-    packetType.create(sessionKey, nodes, payloadsBin, associatedData).packet
+    Sphinx.create(sessionKey, packetPayloadLength, nodes, payloadsBin, associatedData).packet
   }
 
   def makeCommitments(channelId: ByteVector32, testAvailableBalanceForSend: MilliSatoshi = 50000000 msat, testAvailableBalanceForReceive: MilliSatoshi = 50000000 msat, testCapacity: Satoshi = 100000 sat): Commitments = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -697,7 +697,7 @@ object NodeRelayerSpec {
 
   // This is the result of decrypting the incoming trampoline onion packet.
   // It should be forwarded to the next trampoline node.
-  val nextTrampolinePacket = OnionRoutingPacket(0, hex"02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619", randomBytes(Sphinx.TrampolinePacket.PayloadLength), randomBytes32())
+  val nextTrampolinePacket = OnionRoutingPacket(0, hex"02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619", randomBytes(PaymentOnionCodecs.trampolineOnionPayloadLength), randomBytes32())
 
   val outgoingAmount = 4000000 msat
   val outgoingExpiry = CltvExpiry(490000)


### PR DESCRIPTION
We previously created restrictions in `Sphinx.scala` to only allow using it for two types of onions: a 1300 bytes one for HTLCs and a 400 bytes one for trampoline.

This doesn't make sense anymore. The latest version of trampoline allows any onion size, and onion messages also allow any onion size. The Sphinx protocol doesn't care either about the size of the payload.

Another reason to remove it is that it wasn't working that well with pattern matching because of type erasure.

So now the caller must explicitly set the length of the payload, which is more flexible. Verifying that the correct length is used is deferred to higher level components.