### PR TITLE
Raise default connection timeout values

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -192,10 +192,10 @@ eclair {
   revocation-timeout = 20 seconds // after sending a commit_sig, we will wait for at most that duration before disconnecting
 
   peer-connection {
-    auth-timeout = 10 seconds // will disconnect if connection authentication doesn't happen within that timeframe
-    init-timeout = 10 seconds // will disconnect if initialization doesn't happen within that timeframe
+    auth-timeout = 15 seconds // will disconnect if connection authentication doesn't happen within that timeframe
+    init-timeout = 15 seconds // will disconnect if initialization doesn't happen within that timeframe
     ping-interval = 30 seconds
-    ping-timeout = 10 seconds // will disconnect if peer takes longer than that to respond
+    ping-timeout = 20 seconds // will disconnect if peer takes longer than that to respond
     ping-disconnect = true // disconnect if no answer to our pings
   }
 


### PR DESCRIPTION
We've seen users bump into these limits often because many nodes now run behind Tor on poor hardware, so it makes sense to make our default values more robust.