### PR TITLE
Better handling of failed incoming htlcs during force-close

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
@@ -112,12 +112,12 @@ object CheckBalance {
     import l._
     val toLocal = localCommitPublished.claimMainDelayedOutputTx.toSeq.map(c => c.tx.txid -> c.tx.txOut.head.amount.toBtc).toMap
     // incoming htlcs for which we have a preimage and the to-local delay has expired: we have published a claim tx that pays directly to our wallet
-    val htlcsInOnChain = localCommitPublished.htlcTxs.values.flatten.collect { case htlcTx: HtlcSuccessTx => htlcTx }
+    val htlcsInOnChain = localCommitPublished.htlcTxs.values.collect { case LocalCommitPublished.HtlcOutputStatus.Spendable(htlcTx: HtlcSuccessTx) => htlcTx }
       .filter(htlcTx => localCommitPublished.claimHtlcDelayedTxs.exists(_.input.outPoint.txid == htlcTx.tx.txid))
       .map(_.htlcId)
       .toSet
     // outgoing htlcs that have timed out and the to-local delay has expired: we have published a claim tx that pays directly to our wallet
-    val htlcsOutOnChain = localCommitPublished.htlcTxs.values.flatten.collect { case htlcTx: HtlcTimeoutTx => htlcTx }
+    val htlcsOutOnChain = localCommitPublished.htlcTxs.values.collect { case LocalCommitPublished.HtlcOutputStatus.Spendable(htlcTx: HtlcTimeoutTx) => htlcTx }
       .filter(htlcTx => localCommitPublished.claimHtlcDelayedTxs.exists(_.input.outPoint.txid == htlcTx.tx.txid))
       .map(_.htlcId)
       .toSet

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -2491,11 +2491,11 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
     val publishQueue = commitments.commitmentFormat match {
       case Transactions.DefaultCommitmentFormat =>
         val redeemableHtlcTxs = htlcTxs.values.collect { case LocalCommitPublished.HtlcOutputStatus.Spendable(TxGenerationResult.Success(tx)) => PublishFinalTx(tx, tx.fee, Some(commitTx.txid)) }
-        List(PublishFinalTx(commitTx, commitInput, "commit-tx", Closing.commitTxFee(commitments.commitInput, commitTx, isFunder), None)) ++ (claimMainDelayedOutputTx.toOption.map(tx => PublishFinalTx(tx, tx.fee, None)) ++ redeemableHtlcTxs ++ claimHtlcDelayedTxs.flatMap(_.toOption).map(tx => PublishFinalTx(tx, tx.fee, None)))
+        List(PublishFinalTx(commitTx, commitInput, "CommitTx", Closing.commitTxFee(commitments.commitInput, commitTx, isFunder), None)) ++ (claimMainDelayedOutputTx.toOption.map(tx => PublishFinalTx(tx, tx.fee, None)) ++ redeemableHtlcTxs ++ claimHtlcDelayedTxs.flatMap(_.toOption).map(tx => PublishFinalTx(tx, tx.fee, None)))
       case _: Transactions.AnchorOutputsCommitmentFormat =>
         val redeemableHtlcTxs = htlcTxs.values.collect { case LocalCommitPublished.HtlcOutputStatus.Spendable(TxGenerationResult.Success(tx)) => PublishReplaceableTx(tx, commitments) }
         val claimLocalAnchor = claimAnchorTxs.collect { case TxGenerationResult.Success(tx: Transactions.ClaimLocalAnchorOutputTx) => PublishReplaceableTx(tx, commitments) }
-        List(PublishFinalTx(commitTx, commitInput, "commit-tx", Closing.commitTxFee(commitments.commitInput, commitTx, isFunder), None)) ++ claimLocalAnchor ++ claimMainDelayedOutputTx.toOption.map(tx => PublishFinalTx(tx, tx.fee, None)) ++ redeemableHtlcTxs ++ claimHtlcDelayedTxs.flatMap(_.toOption).map(tx => PublishFinalTx(tx, tx.fee, None))
+        List(PublishFinalTx(commitTx, commitInput, "CommitTx", Closing.commitTxFee(commitments.commitInput, commitTx, isFunder), None)) ++ claimLocalAnchor ++ claimMainDelayedOutputTx.toOption.map(tx => PublishFinalTx(tx, tx.fee, None)) ++ redeemableHtlcTxs ++ claimHtlcDelayedTxs.flatMap(_.toOption).map(tx => PublishFinalTx(tx, tx.fee, None))
     }
     publishIfNeeded(publishQueue, irrevocablySpent)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -2564,7 +2564,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, remo
   private def doPublish(remoteCommitPublished: RemoteCommitPublished, commitments: Commitments): Unit = {
     import remoteCommitPublished._
 
-    val redeemableHtlcTxs = claimHtlcTxs.values.flatten.map(tx => PublishReplaceableTx(tx, commitments))
+    val redeemableHtlcTxs = claimHtlcTxs.values.collect { case RemoteCommitPublished.HtlcOutputStatus.Spendable(tx) => PublishReplaceableTx(tx, commitments) }
     val publishQueue = claimMainOutputTx.map(tx => PublishFinalTx(tx, tx.fee, None)).toSeq ++ redeemableHtlcTxs
     publishIfNeeded(publishQueue, irrevocablySpent)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -391,12 +391,17 @@ object RemoteCommitPublished {
 /**
  * Details about a force-close where they published one of their revoked commitments.
  *
- * @param claimMainOutputTx          tx claiming our main output (if we have one).
+ * @param claimMainOutputTx_opt      tx claiming our main output (if we have one).
  * @param mainPenaltyTx              penalty tx claiming their main output (if they have one).
  * @param htlcPenaltyTxs             penalty txs claiming every HTLC output.
  * @param claimHtlcDelayedPenaltyTxs penalty txs claiming the output of their HTLC txs (if they managed to get them confirmed before our htlcPenaltyTxs).
  */
-case class RevokedCommitPublished(commitTx: Transaction, claimMainOutputTx: Option[ClaimRemoteCommitMainOutputTx], mainPenaltyTx: Option[MainPenaltyTx], htlcPenaltyTxs: List[HtlcPenaltyTx], claimHtlcDelayedPenaltyTxs: List[ClaimHtlcDelayedOutputPenaltyTx], irrevocablySpent: Map[OutPoint, Transaction]) extends CommitPublished {
+case class RevokedCommitPublished(commitTx: Transaction,
+                                  claimMainOutputTx_opt: Option[TxGenerationResult[ClaimRemoteCommitMainOutputTx]],
+                                  mainPenaltyTx: TxGenerationResult[MainPenaltyTx],
+                                  htlcPenaltyTxs: List[TxGenerationResult[HtlcPenaltyTx]],
+                                  claimHtlcDelayedPenaltyTxs: List[TxGenerationResult[ClaimHtlcDelayedOutputPenaltyTx]],
+                                  irrevocablySpent: Map[OutPoint, Transaction]) extends CommitPublished {
   /**
    * A revoked commit is considered done when all commitment tx outputs that we can spend have been spent and confirmed
    * (even if the spending tx was not ours).
@@ -406,17 +411,18 @@ case class RevokedCommitPublished(commitTx: Transaction, claimMainOutputTx: Opti
     // is the commitment tx confirmed (we need to check this because we may not have any outputs)?
     val isCommitTxConfirmed = confirmedTxs.contains(commitTx.txid)
     // are there remaining spendable outputs from the commitment tx?
-    val unspentCommitTxOutputs = {
-      val commitOutputsSpendableByUs = (claimMainOutputTx.toSeq ++ mainPenaltyTx.toSeq ++ htlcPenaltyTxs).map(_.input.outPoint)
-      commitOutputsSpendableByUs.toSet -- irrevocablySpent.keys
+    val isMainOutputsConfirmed = claimMainOutputTx_opt match {
+      case Some(claimMainOutputTx) => claimMainOutputTx.isDone(irrevocablySpent)
+      case None => true // this commit tx pays directly to our wallet, there is no claim tx
     }
+    val isMainPenaltyTxSpent = mainPenaltyTx.isDone(irrevocablySpent)
+    val allHtlcsSpent = htlcPenaltyTxs.forall(_.isDone(irrevocablySpent))
     // are all outputs from htlc txs spent?
-    val unconfirmedHtlcDelayedTxs = claimHtlcDelayedPenaltyTxs.map(_.input.outPoint)
+    val allHtlcsDelayedSpent = claimHtlcDelayedPenaltyTxs
       // only the txs which parents are already confirmed may get confirmed (note that this eliminates outputs that have been double-spent by a competing tx)
-      .filter(input => confirmedTxs.contains(input.txid))
-      // if one of the tx inputs has been spent, the tx has already been confirmed or a competing tx has been confirmed
-      .filterNot(input => irrevocablySpent.contains(input))
-    isCommitTxConfirmed && unspentCommitTxOutputs.isEmpty && unconfirmedHtlcDelayedTxs.isEmpty
+      .collect { case txGen@TxGenerationResult.Success(tx) if confirmedTxs.contains(tx.input.outPoint.txid) => txGen }
+      .forall(txGen => txGen.isDone(irrevocablySpent))
+    isCommitTxConfirmed && isMainOutputsConfirmed && isMainPenaltyTxSpent && allHtlcsSpent && allHtlcsDelayedSpent
   }
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -307,7 +307,7 @@ case class LocalCommitPublished(commitTx: Transaction, claimMainDelayedOutputTx:
     // are all htlc outputs from the commitment tx spent (we need to check them all because we may receive preimages later)?
     val allHtlcsSpent = htlcTxs.forall {
       case (outPoint, _: LocalCommitPublished.HtlcOutputStatus.Spendable) => irrevocablySpent.contains(outPoint)
-      case (outPoint, LocalCommitPublished.HtlcOutputStatus.Unknown) => irrevocablySpent.contains(outPoint)
+      case (outPoint, LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement) => irrevocablySpent.contains(outPoint)
       case (_, LocalCommitPublished.HtlcOutputStatus.Unspendable) => true // we will never be able to spend this output so we ignore it (our counterparty may forget to spend it and cause us to wait forever)
     }
     // are all outputs from htlc txs spent?
@@ -329,8 +329,8 @@ object LocalCommitPublished {
   object HtlcOutputStatus {
     /** We know how to spend this output */
     case class Spendable(htlcTx: HtlcTx) extends HtlcOutputStatus
-    /** We may be able to spend incoming htlcs outputs if we get the preimage for the next node */
-    case object Unknown extends HtlcOutputStatus
+    /** We may be able to spend incoming htlcs outputs if we get the preimage from the next node */
+    case object PendingDownstreamSettlement extends HtlcOutputStatus
     /** We know for sure that we will never be able to spend this incoming htlc output, because we got a failure from the next node in the route*/
     case object Unspendable extends HtlcOutputStatus
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -17,6 +17,7 @@
 package fr.acinq.eclair.channel
 
 import akka.event.{DiagnosticLoggingAdapter, LoggingAdapter}
+import fr.acinq.bitcoin.Block.LivenetGenesisBlock
 import fr.acinq.bitcoin.Crypto.{PrivateKey, PublicKey, sha256}
 import fr.acinq.bitcoin.Script._
 import fr.acinq.bitcoin._
@@ -38,6 +39,7 @@ import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
+import scala.reflect.runtime.universe._
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -137,7 +139,7 @@ object Helpers {
     val localFeeratePerKw = nodeParams.onChainFeeConf.getCommitmentFeerate(remoteNodeId, channelType, open.fundingSatoshis, None)
     if (nodeParams.onChainFeeConf.feerateToleranceFor(remoteNodeId).isFeeDiffTooHigh(channelType, localFeeratePerKw, open.feeratePerKw)) return Left(FeerateTooDifferent(open.temporaryChannelId, localFeeratePerKw, open.feeratePerKw))
     // only enforce dust limit check on mainnet
-    if (nodeParams.chainHash == Block.LivenetGenesisBlock.hash) {
+    if (nodeParams.chainHash == LivenetGenesisBlock.hash) {
       if (open.dustLimitSatoshis < Channel.MIN_DUST_LIMIT) return Left(DustLimitTooSmall(open.temporaryChannelId, open.dustLimitSatoshis, Channel.MIN_DUST_LIMIT))
     }
 
@@ -171,7 +173,7 @@ object Helpers {
 
     if (accept.maxAcceptedHtlcs > Channel.MAX_ACCEPTED_HTLCS) return Left(InvalidMaxAcceptedHtlcs(accept.temporaryChannelId, accept.maxAcceptedHtlcs, Channel.MAX_ACCEPTED_HTLCS))
     // only enforce dust limit check on mainnet
-    if (nodeParams.chainHash == Block.LivenetGenesisBlock.hash) {
+    if (nodeParams.chainHash == LivenetGenesisBlock.hash) {
       if (accept.dustLimitSatoshis < Channel.MIN_DUST_LIMIT) return Left(DustLimitTooSmall(accept.temporaryChannelId, accept.dustLimitSatoshis, Channel.MIN_DUST_LIMIT))
     }
 
@@ -604,7 +606,8 @@ object Helpers {
     }
 
     /** Wraps transaction generation in a Try and filters failures to avoid one transaction negatively impacting a whole commitment. */
-    private def withTxGenerationLog[T <: TransactionWithInputInfo](desc: String, logSuccess: Boolean = true, logSkipped: Boolean = true, logFailure: Boolean = true)(generateTx: => TxGenerationResult[T])(implicit log: LoggingAdapter): TxGenerationResult[T] = {
+    private def withTxGenerationLog[T <: TransactionWithInputInfo: TypeTag](logSuccess: Boolean = true, logSkipped: Boolean = true, logFailure: Boolean = true)(generateTx: => TxGenerationResult[T])(implicit log: LoggingAdapter): TxGenerationResult[T] = {
+      val desc = typeOf[T].typeSymbol.name.toString
       Try {
         generateTx
       } match {
@@ -647,7 +650,7 @@ object Helpers {
       val feeratePerKwDelayed = feeEstimator.getFeeratePerKw(feeTargets.claimMainBlockTarget)
 
       // first we will claim our main output as soon as the delay is over
-      val mainDelayedTx = withTxGenerationLog("local-main-delayed") {
+      val mainDelayedTx = withTxGenerationLog() {
         Transactions.makeClaimLocalDelayedOutputTx(tx, localParams.dustLimit, localRevocationPubkey, remoteParams.toSelfDelay, localDelayedPubkey, localParams.defaultFinalScriptPubKey, feeratePerKwDelayed).map(claimDelayed => {
           val sig = keyManager.sign(claimDelayed, keyManager.delayedPaymentPoint(channelKeyPath), localPerCommitmentPoint, TxOwner.Local, commitmentFormat)
           Transactions.addSigs(claimDelayed, sig)
@@ -665,7 +668,7 @@ object Helpers {
         case HtlcTxAndRemoteSig(txInfo@HtlcSuccessTx(_, _, paymentHash, _, _), remoteSig) =>
           if (preimages.contains(paymentHash)) {
             // incoming htlc for which we have the preimage: we can spend it immediately
-            txInfo.input.outPoint -> LocalCommitPublished.HtlcOutputStatus.Spendable(withTxGenerationLog("htlc-success") {
+            txInfo.input.outPoint -> LocalCommitPublished.HtlcOutputStatus.Spendable(withTxGenerationLog() {
               val localSig = keyManager.sign(txInfo, keyManager.htlcPoint(channelKeyPath), localPerCommitmentPoint, TxOwner.Local, commitmentFormat)
               TxGenerationResult.Success(Transactions.addSigs(txInfo, localSig, remoteSig, preimages(paymentHash), commitmentFormat))
             })
@@ -679,7 +682,7 @@ object Helpers {
           }
         case HtlcTxAndRemoteSig(txInfo: HtlcTimeoutTx, remoteSig) =>
           // outgoing htlc: they may or may not have the preimage, the only thing to do is try to get back our funds after timeout
-          txInfo.input.outPoint -> LocalCommitPublished.HtlcOutputStatus.Spendable(withTxGenerationLog("htlc-timeout") {
+          txInfo.input.outPoint -> LocalCommitPublished.HtlcOutputStatus.Spendable(withTxGenerationLog() {
             val localSig = keyManager.sign(txInfo, keyManager.htlcPoint(channelKeyPath), localPerCommitmentPoint, TxOwner.Local, commitmentFormat)
             TxGenerationResult.Success(Transactions.addSigs(txInfo, localSig, remoteSig, commitmentFormat))
           })
@@ -688,10 +691,10 @@ object Helpers {
       // If we don't have pending HTLCs, we don't have funds at risk, so we can aim for a slower confirmation.
       val confirmCommitBefore = htlcTxs.values.collect { case LocalCommitPublished.HtlcOutputStatus.Spendable(TxGenerationResult.Success(htlcTx)) => htlcTx.confirmBefore }.minOption.getOrElse(currentBlockHeight + feeTargets.commitmentWithoutHtlcsBlockTarget)
       val claimAnchorTxs: List[TxGenerationResult[ClaimAnchorOutputTx]] = List(
-        withTxGenerationLog("local-anchor") {
+        withTxGenerationLog() {
           Transactions.makeClaimLocalAnchorOutputTx(tx, localFundingPubKey, confirmCommitBefore)
         },
-        withTxGenerationLog("remote-anchor") {
+        withTxGenerationLog() {
           Transactions.makeClaimRemoteAnchorOutputTx(tx, commitments.remoteParams.fundingPubKey)
         }
       )
@@ -719,7 +722,7 @@ object Helpers {
         val localPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, commitments.localCommit.index.toInt)
         val localRevocationPubkey = Generators.revocationPubKey(remoteParams.revocationBasepoint, localPerCommitmentPoint)
         val localDelayedPubkey = Generators.derivePubKey(keyManager.delayedPaymentPoint(channelKeyPath).publicKey, localPerCommitmentPoint)
-        val htlcDelayedTx = withTxGenerationLog("htlc-delayed") {
+        val htlcDelayedTx = withTxGenerationLog() {
           Transactions.makeHtlcDelayedTx(tx, localParams.dustLimit, localRevocationPubkey, remoteParams.toSelfDelay, localDelayedPubkey, localParams.defaultFinalScriptPubKey, feeratePerKwDelayed).map { claimDelayed =>
             val sig = keyManager.sign(claimDelayed, keyManager.delayedPaymentPoint(channelKeyPath), localPerCommitmentPoint, TxOwner.Local, commitmentFormat)
             Transactions.addSigs(claimDelayed, sig)
@@ -768,12 +771,12 @@ object Helpers {
       val htlcTxs: Map[OutPoint, RemoteCommitPublished.HtlcOutputStatus] = remoteCommit.spec.htlcs.toList.collect {
         case OutgoingHtlc(add: UpdateAddHtlc) =>
           // NB: we first generate the tx skeleton and finalize it below if we have the preimage, so we set logSuccess to false to avoid logging twice
-          withTxGenerationLog("claim-htlc-success", logSuccess = false) { // TODO: refactor this
+          withTxGenerationLog(logSuccess = false) { // TODO: refactor this
             Transactions.makeClaimHtlcSuccessTx(remoteCommitTx.tx, outputs, commitments.localParams.dustLimit, localHtlcPubkey, remoteHtlcPubkey, remoteRevocationPubkey, commitments.localParams.defaultFinalScriptPubKey, add, feeratePerKwHtlc, commitments.commitmentFormat)
           }.toOption.map(claimHtlcTx => {
             if (preimages.contains(add.paymentHash)) {
               // incoming htlc for which we have the preimage: we can spend it immediately
-              claimHtlcTx.input.outPoint -> withTxGenerationLog("claim-htlc-success") {
+              claimHtlcTx.input.outPoint -> withTxGenerationLog() {
                 val sig = keyManager.sign(claimHtlcTx, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint, TxOwner.Local, commitments.commitmentFormat)
                 TxGenerationResult.Success(Transactions.addSigs(claimHtlcTx, sig, preimages(add.paymentHash)))
               }.toOption.map(RemoteCommitPublished.HtlcOutputStatus.Spendable)
@@ -789,10 +792,10 @@ object Helpers {
         case IncomingHtlc(add: UpdateAddHtlc) =>
           // outgoing htlc: they may or may not have the preimage, the only thing to do is try to get back our funds after timeout
           // NB: we first generate the tx skeleton and finalize it below, so we set logSuccess to false to avoid logging twice
-          withTxGenerationLog("claim-htlc-timeout", logSuccess = false) {
+          withTxGenerationLog(logSuccess = false) {
             Transactions.makeClaimHtlcTimeoutTx(remoteCommitTx.tx, outputs, commitments.localParams.dustLimit, localHtlcPubkey, remoteHtlcPubkey, remoteRevocationPubkey, commitments.localParams.defaultFinalScriptPubKey, add, feeratePerKwHtlc, commitments.commitmentFormat)
           }.toOption.map(claimHtlcTx => {
-            claimHtlcTx.input.outPoint -> withTxGenerationLog("claim-htlc-timeout") {
+            claimHtlcTx.input.outPoint -> withTxGenerationLog() {
               val sig = keyManager.sign(claimHtlcTx, keyManager.htlcPoint(channelKeyPath), remoteCommit.remotePerCommitmentPoint, TxOwner.Local, commitments.commitmentFormat)
               TxGenerationResult.Success(Transactions.addSigs(claimHtlcTx, sig))
             }.toOption.map(RemoteCommitPublished.HtlcOutputStatus.Spendable)
@@ -802,10 +805,10 @@ object Helpers {
       // If we don't have pending HTLCs, we don't have funds at risk, so we can aim for a slower confirmation.
       val confirmCommitBefore = htlcTxs.values.collect { case RemoteCommitPublished.HtlcOutputStatus.Spendable(htlcTx) => htlcTx.confirmBefore }.minOption.getOrElse(currentBlockHeight + feeTargets.commitmentWithoutHtlcsBlockTarget)
       val claimAnchorTxs: List[ClaimAnchorOutputTx] = List(
-        withTxGenerationLog("local-anchor") {
+        withTxGenerationLog() {
           Transactions.makeClaimLocalAnchorOutputTx(tx, localFundingPubkey, confirmCommitBefore)
         }.toOption,
-        withTxGenerationLog("remote-anchor") {
+        withTxGenerationLog() {
           Transactions.makeClaimRemoteAnchorOutputTx(tx, commitments.remoteParams.fundingPubKey)
         }.toOption
       ).flatten
@@ -843,13 +846,13 @@ object Helpers {
       val feeratePerKwMain = feeEstimator.getFeeratePerKw(feeTargets.claimMainBlockTarget)
 
       val mainTx = commitments.commitmentFormat match {
-        case DefaultCommitmentFormat => withTxGenerationLog("remote-main") {
+        case DefaultCommitmentFormat => withTxGenerationLog() {
           Transactions.makeClaimP2WPKHOutputTx(tx, commitments.localParams.dustLimit, localPubkey, commitments.localParams.defaultFinalScriptPubKey, feeratePerKwMain).map(claimMain => {
             val sig = keyManager.sign(claimMain, keyManager.paymentPoint(channelKeyPath), remotePerCommitmentPoint, TxOwner.Local, commitments.commitmentFormat)
             Transactions.addSigs(claimMain, localPubkey, sig)
           })
         }.toOption
-        case _: AnchorOutputsCommitmentFormat => withTxGenerationLog("remote-main-delayed") {
+        case _: AnchorOutputsCommitmentFormat => withTxGenerationLog() {
           Transactions.makeClaimRemoteDelayedOutputTx(tx, commitments.localParams.dustLimit, localPaymentPoint, commitments.localParams.defaultFinalScriptPubKey, feeratePerKwMain).map(claimMain => {
             val sig = keyManager.sign(claimMain, keyManager.paymentPoint(channelKeyPath), TxOwner.Local, commitments.commitmentFormat)
             Transactions.addSigs(claimMain, sig)
@@ -906,13 +909,13 @@ object Helpers {
               log.info(s"channel uses option_static_remotekey to pay directly to our wallet, there is nothing to do")
               None
             case ct => ct.commitmentFormat match {
-              case DefaultCommitmentFormat => withTxGenerationLog("claim-p2wpkh-output") {
+              case DefaultCommitmentFormat => withTxGenerationLog() {
                 Transactions.makeClaimP2WPKHOutputTx(commitTx, localParams.dustLimit, localPaymentPubkey, localParams.defaultFinalScriptPubKey, feeratePerKwMain).map(claimMain => {
                   val sig = keyManager.sign(claimMain, keyManager.paymentPoint(channelKeyPath), remotePerCommitmentPoint, TxOwner.Local, commitmentFormat)
                   Transactions.addSigs(claimMain, localPaymentPubkey, sig)
                 })
               }.toOption
-              case _: AnchorOutputsCommitmentFormat => withTxGenerationLog("remote-main-delayed") {
+              case _: AnchorOutputsCommitmentFormat => withTxGenerationLog() {
                 Transactions.makeClaimRemoteDelayedOutputTx(commitTx, localParams.dustLimit, localPaymentPoint, localParams.defaultFinalScriptPubKey, feeratePerKwMain).map(claimMain => {
                   val sig = keyManager.sign(claimMain, keyManager.paymentPoint(channelKeyPath), TxOwner.Local, commitmentFormat)
                   Transactions.addSigs(claimMain, sig)
@@ -922,7 +925,7 @@ object Helpers {
           }
 
           // then we punish them by stealing their main output
-          val mainPenaltyTx = withTxGenerationLog("main-penalty") {
+          val mainPenaltyTx = withTxGenerationLog() {
             Transactions.makeMainPenaltyTx(commitTx, localParams.dustLimit, remoteRevocationPubkey, localParams.defaultFinalScriptPubKey, localParams.toSelfDelay, remoteDelayedPaymentPubkey, feeratePerKwPenalty).map(txinfo => {
               val sig = keyManager.sign(txinfo, keyManager.revocationPoint(channelKeyPath), remotePerCommitmentSecret, TxOwner.Local, commitmentFormat)
               Transactions.addSigs(txinfo, sig)
@@ -942,7 +945,7 @@ object Helpers {
           // and finally we steal the htlc outputs
           val htlcPenaltyTxs = commitTx.txOut.zipWithIndex.collect { case (txOut, outputIndex) if htlcsRedeemScripts.contains(txOut.publicKeyScript) =>
             val htlcRedeemScript = htlcsRedeemScripts(txOut.publicKeyScript)
-            withTxGenerationLog("htlc-penalty") {
+            withTxGenerationLog() {
               Transactions.makeHtlcPenaltyTx(commitTx, outputIndex, htlcRedeemScript, localParams.dustLimit, localParams.defaultFinalScriptPubKey, feeratePerKwPenalty).map(htlcPenalty => {
                 val sig = keyManager.sign(htlcPenalty, keyManager.revocationPoint(channelKeyPath), remotePerCommitmentSecret, TxOwner.Local, commitmentFormat)
                 Transactions.addSigs(htlcPenalty, sig, remoteRevocationPubkey)
@@ -999,7 +1002,7 @@ object Helpers {
             val feeratePerKwPenalty = feeEstimator.getFeeratePerKw(target = 1)
 
             val penaltyTxs = Transactions.makeClaimHtlcDelayedOutputPenaltyTxs(htlcTx, localParams.dustLimit, remoteRevocationPubkey, localParams.toSelfDelay, remoteDelayedPaymentPubkey, localParams.defaultFinalScriptPubKey, feeratePerKwPenalty).flatMap(claimHtlcDelayedOutputPenaltyTx => {
-              withTxGenerationLog("htlc-delayed-penalty") {
+              withTxGenerationLog() {
                 claimHtlcDelayedOutputPenaltyTx.map(htlcDelayedPenalty => {
                   val sig = keyManager.sign(htlcDelayedPenalty, keyManager.revocationPoint(channelKeyPath), remotePerCommitmentSecret, TxOwner.Local, commitmentFormat)
                   val signedTx = Transactions.addSigs(htlcDelayedPenalty, sig)
@@ -1129,7 +1132,7 @@ object Helpers {
             .map(_.witness)
             .collect(Scripts.extractPaymentHashFromHtlcTimeout)
             .flatMap { paymentHash160 =>
-              log.info(s"htlc-timeout tx for paymentHash160=${paymentHash160.toHex} expiry=${tx.lockTime} has been confirmed (tx=$tx)")
+              log.info(s"HtlcTimeoutTx tx for paymentHash160=${paymentHash160.toHex} expiry=${tx.lockTime} has been confirmed (tx=$tx)")
               val timeoutTxs = localCommitPublished.htlcTxs.values.collect { case LocalCommitPublished.HtlcOutputStatus.Spendable(TxGenerationResult.Success(HtlcTimeoutTx(_, tx, _, _))) => tx }.toSeq
               findTimedOutHtlc(tx, paymentHash160, untrimmedHtlcs, timeoutTxs, Scripts.extractPaymentHashFromHtlcTimeout)
             }.toSet
@@ -1138,7 +1141,7 @@ object Helpers {
             case Some(LocalCommitPublished.HtlcOutputStatus.Spendable(TxGenerationResult.Success(HtlcTimeoutTx(_, _, htlcId, _)))) if isHtlcTimeout(tx, localCommitPublished) =>
               untrimmedHtlcs.find(_.id == htlcId) match {
                 case Some(htlc) =>
-                  log.info(s"htlc-timeout tx for htlc #$htlcId paymentHash=${htlc.paymentHash} expiry=${tx.lockTime} has been confirmed (tx=$tx)")
+                  log.info(s"HtlcTimeoutTx tx for htlc #$htlcId paymentHash=${htlc.paymentHash} expiry=${tx.lockTime} has been confirmed (tx=$tx)")
                   Some(htlc)
                 case None =>
                   log.error(s"could not find htlc #$htlcId for htlc-timeout tx=$tx")
@@ -1171,7 +1174,7 @@ object Helpers {
             .map(_.witness)
             .collect(Scripts.extractPaymentHashFromClaimHtlcTimeout)
             .flatMap { paymentHash160 =>
-              log.info(s"claim-htlc-timeout tx for paymentHash160=${paymentHash160.toHex} expiry=${tx.lockTime} has been confirmed (tx=$tx)")
+              log.info(s"ClaimHtlcTimeoutTx tx for paymentHash160=${paymentHash160.toHex} expiry=${tx.lockTime} has been confirmed (tx=$tx)")
               val timeoutTxs = remoteCommitPublished.claimHtlcTxs.values.collect { case RemoteCommitPublished.HtlcOutputStatus.Spendable(ClaimHtlcTimeoutTx(_, tx, _, _)) => tx }.toSeq
               findTimedOutHtlc(tx, paymentHash160, untrimmedHtlcs, timeoutTxs, Scripts.extractPaymentHashFromClaimHtlcTimeout)
             }.toSet
@@ -1180,7 +1183,7 @@ object Helpers {
             case Some(RemoteCommitPublished.HtlcOutputStatus.Spendable(ClaimHtlcTimeoutTx(_, _, htlcId, _))) if isClaimHtlcTimeout(tx, remoteCommitPublished) =>
               untrimmedHtlcs.find(_.id == htlcId) match {
                 case Some(htlc) =>
-                  log.info(s"claim-htlc-timeout tx for htlc #$htlcId paymentHash=${htlc.paymentHash} expiry=${tx.lockTime} has been confirmed (tx=$tx)")
+                  log.info(s"ClaimHtlcTimeoutTx tx for htlc #$htlcId paymentHash=${htlc.paymentHash} expiry=${tx.lockTime} has been confirmed (tx=$tx)")
                   Some(htlc)
                 case None =>
                   log.error(s"could not find htlc #$htlcId for claim-htlc-timeout tx=$tx")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/ReplaceableTxFunder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/ReplaceableTxFunder.scala
@@ -132,7 +132,7 @@ object ReplaceableTxFunder {
    * Adjust the main output of a claim-htlc tx to match our target feerate.
    * If the resulting output is too small, we skip the transaction.
    */
-  def adjustClaimHtlcTxOutput(claimHtlcTx: ClaimHtlcWithWitnessData, targetFeerate: FeeratePerKw, dustLimit: Satoshi): Either[TxGenerationSkipped, ClaimHtlcWithWitnessData] = {
+  def adjustClaimHtlcTxOutput(claimHtlcTx: ClaimHtlcWithWitnessData, targetFeerate: FeeratePerKw, dustLimit: Satoshi): Either[TxGenerationResult.Skipped, ClaimHtlcWithWitnessData] = {
     require(claimHtlcTx.txInfo.tx.txIn.size == 1, "claim-htlc transaction should have a single input")
     require(claimHtlcTx.txInfo.tx.txOut.size == 1, "claim-htlc transaction should have a single output")
     val dummySignedTx = claimHtlcTx.txInfo match {
@@ -143,7 +143,7 @@ object ReplaceableTxFunder {
     val targetFee = weight2fee(targetFeerate, dummySignedTx.tx.weight())
     val outputAmount = claimHtlcTx.txInfo.amountIn - targetFee
     if (outputAmount < dustLimit) {
-      Left(AmountBelowDustLimit)
+      Left(TxGenerationResult.AmountBelowDustLimit)
     } else {
       val updatedClaimHtlcTx = claimHtlcTx match {
         // NB: we don't modify legacy claim-htlc-success, it's already signed.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/TxPublisher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/TxPublisher.scala
@@ -85,13 +85,13 @@ object TxPublisher {
    */
   case class PublishFinalTx(tx: Transaction, input: OutPoint, desc: String, fee: Satoshi, parentTx_opt: Option[ByteVector32]) extends PublishTx
   object PublishFinalTx {
-    def apply(txInfo: TransactionWithInputInfo, fee: Satoshi, parentTx_opt: Option[ByteVector32]): PublishFinalTx = PublishFinalTx(txInfo.tx, txInfo.input.outPoint, txInfo.desc, fee, parentTx_opt)
+    def apply(txInfo: TransactionWithInputInfo, fee: Satoshi, parentTx_opt: Option[ByteVector32]): PublishFinalTx = PublishFinalTx(txInfo.tx, txInfo.input.outPoint, txInfo.getClass.getSimpleName, fee, parentTx_opt)
   }
   /** Publish an unsigned transaction that can be RBF-ed. */
   case class PublishReplaceableTx(txInfo: ReplaceableTransactionWithInputInfo, commitments: Commitments) extends PublishTx {
     override def input: OutPoint = txInfo.input.outPoint
-    override def desc: String = txInfo.desc
-  }
+    override def desc: String = txInfo.getClass.getSimpleName
+}
 
   sealed trait PublishTxResult extends Command { def cmd: PublishTx }
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -16,6 +16,7 @@
 
 package fr.acinq
 
+import com.sun.tools.javac.code.TypeTag
 import fr.acinq.bitcoin.Crypto.PrivateKey
 import fr.acinq.bitcoin._
 import fr.acinq.eclair.crypto.StrongRandom

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -99,7 +99,6 @@ object Transactions {
 
   sealed trait TransactionWithInputInfo {
     def input: InputInfo
-    def desc: String
     def tx: Transaction
     def amountIn: Satoshi = input.txOut.amount
     def fee: Satoshi = amountIn - tx.txOut.map(_.amount).sum
@@ -115,7 +114,7 @@ object Transactions {
     def confirmBefore: BlockHeight
   }
 
-  case class CommitTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo { override def desc: String = "commit-tx" }
+  case class CommitTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
   /**
    * It's important to note that htlc transactions with the default commitment format are not actually replaceable: only
    * anchor outputs htlc transactions are replaceable. We should have used different types for these different kinds of
@@ -138,24 +137,24 @@ object Transactions {
       }
     }
   }
-  case class HtlcSuccessTx(input: InputInfo, tx: Transaction, paymentHash: ByteVector32, htlcId: Long, confirmBefore: BlockHeight) extends HtlcTx { override def desc: String = "htlc-success" }
-  case class HtlcTimeoutTx(input: InputInfo, tx: Transaction, htlcId: Long, confirmBefore: BlockHeight) extends HtlcTx { override def desc: String = "htlc-timeout" }
-  case class HtlcDelayedTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo { override def desc: String = "htlc-delayed" }
+  case class HtlcSuccessTx(input: InputInfo, tx: Transaction, paymentHash: ByteVector32, htlcId: Long, confirmBefore: BlockHeight) extends HtlcTx
+  case class HtlcTimeoutTx(input: InputInfo, tx: Transaction, htlcId: Long, confirmBefore: BlockHeight) extends HtlcTx
+  case class HtlcDelayedTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
   sealed trait ClaimHtlcTx extends ReplaceableTransactionWithInputInfo { def htlcId: Long }
-  case class LegacyClaimHtlcSuccessTx(input: InputInfo, tx: Transaction, htlcId: Long, confirmBefore: BlockHeight) extends ClaimHtlcTx { override def desc: String = "claim-htlc-success" }
-  case class ClaimHtlcSuccessTx(input: InputInfo, tx: Transaction, paymentHash: ByteVector32, htlcId: Long, confirmBefore: BlockHeight) extends ClaimHtlcTx { override def desc: String = "claim-htlc-success" }
-  case class ClaimHtlcTimeoutTx(input: InputInfo, tx: Transaction, htlcId: Long, confirmBefore: BlockHeight) extends ClaimHtlcTx { override def desc: String = "claim-htlc-timeout" }
+  case class LegacyClaimHtlcSuccessTx(input: InputInfo, tx: Transaction, htlcId: Long, confirmBefore: BlockHeight) extends ClaimHtlcTx
+  case class ClaimHtlcSuccessTx(input: InputInfo, tx: Transaction, paymentHash: ByteVector32, htlcId: Long, confirmBefore: BlockHeight) extends ClaimHtlcTx
+  case class ClaimHtlcTimeoutTx(input: InputInfo, tx: Transaction, htlcId: Long, confirmBefore: BlockHeight) extends ClaimHtlcTx
   sealed trait ClaimAnchorOutputTx extends TransactionWithInputInfo
-  case class ClaimLocalAnchorOutputTx(input: InputInfo, tx: Transaction, confirmBefore: BlockHeight) extends ClaimAnchorOutputTx with ReplaceableTransactionWithInputInfo { override def desc: String = "local-anchor" }
-  case class ClaimRemoteAnchorOutputTx(input: InputInfo, tx: Transaction) extends ClaimAnchorOutputTx { override def desc: String = "remote-anchor" }
+  case class ClaimLocalAnchorOutputTx(input: InputInfo, tx: Transaction, confirmBefore: BlockHeight) extends ClaimAnchorOutputTx with ReplaceableTransactionWithInputInfo
+  case class ClaimRemoteAnchorOutputTx(input: InputInfo, tx: Transaction) extends ClaimAnchorOutputTx
   sealed trait ClaimRemoteCommitMainOutputTx extends TransactionWithInputInfo
-  case class ClaimP2WPKHOutputTx(input: InputInfo, tx: Transaction) extends ClaimRemoteCommitMainOutputTx { override def desc: String = "remote-main" }
-  case class ClaimRemoteDelayedOutputTx(input: InputInfo, tx: Transaction) extends ClaimRemoteCommitMainOutputTx { override def desc: String = "remote-main-delayed" }
-  case class ClaimLocalDelayedOutputTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo { override def desc: String = "local-main-delayed" }
-  case class MainPenaltyTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo { override def desc: String = "main-penalty" }
-  case class HtlcPenaltyTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo { override def desc: String = "htlc-penalty" }
-  case class ClaimHtlcDelayedOutputPenaltyTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo { override def desc: String = "htlc-delayed-penalty" }
-  case class ClosingTx(input: InputInfo, tx: Transaction, toLocalOutput: Option[OutputInfo]) extends TransactionWithInputInfo { override def desc: String = "closing" }
+  case class ClaimP2WPKHOutputTx(input: InputInfo, tx: Transaction) extends ClaimRemoteCommitMainOutputTx
+  case class ClaimRemoteDelayedOutputTx(input: InputInfo, tx: Transaction) extends ClaimRemoteCommitMainOutputTx
+  case class ClaimLocalDelayedOutputTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
+  case class MainPenaltyTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
+  case class HtlcPenaltyTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
+  case class ClaimHtlcDelayedOutputPenaltyTx(input: InputInfo, tx: Transaction) extends TransactionWithInputInfo
+  case class ClosingTx(input: InputInfo, tx: Transaction, toLocalOutput: Option[OutputInfo]) extends TransactionWithInputInfo
 
   sealed trait TxGenerationResult[+T <: TransactionWithInputInfo] {
     def map[U <: TransactionWithInputInfo: TypeTag](transform: T => U): TxGenerationResult[U] = this match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelTypes0.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelTypes0.scala
@@ -59,7 +59,7 @@ private[channel] object ChannelTypes0 {
       val claimMainDelayedOutputTxNew = claimMainDelayedOutputTx.map(tx => ClaimLocalDelayedOutputTx(getPartialInputInfo(commitTx, tx), tx))
       val htlcSuccessTxsNew = htlcSuccessTxs.map(tx => HtlcSuccessTx(getPartialInputInfo(commitTx, tx), tx, ByteVector32.Zeroes, 0, BlockHeight(0)))
       val htlcTimeoutTxsNew = htlcTimeoutTxs.map(tx => HtlcTimeoutTx(getPartialInputInfo(commitTx, tx), tx, 0, BlockHeight(0)))
-      val htlcTxsNew = (htlcSuccessTxsNew ++ htlcTimeoutTxsNew).map(tx => tx.input.outPoint -> Some(tx)).toMap
+      val htlcTxsNew = (htlcSuccessTxsNew ++ htlcTimeoutTxsNew).map(tx => tx.input.outPoint -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(tx)).toMap
       val claimHtlcDelayedTxsNew = claimHtlcDelayedTxs.map(tx => {
         val htlcTx = htlcTxs.find(_.txid == tx.txIn.head.outPoint.txid)
         require(htlcTx.nonEmpty, s"3rd-stage htlc tx doesn't spend one of our htlc txs: claim-htlc-tx=$tx, htlc-txs=${htlcTxs.mkString(",")}")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelTypes0.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelTypes0.scala
@@ -79,7 +79,7 @@ private[channel] object ChannelTypes0 {
       val claimMainOutputTxNew = claimMainOutputTx.map(tx => ClaimP2WPKHOutputTx(getPartialInputInfo(commitTx, tx), tx))
       val claimHtlcSuccessTxsNew = claimHtlcSuccessTxs.map(tx => LegacyClaimHtlcSuccessTx(getPartialInputInfo(commitTx, tx), tx, 0, BlockHeight(0)))
       val claimHtlcTimeoutTxsNew = claimHtlcTimeoutTxs.map(tx => ClaimHtlcTimeoutTx(getPartialInputInfo(commitTx, tx), tx, 0, BlockHeight(0)))
-      val claimHtlcTxsNew = (claimHtlcSuccessTxsNew ++ claimHtlcTimeoutTxsNew).map(tx => tx.input.outPoint -> Some(tx)).toMap
+      val claimHtlcTxsNew = (claimHtlcSuccessTxsNew ++ claimHtlcTimeoutTxsNew).map(tx => tx.input.outPoint -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(tx)).toMap
       channel.RemoteCommitPublished(commitTx, claimMainOutputTxNew, claimHtlcTxsNew, Nil, irrevocablySpentNew)
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelTypes0.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelTypes0.scala
@@ -76,10 +76,10 @@ private[channel] object ChannelTypes0 {
       // NB: irrevocablySpent may contain transactions that belong to our peer: we will drop them in this migration but
       // the channel will put a watch at start-up which will make us fetch the spending transaction.
       val irrevocablySpentNew = irrevocablySpent.collect { case (outpoint, txid) if knownTxs.contains(txid) => (outpoint, knownTxs(txid)) }
-      val claimMainOutputTxNew = claimMainOutputTx.map(tx => ClaimP2WPKHOutputTx(getPartialInputInfo(commitTx, tx), tx))
+      val claimMainOutputTxNew = claimMainOutputTx.map(tx => TxGenerationResult.Success(ClaimP2WPKHOutputTx(getPartialInputInfo(commitTx, tx), tx)))
       val claimHtlcSuccessTxsNew = claimHtlcSuccessTxs.map(tx => LegacyClaimHtlcSuccessTx(getPartialInputInfo(commitTx, tx), tx, 0, BlockHeight(0)))
       val claimHtlcTimeoutTxsNew = claimHtlcTimeoutTxs.map(tx => ClaimHtlcTimeoutTx(getPartialInputInfo(commitTx, tx), tx, 0, BlockHeight(0)))
-      val claimHtlcTxsNew = (claimHtlcSuccessTxsNew ++ claimHtlcTimeoutTxsNew).map(tx => tx.input.outPoint -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(tx)).toMap
+      val claimHtlcTxsNew = (claimHtlcSuccessTxsNew ++ claimHtlcTimeoutTxsNew).map(tx => tx.input.outPoint -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(TxGenerationResult.Success(tx))).toMap
       channel.RemoteCommitPublished(commitTx, claimMainOutputTxNew, claimHtlcTxsNew, Nil, irrevocablySpentNew)
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2.scala
@@ -281,12 +281,22 @@ private[channel] object ChannelCodecs2 {
     }.decodeOnly.as[RemoteCommitPublished]
 
     val revokedCommitPublishedCodec: Codec[RevokedCommitPublished] = (
-      ("commitTx" | txCodec) ::
-        ("claimMainOutputTx" | optional(bool8, claimRemoteCommitMainOutputTxCodec)) ::
-        ("mainPenaltyTx" | optional(bool8, mainPenaltyTxCodec)) ::
-        ("htlcPenaltyTxs" | listOfN(uint16, htlcPenaltyTxCodec)) ::
-        ("claimHtlcDelayedPenaltyTxs" | listOfN(uint16, claimHtlcDelayedOutputPenaltyTxCodec)) ::
-        ("spent" | spentMapCodec)).as[RevokedCommitPublished]
+      ("commitTx" | txCodec) ~~
+        ("claimMainOutputTx_opt" | optional(bool8, claimRemoteCommitMainOutputTxCodec)) ~~
+        ("mainPenaltyTx" | optional(bool8, mainPenaltyTxCodec)) ~~
+        ("htlcPenaltyTxs" | listOfN(uint16, htlcPenaltyTxCodec)) ~~
+        ("claimHtlcDelayedPenaltyTxs" | listOfN(uint16, claimHtlcDelayedOutputPenaltyTxCodec)) ~~
+        ("spent" | spentMapCodec)).asDecoder.map {
+      case (commitTx, claimMainOutputTx_opt, mainPenaltyTx, htlcPenaltyTxs, claimHtlcDelayedPenaltyTxs, irrevocablySpent) =>
+        RevokedCommitPublished(
+          commitTx = commitTx,
+          claimMainOutputTx_opt = claimMainOutputTx_opt.map(TxGenerationResult.Success(_)),
+          mainPenaltyTx = mainPenaltyTx.map(TxGenerationResult.Success(_)).getOrElse(TxGenerationResult.BackWardCompatFailure),
+          htlcPenaltyTxs = htlcPenaltyTxs.map(TxGenerationResult.Success(_)),
+          claimHtlcDelayedPenaltyTxs = claimHtlcDelayedPenaltyTxs.map(TxGenerationResult.Success(_)),
+          irrevocablySpent = irrevocablySpent
+        )
+    }.decodeOnly.as[RevokedCommitPublished]
 
     val DATA_WAIT_FOR_FUNDING_CONFIRMED_Codec: Codec[DATA_WAIT_FOR_FUNDING_CONFIRMED] = (
       ("commitments" | commitmentsCodec) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
@@ -289,7 +289,7 @@ private[channel] object ChannelCodecs3 {
         ("localClosingSigned" | lengthDelimited(closingSignedCodec))).as[ClosingTxProposed]
 
     // backward compatible with optional(bool8, htlcTxCodec)
-    val htlcOutputStatusCodec: Codec[LocalCommitPublished.HtlcOutputStatus] = discriminated[LocalCommitPublished.HtlcOutputStatus].by(bits(8))
+    val htlcLocalOutputStatusCodec: Codec[LocalCommitPublished.HtlcOutputStatus] = discriminated[LocalCommitPublished.HtlcOutputStatus].by(bits(8))
       .typecase(bin"00000000", provide(LocalCommitPublished.HtlcOutputStatus.Unknown)) // was previously 'false' encoded as bool8
       .typecase(bin"00000001", provide(LocalCommitPublished.HtlcOutputStatus.Unspendable))
       .typecase(bin"11111111", htlcTxCodec.xmapc(LocalCommitPublished.HtlcOutputStatus.Spendable)(_.htlcTx)) // was previously 'true' encoded as bool8
@@ -297,15 +297,21 @@ private[channel] object ChannelCodecs3 {
     val localCommitPublishedCodec: Codec[LocalCommitPublished] = (
       ("commitTx" | txCodec) ::
         ("claimMainDelayedOutputTx" | optional(bool8, claimLocalDelayedOutputTxCodec)) ::
-        ("htlcTxs" | mapCodec(outPointCodec, htlcOutputStatusCodec)) ::
+        ("htlcTxs" | mapCodec(outPointCodec, htlcLocalOutputStatusCodec)) ::
         ("claimHtlcDelayedTx" | listOfN(uint16, htlcDelayedTxCodec)) ::
         ("claimAnchorTxs" | listOfN(uint16, claimAnchorOutputTxCodec)) ::
         ("spent" | spentMapCodec)).as[LocalCommitPublished]
 
+    // backward compatible with optional(bool8, claimHtlcTxCodec)
+    val htlcRemoteOutputStatusCodec: Codec[RemoteCommitPublished.HtlcOutputStatus] = discriminated[RemoteCommitPublished.HtlcOutputStatus].by(bits(8))
+      .typecase(bin"00000000", provide(RemoteCommitPublished.HtlcOutputStatus.Unknown)) // was previously 'false' encoded as bool8
+      .typecase(bin"00000001", provide(RemoteCommitPublished.HtlcOutputStatus.Unspendable))
+      .typecase(bin"11111111", claimHtlcTxCodec.xmapc(RemoteCommitPublished.HtlcOutputStatus.Spendable)(_.claimHtlcTx)) // was previously 'true' encoded as bool8
+
     val remoteCommitPublishedCodec: Codec[RemoteCommitPublished] = (
       ("commitTx" | txCodec) ::
         ("claimMainOutputTx" | optional(bool8, claimRemoteCommitMainOutputTxCodec)) ::
-        ("claimHtlcTxs" | mapCodec(outPointCodec, optional(bool8, claimHtlcTxCodec))) ::
+        ("claimHtlcTxs" | mapCodec(outPointCodec, htlcRemoteOutputStatusCodec)) ::
         ("claimAnchorTxs" | listOfN(uint16, claimAnchorOutputTxCodec)) ::
         ("spent" | spentMapCodec)).as[RemoteCommitPublished]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
@@ -290,7 +290,7 @@ private[channel] object ChannelCodecs3 {
 
     // backward compatible with optional(bool8, htlcTxCodec)
     val htlcLocalOutputStatusCodec: Codec[LocalCommitPublished.HtlcOutputStatus] = discriminated[LocalCommitPublished.HtlcOutputStatus].by(bits(8))
-      .typecase(bin"00000000", provide(LocalCommitPublished.HtlcOutputStatus.Unknown)) // was previously 'false' encoded as bool8
+      .typecase(bin"00000000", provide(LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement)) // was previously 'false' encoded as bool8
       .typecase(bin"00000001", provide(LocalCommitPublished.HtlcOutputStatus.Unspendable))
       .typecase(bin"11111111", htlcTxCodec.xmapc(LocalCommitPublished.HtlcOutputStatus.Spendable)(_.htlcTx)) // was previously 'true' encoded as bool8
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/balance/CheckBalanceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/balance/CheckBalanceSpec.scala
@@ -99,7 +99,7 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val knownPreimages = Set((commitments.channelId, htlcb1.id))
     assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(commitments.remoteCommit, remoteCommitPublished), knownPreimages) ===
       PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(remoteCommitPublished.claimMainOutputTx.get.tx.txid -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
+        toLocal = Map(remoteCommitPublished.claimMainOutputTx_opt.get.get.tx.txid -> remoteCommitPublished.claimMainOutputTx_opt.get.get.tx.txOut.head.amount),
         htlcs = claimHtlcTxs.map(claimTx => claimTx.txid -> claimTx.txOut.head.amount.toBtc).toMap,
         htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi
       ))
@@ -107,7 +107,7 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val knownPreimages1 = Set((commitments.channelId, htlcb1.id), (commitments.channelId, htlcb2.id))
     assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(commitments.remoteCommit, remoteCommitPublished), knownPreimages1) ===
       PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(remoteCommitPublished.claimMainOutputTx.get.tx.txid -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
+        toLocal = Map(remoteCommitPublished.claimMainOutputTx_opt.get.get.tx.txid -> remoteCommitPublished.claimMainOutputTx_opt.get.get.tx.txOut.head.amount),
         htlcs = claimHtlcTxs.map(claimTx => claimTx.txid -> claimTx.txOut.head.amount.toBtc).toMap,
         htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi + htlcb2.amountMsat.truncateToSatoshi
       ))
@@ -148,7 +148,7 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val Left(waitingForRevocation) = commitments.remoteNextCommitInfo
     assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(waitingForRevocation.nextRemoteCommit, remoteCommitPublished), knownPreimages) ===
       PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(remoteCommitPublished.claimMainOutputTx.get.tx.txid -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
+        toLocal = Map(remoteCommitPublished.claimMainOutputTx_opt.get.get.tx.txid -> remoteCommitPublished.claimMainOutputTx_opt.get.get.tx.txOut.head.amount),
         htlcs = claimHtlcTxs.map(claimTx => claimTx.txid -> claimTx.txOut.head.amount.toBtc).toMap,
         htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi
       ))
@@ -156,7 +156,7 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val knownPreimages1 = Set((commitments.channelId, htlcb1.id), (commitments.channelId, htlcb2.id))
     assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(waitingForRevocation.nextRemoteCommit, remoteCommitPublished), knownPreimages1) ===
       PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(remoteCommitPublished.claimMainOutputTx.get.tx.txid -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
+        toLocal = Map(remoteCommitPublished.claimMainOutputTx_opt.get.get.tx.txid -> remoteCommitPublished.claimMainOutputTx_opt.get.get.tx.txOut.head.amount),
         htlcs = claimHtlcTxs.map(claimTx => claimTx.txid -> claimTx.txOut.head.amount.toBtc).toMap,
         htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi + htlcb2.amountMsat.truncateToSatoshi
       ))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/ChannelDataSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/ChannelDataSpec.scala
@@ -447,7 +447,7 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
     bob ! CMD_FAIL_HTLC(bobPendingHtlc.htlc.id, Right(UnknownNextPeer), replyTo_opt = Some(probe.ref))
     probe.expectMsgType[CommandSuccess[CMD_FAIL_HTLC]]
     val bobClosing1 = bob.stateData.asInstanceOf[DATA_CLOSING]
-    val rcp4 = bobClosing1.remoteCommitPublished.get
+    val rcp4 = bobClosing1.remoteCommitPublished.get.copy(irrevocablySpent = rcp3.irrevocablySpent)
     assert(rcp4.claimHtlcTxs(remainingHtlcOutpoint) === RemoteCommitPublished.HtlcOutputStatus.Unspendable)
     assert(rcp4.claimHtlcTxs.size === 4)
     assert(getClaimHtlcSuccessTxs(rcp4).size == 1)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/ChannelDataSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/ChannelDataSpec.scala
@@ -88,7 +88,7 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
     assert(htlcTimeoutTxs.length === 2)
     val htlcSuccessTxs: Seq[HtlcSuccessTx] = getHtlcSuccessTxs(lcp)
     assert(htlcSuccessTxs.length === 1) // we only have the preimage for 1 of the 2 non-dust htlcs
-    val remainingHtlcOutpoint: OutPoint = lcp.htlcTxs.collectFirst { case (outpoint, LocalCommitPublished.HtlcOutputStatus.Unknown) => outpoint }.head
+    val remainingHtlcOutpoint: OutPoint = lcp.htlcTxs.collectFirst { case (outpoint, LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement) => outpoint }.head
     assert(lcp.claimHtlcDelayedTxs.length === 0) // we will publish 3rd-stage txs once htlc txs confirm
     assert(!lcp.isConfirmed)
     assert(!lcp.isDone)
@@ -245,7 +245,7 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
 
 
     // at this point the pending incoming htlc is waiting for a preimage
-    assert(lcp4.htlcTxs(remainingHtlcOutpoint) === LocalCommitPublished.HtlcOutputStatus.Unknown)
+    assert(lcp4.htlcTxs(remainingHtlcOutpoint) === LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement)
 
     alice ! CMD_FAIL_HTLC(1, Right(UnknownNextPeer), replyTo_opt = Some(probe.ref))
     probe.expectMsgType[CommandSuccess[CMD_FAIL_HTLC]]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
@@ -161,7 +161,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
 
   private def removeHtlcIds(htlcTxs: Map[OutPoint, LocalCommitPublished.HtlcOutputStatus]): Map[OutPoint, LocalCommitPublished.HtlcOutputStatus] = {
     htlcTxs.map {
-      case (outpoint, spendable: LocalCommitPublished.HtlcOutputStatus.Spendable) => (outpoint, spendable.modify(_.htlcTx).using(removeHtlcId))
+      case (outpoint, LocalCommitPublished.HtlcOutputStatus.Spendable(TxGenerationResult.Success(htlcTx))) => (outpoint, LocalCommitPublished.HtlcOutputStatus.Spendable(TxGenerationResult.Success(removeHtlcId(htlcTx))))
       case (outpoint, otherStatus) => (outpoint, otherStatus)
     }
   }
@@ -309,7 +309,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         mutualClosePublished = tx1 :: Nil,
         localCommitPublished = Some(LocalCommitPublished(
           commitTx = tx2.tx,
-          claimMainDelayedOutputTx = Some(ClaimLocalDelayedOutputTx(tx3.input, tx3.tx)),
+          claimMainDelayedOutputTx = TxGenerationResult.Success(ClaimLocalDelayedOutputTx(tx3.input, tx3.tx)),
           htlcTxs = Map.empty,
           claimHtlcDelayedTxs = Nil,
           claimAnchorTxs = Nil,
@@ -331,7 +331,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         mutualClosePublished = tx1 :: Nil,
         localCommitPublished = Some(LocalCommitPublished(
           commitTx = tx2.tx,
-          claimMainDelayedOutputTx = Some(ClaimLocalDelayedOutputTx(tx3.input, tx3.tx)),
+          claimMainDelayedOutputTx = TxGenerationResult.Success(ClaimLocalDelayedOutputTx(tx3.input, tx3.tx)),
           htlcTxs = Map.empty,
           claimHtlcDelayedTxs = Nil,
           claimAnchorTxs = Nil,
@@ -353,7 +353,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         mutualClosePublished = Nil,
         localCommitPublished = Some(LocalCommitPublished(
           commitTx = tx2.tx,
-          claimMainDelayedOutputTx = None,
+          claimMainDelayedOutputTx = TxGenerationResult.Failure("dummy"),
           htlcTxs = Map.empty,
           claimHtlcDelayedTxs = Nil,
           claimAnchorTxs = Nil,
@@ -381,7 +381,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         mutualClosePublished = tx1 :: Nil,
         localCommitPublished = Some(LocalCommitPublished(
           commitTx = tx2.tx,
-          claimMainDelayedOutputTx = None,
+          claimMainDelayedOutputTx = TxGenerationResult.Failure("dummy"),
           htlcTxs = Map.empty,
           claimHtlcDelayedTxs = Nil,
           claimAnchorTxs = Nil,
@@ -409,7 +409,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         mutualClosePublished = tx1 :: Nil,
         localCommitPublished = Some(LocalCommitPublished(
           commitTx = tx2.tx,
-          claimMainDelayedOutputTx = None,
+          claimMainDelayedOutputTx = TxGenerationResult.Failure("dummy"),
           htlcTxs = Map.empty,
           claimHtlcDelayedTxs = Nil,
           claimAnchorTxs = Nil,
@@ -485,7 +485,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         mutualClosePublished = Nil,
         localCommitPublished = Some(LocalCommitPublished(
           commitTx = tx1.tx,
-          claimMainDelayedOutputTx = None,
+          claimMainDelayedOutputTx = TxGenerationResult.Failure("dummy"),
           htlcTxs = Map.empty,
           claimHtlcDelayedTxs = Nil,
           claimAnchorTxs = Nil,
@@ -532,7 +532,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         mutualClosePublished = Nil,
         localCommitPublished = Some(LocalCommitPublished(
           commitTx = tx1.tx,
-          claimMainDelayedOutputTx = None,
+          claimMainDelayedOutputTx = TxGenerationResult.Failure("dummy"),
           htlcTxs = Map.empty,
           claimHtlcDelayedTxs = Nil,
           claimAnchorTxs = Nil,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
@@ -497,24 +497,24 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         revokedCommitPublished =
           RevokedCommitPublished(
             commitTx = tx2.tx,
-            claimMainOutputTx = Some(ClaimP2WPKHOutputTx(tx3.input, tx3.tx)),
-            mainPenaltyTx = None,
+            claimMainOutputTx_opt = Some(TxGenerationResult.Success(ClaimP2WPKHOutputTx(tx3.input, tx3.tx))),
+            mainPenaltyTx = TxGenerationResult.OutputNotFound,
             htlcPenaltyTxs = Nil,
             claimHtlcDelayedPenaltyTxs = Nil,
             irrevocablySpent = Map.empty
           ) ::
             RevokedCommitPublished(
               commitTx = tx4.tx,
-              claimMainOutputTx = Some(ClaimP2WPKHOutputTx(tx5.input, tx5.tx)),
-              mainPenaltyTx = None,
+              claimMainOutputTx_opt = Some(TxGenerationResult.Success(ClaimP2WPKHOutputTx(tx5.input, tx5.tx))),
+              mainPenaltyTx = TxGenerationResult.OutputNotFound,
               htlcPenaltyTxs = Nil,
               claimHtlcDelayedPenaltyTxs = Nil,
               irrevocablySpent = Map.empty
             ) ::
             RevokedCommitPublished(
               commitTx = tx6.tx,
-              claimMainOutputTx = None,
-              mainPenaltyTx = None,
+              claimMainOutputTx_opt = None,
+              mainPenaltyTx = TxGenerationResult.AmountBelowDustLimit,
               htlcPenaltyTxs = Nil,
               claimHtlcDelayedPenaltyTxs = Nil,
               irrevocablySpent = Map.empty
@@ -544,24 +544,24 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         revokedCommitPublished =
           RevokedCommitPublished(
             commitTx = tx2.tx,
-            claimMainOutputTx = Some(ClaimP2WPKHOutputTx(tx3.input, tx3.tx)),
-            mainPenaltyTx = None,
+            claimMainOutputTx_opt = Some(TxGenerationResult.Success(ClaimP2WPKHOutputTx(tx3.input, tx3.tx))),
+            mainPenaltyTx = TxGenerationResult.OutputNotFound,
             htlcPenaltyTxs = Nil,
             claimHtlcDelayedPenaltyTxs = Nil,
             irrevocablySpent = Map.empty
           ) ::
             RevokedCommitPublished(
               commitTx = tx4.tx,
-              claimMainOutputTx = Some(ClaimP2WPKHOutputTx(tx5.input, tx5.tx)),
-              mainPenaltyTx = None,
+              claimMainOutputTx_opt = Some(TxGenerationResult.Success(ClaimP2WPKHOutputTx(tx5.input, tx5.tx))),
+              mainPenaltyTx = TxGenerationResult.OutputNotFound,
               htlcPenaltyTxs = Nil,
               claimHtlcDelayedPenaltyTxs = Nil,
               irrevocablySpent = Map(tx4.input.outPoint -> tx4.tx)
             ) ::
             RevokedCommitPublished(
               commitTx = tx6.tx,
-              claimMainOutputTx = None,
-              mainPenaltyTx = None,
+              claimMainOutputTx_opt = None,
+              mainPenaltyTx = TxGenerationResult.OutputNotFound,
               htlcPenaltyTxs = Nil,
               claimHtlcDelayedPenaltyTxs = Nil,
               irrevocablySpent = Map.empty

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
@@ -174,7 +174,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
 
   private def removeClaimHtlcIds(claimHtlcTxs: Map[OutPoint, RemoteCommitPublished.HtlcOutputStatus]): Map[OutPoint, RemoteCommitPublished.HtlcOutputStatus] = {
     claimHtlcTxs.map {
-      case (outpoint, spendable: RemoteCommitPublished.HtlcOutputStatus.Spendable) => (outpoint, spendable.modify(_.claimHtlcTx).using(removeHtlcId))
+      case (outpoint, RemoteCommitPublished.HtlcOutputStatus.Spendable(TxGenerationResult.Success(claimHtlcTx))) => (outpoint, RemoteCommitPublished.HtlcOutputStatus.Spendable(TxGenerationResult.Success(removeHtlcId(claimHtlcTx))))
       case (outpoint, otherStatus) => (outpoint, otherStatus)
     }
   }
@@ -361,7 +361,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         )),
         remoteCommitPublished = Some(RemoteCommitPublished(
           commitTx = tx3.tx,
-          claimMainOutputTx = None,
+          claimMainOutputTx_opt = None,
           claimHtlcTxs = Map.empty,
           claimAnchorTxs = Nil,
           irrevocablySpent = Map.empty
@@ -389,7 +389,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         )),
         remoteCommitPublished = Some(RemoteCommitPublished(
           commitTx = tx3.tx,
-          claimMainOutputTx = None,
+          claimMainOutputTx_opt = None,
           claimHtlcTxs = Map.empty,
           claimAnchorTxs = Nil,
           irrevocablySpent = Map(tx3.input.outPoint -> tx3.tx)
@@ -417,14 +417,14 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         )),
         remoteCommitPublished = Some(RemoteCommitPublished(
           commitTx = tx3.tx,
-          claimMainOutputTx = None,
+          claimMainOutputTx_opt = None,
           claimHtlcTxs = Map.empty,
           claimAnchorTxs = Nil,
           irrevocablySpent = Map.empty
         )),
         nextRemoteCommitPublished = Some(RemoteCommitPublished(
           commitTx = tx4.tx,
-          claimMainOutputTx = Some(ClaimP2WPKHOutputTx(tx5.input, tx5.tx)),
+          claimMainOutputTx_opt = Some(TxGenerationResult.Success(ClaimP2WPKHOutputTx(tx5.input, tx5.tx))),
           claimHtlcTxs = Map.empty,
           claimAnchorTxs = Nil,
           irrevocablySpent = Map(tx4.input.outPoint -> tx4.tx)
@@ -446,7 +446,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         nextRemoteCommitPublished = None,
         futureRemoteCommitPublished = Some(RemoteCommitPublished(
           commitTx = tx4.tx,
-          claimMainOutputTx = Some(ClaimRemoteDelayedOutputTx(tx5.input, tx5.tx)),
+          claimMainOutputTx_opt = Some(TxGenerationResult.Success(ClaimRemoteDelayedOutputTx(tx5.input, tx5.tx))),
           claimHtlcTxs = Map.empty,
           claimAnchorTxs = Nil,
           irrevocablySpent = Map.empty
@@ -467,7 +467,7 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
         nextRemoteCommitPublished = None,
         futureRemoteCommitPublished = Some(RemoteCommitPublished(
           commitTx = tx4.tx,
-          claimMainOutputTx = Some(ClaimP2WPKHOutputTx(tx5.input, tx5.tx)),
+          claimMainOutputTx_opt = Some(TxGenerationResult.Success(ClaimP2WPKHOutputTx(tx5.input, tx5.tx))),
           claimHtlcTxs = Map.empty,
           claimAnchorTxs = Nil,
           irrevocablySpent = Map(tx4.input.outPoint -> tx4.tx)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
@@ -172,8 +172,11 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
     case claimHtlcTx: ClaimHtlcTimeoutTx => claimHtlcTx.copy(htlcId = 0)
   }
 
-  private def removeClaimHtlcIds(claimHtlcTxs: Map[OutPoint, Option[ClaimHtlcTx]]): Map[OutPoint, Option[ClaimHtlcTx]] = {
-    claimHtlcTxs.map { case (outpoint, claimHtlcTx_opt) => (outpoint, claimHtlcTx_opt.map(removeHtlcId)) }
+  private def removeClaimHtlcIds(claimHtlcTxs: Map[OutPoint, RemoteCommitPublished.HtlcOutputStatus]): Map[OutPoint, RemoteCommitPublished.HtlcOutputStatus] = {
+    claimHtlcTxs.map {
+      case (outpoint, spendable: RemoteCommitPublished.HtlcOutputStatus.Spendable) => (outpoint, spendable.modify(_.claimHtlcTx).using(removeHtlcId))
+      case (outpoint, otherStatus) => (outpoint, otherStatus)
+    }
   }
 
   def findTimedOutHtlcs(f: Fixture, withoutHtlcId: Boolean): Unit = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
@@ -159,8 +159,11 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
     case htlcTx: HtlcTimeoutTx => htlcTx.copy(htlcId = 0)
   }
 
-  private def removeHtlcIds(htlcTxs: Map[OutPoint, Option[HtlcTx]]): Map[OutPoint, Option[HtlcTx]] = {
-    htlcTxs.map { case (outpoint, htlcTx_opt) => (outpoint, htlcTx_opt.map(removeHtlcId)) }
+  private def removeHtlcIds(htlcTxs: Map[OutPoint, LocalCommitPublished.HtlcOutputStatus]): Map[OutPoint, LocalCommitPublished.HtlcOutputStatus] = {
+    htlcTxs.map {
+      case (outpoint, spendable: LocalCommitPublished.HtlcOutputStatus.Spendable) => (outpoint, spendable.modify(_.htlcTx).using(removeHtlcId))
+      case (outpoint, otherStatus) => (outpoint, otherStatus)
+    }
   }
 
   private def removeHtlcId(claimHtlcTx: ClaimHtlcTx): ClaimHtlcTx = claimHtlcTx match {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
@@ -428,7 +428,7 @@ trait ChannelStateTestsHelperMethods extends TestKitBase {
       s2blockchain.expectMsg(TxPublisher.PublishFinalTx(claimMain, claimMain.fee, None))
     })
     // all htlcs success/timeout should be claimed
-    val claimHtlcTxs = remoteCommitPublished.claimHtlcTxs.values.collect { case Some(tx: ClaimHtlcTx) => tx }.toSeq
+    val claimHtlcTxs = remoteCommitPublished.claimHtlcTxs.values.collect { case RemoteCommitPublished.HtlcOutputStatus.Spendable(tx: ClaimHtlcTx) => tx }.toSeq
     claimHtlcTxs.foreach(claimHtlc => Transaction.correctlySpends(claimHtlc.tx, rCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS))
     val publishedClaimHtlcTxs = claimHtlcTxs.map(_ => s2blockchain.expectMsgType[PublishReplaceableTx])
     assert(publishedClaimHtlcTxs.map(_.input).toSet == claimHtlcTxs.map(_.input.outPoint).toSet)
@@ -454,9 +454,9 @@ trait ChannelStateTestsHelperMethods extends TestKitBase {
 
   def getHtlcTimeoutTxs(lcp: LocalCommitPublished): Seq[HtlcTimeoutTx] = lcp.htlcTxs.values.collect { case LocalCommitPublished.HtlcOutputStatus.Spendable(tx: HtlcTimeoutTx) => tx }.toSeq
 
-  def getClaimHtlcSuccessTxs(rcp: RemoteCommitPublished): Seq[ClaimHtlcSuccessTx] = rcp.claimHtlcTxs.values.collect { case Some(tx: ClaimHtlcSuccessTx) => tx }.toSeq
+  def getClaimHtlcSuccessTxs(rcp: RemoteCommitPublished): Seq[ClaimHtlcSuccessTx] = rcp.claimHtlcTxs.values.collect { case RemoteCommitPublished.HtlcOutputStatus.Spendable(tx: ClaimHtlcSuccessTx) => tx }.toSeq
 
-  def getClaimHtlcTimeoutTxs(rcp: RemoteCommitPublished): Seq[ClaimHtlcTimeoutTx] = rcp.claimHtlcTxs.values.collect { case Some(tx: ClaimHtlcTimeoutTx) => tx }.toSeq
+  def getClaimHtlcTimeoutTxs(rcp: RemoteCommitPublished): Seq[ClaimHtlcTimeoutTx] = rcp.claimHtlcTxs.values.collect { case RemoteCommitPublished.HtlcOutputStatus.Spendable(tx: ClaimHtlcTimeoutTx) => tx }.toSeq
 
 }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
@@ -31,7 +31,7 @@ import fr.acinq.eclair.payment.OutgoingPaymentPacket.{Upstream, buildCommand}
 import fr.acinq.eclair.payment.PaymentPacketSpec._
 import fr.acinq.eclair.payment.relay.{PostRestartHtlcCleaner, Relayer}
 import fr.acinq.eclair.router.Router.ChannelHop
-import fr.acinq.eclair.transactions.Transactions.{ClaimRemoteDelayedOutputTx, InputInfo}
+import fr.acinq.eclair.transactions.Transactions.{ClaimRemoteDelayedOutputTx, InputInfo, TxGenerationResult}
 import fr.acinq.eclair.transactions.{DirectedHtlc, IncomingHtlc, OutgoingHtlc}
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecsSpec
 import fr.acinq.eclair.wire.protocol._
@@ -472,7 +472,7 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
       val revokedCommitTx = normal.commitments.localCommit.commitTxAndRemoteSig.commitTx.tx.copy(txOut = Seq(TxOut(4500 sat, Script.pay2wpkh(randomKey().publicKey))))
       val dummyClaimMainTx = Transaction(2, Seq(TxIn(OutPoint(revokedCommitTx, 0), Nil, 0)), Seq(revokedCommitTx.txOut.head.copy(amount = 4000 sat)), 0)
       val dummyClaimMain = ClaimRemoteDelayedOutputTx(InputInfo(OutPoint(revokedCommitTx, 0), revokedCommitTx.txOut.head, Nil), dummyClaimMainTx)
-      val rcp = RevokedCommitPublished(revokedCommitTx, Some(dummyClaimMain), None, Nil, Nil, Map(revokedCommitTx.txIn.head.outPoint -> revokedCommitTx))
+      val rcp = RevokedCommitPublished(revokedCommitTx, Some(TxGenerationResult.Success(dummyClaimMain)), TxGenerationResult.OutputNotFound, Nil, Nil, Map(revokedCommitTx.txIn.head.outPoint -> revokedCommitTx))
       DATA_CLOSING(normal.commitments, None, BlockHeight(0), Nil, revokedCommitPublished = List(rcp))
     }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -120,7 +120,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       // first we create a fake commitTx tx, containing only the output that will be spent by the ClaimP2WPKHOutputTx
       val pubKeyScript = write(pay2wpkh(localPaymentPriv.publicKey))
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(20000 sat, pubKeyScript) :: Nil, lockTime = 0)
-      val Right(claimP2WPKHOutputTx) = makeClaimP2WPKHOutputTx(commitTx, localDustLimit, localPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(claimP2WPKHOutputTx) = makeClaimP2WPKHOutputTx(commitTx, localDustLimit, localPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(claimP2WPKHOutputTx, localPaymentPriv.publicKey, PlaceHolderSig).tx)
       assert(claimP2WPKHOutputWeight == weight)
@@ -131,7 +131,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       // first we create a fake htlcSuccessOrTimeoutTx tx, containing only the output that will be spent by the 3rd-stage tx
       val pubKeyScript = write(pay2wsh(toLocalDelayed(localRevocationPriv.publicKey, toLocalDelay, localPaymentPriv.publicKey)))
       val htlcSuccessOrTimeoutTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(20000 sat, pubKeyScript) :: Nil, lockTime = 0)
-      val Right(htlcDelayedTx) = makeHtlcDelayedTx(htlcSuccessOrTimeoutTx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(htlcDelayedTx) = makeHtlcDelayedTx(htlcSuccessOrTimeoutTx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(htlcDelayedTx, PlaceHolderSig).tx)
       assert(htlcDelayedWeight == weight)
@@ -142,7 +142,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       // first we create a fake commitTx tx, containing only the output that will be spent by the MainPenaltyTx
       val pubKeyScript = write(pay2wsh(toLocalDelayed(localRevocationPriv.publicKey, toLocalDelay, localPaymentPriv.publicKey)))
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(20000 sat, pubKeyScript) :: Nil, lockTime = 0)
-      val Right(mainPenaltyTx) = makeMainPenaltyTx(commitTx, localDustLimit, localRevocationPriv.publicKey, finalPubKeyScript, toLocalDelay, localPaymentPriv.publicKey, feeratePerKw)
+      val TxGenerationResult.Success(mainPenaltyTx) = makeMainPenaltyTx(commitTx, localDustLimit, localRevocationPriv.publicKey, finalPubKeyScript, toLocalDelay, localPaymentPriv.publicKey, feeratePerKw)
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(mainPenaltyTx, PlaceHolderSig).tx)
       assert(mainPenaltyWeight == weight)
@@ -156,7 +156,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       val redeemScript = htlcReceived(localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, localRevocationPriv.publicKey, ripemd160(htlc.paymentHash), htlc.cltvExpiry, DefaultCommitmentFormat)
       val pubKeyScript = write(pay2wsh(redeemScript))
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(htlc.amountMsat.truncateToSatoshi, pubKeyScript) :: Nil, lockTime = 0)
-      val Right(htlcPenaltyTx) = makeHtlcPenaltyTx(commitTx, 0, Script.write(redeemScript), localDustLimit, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(htlcPenaltyTx) = makeHtlcPenaltyTx(commitTx, 0, Script.write(redeemScript), localDustLimit, finalPubKeyScript, feeratePerKw)
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(htlcPenaltyTx, PlaceHolderSig, localRevocationPriv.publicKey).tx)
       assert(htlcPenaltyWeight == weight)
@@ -171,7 +171,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       val outputs = makeCommitTxOutputs(localIsFunder = true, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, remotePaymentPriv.publicKey, localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, localFundingPriv.publicKey, remoteFundingPriv.publicKey, spec, DefaultCommitmentFormat)
       val pubKeyScript = write(pay2wsh(htlcOffered(localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, localRevocationPriv.publicKey, ripemd160(htlc.paymentHash), DefaultCommitmentFormat)))
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(htlc.amountMsat.truncateToSatoshi, pubKeyScript) :: Nil, lockTime = 0)
-      val Right(claimHtlcSuccessTx) = makeClaimHtlcSuccessTx(commitTx, outputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw, DefaultCommitmentFormat)
+      val TxGenerationResult.Success(claimHtlcSuccessTx) = makeClaimHtlcSuccessTx(commitTx, outputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw, DefaultCommitmentFormat)
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(claimHtlcSuccessTx, PlaceHolderSig, paymentPreimage).tx)
       assert(claimHtlcSuccessWeight == weight)
@@ -186,7 +186,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       val outputs = makeCommitTxOutputs(localIsFunder = true, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, remotePaymentPriv.publicKey, localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, localFundingPriv.publicKey, remoteFundingPriv.publicKey, spec, DefaultCommitmentFormat)
       val pubKeyScript = write(pay2wsh(htlcReceived(localHtlcPriv.publicKey, remoteHtlcPriv.publicKey, localRevocationPriv.publicKey, ripemd160(htlc.paymentHash), htlc.cltvExpiry, DefaultCommitmentFormat)))
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(htlc.amountMsat.truncateToSatoshi, pubKeyScript) :: Nil, lockTime = 0)
-      val Right(claimClaimHtlcTimeoutTx) = makeClaimHtlcTimeoutTx(commitTx, outputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw, DefaultCommitmentFormat)
+      val TxGenerationResult.Success(claimClaimHtlcTimeoutTx) = makeClaimHtlcTimeoutTx(commitTx, outputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw, DefaultCommitmentFormat)
       // we use dummy signatures to compute the weight
       val weight = Transaction.weight(addSigs(claimClaimHtlcTimeoutTx, PlaceHolderSig).tx)
       assert(claimHtlcTimeoutWeight == weight)
@@ -197,7 +197,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       // first we create a fake commitTx tx, containing only the output that will be spent by the ClaimAnchorOutputTx
       val pubKeyScript = write(pay2wsh(anchor(localFundingPriv.publicKey)))
       val commitTx = Transaction(version = 0, txIn = Nil, txOut = TxOut(anchorAmount, pubKeyScript) :: Nil, lockTime = 0)
-      val Right(claimAnchorOutputTx) = makeClaimLocalAnchorOutputTx(commitTx, localFundingPriv.publicKey, BlockHeight(1105))
+      val TxGenerationResult.Success(claimAnchorOutputTx) = makeClaimLocalAnchorOutputTx(commitTx, localFundingPriv.publicKey, BlockHeight(1105))
       assert(claimAnchorOutputTx.tx.txOut.isEmpty)
       assert(claimAnchorOutputTx.confirmBefore === BlockHeight(1105))
       // we will always add at least one input and one output to be able to set our desired feerate
@@ -320,18 +320,18 @@ class TransactionsSpec extends AnyFunSuite with Logging {
     }
     {
       // local spends delayed output of htlc1 timeout tx
-      val Right(htlcDelayed) = makeHtlcDelayedTx(htlcTimeoutTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(htlcDelayed) = makeHtlcDelayedTx(htlcTimeoutTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       val localSig = sign(htlcDelayed, localDelayedPaymentPriv, TxOwner.Local, DefaultCommitmentFormat)
       val signedTx = addSigs(htlcDelayed, localSig)
       assert(checkSpendable(signedTx).isSuccess)
       // local can't claim delayed output of htlc3 timeout tx because it is below the dust limit
       val htlcDelayed1 = makeHtlcDelayedTx(htlcTimeoutTxs(0).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      assert(htlcDelayed1 === Left(OutputNotFound))
+      assert(htlcDelayed1 === TxGenerationResult.OutputNotFound)
     }
     {
       // remote spends local->remote htlc1/htlc3 output directly in case of success
       for ((htlc, paymentPreimage) <- (htlc1, paymentPreimage1) :: (htlc3, paymentPreimage3) :: Nil) {
-        val Right(claimHtlcSuccessTx) = makeClaimHtlcSuccessTx(commitTx.tx, outputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw, DefaultCommitmentFormat)
+        val TxGenerationResult.Success(claimHtlcSuccessTx) = makeClaimHtlcSuccessTx(commitTx.tx, outputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw, DefaultCommitmentFormat)
         val localSig = sign(claimHtlcSuccessTx, remoteHtlcPriv, TxOwner.Local, DefaultCommitmentFormat)
         val signed = addSigs(claimHtlcSuccessTx, localSig, paymentPreimage)
         assert(checkSpendable(signed).isSuccess)
@@ -350,51 +350,51 @@ class TransactionsSpec extends AnyFunSuite with Logging {
     }
     {
       // local spends delayed output of htlc2 success tx
-      val Right(htlcDelayed) = makeHtlcDelayedTx(htlcSuccessTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(htlcDelayed) = makeHtlcDelayedTx(htlcSuccessTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       val localSig = sign(htlcDelayed, localDelayedPaymentPriv, TxOwner.Local, DefaultCommitmentFormat)
       val signedTx = addSigs(htlcDelayed, localSig)
       assert(checkSpendable(signedTx).isSuccess)
       // local can't claim delayed output of htlc4 success tx because it is below the dust limit
       val htlcDelayed1 = makeHtlcDelayedTx(htlcSuccessTxs(0).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      assert(htlcDelayed1 === Left(AmountBelowDustLimit))
+      assert(htlcDelayed1 === TxGenerationResult.AmountBelowDustLimit)
     }
     {
       // local spends main delayed output
-      val Right(claimMainOutputTx) = makeClaimLocalDelayedOutputTx(commitTx.tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(claimMainOutputTx) = makeClaimLocalDelayedOutputTx(commitTx.tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       val localSig = sign(claimMainOutputTx, localDelayedPaymentPriv, TxOwner.Local, DefaultCommitmentFormat)
       val signedTx = addSigs(claimMainOutputTx, localSig)
       assert(checkSpendable(signedTx).isSuccess)
     }
     {
       // remote spends main output
-      val Right(claimP2WPKHOutputTx) = makeClaimP2WPKHOutputTx(commitTx.tx, localDustLimit, remotePaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(claimP2WPKHOutputTx) = makeClaimP2WPKHOutputTx(commitTx.tx, localDustLimit, remotePaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       val localSig = sign(claimP2WPKHOutputTx, remotePaymentPriv, TxOwner.Local, DefaultCommitmentFormat)
       val signedTx = addSigs(claimP2WPKHOutputTx, remotePaymentPriv.publicKey, localSig)
       assert(checkSpendable(signedTx).isSuccess)
     }
     {
       // remote spends remote->local htlc output directly in case of timeout
-      val Right(claimHtlcTimeoutTx) = makeClaimHtlcTimeoutTx(commitTx.tx, outputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc2, feeratePerKw, DefaultCommitmentFormat)
+      val TxGenerationResult.Success(claimHtlcTimeoutTx) = makeClaimHtlcTimeoutTx(commitTx.tx, outputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc2, feeratePerKw, DefaultCommitmentFormat)
       val localSig = sign(claimHtlcTimeoutTx, remoteHtlcPriv, TxOwner.Local, DefaultCommitmentFormat)
       val signed = addSigs(claimHtlcTimeoutTx, localSig)
       assert(checkSpendable(signed).isSuccess)
     }
     {
       // remote spends local main delayed output with revocation key
-      val Right(mainPenaltyTx) = makeMainPenaltyTx(commitTx.tx, localDustLimit, localRevocationPriv.publicKey, finalPubKeyScript, toLocalDelay, localDelayedPaymentPriv.publicKey, feeratePerKw)
+      val TxGenerationResult.Success(mainPenaltyTx) = makeMainPenaltyTx(commitTx.tx, localDustLimit, localRevocationPriv.publicKey, finalPubKeyScript, toLocalDelay, localDelayedPaymentPriv.publicKey, feeratePerKw)
       val sig = sign(mainPenaltyTx, localRevocationPriv, TxOwner.Local, DefaultCommitmentFormat)
       val signed = addSigs(mainPenaltyTx, sig)
       assert(checkSpendable(signed).isSuccess)
     }
     {
       // remote spends htlc1's htlc-timeout tx with revocation key
-      val Seq(Right(claimHtlcDelayedPenaltyTx)) = makeClaimHtlcDelayedOutputPenaltyTxs(htlcTimeoutTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val Seq(TxGenerationResult.Success(claimHtlcDelayedPenaltyTx)) = makeClaimHtlcDelayedOutputPenaltyTxs(htlcTimeoutTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       val sig = sign(claimHtlcDelayedPenaltyTx, localRevocationPriv, TxOwner.Local, DefaultCommitmentFormat)
       val signed = addSigs(claimHtlcDelayedPenaltyTx, sig)
       assert(checkSpendable(signed).isSuccess)
       // remote can't claim revoked output of htlc3's htlc-timeout tx because it is below the dust limit
       val claimHtlcDelayedPenaltyTx1 = makeClaimHtlcDelayedOutputPenaltyTxs(htlcTimeoutTxs(0).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      assert(claimHtlcDelayedPenaltyTx1 === Seq(Left(AmountBelowDustLimit)))
+      assert(claimHtlcDelayedPenaltyTx1 === Seq(TxGenerationResult.AmountBelowDustLimit))
     }
     {
       // remote spends offered HTLC output with revocation key
@@ -403,20 +403,20 @@ class TransactionsSpec extends AnyFunSuite with Logging {
         case (CommitmentOutputLink(_, _, OutHtlc(OutgoingHtlc(someHtlc))), _) => someHtlc.id == htlc1.id
         case _ => false
       }.map(_._2)
-      val Right(htlcPenaltyTx) = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(htlcPenaltyTx) = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feeratePerKw)
       val sig = sign(htlcPenaltyTx, localRevocationPriv, TxOwner.Local, DefaultCommitmentFormat)
       val signed = addSigs(htlcPenaltyTx, sig, localRevocationPriv.publicKey)
       assert(checkSpendable(signed).isSuccess)
     }
     {
       // remote spends htlc2's htlc-success tx with revocation key
-      val Seq(Right(claimHtlcDelayedPenaltyTx)) = makeClaimHtlcDelayedOutputPenaltyTxs(htlcSuccessTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val Seq(TxGenerationResult.Success(claimHtlcDelayedPenaltyTx)) = makeClaimHtlcDelayedOutputPenaltyTxs(htlcSuccessTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       val sig = sign(claimHtlcDelayedPenaltyTx, localRevocationPriv, TxOwner.Local, DefaultCommitmentFormat)
       val signed = addSigs(claimHtlcDelayedPenaltyTx, sig)
       assert(checkSpendable(signed).isSuccess)
       // remote can't claim revoked output of htlc4's htlc-success tx because it is below the dust limit
       val claimHtlcDelayedPenaltyTx1 = makeClaimHtlcDelayedOutputPenaltyTxs(htlcSuccessTxs(0).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      assert(claimHtlcDelayedPenaltyTx1 === Seq(Left(AmountBelowDustLimit)))
+      assert(claimHtlcDelayedPenaltyTx1 === Seq(TxGenerationResult.AmountBelowDustLimit))
     }
     {
       // remote spends received HTLC output with revocation key
@@ -425,7 +425,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
         case (CommitmentOutputLink(_, _, InHtlc(IncomingHtlc(someHtlc))), _) => someHtlc.id == htlc2.id
         case _ => false
       }.map(_._2)
-      val Right(htlcPenaltyTx) = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(htlcPenaltyTx) = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feeratePerKw)
       val sig = sign(htlcPenaltyTx, localRevocationPriv, TxOwner.Local, DefaultCommitmentFormat)
       val signed = addSigs(htlcPenaltyTx, sig, localRevocationPriv.publicKey)
       assert(checkSpendable(signed).isSuccess)
@@ -557,26 +557,26 @@ class TransactionsSpec extends AnyFunSuite with Logging {
 
     {
       // local spends main delayed output
-      val Right(claimMainOutputTx) = makeClaimLocalDelayedOutputTx(commitTx.tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(claimMainOutputTx) = makeClaimLocalDelayedOutputTx(commitTx.tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       val localSig = sign(claimMainOutputTx, localDelayedPaymentPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
       val signedTx = addSigs(claimMainOutputTx, localSig)
       assert(checkSpendable(signedTx).isSuccess)
     }
     {
       // remote cannot spend main output with default commitment format
-      val Left(failure) = makeClaimP2WPKHOutputTx(commitTx.tx, localDustLimit, remotePaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      assert(failure === OutputNotFound)
+      val claimMainTx = makeClaimP2WPKHOutputTx(commitTx.tx, localDustLimit, remotePaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      assert(claimMainTx === TxGenerationResult.OutputNotFound)
     }
     {
       // remote spends main delayed output
-      val Right(claimRemoteDelayedOutputTx) = makeClaimRemoteDelayedOutputTx(commitTx.tx, localDustLimit, remotePaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(claimRemoteDelayedOutputTx) = makeClaimRemoteDelayedOutputTx(commitTx.tx, localDustLimit, remotePaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       val localSig = sign(claimRemoteDelayedOutputTx, remotePaymentPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
       val signedTx = addSigs(claimRemoteDelayedOutputTx, localSig)
       assert(checkSpendable(signedTx).isSuccess)
     }
     {
       // local spends local anchor
-      val Right(claimAnchorOutputTx) = makeClaimLocalAnchorOutputTx(commitTx.tx, localFundingPriv.publicKey, BlockHeight(0))
+      val TxGenerationResult.Success(claimAnchorOutputTx) = makeClaimLocalAnchorOutputTx(commitTx.tx, localFundingPriv.publicKey, BlockHeight(0))
       assert(checkSpendable(claimAnchorOutputTx).isFailure)
       val localSig = sign(claimAnchorOutputTx, localFundingPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
       val signedTx = addSigs(claimAnchorOutputTx, localSig)
@@ -584,7 +584,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
     }
     {
       // remote spends remote anchor
-      val Right(claimAnchorOutputTx) = makeClaimLocalAnchorOutputTx(commitTx.tx, remoteFundingPriv.publicKey, BlockHeight(0))
+      val TxGenerationResult.Success(claimAnchorOutputTx) = makeClaimLocalAnchorOutputTx(commitTx.tx, remoteFundingPriv.publicKey, BlockHeight(0))
       assert(checkSpendable(claimAnchorOutputTx).isFailure)
       val localSig = sign(claimAnchorOutputTx, remoteFundingPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
       val signedTx = addSigs(claimAnchorOutputTx, localSig)
@@ -592,7 +592,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
     }
     {
       // remote spends local main delayed output with revocation key
-      val Right(mainPenaltyTx) = makeMainPenaltyTx(commitTx.tx, localDustLimit, localRevocationPriv.publicKey, finalPubKeyScript, toLocalDelay, localDelayedPaymentPriv.publicKey, feeratePerKw)
+      val TxGenerationResult.Success(mainPenaltyTx) = makeMainPenaltyTx(commitTx.tx, localDustLimit, localRevocationPriv.publicKey, finalPubKeyScript, toLocalDelay, localDelayedPaymentPriv.publicKey, feeratePerKw)
       val sig = sign(mainPenaltyTx, localRevocationPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
       val signed = addSigs(mainPenaltyTx, sig)
       assert(checkSpendable(signed).isSuccess)
@@ -615,13 +615,13 @@ class TransactionsSpec extends AnyFunSuite with Logging {
     }
     {
       // local spends delayed output of htlc1 timeout tx
-      val Right(htlcDelayed) = makeHtlcDelayedTx(htlcTimeoutTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(htlcDelayed) = makeHtlcDelayedTx(htlcTimeoutTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       val localSig = sign(htlcDelayed, localDelayedPaymentPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
       val signedTx = addSigs(htlcDelayed, localSig)
       assert(checkSpendable(signedTx).isSuccess)
       // local can't claim delayed output of htlc3 timeout tx because it is below the dust limit
       val htlcDelayed1 = makeHtlcDelayedTx(htlcTimeoutTxs(0).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      assert(htlcDelayed1 === Left(OutputNotFound))
+      assert(htlcDelayed1 === TxGenerationResult.OutputNotFound)
     }
     {
       // local spends offered htlc with HTLC-success tx
@@ -644,8 +644,8 @@ class TransactionsSpec extends AnyFunSuite with Logging {
     }
     {
       // local spends delayed output of htlc2a and htlc2b success txs
-      val Right(htlcDelayedA) = makeHtlcDelayedTx(htlcSuccessTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      val Right(htlcDelayedB) = makeHtlcDelayedTx(htlcSuccessTxs(2).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(htlcDelayedA) = makeHtlcDelayedTx(htlcSuccessTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(htlcDelayedB) = makeHtlcDelayedTx(htlcSuccessTxs(2).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       for (htlcDelayed <- Seq(htlcDelayedA, htlcDelayedB)) {
         val localSig = sign(htlcDelayed, localDelayedPaymentPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
         val signedTx = addSigs(htlcDelayed, localSig)
@@ -653,12 +653,12 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       }
       // local can't claim delayed output of htlc4 success tx because it is below the dust limit
       val claimHtlcDelayed1 = makeClaimLocalDelayedOutputTx(htlcSuccessTxs(0).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      assert(claimHtlcDelayed1 === Left(AmountBelowDustLimit))
+      assert(claimHtlcDelayed1 === TxGenerationResult.AmountBelowDustLimit)
     }
     {
       // remote spends local->remote htlc outputs directly in case of success
       for ((htlc, paymentPreimage) <- (htlc1, paymentPreimage1) :: (htlc3, paymentPreimage3) :: Nil) {
-        val Right(claimHtlcSuccessTx) = makeClaimHtlcSuccessTx(commitTx.tx, commitTxOutputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw, UnsafeLegacyAnchorOutputsCommitmentFormat)
+        val TxGenerationResult.Success(claimHtlcSuccessTx) = makeClaimHtlcSuccessTx(commitTx.tx, commitTxOutputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw, UnsafeLegacyAnchorOutputsCommitmentFormat)
         val localSig = sign(claimHtlcSuccessTx, remoteHtlcPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
         val signed = addSigs(claimHtlcSuccessTx, localSig, paymentPreimage)
         assert(checkSpendable(signed).isSuccess)
@@ -666,18 +666,18 @@ class TransactionsSpec extends AnyFunSuite with Logging {
     }
     {
       // remote spends htlc1's htlc-timeout tx with revocation key
-      val Seq(Right(claimHtlcDelayedPenaltyTx)) = makeClaimHtlcDelayedOutputPenaltyTxs(htlcTimeoutTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val Seq(TxGenerationResult.Success(claimHtlcDelayedPenaltyTx)) = makeClaimHtlcDelayedOutputPenaltyTxs(htlcTimeoutTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       val sig = sign(claimHtlcDelayedPenaltyTx, localRevocationPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
       val signed = addSigs(claimHtlcDelayedPenaltyTx, sig)
       assert(checkSpendable(signed).isSuccess)
       // remote can't claim revoked output of htlc3's htlc-timeout tx because it is below the dust limit
       val claimHtlcDelayedPenaltyTx1 = makeClaimHtlcDelayedOutputPenaltyTxs(htlcTimeoutTxs(0).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      assert(claimHtlcDelayedPenaltyTx1 === Seq(Left(AmountBelowDustLimit)))
+      assert(claimHtlcDelayedPenaltyTx1 === Seq(TxGenerationResult.AmountBelowDustLimit))
     }
     {
       // remote spends remote->local htlc output directly in case of timeout
       for (htlc <- Seq(htlc2a, htlc2b)) {
-        val Right(claimHtlcTimeoutTx) = makeClaimHtlcTimeoutTx(commitTx.tx, commitTxOutputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw, UnsafeLegacyAnchorOutputsCommitmentFormat)
+        val TxGenerationResult.Success(claimHtlcTimeoutTx) = makeClaimHtlcTimeoutTx(commitTx.tx, commitTxOutputs, localDustLimit, remoteHtlcPriv.publicKey, localHtlcPriv.publicKey, localRevocationPriv.publicKey, finalPubKeyScript, htlc, feeratePerKw, UnsafeLegacyAnchorOutputsCommitmentFormat)
         val localSig = sign(claimHtlcTimeoutTx, remoteHtlcPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
         val signed = addSigs(claimHtlcTimeoutTx, localSig)
         assert(checkSpendable(signed).isSuccess)
@@ -685,8 +685,8 @@ class TransactionsSpec extends AnyFunSuite with Logging {
     }
     {
       // remote spends htlc2a/htlc2b's htlc-success tx with revocation key
-      val Seq(Right(claimHtlcDelayedPenaltyTxA)) = makeClaimHtlcDelayedOutputPenaltyTxs(htlcSuccessTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      val Seq(Right(claimHtlcDelayedPenaltyTxB)) = makeClaimHtlcDelayedOutputPenaltyTxs(htlcSuccessTxs(2).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val Seq(TxGenerationResult.Success(claimHtlcDelayedPenaltyTxA)) = makeClaimHtlcDelayedOutputPenaltyTxs(htlcSuccessTxs(1).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
+      val Seq(TxGenerationResult.Success(claimHtlcDelayedPenaltyTxB)) = makeClaimHtlcDelayedOutputPenaltyTxs(htlcSuccessTxs(2).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       for (claimHtlcSuccessPenaltyTx <- Seq(claimHtlcDelayedPenaltyTxA, claimHtlcDelayedPenaltyTxB)) {
         val sig = sign(claimHtlcSuccessPenaltyTx, localRevocationPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
         val signed = addSigs(claimHtlcSuccessPenaltyTx, sig)
@@ -694,7 +694,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       }
       // remote can't claim revoked output of htlc4's htlc-success tx because it is below the dust limit
       val claimHtlcDelayedPenaltyTx1 = makeClaimHtlcDelayedOutputPenaltyTxs(htlcSuccessTxs(0).tx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
-      assert(claimHtlcDelayedPenaltyTx1 === Seq(Left(AmountBelowDustLimit)))
+      assert(claimHtlcDelayedPenaltyTx1 === Seq(TxGenerationResult.AmountBelowDustLimit))
     }
     {
       // remote spends all htlc txs aggregated in a single tx
@@ -703,12 +703,14 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       val aggregatedHtlcTx = Transaction(2, txIn, txOut, 0)
       val claimHtlcDelayedPenaltyTxs = makeClaimHtlcDelayedOutputPenaltyTxs(aggregatedHtlcTx, localDustLimit, localRevocationPriv.publicKey, toLocalDelay, localDelayedPaymentPriv.publicKey, finalPubKeyScript, feeratePerKw)
       assert(claimHtlcDelayedPenaltyTxs.size === 5)
-      val skipped = claimHtlcDelayedPenaltyTxs.collect { case Left(reason) => reason }
+      val (claimed, skipped) = claimHtlcDelayedPenaltyTxs.partition {
+        case _: TxGenerationResult.Success[_] => true
+        case _ => false
+      }
       assert(skipped.size === 2)
-      assert(skipped.toSet === Set(AmountBelowDustLimit))
-      val claimed = claimHtlcDelayedPenaltyTxs.collect { case Right(tx) => tx }
+      assert(skipped.toSet === Set(TxGenerationResult.AmountBelowDustLimit))
       assert(claimed.size === 3)
-      assert(claimed.map(_.input.outPoint).toSet.size === 3)
+      assert(claimed.map(_.get.input.outPoint).toSet.size === 3)
     }
     {
       // remote spends offered htlc output with revocation key
@@ -717,7 +719,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
         case (CommitmentOutputLink(_, _, OutHtlc(OutgoingHtlc(someHtlc))), _) => someHtlc.id == htlc1.id
         case _ => false
       }.map(_._2)
-      val Right(htlcPenaltyTx) = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feeratePerKw)
+      val TxGenerationResult.Success(htlcPenaltyTx) = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feeratePerKw)
       val sig = sign(htlcPenaltyTx, localRevocationPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
       val signed = addSigs(htlcPenaltyTx, sig, localRevocationPriv.publicKey)
       assert(checkSpendable(signed).isSuccess)
@@ -730,7 +732,7 @@ class TransactionsSpec extends AnyFunSuite with Logging {
           case (CommitmentOutputLink(_, _, InHtlc(IncomingHtlc(someHtlc))), _) => someHtlc.id == htlc.id
           case _ => false
         }.map(_._2)
-        val Right(htlcPenaltyTx) = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feeratePerKw)
+        val TxGenerationResult.Success(htlcPenaltyTx) = makeHtlcPenaltyTx(commitTx.tx, htlcOutputIndex, script, localDustLimit, finalPubKeyScript, feeratePerKw)
         val sig = sign(htlcPenaltyTx, localRevocationPriv, TxOwner.Local, UnsafeLegacyAnchorOutputsCommitmentFormat)
         val signed = addSigs(htlcPenaltyTx, sig, localRevocationPriv.publicKey)
         assert(checkSpendable(signed).isSuccess)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2Spec.scala
@@ -1,12 +1,17 @@
 package fr.acinq.eclair.wire.internal.channel.version2
 
-import fr.acinq.bitcoin.{ByteVector64, OutPoint, Transaction}
+import fr.acinq.bitcoin.{ByteVector64, OutPoint, SatoshiLong, Transaction, TxOut}
 import fr.acinq.eclair.channel.{ChannelConfig, ChannelFeatures, HtlcTxAndRemoteSig}
+import fr.acinq.eclair.transactions.Transactions
+import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.wire.internal.channel.version2.ChannelCodecs2.Codecs._
 import fr.acinq.eclair.wire.internal.channel.version2.ChannelCodecs2.stateDataCodec
-import fr.acinq.eclair.{FeatureSupport, Features, randomBytes32}
+import fr.acinq.eclair.wire.protocol.CommonCodecs.bool8
+import fr.acinq.eclair.{BlockHeight, Features, channel, randomBytes, randomBytes32}
 import org.scalatest.funsuite.AnyFunSuite
-import scodec.bits.HexStringSyntax
+import scodec.bits.{BitVector, HexStringSyntax}
+import scodec.codecs.optional
+import scodec.{Codec, DecodeResult}
 
 class ChannelCodecs2Spec extends AnyFunSuite {
 
@@ -21,6 +26,50 @@ class ChannelCodecs2Spec extends AnyFunSuite {
       OutPoint(randomBytes32(), 454513) -> Transaction.read("02000000000101ab84ff284f162cfbfef241f853b47d4368d171f9e2a1445160cd591c4c7d882b00000000000000000001e8030000000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e0500483045022100d9e29616b8f3959f1d3d7f7ce893ffedcdc407717d0de8e37d808c91d3a7c50d022078c3033f6d00095c8720a4bc943c1b45727818c082e4e3ddbc6d3116435b624b014730440220636de5682ef0c5b61f124ec74e8aa2461a69777521d6998295dcea36bc3338110220165285594b23c50b28b82df200234566628a27bcd17f7f14404bd865354eb3ce012000000000000000000000000000000000000000000000000000000000000000008a76a91414011f7254d96b819c76986c277d115efce6f7b58763ac67210394854aa6eab5b2a8122cc726e9dded053a2184d88256816826d6231c068d4a5b7c8201208763a914b8bcb07f6344b42ab04250c86a6e8b75d3fdbbc688527c21030d417a46946384f88d5f3337267c5e579765875dc4daca813e21734b140639e752ae677502f401b175ac686800000000")
     )
     assert(spentMapCodec.decodeValue(spentMapCodec.encode(map).require).require === map)
+  }
+
+  test("backward compatibility for htlc status (local)") {
+    val legacyCodec: Codec[Option[Transactions.HtlcTx]] = optional(bool8, htlcTxCodec)
+
+    val inputInfo = InputInfo(OutPoint(randomBytes32(), 42), TxOut(123456L sat, randomBytes(90)), randomBytes(128))
+    val tx = Transaction.read("020000000001018154ecccf11a5fb56c39654c4deb4d2296f83c69268280b94d021370c94e219701000000000000000001d0070000000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e0500483045022100d5275b3619953cb0c3b5aa577f04bc512380e60fa551762ce3d7a1bb7401cff9022037237ab0dac3fe100cde094e82e2bed9ba0ed1bb40154b48e56aa70f259e608b01483045022100c89172099507ff50f4c925e6c5150e871fb6e83dd73ff9fbb72f6ce829a9633f02203a63821d9162e99f9be712a68f9e589483994feae2661e4546cd5b6cec007be501008576a91414011f7254d96b819c76986c277d115efce6f7b58763ac67210394854aa6eab5b2a8122cc726e9dded053a2184d88256816826d6231c068d4a5b7c820120876475527c21030d417a46946384f88d5f3337267c5e579765875dc4daca813e21734b140639e752ae67a914b43e1b38138a41b37f7cd9a1d274bc63e3a9b5d188ac6868f6010000")
+
+    val htlcTimeoutTx = HtlcTimeoutTx(inputInfo, tx, 74846, BlockHeight(800000))
+    val htlcSuccessTx = HtlcSuccessTx(inputInfo, tx, randomBytes32(), 4861, BlockHeight(800000))
+
+    val htlc_opts = Map(
+      Option.empty[HtlcTimeoutTx] -> channel.LocalCommitPublished.HtlcOutputStatus.Unknown,
+      Option.empty[HtlcSuccessTx] -> channel.LocalCommitPublished.HtlcOutputStatus.Unknown,
+      Some(htlcTimeoutTx) -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(htlcTimeoutTx.copy(confirmBefore = BlockHeight(0))),
+      Some(htlcSuccessTx) -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(htlcSuccessTx.copy(confirmBefore = BlockHeight(0)))
+    )
+
+    htlc_opts.foreach { case (htlc_opt, ref) =>
+      val bin = legacyCodec.encode(htlc_opt).require
+      assert(htlcLocalOutputStatusCodec.decode(bin).require === DecodeResult(ref, BitVector.empty))
+    }
+  }
+
+  test("backward compatibility for htlc status (remote)") {
+    val legacyCodec: Codec[Option[Transactions.ClaimHtlcTx]] = optional(bool8, claimHtlcTxCodec)
+
+    val inputInfo = InputInfo(OutPoint(randomBytes32(), 42), TxOut(123456L sat, randomBytes(90)), randomBytes(128))
+    val tx = Transaction.read("020000000001018154ecccf11a5fb56c39654c4deb4d2296f83c69268280b94d021370c94e219701000000000000000001d0070000000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e0500483045022100d5275b3619953cb0c3b5aa577f04bc512380e60fa551762ce3d7a1bb7401cff9022037237ab0dac3fe100cde094e82e2bed9ba0ed1bb40154b48e56aa70f259e608b01483045022100c89172099507ff50f4c925e6c5150e871fb6e83dd73ff9fbb72f6ce829a9633f02203a63821d9162e99f9be712a68f9e589483994feae2661e4546cd5b6cec007be501008576a91414011f7254d96b819c76986c277d115efce6f7b58763ac67210394854aa6eab5b2a8122cc726e9dded053a2184d88256816826d6231c068d4a5b7c820120876475527c21030d417a46946384f88d5f3337267c5e579765875dc4daca813e21734b140639e752ae67a914b43e1b38138a41b37f7cd9a1d274bc63e3a9b5d188ac6868f6010000")
+
+    val claimHtlcTimeoutTx = ClaimHtlcTimeoutTx(inputInfo, tx, 74846, BlockHeight(800000))
+    val claimHtlcSuccessTx = LegacyClaimHtlcSuccessTx(inputInfo, tx, 4861, BlockHeight(800000))
+
+    val htlc_opts = Map(
+      Option.empty[ClaimHtlcTimeoutTx] -> channel.RemoteCommitPublished.HtlcOutputStatus.Unknown,
+      Option.empty[ClaimHtlcSuccessTx] -> channel.RemoteCommitPublished.HtlcOutputStatus.Unknown,
+      Some(claimHtlcTimeoutTx) -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(claimHtlcTimeoutTx.copy(confirmBefore = BlockHeight(0))),
+      Some(claimHtlcSuccessTx) -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(claimHtlcSuccessTx.copy(confirmBefore = BlockHeight(0)))
+    )
+
+    htlc_opts.foreach { case (htlc_opt, ref) =>
+      val bin = legacyCodec.encode(htlc_opt).require
+      assert(htlcRemoteOutputStatusCodec.decode(bin).require === DecodeResult(ref, BitVector.empty))
+    }
   }
 
   test("remove signatures from commitment txs") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2Spec.scala
@@ -37,9 +37,9 @@ class ChannelCodecs2Spec extends AnyFunSuite {
     val htlcTimeoutTx = HtlcTimeoutTx(inputInfo, tx, 74846, BlockHeight(800000))
     val htlcSuccessTx = HtlcSuccessTx(inputInfo, tx, randomBytes32(), 4861, BlockHeight(800000))
 
-    val htlc_opts = Map(
-      Option.empty[HtlcTimeoutTx] -> channel.LocalCommitPublished.HtlcOutputStatus.Unknown,
-      Option.empty[HtlcSuccessTx] -> channel.LocalCommitPublished.HtlcOutputStatus.Unknown,
+    val htlc_opts = Seq(
+      Option.empty[HtlcTimeoutTx] -> channel.LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement,
+      Option.empty[HtlcSuccessTx] -> channel.LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement,
       Some(htlcTimeoutTx) -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(htlcTimeoutTx.copy(confirmBefore = BlockHeight(0))),
       Some(htlcSuccessTx) -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(htlcSuccessTx.copy(confirmBefore = BlockHeight(0)))
     )
@@ -59,7 +59,7 @@ class ChannelCodecs2Spec extends AnyFunSuite {
     val claimHtlcTimeoutTx = ClaimHtlcTimeoutTx(inputInfo, tx, 74846, BlockHeight(800000))
     val claimHtlcSuccessTx = LegacyClaimHtlcSuccessTx(inputInfo, tx, 4861, BlockHeight(800000))
 
-    val htlc_opts = Map(
+    val htlc_opts = Seq(
       Option.empty[ClaimHtlcTimeoutTx] -> channel.RemoteCommitPublished.HtlcOutputStatus.Unknown,
       Option.empty[ClaimHtlcSuccessTx] -> channel.RemoteCommitPublished.HtlcOutputStatus.Unknown,
       Some(claimHtlcTimeoutTx) -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(claimHtlcTimeoutTx.copy(confirmBefore = BlockHeight(0))),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2Spec.scala
@@ -1,17 +1,12 @@
 package fr.acinq.eclair.wire.internal.channel.version2
 
-import fr.acinq.bitcoin.{ByteVector64, OutPoint, SatoshiLong, Transaction, TxOut}
+import fr.acinq.bitcoin.{ByteVector64, OutPoint, Transaction}
 import fr.acinq.eclair.channel.{ChannelConfig, ChannelFeatures, HtlcTxAndRemoteSig}
-import fr.acinq.eclair.transactions.Transactions
-import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.wire.internal.channel.version2.ChannelCodecs2.Codecs._
 import fr.acinq.eclair.wire.internal.channel.version2.ChannelCodecs2.stateDataCodec
-import fr.acinq.eclair.wire.protocol.CommonCodecs.bool8
-import fr.acinq.eclair.{BlockHeight, Features, channel, randomBytes, randomBytes32}
+import fr.acinq.eclair.{Features, randomBytes32}
 import org.scalatest.funsuite.AnyFunSuite
-import scodec.bits.{BitVector, HexStringSyntax}
-import scodec.codecs.optional
-import scodec.{Codec, DecodeResult}
+import scodec.bits.HexStringSyntax
 
 class ChannelCodecs2Spec extends AnyFunSuite {
 
@@ -26,50 +21,6 @@ class ChannelCodecs2Spec extends AnyFunSuite {
       OutPoint(randomBytes32(), 454513) -> Transaction.read("02000000000101ab84ff284f162cfbfef241f853b47d4368d171f9e2a1445160cd591c4c7d882b00000000000000000001e8030000000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e0500483045022100d9e29616b8f3959f1d3d7f7ce893ffedcdc407717d0de8e37d808c91d3a7c50d022078c3033f6d00095c8720a4bc943c1b45727818c082e4e3ddbc6d3116435b624b014730440220636de5682ef0c5b61f124ec74e8aa2461a69777521d6998295dcea36bc3338110220165285594b23c50b28b82df200234566628a27bcd17f7f14404bd865354eb3ce012000000000000000000000000000000000000000000000000000000000000000008a76a91414011f7254d96b819c76986c277d115efce6f7b58763ac67210394854aa6eab5b2a8122cc726e9dded053a2184d88256816826d6231c068d4a5b7c8201208763a914b8bcb07f6344b42ab04250c86a6e8b75d3fdbbc688527c21030d417a46946384f88d5f3337267c5e579765875dc4daca813e21734b140639e752ae677502f401b175ac686800000000")
     )
     assert(spentMapCodec.decodeValue(spentMapCodec.encode(map).require).require === map)
-  }
-
-  test("backward compatibility for htlc status (local)") {
-    val legacyCodec: Codec[Option[Transactions.HtlcTx]] = optional(bool8, htlcTxCodec)
-
-    val inputInfo = InputInfo(OutPoint(randomBytes32(), 42), TxOut(123456L sat, randomBytes(90)), randomBytes(128))
-    val tx = Transaction.read("020000000001018154ecccf11a5fb56c39654c4deb4d2296f83c69268280b94d021370c94e219701000000000000000001d0070000000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e0500483045022100d5275b3619953cb0c3b5aa577f04bc512380e60fa551762ce3d7a1bb7401cff9022037237ab0dac3fe100cde094e82e2bed9ba0ed1bb40154b48e56aa70f259e608b01483045022100c89172099507ff50f4c925e6c5150e871fb6e83dd73ff9fbb72f6ce829a9633f02203a63821d9162e99f9be712a68f9e589483994feae2661e4546cd5b6cec007be501008576a91414011f7254d96b819c76986c277d115efce6f7b58763ac67210394854aa6eab5b2a8122cc726e9dded053a2184d88256816826d6231c068d4a5b7c820120876475527c21030d417a46946384f88d5f3337267c5e579765875dc4daca813e21734b140639e752ae67a914b43e1b38138a41b37f7cd9a1d274bc63e3a9b5d188ac6868f6010000")
-
-    val htlcTimeoutTx = HtlcTimeoutTx(inputInfo, tx, 74846, BlockHeight(800000))
-    val htlcSuccessTx = HtlcSuccessTx(inputInfo, tx, randomBytes32(), 4861, BlockHeight(800000))
-
-    val htlc_opts = Seq(
-      Option.empty[HtlcTimeoutTx] -> channel.LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement,
-      Option.empty[HtlcSuccessTx] -> channel.LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement,
-      Some(htlcTimeoutTx) -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(htlcTimeoutTx.copy(confirmBefore = BlockHeight(0))),
-      Some(htlcSuccessTx) -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(htlcSuccessTx.copy(confirmBefore = BlockHeight(0)))
-    )
-
-    htlc_opts.foreach { case (htlc_opt, ref) =>
-      val bin = legacyCodec.encode(htlc_opt).require
-      assert(htlcLocalOutputStatusCodec.decode(bin).require === DecodeResult(ref, BitVector.empty))
-    }
-  }
-
-  test("backward compatibility for htlc status (remote)") {
-    val legacyCodec: Codec[Option[Transactions.ClaimHtlcTx]] = optional(bool8, claimHtlcTxCodec)
-
-    val inputInfo = InputInfo(OutPoint(randomBytes32(), 42), TxOut(123456L sat, randomBytes(90)), randomBytes(128))
-    val tx = Transaction.read("020000000001018154ecccf11a5fb56c39654c4deb4d2296f83c69268280b94d021370c94e219701000000000000000001d0070000000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e0500483045022100d5275b3619953cb0c3b5aa577f04bc512380e60fa551762ce3d7a1bb7401cff9022037237ab0dac3fe100cde094e82e2bed9ba0ed1bb40154b48e56aa70f259e608b01483045022100c89172099507ff50f4c925e6c5150e871fb6e83dd73ff9fbb72f6ce829a9633f02203a63821d9162e99f9be712a68f9e589483994feae2661e4546cd5b6cec007be501008576a91414011f7254d96b819c76986c277d115efce6f7b58763ac67210394854aa6eab5b2a8122cc726e9dded053a2184d88256816826d6231c068d4a5b7c820120876475527c21030d417a46946384f88d5f3337267c5e579765875dc4daca813e21734b140639e752ae67a914b43e1b38138a41b37f7cd9a1d274bc63e3a9b5d188ac6868f6010000")
-
-    val claimHtlcTimeoutTx = ClaimHtlcTimeoutTx(inputInfo, tx, 74846, BlockHeight(800000))
-    val claimHtlcSuccessTx = LegacyClaimHtlcSuccessTx(inputInfo, tx, 4861, BlockHeight(800000))
-
-    val htlc_opts = Seq(
-      Option.empty[ClaimHtlcTimeoutTx] -> channel.RemoteCommitPublished.HtlcOutputStatus.Unknown,
-      Option.empty[ClaimHtlcSuccessTx] -> channel.RemoteCommitPublished.HtlcOutputStatus.Unknown,
-      Some(claimHtlcTimeoutTx) -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(claimHtlcTimeoutTx.copy(confirmBefore = BlockHeight(0))),
-      Some(claimHtlcSuccessTx) -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(claimHtlcSuccessTx.copy(confirmBefore = BlockHeight(0)))
-    )
-
-    htlc_opts.foreach { case (htlc_opt, ref) =>
-      val bin = legacyCodec.encode(htlc_opt).require
-      assert(htlcRemoteOutputStatusCodec.decode(bin).require === DecodeResult(ref, BitVector.empty))
-    }
   }
 
   test("remove signatures from commitment txs") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3Spec.scala
@@ -19,17 +19,14 @@ import fr.acinq.bitcoin.{ByteVector32, OutPoint, Satoshi, SatoshiLong, Transacti
 import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
 import fr.acinq.eclair.Features.{ChannelRangeQueries, PaymentSecret, VariableLengthOnion}
 import fr.acinq.eclair.channel._
-import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecsSpec.normal
 import fr.acinq.eclair.wire.internal.channel.version3.ChannelCodecs3.Codecs._
 import fr.acinq.eclair.wire.internal.channel.version3.ChannelCodecs3.stateDataCodec
-import fr.acinq.eclair.wire.protocol.CommonCodecs.bool8
-import fr.acinq.eclair.{BlockHeight, CltvExpiryDelta, Features, MilliSatoshi, UInt64, channel, randomBytes, randomBytes32, randomKey}
+import fr.acinq.eclair.{BlockHeight, CltvExpiryDelta, Features, MilliSatoshi, UInt64, randomBytes, randomBytes32, randomKey}
 import org.scalatest.funsuite.AnyFunSuite
-import scodec.{Codec, DecodeResult}
+import scodec.DecodeResult
 import scodec.bits.{BitVector, ByteVector, HexStringSyntax}
-import scodec.codecs.optional
 
 class ChannelCodecs3Spec extends AnyFunSuite {
 
@@ -203,48 +200,14 @@ class ChannelCodecs3Spec extends AnyFunSuite {
     }
   }
 
-  test("backward compatibility for htlc status (local)") {
-    val legacyCodec: Codec[Option[Transactions.HtlcTx]] = optional(bool8, htlcTxCodec)
-
+  test("txGenerationResultCodec codec") {
     val inputInfo = InputInfo(OutPoint(randomBytes32(), 42), TxOut(123456L sat, randomBytes(90)), randomBytes(128))
     val tx = Transaction.read("020000000001018154ecccf11a5fb56c39654c4deb4d2296f83c69268280b94d021370c94e219701000000000000000001d0070000000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e0500483045022100d5275b3619953cb0c3b5aa577f04bc512380e60fa551762ce3d7a1bb7401cff9022037237ab0dac3fe100cde094e82e2bed9ba0ed1bb40154b48e56aa70f259e608b01483045022100c89172099507ff50f4c925e6c5150e871fb6e83dd73ff9fbb72f6ce829a9633f02203a63821d9162e99f9be712a68f9e589483994feae2661e4546cd5b6cec007be501008576a91414011f7254d96b819c76986c277d115efce6f7b58763ac67210394854aa6eab5b2a8122cc726e9dded053a2184d88256816826d6231c068d4a5b7c820120876475527c21030d417a46946384f88d5f3337267c5e579765875dc4daca813e21734b140639e752ae67a914b43e1b38138a41b37f7cd9a1d274bc63e3a9b5d188ac6868f6010000")
-
-    val htlcTimeoutTx = HtlcTimeoutTx(inputInfo, tx, 74846, BlockHeight(800000))
-    val htlcSuccessTx = HtlcSuccessTx(inputInfo, tx, randomBytes32(), 4861, BlockHeight(800000))
-
-    val htlc_opts = Seq(
-      Option.empty[HtlcTimeoutTx] -> channel.LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement,
-      Option.empty[HtlcSuccessTx] -> channel.LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement,
-      Some(htlcTimeoutTx) -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(htlcTimeoutTx),
-      Some(htlcSuccessTx) -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(htlcSuccessTx)
-    )
-
-    htlc_opts.foreach { case (htlc_opt, ref) =>
-      val bin = legacyCodec.encode(htlc_opt).require
-      assert(htlcLocalOutputStatusCodec.decode(bin).require === DecodeResult(ref, BitVector.empty))
-    }
-  }
-
-  test("backward compatibility for htlc status (remote)") {
-    val legacyCodec: Codec[Option[Transactions.ClaimHtlcTx]] = optional(bool8, claimHtlcTxCodec)
-
-    val inputInfo = InputInfo(OutPoint(randomBytes32(), 42), TxOut(123456L sat, randomBytes(90)), randomBytes(128))
-    val tx = Transaction.read("020000000001018154ecccf11a5fb56c39654c4deb4d2296f83c69268280b94d021370c94e219701000000000000000001d0070000000000002200204adb4e2f00643db396dd120d4e7dc17625f5f2c11a40d857accc862d6b7dd80e0500483045022100d5275b3619953cb0c3b5aa577f04bc512380e60fa551762ce3d7a1bb7401cff9022037237ab0dac3fe100cde094e82e2bed9ba0ed1bb40154b48e56aa70f259e608b01483045022100c89172099507ff50f4c925e6c5150e871fb6e83dd73ff9fbb72f6ce829a9633f02203a63821d9162e99f9be712a68f9e589483994feae2661e4546cd5b6cec007be501008576a91414011f7254d96b819c76986c277d115efce6f7b58763ac67210394854aa6eab5b2a8122cc726e9dded053a2184d88256816826d6231c068d4a5b7c820120876475527c21030d417a46946384f88d5f3337267c5e579765875dc4daca813e21734b140639e752ae67a914b43e1b38138a41b37f7cd9a1d274bc63e3a9b5d188ac6868f6010000")
-
     val claimHtlcTimeoutTx = ClaimHtlcTimeoutTx(inputInfo, tx, 74846, BlockHeight(800000))
-    val claimHtlcSuccessTx = ClaimHtlcSuccessTx(inputInfo, tx, randomBytes32(), 4861, BlockHeight(800000))
+    val txResult = TxGenerationResult.Success(claimHtlcTimeoutTx)
 
-    val htlc_opts = Seq(
-      Option.empty[ClaimHtlcTimeoutTx] -> channel.RemoteCommitPublished.HtlcOutputStatus.Unknown,
-      Option.empty[ClaimHtlcSuccessTx] -> channel.RemoteCommitPublished.HtlcOutputStatus.Unknown,
-      Some(claimHtlcTimeoutTx) -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(claimHtlcTimeoutTx),
-      Some(claimHtlcSuccessTx) -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(claimHtlcSuccessTx)
-    )
-
-    htlc_opts.foreach { case (htlc_opt, ref) =>
-      val bin = legacyCodec.encode(htlc_opt).require
-      assert(htlcRemoteOutputStatusCodec.decode(bin).require === DecodeResult(ref, BitVector.empty))
-    }
+    val codec = txGenerationResultCodec(claimHtlcTimeoutTxCodec)
+    assert(codec.decode(codec.encode(txResult).require).require == DecodeResult(txResult, BitVector.empty))
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3Spec.scala
@@ -212,9 +212,9 @@ class ChannelCodecs3Spec extends AnyFunSuite {
     val htlcTimeoutTx = HtlcTimeoutTx(inputInfo, tx, 74846, BlockHeight(800000))
     val htlcSuccessTx = HtlcSuccessTx(inputInfo, tx, randomBytes32(), 4861, BlockHeight(800000))
 
-    val htlc_opts = Map(
-      Option.empty[HtlcTimeoutTx] -> channel.LocalCommitPublished.HtlcOutputStatus.Unknown,
-      Option.empty[HtlcSuccessTx] -> channel.LocalCommitPublished.HtlcOutputStatus.Unknown,
+    val htlc_opts = Seq(
+      Option.empty[HtlcTimeoutTx] -> channel.LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement,
+      Option.empty[HtlcSuccessTx] -> channel.LocalCommitPublished.HtlcOutputStatus.PendingDownstreamSettlement,
       Some(htlcTimeoutTx) -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(htlcTimeoutTx),
       Some(htlcSuccessTx) -> channel.LocalCommitPublished.HtlcOutputStatus.Spendable(htlcSuccessTx)
     )
@@ -234,7 +234,7 @@ class ChannelCodecs3Spec extends AnyFunSuite {
     val claimHtlcTimeoutTx = ClaimHtlcTimeoutTx(inputInfo, tx, 74846, BlockHeight(800000))
     val claimHtlcSuccessTx = ClaimHtlcSuccessTx(inputInfo, tx, randomBytes32(), 4861, BlockHeight(800000))
 
-    val htlc_opts = Map(
+    val htlc_opts = Seq(
       Option.empty[ClaimHtlcTimeoutTx] -> channel.RemoteCommitPublished.HtlcOutputStatus.Unknown,
       Option.empty[ClaimHtlcSuccessTx] -> channel.RemoteCommitPublished.HtlcOutputStatus.Unknown,
       Some(claimHtlcTimeoutTx) -> channel.RemoteCommitPublished.HtlcOutputStatus.Spendable(claimHtlcTimeoutTx),


### PR DESCRIPTION
We make a disctinction between `Unknown`/`Unspendable`/`Spendable` htlc outputs. When we know for sure that an incoming htlc will never be fulfilled, we can safely ignore it. See #2168.

- [x] type htlc outputs in local force close
- [x] use the new `Unspendable` tag
- [x] same for remote close

This PR is pretty straightforward, but touches sensitive parts of the code. Reviewer beware 👓 .
