### PR TITLE
Make safety checks independent from db backend

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -333,24 +333,24 @@ eclair {
         lock-timeout = 5 seconds // timeout for the lock statement on the lease table
         auto-release-at-shutdown = true // automatically release the lock when eclair is stopping
       }
-      safety-checks {
-        // A set of basic checks on data to make sure we use the correct database
-        // Those checks are disabled by default because they wouldn't pass on a fresh new node with
-        // zero channels. You should enable them when you already have channels, so that there is
-        // something to compare to, and the values should be specific to your setup, especially
-        // for local channels. If your operate a busy node, you can reduce max-age.local-channels
-        // and max-age.audit-relayed to just a few minutes, this will significantly improve the safety.
-        enabled = false
-        max-age {
-          local-channels = 15 minutes // last time a local channel was updated
-          network-nodes = 30 minutes // most recent public node announcement
-          audit-relayed = 1 hour // last time a payment was relayed
-        }
-        min-count {
-          local-channels = 10 // minimum number of local channels, this entirely depends on your setup
-          network-nodes = 3000 // minimum number of public nodes in the routing table
-          network-channels = 20000 // minimum number of public channels in the routing table
-        }
+    }
+    safety-checks {
+      // A set of basic checks on data to make sure we use the correct database
+      // Those checks are disabled by default because they wouldn't pass on a fresh new node with
+      // zero channels. You should enable them when you already have channels, so that there is
+      // something to compare to, and the values should be specific to your setup, especially
+      // for local channels. If your operate a busy node, you can reduce max-age.local-channels
+      // and max-age.audit-relayed to just a few minutes, this will significantly improve the safety.
+      enabled = false
+      max-age {
+        local-channels = 15 minutes // last time a local channel was updated
+        network-nodes = 30 minutes // most recent public node announcement
+        audit-relayed = 1 hour // last time a payment was relayed
+      }
+      min-count {
+        local-channels = 10 // minimum number of local channels, this entirely depends on your setup
+        network-nodes = 3000 // minimum number of public nodes in the routing table. NB: ignored on sqlite!
+        network-channels = 20000 // minimum number of public channels in the routing table
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteAuditDb.scala
@@ -37,7 +37,7 @@ object SqliteAuditDb {
   val CURRENT_VERSION = 8
 }
 
-class SqliteAuditDb(sqlite: Connection) extends AuditDb with Logging {
+class SqliteAuditDb(val sqlite: Connection) extends AuditDb with Logging {
 
   import SqliteUtils._
   import ExtendedResultSet._

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -34,7 +34,7 @@ object SqliteNetworkDb {
   val DB_NAME = "network"
 }
 
-class SqliteNetworkDb(sqlite: Connection) extends NetworkDb with Logging {
+class SqliteNetworkDb(val sqlite: Connection) extends NetworkDb with Logging {
 
   import SqliteNetworkDb._
   import SqliteUtils.ExtendedResultSet._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/InitChecksSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/InitChecksSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.db
+
+import fr.acinq.eclair.db.Databases.SafetyChecks
+import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
+import fr.acinq.eclair.payment.ChannelPaymentRelayed
+import fr.acinq.eclair.router.Announcements
+import fr.acinq.eclair.wire.internal.channel.ChannelCodecsSpec
+import fr.acinq.eclair.wire.protocol._
+import fr.acinq.eclair.{Features, MilliSatoshiLong, TestDatabases, TimestampMilli, TimestampSecond, randomBytes32, randomKey}
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.concurrent.duration.DurationInt
+
+class InitChecksSpec extends AnyFunSuite {
+
+  import fr.acinq.eclair.TestDatabases.forAllDbs
+
+  test("db init checks") {
+    forAllDbs { db: TestDatabases =>
+
+      // populating data
+      db.channels.addOrUpdateChannel(ChannelCodecsSpec.normal)
+      db.channels.updateChannelMeta(ChannelCodecsSpec.normal.channelId, ChannelEvent.EventType.Created)
+      db.network.addNode(Announcements.makeNodeAnnouncement(randomKey(), "node-A", Color(50, 99, -80), Nil, Features.empty, TimestampSecond.now() - 45.days))
+      db.network.addNode(Announcements.makeNodeAnnouncement(randomKey(), "node-B", Color(50, 99, -80), Nil, Features.empty, TimestampSecond.now() - 3.days))
+      db.network.addNode(Announcements.makeNodeAnnouncement(randomKey(), "node-C", Color(50, 99, -80), Nil, Features.empty, TimestampSecond.now() - 7.minutes))
+      db.audit.add(ChannelPaymentRelayed(421 msat, 400 msat, randomBytes32(), randomBytes32(), randomBytes32(), TimestampMilli.now() - 3.seconds))
+
+      // this check is passing
+      db.check(SafetyChecks(
+        localChannelsMaxAge = 3 minutes,
+        networkNodesMaxAge = 30 minutes,
+        auditRelayedMaxAge = 10 minutes,
+        localChannelsMinCount = 1,
+        networkNodesMinCount = 2,
+        networkChannelsMinCount = 0
+      ))
+
+      // this check is failing
+      intercept[IllegalArgumentException] {
+        db.check(SafetyChecks(
+          localChannelsMaxAge = 3 minutes,
+          networkNodesMaxAge = 30 minutes,
+          auditRelayedMaxAge = 10 minutes,
+          localChannelsMinCount = 10,
+          networkNodesMinCount = 2,
+          networkChannelsMinCount = 0
+        ))
+      }
+    }
+  }
+
+
+}
+
+


### PR DESCRIPTION
Should we rename `safety-checks` to `init-checks`?