### PR TITLE
Update experimental trampoline feature bit

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -57,7 +57,7 @@ eclair {
     option_onion_messages = optional
     option_channel_type = optional
     option_payment_metadata = optional
-    trampoline_payment = disabled
+    trampoline_payment_prototype = disabled
     keysend = disabled
   }
   override-init-features = [ // optional per-node features

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -226,17 +226,20 @@ object Features {
     val mandatory = 48
   }
 
-  // TODO: @t-bast: update feature bits once spec-ed (currently reserved here: https://github.com/lightningnetwork/lightning-rfc/issues/605)
-  // We're not advertising these bits yet in our announcements, clients have to assume support.
-  // This is why we haven't added them yet to `areSupported`.
-  case object TrampolinePayment extends Feature with InitFeature with NodeFeature with InvoiceFeature {
-    val rfcName = "trampoline_payment"
-    val mandatory = 50
-  }
-
   case object KeySend extends Feature with NodeFeature {
     val rfcName = "keysend"
     val mandatory = 54
+  }
+
+  // TODO: @t-bast: update feature bits once spec-ed (currently reserved here: https://github.com/lightningnetwork/lightning-rfc/issues/605)
+  // We're not advertising these bits yet in our announcements, clients have to assume support.
+  // This is why we haven't added them yet to `areSupported`.
+  // The version of trampoline enabled by this feature bit does not match the latest spec PR: once the spec is accepted,
+  // we will introduce a new version of trampoline that will work in parallel to this legacy one, until we can safely
+  // deprecate it.
+  case object TrampolinePaymentPrototype extends Feature with InitFeature with NodeFeature with InvoiceFeature {
+    val rfcName = "trampoline_payment_prototype"
+    val mandatory = 148
   }
 
   val knownFeatures: Set[Feature] = Set(
@@ -256,7 +259,7 @@ object Features {
     OnionMessages,
     ChannelType,
     PaymentMetadata,
-    TrampolinePayment,
+    TrampolinePaymentPrototype,
     KeySend
   )
 
@@ -269,7 +272,7 @@ object Features {
     BasicMultiPartPayment -> (PaymentSecret :: Nil),
     AnchorOutputs -> (StaticRemoteKey :: Nil),
     AnchorOutputsZeroFeeHtlcTx -> (StaticRemoteKey :: Nil),
-    TrampolinePayment -> (PaymentSecret :: Nil),
+    TrampolinePaymentPrototype -> (PaymentSecret :: Nil),
     KeySend -> (VariableLengthOnion :: Nil)
   )
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
@@ -232,7 +232,7 @@ object MultiPartHandler {
               val expirySeconds = expirySeconds_opt.getOrElse(nodeParams.invoiceExpiry.toSeconds)
               val paymentMetadata = hex"2a"
               val invoiceFeatures = if (nodeParams.enableTrampolinePayment) {
-                Features[InvoiceFeature](nodeParams.features.invoiceFeatures().activated + (Features.TrampolinePayment -> FeatureSupport.Optional))
+                Features[InvoiceFeature](nodeParams.features.invoiceFeatures().activated + (Features.TrampolinePaymentPrototype -> FeatureSupport.Optional))
               } else {
                 nodeParams.features.invoiceFeatures()
               }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -85,7 +85,7 @@ class PaymentInitiator(nodeParams: NodeParams, outgoingPaymentFactory: PaymentIn
       r.trampolineAttempts match {
         case Nil =>
           sender() ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(r.recipientAmount, Nil, TrampolineFeesMissing) :: Nil)
-        case _ if !r.invoice.features.hasFeature(Features.TrampolinePayment) && r.invoice.amount_opt.isEmpty =>
+        case _ if !r.invoice.features.hasFeature(Features.TrampolinePaymentPrototype) && r.invoice.amount_opt.isEmpty =>
           sender() ! PaymentFailed(paymentId, r.paymentHash, LocalFailure(r.recipientAmount, Nil, TrampolineLegacyAmountLessInvoice) :: Nil)
         case (trampolineFees, trampolineExpiryDelta) :: remainingAttempts =>
           log.info(s"sending trampoline payment with trampoline fees=$trampolineFees and expiry delta=$trampolineExpiryDelta")
@@ -203,7 +203,7 @@ class PaymentInitiator(nodeParams: NodeParams, outgoingPaymentFactory: PaymentIn
       PaymentOnion.createSinglePartPayload(r.recipientAmount, r.finalExpiry(nodeParams.currentBlockHeight), r.invoice.paymentSecret.get, r.invoice.paymentMetadata)
     }
     // We assume that the trampoline node supports multi-part payments (it should).
-    val trampolinePacket_opt = if (r.invoice.features.hasFeature(Features.TrampolinePayment)) {
+    val trampolinePacket_opt = if (r.invoice.features.hasFeature(Features.TrampolinePaymentPrototype)) {
       OutgoingPaymentPacket.buildTrampolinePacket(r.paymentHash, trampolineRoute, finalPayload)
     } else {
       OutgoingPaymentPacket.buildTrampolineToLegacyPacket(r.invoice, trampolineRoute, finalPayload)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
@@ -465,7 +465,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     sender.send(nodes("F").paymentHandler, ReceivePayment(Some(amount), Left("like trampoline much?")))
     val invoice = sender.expectMsgType[Invoice]
     assert(invoice.features.hasFeature(Features.BasicMultiPartPayment))
-    assert(invoice.features.hasFeature(Features.TrampolinePayment))
+    assert(invoice.features.hasFeature(Features.TrampolinePaymentPrototype))
 
     // The best route from G is G -> C -> F which has a fee of 1210091 msat
 
@@ -510,7 +510,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     sender.send(nodes("B").paymentHandler, ReceivePayment(Some(amount), Left("trampoline-MPP is so #reckless")))
     val invoice = sender.expectMsgType[Invoice]
     assert(invoice.features.hasFeature(Features.BasicMultiPartPayment))
-    assert(invoice.features.hasFeature(Features.TrampolinePayment))
+    assert(invoice.features.hasFeature(Features.TrampolinePaymentPrototype))
     assert(invoice.paymentMetadata.nonEmpty)
 
     // The direct route C -> B does not have enough capacity, the payment will be split between
@@ -566,7 +566,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     sender.send(nodes("A").paymentHandler, ReceivePayment(Some(amount), Left("trampoline to non-trampoline is so #vintage"), extraHops = routingHints))
     val invoice = sender.expectMsgType[Invoice]
     assert(invoice.features.hasFeature(Features.BasicMultiPartPayment))
-    assert(!invoice.features.hasFeature(Features.TrampolinePayment))
+    assert(!invoice.features.hasFeature(Features.TrampolinePaymentPrototype))
     assert(invoice.paymentMetadata.nonEmpty)
 
     val payment = SendTrampolinePayment(amount, invoice, nodes("C").nodeParams.nodeId, Seq((1500000 msat, CltvExpiryDelta(432))), routeParams = integrationTestRouteParams)
@@ -614,7 +614,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     sender.send(nodes("D").paymentHandler, ReceivePayment(Some(amount), Left("I iz Satoshi")))
     val invoice = sender.expectMsgType[Invoice]
     assert(invoice.features.hasFeature(Features.BasicMultiPartPayment))
-    assert(invoice.features.hasFeature(Features.TrampolinePayment))
+    assert(invoice.features.hasFeature(Features.TrampolinePaymentPrototype))
 
     val payment = SendTrampolinePayment(amount, invoice, nodes("C").nodeParams.nodeId, Seq((250000 msat, CltvExpiryDelta(288))), routeParams = integrationTestRouteParams)
     sender.send(nodes("B").paymentInitiator, payment)
@@ -635,7 +635,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     sender.send(nodes("D").paymentHandler, ReceivePayment(Some(amount), Left("I iz not Satoshi")))
     val invoice = sender.expectMsgType[Invoice]
     assert(invoice.features.hasFeature(Features.BasicMultiPartPayment))
-    assert(invoice.features.hasFeature(Features.TrampolinePayment))
+    assert(invoice.features.hasFeature(Features.TrampolinePaymentPrototype))
 
     val payment = SendTrampolinePayment(amount, invoice, nodes("B").nodeParams.nodeId, Seq((450000 msat, CltvExpiryDelta(288))), routeParams = integrationTestRouteParams)
     sender.send(nodes("A").paymentInitiator, payment)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt11InvoiceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt11InvoiceSpec.scala
@@ -309,7 +309,7 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
       assert(features2bits(invoice.features) === bin"1000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000100000000")
       assert(!invoice.features.hasFeature(BasicMultiPartPayment))
       assert(invoice.features.hasFeature(PaymentSecret, Some(Mandatory)))
-      assert(!invoice.features.hasFeature(TrampolinePayment))
+      assert(!invoice.features.hasFeature(TrampolinePaymentPrototype))
       assert(TestConstants.Alice.nodeParams.features.invoiceFeatures().areSupported(invoice.features))
       assert(invoice.sign(priv).toString === ref.toLowerCase)
     }
@@ -329,7 +329,7 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     assert(features2bits(invoice.features) === bin"000011000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000100000000")
     assert(!invoice.features.hasFeature(BasicMultiPartPayment))
     assert(invoice.features.hasFeature(PaymentSecret, Some(Mandatory)))
-    assert(!invoice.features.hasFeature(TrampolinePayment))
+    assert(!invoice.features.hasFeature(TrampolinePaymentPrototype))
     assert(!TestConstants.Alice.nodeParams.features.invoiceFeatures().areSupported(invoice.features))
     assert(invoice.sign(priv).toString === ref)
   }
@@ -534,18 +534,18 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
 
   test("trampoline") {
     val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(123 msat), ByteVector32.One, priv, Left("Some invoice"), CltvExpiryDelta(18))
-    assert(!invoice.features.hasFeature(TrampolinePayment))
+    assert(!invoice.features.hasFeature(TrampolinePaymentPrototype))
 
-    val pr1 = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(123 msat), ByteVector32.One, priv, Left("Some invoice"), CltvExpiryDelta(18), features = Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory, TrampolinePayment -> Optional))
+    val pr1 = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(123 msat), ByteVector32.One, priv, Left("Some invoice"), CltvExpiryDelta(18), features = Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory, TrampolinePaymentPrototype -> Optional))
     assert(!pr1.features.hasFeature(BasicMultiPartPayment))
-    assert(pr1.features.hasFeature(TrampolinePayment))
+    assert(pr1.features.hasFeature(TrampolinePaymentPrototype))
 
-    val pr2 = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(123 msat), ByteVector32.One, priv, Left("Some invoice"), CltvExpiryDelta(18), features = Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory, BasicMultiPartPayment -> Optional, TrampolinePayment -> Optional))
+    val pr2 = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(123 msat), ByteVector32.One, priv, Left("Some invoice"), CltvExpiryDelta(18), features = Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory, BasicMultiPartPayment -> Optional, TrampolinePaymentPrototype -> Optional))
     assert(pr2.features.hasFeature(BasicMultiPartPayment))
-    assert(pr2.features.hasFeature(TrampolinePayment))
+    assert(pr2.features.hasFeature(TrampolinePaymentPrototype))
 
     val pr3 = Bolt11Invoice.fromString("lnbc40n1pw9qjvwpp5qq3w2ln6krepcslqszkrsfzwy49y0407hvks30ec6pu9s07jur3sdpstfshq5n9v9jzucm0d5s8vmm5v5s8qmmnwssyj3p6yqenwdencqzysxqrrss7ju0s4dwx6w8a95a9p2xc5vudl09gjl0w2n02sjrvffde632nxwh2l4w35nqepj4j5njhh4z65wyfc724yj6dn9wajvajfn5j7em6wsq2elakl")
-    assert(!pr3.features.hasFeature(TrampolinePayment))
+    assert(!pr3.features.hasFeature(TrampolinePaymentPrototype))
   }
 
   test("nonreg") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
@@ -190,28 +190,28 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
       sender.send(handler, ReceivePayment(Some(42 msat), Left("1 coffee")))
       val invoice = sender.expectMsgType[Invoice]
       assert(!invoice.features.hasFeature(Features.BasicMultiPartPayment))
-      assert(!invoice.features.hasFeature(Features.TrampolinePayment))
+      assert(!invoice.features.hasFeature(Features.TrampolinePaymentPrototype))
     }
     {
       val handler = TestActorRef[PaymentHandler](PaymentHandler.props(Alice.nodeParams.copy(enableTrampolinePayment = false, features = featuresWithMpp), TestProbe().ref))
       sender.send(handler, ReceivePayment(Some(42 msat), Left("1 coffee")))
       val invoice = sender.expectMsgType[Invoice]
       assert(invoice.features.hasFeature(Features.BasicMultiPartPayment))
-      assert(!invoice.features.hasFeature(Features.TrampolinePayment))
+      assert(!invoice.features.hasFeature(Features.TrampolinePaymentPrototype))
     }
     {
       val handler = TestActorRef[PaymentHandler](PaymentHandler.props(Alice.nodeParams.copy(enableTrampolinePayment = true, features = featuresWithoutMpp), TestProbe().ref))
       sender.send(handler, ReceivePayment(Some(42 msat), Left("1 coffee")))
       val invoice = sender.expectMsgType[Invoice]
       assert(!invoice.features.hasFeature(Features.BasicMultiPartPayment))
-      assert(invoice.features.hasFeature(Features.TrampolinePayment))
+      assert(invoice.features.hasFeature(Features.TrampolinePaymentPrototype))
     }
     {
       val handler = TestActorRef[PaymentHandler](PaymentHandler.props(Alice.nodeParams.copy(enableTrampolinePayment = true, features = featuresWithMpp), TestProbe().ref))
       sender.send(handler, ReceivePayment(Some(42 msat), Left("1 coffee")))
       val invoice = sender.expectMsgType[Invoice]
       assert(invoice.features.hasFeature(Features.BasicMultiPartPayment))
-      assert(invoice.features.hasFeature(Features.TrampolinePayment))
+      assert(invoice.features.hasFeature(Features.TrampolinePaymentPrototype))
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -68,7 +68,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     VariableLengthOnion -> Mandatory,
     PaymentSecret -> Mandatory,
     BasicMultiPartPayment -> Optional,
-    TrampolinePayment -> Optional,
+    TrampolinePaymentPrototype -> Optional,
   )
 
   case class FakePaymentFactory(payFsm: TestProbe, multiPartPayFsm: TestProbe) extends PaymentInitiator.MultiPartPaymentFactory {


### PR DESCRIPTION
The `option_scid_alias` feature (https://github.com/lightning/bolts/pull/910) is going to clash with the feature bit we use for trampoline payments. Fortunately we've never advertised it, so we can simply update it to a much higher value for now (until the final version of trampoline is specified).

We don't need to implement backwards-compatibility because no-one is generating trampoline invoices from eclair or paying trampoline invoices from eclair AFAIK. We will need to implement some backwards-compatibility in `lightning-kmp` however to ensure that Phoenix can smoothly transition to the new feature bit.