### PR TITLE
Use psbt to fund and sign transactions

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
@@ -16,8 +16,10 @@
 
 package fr.acinq.eclair.blockchain
 
+import fr.acinq.bitcoin.psbt.Psbt
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, Transaction}
+import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.ProcessPsbtResponse
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import scodec.bits.ByteVector
 
@@ -35,8 +37,10 @@ trait OnChainChannelFunder {
   /** Fund the provided transaction by adding inputs (and a change output if necessary). */
   def fundTransaction(tx: Transaction, feeRate: FeeratePerKw, replaceable: Boolean, lockUtxos: Boolean)(implicit ec: ExecutionContext): Future[FundTransactionResponse]
 
-  /** Sign the wallet inputs of the provided transaction. */
-  def signTransaction(tx: Transaction, allowIncomplete: Boolean)(implicit ec: ExecutionContext): Future[SignTransactionResponse]
+  /**
+   * sign a PSBT. Result may be partially signed: only inputs known to our bitcoin core wallet will be signed
+   */
+  def signPsbt(psbt: Psbt)(implicit ec: ExecutionContext): Future[ProcessPsbtResponse]
 
   /**
    * Publish a transaction on the bitcoin network.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/InteractiveTxBuilder.scala
@@ -19,10 +19,11 @@ package fr.acinq.eclair.channel
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
 import akka.actor.typed.{ActorRef, Behavior}
 import fr.acinq.bitcoin.ScriptFlags
+import fr.acinq.bitcoin.psbt.Psbt
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, LexicographicalOrdering, OutPoint, Satoshi, SatoshiLong, Script, Transaction, TxIn, TxOut}
 import fr.acinq.eclair.blockchain.OnChainChannelFunder
-import fr.acinq.eclair.blockchain.OnChainWallet.SignTransactionResponse
+import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.ProcessPsbtResponse
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.Helpers.Funding
 import fr.acinq.eclair.crypto.ShaChain
@@ -315,6 +316,7 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
    * inputs.
    */
   def fund(txNotFunded: Transaction, currentInputs: Seq[TxAddInput], unusableInputs: Set[UnusableInput]): Behavior[Command] = {
+
     context.pipeToSelf(wallet.fundTransaction(txNotFunded, fundingParams.targetFeerate, replaceable = true, lockUtxos = true)) {
       case Failure(t) => WalletFailure(t)
       case Success(result) => FundTransactionResult(result.tx)
@@ -806,15 +808,18 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
   }
 
   private def signTx(unsignedTx: SharedTransaction, remoteSigs_opt: Option[TxSignatures]): Unit = {
+    import fr.acinq.bitcoin.scalacompat.KotlinUtils._
+
     val tx = unsignedTx.buildUnsignedTx()
     if (unsignedTx.localInputs.isEmpty) {
       context.self ! SignTransactionResult(PartiallySignedSharedTransaction(unsignedTx, TxSignatures(fundingParams.channelId, tx, Nil)), remoteSigs_opt)
     } else {
-      context.pipeToSelf(wallet.signTransaction(tx, allowIncomplete = true).map {
-        case SignTransactionResponse(signedTx, _) =>
+      context.pipeToSelf(wallet.signPsbt(new Psbt(tx)).map {
+        response =>
           val localOutpoints = unsignedTx.localInputs.map(toOutPoint).toSet
-          val sigs = signedTx.txIn.filter(txIn => localOutpoints.contains(txIn.outPoint)).map(_.witness)
-          PartiallySignedSharedTransaction(unsignedTx, TxSignatures(fundingParams.channelId, tx, sigs))
+          val partiallySignedTx = response.extractPartiallySignedTx
+          val sigs = partiallySignedTx.txIn.filter(txIn => localOutpoints.contains(txIn.outPoint)).map(_.witness)
+          PartiallySignedSharedTransaction(unsignedTx, TxSignatures(fundingParams.channelId, partiallySignedTx, sigs))
       }) {
         case Failure(t) => WalletFailure(t)
         case Success(signedTx) => SignTransactionResult(signedTx, remoteSigs_opt)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
@@ -17,16 +17,20 @@
 package fr.acinq.eclair.blockchain
 
 import fr.acinq.bitcoin.TxIn.SEQUENCE_FINAL
+import fr.acinq.bitcoin.psbt.Psbt
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, Crypto, OutPoint, Satoshi, SatoshiLong, Script, Transaction, TxIn, TxOut}
+import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, Crypto, OutPoint, Satoshi, SatoshiLong, Script, Transaction, TxIn, TxOut}
 import fr.acinq.bitcoin.{Bech32, SigHash, SigVersion}
 import fr.acinq.eclair.blockchain.OnChainWallet.{FundTransactionResponse, MakeFundingTxResponse, OnChainBalance, SignTransactionResponse}
+import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
+import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.ProcessPsbtResponse
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.transactions.Transactions
-import fr.acinq.eclair.{randomBytes32, randomKey}
+import fr.acinq.eclair.{addressToPublicKeyScript, randomBytes32, randomKey}
 import scodec.bits._
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.jdk.CollectionConverters.SeqHasAsJava
 
 /**
  * Created by PM on 06/07/2017.
@@ -50,7 +54,7 @@ class DummyOnChainWallet extends OnChainWallet {
     Future.successful(FundTransactionResponse(tx, 0 sat, None))
   }
 
-  override def signTransaction(tx: Transaction, allowIncomplete: Boolean)(implicit ec: ExecutionContext): Future[SignTransactionResponse] = Future.successful(SignTransactionResponse(tx, complete = true))
+  override def signPsbt(psbt: Psbt)(implicit ec: ExecutionContext): Future[BitcoinCoreClient.ProcessPsbtResponse] = Future.successful(ProcessPsbtResponse(psbt, complete = true))
 
   override def publishTransaction(tx: Transaction)(implicit ec: ExecutionContext): Future[ByteVector32] = {
     published += (tx.txid -> tx)
@@ -93,7 +97,7 @@ class NoOpOnChainWallet extends OnChainWallet {
 
   override def fundTransaction(tx: Transaction, feeRate: FeeratePerKw, replaceable: Boolean, lockUtxos: Boolean)(implicit ec: ExecutionContext): Future[FundTransactionResponse] = Promise().future // will never be completed
 
-  override def signTransaction(tx: Transaction, allowIncomplete: Boolean)(implicit ec: ExecutionContext): Future[SignTransactionResponse] = Promise().future // will never be completed
+  override def signPsbt(psbt: Psbt)(implicit ec: ExecutionContext): Future[ProcessPsbtResponse] = Promise().future // will never be completed
 
   override def publishTransaction(tx: Transaction)(implicit ec: ExecutionContext): Future[ByteVector32] = Future.successful(tx.txid)
 
@@ -148,7 +152,7 @@ class SingleKeyOnChainWallet extends OnChainWallet {
     Future.successful(FundTransactionResponse(fundedTx, fee, Some(tx.txOut.length)))
   }
 
-  override def signTransaction(tx: Transaction, allowIncomplete: Boolean)(implicit ec: ExecutionContext): Future[SignTransactionResponse] = {
+  private def signTransaction(tx: Transaction, allowIncomplete: Boolean)(implicit ec: ExecutionContext): Future[SignTransactionResponse] = {
     val signedTx = tx.txIn.zipWithIndex.foldLeft(tx) {
       case (currentTx, (txIn, index)) => inputs.find(_.txid == txIn.outPoint.txid) match {
         case Some(inputTx) =>
@@ -159,6 +163,24 @@ class SingleKeyOnChainWallet extends OnChainWallet {
     }
     val complete = tx.txIn.forall(txIn => inputs.exists(_.txid == txIn.outPoint.txid))
     Future.successful(SignTransactionResponse(signedTx, complete))
+  }
+
+  override def signPsbt(psbt: Psbt)(implicit ec: ExecutionContext): Future[ProcessPsbtResponse] = {
+    import fr.acinq.bitcoin.scalacompat.KotlinUtils._
+
+    val tx: Transaction = psbt.getGlobal.getTx
+    val signedPsbt = tx.txIn.zipWithIndex.foldLeft(new Psbt(tx)) {
+      case (currentPsbt, (txIn, index)) => inputs.find(_.txid == txIn.outPoint.txid) match {
+        case Some(inputTx) =>
+          val sig = Transaction.signInput(tx, index, Script.pay2pkh(pubkey), SigHash.SIGHASH_ALL, inputTx.txOut.head.amount, SigVersion.SIGVERSION_WITNESS_V0, privkey)
+          val updated = currentPsbt.updateWitnessInput(OutPoint(inputTx, 0), inputTx.txOut.head, null, Script.pay2pkh(pubkey).map(scala2kmp).asJava, null, java.util.Map.of()).getRight
+          val finalized = updated.finalizeWitnessInput(OutPoint(inputTx, 0), Script.witnessPay2wpkh(pubkey, sig))
+          finalized.getRight
+        case None => currentPsbt
+      }
+    }
+    val complete = signedPsbt.extract().isRight
+    Future.successful(ProcessPsbtResponse(signedPsbt, complete))
   }
 
   override def publishTransaction(tx: Transaction)(implicit ec: ExecutionContext): Future[ByteVector32] = Future.successful(tx.txid)


### PR DESCRIPTION
Based on https://github.com/ACINQ/eclair/pull/2038. We use bitcoin-kmp's Psbt classes and methods directly (there is no need for a wrapper here imho). 