### PR TITLE
Fix fees for trampoline relay

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -348,7 +348,7 @@ object RouteCalculation {
       case Right(routes) =>
         // We use these shortest paths to find a set of non-conflicting HTLCs that send the total amount.
         split(amount, mutable.Queue(routes: _*), initializeUsedCapacity(pendingHtlcs), routeParams1) match {
-          case Right(routes) if validateMultiPartRoute(amount, maxFee, routes) => Right(routes)
+          case Right(routes) if validateMultiPartRoute(amount, maxFee, routes, routeParams.includeLocalChannelCost) => Right(routes)
           case _ => Left(RouteNotFound)
         }
       case Left(ex) => Left(ex)
@@ -416,9 +416,9 @@ object RouteCalculation {
     }
   }
 
-  private def validateMultiPartRoute(amount: MilliSatoshi, maxFee: MilliSatoshi, routes: Seq[Route]): Boolean = {
+  private def validateMultiPartRoute(amount: MilliSatoshi, maxFee: MilliSatoshi, routes: Seq[Route], includeLocalChannelCost: Boolean): Boolean = {
     val amountOk = routes.map(_.amount).sum == amount
-    val feeOk = routes.map(_.fee).sum <= maxFee
+    val feeOk = routes.map(_.fee(includeLocalChannelCost)).sum <= maxFee
     amountOk && feeOk
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -473,8 +473,10 @@ object Router {
     require(hops.nonEmpty, "route cannot be empty")
 
     val length = hops.length
-    lazy val fee: MilliSatoshi = {
-      val amountToSend = hops.drop(1).reverse.foldLeft(amount) { case (amount1, hop) => amount1 + hop.fee(amount1) }
+
+    def fee(includeLocalChannelCost: Boolean): MilliSatoshi = {
+      val hopsToPay = if (includeLocalChannelCost) hops else hops.drop(1)
+      val amountToSend = hopsToPay.reverse.foldLeft(amount) { case (amount1, hop) => amount1 + hop.fee(amount1) }
       amountToSend - amount
     }
 


### PR DESCRIPTION
When using multipart payments, the path-finding request sent to the router does not match the actual payment, it is only a request to route a fraction of the amount but the fee budget is still the one for the full payment. As a consequence the router will return routes that will not satisfy the fee budget.
The fee budget is checked one last time before relaying the payment but ignoring the fee of the first channel (which should not be ignored for trampoline relays). I fix this last check.