### PR TITLE
Bump postgres-jdbc version

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -235,7 +235,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.2</version>
+            <version>42.3.3</version>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
See https://github.com/advisories/GHSA-673j-qm5f-xpv8.

We're not vulnerable, but it doesn't cost much.