### PR TITLE
Stop compressing with zlib

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -230,7 +230,6 @@ eclair {
 
     sync {
       request-node-announcements = true // if true we will ask for node announcements when we receive channel ids that we don't know
-      encoding-type = zlib // encoding for short_channel_ids and timestamps in query channel sync messages; other possible value is "uncompressed"
       channel-range-chunk-size = 1500 // max number of short_channel_ids (+ timestamps + checksums) in reply_channel_range *do not change this unless you know what you are doing*
       channel-query-chunk-size = 100 // max number of short_channel_ids in query_short_channel_ids *do not change this unless you know what you are doing*
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -384,11 +384,6 @@ object NodeParams extends Logging {
       case "stop" => UnhandledExceptionStrategy.Stop
     }
 
-    val routerSyncEncodingType = config.getString("router.sync.encoding-type") match {
-      case "uncompressed" => EncodingType.UNCOMPRESSED
-      case "zlib" => EncodingType.COMPRESSED_ZLIB
-    }
-
     val onionMessageRelayPolicy: RelayPolicy = config.getString("onion-messages.relay-policy") match {
       case "no-relay" => NoRelay
       case "channels-only" => RelayChannelsOnly
@@ -493,7 +488,7 @@ object NodeParams extends Logging {
         channelExcludeDuration = FiniteDuration(config.getDuration("router.channel-exclude-duration").getSeconds, TimeUnit.SECONDS),
         routerBroadcastInterval = FiniteDuration(config.getDuration("router.broadcast-interval").getSeconds, TimeUnit.SECONDS),
         requestNodeAnnouncements = config.getBoolean("router.sync.request-node-announcements"),
-        encodingType = routerSyncEncodingType,
+        encodingType = EncodingType.UNCOMPRESSED,
         channelRangeChunkSize = config.getInt("router.sync.channel-range-chunk-size"),
         channelQueryChunkSize = config.getInt("router.sync.channel-query-chunk-size"),
         pathFindingExperimentConf = getPathFindingExperimentConf(config.getConfig("router.path-finding.experiments"))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -304,7 +304,10 @@ object Router {
                         encodingType: EncodingType,
                         channelRangeChunkSize: Int,
                         channelQueryChunkSize: Int,
-                        pathFindingExperimentConf: PathFindingExperimentConf)
+                        pathFindingExperimentConf: PathFindingExperimentConf) {
+    require(channelRangeChunkSize <= Sync.MAXIMUM_CHUNK_SIZE, "channel range chunk size exceeds the size of a lightning message")
+    require(channelQueryChunkSize <= Sync.MAXIMUM_CHUNK_SIZE, "channel query chunk size exceeds the size of a lightning message")
+  }
 
   // @formatter:off
   case class ChannelDesc(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Sync.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Sync.scala
@@ -38,9 +38,9 @@ object Sync {
   // maximum number of ids we can keep in a single chunk and still have an encoded reply that is smaller than 65Kb
   // please note that:
   // - this is based on the worst case scenario where peer want timestamps and checksums and the reply is not compressed
-  // - the maximum number of public channels in a single block so far is less than 300, and the maximum number of tx per block
-  // almost never exceeds 2800 so this is not a real limitation yet
-  val MAXIMUM_CHUNK_SIZE = 3200
+  // - the maximum number of public channels in a single block so far is less than 300, and the maximum number of tx per
+  //   block almost never exceeds 2800 so this should very rarely be limiting
+  val MAXIMUM_CHUNK_SIZE = 2700
 
   def handleSendChannelQuery(d: Data, s: SendChannelQuery)(implicit ctx: ActorContext, log: LoggingAdapter): Data = {
     implicit val sender: ActorRef = ctx.self // necessary to preserve origin when sending messages to other actors


### PR DESCRIPTION
While zlib provides good compression results for gossip, it's a dependency that had a few important CVEs in the past. Some implementations are reluctant to import it, so we decided to remove it from the specification in https://github.com/lightning/bolts/pull/981

We stop compressing with zlib and only send uncompressed results, while still supporting receiving compressed data. We will remove support for decompression once our monitoring indicates that we stopped receiving compressed data.