### PR TITLE
Restrict building and publishing docker images to new pushes on master

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,8 +3,6 @@ name: Docker Image CI
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
 


### PR DESCRIPTION
It is not really useful to build docker images for PRs and would not work anyway for forks that are not in the ACINQ repo.