### PR TITLE
Don't broadcast commit before funding locked

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -2391,6 +2391,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
       case negotiating@DATA_NEGOTIATING(_, _, _, _, Some(bestUnpublishedClosingTx)) =>
         // if we were in the process of closing and already received a closing sig from the counterparty, it's always better to use that
         handleMutualClose(bestUnpublishedClosingTx, Left(negotiating))
+      case d: DATA_WAIT_FOR_FUNDING_CONFIRMED if Closing.nothingAtStake(d) => goto(CLOSED) // the channel was never used and the funding tx may be double-spent
       case hasCommitments: HasCommitments => spendLocalCurrent(hasCommitments) // NB: we publish the commitment even if we have nothing at stake (in a dataloss situation our peer will send us an error just for that)
       case _ => goto(CLOSED) // when there is no commitment yet, we just go to CLOSED state in case an error occurs
     }


### PR DESCRIPTION
If a channel is force-closed before the funding transaction is deeply confirmed, broadcasting our local commit can be a problem if the funding tx is double spent. When that happens, the channel stays stuck in the closing state trying to publish a commit tx with an invalid input.

If we haven't even seen the funding tx in the mempool, we have no way of being sure that it was double spent, so we would need to keep trying forever, which pollutes the logs with publishing errors.

Whenever we have nothing at stake and a channel closes before reaching the normal state, we now directly go to closed.