### PR TITLE
Send additional commitment sigs with various feerates

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/JsonSerializers.scala
@@ -69,6 +69,7 @@ object JsonSerializers {
   implicit val remoteCommitsReadWriter: ReadWriter[RemoteCommit] = macroRW
   implicit val commitSgReadWriter: ReadWriter[CommitSig] = macroRW
   implicit val waitingForRevocationReadWriter: ReadWriter[WaitingForRevocation] = macroRW
+  implicit val customRemoteSigReadWriter: ReadWriter[CustomRemoteSig] = macroRW
   implicit val localOriginReadWriter: ReadWriter[Origin.Local] = macroRW
   implicit val relayedOriginReadWriter: ReadWriter[Origin.Relayed] = macroRW
   implicit val paymentOriginReadWriter: ReadWriter[Origin] = ReadWriter.merge(localOriginReadWriter, relayedOriginReadWriter)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -484,7 +484,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
   })
 
   when(WAIT_FOR_FUNDING_SIGNED)(handleExceptions {
-    case Event(msg@FundingSigned(_, remoteSig, _), d@DATA_WAIT_FOR_FUNDING_SIGNED(channelId, localParams, remoteParams, fundingTx, fundingTxFee, localSpec, localCommitTx, remoteCommit, channelFlags, channelVersion, fundingCreated)) =>
+    case Event(msg@FundingSigned(_, remoteSig, _, _), d@DATA_WAIT_FOR_FUNDING_SIGNED(channelId, localParams, remoteParams, fundingTx, fundingTxFee, localSpec, localCommitTx, remoteCommit, channelFlags, channelVersion, fundingCreated)) =>
       // we make sure that their sig checks out and that our first commit tx is spendable
       val fundingPubKey = keyManager.fundingPublicKey(localParams.fundingKeyPath)
       val localSigOfLocalTx = keyManager.sign(localCommitTx, fundingPubKey)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Channel.scala
@@ -234,7 +234,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
               closing.localCommitPublished.foreach(doPublish)
               closing.remoteCommitPublished.foreach(doPublish)
               closing.nextRemoteCommitPublished.foreach(doPublish)
-              closing.customRemoteCommitPublished.values.foreach(doPublish)
+              closing.customRemoteCommitPublished.values.foreach(doPublish) // here for consistency, won't be used since we are not persisting the customRemoteCommitPublished field
               closing.revokedCommitPublished.foreach(doPublish)
               closing.futureRemoteCommitPublished.foreach(doPublish)
 
@@ -2229,7 +2229,7 @@ class Channel(val nodeParams: NodeParams, val wallet: EclairWallet, remoteNodeId
   }
 
   def handleRemoteSpentCustom(commitTx: Transaction, d: HasCommitments, customRemoteCommit: RemoteCommit) = {
-    log.warning(s"they published a custom commitment with feerate={} sat/kw ({} sat/B), uin txid=${commitTx.txid}", customRemoteCommit.spec.feeratePerKw, feerateKw2Byte(customRemoteCommit.spec.feeratePerKw))
+    log.warning(s"they published a custom commitment with feerate={} sat/kw ({} sat/byte) in txid=${commitTx.txid}", customRemoteCommit.spec.feeratePerKw, feerateKw2Byte(customRemoteCommit.spec.feeratePerKw))
     require(commitTx.txid == customRemoteCommit.txid, "txid mismatch")
 
     val remoteCommitPublished = Helpers.Closing.claimRemoteCommitTxOutputs(keyManager, d.commitments, customRemoteCommit, commitTx, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelTypes.scala
@@ -212,9 +212,10 @@ final case class DATA_CLOSING(commitments: Commitments,
                               localCommitPublished: Option[LocalCommitPublished] = None,
                               remoteCommitPublished: Option[RemoteCommitPublished] = None,
                               nextRemoteCommitPublished: Option[RemoteCommitPublished] = None,
+                              customRemoteCommitPublished: Map[RemoteCommit, RemoteCommitPublished] = Map.empty,
                               futureRemoteCommitPublished: Option[RemoteCommitPublished] = None,
                               revokedCommitPublished: List[RevokedCommitPublished] = Nil) extends Data with HasCommitments {
-  val spendingTxes = mutualClosePublished ::: localCommitPublished.map(_.commitTx).toList ::: remoteCommitPublished.map(_.commitTx).toList ::: nextRemoteCommitPublished.map(_.commitTx).toList ::: futureRemoteCommitPublished.map(_.commitTx).toList ::: revokedCommitPublished.map(_.commitTx)
+  val spendingTxes = mutualClosePublished ::: localCommitPublished.map(_.commitTx).toList ::: remoteCommitPublished.map(_.commitTx).toList ::: nextRemoteCommitPublished.map(_.commitTx).toList ::: customRemoteCommitPublished.values.map(_.commitTx).toList ::: futureRemoteCommitPublished.map(_.commitTx).toList ::: revokedCommitPublished.map(_.commitTx)
   require(spendingTxes.nonEmpty, "there must be at least one tx published in this state")
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -466,7 +466,7 @@ object Commitments {
 
   def revocationHash(seed: ByteVector32, index: Long): ByteVector32 = Crypto.sha256(revocationPreimage(seed, index))
 
-  /** /!\ WARNING : never remove a feerate from the list, because we will only try thosecan only add more */
+  /** /!\ WARNING : never remove a feerate from the list, we can only add more, otherwise we will not be able to detect when our peer broadcasts the commit tx at the removed feerate. */
   val customRemoteSigsFeerates: Seq[Long] = List(1 sat, 2 sat, 5 sat, 10 sat).map(satPerByte => feerateByte2Kw(satPerByte.toLong))
 
   def computeCustomRemoteSigs(commitments: Commitments, keyManager: KeyManager, remoteCommitIndex: Long, spec: CommitmentSpec, remotePerCommitmentPoint: PublicKey): Seq[CustomRemoteSig] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -45,6 +45,7 @@ case class PublishableTxs(commitTx: CommitTx, htlcTxsAndSigs: List[HtlcTxAndSigs
 case class LocalCommit(index: Long, spec: CommitmentSpec, publishableTxs: PublishableTxs)
 case class RemoteCommit(index: Long, spec: CommitmentSpec, txid: ByteVector32, remotePerCommitmentPoint: PublicKey)
 case class WaitingForRevocation(nextRemoteCommit: RemoteCommit, sent: CommitSig, sentAfterLocalCommitIndex: Long, reSignAsap: Boolean = false)
+final case class CustomRemoteSig(feeratePerKw: Long, signature: ByteVector64)
 // @formatter:on
 
 /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
@@ -269,6 +269,7 @@ object ChannelCodecs extends Logging {
       ("localCommitPublished" | optional(bool8, localCommitPublishedCodec)) ::
       ("remoteCommitPublished" | optional(bool8, remoteCommitPublishedCodec)) ::
       ("nextRemoteCommitPublished" | optional(bool8, remoteCommitPublishedCodec)) ::
+      ("customRemoteCommitPublished" | provide(Map.empty[RemoteCommit, RemoteCommitPublished])) ::
       ("futureRemoteCommitPublished" | optional(bool8, remoteCommitPublishedCodec)) ::
       ("revokedCommitPublished" | listOfN(uint16, revokedCommitPublishedCodec))).as[DATA_CLOSING]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/ChannelCodecs.scala
@@ -269,6 +269,9 @@ object ChannelCodecs extends Logging {
       ("localCommitPublished" | optional(bool8, localCommitPublishedCodec)) ::
       ("remoteCommitPublished" | optional(bool8, remoteCommitPublishedCodec)) ::
       ("nextRemoteCommitPublished" | optional(bool8, remoteCommitPublishedCodec)) ::
+      // We don't persist the custom remote commit and will forget everything about it on restart, but that's not an
+      // issue because we will re-create it automatically because we will watch the funding output being spent. And
+      // we don't have anything to claim on our side anyway, thanks to static_remotekey.
       ("customRemoteCommitPublished" | provide(Map.empty[RemoteCommit, RemoteCommitPublished])) ::
       ("futureRemoteCommitPublished" | optional(bool8, remoteCommitPublishedCodec)) ::
       ("revokedCommitPublished" | listOfN(uint16, revokedCommitPublishedCodec))).as[DATA_CLOSING]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LegacyChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LegacyChannelCodecs.scala
@@ -335,6 +335,7 @@ private[wire] object LegacyChannelCodecs extends Logging {
       ("localCommitPublished" | optional(bool, localCommitPublishedCodec)) ::
       ("remoteCommitPublished" | optional(bool, remoteCommitPublishedCodec)) ::
       ("nextRemoteCommitPublished" | optional(bool, remoteCommitPublishedCodec)) ::
+      ("customRemoteCommitPublished" | provide(Map.empty[RemoteCommit, RemoteCommitPublished])) ::
       ("futureRemoteCommitPublished" | optional(bool, remoteCommitPublishedCodec)) ::
       ("revokedCommitPublished" | listOfN(uint16, revokedCommitPublishedCodec))).as[DATA_CLOSING].decodeOnly
 
@@ -347,6 +348,7 @@ private[wire] object LegacyChannelCodecs extends Logging {
       ("localCommitPublished" | optional(bool, localCommitPublishedCodec)) ::
       ("remoteCommitPublished" | optional(bool, remoteCommitPublishedCodec)) ::
       ("nextRemoteCommitPublished" | optional(bool, remoteCommitPublishedCodec)) ::
+      ("customRemoteCommitPublished" | provide(Map.empty[RemoteCommit, RemoteCommitPublished])) ::
       ("futureRemoteCommitPublished" | optional(bool, remoteCommitPublishedCodec)) ::
       ("revokedCommitPublished" | listOfN(uint16, revokedCommitPublishedCodec))).as[DATA_CLOSING].decodeOnly
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/LightningMessageTypes.scala
@@ -18,10 +18,10 @@ package fr.acinq.eclair.wire
 
 import java.net.{Inet4Address, Inet6Address, InetAddress, InetSocketAddress}
 import java.nio.charset.StandardCharsets
-
 import com.google.common.base.Charsets
 import fr.acinq.bitcoin.scala.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.scala.{ByteVector32, ByteVector64, Satoshi}
+import fr.acinq.eclair.channel.CustomRemoteSig
 import fr.acinq.eclair.payment.OutgoingPacket
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshi, ShortChannelId, UInt64, _}
@@ -113,7 +113,8 @@ case class FundingCreated(temporaryChannelId: ByteVector32,
 
 case class FundingSigned(channelId: ByteVector32,
                          signature: ByteVector64,
-                         channelData: Option[ByteVector] = None) extends ChannelMessage with HasChannelId
+                         channelData: Option[ByteVector] = None,
+                         customRemoteSigs: Option[List[CustomRemoteSig]] = None) extends ChannelMessage with HasChannelId
 
 case class FundingLocked(channelId: ByteVector32,
                          nextPerCommitmentPoint: PublicKey) extends ChannelMessage with HasChannelId
@@ -150,7 +151,8 @@ case class UpdateFailMalformedHtlc(channelId: ByteVector32,
 case class CommitSig(channelId: ByteVector32,
                      signature: ByteVector64,
                      htlcSignatures: List[ByteVector64],
-                     channelData: Option[ByteVector] = None) extends HtlcMessage with HasChannelId
+                     channelData: Option[ByteVector] = None,
+                     customRemoteSigs: Option[List[CustomRemoteSig]] = None) extends HtlcMessage with HasChannelId
 
 case class RevokeAndAck(channelId: ByteVector32,
                         perCommitmentSecret: PrivateKey,


### PR DESCRIPTION
We add a new TLV-compatible field to `funding_signed`/`commit_sig` and send additional commitment signatures for a set of feerates (1, 2, 5, 10 sat/B) (only when there are no htlcs).

We also gracefully handle the case where remote decides to use one of those additional signatures to unilaterally close the channel. This creates yet another remote-close scenario, named _custom_, on top of the existing with _current_/_next_/_future_. 

Note that:
- since we use static remote key, there isn't anything to do in case of a custom close, since there are no htlcs
- codecs haven't been updated, there is no need.