### PR TITLE
Add dual funding codecs and feature bit

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -54,6 +54,7 @@ eclair {
     option_anchor_outputs = disabled
     option_anchors_zero_fee_htlc_tx = optional
     option_shutdown_anysegwit = optional
+    option_dual_fund = disabled
     option_onion_messages = optional
     option_channel_type = optional
     option_payment_metadata = optional

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -213,6 +213,11 @@ object Features {
     val mandatory = 26
   }
 
+  case object DualFunding extends Feature with InitFeature with NodeFeature {
+    val rfcName = "option_dual_fund"
+    val mandatory = 28
+  }
+
   case object OnionMessages extends Feature with InitFeature with NodeFeature {
     val rfcName = "option_onion_messages"
     val mandatory = 38
@@ -258,6 +263,7 @@ object Features {
     AnchorOutputs,
     AnchorOutputsZeroFeeHtlcTx,
     ShutdownAnySegwit,
+    DualFunding,
     OnionMessages,
     ChannelType,
     PaymentMetadata,
@@ -272,6 +278,7 @@ object Features {
     BasicMultiPartPayment -> (PaymentSecret :: Nil),
     AnchorOutputs -> (StaticRemoteKey :: Nil),
     AnchorOutputsZeroFeeHtlcTx -> (StaticRemoteKey :: Nil),
+    DualFunding -> (AnchorOutputsZeroFeeHtlcTx :: Nil),
     TrampolinePaymentPrototype -> (PaymentSecret :: Nil),
     KeySend -> (VariableLengthOnion :: Nil)
   )

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/ChannelTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/ChannelTlv.scala
@@ -50,13 +50,6 @@ object ChannelTlv {
     tlv => Features(tlv.channelType.features.map(f => f -> FeatureSupport.Mandatory).toMap).toByteVector
   )
 
-  case class DualFundedChannelFlagsTlv(announceChannel: Boolean) extends OpenDualFundedChannelTlv with AcceptDualFundedChannelTlv
-
-  val dualFundedChannelFlagsCodec: Codec[DualFundedChannelFlagsTlv] = variableSizeBytesLong(varintoverflow, bytes).xmap(
-    b => DualFundedChannelFlagsTlv(b.lastOption.exists(v => (v % 2) == 1)),
-    tlv => if (tlv.announceChannel) ByteVector(1.toByte) else ByteVector(0.toByte)
-  )
-
 }
 
 object OpenChannelTlv {
@@ -87,7 +80,6 @@ object OpenDualFundedChannelTlv {
   val openTlvCodec: Codec[TlvStream[OpenDualFundedChannelTlv]] = tlvStream(discriminated[OpenDualFundedChannelTlv].by(varint)
     .typecase(UInt64(0), upfrontShutdownScriptCodec)
     .typecase(UInt64(1), channelTypeCodec)
-    .typecase(UInt64(2), dualFundedChannelFlagsCodec)
   )
 
 }
@@ -99,7 +91,6 @@ object AcceptDualFundedChannelTlv {
   val acceptTlvCodec: Codec[TlvStream[AcceptDualFundedChannelTlv]] = tlvStream(discriminated[AcceptDualFundedChannelTlv].by(varint)
     .typecase(UInt64(0), upfrontShutdownScriptCodec)
     .typecase(UInt64(1), channelTypeCodec)
-    .typecase(UInt64(2), dualFundedChannelFlagsCodec)
   )
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/CommonCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/CommonCodecs.scala
@@ -115,6 +115,11 @@ object CommonCodecs {
 
   val channelflags: Codec[ChannelFlags] = (ignore(7) dropLeft bool).as[ChannelFlags]
 
+  val extendedChannelFlags: Codec[ChannelFlags] = variableSizeBytesLong(varintoverflow, bytes).xmap(
+    bin => ChannelFlags(bin.lastOption.exists(_ % 2 == 1)),
+    flags => if (flags.announceChannel) ByteVector(1) else ByteVector(0)
+  )
+
   val ipv4address: Codec[Inet4Address] = bytes(4).xmap(b => InetAddress.getByAddress(b.toArray).asInstanceOf[Inet4Address], a => ByteVector(a.getAddress))
 
   val ipv6address: Codec[Inet6Address] = bytes(16).exmap(b => Attempt.fromTry(Try(Inet6Address.getByAddress(null, b.toArray, null))), a => Attempt.fromTry(Try(ByteVector(a.getAddress))))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/InteractiveTxTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/InteractiveTxTlv.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.wire.protocol
+
+import fr.acinq.bitcoin.scalacompat.Satoshi
+import fr.acinq.eclair.UInt64
+import fr.acinq.eclair.wire.protocol.CommonCodecs.{varint, varintoverflow}
+import fr.acinq.eclair.wire.protocol.TlvCodecs.{tlvStream, tsatoshi}
+import scodec.Codec
+import scodec.codecs.{discriminated, variableSizeBytesLong}
+
+/**
+ * Created by t-bast on 08/04/2022.
+ */
+
+sealed trait TxAddInputTlv extends Tlv
+
+object TxAddInputTlv {
+  val txAddInputTlvCodec: Codec[TlvStream[TxAddInputTlv]] = tlvStream(discriminated[TxAddInputTlv].by(varint))
+}
+
+sealed trait TxAddOutputTlv extends Tlv
+
+object TxAddOutputTlv {
+  val txAddOutputTlvCodec: Codec[TlvStream[TxAddOutputTlv]] = tlvStream(discriminated[TxAddOutputTlv].by(varint))
+}
+
+sealed trait TxRemoveInputTlv extends Tlv
+
+object TxRemoveInputTlv {
+  val txRemoveInputTlvCodec: Codec[TlvStream[TxRemoveInputTlv]] = tlvStream(discriminated[TxRemoveInputTlv].by(varint))
+}
+
+sealed trait TxRemoveOutputTlv extends Tlv
+
+object TxRemoveOutputTlv {
+  val txRemoveOutputTlvCodec: Codec[TlvStream[TxRemoveOutputTlv]] = tlvStream(discriminated[TxRemoveOutputTlv].by(varint))
+}
+
+sealed trait TxCompleteTlv extends Tlv
+
+object TxCompleteTlv {
+  val txCompleteTlvCodec: Codec[TlvStream[TxCompleteTlv]] = tlvStream(discriminated[TxCompleteTlv].by(varint))
+}
+
+sealed trait TxSignaturesTlv extends Tlv
+
+object TxSignaturesTlv {
+  val txSignaturesTlvCodec: Codec[TlvStream[TxSignaturesTlv]] = tlvStream(discriminated[TxSignaturesTlv].by(varint))
+}
+
+sealed trait TxInitRbfTlv extends Tlv
+
+sealed trait TxAckRbfTlv extends Tlv
+
+object TxRbfTlv {
+  /** Amount that the peer will contribute to the transaction's shared output. */
+  case class SharedOutputContributionTlv(amount: Satoshi) extends TxInitRbfTlv with TxAckRbfTlv
+}
+
+object TxInitRbfTlv {
+
+  import TxRbfTlv._
+
+  val txInitRbfTlvCodec: Codec[TlvStream[TxInitRbfTlv]] = tlvStream(discriminated[TxInitRbfTlv].by(varint)
+    .typecase(UInt64(0), variableSizeBytesLong(varintoverflow, tsatoshi).as[SharedOutputContributionTlv])
+  )
+
+}
+
+object TxAckRbfTlv {
+
+  import TxRbfTlv._
+
+  val txAckRbfTlvCodec: Codec[TlvStream[TxAckRbfTlv]] = tlvStream(discriminated[TxAckRbfTlv].by(varint)
+    .typecase(UInt64(0), variableSizeBytesLong(varintoverflow, tsatoshi).as[SharedOutputContributionTlv])
+  )
+
+}
+
+sealed trait TxAbortTlv extends Tlv
+
+object TxAbortTlv {
+  val txAbortTlvCodec: Codec[TlvStream[TxAbortTlv]] = tlvStream(discriminated[TxAbortTlv].by(varint))
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecs.scala
@@ -115,6 +115,7 @@ object LightningMessageCodecs {
       ("delayedPaymentBasepoint" | publicKey) ::
       ("htlcBasepoint" | publicKey) ::
       ("firstPerCommitmentPoint" | publicKey) ::
+      ("channelFlags" | extendedChannelFlags) ::
       ("tlvStream" | OpenDualFundedChannelTlv.openTlvCodec)).as[OpenDualFundedChannel]
 
   val acceptChannelCodec: Codec[AcceptChannel] = (
@@ -149,6 +150,7 @@ object LightningMessageCodecs {
       ("delayedPaymentBasepoint" | publicKey) ::
       ("htlcBasepoint" | publicKey) ::
       ("firstPerCommitmentPoint" | publicKey) ::
+      ("channelFlags" | extendedChannelFlags) ::
       ("tlvStream" | AcceptDualFundedChannelTlv.acceptTlvCodec)).as[AcceptDualFundedChannel]
 
   val fundingCreatedCodec: Codec[FundingCreated] = (

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
@@ -189,10 +189,10 @@ case class OpenDualFundedChannel(chainHash: ByteVector32,
                                  delayedPaymentBasepoint: PublicKey,
                                  htlcBasepoint: PublicKey,
                                  firstPerCommitmentPoint: PublicKey,
+                                 channelFlags: ChannelFlags,
                                  tlvStream: TlvStream[OpenDualFundedChannelTlv] = TlvStream.empty) extends ChannelMessage with HasTemporaryChannelId with HasChainHash {
   val upfrontShutdownScript_opt: Option[ByteVector] = tlvStream.get[ChannelTlv.UpfrontShutdownScriptTlv].map(_.script)
   val channelType_opt: Option[ChannelType] = tlvStream.get[ChannelTlv.ChannelTypeTlv].map(_.channelType)
-  val announceChannel: Boolean = tlvStream.get[ChannelTlv.DualFundedChannelFlagsTlv].exists(_.announceChannel)
 }
 
 // NB: this message is named accept_channel2 in the specification.
@@ -210,10 +210,10 @@ case class AcceptDualFundedChannel(temporaryChannelId: ByteVector32,
                                    delayedPaymentBasepoint: PublicKey,
                                    htlcBasepoint: PublicKey,
                                    firstPerCommitmentPoint: PublicKey,
+                                   channelFlags: ChannelFlags,
                                    tlvStream: TlvStream[AcceptDualFundedChannelTlv] = TlvStream.empty) extends ChannelMessage with HasTemporaryChannelId {
   val upfrontShutdownScript_opt: Option[ByteVector] = tlvStream.get[ChannelTlv.UpfrontShutdownScriptTlv].map(_.script)
   val channelType_opt: Option[ChannelType] = tlvStream.get[ChannelTlv.ChannelTypeTlv].map(_.channelType)
-  val announceChannel: Boolean = tlvStream.get[ChannelTlv.DualFundedChannelFlagsTlv].exists(_.announceChannel)
 }
 
 case class FundingCreated(temporaryChannelId: ByteVector32,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/TlvCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/TlvCodecs.scala
@@ -16,6 +16,7 @@
 
 package fr.acinq.eclair.wire.protocol
 
+import fr.acinq.bitcoin.scalacompat.Satoshi
 import fr.acinq.eclair.UInt64.Conversions._
 import fr.acinq.eclair.wire.protocol.CommonCodecs.{minimalvalue, uint64, varint, varintoverflow}
 import fr.acinq.eclair.{MilliSatoshi, UInt64}
@@ -76,6 +77,9 @@ object TlvCodecs {
    * This codec can be safely used for values < `2^63` and will fail otherwise.
    */
   val tmillisatoshi: Codec[MilliSatoshi] = tu64overflow.xmap(l => MilliSatoshi(l), m => m.toLong)
+
+  /** Truncated satoshi (0 to 8 bytes unsigned). */
+  val tsatoshi: Codec[Satoshi] = tu64overflow.xmap(l => Satoshi(l), s => s.toLong)
 
   /** Truncated uint32 (0 to 4 bytes unsigned integer). */
   val tu32: Codec[Long] = tu64.exmap({

--- a/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/FeaturesSpec.scala
@@ -62,39 +62,54 @@ class FeaturesSpec extends AnyFunSuite {
 
   test("features dependencies") {
     val testCases = Map(
-      bin"                        " -> true,
-      bin"                00000000" -> true,
-      bin"                01011000" -> true,
+      bin"                                " -> true,
+      bin"                        00000000" -> true,
+      bin"                        01011000" -> true,
       // gossip_queries_ex depend on gossip_queries
-      bin"000000000000100000000000" -> false,
-      bin"000000000000010000000000" -> false,
-      bin"000000000000100010000000" -> true,
-      bin"000000000000100001000000" -> true,
+      bin"        000000000000100000000000" -> false,
+      bin"        000000000000010000000000" -> false,
+      bin"        000000000000100010000000" -> true,
+      bin"        000000000000100001000000" -> true,
       // payment_secret depends on var_onion_optin
-      bin"000000001000000000000000" -> false,
-      bin"000000000100000000000000" -> false,
-      bin"000000000100001000000000" -> true,
+      bin"        000000001000000000000000" -> false,
+      bin"        000000000100000000000000" -> false,
+      bin"        000000000100001000000000" -> true,
       // basic_mpp depends on payment_secret
-      bin"000000100000000000000000" -> false,
-      bin"000000010000000000000000" -> false,
-      bin"000000101000000100000000" -> true,
-      bin"000000011000000100000000" -> true,
-      bin"000000011000001000000000" -> true,
-      bin"000000100100000100000000" -> true,
+      bin"        000000100000000000000000" -> false,
+      bin"        000000010000000000000000" -> false,
+      bin"        000000101000000100000000" -> true,
+      bin"        000000011000000100000000" -> true,
+      bin"        000000011000001000000000" -> true,
+      bin"        000000100100000100000000" -> true,
       // option_anchor_outputs depends on option_static_remotekey
-      bin"001000000000000000000000" -> false,
-      bin"000100000000000000000000" -> false,
-      bin"001000000010000000000000" -> true,
-      bin"001000000001000000000000" -> true,
-      bin"000100000010000000000000" -> true,
-      bin"000100000001000000000000" -> true,
+      bin"        001000000000000000000000" -> false,
+      bin"        000100000000000000000000" -> false,
+      bin"        001000000010000000000000" -> true,
+      bin"        001000000001000000000000" -> true,
+      bin"        000100000010000000000000" -> true,
+      bin"        000100000001000000000000" -> true,
       // option_anchors_zero_fee_htlc_tx depends on option_static_remotekey
-      bin"100000000000000000000000" -> false,
-      bin"010000000000000000000000" -> false,
-      bin"100000000010000000000000" -> true,
-      bin"100000000001000000000000" -> true,
-      bin"010000000010000000000000" -> true,
-      bin"010000000001000000000000" -> true,
+      bin"        100000000000000000000000" -> false,
+      bin"        010000000000000000000000" -> false,
+      bin"        100000000010000000000000" -> true,
+      bin"        100000000001000000000000" -> true,
+      bin"        010000000010000000000000" -> true,
+      bin"        010000000001000000000000" -> true,
+      // option_dual_fund depends on option_anchors_zero_fee_htlc_tx, which itself depends on option_static_remotekey
+      bin"00100000000000000000000000000000" -> false,
+      bin"00010000000000000000000000000000" -> false,
+      bin"00100000100000000000000000000000" -> false,
+      bin"00100000010000000000000000000000" -> false,
+      bin"00010000100000000000000000000000" -> false,
+      bin"00010000010000000000000000000000" -> false,
+      bin"00100000100000000010000000000000" -> true,
+      bin"00100000100000000001000000000000" -> true,
+      bin"00100000010000000010000000000000" -> true,
+      bin"00100000010000000001000000000000" -> true,
+      bin"00010000100000000010000000000000" -> true,
+      bin"00010000100000000001000000000000" -> true,
+      bin"00010000010000000010000000000000" -> true,
+      bin"00010000010000000001000000000000" -> true,
     )
 
     for ((testCase, valid) <- testCases) {
@@ -236,7 +251,7 @@ class FeaturesSpec extends AnyFunSuite {
       hex"0100" -> Features(VariableLengthOnion -> Mandatory),
       hex"028a8a" -> Features(DataLossProtect -> Optional, InitialRoutingSync -> Optional, ChannelRangeQueries -> Optional, VariableLengthOnion -> Optional, ChannelRangeQueriesExtended -> Optional, PaymentSecret -> Optional, BasicMultiPartPayment -> Optional),
       hex"09004200" -> Features(Map(VariableLengthOnion -> Optional, PaymentSecret -> Mandatory, ShutdownAnySegwit -> Optional), Set(UnknownFeature(24))),
-      hex"52000000" -> Features(Map.empty[Feature, FeatureSupport], Set(UnknownFeature(25), UnknownFeature(28), UnknownFeature(30)))
+      hex"80010080000000000000000000000000000000000000" -> Features(Map.empty[Feature, FeatureSupport], Set(UnknownFeature(151), UnknownFeature(160), UnknownFeature(175)))
     )
 
     for ((bin, features) <- testCases) {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt11InvoiceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt11InvoiceSpec.scala
@@ -480,7 +480,7 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
       // those are useful for nonreg testing of the areSupported method (which needs to be updated with every new supported mandatory bit)
       Features(bin"     000001000000000100000100000000") -> Result(allowMultiPart = false, requirePaymentSecret = true, areSupported = false),
       Features(bin"     000100000000000100000100000000") -> Result(allowMultiPart = false, requirePaymentSecret = true, areSupported = true),
-      Features(bin"00000010000000000000100000100000000") -> Result(allowMultiPart = false, requirePaymentSecret = true, areSupported = false),
+      Features(bin"00000010000000000000100000100000000") -> Result(allowMultiPart = false, requirePaymentSecret = true, areSupported = true),
       Features(bin"00001000000000000000100000100000000") -> Result(allowMultiPart = false, requirePaymentSecret = true, areSupported = false)
     )
 


### PR DESCRIPTION
This PR adds definitions for the messages and types used by [dual funding](https://github.com/lightning/bolts/pull/851).
Note that the codecs are slightly different from what is currently proposed in the spec, but [a PR has been opened](https://github.com/niftynei/lightning-rfc/pull/3) to add the proposed changes to the spec.

This is very tedious to review, don't focus on all the byte-level details, but it's interesting to look at what changes between `open_channel`/`accept_channel` v1 and this v2.
