### PR TITLE
Add a "stop" API method

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -9,6 +9,7 @@
 ### API changes
 
 - `channelbalances` Retrieves information about the balances of all local channels. (#2196)
+- `stop` Stops eclair. Please note that the recommended way of stopping eclair is simply to kill its process (#2233)
 
 ### Miscellaneous improvements and bug fixes
 

--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -34,6 +34,7 @@ and COMMAND is one of the available commands:
     - disconnect
     - peers
     - audit
+    - stop
 
   === Channel ===
     - open

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -159,6 +159,8 @@ trait Eclair {
   def verifyMessage(message: ByteVector, recoverableSignature: ByteVector): VerifiedMessage
 
   def sendOnionMessage(intermediateNodes: Seq[PublicKey], destination: Either[PublicKey, Sphinx.RouteBlinding.BlindedRoute], replyPath: Option[Seq[PublicKey]], userCustomContent: ByteVector)(implicit timeout: Timeout): Future[SendOnionMessageResponse]
+
+  def stop(exitCode: Int): Future[Unit]
 }
 
 class EclairImpl(appKit: Kit) extends Eclair with Logging {
@@ -558,5 +560,13 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
         }
       case Attempt.Failure(cause) => Future.successful(SendOnionMessageResponse(sent = false, failureMessage = Some(s"the `content` field is invalid, it must contain encoded tlvs: ${cause.message}"), response = None))
     }
+  }
+
+  override def stop(exitCode: Int): Future[Unit] = {
+    // README: do not make this smarter or more complex !
+    // eclair can simply and cleanly be stopped by killing its process without fear of losing data, payments, ... and it should remain this way.
+    logger.info(s"stopping eclair with exit code $exitCode")
+    sys.exit(exitCode)
+    Future.successful(())
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -160,7 +160,7 @@ trait Eclair {
 
   def sendOnionMessage(intermediateNodes: Seq[PublicKey], destination: Either[PublicKey, Sphinx.RouteBlinding.BlindedRoute], replyPath: Option[Seq[PublicKey]], userCustomContent: ByteVector)(implicit timeout: Timeout): Future[SendOnionMessageResponse]
 
-  def stop(exitCode: Int): Future[Unit]
+  def stop(): Future[Unit]
 }
 
 class EclairImpl(appKit: Kit) extends Eclair with Logging {
@@ -562,11 +562,11 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     }
   }
 
-  override def stop(exitCode: Int): Future[Unit] = {
+  override def stop(): Future[Unit] = {
     // README: do not make this smarter or more complex !
     // eclair can simply and cleanly be stopped by killing its process without fear of losing data, payments, ... and it should remain this way.
-    logger.info(s"stopping eclair with exit code $exitCode")
-    sys.exit(exitCode)
+    logger.info("stopping eclair")
+    sys.exit(0)
     Future.successful(())
   }
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Node.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Node.scala
@@ -63,11 +63,7 @@ trait Node {
   }
 
   val stop: Route = postRequest("stop") { implicit t =>
-    formFields("exitCode".as[Int].?) { exitCode_opt =>
-      val exitCode = exitCode_opt.getOrElse(0)
-      eclairApi.stop(exitCode)
-      complete("ok")
-    }
+    complete(eclairApi.stop())
   }
 
   val nodeRoutes: Route = getInfo ~ connect ~ disconnect ~ peers ~ audit ~ stop

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Node.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Node.scala
@@ -62,5 +62,13 @@ trait Node {
     }
   }
 
-  val nodeRoutes: Route = getInfo ~ connect ~ disconnect ~ peers ~ audit
+  val stop: Route = postRequest("stop") { implicit t =>
+    formFields("exitCode".as[Int].?) { exitCode_opt =>
+      val exitCode = exitCode_opt.getOrElse(0)
+      eclairApi.stop(exitCode)
+      complete("ok")
+    }
+  }
+
+  val nodeRoutes: Route = getInfo ~ connect ~ disconnect ~ peers ~ audit ~ stop
 }

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -1188,7 +1188,6 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
   test("stop eclair") {
     val eclair = mock[Eclair]
     val mockService = new MockService(eclair)
-    eclair.stop(0) returns Future.successful(())
 
     Post("/stop") ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -1188,6 +1188,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
   test("stop eclair") {
     val eclair = mock[Eclair]
     val mockService = new MockService(eclair)
+    eclair.stop() returns Future.successful(())
 
     Post("/stop") ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -1185,6 +1185,20 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       }
   }
 
+  test("stop eclair") {
+    val eclair = mock[Eclair]
+    val mockService = new MockService(eclair)
+    eclair.stop(0) returns Future.successful(())
+
+    Post("/stop") ~>
+      addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
+      Route.seal(mockService.stop) ~>
+      check {
+        assert(handled)
+        assert(status == OK)
+      }
+  }
+
   private def matchTestJson(apiName: String, response: String) = {
     val resource = getClass.getResourceAsStream(s"/api/$apiName")
     val expectedResponse = Try(Source.fromInputStream(resource).mkString).getOrElse {


### PR DESCRIPTION
This API call was added for certain uses cases where killing the process was impractical but internally it just calls `sys.exit()`.
Eclair is designed to shutdown cleanly when its process is killed and this is still the recommended way of stopping it.