### PR TITLE
Fix flaky MempoolTxMonitor test

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitorSpec.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.channel.publish
 
 import akka.actor.typed.ActorRef
-import akka.actor.typed.scaladsl.adapter.{ClassicActorSystemOps, TypedActorRefOps, actorRefAdapter}
+import akka.actor.typed.scaladsl.adapter.{ClassicActorSystemOps, actorRefAdapter}
 import akka.pattern.pipe
 import akka.testkit.TestProbe
 import fr.acinq.bitcoin.scalacompat.Crypto.PrivateKey
@@ -82,18 +82,18 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     waitTxInMempool(bitcoinClient, tx.txid, probe)
 
     // NB: we don't really generate a block, we're testing the case where the tx is still in the mempool.
-    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
-    probe.expectMsg(TxInMempool(tx.txid, currentBlockHeight(probe)))
+    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight()))
+    probe.expectMsg(TxInMempool(tx.txid, currentBlockHeight()))
     probe.expectNoMessage(100 millis)
 
     assert(TestConstants.Alice.nodeParams.channelConf.minDepthBlocks > 1)
     generateBlocks(1)
-    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
+    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight()))
     probe.expectMsg(TxRecentlyConfirmed(tx.txid, 1))
     probe.expectNoMessage(100 millis) // we wait for more than one confirmation to protect against reorgs
 
     generateBlocks(TestConstants.Alice.nodeParams.channelConf.minDepthBlocks - 1)
-    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
+    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight()))
     probe.expectMsg(TxDeeplyBuried(tx))
   }
 
@@ -110,7 +110,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     waitTxInMempool(bitcoinClient, tx2.txid, probe)
 
     generateBlocks(TestConstants.Alice.nodeParams.channelConf.minDepthBlocks)
-    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
+    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight()))
     probe.expectMsg(TxDeeplyBuried(tx2))
   }
 
@@ -192,7 +192,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     probe.expectMsg(tx2.txid)
 
     // When a new block is found, we detect that the transaction has been replaced.
-    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
+    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight()))
     probe.expectMsg(TxRejected(tx1.txid, ConflictingTxUnconfirmed))
   }
 
@@ -210,7 +210,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
 
     // When a new block is found, we detect that the transaction has been replaced.
     generateBlocks(1)
-    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
+    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight()))
     probe.expectMsg(TxRejected(tx1.txid, ConflictingTxConfirmed))
   }
 
@@ -234,7 +234,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
 
     // When a new block is found, we detect that the transaction has been evicted.
     generateBlocks(1)
-    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
+    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight()))
     probe.expectMsg(TxRejected(tx.txid, InputGone))
   }
 
@@ -258,7 +258,7 @@ class MempoolTxMonitorSpec extends TestKitBaseClass with AnyFunSuiteLike with Bi
     assert(txPublished.desc === "test-tx")
 
     generateBlocks(TestConstants.Alice.nodeParams.channelConf.minDepthBlocks)
-    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
+    system.eventStream.publish(CurrentBlockHeight(currentBlockHeight()))
     eventListener.expectMsg(TransactionConfirmed(txPublished.channelId, txPublished.remoteNodeId, tx))
   }
 


### PR DESCRIPTION
Using the same test probe to get the current block height and watch the mempool can lead to rare race conditions, such as:

```
MempoolTxMonitorSpec:

- transaction confirmed *** FAILED ***
  java.lang.AssertionError: assertion failed: expected class org.json4s.JInt, found class fr.acinq.eclair.channel.publish.MempoolTxMonitor$TxInMempool (TxInMempool(649207d7e7b8fcb8fdf851f28c4abfffadf926b8917c2ca53ca729b4fb5bb8bd,BlockHeight(151)))
  at scala.Predef$.assert(Predef.scala:279)
  at akka.testkit.TestKitBase.expectMsgClass_internal(TestKit.scala:572)
  at akka.testkit.TestKitBase.expectMsgType(TestKit.scala:543)
  at akka.testkit.TestKitBase.expectMsgType$(TestKit.scala:542)
  at akka.testkit.TestKit.expectMsgType(TestKit.scala:973)
  at fr.acinq.eclair.blockchain.bitcoind.BitcoindService.currentBlockHeight(BitcoindService.scala:165)
  at fr.acinq.eclair.blockchain.bitcoind.BitcoindService.currentBlockHeight$(BitcoindService.scala:163)
  at fr.acinq.eclair.channel.publish.MempoolTxMonitorSpec.currentBlockHeight(MempoolTxMonitorSpec.scala:41)
  at fr.acinq.eclair.channel.publish.MempoolTxMonitorSpec.$anonfun$new$1(MempoolTxMonitorSpec.scala:86)
  at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
```