### PR TITLE
Rate limit onion messages

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -356,6 +356,8 @@ eclair {
 
     # Transient connections opened to relay messages will be closed after this delay of inactivity
     kill-transient-connection-after = 30 seconds
+
+    max-per-peer-per-second = 10
   }
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -459,7 +459,8 @@ object NodeParams extends Logging {
         pingTimeout = FiniteDuration(config.getDuration("peer-connection.ping-timeout").getSeconds, TimeUnit.SECONDS),
         pingDisconnect = config.getBoolean("peer-connection.ping-disconnect"),
         maxRebroadcastDelay = FiniteDuration(config.getDuration("router.broadcast-interval").getSeconds, TimeUnit.SECONDS), // it makes sense to not delay rebroadcast by more than the rebroadcast period
-        killIdleDelay = FiniteDuration(config.getDuration("onion-messages.kill-transient-connection-after").getSeconds, TimeUnit.SECONDS)
+        killIdleDelay = FiniteDuration(config.getDuration("onion-messages.kill-transient-connection-after").getSeconds, TimeUnit.SECONDS),
+        maxOnionMessagesPerSecond = config.getDouble("onion-messages.max-per-peer-per-second")
       ),
       routerConf = RouterConf(
         channelExcludeDuration = FiniteDuration(config.getDuration("router.channel-exclude-duration").getSeconds, TimeUnit.SECONDS),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
@@ -27,6 +27,10 @@ object Monitoring {
     val PeersConnected = Kamon.gauge("peers.connected")
 
     val ReconnectionsAttempts = Kamon.counter("reconnections.attempts")
+
+    val OnionMessagesReceived = Kamon.counter("onionmessages.received")
+    val OnionMessagesSent = Kamon.counter("onionmessages.sent")
+    val OnionMessagesThrottled = Kamon.counter("onionmessages.throttled")
   }
 
   object Tags {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -106,7 +106,8 @@ object EclairInternalsSerializer {
       ("pingTimeout" | finiteDurationCodec) ::
       ("pingDisconnect" | bool(8)) ::
       ("maxRebroadcastDelay" | finiteDurationCodec) ::
-      ("killIdleDelay" | finiteDurationCodec)).as[PeerConnection.Conf]
+      ("killIdleDelay" | finiteDurationCodec) ::
+      ("maxOnionMessagesPerSecond" | double)).as[PeerConnection.Conf]
 
   val peerConnectionDoSyncCodec: Codec[PeerConnection.DoSync] = bool(8).as[PeerConnection.DoSync]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -165,7 +165,8 @@ object TestConstants {
         pingTimeout = 10 seconds,
         pingDisconnect = true,
         maxRebroadcastDelay = 5 seconds,
-        killIdleDelay = 1 seconds
+        killIdleDelay = 1 seconds,
+        maxOnionMessagesPerSecond = 10
       ),
       routerConf = RouterConf(
         channelExcludeDuration = 60 seconds,
@@ -293,7 +294,8 @@ object TestConstants {
         pingTimeout = 10 seconds,
         pingDisconnect = true,
         maxRebroadcastDelay = 5 seconds,
-        killIdleDelay = 10 seconds
+        killIdleDelay = 10 seconds,
+        maxOnionMessagesPerSecond = 10
       ),
       routerConf = RouterConf(
         channelExcludeDuration = 60 seconds,


### PR DESCRIPTION
The rate limit is applied on the destination side as it is too easy to cheat on the origin side.