### PR TITLE
Add random speed up to replaceable tx publishing

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -145,6 +145,10 @@ eclair {
 
     // number of blocks to target when computing fees for each transaction type
     target-blocks {
+      // When this field is set, eclair will randomly target a more aggressive confirmation window.
+      // This makes eclair's fee-bumping less predictable for potentially malicious peers, and makes force-close
+      // transactions confirm more quickly (at the cost of paying more on-chain fees).
+      randomize = true
       funding = 6                       // target for the funding transaction
       commitment = 2                    // target for the commitment transaction (used in force-close scenario) *do not change this unless you know what you are doing*
       commitment-without-htlcs = 12     // target for the commitment transaction when we have no htlcs to claim (used in force-close scenario) *do not change this unless you know what you are doing*

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -319,7 +319,8 @@ object NodeParams extends Logging {
       commitmentBlockTarget = config.getInt("on-chain-fees.target-blocks.commitment"),
       commitmentWithoutHtlcsBlockTarget = config.getInt("on-chain-fees.target-blocks.commitment-without-htlcs"),
       mutualCloseBlockTarget = config.getInt("on-chain-fees.target-blocks.mutual-close"),
-      claimMainBlockTarget = config.getInt("on-chain-fees.target-blocks.claim-main")
+      claimMainBlockTarget = config.getInt("on-chain-fees.target-blocks.claim-main"),
+      randomize = config.getBoolean("on-chain-fees.target-blocks.randomize")
     )
 
     def getRelayFees(relayFeesConfig: Config): RelayFees = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeEstimator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeEstimator.scala
@@ -30,7 +30,7 @@ trait FeeEstimator {
   // @formatter:on
 }
 
-case class FeeTargets(fundingBlockTarget: Int, commitmentBlockTarget: Int, commitmentWithoutHtlcsBlockTarget: Int, mutualCloseBlockTarget: Int, claimMainBlockTarget: Int)
+case class FeeTargets(fundingBlockTarget: Int, commitmentBlockTarget: Int, commitmentWithoutHtlcsBlockTarget: Int, mutualCloseBlockTarget: Int, claimMainBlockTarget: Int, randomize: Boolean)
 
 /**
  * @param maxExposure              maximum exposure to pending dust htlcs we tolerate: we will automatically fail HTLCs when going above this threshold.

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -102,7 +102,7 @@ object TestConstants {
       dustLimit = 1100 sat,
       maxRemoteDustLimit = 1500 sat,
       onChainFeeConf = OnChainFeeConf(
-        feeTargets = FeeTargets(6, 2, 36, 12, 18),
+        feeTargets = FeeTargets(6, 2, 36, 12, 18, randomize = false),
         feeEstimator = new TestFeeEstimator,
         closeOnOfflineMismatch = true,
         updateFeeMinDiffRatio = 0.1,
@@ -235,7 +235,7 @@ object TestConstants {
       dustLimit = 1000 sat,
       maxRemoteDustLimit = 1500 sat,
       onChainFeeConf = OnChainFeeConf(
-        feeTargets = FeeTargets(6, 2, 36, 12, 18),
+        feeTargets = FeeTargets(6, 2, 36, 12, 18, randomize = false),
         feeEstimator = new TestFeeEstimator,
         closeOnOfflineMismatch = true,
         updateFeeMinDiffRatio = 0.1,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FeeEstimatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FeeEstimatorSpec.scala
@@ -27,7 +27,7 @@ class FeeEstimatorSpec extends AnyFunSuite {
   val defaultFeerateTolerance = FeerateTolerance(0.5, 2.0, FeeratePerKw(2500 sat), DustTolerance(15000 sat, closeOnUpdateFeeOverflow = false))
 
   test("should update fee when diff ratio exceeded") {
-    val feeConf = OnChainFeeConf(FeeTargets(1, 1, 1, 1, 1), new TestFeeEstimator(), closeOnOfflineMismatch = true, updateFeeMinDiffRatio = 0.1, defaultFeerateTolerance, Map.empty)
+    val feeConf = OnChainFeeConf(FeeTargets(1, 1, 1, 1, 1, randomize = false), new TestFeeEstimator(), closeOnOfflineMismatch = true, updateFeeMinDiffRatio = 0.1, defaultFeerateTolerance, Map.empty)
     assert(!feeConf.shouldUpdateFee(FeeratePerKw(1000 sat), FeeratePerKw(1000 sat)))
     assert(!feeConf.shouldUpdateFee(FeeratePerKw(1000 sat), FeeratePerKw(900 sat)))
     assert(!feeConf.shouldUpdateFee(FeeratePerKw(1000 sat), FeeratePerKw(1100 sat)))
@@ -38,7 +38,7 @@ class FeeEstimatorSpec extends AnyFunSuite {
   test("get commitment feerate") {
     val feeEstimator = new TestFeeEstimator()
     val channelType = ChannelTypes.Standard
-    val feeConf = OnChainFeeConf(FeeTargets(1, 2, 6, 1, 1), feeEstimator, closeOnOfflineMismatch = true, updateFeeMinDiffRatio = 0.1, defaultFeerateTolerance, Map.empty)
+    val feeConf = OnChainFeeConf(FeeTargets(1, 2, 6, 1, 1, randomize = false), feeEstimator, closeOnOfflineMismatch = true, updateFeeMinDiffRatio = 0.1, defaultFeerateTolerance, Map.empty)
 
     feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(10000 sat)).copy(blocks_2 = FeeratePerKw(5000 sat)))
     assert(feeConf.getCommitmentFeerate(randomKey().publicKey, channelType, 100000 sat, None) === FeeratePerKw(5000 sat))
@@ -53,7 +53,7 @@ class FeeEstimatorSpec extends AnyFunSuite {
     val defaultMaxCommitFeerate = defaultFeerateTolerance.anchorOutputMaxCommitFeerate
     val overrideNodeId = randomKey().publicKey
     val overrideMaxCommitFeerate = defaultMaxCommitFeerate * 2
-    val feeConf = OnChainFeeConf(FeeTargets(1, 2, 6, 1, 1), feeEstimator, closeOnOfflineMismatch = true, updateFeeMinDiffRatio = 0.1, defaultFeerateTolerance, Map(overrideNodeId -> defaultFeerateTolerance.copy(anchorOutputMaxCommitFeerate = overrideMaxCommitFeerate)))
+    val feeConf = OnChainFeeConf(FeeTargets(1, 2, 6, 1, 1, randomize = false), feeEstimator, closeOnOfflineMismatch = true, updateFeeMinDiffRatio = 0.1, defaultFeerateTolerance, Map(overrideNodeId -> defaultFeerateTolerance.copy(anchorOutputMaxCommitFeerate = overrideMaxCommitFeerate)))
 
     feeEstimator.setFeerate(FeeratesPerKw.single(FeeratePerKw(10000 sat)).copy(blocks_2 = defaultMaxCommitFeerate / 2, mempoolMinFee = FeeratePerKw(250 sat)))
     assert(feeConf.getCommitmentFeerate(defaultNodeId, ChannelTypes.AnchorOutputs, 100000 sat, None) === defaultMaxCommitFeerate / 2)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -41,7 +41,7 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   implicit val log: akka.event.LoggingAdapter = akka.event.NoLogging
 
   val feeConfNoMismatch = OnChainFeeConf(
-    FeeTargets(6, 2, 12, 2, 6),
+    FeeTargets(6, 2, 12, 2, 6, randomize = false),
     new TestFeeEstimator(),
     closeOnOfflineMismatch = false,
     1.0,


### PR DESCRIPTION
Now that #2113 is out of the way, we can start tweaking and making small improvements to the fee-bumping mechanism.

A deterministic schedule for confirmation during force-close scenarios could in theory help malicious peers starve us of our utxos in a high-fee environment, making it hard to fee-bump HTLC transactions.

Adding some randomness into the mix to non-deterministically speed up confirmations (which gives us newly confirmed utxos to bump other txs) shouldn't hurt.