### PR TITLE
Fix potential loop in path-finding

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -325,7 +325,7 @@ object Graph {
         val riskCost = totalAmount.toLong * totalCltv.toInt * heuristicsConstants.lockedFundsRisk
         // If the edge was added by the invoice, it is assumed that it can route the payment.
         // If we know the balance of the channel, then we will check separately that it can relay the payment.
-        val successProbability = if (edge.update.chainHash == ByteVector32.Zeroes || edge.balance_opt.nonEmpty) 1.0 else 1.0 - totalAmount.toLong.toDouble / edge.capacity.toMilliSatoshi.toLong.toDouble
+        val successProbability = if (edge.update.chainHash == ByteVector32.Zeroes || edge.balance_opt.nonEmpty) 1.0 else 1.0 - prev.amount.toLong.toDouble / edge.capacity.toMilliSatoshi.toLong.toDouble
         val totalSuccessProbability = prev.successProbability * successProbability
         val failureCost = nodeFee(heuristicsConstants.failureCost.feeBase, heuristicsConstants.failureCost.feeProportionalMillionths, totalAmount)
         val weight = totalFees.toLong + totalHopsCost.toLong + riskCost + failureCost.toLong / totalSuccessProbability

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
@@ -245,6 +245,7 @@ class GraphSpec extends AnyFunSuite {
                  \   /
                   \ /
                    E
+    This tests that the success probability for the channel C -> D is computed properly and is positive.
     */
     val edgeAB = makeEdge(1L, a, b, 10001 msat, 0, capacity = 200000 sat)
     val edgeBC = makeEdge(2L, b, c, 10000 msat, 0, capacity = 200000 sat)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
@@ -239,6 +239,13 @@ class GraphSpec extends AnyFunSuite {
   def edgeFromNodes(shortChannelId: Long, a: PublicKey, b: PublicKey): GraphEdge = makeEdge(shortChannelId, a, b, 0 msat, 0)
 
   test("amount with fees larger than channel capacity") {
+    /*
+    The channel C -> D is just large enough for the payment to go through but when adding the channel fee it becomes too big.
+    A --> B --> C <-> D
+                 \   /
+                  \ /
+                   E
+    */
     val edgeAB = makeEdge(1L, a, b, 10001 msat, 0, capacity = 200000 sat)
     val edgeBC = makeEdge(2L, b, c, 10000 msat, 0, capacity = 200000 sat)
     val edgeCD = makeEdge(3L, c, d, 20001 msat, 0, capacity = 100011 sat)


### PR DESCRIPTION
Use the amount **without** the fees when computing the success probability of routing through an edge.
This fixes a problem where the computed probability could be negative, leading to a shorter path after adding an edge.