### PR TITLE
Fix path-finding

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -246,14 +246,14 @@ object Graph {
         }
         neighborEdges.foreach { edge =>
           val neighbor = edge.desc.a
-          // NB: this contains the amount (including fees) that will need to be sent to `neighbor`, but the amount that
-          // will be relayed through that edge is the one in `currentWeight`.
           if (current.weight.amount <= edge.capacity &&
             edge.balance_opt.forall(current.weight.amount <= _) &&
             edge.update.htlcMaximumMsat.forall(current.weight.amount <= _) &&
             current.weight.amount >= edge.update.htlcMinimumMsat &&
             !ignoredEdges.contains(edge.desc) &&
             !ignoredVertices.contains(neighbor)) {
+            // NB: this contains the amount (including fees) that will need to be sent to `neighbor`, but the amount that
+            // will be relayed through that edge is the one in `currentWeight`.
             val neighborWeight = addEdgeWeight(sourceNode, edge, current.weight, currentBlockHeight, wr, includeLocalChannelCost)
             if (boundaries(neighborWeight)) {
               val previousNeighborWeight = bestWeights.getOrElse(neighbor, RichWeight(MilliSatoshi(Long.MaxValue), Int.MaxValue, CltvExpiryDelta(Int.MaxValue), 0.0, MilliSatoshi(Long.MaxValue), MilliSatoshi(Long.MaxValue), Double.MaxValue))


### PR DESCRIPTION
We used to compute the edge weight before checking that the edge could actually relay the payment.
Since #2111 we throw an exception in case `heuristicsConstants` are used and the edge can't relay the payment instead of just ignoring the edge.
We fix this by checking that the edge can relay the payment before trying to call `addEdgeWeight`.