### PR TITLE
Add messages for when startup fails due to wrong bitcoind wallet(s) loaded

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/StartupIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/StartupIntegrationSpec.scala
@@ -20,7 +20,7 @@ import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{Error, JsonRPCError}
-import fr.acinq.eclair.{BitcoinDefaultWalletException, BitcoinWalletDisabledException, BitcoinWalletNotLoadedException}
+import fr.acinq.eclair.{BitcoinDefaultWalletException, BitcoinWalletDisabledException, BitcoinWalletNotLoadedException, TestUtils}
 import org.json4s.JsonAST.JValue
 
 import scala.jdk.CollectionConverters._
@@ -32,7 +32,7 @@ import scala.jdk.CollectionConverters._
 class StartupIntegrationSpec extends IntegrationSpec {
 
   test("no bitcoind wallet configured and one wallet loaded") {
-    instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> 29730).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+    instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> TestUtils.availablePort).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
   }
 
   test("no bitcoind wallets loaded") {
@@ -40,7 +40,7 @@ class StartupIntegrationSpec extends IntegrationSpec {
     sender.send(bitcoincli, BitcoinReq("unloadwallet", defaultWallet))
     sender.expectMsgType[JValue]
     val thrown = intercept[BitcoinWalletNotLoadedException] {
-      instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> 29731).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+      instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> TestUtils.availablePort).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
     }
     sender.send(bitcoincli, BitcoinReq("loadwallet", defaultWallet))
     sender.expectMsgType[JValue]
@@ -52,7 +52,7 @@ class StartupIntegrationSpec extends IntegrationSpec {
     sender.send(bitcoincli, BitcoinReq("createwallet", ""))
     sender.expectMsgType[Any]
     val thrown = intercept[BitcoinDefaultWalletException] {
-      instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> 29732).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+      instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> TestUtils.availablePort).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
     }
     assert(thrown === BitcoinDefaultWalletException(List(defaultWallet, "")))
   }
@@ -61,7 +61,7 @@ class StartupIntegrationSpec extends IntegrationSpec {
     val sender = TestProbe()
     sender.send(bitcoincli, BitcoinReq("createwallet", ""))
     sender.expectMsgType[Any]
-    instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.server.port" -> 29733).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+    instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.server.port" -> TestUtils.availablePort).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
   }
 
   test("explicit bitcoind wallet configured but not loaded") {
@@ -69,7 +69,7 @@ class StartupIntegrationSpec extends IntegrationSpec {
     sender.send(bitcoincli, BitcoinReq("createwallet", ""))
     sender.expectMsgType[Any]
     val thrown = intercept[BitcoinWalletNotLoadedException] {
-      instantiateEclairNode("E", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "notloaded", "eclair.server.port" -> 29734).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+      instantiateEclairNode("E", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "notloaded", "eclair.server.port" -> TestUtils.availablePort).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
     }
     assert(thrown === BitcoinWalletNotLoadedException("notloaded", List(defaultWallet, "")))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/StartupIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/StartupIntegrationSpec.scala
@@ -21,7 +21,6 @@ import com.typesafe.config.ConfigFactory
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{Error, JsonRPCError}
 import fr.acinq.eclair.{BitcoinDefaultWalletException, BitcoinWalletDisabledException, BitcoinWalletNotLoadedException, TestUtils}
-import org.json4s.JsonAST.JValue
 
 import scala.jdk.CollectionConverters._
 
@@ -33,18 +32,6 @@ class StartupIntegrationSpec extends IntegrationSpec {
 
   test("no bitcoind wallet configured and one wallet loaded") {
     instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> TestUtils.availablePort).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
-  }
-
-  test("no bitcoind wallets loaded") {
-    val sender = TestProbe()
-    sender.send(bitcoincli, BitcoinReq("unloadwallet", defaultWallet))
-    sender.expectMsgType[JValue]
-    val thrown = intercept[BitcoinWalletNotLoadedException] {
-      instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> TestUtils.availablePort).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
-    }
-    sender.send(bitcoincli, BitcoinReq("loadwallet", defaultWallet))
-    sender.expectMsgType[JValue]
-    assert(thrown === BitcoinWalletNotLoadedException("", List()))
   }
 
   test("no bitcoind wallet configured and two wallets loaded") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/StartupIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/StartupIntegrationSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.integration
+
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
+import fr.acinq.eclair.blockchain.bitcoind.rpc.{Error, JsonRPCError}
+import fr.acinq.eclair.{BitcoinDefaultWalletException, BitcoinWalletDisabledException, BitcoinWalletNotLoadedException}
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * Created by remyers on 16/03/2022.
+ */
+
+class StartupIntegrationSpec extends IntegrationSpec {
+
+  test("no bitcoind wallet configured and one wallet loaded") {
+    val sender = TestProbe()
+    instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> 29730).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+  }
+
+  test("no bitcoind wallet configured and two wallets loaded") {
+    val sender = TestProbe()
+    sender.send(bitcoincli, BitcoinReq("createwallet", ""))
+    sender.expectMsgType[Any]
+    val thrown = intercept[BitcoinDefaultWalletException] {
+      instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> 29731).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+    }
+    assert(thrown === BitcoinDefaultWalletException(List(defaultWallet, "")))
+  }
+
+  test("explicit bitcoind wallet configured and two wallets loaded") {
+    val sender = TestProbe()
+    sender.send(bitcoincli, BitcoinReq("createwallet", ""))
+    sender.expectMsgType[Any]
+    instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.server.port" -> 29732).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+  }
+
+  test("explicit bitcoind wallet configured but not loaded") {
+    val sender = TestProbe()
+    sender.send(bitcoincli, BitcoinReq("createwallet", ""))
+    sender.expectMsgType[Any]
+    val thrown = intercept[BitcoinWalletNotLoadedException] {
+      instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "notloaded", "eclair.server.port" -> 29733).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+    }
+    assert(thrown === BitcoinWalletNotLoadedException("notloaded", List(defaultWallet, "")))
+  }
+
+  test("bitcoind started with wallets disabled") {
+    restartBitcoind(startupFlags = "-disablewallet", loadWallet = false)
+    val thrown = intercept[BitcoinWalletDisabledException] {
+      instantiateEclairNode("E", ConfigFactory.load().getConfig("eclair").withFallback(withDefaultCommitment).withFallback(commonConfig))
+    }
+    assert(thrown === BitcoinWalletDisabledException(e = JsonRPCError(Error(-32601, "Method not found"))))
+  }
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/StartupIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/StartupIntegrationSpec.scala
@@ -21,6 +21,7 @@ import com.typesafe.config.ConfigFactory
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.BitcoinReq
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{Error, JsonRPCError}
 import fr.acinq.eclair.{BitcoinDefaultWalletException, BitcoinWalletDisabledException, BitcoinWalletNotLoadedException}
+import org.json4s.JsonAST.JValue
 
 import scala.jdk.CollectionConverters._
 
@@ -31,8 +32,19 @@ import scala.jdk.CollectionConverters._
 class StartupIntegrationSpec extends IntegrationSpec {
 
   test("no bitcoind wallet configured and one wallet loaded") {
-    val sender = TestProbe()
     instantiateEclairNode("A", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> 29730).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+  }
+
+  test("no bitcoind wallets loaded") {
+    val sender = TestProbe()
+    sender.send(bitcoincli, BitcoinReq("unloadwallet", defaultWallet))
+    sender.expectMsgType[JValue]
+    val thrown = intercept[BitcoinWalletNotLoadedException] {
+      instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> 29731).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+    }
+    sender.send(bitcoincli, BitcoinReq("loadwallet", defaultWallet))
+    sender.expectMsgType[JValue]
+    assert(thrown === BitcoinWalletNotLoadedException("", List()))
   }
 
   test("no bitcoind wallet configured and two wallets loaded") {
@@ -40,7 +52,7 @@ class StartupIntegrationSpec extends IntegrationSpec {
     sender.send(bitcoincli, BitcoinReq("createwallet", ""))
     sender.expectMsgType[Any]
     val thrown = intercept[BitcoinDefaultWalletException] {
-      instantiateEclairNode("B", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> 29731).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+      instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "", "eclair.server.port" -> 29732).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
     }
     assert(thrown === BitcoinDefaultWalletException(List(defaultWallet, "")))
   }
@@ -49,7 +61,7 @@ class StartupIntegrationSpec extends IntegrationSpec {
     val sender = TestProbe()
     sender.send(bitcoincli, BitcoinReq("createwallet", ""))
     sender.expectMsgType[Any]
-    instantiateEclairNode("C", ConfigFactory.parseMap(Map("eclair.server.port" -> 29732).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+    instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.server.port" -> 29733).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
   }
 
   test("explicit bitcoind wallet configured but not loaded") {
@@ -57,7 +69,7 @@ class StartupIntegrationSpec extends IntegrationSpec {
     sender.send(bitcoincli, BitcoinReq("createwallet", ""))
     sender.expectMsgType[Any]
     val thrown = intercept[BitcoinWalletNotLoadedException] {
-      instantiateEclairNode("D", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "notloaded", "eclair.server.port" -> 29733).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
+      instantiateEclairNode("E", ConfigFactory.parseMap(Map("eclair.bitcoind.wallet" -> "notloaded", "eclair.server.port" -> 29734).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
     }
     assert(thrown === BitcoinWalletNotLoadedException("notloaded", List(defaultWallet, "")))
   }
@@ -65,7 +77,7 @@ class StartupIntegrationSpec extends IntegrationSpec {
   test("bitcoind started with wallets disabled") {
     restartBitcoind(startupFlags = "-disablewallet", loadWallet = false)
     val thrown = intercept[BitcoinWalletDisabledException] {
-      instantiateEclairNode("E", ConfigFactory.load().getConfig("eclair").withFallback(withDefaultCommitment).withFallback(commonConfig))
+      instantiateEclairNode("F", ConfigFactory.load().getConfig("eclair").withFallback(withDefaultCommitment).withFallback(commonConfig))
     }
     assert(thrown === BitcoinWalletDisabledException(e = JsonRPCError(Error(-32601, "Method not found"))))
   }


### PR DESCRIPTION
Add more specific startup failure messages for situations when the configured `eclair.bitcoind.wallet` does not match the wallet(s) loaded in bitcoind.

The default `eclair.bitcoind.wallet` is the empty string. This corresponds with the situation before multi-wallet support was added to bitcoind where only one wallet could be loaded at a time. When this default setting is used, Eclair will fail at startup if more than one wallet is loaded in bitcoind. 

If only one wallet is loaded in bitcoind, then it will be used regardless of its name if `eclair.bitcoind.wallet = ""`.

If `eclair.bitcoind.wallet` is configured with a wallet name other than the empty string, then multiple wallets can be loaded in bitcoind as long as one of them is the configured wallet.

If bitcoind is launched (or compiled) with `-disablewallet` then Eclair will fail at startup with a message to indicate this.

This PR addresses issue: "Mainnet node doesn't start without wallet name" [#1868](https://github.com/ACINQ/eclair/issues/1868)