### PR TITLE
Relay if fees satisfy previous channel update for X minutes after current update

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -132,6 +132,8 @@ eclair {
         fee-base-msat = 1000
         fee-proportional-millionths = 100
       }
+      // Delay enforcement of channel fee updates
+      enforce-delay = 10 minutes
     }
   }
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -133,7 +133,7 @@ eclair {
         fee-proportional-millionths = 100
       }
       // Delay enforcement of channel fee updates
-      enforce-delay = 10 minutes
+      enforcement-delay = 10 minutes
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -21,8 +21,8 @@ import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.bitcoin.{Block, ByteVector32, Crypto, Satoshi}
 import fr.acinq.eclair.Setup.Seeds
 import fr.acinq.eclair.blockchain.fee._
-import fr.acinq.eclair.channel.{Channel, ChannelFlags}
 import fr.acinq.eclair.channel.Channel.{ChannelConf, UnhandledExceptionStrategy}
+import fr.acinq.eclair.channel.{Channel, ChannelFlags}
 import fr.acinq.eclair.crypto.Noise.KeyPair
 import fr.acinq.eclair.crypto.keymanager.{ChannelKeyManager, NodeKeyManager}
 import fr.acinq.eclair.db._
@@ -80,7 +80,8 @@ case class NodeParams(nodeKeyManager: NodeKeyManager,
                       balanceCheckInterval: FiniteDuration,
                       blockchainWatchdogSources: Seq[String],
                       onionMessageConfig: OnionMessageConfig,
-                      purgeInvoicesInterval: Option[FiniteDuration]) {
+                      purgeInvoicesInterval: Option[FiniteDuration],
+                      enforceDelay: FiniteDuration) {
   val privateKey: Crypto.PrivateKey = nodeKeyManager.nodeKey.privateKey
 
   val nodeId: PublicKey = nodeKeyManager.nodeId
@@ -499,7 +500,8 @@ object NodeParams extends Logging {
         relayPolicy = onionMessageRelayPolicy,
         timeout = FiniteDuration(config.getDuration("onion-messages.reply-timeout").getSeconds, TimeUnit.SECONDS),
       ),
-      purgeInvoicesInterval = purgeInvoicesInterval
+      purgeInvoicesInterval = purgeInvoicesInterval,
+      enforceDelay = FiniteDuration(config.getDuration("relay.fees.enforce-delay").toMinutes, TimeUnit.MINUTES)
     )
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -462,7 +462,7 @@ object NodeParams extends Logging {
         publicChannelFees = getRelayFees(config.getConfig("relay.fees.public-channels")),
         privateChannelFees = getRelayFees(config.getConfig("relay.fees.private-channels")),
         minTrampolineFees = getRelayFees(config.getConfig("relay.fees.min-trampoline")),
-        enforceDelay = FiniteDuration(config.getDuration("relay.fees.enforcement-delay").getSeconds, TimeUnit.SECONDS)
+        enforcementDelay = FiniteDuration(config.getDuration("relay.fees.enforcement-delay").getSeconds, TimeUnit.SECONDS)
       ),
       db = database,
       autoReconnect = config.getBoolean("auto-reconnect"),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -80,8 +80,7 @@ case class NodeParams(nodeKeyManager: NodeKeyManager,
                       balanceCheckInterval: FiniteDuration,
                       blockchainWatchdogSources: Seq[String],
                       onionMessageConfig: OnionMessageConfig,
-                      purgeInvoicesInterval: Option[FiniteDuration],
-                      enforceDelay: FiniteDuration) {
+                      purgeInvoicesInterval: Option[FiniteDuration]) {
   val privateKey: Crypto.PrivateKey = nodeKeyManager.nodeKey.privateKey
 
   val nodeId: PublicKey = nodeKeyManager.nodeId
@@ -463,6 +462,7 @@ object NodeParams extends Logging {
         publicChannelFees = getRelayFees(config.getConfig("relay.fees.public-channels")),
         privateChannelFees = getRelayFees(config.getConfig("relay.fees.private-channels")),
         minTrampolineFees = getRelayFees(config.getConfig("relay.fees.min-trampoline")),
+        enforceDelay = FiniteDuration(config.getDuration("relay.fees.enforcement-delay").getSeconds, TimeUnit.SECONDS)
       ),
       db = database,
       autoReconnect = config.getBoolean("auto-reconnect"),
@@ -500,8 +500,7 @@ object NodeParams extends Logging {
         relayPolicy = onionMessageRelayPolicy,
         timeout = FiniteDuration(config.getDuration("onion-messages.reply-timeout").getSeconds, TimeUnit.SECONDS),
       ),
-      purgeInvoicesInterval = purgeInvoicesInterval,
-      enforceDelay = FiniteDuration(config.getDuration("relay.fees.enforce-delay").toMinutes, TimeUnit.MINUTES)
+      purgeInvoicesInterval = purgeInvoicesInterval
     )
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
@@ -252,12 +252,6 @@ class ChannelRelay private(nodeParams: NodeParams,
    */
   def relayOrFail(outgoingChannel_opt: Option[OutgoingChannel]): RelayResult = {
     import r._
-    // relay if fees satisfy previous channel update for 10 minutes after current update
-    val usePrevFees = outgoingChannel_opt.filter(_.channelUpdate.timestamp > (TimestampSecond.now() - nodeParams.relayParams.enforceDelay)).
-      flatMap(_.prevChannelUpdate) match {
-      case Some(prevChannelUpdate) => r.relayFeeMsat >= nodeFee(prevChannelUpdate, payload.amountToForward)
-      case None => false
-    }
     outgoingChannel_opt.map(_.channelUpdate) match {
       case None =>
         RelayFailure(CMD_FAIL_HTLC(add.id, Right(UnknownNextPeer), commit = true))
@@ -267,7 +261,10 @@ class ChannelRelay private(nodeParams: NodeParams,
         RelayFailure(CMD_FAIL_HTLC(add.id, Right(AmountBelowMinimum(payload.amountToForward, channelUpdate)), commit = true))
       case Some(channelUpdate) if r.expiryDelta < channelUpdate.cltvExpiryDelta =>
         RelayFailure(CMD_FAIL_HTLC(add.id, Right(IncorrectCltvExpiry(payload.outgoingCltv, channelUpdate)), commit = true))
-      case Some(channelUpdate) if r.relayFeeMsat < nodeFee(channelUpdate, payload.amountToForward) && !usePrevFees =>
+      case Some(channelUpdate) if r.relayFeeMsat < nodeFee(channelUpdate, payload.amountToForward) &&
+        // fees also do not satisfy the previous channel update for `enforceDelay` seconds after current update
+        (TimestampSecond.now() - channelUpdate.timestamp > nodeParams.relayParams.enforceDelay ||
+          outgoingChannel_opt.flatMap(_.prevChannelUpdate).forall(c => r.relayFeeMsat < nodeFee(c, payload.amountToForward))) =>
         RelayFailure(CMD_FAIL_HTLC(add.id, Right(FeeInsufficient(add.amountMsat, channelUpdate)), commit = true))
       case Some(channelUpdate) =>
         val origin = Origin.ChannelRelayedHot(addResponseAdapter.toClassic, add, payload.amountToForward)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
@@ -262,8 +262,8 @@ class ChannelRelay private(nodeParams: NodeParams,
       case Some(channelUpdate) if r.expiryDelta < channelUpdate.cltvExpiryDelta =>
         RelayFailure(CMD_FAIL_HTLC(add.id, Right(IncorrectCltvExpiry(payload.outgoingCltv, channelUpdate)), commit = true))
       case Some(channelUpdate) if r.relayFeeMsat < nodeFee(channelUpdate, payload.amountToForward) &&
-        // fees also do not satisfy the previous channel update for `enforceDelay` seconds after current update
-        (TimestampSecond.now() - channelUpdate.timestamp > nodeParams.relayParams.enforceDelay ||
+        // fees also do not satisfy the previous channel update for `enforcementDelay` seconds after current update
+        (TimestampSecond.now() - channelUpdate.timestamp > nodeParams.relayParams.enforcementDelay ||
           outgoingChannel_opt.flatMap(_.prevChannelUpdate).forall(c => r.relayFeeMsat < nodeFee(c, payload.amountToForward))) =>
         RelayFailure(CMD_FAIL_HTLC(add.id, Right(FeeInsufficient(add.amountMsat, channelUpdate)), commit = true))
       case Some(channelUpdate) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
@@ -253,7 +253,7 @@ class ChannelRelay private(nodeParams: NodeParams,
   def relayOrFail(outgoingChannel_opt: Option[OutgoingChannel]): RelayResult = {
     import r._
     // relay if fees satisfy previous channel update for 10 minutes after current update
-    val usePrevFees = outgoingChannel_opt.filter(_.channelUpdate.timestamp > (TimestampSecond.now() - nodeParams.enforceDelay)).
+    val usePrevFees = outgoingChannel_opt.filter(_.channelUpdate.timestamp > (TimestampSecond.now() - nodeParams.relayParams.enforceDelay)).
       flatMap(_.prevChannelUpdate) match {
       case Some(prevChannelUpdate) => r.relayFeeMsat >= nodeFee(prevChannelUpdate, payload.amountToForward)
       case None => false

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.payment.Monitoring.{Metrics, Tags}
 import fr.acinq.eclair.payment.relay.Relayer.OutgoingChannel
 import fr.acinq.eclair.payment.{ChannelPaymentRelayed, IncomingPaymentPacket}
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{Logs, NodeParams, ShortChannelId, channel, nodeFee}
+import fr.acinq.eclair.{Logs, NodeParams, ShortChannelId, TimestampSecond, channel, nodeFee}
 
 import java.util.UUID
 
@@ -172,7 +172,7 @@ class ChannelRelay private(nodeParams: NodeParams,
   def handleRelay(previousFailures: Seq[PreviouslyTried]): RelayResult = {
     val alreadyTried = previousFailures.map(_.shortChannelId)
     selectPreferredChannel(alreadyTried)
-      .flatMap(selectedShortChannelId => channels.get(selectedShortChannelId).map(_.channelUpdate)) match {
+      .flatMap(selectedShortChannelId => channels.get(selectedShortChannelId)) match {
       case None if previousFailures.nonEmpty =>
         // no more channels to try
         val error = previousFailures
@@ -182,8 +182,8 @@ class ChannelRelay private(nodeParams: NodeParams,
           .getOrElse(previousFailures.head)
           .failure
         RelayFailure(CMD_FAIL_HTLC(r.add.id, Right(translateLocalError(error.t, error.channelUpdate)), commit = true))
-      case channelUpdate_opt =>
-        relayOrFail(channelUpdate_opt)
+      case outgoingChannel_opt =>
+        relayOrFail(outgoingChannel_opt)
     }
   }
 
@@ -206,7 +206,7 @@ class ChannelRelay private(nodeParams: NodeParams,
         // and we filter again to keep the ones that are compatible with this payment (mainly fees, expiry delta)
         candidateChannels
           .map { case (shortChannelId, channelInfo) =>
-            val relayResult = relayOrFail(Some(channelInfo.channelUpdate))
+            val relayResult = relayOrFail(Some(channelInfo))
             context.log.debug(s"candidate channel: shortChannelId=$shortChannelId availableForSend={} capacity={} channelUpdate={} result={}",
               channelInfo.commitments.availableBalanceForSend,
               channelInfo.commitments.capacity,
@@ -250,9 +250,15 @@ class ChannelRelay private(nodeParams: NodeParams,
    * channel, because some parameters don't match with our settings for that channel. In that case we directly fail the
    * htlc.
    */
-  def relayOrFail(channelUpdate_opt: Option[ChannelUpdate]): RelayResult = {
+  def relayOrFail(outgoingChannel_opt: Option[OutgoingChannel]): RelayResult = {
     import r._
-    channelUpdate_opt match {
+    // relay if fees satisfy previous channel update for 10 minutes after current update
+    val usePrevFees = outgoingChannel_opt.filter(_.channelUpdate.timestamp > (TimestampSecond.now() - 600)).
+      flatMap(_.prevChannelUpdate) match {
+      case Some(prevChannelUpdate) => r.relayFeeMsat >= nodeFee(prevChannelUpdate, payload.amountToForward)
+      case None => false
+    }
+    outgoingChannel_opt.map(_.channelUpdate) match {
       case None =>
         RelayFailure(CMD_FAIL_HTLC(add.id, Right(UnknownNextPeer), commit = true))
       case Some(channelUpdate) if !channelUpdate.channelFlags.isEnabled =>
@@ -261,7 +267,7 @@ class ChannelRelay private(nodeParams: NodeParams,
         RelayFailure(CMD_FAIL_HTLC(add.id, Right(AmountBelowMinimum(payload.amountToForward, channelUpdate)), commit = true))
       case Some(channelUpdate) if r.expiryDelta < channelUpdate.cltvExpiryDelta =>
         RelayFailure(CMD_FAIL_HTLC(add.id, Right(IncorrectCltvExpiry(payload.outgoingCltv, channelUpdate)), commit = true))
-      case Some(channelUpdate) if r.relayFeeMsat < nodeFee(channelUpdate, payload.amountToForward) =>
+      case Some(channelUpdate) if r.relayFeeMsat < nodeFee(channelUpdate, payload.amountToForward) && !usePrevFees =>
         RelayFailure(CMD_FAIL_HTLC(add.id, Right(FeeInsufficient(add.amountMsat, channelUpdate)), commit = true))
       case Some(channelUpdate) =>
         val origin = Origin.ChannelRelayedHot(addResponseAdapter.toClassic, add, payload.amountToForward)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
@@ -253,7 +253,7 @@ class ChannelRelay private(nodeParams: NodeParams,
   def relayOrFail(outgoingChannel_opt: Option[OutgoingChannel]): RelayResult = {
     import r._
     // relay if fees satisfy previous channel update for 10 minutes after current update
-    val usePrevFees = outgoingChannel_opt.filter(_.channelUpdate.timestamp > (TimestampSecond.now() - 600)).
+    val usePrevFees = outgoingChannel_opt.filter(_.channelUpdate.timestamp > (TimestampSecond.now() - nodeParams.enforceDelay)).
       flatMap(_.prevChannelUpdate) match {
       case Some(prevChannelUpdate) => r.relayFeeMsat >= nodeFee(prevChannelUpdate, payload.amountToForward)
       case None => false

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelayer.scala
@@ -16,8 +16,6 @@
 
 package fr.acinq.eclair.payment.relay
 
-import java.util.UUID
-
 import akka.actor.ActorRef
 import akka.actor.typed.Behavior
 import akka.actor.typed.eventstream.EventStream
@@ -25,9 +23,9 @@ import akka.actor.typed.scaladsl.Behaviors
 import fr.acinq.bitcoin.Crypto.PublicKey
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.payment.IncomingPaymentPacket
-import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.{Logs, NodeParams, ShortChannelId}
 
+import java.util.UUID
 import scala.collection.mutable
 
 /**
@@ -95,7 +93,8 @@ object ChannelRelayer {
 
           case WrappedLocalChannelUpdate(LocalChannelUpdate(_, channelId, shortChannelId, remoteNodeId, _, channelUpdate, commitments)) =>
             context.log.debug(s"updating local channel info for channelId=$channelId shortChannelId=$shortChannelId remoteNodeId=$remoteNodeId channelUpdate={} commitments={}", channelUpdate, commitments)
-            val channelUpdates1 = channelUpdates + (channelUpdate.shortChannelId -> Relayer.OutgoingChannel(remoteNodeId, channelUpdate, commitments))
+            val prevChannelUpdate = channelUpdates.get(shortChannelId).map(_.channelUpdate)
+            val channelUpdates1 = channelUpdates + (channelUpdate.shortChannelId -> Relayer.OutgoingChannel(remoteNodeId, channelUpdate, prevChannelUpdate, commitments))
             val node2channels1 = node2channels.addOne(remoteNodeId, channelUpdate.shortChannelId)
             apply(nodeParams, register, channelUpdates1, node2channels1)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -121,7 +121,7 @@ object Relayer extends Logging {
   case class RelayParams(publicChannelFees: RelayFees,
                          privateChannelFees: RelayFees,
                          minTrampolineFees: RelayFees,
-                         enforceDelay: FiniteDuration) {
+                         enforcementDelay: FiniteDuration) {
     def defaultFees(announceChannel: Boolean): RelayFees = {
       if (announceChannel) {
         publicChannelFees

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -32,6 +32,7 @@ import fr.acinq.eclair.{Logs, MilliSatoshi, NodeParams, ShortChannelId}
 import grizzled.slf4j.Logging
 
 import scala.concurrent.Promise
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * Created by PM on 01/02/2017.
@@ -119,7 +120,8 @@ object Relayer extends Logging {
 
   case class RelayParams(publicChannelFees: RelayFees,
                          privateChannelFees: RelayFees,
-                         minTrampolineFees: RelayFees) {
+                         minTrampolineFees: RelayFees,
+                         enforceDelay: FiniteDuration) {
     def defaultFees(announceChannel: Boolean): RelayFees = {
       if (announceChannel) {
         publicChannelFees

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -130,6 +130,7 @@ object Relayer extends Logging {
   }
 
   case class RelayForward(add: UpdateAddHtlc)
+
   case class UsableBalance(remoteNodeId: PublicKey, shortChannelId: ShortChannelId, canSend: MilliSatoshi, canReceive: MilliSatoshi, isPublic: Boolean)
 
   /**
@@ -138,7 +139,7 @@ object Relayer extends Logging {
    * @param enabledOnly if true, filter out disabled channels.
    */
   case class GetOutgoingChannels(enabledOnly: Boolean = true)
-  case class OutgoingChannel(nextNodeId: PublicKey, channelUpdate: ChannelUpdate, commitments: AbstractCommitments) {
+  case class OutgoingChannel(nextNodeId: PublicKey, channelUpdate: ChannelUpdate, prevChannelUpdate: Option[ChannelUpdate], commitments: AbstractCommitments) {
     def toUsableBalance: UsableBalance = UsableBalance(
       remoteNodeId = nextNodeId,
       shortChannelId = channelUpdate.shortChannelId,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -132,7 +132,6 @@ object Relayer extends Logging {
   }
 
   case class RelayForward(add: UpdateAddHtlc)
-
   case class UsableBalance(remoteNodeId: PublicKey, shortChannelId: ShortChannelId, canSend: MilliSatoshi, canReceive: MilliSatoshi, isPublic: Boolean)
 
   /**

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -138,7 +138,8 @@ object TestConstants {
           feeProportionalMillionths = 20),
         minTrampolineFees = RelayFees(
           feeBase = 548000 msat,
-          feeProportionalMillionths = 30)),
+          feeProportionalMillionths = 30),
+        enforceDelay = 10 minutes),
       db = TestDatabases.inMemoryDb(),
       autoReconnect = false,
       initialRandomReconnectDelay = 5 seconds,
@@ -196,7 +197,6 @@ object TestConstants {
         timeout = 1 minute
       ),
       purgeInvoicesInterval = Some(24 hours),
-      enforceDelay = 10 minutes
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(
@@ -275,7 +275,8 @@ object TestConstants {
           feeProportionalMillionths = 20),
         minTrampolineFees = RelayFees(
           feeBase = 548000 msat,
-          feeProportionalMillionths = 30)),
+          feeProportionalMillionths = 30),
+        enforceDelay = 10 minutes),
       db = TestDatabases.inMemoryDb(),
       autoReconnect = false,
       initialRandomReconnectDelay = 5 seconds,
@@ -332,8 +333,7 @@ object TestConstants {
         relayPolicy = RelayAll,
         timeout = 1 minute
       ),
-      purgeInvoicesInterval = Some(24 hours),
-      enforceDelay = 10 minutes
+      purgeInvoicesInterval = Some(24 hours)
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -195,7 +195,8 @@ object TestConstants {
         relayPolicy = RelayAll,
         timeout = 1 minute
       ),
-      purgeInvoicesInterval = Some(24 hours)
+      purgeInvoicesInterval = Some(24 hours),
+      enforceDelay = 10 minutes
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(
@@ -331,7 +332,8 @@ object TestConstants {
         relayPolicy = RelayAll,
         timeout = 1 minute
       ),
-      purgeInvoicesInterval = Some(24 hours)
+      purgeInvoicesInterval = Some(24 hours),
+      enforceDelay = 10 minutes
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -139,7 +139,7 @@ object TestConstants {
         minTrampolineFees = RelayFees(
           feeBase = 548000 msat,
           feeProportionalMillionths = 30),
-        enforceDelay = 10 minutes),
+        enforcementDelay = 10 minutes),
       db = TestDatabases.inMemoryDb(),
       autoReconnect = false,
       initialRandomReconnectDelay = 5 seconds,
@@ -276,7 +276,7 @@ object TestConstants {
         minTrampolineFees = RelayFees(
           feeBase = 548000 msat,
           feeProportionalMillionths = 30),
-        enforceDelay = 10 minutes),
+        enforcementDelay = 10 minutes),
       db = TestDatabases.inMemoryDb(),
       autoReconnect = false,
       initialRandomReconnectDelay = 5 seconds,


### PR DESCRIPTION
Adds feature  "Delay channel fee update until gossip has caught up [#2110](https://github.com/ACINQ/eclair/issues/2110)"

During the `relay.fees.enforce-delay` period after a local channel update, the channel relayer will not fail payments that satisfy the base and proportional relay fee from either the current or previous channel update.

When a local channel update comes in, we store the previous channel update in the `OutgoingChannel` of the relayer along with the new current channel update. If the current channel update is less than `relay.fees.enforce-delay` minutes old we will not fail for insufficient relay fees if a relayed payment satisfies either the current or previous channel update.