### PR TITLE
Add logs about local channel graph inclusion

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -118,6 +118,7 @@ object RouteCalculation {
 
       log.info(s"finding routes ${r.source}->${r.target} with assistedChannels={} ignoreNodes={} ignoreChannels={} excludedChannels={}", assistedChannels.keys.mkString(","), r.ignore.nodes.map(_.value).mkString(","), r.ignore.channels.mkString(","), d.excludedChannels.mkString(","))
       log.info("finding routes with params={}, multiPart={}", params, r.allowMultiPart)
+      log.info("local channels to recipient: {}", d.graph.getEdgesBetween(r.source, r.target).map(e => s"${e.desc.shortChannelId} (${e.balance_opt}/${e.capacity})").mkString(", "))
       val tags = TagSet.Empty.withTag(Tags.MultiPart, r.allowMultiPart).withTag(Tags.Amount, Tags.amountBucket(r.amount))
       KamonExt.time(Metrics.FindRouteDuration.withTags(tags.withTag(Tags.NumberOfRoutes, routesToFind.toLong))) {
         val result = if (r.allowMultiPart) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -300,8 +300,10 @@ object Validation {
         // update the graph
         val pc1 = pc.applyChannelUpdate(update)
         val graph1 = if (u.channelFlags.isEnabled) {
+          update.left.foreach(_ => log.info("added local shortChannelId={} public={} to the network graph", u.shortChannelId, publicChannel))
           d.graph.addEdge(desc, u, pc1.capacity, pc1.getBalanceSameSideAs(u))
         } else {
+          update.left.foreach(_ => log.info("removed local shortChannelId={} public={} from the network graph", u.shortChannelId, publicChannel))
           d.graph.removeEdge(desc)
         }
         d.copy(channels = d.channels + (u.shortChannelId -> pc1), rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins)), graph = graph1)
@@ -313,6 +315,7 @@ object Validation {
         // we also need to update the graph
         val pc1 = pc.applyChannelUpdate(update)
         val graph1 = d.graph.addEdge(desc, u, pc1.capacity, pc1.getBalanceSameSideAs(u))
+        update.left.foreach(_ => log.info("added local shortChannelId={} public={} to the network graph", u.shortChannelId, publicChannel))
         d.copy(channels = d.channels + (u.shortChannelId -> pc1), privateChannels = d.privateChannels - u.shortChannelId, rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins)), graph = graph1)
       }
     } else if (d.awaiting.keys.exists(c => c.shortChannelId == u.shortChannelId)) {
@@ -349,8 +352,10 @@ object Validation {
         // we also need to update the graph
         val pc1 = pc.applyChannelUpdate(update)
         val graph1 = if (u.channelFlags.isEnabled) {
+          update.left.foreach(_ => log.info("added local shortChannelId={} public={} to the network graph", u.shortChannelId, publicChannel))
           d.graph.addEdge(desc, u, pc1.capacity, pc1.getBalanceSameSideAs(u))
         } else {
+          update.left.foreach(_ => log.info("removed local shortChannelId={} public={} from the network graph", u.shortChannelId, publicChannel))
           d.graph.removeEdge(desc)
         }
         d.copy(privateChannels = d.privateChannels + (u.shortChannelId -> pc1), graph = graph1)
@@ -361,6 +366,7 @@ object Validation {
         // we also need to update the graph
         val pc1 = pc.applyChannelUpdate(update)
         val graph1 = d.graph.addEdge(desc, u, pc1.capacity, pc1.getBalanceSameSideAs(u))
+        update.left.foreach(_ => log.info("added local shortChannelId={} public={} to the network graph", u.shortChannelId, publicChannel))
         d.copy(privateChannels = d.privateChannels + (u.shortChannelId -> pc1), graph = graph1)
       }
     } else if (db.isPruned(u.shortChannelId) && !StaleChannels.isStale(u)) {
@@ -441,7 +447,7 @@ object Validation {
       d
     } else if (d.privateChannels.contains(shortChannelId)) {
       // the channel was private or public-but-not-yet-announced, let's do the clean up
-      log.debug("removing private local channel and channel_update for channelId={} shortChannelId={}", channelId, shortChannelId)
+      log.info("removing private local channel and channel_update for channelId={} shortChannelId={}", channelId, shortChannelId)
       val desc1 = ChannelDesc(shortChannelId, localNodeId, remoteNodeId)
       val desc2 = ChannelDesc(shortChannelId, remoteNodeId, localNodeId)
       // we remove the corresponding updates from the graph


### PR DESCRIPTION
We've seen a few reports of local channels sometimes being ignored during path-finding (e.g. #2176). When that happens, it's currently hard to know whether the channel is in the graph or not: knowing that would let us know if there is a bug in the graph management code or the path-finding algorithm itself.

I'm adding a few logs to the relevant components:

- when a route request is received, we log the direct channels we have with that peer (if any): that will let us know whether our channels are considered or not
- when a local channel is added or removed from the graph, we log something: that will let us pinpoint whether some channels are missing from the graph when they should be in it