### PR TITLE
No error when updating the relay fees not in normal state

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1888,7 +1888,10 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
         case _ => handleCommandError(CommandUnavailableInThisState(d.channelId, "forceclose", stateName), c)
       }
 
-    case Event(c: CMD_UPDATE_RELAY_FEE, d) => handleCommandError(CommandUnavailableInThisState(d.channelId, "updaterelayfee", stateName), c)
+    case Event(c: CMD_UPDATE_RELAY_FEE, d) =>
+      val replyTo = if (c.replyTo == ActorRef.noSender) sender() else c.replyTo
+      replyTo ! RES_SUCCESS(c, d.channelId)
+      stay()
 
     // at restore, if the configuration has changed, the channel will send a command to itself to update the relay fees
     case Event(RES_SUCCESS(_: CMD_UPDATE_RELAY_FEE, channelId), d: DATA_NORMAL) if channelId == d.channelId => stay()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -1888,6 +1888,8 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
         case _ => handleCommandError(CommandUnavailableInThisState(d.channelId, "forceclose", stateName), c)
       }
 
+    // In states where we don't explicitly handle this command, we won't broadcast a new channel update immediately,
+    // but we will once we get back to NORMAL, because the updated fees have been saved to our peers DB.
     case Event(c: CMD_UPDATE_RELAY_FEE, d) =>
       val replyTo = if (c.replyTo == ActorRef.noSender) sender() else c.replyTo
       replyTo ! RES_SUCCESS(c, d.channelId)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -599,7 +599,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     val newFeeBaseMsat = TestConstants.Alice.nodeParams.relayParams.publicChannelFees.feeBase * 2
     val newFeeProportionalMillionth = TestConstants.Alice.nodeParams.relayParams.publicChannelFees.feeProportionalMillionths * 2
     alice ! CMD_UPDATE_RELAY_FEE(sender.ref, newFeeBaseMsat, newFeeProportionalMillionth, cltvExpiryDelta_opt = None)
-    sender.expectMsgType[RES_FAILURE[CMD_UPDATE_RELAY_FEE, _]]
+    sender.expectMsgType[RES_SUCCESS[CMD_UPDATE_RELAY_FEE]]
     relayerA.expectNoMessage(1 seconds)
   }
 


### PR DESCRIPTION
When using the API to update the relay fees of a channel, the changes are saved in the DB and then the channel is updated. If the channel can't be updated, because it is not ready yet for instance, that's fine because it will use the values from the DB as soon as it is ready. So there is no need to return an error in that case.
Fixes #2085