### PR TITLE
Simplify onion message codec

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/CommonCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/CommonCodecsSpec.scala
@@ -196,6 +196,57 @@ class CommonCodecsSpec extends AnyFunSuite {
     }
   }
 
+  test("encode/decode bytevector32") {
+    val testCases = Seq(
+      (hex"0000000000000000000000000000000000000000000000000000000000000000", Some(ByteVector32.Zeroes)),
+      (hex"0101010101010101010101010101010101010101010101010101010101010101", Some(ByteVector32(hex"0101010101010101010101010101010101010101010101010101010101010101"))),
+      (hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", Some(ByteVector32(hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"))),
+      // Ignore additional trailing bytes
+      (hex"000000000000000000000000000000000000000000000000000000000000000000", Some(ByteVector32.Zeroes)),
+      (hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00", Some(ByteVector32(hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"))),
+      // Not enough bytes
+      (hex"00000000000000000000000000000000000000000000000000000000000000", None),
+      (hex"", None)
+    )
+
+    for ((encoded, expected_opt) <- testCases) {
+      expected_opt match {
+        case Some(expected) =>
+          val decoded = bytes32.decode(encoded.bits).require.value
+          assert(decoded === expected)
+          assert(expected.bytes === bytes32.encode(decoded).require.bytes)
+        case None =>
+          assert(bytes32.decode(encoded.bits).isFailure)
+      }
+    }
+  }
+
+  test("encode/decode bytevector64") {
+    val testCases = Seq(
+      (hex"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Some(ByteVector64.Zeroes)),
+      (hex"01010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101", Some(ByteVector64(hex"01010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101"))),
+      (hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", Some(ByteVector64(hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"))),
+      // Ignore additional trailing bytes
+      (hex"0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", Some(ByteVector64.Zeroes)),
+      (hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00", Some(ByteVector64(hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"))),
+      // Not enough bytes
+      (hex"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", None),
+      (hex"00000000000000000000000000000000000000000000000000000000000000", None),
+      (hex"", None)
+    )
+
+    for ((encoded, expected_opt) <- testCases) {
+      expected_opt match {
+        case Some(expected) =>
+          val decoded = bytes64.decode(encoded.bits).require.value
+          assert(decoded === expected)
+          assert(expected.bytes === bytes64.encode(decoded).require.bytes)
+        case None =>
+          assert(bytes64.decode(encoded.bits).isFailure)
+      }
+    }
+  }
+
   test("encode/decode with private key codec") {
     val value = PrivateKey(randomBytes32())
     val wire = privateKey.encode(value).require


### PR DESCRIPTION
This PR was quite a trip. It started because I realized after merging #1957 that since the sphinx packet doesn't really use a prefix, but rather a mix of prefix and suffix (since the mac is encoded after the payload), I actually wasn't sure the `_ - 66, _ + 66` trick was correct.

So I dived into the tests and added new ones playing with length more extensively, and I ended up with some failing tests. At some point I thought our `bytes32` codec was the culprit, so I added tests for that, but it turned out it wasn't the culprit (but I think it's worth keeping the tests, we didn't have enough coverage there). It took me quite a while to realize that it was actually my test that wasn't correctly written :face_with_head_bandage: 

Now everything is green, we have more coverage (in particular for the remaining bytes / not enough bytes cases) and I think the codec is simpler to understand, let me know what you think.

Note that the previous codec was correct, it did pass all tests, but I found it harder to understand (scodec wizardry).