### PR TITLE
Check that channel seed has not been modified

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -419,4 +419,4 @@ case object IncompatibleDBException extends RuntimeException("database is not co
 
 case object IncompatibleNetworkDBException extends RuntimeException("network database is not compatible with this version of eclair")
 
-case class InvalidChannelSeedException(e: Throwable) extends RuntimeException("Channel seed has been modified", e)
+case class InvalidChannelSeedException(channelId: ByteVector32) extends RuntimeException(s"channel seed has been modified for channel $channelId")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -30,7 +30,7 @@ import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, BatchingBitcoinJsonRPCClient, BitcoinCoreClient, BitcoinJsonRPCAuthMethod}
 import fr.acinq.eclair.blockchain.bitcoind.zmq.ZMQActor
 import fr.acinq.eclair.blockchain.fee._
-import fr.acinq.eclair.channel.{Commitments, Register}
+import fr.acinq.eclair.channel.Register
 import fr.acinq.eclair.channel.fsm.Channel
 import fr.acinq.eclair.crypto.WeakEntropyPool
 import fr.acinq.eclair.crypto.keymanager.{LocalChannelKeyManager, LocalNodeKeyManager}
@@ -59,7 +59,7 @@ import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 import scala.concurrent._
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 /**
  * Setup eclair from a data directory.
@@ -134,20 +134,13 @@ class Setup(val datadir: File,
   }
 
   val nodeParams = NodeParams.makeNodeParams(config, instanceId, nodeKeyManager, channelKeyManager, initTor(), databases, blockHeight, feeEstimator, pluginParams)
-
-  // validate that channel seed is the same that was used when local channels were created
-  nodeParams.db.channels.listLocalChannels().foreach(hasCommitments => Try(Commitments.validateSeed(hasCommitments.commitments, channelKeyManager)) match {
-    case Success(_) => ()
-    case Failure(e) => throw InvalidChannelSeedException(e)
-  })
-
   pluginParams.foreach(param => logger.info(s"using plugin=${param.name}"))
 
   val serverBindingAddress = new InetSocketAddress(config.getString("server.binding-ip"), config.getInt("server.port"))
 
   // early checks
-  DBCompatChecker.checkDBCompatibility(nodeParams)
-  DBCompatChecker.checkNetworkDBCompatibility(nodeParams)
+  DBChecker.checkChannelsDB(nodeParams)
+  DBChecker.checkNetworkDB(nodeParams)
   PortChecker.checkAvailable(serverBindingAddress)
 
   logger.info(s"nodeid=${nodeParams.nodeId} alias=${nodeParams.alias}")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.channel
 
 import akka.event.LoggingAdapter
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey, sha256}
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, Crypto, Satoshi, SatoshiLong}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, Crypto, Satoshi, SatoshiLong, Script}
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.fee.{FeeratePerKw, OnChainFeeConf}
 import fr.acinq.eclair.channel.Helpers.Closing
@@ -293,6 +293,13 @@ case class Commitments(channelId: ByteVector32,
 }
 
 object Commitments {
+
+  def validateSeed(commitments: Commitments, keyManager: ChannelKeyManager): Unit = {
+    val localFundingKey = keyManager.fundingPublicKey(commitments.localParams.fundingKeyPath).publicKey
+    val remoteFundingKey = commitments.remoteParams.fundingPubKey
+    val fundingScript = Script.write(Scripts.multiSig2of2(localFundingKey, remoteFundingKey))
+    require(commitments.commitInput.redeemScript == fundingScript, s"public key does not match channel funding transaction for channel ${commitments.channelId}")
+  }
 
   /**
    * Add a change to our proposed change list.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -294,11 +294,11 @@ case class Commitments(channelId: ByteVector32,
 
 object Commitments {
 
-  def validateSeed(commitments: Commitments, keyManager: ChannelKeyManager): Unit = {
+  def validateSeed(commitments: Commitments, keyManager: ChannelKeyManager): Boolean = {
     val localFundingKey = keyManager.fundingPublicKey(commitments.localParams.fundingKeyPath).publicKey
     val remoteFundingKey = commitments.remoteParams.fundingPubKey
     val fundingScript = Script.write(Scripts.multiSig2of2(localFundingKey, remoteFundingKey))
-    require(commitments.commitInput.redeemScript == fundingScript, s"public key does not match channel funding transaction for channel ${commitments.channelId}")
+    commitments.commitInput.redeemScript == fundingScript
   }
 
   /**

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -472,11 +472,8 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
 
   test("check if channel seed has been modified") { f =>
     val commitments = f.alice.stateData.asInstanceOf[DATA_NORMAL].commitments
-    Commitments.validateSeed(commitments, TestConstants.Alice.channelKeyManager)
-    val error = intercept[Throwable] {
-      Commitments.validateSeed(commitments, new LocalChannelKeyManager(ByteVector32.fromValidHex("42" * 32), Block.RegtestGenesisBlock.hash))
-    }
-    assert(error.getMessage.contains("public key does not match channel funding transaction"))
+    assert(Commitments.validateSeed(commitments, TestConstants.Alice.channelKeyManager))
+    assert(!Commitments.validateSeed(commitments, new LocalChannelKeyManager(ByteVector32.fromValidHex("42" * 32), Block.RegtestGenesisBlock.hash)))
   }
 }
 


### PR DESCRIPTION
On startup, we check that for each of our channels the public key derived from the channel seed matches the key that was
used when the channel was funded.