### PR TITLE
Remove dumpprivkey from tests

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitorSpec.scala
@@ -56,8 +56,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     val bitcoinClient = new BitcoinCoreClient(bitcoinrpcclient)
     val monitor = system.spawnAnonymous(MempoolTxMonitor(TestConstants.Alice.nodeParams, bitcoinClient, TxPublishLogContext(UUID.randomUUID(), randomKey().publicKey, None)))
 
-    val address = getNewAddress(probe)
-    val priv = dumpPrivateKey(address, probe)
+    val (priv, address) = createExternalAddress()
     val parentTx = sendToAddress(address, 125_000 sat, probe)
     Fixture(priv, address, parentTx, monitor, bitcoinClient, probe)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/RawTxPublisherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/RawTxPublisherSpec.scala
@@ -76,8 +76,7 @@ class RawTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitc
     val f = createFixture()
     import f._
 
-    val address = getNewAddress(probe)
-    val priv = dumpPrivateKey(address)
+    val (priv, address) = createExternalAddress()
     val parentTx = sendToAddress(address, 125_000 sat, probe)
     val tx = createSpendP2WPKH(parentTx, priv, priv.publicKey, 2_500 sat, sequence = 5, lockTime = 0)
     val cmd = PublishRawTx(tx, tx.txIn.head.outPoint, "tx-time-locks", 0 sat, None)
@@ -106,8 +105,7 @@ class RawTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitc
     val f = createFixture()
     import f._
 
-    val address = getNewAddress(probe)
-    val priv = dumpPrivateKey(address)
+    val (priv, address) = createExternalAddress()
     val ancestorTx = sendToAddress(address, 125_000 sat, probe)
     val parentTx = createSpendP2WPKH(ancestorTx, priv, priv.publicKey, 2_500 sat, 0, 0)
     val tx = createSpendP2WPKH(parentTx, priv, priv.publicKey, 2_000 sat, 0, 0)
@@ -131,8 +129,7 @@ class RawTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike with Bitc
     val f = createFixture()
     import f._
 
-    val address = getNewAddress(probe)
-    val priv = dumpPrivateKey(address)
+    val (priv, address) = createExternalAddress()
     val parentTx = sendToAddress(address, 125_000 sat, probe)
     val tx1 = createSpendP2WPKH(parentTx, priv, priv.publicKey, 2_500 sat, 0, 0)
     val cmd = PublishRawTx(tx1, tx1.txIn.head.outPoint, "tx-time-locks", 10 sat, None)


### PR DESCRIPTION
We previously relied on bitcoind's `dumpprivkey` RPC in some of our tests.
That RPC isn't available with descriptor wallets, and descriptor wallets are now the default wallet type.

Removing this dependency should unblock #2027