### PR TITLE
Fix latest bitcoin build

### DIFF
--- a/.github/workflows/latest-bitcoind.yml
+++ b/.github/workflows/latest-bitcoind.yml
@@ -23,7 +23,7 @@ jobs:
           path: bitcoin
 
       - name: Install bitcoind dependencies
-        run: sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 libssl-dev libevent-dev libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libminiupnpc-dev libzmq3-dev libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler git libsqlite3-dev ccache
+        run: sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 libevent-dev libboost-dev                                                                                          libminiupnpc-dev libnatpmp-dev    libzmq3-dev                                        libsqlite3-dev            systemtap-sdt-dev
         working-directory: ./bitcoin
 
       - name: Autogen bitcoind

--- a/.github/workflows/latest-bitcoind.yml
+++ b/.github/workflows/latest-bitcoind.yml
@@ -1,8 +1,6 @@
 name: Latest Bitcoin Core
 
 on:
-  pull_request:
-    branches: [ master ]
   schedule:
     # Run at midnight on Sunday and Wednesday.
     - cron: '0 0 * * 0,3'

--- a/.github/workflows/latest-bitcoind.yml
+++ b/.github/workflows/latest-bitcoind.yml
@@ -1,6 +1,8 @@
 name: Latest Bitcoin Core
 
 on:
+  pull_request:
+    branches: [ master ]
   schedule:
     # Run at midnight on Sunday and Wednesday.
     - cron: '0 0 * * 0,3'


### PR DESCRIPTION
The build against bitcoind master (see https://github.com/ACINQ/eclair/actions/workflows/latest-bitcoind.yml) broke on march 12 (and subsequent builds as well) with the following errors while installing dependencies:

```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/m/mesa/libegl-mesa0_21.2.6-0ubuntu0.1~20.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/libg/libglvnd/libegl1_1.3.2-1~ubuntu0.20.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/libg/libglvnd/libglx-dev_1.3.2-1~ubuntu0.20.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/libg/libglvnd/libgl-dev_1.3.2-1~ubuntu0.20.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/libg/libglvnd/libegl-dev_1.3.2-1~ubuntu0.20.04.1_amd64.deb  404  Not Found [IP: 52.154.174.208 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

The build dependencies of bitcoin core have been updated recently (see https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md#ubuntu--debian), this PR fixes them.