### PR TITLE
Remove Phoenix workaround for `payment_secret` dependency

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -266,9 +266,7 @@ object Features {
   // Features may depend on other features, as specified in Bolt 9.
   private val featuresDependency = Map(
     ChannelRangeQueriesExtended -> (ChannelRangeQueries :: Nil),
-    // This dependency requirement was added to the spec after the Phoenix release, which means Phoenix users have "invalid"
-    // invoices in their payment history. We choose to treat such invoices as valid; this is a harmless spec violation.
-    // PaymentSecret -> (VariableLengthOnion :: Nil),
+    PaymentSecret -> (VariableLengthOnion :: Nil),
     BasicMultiPartPayment -> (PaymentSecret :: Nil),
     AnchorOutputs -> (StaticRemoteKey :: Nil),
     AnchorOutputsZeroFeeHtlcTx -> (StaticRemoteKey :: Nil),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
@@ -70,15 +70,15 @@ class FeaturesSpec extends AnyFunSuite {
       bin"000000000000010000000000" -> false,
       bin"000000000000100010000000" -> true,
       bin"000000000000100001000000" -> true,
-      // payment_secret depends on var_onion_optin, but we allow not setting it to be compatible with Phoenix
-      bin"000000001000000000000000" -> true,
-      bin"000000000100000000000000" -> true,
+      // payment_secret depends on var_onion_optin
+      bin"000000001000000000000000" -> false,
+      bin"000000000100000000000000" -> false,
       bin"000000000100001000000000" -> true,
       // basic_mpp depends on payment_secret
       bin"000000100000000000000000" -> false,
       bin"000000010000000000000000" -> false,
-      bin"000000101000000000000000" -> true, // we allow not setting var_onion_optin
-      bin"000000011000000000000000" -> true, // we allow not setting var_onion_optin
+      bin"000000101000000100000000" -> true,
+      bin"000000011000000100000000" -> true,
       bin"000000011000001000000000" -> true,
       bin"000000100100000100000000" -> true,
       // option_anchor_outputs depends on option_static_remotekey


### PR DESCRIPTION
When Phoenix was based on a branch of eclair, we needed a workaround for invoice backwards-compatibility.
Now that Phoenix uses `lightning-kmp` instead of eclair, we can remove that work-around.
We are now fully spec-compliant regarding feature dependency validation.