### PR TITLE
Improve `getsentinfo` accuracy

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -90,6 +90,13 @@ The detailed balance json format has been slightly updated for channels in state
 Amounts corresponding to incoming htlcs for which we knew the preimage were previously included in `toLocal`, they are
 now grouped with outgoing htlcs amounts and the field has been renamed from `htlcOut` to `htlcs`.
 
+#### `getsentinfo`
+
+The `getsentinfo` API has been updated to avoid returning an empty array while a multi-part payment is starting (#2126).
+While a payment is still pending, `getsentinfo` will now return an additional "virtual" entry that summarizes the whole payment.
+This entry uses the same value for `id` and `parentId`, which makes it easy to detect it.
+Once the payment is complete, this entry will be removed (unless it's the only entry, which can happen when there are no routes available to send the payment).
+
 #### Miscellaneous
 
 This release contains many other API updates:

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DualDatabases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DualDatabases.scala
@@ -361,6 +361,11 @@ case class DualPaymentsDb(sqlite: SqlitePaymentsDb, postgres: PgPaymentsDb) exte
     sqlite.updateOutgoingPayment(paymentResult)
   }
 
+  override def completeOutgoingPayment(parentId: UUID): Unit = {
+    runAsync(postgres.completeOutgoingPayment(parentId))
+    sqlite.completeOutgoingPayment(parentId)
+  }
+
   override def getOutgoingPayment(id: UUID): Option[OutgoingPayment] = {
     runAsync(postgres.getOutgoingPayment(id))
     sqlite.getOutgoingPayment(id)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/PaymentsDb.scala
@@ -73,6 +73,9 @@ trait OutgoingPaymentsDb {
   /** Update the status of the payment in case of failure. */
   def updateOutgoingPayment(paymentResult: PaymentFailed): Unit
 
+  /** Complete an outgoing multi-part payment by removing any dummy global entry when child payments exist. */
+  def completeOutgoingPayment(parentId: UUID): Unit
+
   /** Get an outgoing payment attempt. */
   def getOutgoingPayment(id: UUID): Option[OutgoingPayment]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPaymentsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPaymentsDb.scala
@@ -139,6 +139,17 @@ class PgPaymentsDb(implicit ds: DataSource, lock: PgLock) extends PaymentsDb wit
     }
   }
 
+  override def completeOutgoingPayment(parentId: UUID): Unit = withMetrics("payments/complete-outgoing-payment", DbBackends.Postgres) {
+    withLock { pg =>
+      using(pg.prepareStatement("DELETE FROM payments.sent WHERE id = ? AND EXISTS(SELECT 1 FROM payments.sent WHERE parent_id = ? AND id != ? LIMIT 1)")) { statement =>
+        statement.setString(1, parentId.toString)
+        statement.setString(2, parentId.toString)
+        statement.setString(3, parentId.toString)
+        statement.executeUpdate()
+      }
+    }
+  }
+
   private def parseOutgoingPayment(rs: ResultSet): OutgoingPayment = {
     val status = buildOutgoingPaymentStatus(
       rs.getByteVector32FromHexNullable("payment_preimage"),


### PR DESCRIPTION
When using MPP, we previously inserted an entry in the payments DB only after path-finding completed. Meanwhile, `getsentinfo` would return an empty array, so users cannot know that the payment is being attempted. This could lead to users eagerly retrying and double-paying.

We now store an entry in the DB as early as possible, and remove it once the payment is complete (unless the payment failed without sending any HTLC, otherwise `getsentinfo` would return an empty array).

However, this doesn't entirely fix the risk of double-paying, which cannot be completely fixed from inside eclair. External applications that make payments on behalf of users must use the `externalId` and check for double payments themselves before calling eclair if they want to ensure that there's no risk of double payments.

One drawback of this approach that must be properly documented is that while the payment is pending, if the user calls `getsentinfo`, there will be a "global" entry (with `id == parentId`) which could make the user think that there are too many pending outgoing payments and eclair is overpaying. We should document that an entry with `id == paymentId` is a summary of the whole payment, but only entries with `id != parentId` correspond to actual HTLCs. I don't think this is a big issue, users shouldn't be interpreting pending payments on-the-fly and reacting to it, and that "global" entry is removed whenever the payment completes.

Fixes #2055