### PR TITLE
Make `ClaimHtlcTx` replaceable

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -124,7 +124,7 @@ object Transactions {
   case class HtlcSuccessTx(input: InputInfo, tx: Transaction, paymentHash: ByteVector32, htlcId: Long) extends HtlcTx { override def desc: String = "htlc-success" }
   case class HtlcTimeoutTx(input: InputInfo, tx: Transaction, htlcId: Long) extends HtlcTx { override def desc: String = "htlc-timeout" }
   case class HtlcDelayedTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo { override def desc: String = "htlc-delayed" }
-  sealed trait ClaimHtlcTx extends TransactionWithInputInfo { def htlcId: Long }
+  sealed trait ClaimHtlcTx extends ReplaceableTransactionWithInputInfo { def htlcId: Long }
   case class LegacyClaimHtlcSuccessTx(input: InputInfo, tx: Transaction, htlcId: Long) extends ClaimHtlcTx { override def desc: String = "claim-htlc-success" }
   case class ClaimHtlcSuccessTx(input: InputInfo, tx: Transaction, paymentHash: ByteVector32, htlcId: Long) extends ClaimHtlcTx { override def desc: String = "claim-htlc-success" }
   case class ClaimHtlcTimeoutTx(input: InputInfo, tx: Transaction, htlcId: Long) extends ClaimHtlcTx { override def desc: String = "claim-htlc-timeout" }


### PR DESCRIPTION
We add `claim-htlc` transactions to the set of transactions that we will RBF if they don't confirm quickly.

This is important because the feerate is evaluated [when we see the remote commitment in the mempool](https://github.com/ACINQ/eclair/blob/ac9e274f0d1083319f70e08d495f20e27dd4cccd/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala#L1048), so it may be outdated by the time we can actually publish the `claim-htlc` transaction (either because of the absolute timelock or because the remote commitment took a long time to confirm).

It's very simple to set the fees for these transactions: since we can unilaterally sign, we simply decrease the output amount and re-sign. Note that we do it for both standard commitments and anchor output commitments. For standard commitments, these transactions are marked as non-RBFable, so RBF attempts will simply fail if the previous transaction is in the mempool. But it's still worth attempting it, as it may have been dropped from the mempool in high-fee environments.

The `ReplaceableTxPublisher` deserves some refactoring: integrating these various types of transactions shows where the model works and where it doesn't. But I've got a few other changes I'd like to make which impact the architecture, so I'd like to keep it like this for now and refactor after a few more PRs.