### PR TITLE
Fix TLV tag number in exception

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/MessageOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/MessageOnion.scala
@@ -94,7 +94,7 @@ object MessageOnionCodecs {
   val perHopPayloadCodec: Codec[TlvStream[OnionMessagePayloadTlv]] = TlvCodecs.lengthPrefixedTlvStream[OnionMessagePayloadTlv](onionTlvCodec).complete
 
   val relayPerHopPayloadCodec: Codec[RelayPayload] = perHopPayloadCodec.narrow({
-    case tlvs if tlvs.get[EncryptedData].isEmpty => Attempt.failure(MissingRequiredTlv(UInt64(10)))
+    case tlvs if tlvs.get[EncryptedData].isEmpty => Attempt.failure(MissingRequiredTlv(UInt64(4)))
     case tlvs if tlvs.get[ReplyPath].nonEmpty => Attempt.failure(ForbiddenTlv(UInt64(2)))
     case tlvs => Attempt.successful(RelayPayload(tlvs))
   }, {
@@ -102,7 +102,7 @@ object MessageOnionCodecs {
   })
 
   val finalPerHopPayloadCodec: Codec[FinalPayload] = perHopPayloadCodec.narrow({
-    case tlvs if tlvs.get[EncryptedData].isEmpty => Attempt.failure(MissingRequiredTlv(UInt64(10)))
+    case tlvs if tlvs.get[EncryptedData].isEmpty => Attempt.failure(MissingRequiredTlv(UInt64(4)))
     case tlvs => Attempt.successful(FinalPayload(tlvs))
   }, {
     case FinalPayload(tlvs) => tlvs


### PR DESCRIPTION
When the TLV tag for encrypted data was changed from 10 to 4 (https://github.com/lightning/bolts/pull/759/commits/6e99c5feaf60cb797507d181fe583224309318e9#diff-ad65f0beaac5cef88f5fd7a8b9ca36cbc5a790f4815b4b50b9ea794a55aaf012L551) I forgot to change it in the failure case.