### PR TITLE
Disable invoice purger in tests

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -197,7 +197,7 @@ object TestConstants {
         relayPolicy = RelayAll,
         timeout = 1 minute
       ),
-      purgeInvoicesInterval = Some(24 hours),
+      purgeInvoicesInterval = None,
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(
@@ -335,7 +335,7 @@ object TestConstants {
         relayPolicy = RelayAll,
         timeout = 1 minute
       ),
-      purgeInvoicesInterval = Some(24 hours)
+      purgeInvoicesInterval = None
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(


### PR DESCRIPTION
It was creating a race condition in the test `MultiPartHandlerSpec`.`PaymentHandler should reject incoming multi-part payment with an invalid expiry` due the 0-expiry invoice being immediately purged.