### PR TITLE
Postgres: add safety checks at startup

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -75,6 +75,27 @@ This is particularly useful for payment hubs that generate a lot of invoices (e.
 Eclair includes a small `payment_metadata` field in all invoices it generates.
 This lets node operators verify that payers actually support that feature.
 
+### Optional safety checks when using Postgres
+
+When using postgres, at startup we optionnally run a few basic safety checks, e.g. the number of local channels, how long since the last local channel update, etc. The goal is to make sure that we are connected to the correct database instance.
+
+Those checks are configured as follows and are disabled by default:
+```
+eclair.db.postgres.safety-checks {
+  enabled = false
+  max-age {
+    local-channels = 3 minutes
+    network-nodes = 30 minutes
+    audit-relayed = 10 minutes
+  }
+  min-count {
+    local-channels = 10
+    network-nodes = 3000
+    network-channels = 20000
+  }
+}
+```
+
 ### API changes
 
 #### Timestamps

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -77,12 +77,13 @@ This lets node operators verify that payers actually support that feature.
 
 ### Optional safety checks when using Postgres
 
-When using postgres, at startup we optionnally run a few basic safety checks, e.g. the number of local channels, how long since the last local channel update, etc. The goal is to make sure that we are connected to the correct database instance.
+When using postgres, at startup we optionally run a few basic safety checks, e.g. the number of local channels, how long since the last local channel update, etc. The goal is to make sure that we are connected to the correct database instance.
 
-Those checks are configured as follows and are disabled by default:
+Those checks are disabled by default because they wouldn't pass on a fresh new node with zero channels. You should enable them when you already have channels, so that there is something to compare to, and the values should be specific to your setup, particularly for local channels. Configuration is done by overriding `max-age` and `min-count` values in your `eclair.conf`:  
 ```
-eclair.db.postgres.safety-checks {
-  enabled = false
+eclair.db.postgres.safety-checks
+ {
+  enabled = true
   max-age {
     local-channels = 3 minutes
     network-nodes = 30 minutes

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -328,17 +328,22 @@ eclair {
         auto-release-at-shutdown = true // automatically release the lock when eclair is stopping
       }
       safety-checks {
-        // a set of basic checks on data to make sure we use the correct database
+        // A set of basic checks on data to make sure we use the correct database
+        // Those checks are disabled by default because they wouldn't pass on a fresh new node with
+        // zero channels. You should enable them when you already have channels, so that there is
+        // something to compare to, and the values should be specific to your setup, especially
+        // for local channels. If your operate a busy node, you can reduce max-age.local-channels
+        // and max-age.audit-relayed to just a few minutes, this will significantly improve the safety.
         enabled = false
         max-age {
-          local-channels = 3 minutes
-          network-nodes = 30 minutes
-          audit-relayed = 10 minutes
+          local-channels = 15 minutes // last time a local channel was updated
+          network-nodes = 30 minutes // most recent public node announcement
+          audit-relayed = 1 hour // last time a payment was relayed
         }
         min-count {
-          local-channels = 10
-          network-nodes = 3000
-          network-channels = 20000
+          local-channels = 10 // minimum number of local channels, this entirely depends on your setup
+          network-nodes = 3000 // minimum number of public nodes in the routing table
+          network-channels = 20000 // minimum number of public channels in the routing table
         }
       }
     }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -327,6 +327,20 @@ eclair {
         lock-timeout = 5 seconds // timeout for the lock statement on the lease table
         auto-release-at-shutdown = true // automatically release the lock when eclair is stopping
       }
+      safety-checks {
+        // a set of basic checks on data to make sure we use the correct database
+        enabled = false
+        max-age {
+          local-channels = 3 minutes
+          network-nodes = 30 minutes
+          audit-relayed = 10 minutes
+        }
+        min-count {
+          local-channels = 10
+          network-nodes = 3000
+          network-channels = 20000
+        }
+      }
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
@@ -218,7 +218,7 @@ object Databases extends Logging {
               val count = statement
                 .executeQuery(sqlQuery)
                 .map(_.getInt("count"))
-                .head
+                .head // NB: COUNT(*) always returns exactly one row
               require(count >= minCount, s"db check failed: min count not reached for $name ($count < $minCount)")
               logger.info(s"db check ok: min count $count > $minCount for $name")
             }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
@@ -111,7 +111,7 @@ object TestDatabases {
     // @formatter:off
     override val connection: PgConnection = pg.getPostgresDatabase.getConnection.asInstanceOf[PgConnection]
     // NB: we use a lazy val here: databases won't be initialized until we reference that variable
-    override lazy val db: Databases = Databases.PostgresDatabases(hikariConfig, UUID.randomUUID(), lock, jdbcUrlFile_opt = Some(jdbcUrlFile), readOnlyUser_opt = None, resetJsonColumns = false)
+    override lazy val db: Databases = Databases.PostgresDatabases(hikariConfig, UUID.randomUUID(), lock, jdbcUrlFile_opt = Some(jdbcUrlFile), readOnlyUser_opt = None, resetJsonColumns = false, safetyChecks_opt = None)
     override def close(): Unit = pg.close()
     // @formatter:on
   }


### PR DESCRIPTION
When using postgres, at startup we optionnally run a few basic safety checks, e.g. the number of local channels, how long since the last local channel update, etc. The goal is to make sure that we are connected to the correct database instance.