### PR TITLE
(Minor) Use `sys` package instead of `System` when applicable

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -124,11 +124,10 @@ object NodeParams extends Logging {
    * Order of precedence for the configuration parameters:
    * 1) Java environment variables (-D...)
    * 2) Configuration file eclair.conf
-   * 3) Optionally provided config
-   * 4) Default values in reference.conf
+   * 3) Default values in reference.conf
    */
   def loadConfiguration(datadir: File): Config =
-    ConfigFactory.parseProperties(System.getProperties)
+    ConfigFactory.systemProperties()
       .withFallback(ConfigFactory.parseFile(new File(datadir, "eclair.conf")))
       .withFallback(ConfigFactory.load())
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -105,7 +105,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient) extends OnChainWall
         .recover {
           case JsonRPCError(Error(_, message)) if message.contains("index") =>
             sys.error("Fatal error: bitcoind is indexing!!")
-            sys.exit(1) // bitcoind is indexing, that's a fatal error!!
+            sys.exit(2) // bitcoind is indexing, that's a fatal error!!
             false // won't be reached
           case _ => false
         }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -105,7 +105,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient) extends OnChainWall
         .recover {
           case JsonRPCError(Error(_, message)) if message.contains("index") =>
             sys.error("Fatal error: bitcoind is indexing!!")
-            sys.exit(2) // bitcoind is indexing, that's a fatal error!!
+            sys.exit(1) // bitcoind is indexing, that's a fatal error!!
             false // won't be reached
           case _ => false
         }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -2352,7 +2352,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
                      |
                      |You should get in touch with Eclair developers and provide logs of your node for analysis.
                      |""".stripMargin, cause)
-                System.exit(1)
+                sys.exit(5)
                 stop(FSM.Shutdown)
             }
         }
@@ -2624,7 +2624,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
         case t: SQLException =>
           log.error(t, "fatal database error\n")
           NotificationsLogger.logFatalError("eclair is shutting down because of a fatal database error", t)
-          sys.exit(-2)
+          sys.exit(4)
         case t: Throwable => handleLocalError(t, event.stateData, None)
       }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -2352,7 +2352,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
                      |
                      |You should get in touch with Eclair developers and provide logs of your node for analysis.
                      |""".stripMargin, cause)
-                sys.exit(5)
+                sys.exit(1)
                 stop(FSM.Shutdown)
             }
         }
@@ -2624,7 +2624,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
         case t: SQLException =>
           log.error(t, "fatal database error\n")
           NotificationsLogger.logFatalError("eclair is shutting down because of a fatal database error", t)
-          sys.exit(4)
+          sys.exit(1)
         case t: Throwable => handleLocalError(t, event.stateData, None)
       }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgUtils.scala
@@ -85,7 +85,7 @@ object PgUtils extends JdbcUtils {
       def logAndStop: LockFailureHandler = { ex =>
         log(ex)
         logger.error("db locking error is a fatal error")
-        sys.exit(3)
+        sys.exit(1)
       }
     }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgUtils.scala
@@ -85,7 +85,7 @@ object PgUtils extends JdbcUtils {
       def logAndStop: LockFailureHandler = { ex =>
         log(ex)
         logger.error("db locking error is a fatal error")
-        sys.exit(-2)
+        sys.exit(3)
       }
     }
 

--- a/eclair-front/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-front/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -28,9 +28,9 @@ import scala.util.{Failure, Success}
 
 object Boot extends App with Logging {
   try {
-    val datadir = new File(System.getProperty("eclair.datadir", System.getProperty("user.home") + "/.eclair"))
+    val datadir = new File(sys.props.getOrElse("eclair.datadir", sys.props("user.home") + "/.eclair"))
     val config = ConfigFactory.parseString(
-      Option(System.getenv("AKKA_CONF")).getOrElse("").replace(";", "\n"),
+      sys.env.getOrElse("AKKA_CONF", "").replace(";", "\n"),
       ConfigParseOptions.defaults().setSyntax(ConfigSyntax.PROPERTIES))
       .withFallback(ConfigFactory.parseProperties(System.getProperties))
       .withFallback(ConfigFactory.parseFile(new File(datadir, "eclair.conf")))

--- a/eclair-front/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-front/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -58,6 +58,6 @@ object Boot extends App with Logging {
     val errorMsg = if (t.getMessage != null) t.getMessage else t.getClass.getSimpleName
     System.err.println(s"fatal error: $errorMsg")
     logger.error(s"fatal error: $errorMsg", t)
-    System.exit(1)
+    sys.exit(1)
   }
 }

--- a/eclair-front/src/main/scala/fr/acinq/eclair/ClusterListener.scala
+++ b/eclair-front/src/main/scala/fr/acinq/eclair/ClusterListener.scala
@@ -46,7 +46,7 @@ class ClusterListener(frontJoinedCluster: Promise[Done], backendAddressFound: Pr
   private def maybeShutdown(member: Member): Unit = {
     if (member.roles.contains(BackendRole)) {
       log.info(s"backend is down, stopping...")
-      System.exit(0)
+      sys.exit(0)
     }
   }
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -89,6 +89,6 @@ object Boot extends App with Logging {
     System.err.println(s"fatal error: $errorMsg")
     logger.error(s"fatal error: $errorMsg", t)
     NotificationsLogger.logFatalError("could not start eclair", t)
-    System.exit(1)
+    sys.exit(1)
   }
 }


### PR DESCRIPTION
We use scala's `sys.exit()` instead of java's `System.exit()`, etc.