### PR TITLE
Use balance estimates from past payments in path-finding

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -227,6 +227,7 @@ eclair {
     channel-exclude-duration = 60 seconds // when a temporary channel failure is returned, we exclude the channel from our payment routes for this duration
     broadcast-interval = 60 seconds // see BOLT #7
     init-timeout = 5 minutes
+    balance-estimate-half-life = 1 day
 
     sync {
       request-node-announcements = true // if true we will ask for node announcements when we receive channel ids that we don't know

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -227,7 +227,7 @@ eclair {
     channel-exclude-duration = 60 seconds // when a temporary channel failure is returned, we exclude the channel from our payment routes for this duration
     broadcast-interval = 60 seconds // see BOLT #7
     init-timeout = 5 minutes
-    balance-estimate-half-life = 1 day
+    balance-estimate-half-life = 1 day // time after which the confidence of the balance estimate is halved
 
     sync {
       request-node-announcements = true // if true we will ask for node announcements when we receive channel ids that we don't know

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -365,6 +365,7 @@ object NodeParams extends Logging {
           lockedFundsRisk = config.getDouble("locked-funds-risk"),
           failureCost = getRelayFees(config.getConfig("failure-cost")),
           hopCost = getRelayFees(config.getConfig("hop-cost")),
+          usePastRelaysData = config.getBoolean("use-past-relay-data"),
         ))
       },
       mpp = MultiPartParams(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -496,7 +496,8 @@ object NodeParams extends Logging {
         encodingType = routerSyncEncodingType,
         channelRangeChunkSize = config.getInt("router.sync.channel-range-chunk-size"),
         channelQueryChunkSize = config.getInt("router.sync.channel-query-chunk-size"),
-        pathFindingExperimentConf = getPathFindingExperimentConf(config.getConfig("router.path-finding.experiments"))
+        pathFindingExperimentConf = getPathFindingExperimentConf(config.getConfig("router.path-finding.experiments")),
+        balanceEstimateHalfLife = FiniteDuration(config.getDuration("router.balance-estimate-half-life").getSeconds, TimeUnit.SECONDS)
       ),
       socksProxy_opt = socksProxy_opt,
       maxPaymentAttempts = config.getInt("max-payment-attempts"),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -95,7 +95,8 @@ object EclairInternalsSerializer {
         .typecase(1, provide(EncodingType.COMPRESSED_ZLIB))) ::
       ("channelRangeChunkSize" | int32) ::
       ("channelQueryChunkSize" | int32) ::
-      ("pathFindingExperimentConf" | pathFindingExperimentConfCodec)).as[RouterConf]
+      ("pathFindingExperimentConf" | pathFindingExperimentConfCodec) ::
+      ("balanceEstimateHalfLife" | finiteDurationCodec)).as[RouterConf]
 
   val overrideFeaturesListCodec: Codec[List[(PublicKey, Features[Feature])]] = listOfN(uint16, publicKey ~ variableSizeBytes(uint16, featuresCodec))
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -67,7 +67,8 @@ object EclairInternalsSerializer {
   val heuristicsConstantsCodec: Codec[HeuristicsConstants] = (
     ("lockedFundsRisk" | double) ::
       ("failureCost" | relayFeesCodec) ::
-      ("hopCost" | relayFeesCodec)).as[HeuristicsConstants]
+      ("hopCost" | relayFeesCodec) ::
+      ("usePastRelaysData" | bool(8))).as[HeuristicsConstants]
 
   val multiPartParamsCodec: Codec[MultiPartParams] = (
     ("minPartAmount" | millisatoshi) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/BalanceEstimate.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/BalanceEstimate.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.router
+
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.bitcoin.scalacompat.{LexicographicalOrdering, Satoshi}
+import fr.acinq.eclair.MilliSatoshi.toMilliSatoshi
+import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
+import fr.acinq.eclair.router.Router.{ChannelHop, PublicChannel}
+import fr.acinq.eclair.{MilliSatoshi, TimestampSecond}
+
+import scala.concurrent.duration.FiniteDuration
+
+/** Estimates the balance between a pair of nodes
+ *
+ * @param low           lower bound on the balance
+ * @param lowTimestamp  time at which the lower bound was known to be correct
+ * @param high          upper bound on the balance
+ * @param highTimestamp time at which the upper bound was known to be correct
+ * @param totalCapacity total capacity of all the channels between the pair of nodes
+ * @param halfLife      time after which the certainty of the lower/upper bounds is halved
+ */
+case class BalanceEstimate private(low: MilliSatoshi, lowTimestamp: TimestampSecond, high: MilliSatoshi, highTimestamp: TimestampSecond, totalCapacity: Satoshi, halfLife: FiniteDuration) {
+
+  def otherSide: BalanceEstimate = BalanceEstimate(totalCapacity - high, highTimestamp, totalCapacity - low, lowTimestamp, totalCapacity, halfLife)
+
+  /* When we probe an edge, we get certain information on its balance, we know for sure that it can relay at least X or
+   * at most Y. However after some time has passed, other payments may have changed the balance and we can't be so sure
+   * anymore.
+   * We model this decay with a half-life H: every H units of time, our confidence decreases by half and our estimated
+   * probability distribution gets closer to the baseline uniform distribution of balances between 0 and totalCapacity.
+   */
+  private def decay(amount: MilliSatoshi, successProbabilityAtT: Double, t: TimestampSecond): Double = {
+    val decayRatio = 1 / math.pow(2, (TimestampSecond.now() - t) / halfLife)
+    val baseline = 1 - amount.toLong.toDouble / toMilliSatoshi(totalCapacity).toLong.toDouble
+    baseline * (1 - decayRatio) + successProbabilityAtT * decayRatio
+  }
+
+  def couldNotSend(amount: MilliSatoshi, timestamp: TimestampSecond): BalanceEstimate =
+    if (amount < high) {
+      if (amount > low) {
+        copy(high = amount, highTimestamp = timestamp)
+      } else {
+        // the balance is actually below `low`, we discard our lower bound
+        copy(low = MilliSatoshi(0), lowTimestamp = timestamp, high = amount, highTimestamp = timestamp)
+      }
+    } else {
+      /* We already expected not to be able to relay that amount as it above our upper bound. However if the upper bound
+       * was old enough that replacing it with the current amount decreases the success probability for `high`, then we
+       * replace it.
+       */
+      val pLow = decay(low, 1, lowTimestamp)
+      val pHigh = decay(high, 0, highTimestamp)
+      val x = low + (high - low) * (pLow / (pLow - pHigh))
+      if (amount <= x) {
+        copy(high = amount, highTimestamp = timestamp)
+      } else {
+        copy()
+      }
+    }
+
+  def couldSend(amount: MilliSatoshi, timestamp: TimestampSecond): BalanceEstimate =
+    otherSide.couldNotSend(totalCapacity - amount, timestamp).otherSide
+
+  def didSend(amount: MilliSatoshi, timestamp: TimestampSecond): BalanceEstimate =
+    copy(low = (low - amount) max MilliSatoshi(0), high = (high - amount) max MilliSatoshi(0))
+
+  def addChannel(capacity: Satoshi): BalanceEstimate = copy(high = high + toMilliSatoshi(capacity), totalCapacity = totalCapacity + capacity)
+
+  def removeChannel(capacity: Satoshi): BalanceEstimate = copy(low = (low - toMilliSatoshi(capacity)) max MilliSatoshi(0), high = high min toMilliSatoshi(totalCapacity - capacity), totalCapacity = totalCapacity - capacity)
+
+  /* Estimate the probability that we can successfully send `amount` through the channel
+   *
+   * We estimate this probability with a piecewise linear function:
+   * - probability that it can relay a payment of 0 is 1
+   * - probability that it can relay a payment of low is close to 1 if lowTimestamp is recent
+   * - probability that it can relay a payment of high is close to 0 if highTimestamp is recent
+   * - probability that it can relay a payment of totalCapacity is 0
+   */
+  def canSend(amount: MilliSatoshi): Double = {
+    val x = amount.toLong.toDouble
+    val a = low.toLong.toDouble
+    val b = high.toLong.toDouble
+    val c = toMilliSatoshi(totalCapacity).toLong.toDouble
+
+    // Success probability at the low and high points
+    val pLow = decay(low, 1, lowTimestamp)
+    val pHigh = decay(high, 0, highTimestamp)
+
+    if (amount < low) {
+      ((a - x) + x * pLow) / a
+    } else if (amount <= high) {
+      ((b - x) * pLow + (x - a) * pHigh) / (b - a)
+    } else {
+      ((c - x) * pHigh) / (c - b)
+    }
+  }
+}
+
+object BalanceEstimate {
+  def noChannels(halfLife: FiniteDuration): BalanceEstimate = BalanceEstimate(MilliSatoshi(0), TimestampSecond(0), MilliSatoshi(0), TimestampSecond(0), Satoshi(0), halfLife)
+
+  def baseline(capacity: Satoshi, halfLife: FiniteDuration): BalanceEstimate = noChannels(halfLife).addChannel(capacity)
+}
+
+case class BalancesEstimates(balances: Map[(PublicKey, PublicKey), BalanceEstimate], defaultHalfLife: FiniteDuration) {
+  def get(edge: GraphEdge): BalanceEstimate =
+    if (LexicographicalOrdering.isLessThan(edge.desc.a.value, edge.desc.b.value)) {
+      balances.getOrElse((edge.desc.a, edge.desc.b), BalanceEstimate.baseline(edge.capacity, defaultHalfLife))
+    } else {
+      balances.getOrElse((edge.desc.b, edge.desc.a), BalanceEstimate.baseline(edge.capacity, defaultHalfLife)).otherSide
+    }
+
+  def addChannel(channel: PublicChannel): BalancesEstimates =
+    BalancesEstimates(
+      balances.updatedWith((channel.ann.nodeId1, channel.ann.nodeId2))(opt => Some(opt.getOrElse(BalanceEstimate.noChannels(defaultHalfLife).addChannel(channel.capacity)))),
+      defaultHalfLife)
+
+  def removeChannel(channel: PublicChannel): BalancesEstimates =
+    BalancesEstimates(
+      balances.updatedWith((channel.ann.nodeId1, channel.ann.nodeId2)) {
+        case None => None
+        case Some(balance) =>
+          val newBalance = balance.removeChannel(channel.capacity)
+          if (newBalance.totalCapacity.toLong > 0) {
+            Some(newBalance)
+          } else {
+            None
+          }
+      }, defaultHalfLife)
+
+  private def channelXSend(x: (BalanceEstimate, MilliSatoshi, TimestampSecond) => BalanceEstimate, hop: ChannelHop, amount: MilliSatoshi): BalancesEstimates =
+    if (LexicographicalOrdering.isLessThan(hop.nodeId.value, hop.nextNodeId.value)) {
+      BalancesEstimates(balances.updatedWith((hop.nodeId, hop.nextNodeId))(_.map(x(_, amount, TimestampSecond.now()))), defaultHalfLife)
+    } else {
+      BalancesEstimates(balances.updatedWith((hop.nextNodeId, hop.nodeId))(_.map(b => x(b.otherSide, amount, TimestampSecond.now()).otherSide)), defaultHalfLife)
+    }
+
+  def channelCouldSend(hop: ChannelHop, amount: MilliSatoshi): BalancesEstimates =
+    channelXSend(_.couldSend(_, _), hop, amount)
+
+  def channelCouldNotSend(hop: ChannelHop, amount: MilliSatoshi): BalancesEstimates =
+    channelXSend(_.couldNotSend(_, _), hop, amount)
+
+  def channelDidSend(hop: ChannelHop, amount: MilliSatoshi): BalancesEstimates =
+    channelXSend(_.didSend(_, _), hop, amount)
+
+}
+
+object BalancesEstimates {
+  def baseline(graph: DirectedGraph, defaultHalfLife: FiniteDuration): BalancesEstimates = BalancesEstimates((
+    for (edge <- graph.edgeSet() if edge.balance_opt.isEmpty)
+      yield (if (LexicographicalOrdering.isLessThan(edge.desc.a.value, edge.desc.b.value)) (edge.desc.a, edge.desc.b) else (edge.desc.b, edge.desc.a)) -> BalanceEstimate.baseline(edge.capacity, defaultHalfLife)
+    ).toMap,
+    defaultHalfLife)
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -632,7 +632,12 @@ object Router {
 
   def hasChannels(nodeId: PublicKey, channels: Iterable[PublicChannel]): Boolean = channels.exists(c => isRelatedTo(c.ann, nodeId))
 
+  /** We know that this route could relay because we have tried it but the payment was eventually cancelled */
   case class RouteCouldRelay(route: Route)
+
+  /** We have relayed using this route. */
   case class RouteDidRelay(route: Route)
+
+  /** We have tried to relay this amount from this channel and it failed. */
   case class ChannelCouldNotRelay(amount: MilliSatoshi, hop: ChannelHop)
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -100,7 +100,16 @@ class Router(val nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Comm
 
     log.info(s"initialization completed, ready to process messages")
     Try(initialized.map(_.success(Done)))
-    startWith(NORMAL, Data(initNodes, initChannels, Stash(Map.empty, Map.empty), rebroadcast = Rebroadcast(channels = Map.empty, updates = Map.empty, nodes = Map.empty), awaiting = Map.empty, privateChannels = Map.empty, excludedChannels = Set.empty, graph, sync = Map.empty))
+    startWith(NORMAL, Data(
+      initNodes, initChannels,
+      Stash(Map.empty, Map.empty),
+      rebroadcast = Rebroadcast(channels = Map.empty, updates = Map.empty, nodes = Map.empty),
+      awaiting = Map.empty,
+      privateChannels = Map.empty,
+      excludedChannels = Set.empty,
+      graph,
+      balances = BalancesEstimates.baseline(graph, nodeParams.routerConf.balanceEstimateHalfLife),
+      sync = Map.empty))
   }
 
   when(NORMAL) {
@@ -173,7 +182,7 @@ class Router(val nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Comm
       stay()
 
     case Event(GetLocalChannels, d) =>
-      val scids = d.graph.getIncomingEdgesOf(nodeParams.nodeId).map(_.desc.shortChannelId)
+      val scids = d.graph.getIncomingEdgesOf(nodeParams.nodeId).values.flatten.map(_.desc.shortChannelId)
       val localChannels = scids.flatMap(scid => d.channels.get(scid).orElse(d.privateChannels.get(scid)).map(c => LocalChannel(nodeParams.nodeId, scid, c)))
       sender() ! localChannels
       stay()
@@ -254,6 +263,22 @@ class Router(val nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Comm
     case Event(PeerRoutingMessage(peerConnection, remoteNodeId, r: ReplyShortChannelIdsEnd), d) =>
       stay() using Sync.handleReplyShortChannelIdsEnd(d, RemoteGossip(peerConnection, remoteNodeId), r)
 
+    case Event(RouteCouldRelay(route), d) =>
+      val (balances1, _) = route.hops.foldRight((d.balances, route.amount)) {
+        case (hop, (balances, amount)) =>
+          (balances.channelCouldSend(hop, amount) , amount + hop.fee(amount))
+      }
+      stay() using d.copy(balances = balances1)
+
+    case Event(RouteDidRelay(route), d) =>
+      val (balances1, _) = route.hops.foldRight((d.balances, route.amount)) {
+        case (hop, (balances, amount)) =>
+          (balances.channelDidSend(hop, amount) , amount + hop.fee(amount))
+      }
+      stay() using d.copy(balances = balances1)
+
+    case Event(ChannelCouldNotRelay(amount, hop), d) =>
+      stay() using d.copy(balances = d.balances.channelCouldNotSend(hop, amount))
   }
 
   initialize()
@@ -304,7 +329,8 @@ object Router {
                         encodingType: EncodingType,
                         channelRangeChunkSize: Int,
                         channelQueryChunkSize: Int,
-                        pathFindingExperimentConf: PathFindingExperimentConf)
+                        pathFindingExperimentConf: PathFindingExperimentConf,
+                        balanceEstimateHalfLife: FiniteDuration)
 
   // @formatter:off
   case class ChannelDesc(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey)
@@ -487,6 +513,10 @@ object Router {
 
     def printChannels(): String = hops.map(_.lastUpdate.shortChannelId).mkString("->")
 
+    def stopAt(nodeId: PublicKey): Route = {
+      val amountAtStop = hops.reverse.takeWhile(_.nextNodeId != nodeId).foldLeft(amount) { case (amount1, hop) => amount1 + hop.fee(amount1) }
+      Route(amountAtStop, hops.takeWhile(_.nodeId != nodeId))
+    }
   }
 
   case class RouteResponse(routes: Seq[Route]) {
@@ -576,6 +606,7 @@ object Router {
                   privateChannels: Map[ShortChannelId, PrivateChannel],
                   excludedChannels: Set[ChannelDesc], // those channels are temporarily excluded from route calculation, because their node returned a TemporaryChannelFailure
                   graph: DirectedGraph,
+                  balances: BalancesEstimates,
                   sync: Map[PublicKey, Syncing] // keep tracks of channel range queries sent to each peer. If there is an entry in the map, it means that there is an ongoing query for which we have not yet received an 'end' message
                  )
 
@@ -600,4 +631,8 @@ object Router {
   def isRelatedTo(c: ChannelAnnouncement, nodeId: PublicKey) = nodeId == c.nodeId1 || nodeId == c.nodeId2
 
   def hasChannels(nodeId: PublicKey, channels: Iterable[PublicChannel]): Boolean = channels.exists(c => isRelatedTo(c.ann, nodeId))
+
+  case class RouteCouldRelay(route: Route)
+  case class RouteDidRelay(route: Route)
+  case class ChannelCouldNotRelay(amount: MilliSatoshi, hop: ChannelHop)
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -185,7 +185,8 @@ object TestConstants {
             maxParts = 10,
           ),
           experimentName = "alice-test-experiment",
-          experimentPercentage = 100)))
+          experimentPercentage = 100))),
+        balanceEstimateHalfLife = 1 day
       ),
       socksProxy_opt = None,
       maxPaymentAttempts = 5,
@@ -323,7 +324,8 @@ object TestConstants {
             maxParts = 10,
           ),
           experimentName = "bob-test-experiment",
-          experimentPercentage = 100)))
+          experimentPercentage = 100))),
+        balanceEstimateHalfLife = 1 day
       ),
       socksProxy_opt = None,
       maxPaymentAttempts = 5,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -450,6 +450,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.send(paymentFSM, addCompleted(HtlcResult.RemoteFail(UpdateFailHtlc(ByteVector32.Zeroes, 0, Sphinx.FailurePacket.create(sharedSecrets1.head._1, failure)))))
 
     // payment lifecycle will ask the router to temporarily exclude this channel from its route calculations
+    routerForwarder.expectMsgType[ChannelCouldNotRelay]
     routerForwarder.expectMsg(ExcludeChannel(ChannelDesc(update_bc.shortChannelId, b, c)))
     routerForwarder.forward(routerFixture.router)
     // payment lifecycle forwards the embedded channelUpdate to the router

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2021 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.router
+
+import fr.acinq.bitcoin.scalacompat.Satoshi
+import fr.acinq.eclair.{MilliSatoshiLong, TimestampSecond}
+import org.scalactic.Tolerance.convertNumericToPlusOrMinusWrapper
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.concurrent.duration.DurationInt
+
+class BalanceEstimateSpec extends AnyFunSuite {
+  def isValid(balance: BalanceEstimate): Boolean = {
+    balance.low >= 0.msat &&
+      balance.low < balance.high &&
+      balance.high <= balance.totalCapacity
+  }
+
+  test("symmetry") {
+    var balanceA = BalanceEstimate.noChannels(1 day)
+    var balanceB = balanceA.otherSide
+    assert(balanceA === balanceB)
+
+    balanceA = balanceA.addChannel(Satoshi(40000))
+    balanceB = balanceB.addChannel(Satoshi(40000))
+    assert(isValid(balanceA))
+    assert(isValid(balanceB))
+    assert(balanceB.otherSide === balanceA)
+
+    balanceA = balanceA.couldNotSend(35000000 msat, TimestampSecond(1000))
+    balanceB = balanceB.couldSend(balanceB.totalCapacity - 35000000.msat, TimestampSecond(1000))
+    assert(isValid(balanceA))
+    assert(isValid(balanceB))
+    assert(balanceB.otherSide === balanceA)
+
+    balanceA = balanceA.couldSend(10000000 msat, TimestampSecond(2000))
+    balanceB = balanceB.couldNotSend(balanceB.totalCapacity - 10000000.msat, TimestampSecond(2000))
+    assert(isValid(balanceA))
+    assert(isValid(balanceB))
+    assert(balanceB.otherSide === balanceA)
+
+    balanceA = balanceA.addChannel(Satoshi(5000))
+    balanceB = balanceB.addChannel(Satoshi(5000))
+    assert(isValid(balanceA))
+    assert(isValid(balanceB))
+    assert(balanceB.otherSide === balanceA)
+
+    balanceA = balanceA.couldSend(balanceA.totalCapacity - 1000000.msat, TimestampSecond(15000))
+    balanceB = balanceB.couldNotSend(1000000 msat, TimestampSecond(15000))
+    assert(isValid(balanceA))
+    assert(isValid(balanceB))
+    assert(balanceB.otherSide === balanceA)
+
+    balanceA = balanceA.removeChannel(Satoshi(5000))
+    balanceB = balanceB.removeChannel(Satoshi(5000))
+    assert(isValid(balanceA))
+    assert(isValid(balanceB))
+    assert(balanceB.otherSide === balanceA)
+  }
+
+  test("no balance information") {
+    val balance = BalanceEstimate.noChannels(1 day).addChannel(Satoshi(100))
+    assert(balance.canSend(0 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(1 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(50000 msat) === 0.5 +- 0.001)
+    assert(balance.canSend(99999 msat) === 0.0 +- 0.001)
+    assert(balance.canSend(100000 msat) === 0.0 +- 0.001)
+  }
+
+  test("can send balance info bounds") {
+    val now = TimestampSecond.now()
+    val balance = BalanceEstimate.noChannels(1 day).addChannel(Satoshi(100)).couldSend(24000 msat, now).couldNotSend(30000 msat, now)
+    assert(balance.canSend(0 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(1 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(23999 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(24000 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(24001 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(27000 msat) === 0.5 +- 0.001)
+    assert(balance.canSend(29999 msat) === 0.0 +- 0.001)
+    assert(balance.canSend(30000 msat) === 0.0 +- 0.001)
+    assert(balance.canSend(30001 msat) === 0.0 +- 0.001)
+    assert(balance.canSend(99999 msat) === 0.0 +- 0.001)
+    assert(balance.canSend(100000 msat) === 0.0 +- 0.001)
+  }
+
+  test("could and couldn't send at the same time") {
+    val now = TimestampSecond.now()
+    val balance = BalanceEstimate.noChannels(1 day).addChannel(Satoshi(100)).couldSend(26000 msat, now).couldNotSend(26000 msat, now)
+    assert(isValid(balance))
+    assert(balance.canSend(0 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(1 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(26000 msat) >= 0)
+    assert(balance.canSend(26000 msat) <= 1)
+    assert(balance.canSend(99999 msat) === 0.0 +- 0.001)
+    assert(balance.canSend(100000 msat) === 0.0 +- 0.001)
+  }
+
+  test("couldn't and could send at the same time") {
+    val now = TimestampSecond.now()
+    val balance = BalanceEstimate.noChannels(1 day).addChannel(Satoshi(100)).couldNotSend(26000 msat, now).couldSend(26000 msat, now)
+    assert(isValid(balance))
+    assert(balance.canSend(0 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(1 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(26000 msat) >= 0)
+    assert(balance.canSend(26000 msat) <= 1)
+    assert(balance.canSend(99999 msat) === 0.0 +- 0.001)
+    assert(balance.canSend(100000 msat) === 0.0 +- 0.001)
+  }
+
+  test("decay") {
+    val longAgo = TimestampSecond.now() - 1.day
+    val balance = BalanceEstimate.noChannels(1 second).addChannel(Satoshi(100)).couldNotSend(32000 msat, longAgo).couldSend(28000 msat, longAgo)
+    assert(isValid(balance))
+    assert(balance.canSend(1 msat) === 1.0 +- 0.01)
+    assert(balance.canSend(33333 msat) === 0.666 +- 0.01)
+    assert(balance.canSend(66666 msat) === 0.333 +- 0.01)
+    assert(balance.canSend(99999 msat) === 0.0 +- 0.01)
+  }
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
@@ -259,7 +259,7 @@ class GraphSpec extends AnyFunSuite {
 
     val path :: Nil = yenKshortestPaths(graph, BalancesEstimates.baseline(graph, 1 day), a, e, 100000000 msat,
       Set.empty, Set.empty, Set.empty, 1,
-      Right(HeuristicsConstants(1.0E-8, RelayFees(2000 msat, 500), RelayFees(50 msat, 20))),
+      Right(HeuristicsConstants(1.0E-8, RelayFees(2000 msat, 500), RelayFees(50 msat, 20), false)),
       BlockHeight(714930), _ => true, includeLocalChannelCost = true)
     assert(path.path == Seq(edgeAB, edgeBC, edgeCE))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -1797,6 +1797,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       lockedFundsRisk = 0.0,
       failureCost = RelayFees(1000 msat, 500),
       hopCost = RelayFees(0 msat, 0),
+      false,
     )
     val Success(routes) = findRoute(g, BalancesEstimates.baseline(g, 1 day), start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Right(hc)), currentBlockHeight = BlockHeight(400000))
     assert(routes.distinct.length == 1)
@@ -1822,6 +1823,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       lockedFundsRisk = 1e-7,
       failureCost = RelayFees(0 msat, 0),
       hopCost = RelayFees(0 msat, 0),
+      false,
     )
     val Success(routes) = findRoute(g, BalancesEstimates.baseline(g, 1 day), start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Right(hc)), currentBlockHeight = BlockHeight(400000))
     assert(routes.distinct.length == 1)
@@ -1841,6 +1843,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       lockedFundsRisk = 1e-7,
       failureCost = RelayFees(0 msat, 0),
       hopCost = RelayFees(0 msat, 0),
+      false,
     )
     val Success(routes) = findRoute(g, BalancesEstimates.baseline(g, 1 day), a, c, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Right(hc)), currentBlockHeight = BlockHeight(400000))
     assert(routes.distinct.length == 1)
@@ -1928,6 +1931,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       lockedFundsRisk = 0.0,
       failureCost = RelayFees(1000 msat, 500),
       hopCost = RelayFees(0 msat, 0),
+      true,
     )
     val Success(routes) = findRoute(g, balances, start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Right(hc)), currentBlockHeight = BlockHeight(400000))
     assert(routes.distinct.length == 1)
@@ -1956,6 +1960,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       lockedFundsRisk = 0.0,
       failureCost = RelayFees(1000 msat, 500),
       hopCost = RelayFees(0 msat, 0),
+      true,
     )
     val Success(routes) = findRoute(g, balances, start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Right(hc)), currentBlockHeight = BlockHeight(400000))
     assert(routes.distinct.length == 1)


### PR DESCRIPTION
Currently when a payment fails we ban the channel for some time (60 seconds by default). There are several problems with that:
- If we try to relay a huge payment and it fails, we may still be able to relay a smaller payment
- If the ban duration is too short, it still won't be able to relay payments when we unban it. Many channels are unbalanced and inactive and if they are considered attractive by our path-finding algorithm (because they're big and cheap), they'll keep coming back and make our payment attempts fail.
In this PR, I introduce a probabilistic estimation of the channel balance to replace this binary behavior.