### PR TITLE
fixup! Convert wiki pages in to files in the docs directory and general docs file cleanups

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -15,7 +15,7 @@ Then you'll have to install jq:
 
 - Download the eclair-cli file from [our sources](https://github.com/ACINQ/eclair/blob/master/eclair-core/eclair-cli)
 - (optional) Move the file to `~/bin`
-- Enable the [JSON API](https://github.com/ACINQ/eclair/wiki/API) in your `eclair.conf` settings.
+- Enable the [JSON API](./API.md) in your `eclair.conf` settings.
 
 Run this command to list the available calls:
 


### PR DESCRIPTION
Fixup for  #2165,  Usage.md  should link to ./API.md and not the deprecated wiki