### PR TITLE
Switchboard exposes peer information

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -35,7 +35,7 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
 import fr.acinq.eclair.db.{IncomingPayment, OutgoingPayment}
 import fr.acinq.eclair.io.Peer.{GetPeerInfo, PeerInfo}
-import fr.acinq.eclair.io.{MessageRelay, NodeURI, Peer, PeerConnection}
+import fr.acinq.eclair.io.{MessageRelay, NodeURI, Peer, PeerConnection, Switchboard}
 import fr.acinq.eclair.message.OnionMessages
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceivePayment
@@ -200,7 +200,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
   }
 
   override def peers()(implicit timeout: Timeout): Future[Iterable[PeerInfo]] = for {
-    peers <- (appKit.switchboard ? Symbol("peers")).mapTo[Iterable[ActorRef]]
+    peers <- (appKit.switchboard ? Switchboard.GetPeers).mapTo[Iterable[ActorRef]]
     peerinfos <- Future.sequence(peers.map(peer => (peer ? GetPeerInfo).mapTo[PeerInfo]))
   } yield peerinfos
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -461,7 +461,11 @@ object Peer {
   }
 
   case class GetPeerInfo(replyTo: ActorRef)
-  case class PeerInfo(peer: ActorRef, nodeId: PublicKey, state: State, address: Option[InetSocketAddress], channels: Int)
+  sealed trait PeerInfoResponse {
+    def nodeId: PublicKey
+  }
+  case class PeerInfo(peer: ActorRef, nodeId: PublicKey, state: State, address: Option[InetSocketAddress], channels: Int) extends PeerInfoResponse
+  case class PeerNotFound(nodeId: PublicKey) extends PeerInfoResponse { override def toString: String = s"peer $nodeId not found" }
 
   case class PeerRoutingMessage(peerConnection: ActorRef, remoteNodeId: PublicKey, message: RoutingMessage) extends RemoteTypes
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -65,7 +65,6 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnChainA
         channel ! INPUT_RESTORED(state)
         FinalChannelId(state.channelId) -> channel
       }.toMap
-
       goto(DISCONNECTED) using DisconnectedData(channels) // when we restart, we will attempt to reconnect right away, but then we'll wait
   }
 
@@ -77,11 +76,14 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnChainA
     case Event(connectionReady: PeerConnection.ConnectionReady, d: DisconnectedData) =>
       gotoConnected(connectionReady, d.channels.map { case (k: ChannelId, v) => (k, v) })
 
-    case Event(Terminated(actor), d: DisconnectedData) if d.channels.exists(_._2 == actor) =>
-      val h = d.channels.filter(_._2 == actor).keys
-      log.info(s"channel closed: channelId=${h.mkString("/")}")
-      val channels1 = d.channels -- h
+    case Event(Terminated(actor), d: DisconnectedData) if d.channels.values.toSet.contains(actor) =>
+      // we have at most 2 ids: a TemporaryChannelId and a FinalChannelId
+      val channelIds = d.channels.filter(_._2 == actor).keys
+      log.info(s"channel closed: channelId=${channelIds.mkString("/")}")
+      val channels1 = d.channels -- channelIds
       if (channels1.isEmpty) {
+        log.info("that was the last open channel")
+        context.system.eventStream.publish(LastChannelClosed(self, remoteNodeId))
         // we have no existing channels, we can forget about this peer
         stopPeer()
       } else {
@@ -230,15 +232,16 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnChainA
         }
 
       case Event(Terminated(actor), d: ConnectedData) if d.channels.values.toSet.contains(actor) =>
-        // we will have at most 2 ids: a TemporaryChannelId and a FinalChannelId
+        // we have at most 2 ids: a TemporaryChannelId and a FinalChannelId
         val channelIds = d.channels.filter(_._2 == actor).keys
         log.info(s"channel closed: channelId=${channelIds.mkString("/")}")
-        if (d.channels.values.toSet - actor == Set.empty) {
-          log.info(s"that was the last open channel, closing the connection")
+        val channels1 = d.channels -- channelIds
+        if (channels1.isEmpty) {
+          log.info("that was the last open channel, closing the connection")
           context.system.eventStream.publish(LastChannelClosed(self, remoteNodeId))
           d.peerConnection ! PeerConnection.Kill(KillReason.NoRemainingChannel)
         }
-        stay() using d.copy(channels = d.channels -- channelIds)
+        stay() using d.copy(channels = channels1)
 
       case Event(connectionReady: PeerConnection.ConnectionReady, d: ConnectedData) =>
         log.info(s"got new connection, killing current one and switching")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -102,7 +102,7 @@ class Switchboard(nodeParams: NodeParams, peerFactory: Switchboard.PeerFactory) 
     case GetPeerInfo(replyTo, remoteNodeId) =>
       getPeer(remoteNodeId) match {
         case Some(peer) => peer ! Peer.GetPeerInfo(replyTo)
-        case None => replyTo ! PeerNotFound(remoteNodeId)
+        case None => replyTo ! Peer.PeerNotFound(remoteNodeId)
       }
 
     case GetRouterPeerConf => sender() ! RouterPeerConf(nodeParams.routerConf, nodeParams.peerConnectionConf)
@@ -158,9 +158,7 @@ object Switchboard {
 
   // @formatter:off
   case object GetPeers
-
   case class GetPeerInfo(replyTo: ActorRef, remoteNodeId: PublicKey)
-  case class PeerNotFound(remoteNodeId: PublicKey) { override def toString: String = s"peer $remoteNodeId not found" }
 
   case object GetRouterPeerConf extends RemoteTypes
   case class RouterPeerConf(routerConf: RouterConf, peerConf: PeerConnection.Conf) extends RemoteTypes

--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -26,6 +26,7 @@ import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.BlindedRoute
 import fr.acinq.eclair.crypto.{ShaChain, Sphinx}
 import fr.acinq.eclair.db.FailureType.FailureType
 import fr.acinq.eclair.db.{IncomingPaymentStatus, OutgoingPaymentStatus}
+import fr.acinq.eclair.io.Peer
 import fr.acinq.eclair.message.OnionMessages
 import fr.acinq.eclair.payment.PaymentFailure.PaymentFailedSummary
 import fr.acinq.eclair.payment._
@@ -404,10 +405,17 @@ object GlobalBalanceSerializer extends MinimalSerializer({
     JObject(JField("total", JDecimal(o.total.toDouble))) merge Extraction.decompose(o)(formats)
 })
 
+// @formatter:off
+private case class PeerInfoJson(nodeId: PublicKey, state: String, address: Option[InetSocketAddress], channels: Int)
+object PeerInfoSerializer extends ConvertClassSerializer[Peer.PeerInfo](peerInfo => PeerInfoJson(peerInfo.nodeId, peerInfo.state.toString, peerInfo.address, peerInfo.channels))
+// @formatter:on
+
+// @formatter:off
 private[json] case class MessageReceivedJson(pathId: Option[ByteVector], replyPath: Option[BlindedRoute], unknownTlvs: Map[String, ByteVector])
 object OnionMessageReceivedSerializer extends ConvertClassSerializer[OnionMessages.ReceiveMessage]({ m: OnionMessages.ReceiveMessage =>
   MessageReceivedJson(m.pathId, m.finalPayload.replyPath.map(_.blindedRoute), m.finalPayload.records.unknown.map(tlv => (tlv.tag.toString -> tlv.value)).toMap)
 })
+// @formatter:on
 
 case class CustomTypeHints(custom: Map[Class[_], String]) extends TypeHints {
   val reverse: Map[String, Class[_]] = custom.map(_.swap)
@@ -517,6 +525,7 @@ object JsonSerializers {
     JavaUUIDSerializer +
     OriginSerializer +
     GlobalBalanceSerializer +
+    PeerInfoSerializer +
     PaymentFailedSummarySerializer +
     OnionMessageReceivedSerializer
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.Sphinx.DecryptedFailurePacket
-import fr.acinq.eclair.io.{Peer, PeerConnection}
+import fr.acinq.eclair.io.{Peer, PeerConnection, Switchboard}
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceivePayment
 import fr.acinq.eclair.payment.receive.{ForwardHandler, PaymentHandler}
@@ -109,7 +109,7 @@ abstract class ChannelIntegrationSpec extends IntegrationSpec {
     nodes("C").system.eventStream.subscribe(stateListenerC.ref, classOf[ChannelStateChanged])
     nodes("F").system.eventStream.subscribe(stateListenerF.ref, classOf[ChannelStateChanged])
 
-    sender.send(nodes("F").switchboard, Symbol("peers"))
+    sender.send(nodes("F").switchboard, Switchboard.GetPeers)
     val peers = sender.expectMsgType[Iterable[ActorRef]]
     // F's only node is C
     peers.head ! Peer.Disconnect(nodes("C").nodeParams.nodeId)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
@@ -27,6 +27,7 @@ import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{Watch, WatchFundingConfirmed}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
 import fr.acinq.eclair.channel.{CMD_CLOSE, RES_SUCCESS}
+import fr.acinq.eclair.io.Switchboard
 import fr.acinq.eclair.message.OnionMessages
 import fr.acinq.eclair.router.Router
 import fr.acinq.eclair.wire.protocol.{GenericTlv, NodeAnnouncement}
@@ -165,9 +166,9 @@ class MessageIntegrationSpec extends IntegrationSpec {
 
     // nodes should disconnect automatically once they don't have any channels left
     awaitCond({
-      probe.send(nodes("A").switchboard, Symbol("peers"))
+      probe.send(nodes("A").switchboard, Switchboard.GetPeers)
       val peersA = probe.expectMsgType[Iterable[ActorRef]]
-      probe.send(nodes("B").switchboard, Symbol("peers"))
+      probe.send(nodes("B").switchboard, Switchboard.GetPeers)
       val peersB = probe.expectMsgType[Iterable[ActorRef]]
       // A and B are now only connected to D
       peersA.size == 1 && peersB.size == 1

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
@@ -131,7 +131,7 @@ class SwitchboardSpec extends TestKitBaseClass with AnyFunSuiteLike {
 
     val unknownPeerNodeId = randomKey().publicKey
     probe.send(switchboard, GetPeerInfo(probe.ref, unknownPeerNodeId))
-    probe.expectMsg(PeerNotFound(unknownPeerNodeId))
+    probe.expectMsg(Peer.PeerNotFound(unknownPeerNodeId))
 
     probe.send(switchboard, GetPeerInfo(probe.ref, knownPeerNodeId))
     peer.expectMsg(Peer.GetPeerInfo(probe.ref))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
@@ -17,11 +17,14 @@
 package fr.acinq.eclair.json
 
 import akka.actor.ActorRef
+import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{Btc, ByteVector32, OutPoint, Satoshi, SatoshiLong, Transaction, TxOut}
 import fr.acinq.eclair._
 import fr.acinq.eclair.balance.CheckBalance
 import fr.acinq.eclair.balance.CheckBalance.{ClosingBalance, GlobalBalance, MainAndHtlcBalance, PossiblyPublishedMainAndHtlcBalance, PossiblyPublishedMainBalance}
 import fr.acinq.eclair.channel.{CMD_UPDATE_RELAY_FEE, CommandResponse, CommandUnavailableInThisState, Origin, RES_FAILURE, RES_SUCCESS}
+import fr.acinq.eclair.io.Peer
+import fr.acinq.eclair.io.Peer.PeerInfo
 import fr.acinq.eclair.payment.{PaymentRequest, PaymentSettlingOnChain}
 import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.transactions.{IncomingHtlc, OutgoingHtlc}
@@ -96,6 +99,12 @@ class JsonSerializersSpec extends AnyFunSuite with Matchers {
     JsonSerializers.serialization.write(ipv6LocalHost)(org.json4s.DefaultFormats + NodeAddressSerializer) shouldBe s""""[0:0:0:0:0:0:0:1]:9735""""
     JsonSerializers.serialization.write(tor2)(org.json4s.DefaultFormats + NodeAddressSerializer) shouldBe s""""aaaqeayeaudaocaj.onion:7777""""
     JsonSerializers.serialization.write(tor3)(org.json4s.DefaultFormats + NodeAddressSerializer) shouldBe s""""aaaqeayeaudaocajbifqydiob4ibceqtcqkrmfyydenbwha5dypsaijc.onion:9999""""
+  }
+
+  test("PeerInfo serialization") {
+    val peerInfo = PeerInfo(ActorRef.noSender, PublicKey(hex"0270685ca81a8e4d4d01beec5781f4cc924684072ae52c507f8ebe9daf0caaab7b"), Peer.CONNECTED, None, 5)
+    val expected = """{"nodeId":"0270685ca81a8e4d4d01beec5781f4cc924684072ae52c507f8ebe9daf0caaab7b","state":"CONNECTED","channels":5}"""
+    JsonSerializers.serialization.write(peerInfo)(JsonSerializers.formats) shouldBe expected
   }
 
   test("DirectedHtlc serialization") {

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -38,16 +38,16 @@ import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.db._
-import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.io.Peer.PeerInfo
+import fr.acinq.eclair.io.{NodeURI, Peer}
 import fr.acinq.eclair.message.OnionMessages
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.relay.Relayer.UsableBalance
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.PreimageReceived
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentToRouteResponse
-import fr.acinq.eclair.router.Router.PredefinedNodeRoute
 import fr.acinq.eclair.router.Router
-import fr.acinq.eclair.wire.protocol.{ChannelUpdate, Color, GenericTlv, MessageOnion, NodeAddress, OnionMessagePayloadTlv, TlvStream}
+import fr.acinq.eclair.router.Router.PredefinedNodeRoute
+import fr.acinq.eclair.wire.protocol._
 import org.mockito.scalatest.IdiomaticMockito
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -164,13 +164,15 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
 
     eclair.peers()(any[Timeout]) returns Future.successful(List(
       PeerInfo(
+        ActorRef.noSender,
         nodeId = aliceNodeId,
-        state = "CONNECTED",
+        state = Peer.CONNECTED,
         address = Some(NodeAddress.fromParts("localhost", 9731).get.socketAddress),
         channels = 1),
       PeerInfo(
+        ActorRef.noSender,
         nodeId = bobNodeId,
-        state = "DISCONNECTED",
+        state = Peer.DISCONNECTED,
         address = None,
         channels = 1)))
 


### PR DESCRIPTION
The switchboard is our singleton actor entry point to all of our peers and peer connections, it can be useful to have it deliver basic information about our peers, especially when we don't have access to a peer `actorRef` yet.

This PR also fixes a bug where the `Peer` wouldn't correctly notify the `LastChannelClosed` event if it happened while the peer was disconnected.