### PR TITLE
Set max timestamp in API call to 9999/12/31

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
@@ -43,7 +43,7 @@ trait ExtraDirectives extends Directives {
   val nodeIdsFormParam: NameUnmarshallerReceptacle[List[PublicKey]] = "nodeIds".as[List[PublicKey]](pubkeyListUnmarshaller)
   val paymentHashFormParam: NameUnmarshallerReceptacle[ByteVector32] = "paymentHash".as[ByteVector32](sha256HashUnmarshaller)
   val fromFormParam: NameDefaultUnmarshallerReceptacle[TimestampSecond] = "from".as[TimestampSecond](timestampSecondUnmarshaller).?(TimestampSecond.min)
-  val toFormParam: NameDefaultUnmarshallerReceptacle[TimestampSecond] = "to".as[TimestampSecond](timestampSecondUnmarshaller).?(TimestampSecond.max)
+  val toFormParam: NameDefaultUnmarshallerReceptacle[TimestampSecond] = "to".as[TimestampSecond](timestampSecondUnmarshaller).?(TimestampSecond(253402300799L)) // 31/12/9999
   val amountMsatFormParam: NameReceptacle[MilliSatoshi] = "amountMsat".as[MilliSatoshi]
   val invoiceFormParam: NameReceptacle[PaymentRequest] = "invoice".as[PaymentRequest]
   val routeFormatFormParam: NameUnmarshallerReceptacle[RouteFormat] = "format".as[RouteFormat](routeFormatUnmarshaller)

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -1056,6 +1056,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
   test("'audit'") {
     val eclair = mock[Eclair]
     val mockService = new MockService(eclair)
+    val year9999 = TimestampSecond(253402300799L)
     val auditResponse = AuditResponse(Seq.empty, Seq.empty, Seq.empty)
     eclair.audit(any, any)(any[Timeout]) returns Future.successful(auditResponse)
 
@@ -1065,16 +1066,16 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       check {
         assert(handled)
         assert(status == OK)
-        eclair.audit(TimestampSecond.min, TimestampSecond.max)(any[Timeout]).wasCalled(once)
+        eclair.audit(TimestampSecond.min, year9999)(any[Timeout]).wasCalled(once)
       }
 
-    Post("/audit", FormData("from" -> TimestampSecond.min.toLong.toString, "to" -> TimestampSecond.max.toLong.toString)) ~>
+    Post("/audit", FormData("from" -> TimestampSecond.min.toLong.toString, "to" -> year9999.toLong.toString)) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
       Route.seal(mockService.audit) ~>
       check {
         assert(handled)
         assert(status == OK)
-        eclair.audit(TimestampSecond.min, TimestampSecond.max)(any[Timeout]).wasCalled(twice)
+        eclair.audit(TimestampSecond.min, year9999)(any[Timeout]).wasCalled(twice)
       }
 
     Post("/audit", FormData("from" -> 123456.toString, "to" -> 654321.toString)) ~>


### PR DESCRIPTION
Previous value was `10001950-04-24 09:07:11+00` which is out of range for Postgresql, which broke the `audit` API call on eclair nodes that were using Postgres.

9999 seems far away enough for most databases (for most SQLdialects anyway).

I chose to just change how we handle API parameters instead of modifying `Timespamp.max` to minimize the impact of this change, but it's debatable.