### PR TITLE
Activate onion messages

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -18,11 +18,27 @@ Node operators should watch this file very regularly.
 An event is also sent to the event stream for every such notification.
 This lets plugins notify the node operator via external systems (push notifications, email, etc).
 
-### Initial support for onion messages
+### Support for onion messages
 
-Eclair now supports the feature `option_onion_messages`. If this feature is enabled, eclair will relay onion messages.
-It can also send onion messages with the `sendonionmessage` API.
-Messages sent to Eclair can be read with the websocket API.
+Eclair now supports the `option_onion_messages` feature (see <https://github.com/lightning/bolts/pull/759)>.
+This feature is enabled by default: eclair will automatically relay onion messages it receives.
+
+By default, eclair will only accept and relay onion messages from peers with whom you have channels.
+You can change that strategy by updating `eclair.onion-messages.relay-policy` in your `eclair.conf`.
+
+Eclair applies some rate-limiting on the number of messages that can be relayed to and from each peer.
+You can choose what limits to apply by updating `eclair.onion-messages.max-per-peer-per-second` in your `eclair.conf`.
+
+Whenever an onion message for your node is received, eclair will emit an event, that can for example be received on the websocket (`onion-message-received`).
+
+You can also send onion messages via the API.
+This will be covered in the API changes section below.
+
+To disable the feature, you can simply update your `eclair.conf`:
+
+```conf
+eclair.features.option_onion_messages = disabled
+```
 
 ### Support for `option_payment_metadata`
 
@@ -80,8 +96,19 @@ Examples:
 #### Sending onion messages
 
 You can now send onion messages with `sendonionmessage`.
-It expects `--recipientNode`, the node id of the recipient if it is known or `--recipientBlindedRoute` a hexadecimal encoded blinded route to send the message to, and `--content` the content of the message as an encoded TLV stream in hexadecimal.
-It also accepts `--intermediateNodes` a list of intermediate node ids to hide the origin of the message and `--replyPath` a possibly empty list of intermediate node ids for the reply path if we expect a response to the message.
+
+There are two ways to specify the recipient:
+
+- when you're sending to a known `nodeId`, you must set it in the `--recipientNode` field
+- when you're sending to an unknown node behind a blinded route, you must provide the blinded route in the `--recipientBlindedRoute` field (hex-encoded)
+
+If you're not connected to the recipient and don't have channels with them, eclair will try connecting to them based on the best address it knows (usually from their `node_announcement`).
+If that fails, or if you don't want to expose your `nodeId` by directly connecting to the recipient, you should find a route to them and specify the nodes in that route in the `--intermediateNodes` field.
+
+You can send arbitrary content to the recipient, by providing a hex-encoded tlv in the `--content` field.
+
+If you expect a response, you should provide a route from the recipient back to you in the `--replyPath` field.
+Eclair will create a corresponding blinded route, and the API will wait for a response (or timeout if it doesn't receive a response).
 
 #### Balance
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -56,7 +56,7 @@ eclair {
     option_anchor_outputs = disabled
     option_anchors_zero_fee_htlc_tx = disabled
     option_shutdown_anysegwit = optional
-    option_onion_messages = disabled
+    option_onion_messages = optional
     option_channel_type = optional
     option_payment_metadata = optional
     trampoline_payment = disabled

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -258,7 +258,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnChainA
             case OnionMessages.DropMessage(reason) =>
               log.debug(s"dropping message from ${remoteNodeId.value.toHex}: ${reason.toString}")
             case OnionMessages.SendMessage(nextNodeId, message) =>
-              switchboard ! RelayMessage(randomBytes32(), Some(remoteNodeId), nextNodeId, message, nodeParams.onionMessageConfig.relayPolicy, ActorRef.noSender.toTyped)
+              switchboard ! RelayMessage(randomBytes32(), Some(remoteNodeId), nextNodeId, message, nodeParams.onionMessageConfig.relayPolicy, None)
             case received: OnionMessages.ReceiveMessage =>
               log.info(s"received message from ${remoteNodeId.value.toHex}: $received")
               context.system.eventStream.publish(received)
@@ -266,9 +266,9 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnChainA
         }
         stay()
 
-      case Event(RelayOnionMessage(messageId, msg, replyTo), d: ConnectedData) =>
+      case Event(RelayOnionMessage(messageId, msg, replyTo_opt), d: ConnectedData) =>
         d.peerConnection ! msg
-        replyTo ! MessageRelay.Sent(messageId)
+        replyTo_opt.foreach(_ ! MessageRelay.Sent(messageId))
         stay()
 
       case Event(unknownMsg: UnknownMessage, d: ConnectedData) if nodeParams.pluginMessageTags.contains(unknownMsg.tag) =>
@@ -300,8 +300,8 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnChainA
 
     case Event(_: Peer.OutgoingMessage, _) => stay() // we got disconnected or reconnected and this message was for the previous connection
 
-    case Event(RelayOnionMessage(messageId, _, replyTo), _) =>
-      replyTo ! MessageRelay.Disconnected(messageId)
+    case Event(RelayOnionMessage(messageId, _, replyTo_opt), _) =>
+      replyTo_opt.foreach(_ ! MessageRelay.Disconnected(messageId))
       stay()
   }
 
@@ -498,7 +498,7 @@ object Peer {
    */
   case class ConnectionDown(peerConnection: ActorRef) extends RemoteTypes
 
-  case class RelayOnionMessage(messageId: ByteVector32, msg: OnionMessage, replyTo: typed.ActorRef[Status])
+  case class RelayOnionMessage(messageId: ByteVector32, msg: OnionMessage, replyTo_opt: Option[typed.ActorRef[Status]])
   // @formatter:on
 
   def makeChannelParams(nodeParams: NodeParams, initFeatures: Features, defaultFinalScriptPubkey: ByteVector, walletStaticPaymentBasepoint: Option[PublicKey], isFunder: Boolean, fundingAmount: Satoshi): LocalParams = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.io
 
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.adapter.{ClassicActorContextOps, ClassicActorRefOps}
+import akka.actor.typed.scaladsl.adapter.ClassicActorContextOps
 import akka.actor.{Actor, ActorContext, ActorLogging, ActorRef, OneForOneStrategy, Props, Status, SupervisorStrategy, typed}
 import fr.acinq.bitcoin.ByteVector32
 import fr.acinq.bitcoin.Crypto.PublicKey
@@ -25,7 +25,7 @@ import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.blockchain.OnChainAddressGenerator
 import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel._
-import fr.acinq.eclair.io.MessageRelay.{RelayAll, RelayPolicy}
+import fr.acinq.eclair.io.MessageRelay.RelayPolicy
 import fr.acinq.eclair.io.Peer.PeerInfoResponse
 import fr.acinq.eclair.remote.EclairInternalsSerializer.RemoteTypes
 import fr.acinq.eclair.router.Router.RouterConf
@@ -67,12 +67,12 @@ class Switchboard(nodeParams: NodeParams, peerFactory: Switchboard.PeerFactory) 
       sender() ! Status.Failure(new RuntimeException("cannot open connection with oneself"))
 
     case Peer.Connect(nodeId, address_opt, replyTo, isPersistent) =>
-        // we create a peer if it doesn't exist: when the peer doesn't exist, we can be sure that we don't have channels,
-        // otherwise the peer would have been created during the initialization step.
+      // we create a peer if it doesn't exist: when the peer doesn't exist, we can be sure that we don't have channels,
+      // otherwise the peer would have been created during the initialization step.
       val peer = createOrGetPeer(nodeId, offlineChannels = Set.empty)
-      val c = if (replyTo == ActorRef.noSender){
+      val c = if (replyTo == ActorRef.noSender) {
         Peer.Connect(nodeId, address_opt, sender(), isPersistent)
-      }else{
+      } else {
         Peer.Connect(nodeId, address_opt, replyTo, isPersistent)
       }
       peer forward c
@@ -112,7 +112,7 @@ class Switchboard(nodeParams: NodeParams, peerFactory: Switchboard.PeerFactory) 
     case GetRouterPeerConf => sender() ! RouterPeerConf(nodeParams.routerConf, nodeParams.peerConnectionConf)
 
     case RelayMessage(messageId, prevNodeId, nextNodeId, dataToRelay, relayPolicy, replyTo) =>
-      val relay = context.spawnAnonymous(MessageRelay())
+      val relay = context.spawn(Behaviors.supervise(MessageRelay()).onFailure(typed.SupervisorStrategy.stop), s"relay-message-$messageId")
       relay ! MessageRelay.RelayMessage(messageId, self, prevNodeId.getOrElse(nodeParams.nodeId), nextNodeId, dataToRelay, relayPolicy, replyTo)
   }
 
@@ -167,6 +167,7 @@ object Switchboard {
   case object GetRouterPeerConf extends RemoteTypes
   case class RouterPeerConf(routerConf: RouterConf, peerConf: PeerConnection.Conf) extends RemoteTypes
 
-  case class RelayMessage(messageId: ByteVector32, prevNodeId: Option[PublicKey], nextNodeId: PublicKey, message: OnionMessage, relayPolicy: RelayPolicy, replyTo: typed.ActorRef[MessageRelay.Status])
+  case class RelayMessage(messageId: ByteVector32, prevNodeId: Option[PublicKey], nextNodeId: PublicKey, message: OnionMessage, relayPolicy: RelayPolicy, replyTo_opt: Option[typed.ActorRef[MessageRelay.Status]])
   // @formatter:on
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
@@ -67,8 +67,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     nodes("B").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
     alice.sendOnionMessage(Nil, Left(nodes("B").nodeParams.nodeId), None, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
-
-    val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
+    eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }
 
   test("expect reply") {
@@ -112,8 +111,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     nodes("A").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
     eve.sendOnionMessage(Nil, Left(nodes("A").nodeParams.nodeId), None, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
-
-    val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
+    eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }
 
   test("send to connected node with no-relay") {
@@ -125,8 +123,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     nodes("A").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
     fabrice.sendOnionMessage(Nil, Left(nodes("A").nodeParams.nodeId), None, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
-
-    val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
+    eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }
 
   test("send with hop") {
@@ -256,8 +253,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
     alice.sendOnionMessage(Nil, Left(nodes("C").nodeParams.nodeId), None, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
-
-    val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
+    eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
 
     // We disconnect A from C for future tests.
     alice.disconnect(nodes("C").nodeParams.nodeId)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/MessageRelaySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/MessageRelaySpec.scala
@@ -58,7 +58,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     val (_, message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(IntermediateNode(aliceId)), Left(Recipient(bobId, None)), Nil)
     val messageId = randomBytes32()
-    relay ! RelayMessage(messageId, switchboard.ref, randomKey().publicKey, bobId, message, RelayAll, probe.ref)
+    relay ! RelayMessage(messageId, switchboard.ref, randomKey().publicKey, bobId, message, RelayAll, None)
 
     val connectToNextPeer = switchboard.expectMsgType[Peer.Connect]
     assert(connectToNextPeer.nodeId === bobId)
@@ -71,7 +71,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     val (_, message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(IntermediateNode(aliceId)), Left(Recipient(bobId, None)), Nil)
     val messageId = randomBytes32()
-    relay ! RelayMessage(messageId, switchboard.ref, randomKey().publicKey, bobId, message, RelayAll, probe.ref)
+    relay ! RelayMessage(messageId, switchboard.ref, randomKey().publicKey, bobId, message, RelayAll, None)
 
     val connectToNextPeer = switchboard.expectMsgType[Peer.Connect]
     assert(connectToNextPeer.nodeId === bobId)
@@ -84,7 +84,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     val (_, message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(IntermediateNode(aliceId)), Left(Recipient(bobId, None)), Nil)
     val messageId = randomBytes32()
-    relay ! RelayMessage(messageId, switchboard.ref, randomKey().publicKey, bobId, message, RelayAll, probe.ref)
+    relay ! RelayMessage(messageId, switchboard.ref, randomKey().publicKey, bobId, message, RelayAll, Some(probe.ref))
 
     val connectToNextPeer = switchboard.expectMsgType[Peer.Connect]
     assert(connectToNextPeer.nodeId === bobId)
@@ -98,7 +98,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     val (_, message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(IntermediateNode(aliceId)), Left(Recipient(bobId, None)), Nil)
     val messageId = randomBytes32()
     val previousNodeId = randomKey().publicKey
-    relay ! RelayMessage(messageId, switchboard.ref, previousNodeId, bobId, message, RelayChannelsOnly, probe.ref)
+    relay ! RelayMessage(messageId, switchboard.ref, previousNodeId, bobId, message, RelayChannelsOnly, Some(probe.ref))
 
     val getPeerInfo = switchboard.expectMsgType[GetPeerInfo]
     assert(getPeerInfo.remoteNodeId === previousNodeId)
@@ -114,7 +114,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     val (_, message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(IntermediateNode(aliceId)), Left(Recipient(bobId, None)), Nil)
     val messageId = randomBytes32()
     val previousNodeId = randomKey().publicKey
-    relay ! RelayMessage(messageId, switchboard.ref, previousNodeId, bobId, message, RelayChannelsOnly, probe.ref)
+    relay ! RelayMessage(messageId, switchboard.ref, previousNodeId, bobId, message, RelayChannelsOnly, Some(probe.ref))
 
     val getPeerInfo1 = switchboard.expectMsgType[GetPeerInfo]
     assert(getPeerInfo1.remoteNodeId === previousNodeId)
@@ -134,7 +134,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     val (_, message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(IntermediateNode(aliceId)), Left(Recipient(bobId, None)), Nil)
     val messageId = randomBytes32()
     val previousNodeId = randomKey().publicKey
-    relay ! RelayMessage(messageId, switchboard.ref, previousNodeId, bobId, message, RelayChannelsOnly, probe.ref)
+    relay ! RelayMessage(messageId, switchboard.ref, previousNodeId, bobId, message, RelayChannelsOnly, None)
 
     val getPeerInfo1 = switchboard.expectMsgType[GetPeerInfo]
     assert(getPeerInfo1.remoteNodeId === previousNodeId)
@@ -153,7 +153,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     val (_, message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(IntermediateNode(aliceId)), Left(Recipient(bobId, None)), Nil)
     val messageId = randomBytes32()
     val previousNodeId = randomKey().publicKey
-    relay ! RelayMessage(messageId, switchboard.ref, previousNodeId, bobId, message, NoRelay, probe.ref)
+    relay ! RelayMessage(messageId, switchboard.ref, previousNodeId, bobId, message, NoRelay, Some(probe.ref))
 
     switchboard.expectNoMessage(100 millis)
     probe.expectMessage(AgainstPolicy(messageId, NoRelay))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -509,7 +509,7 @@ class PeerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Paralle
     val (_, msg) = buildMessage(randomKey(), randomKey(), Nil, Left(Recipient(remoteNodeId, None)), Nil)
     val messageId = randomBytes32()
     val probe = TestProbe()
-    peer ! RelayOnionMessage(messageId, msg, probe.ref.toTyped)
+    peer ! RelayOnionMessage(messageId, msg, Some(probe.ref.toTyped))
     probe.expectMsg(MessageRelay.Sent(messageId))
   }
 
@@ -518,7 +518,7 @@ class PeerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Paralle
     val (_, msg) = buildMessage(randomKey(), randomKey(), Nil, Left(Recipient(remoteNodeId, None)), Nil)
     val messageId = randomBytes32()
     val probe = TestProbe()
-    peer ! RelayOnionMessage(messageId, msg, probe.ref.toTyped)
+    peer ! RelayOnionMessage(messageId, msg, Some(probe.ref.toTyped))
     probe.expectMsg(MessageRelay.Disconnected(messageId))
   }
 }


### PR DESCRIPTION
I believe we can safely activate onion messages by default in our next release.
It will be interesting to see how people use it and what feature requests emerge.
We already have some rate-limiting with safe defaults in place, so I don't think this creates any risk for node operators.
On top of that, it can be very easily disabled (as explained in the release notes).

I also took this opportunity to fix an issue with the supervisor for `MessageRelay` actors, which incorrectly inherited the `resume` strategy (which makes sense for `Peer` actors).
Running the integration tests with logs activated showed many errors and warnings about this, we should have caught it earlier.
I don't know if it is related to the transient test failure we've seen.