### PR TITLE
Ignore revoked htlcs after restart

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/PostRestartHtlcCleaner.scala
@@ -366,11 +366,13 @@ object PostRestartHtlcCleaner {
             val overriddenHtlcs: Set[Long] = (closingType_opt match {
               case Some(c: Closing.LocalClose) => Closing.overriddenOutgoingHtlcs(d, c.localCommitPublished.commitTx)
               case Some(c: Closing.RemoteClose) => Closing.overriddenOutgoingHtlcs(d, c.remoteCommitPublished.commitTx)
+              case Some(c: Closing.RevokedClose) => Closing.overriddenOutgoingHtlcs(d, c.revokedCommitPublished.commitTx)
               case _ => Set.empty[UpdateAddHtlc]
             }).map(_.id)
             val irrevocablySpent = closingType_opt match {
               case Some(c: Closing.LocalClose) => c.localCommitPublished.irrevocablySpent.values.toSeq
               case Some(c: Closing.RemoteClose) => c.remoteCommitPublished.irrevocablySpent.values.toSeq
+              case Some(c: Closing.RevokedClose) => c.revokedCommitPublished.irrevocablySpent.values.toSeq
               case _ => Nil
             }
             val timedOutHtlcs: Set[Long] = (closingType_opt match {


### PR DESCRIPTION
When we restart, if a downstream channel is closing with a revoked commit, we should fail the corresponding htlcs in upstream channels (because we will claim all the outgoing htlcs on-chain).

Otherwise they will be ignored until they timeout, which will cause the upstream channel to force-close (because if the revoked commit has previously been confirmed, we will not put a `WatchConfirmed` on it after a restart so we won't have the opportunity to run the corresponding `Channel.scala` code).