### PR TITLE
Use log probability in path-finding

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -256,18 +256,27 @@ eclair {
           channel-age = 0.4       // when computing the weight for a channel, consider its AGE in this proportion
           channel-capacity = 0.55 // when computing the weight for a channel, consider its CAPACITY in this proportion
         }
-        locked-funds-risk = 1e-8 // msat per msat locked per block. It should be your expected interest rate per block multiplied by the probability that something goes wrong and your funds stay locked.
-        // 1e-8 corresponds to an interest rate of ~5% per year (1e-6 per block) and a probability of 1% that the channel will fail and our funds will be locked.
-        // virtual fee for failed payments: how much you are willing to pay to get one less failed payment attempt
-        failure-cost {
-          fee-base-msat = 2000
-          fee-proportional-millionths = 500
-        }
+
         hop-cost {
           // virtual fee for additional hops: how much you are willing to pay to get one less hop in the payment path
           fee-base-msat = 500
           fee-proportional-millionths = 200
         }
+
+        locked-funds-risk = 1e-8 // msat per msat locked per block. It should be your expected interest rate per block multiplied by the probability that something goes wrong and your funds stay locked.
+        // 1e-8 corresponds to an interest rate of ~5% per year (1e-6 per block) and a probability of 1% that the channel will fail and our funds will be locked.
+
+        // virtual fee for failed payments: how much you are willing to pay to get one less failed payment attempt
+        // ignored if use-ratio = true
+        failure-cost {
+          fee-base-msat = 2000
+          fee-proportional-millionths = 500
+        }
+        // Using a failure cost breaks Dijkstra (the path returned is no longer guaranteed to be shortest one), if
+        // that's a concern, you can penalize paths with a low success chance by using the logarithm of the probability
+        // of success. It satisfies Dijkstra's requirements and is a very good approximation for paths with a high
+        // probability of success, however is penalizes less the paths with a low probability of success.
+        use-log-probability = false
 
         mpp {
           min-amount-satoshis = 15000 // minimum amount sent via partial HTLCs

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -365,6 +365,7 @@ object NodeParams extends Logging {
           lockedFundsRisk = config.getDouble("locked-funds-risk"),
           failureCost = getRelayFees(config.getConfig("failure-cost")),
           hopCost = getRelayFees(config.getConfig("hop-cost")),
+          useLogProbability = config.getBoolean("use-log-probability"),
         ))
       },
       mpp = MultiPartParams(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -67,7 +67,8 @@ object EclairInternalsSerializer {
   val heuristicsConstantsCodec: Codec[HeuristicsConstants] = (
     ("lockedFundsRisk" | double) ::
       ("failureCost" | relayFeesCodec) ::
-      ("hopCost" | relayFeesCodec)).as[HeuristicsConstants]
+      ("hopCost" | relayFeesCodec) ::
+      ("useLogProbability" | bool(8))).as[HeuristicsConstants]
 
   val multiPartParamsCodec: Codec[MultiPartParams] = (
     ("minPartAmount" | millisatoshi) ::

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
@@ -257,7 +257,7 @@ class GraphSpec extends AnyFunSuite {
 
     val path :: Nil = yenKshortestPaths(graph, a, e, 100000000 msat,
       Set.empty, Set.empty, Set.empty, 1,
-      Right(HeuristicsConstants(1.0E-8, RelayFees(2000 msat, 500), RelayFees(50 msat, 20))),
+      Right(HeuristicsConstants(1.0E-8, RelayFees(2000 msat, 500), RelayFees(50 msat, 20), useLogProbability = true)),
       BlockHeight(714930), _ => true, includeLocalChannelCost = true)
     assert(path.path == Seq(edgeAB, edgeBC, edgeCE))
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -1792,16 +1792,32 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       makeEdge(4L, d, b, 400 msat, 500, capacity = (DEFAULT_AMOUNT_MSAT * 3).truncateToSatoshi),
     ))
 
-    val hc = HeuristicsConstants(
-      lockedFundsRisk = 0.0,
-      failureCost = RelayFees(1000 msat, 500),
-      hopCost = RelayFees(0 msat, 0),
-    )
-    val Success(routes) = findRoute(g, start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Right(hc)), currentBlockHeight = BlockHeight(400000))
-    assert(routes.distinct.length == 1)
-    val route :: Nil = routes
-    assert(route2Ids(route) === 0 :: 2 :: 3 :: 4 :: Nil)
+    {
+      val hc = HeuristicsConstants(
+        lockedFundsRisk = 0.0,
+        failureCost = RelayFees(1000 msat, 500),
+        hopCost = RelayFees(0 msat, 0),
+        useLogProbability = false,
+      )
+      val Success(routes) = findRoute(g, start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Right(hc)), currentBlockHeight = BlockHeight(400000))
+      assert(routes.distinct.length == 1)
+      val route :: Nil = routes
+      assert(route2Ids(route) === 0 :: 2 :: 3 :: 4 :: Nil)
 
+    }
+
+    {
+      val hc = HeuristicsConstants(
+        lockedFundsRisk = 0.0,
+        failureCost = RelayFees(10000 msat, 1000),
+        hopCost = RelayFees(0 msat, 0),
+        useLogProbability = true,
+      )
+      val Success(routes) = findRoute(g, start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Right(hc)), currentBlockHeight = BlockHeight(400000))
+      assert(routes.distinct.length == 1)
+      val route :: Nil = routes
+      assert(route2Ids(route) === 0 :: 2 :: 3 :: 4 :: Nil)
+    }
   }
 
   test("no path that can get our funds stuck for too long") {
@@ -1822,6 +1838,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       lockedFundsRisk = 1e-7,
       failureCost = RelayFees(0 msat, 0),
       hopCost = RelayFees(0 msat, 0),
+      useLogProbability = true,
     )
     val Success(routes) = findRoute(g, start, b, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Right(hc)), currentBlockHeight = BlockHeight(400000))
     assert(routes.distinct.length == 1)
@@ -1841,6 +1858,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       lockedFundsRisk = 1e-7,
       failureCost = RelayFees(0 msat, 0),
       hopCost = RelayFees(0 msat, 0),
+      useLogProbability = true,
     )
     val Success(routes) = findRoute(g, a, c, DEFAULT_AMOUNT_MSAT, 100000000 msat, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Right(hc)), currentBlockHeight = BlockHeight(400000))
     assert(routes.distinct.length == 1)


### PR DESCRIPTION
Dijkstra's algorithm assumes that each edge has a fixed weight that does not depend on the rest of the path. In our case this assumption is broken when computing a cost for failed payments as it depends on all the edges of the path. We fix this by adding the possibility to use log probabilities which can be added per edge and offer a good approximation as long as the probabilities stay close to 1.

Edges still don't have a perfectly fixed weight because the fee of an edge depends on the fees of the previous edges, however since fees are typically low, it shouldn't matter in practice.