### PR TITLE
Add simple integration test between `Channel` and `Router` 

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonHandlers.scala
@@ -52,7 +52,7 @@ trait CommonHandlers {
         case d: PersistentChannelData =>
           log.debug("updating database record for channelId={}", d.channelId)
           nodeParams.db.channels.addOrUpdateChannel(d)
-          context.system.eventStream.publish(ChannelPersisted(self, remoteNodeId, d.channelId, d))
+          eventStream.publish(ChannelPersisted(self, remoteNodeId, d.channelId, d))
           state
         case _: TransientChannelData =>
           log.error(s"can't store data=${state.stateData} in state=${state.stateName}")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/FundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/FundingHandlers.scala
@@ -108,7 +108,7 @@ trait FundingHandlers extends CommonHandlers {
     val error = Error(d.channelId, exc.getMessage)
     // NB: we don't use the handleLocalError handler because it would result in the commit tx being published, which we don't want:
     // implementation *guarantees* that in case of BITCOIN_FUNDING_PUBLISH_FAILED, the funding tx hasn't and will never be published, so we can close the channel right away
-    context.system.eventStream.publish(ChannelErrorOccurred(self, stateData.channelId, remoteNodeId, LocalError(exc), isFatal = true))
+    eventStream.publish(ChannelErrorOccurred(self, stateData.channelId, remoteNodeId, LocalError(exc), isFatal = true))
     goto(CLOSED) sending error
   }
 
@@ -116,7 +116,7 @@ trait FundingHandlers extends CommonHandlers {
     log.warning(s"funding tx hasn't been confirmed in time, cancelling channel delay=$FUNDING_TIMEOUT_FUNDEE")
     val exc = FundingTxTimedout(d.channelId)
     val error = Error(d.channelId, exc.getMessage)
-    context.system.eventStream.publish(ChannelErrorOccurred(self, stateData.channelId, remoteNodeId, LocalError(exc), isFatal = true))
+    eventStream.publish(ChannelErrorOccurred(self, stateData.channelId, remoteNodeId, LocalError(exc), isFatal = true))
     goto(CLOSED) sending error
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -187,6 +187,14 @@ class Router(val nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Comm
       sender() ! updates
       stay()
 
+    case Event(PrintChannelUpdates, d) =>
+      println("public:")
+      d.channels.foreach { case (scid, pc) => println(s"$scid updates=${(pc.update_1_opt.toSeq ++ pc.update_2_opt.toSeq).size}") }
+      println("private:")
+      d.privateChannels.foreach { case (scid, pc) => println(s"$scid updates=${(pc.update_1_opt.toSeq ++ pc.update_2_opt.toSeq).size}") }
+      println("---------------------------------------------------")
+      stay()
+
     case Event(GetRouterData, d) =>
       sender() ! d
       stay()
@@ -558,6 +566,7 @@ object Router {
   case object GetChannels
   case object GetChannelsMap
   case object GetChannelUpdates
+  case object PrintChannelUpdates
   // @formatter:on
 
   // @formatter:off

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -616,7 +616,7 @@ object Router {
                   channels: SortedMap[ShortChannelId, PublicChannel],
                   stash: Stash,
                   rebroadcast: Rebroadcast,
-                  awaiting: Map[ChannelAnnouncement, Seq[RemoteGossip]], // note: this is a seq because we want to preserve order: first actor is the one who we need to send a tcp-ack when validation is done
+                  awaiting: Map[ChannelAnnouncement, Seq[GossipOrigin]], // note: this is a seq because we want to preserve order: first actor is the one who we need to send a tcp-ack when validation is done
                   privateChannels: Map[ShortChannelId, PrivateChannel],
                   excludedChannels: Set[ChannelDesc], // those channels are temporarily excluded from route calculation, because their node returned a TemporaryChannelFailure
                   graph: DirectedGraph,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -161,7 +161,7 @@ object TestConstants {
       routerConf = RouterConf(
         watchSpentWindow = 1 second,
         channelExcludeDuration = 60 seconds,
-        routerBroadcastInterval = 5 seconds,
+        routerBroadcastInterval = 1 day, // "disables" rebroadcast
         requestNodeAnnouncements = true,
         encodingType = EncodingType.COMPRESSED_ZLIB,
         channelRangeChunkSize = 20,
@@ -299,7 +299,7 @@ object TestConstants {
       routerConf = RouterConf(
         watchSpentWindow = 1 second,
         channelExcludeDuration = 60 seconds,
-        routerBroadcastInterval = 5 seconds,
+        routerBroadcastInterval = 1 day, // "disables" rebroadcast
         requestNodeAnnouncements = true,
         encodingType = EncodingType.UNCOMPRESSED,
         channelRangeChunkSize = 20,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
@@ -185,7 +185,7 @@ trait ChannelStateTestsHelperMethods extends TestKitBase {
     (aliceParams, bobParams, channelType)
   }
 
-  def reachNormal(setup: SetupFixture, tags: Set[String] = Set.empty): Unit = {
+  def reachNormal(setup: SetupFixture, tags: Set[String] = Set.empty): Transaction = {
 
     import setup._
 
@@ -237,6 +237,7 @@ trait ChannelStateTestsHelperMethods extends TestKitBase {
     // x2 because alice and bob share the same relayer
     channelUpdateListener.expectMsgType[LocalChannelUpdate]
     channelUpdateListener.expectMsgType[LocalChannelUpdate]
+    fundingTx
   }
 
   def localOrigin(replyTo: ActorRef): Origin.LocalHot = Origin.LocalHot(replyTo, UUID.randomUUID())

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -82,7 +82,7 @@ class WaitForFundingSignedStateSpec extends TestKitBaseClass with FixtureAnyFunS
   test("recv FundingSigned with valid signature") { f =>
     import f._
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
+    alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
     bob2alice.expectMsgType[FundingSigned]
     bob2alice.forward(alice)
     awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -54,7 +54,7 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
 
     within(30 seconds) {
       val listener = TestProbe()
-      system.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
+      alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
       alice ! INPUT_INIT_FUNDER(ByteVector32.Zeroes, TestConstants.fundingSatoshis, pushMsat, TestConstants.feeratePerKw, TestConstants.feeratePerKw, aliceParams, alice2bob.ref, bobInit, ChannelFlags.Private, channelConfig, channelType)
       alice2blockchain.expectMsgType[TxPublisher.SetChannelId]
       bob ! INPUT_INIT_FUNDEE(ByteVector32.Zeroes, bobParams, bob2alice.ref, aliceInit, channelConfig, channelType)
@@ -83,8 +83,8 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     import f._
     // we create a new listener that registers after alice has published the funding tx
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
-    system.eventStream.subscribe(listener.ref, classOf[TransactionConfirmed])
+    bob.underlyingActor.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
+    bob.underlyingActor.eventStream.subscribe(listener.ref, classOf[TransactionConfirmed])
     // make bob send a FundingLocked msg
     val fundingTx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].fundingTx.get
     bob ! WatchFundingConfirmedTriggered(BlockHeight(42000), 42, fundingTx)
@@ -102,8 +102,8 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     import f._
     // we create a new listener that registers after alice has published the funding tx
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
-    system.eventStream.subscribe(listener.ref, classOf[TransactionConfirmed])
+    alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
+    alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[TransactionConfirmed])
     val fundingTx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].fundingTx.get
     alice ! WatchFundingConfirmedTriggered(BlockHeight(42000), 42, fundingTx)
     assert(listener.expectMsgType[TransactionConfirmed].tx === fundingTx)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -74,7 +74,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
     val sender = TestProbe()
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[AvailableBalanceChanged])
+    alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[AvailableBalanceChanged])
     val h = randomBytes32()
     val add = CMD_ADD_HTLC(sender.ref, 50000000 msat, h, CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, localOrigin(sender.ref))
     alice ! add
@@ -881,7 +881,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     bob2alice.expectMsgType[UpdateFulfillHtlc]
     // we listen to channel_update events
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[LocalChannelUpdate])
+    bob.underlyingActor.eventStream.subscribe(listener.ref, classOf[LocalChannelUpdate])
 
     // actual test starts here
     // when signing the fulfill, bob will have its main output go above reserve in alice's commitment tx
@@ -896,7 +896,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
   test("recv CMD_SIGN (after CMD_UPDATE_FEE)") { f =>
     import f._
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[AvailableBalanceChanged])
+    alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[AvailableBalanceChanged])
     alice ! CMD_UPDATE_FEE(FeeratePerKw(654564 sat))
     alice2bob.expectMsgType[UpdateFee]
     alice ! CMD_SIGN()
@@ -2734,7 +2734,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     crossSign(alice, bob, alice2bob, bob2alice)
 
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[ChannelErrorOccurred])
+    bob.underlyingActor.eventStream.subscribe(listener.ref, classOf[ChannelErrorOccurred])
 
     // actual test begins:
     //  * Bob receives the HTLC pre-image and wants to fulfill
@@ -2767,7 +2767,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     crossSign(alice, bob, alice2bob, bob2alice)
 
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[ChannelErrorOccurred])
+    bob.underlyingActor.eventStream.subscribe(listener.ref, classOf[ChannelErrorOccurred])
 
     // actual test begins:
     //  * Bob receives the HTLC pre-image and wants to fulfill but doesn't sign
@@ -2800,7 +2800,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     crossSign(alice, bob, alice2bob, bob2alice)
 
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[ChannelErrorOccurred])
+    bob.underlyingActor.eventStream.subscribe(listener.ref, classOf[ChannelErrorOccurred])
 
     // actual test begins:
     //  * Bob receives the HTLC pre-image and wants to fulfill

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -527,7 +527,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     crossSign(alice, bob, alice2bob, bob2alice)
 
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[ChannelErrorOccurred])
+    bob.underlyingActor.eventStream.subscribe(listener.ref, classOf[ChannelErrorOccurred])
 
     val initialState = bob.stateData.asInstanceOf[DATA_NORMAL]
     val initialCommitTx = initialState.commitments.localCommit.commitTxAndRemoteSig.commitTx.tx

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -89,15 +89,19 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
         bob2blockchain.expectMsgType[WatchFundingConfirmed]
         awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
         awaitCond(bob.stateName == WAIT_FOR_FUNDING_CONFIRMED)
-        system.eventStream.subscribe(eventListener.ref, classOf[TransactionPublished])
-        system.eventStream.subscribe(eventListener.ref, classOf[TransactionConfirmed])
+        alice.underlyingActor.eventStream.subscribe(eventListener.ref, classOf[TransactionPublished])
+        alice.underlyingActor.eventStream.subscribe(eventListener.ref, classOf[TransactionConfirmed])
+        bob.underlyingActor.eventStream.subscribe(eventListener.ref, classOf[TransactionPublished])
+        bob.underlyingActor.eventStream.subscribe(eventListener.ref, classOf[TransactionConfirmed])
         withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain, alice2relayer, bob2relayer, channelUpdateListener, eventListener, Nil)))
       }
     } else {
       within(30 seconds) {
         reachNormal(setup, test.tags)
-        system.eventStream.subscribe(eventListener.ref, classOf[TransactionPublished])
-        system.eventStream.subscribe(eventListener.ref, classOf[TransactionConfirmed])
+        alice.underlyingActor.eventStream.subscribe(eventListener.ref, classOf[TransactionPublished])
+        alice.underlyingActor.eventStream.subscribe(eventListener.ref, classOf[TransactionConfirmed])
+        bob.underlyingActor.eventStream.subscribe(eventListener.ref, classOf[TransactionPublished])
+        bob.underlyingActor.eventStream.subscribe(eventListener.ref, classOf[TransactionConfirmed])
         val bobCommitTxs: List[CommitTxAndRemoteSig] = (for (amt <- List(100000000 msat, 200000000 msat, 300000000 msat)) yield {
           val (r, htlc) = addHtlc(amt, alice, bob, alice2bob, bob2alice)
           crossSign(alice, bob, alice2bob, bob2alice)
@@ -368,8 +372,8 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.channelFeatures === channelFeatures)
 
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[LocalCommitConfirmed])
-    system.eventStream.subscribe(listener.ref, classOf[PaymentSettlingOnChain])
+    alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[LocalCommitConfirmed])
+    alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[PaymentSettlingOnChain])
 
     // alice sends an htlc to bob
     val (_, htlca1) = addHtlc(50000000 msat, alice, bob, alice2bob, bob2alice)
@@ -473,7 +477,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
   test("recv WatchTxConfirmedTriggered (local commit with htlcs only signed by local)") { f =>
     import f._
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[PaymentSettlingOnChain])
+    alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[PaymentSettlingOnChain])
     val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.commitTxAndRemoteSig.commitTx.tx
     // alice sends an htlc
     val (_, htlc) = addHtlc(4200000 msat, alice, bob, alice2bob, bob2alice)
@@ -522,7 +526,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
   test("recv WatchTxConfirmedTriggered (local commit with fail not acked by remote)") { f =>
     import f._
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[PaymentSettlingOnChain])
+    alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[PaymentSettlingOnChain])
     val (_, htlc) = addHtlc(25000000 msat, alice, bob, alice2bob, bob2alice)
     crossSign(alice, bob, alice2bob, bob2alice)
     failHtlc(htlc.id, bob, alice, bob2alice, alice2bob)
@@ -603,7 +607,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
   test("recv WatchTxConfirmedTriggered (remote commit with htlcs only signed by local in next remote commit)") { f =>
     import f._
     val listener = TestProbe()
-    system.eventStream.subscribe(listener.ref, classOf[PaymentSettlingOnChain])
+    alice.underlyingActor.eventStream.subscribe(listener.ref, classOf[PaymentSettlingOnChain])
     val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.localCommit.commitTxAndRemoteSig.commitTx.tx
     // alice sends an htlc
     val (_, htlc) = addHtlc(4200000 msat, alice, bob, alice2bob, bob2alice)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -122,7 +122,6 @@ abstract class BaseRouterSpec extends TestKitBaseClass with FixtureAnyFunSuiteLi
       import com.softwaremill.quicklens._
       val nodeParams = Alice.nodeParams
         .modify(_.nodeKeyManager).setTo(testNodeKeyManager)
-        .modify(_.routerConf.routerBroadcastInterval).setTo(1 day) // "disable" auto rebroadcast
       val router = system.actorOf(Router.props(nodeParams, watcher.ref))
       // we announce channels
       peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, chan_ab))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRouterIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRouterIntegrationSpec.scala
@@ -1,11 +1,12 @@
 package fr.acinq.eclair.router
 
 import akka.testkit.{TestFSMRef, TestProbe}
+import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.WatchFundingDeeplyBuriedTriggered
-import fr.acinq.eclair.blockchain.bitcoind.{ZmqWatcher, ZmqWatcherSpec}
 import fr.acinq.eclair.channel.DATA_NORMAL
 import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
+import fr.acinq.eclair.router.Router.{GossipOrigin, LocalGossip}
 import fr.acinq.eclair.wire.protocol.AnnouncementSignatures
 import fr.acinq.eclair.{BlockHeight, TestKitBaseClass}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
@@ -16,14 +17,17 @@ import org.scalatest.{Outcome, Tag}
  */
 class ChannelRouterIntegrationSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ChannelStateTestsBase {
 
-  case class FixtureParam(router: TestFSMRef[Router.State, Router.Data, Router], channels: SetupFixture, testTags: Set[String])
+  case class FixtureParam(router: TestFSMRef[Router.State, Router.Data, Router], rebroadcastListener: TestProbe, channels: SetupFixture, testTags: Set[String])
 
   implicit val log: akka.event.LoggingAdapter = akka.event.NoLogging
 
   override def withFixture(test: OneArgTest): Outcome = {
     val channels = init(tags = test.tags)
     val router: TestFSMRef[Router.State, Router.Data, Router] = TestFSMRef(new Router(channels.alice.underlyingActor.nodeParams, channels.alice.underlyingActor.blockchain, initialized = None, eventStream_opt = Some(channels.alice.underlyingActor.eventStream)))
-    withFixture(test.toNoArgTest(FixtureParam(router, channels, test.tags)))
+    val rebroadcastListener = TestProbe()
+    // router publishes on the system's eventstream
+    system.eventStream.subscribe(rebroadcastListener.ref, classOf[Router.Rebroadcast])
+    withFixture(test.toNoArgTest(FixtureParam(router, rebroadcastListener, channels, test.tags)))
   }
 
   test("private local channel") { f =>
@@ -35,7 +39,7 @@ class ChannelRouterIntegrationSpec extends TestKitBaseClass with FixtureAnyFunSu
 
     {
       // only the local channel_update is known
-      val pc = router.stateData.privateChannels.head._2
+      val pc = router.stateData.privateChannels.values.head
       assert(pc.update_1_opt.isDefined ^ pc.update_2_opt.isDefined)
     }
 
@@ -45,9 +49,13 @@ class ChannelRouterIntegrationSpec extends TestKitBaseClass with FixtureAnyFunSu
 
     awaitCond {
       // only the local channel_update is known
-      val pc = router.stateData.privateChannels.head._2
+      val pc = router.stateData.privateChannels.values.head
       pc.update_1_opt.isDefined && pc.update_2_opt.isDefined
     }
+
+    // manual rebroadcast
+    router ! Router.TickBroadcast
+    rebroadcastListener.expectNoMessage()
 
   }
 
@@ -59,20 +67,22 @@ class ChannelRouterIntegrationSpec extends TestKitBaseClass with FixtureAnyFunSu
     awaitCond(router.stateData.privateChannels.size == 1)
 
     {
-      val pc = router.stateData.privateChannels.head._2
+      val pc = router.stateData.privateChannels.values.head
       // only the local channel_update is known
       assert(pc.update_1_opt.isDefined ^ pc.update_2_opt.isDefined)
     }
 
     val peerConnection = TestProbe()
+    val aliceChannelUpdate = channels.alice.stateData.asInstanceOf[DATA_NORMAL].channelUpdate
     val bobChannelUpdate = channels.bob.stateData.asInstanceOf[DATA_NORMAL].channelUpdate
     router ! PeerRoutingMessage(peerConnection.ref, channels.bob.underlyingActor.nodeParams.nodeId, bobChannelUpdate)
 
     awaitCond {
-      val pc = router.stateData.privateChannels.head._2
+      val pc = router.stateData.privateChannels.values.head
       // both channel_updates are known
       pc.update_1_opt.isDefined && pc.update_2_opt.isDefined
     }
+    val privateChannel = router.stateData.privateChannels.values.head
 
     // funding tx reaches 6 blocks, announcements are exchanged
     channels.alice ! WatchFundingDeeplyBuriedTriggered(BlockHeight(400000), 42, null)
@@ -92,10 +102,18 @@ class ChannelRouterIntegrationSpec extends TestKitBaseClass with FixtureAnyFunSu
     }
 
     awaitCond {
-      val pc = router.stateData.channels.head._2
+      val pc = router.stateData.channels.values.head
       // both channel updates are preserved
       pc.update_1_opt.isDefined && pc.update_2_opt.isDefined
     }
+
+    // manual rebroadcast
+    router ! Router.TickBroadcast
+    rebroadcastListener.expectMsg(Router.Rebroadcast(
+      channels = Map(vr.ann -> Set[GossipOrigin](LocalGossip)),
+      updates = Map(aliceChannelUpdate -> Set[GossipOrigin](LocalGossip), bobChannelUpdate -> Set.empty[GossipOrigin]), // broadcast the channel_updates (they were previously unannounced)
+      nodes = Map(router.underlyingActor.stateData.nodes.values.head -> Set[GossipOrigin](LocalGossip)), // new node_announcement
+    ))
 
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRouterIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRouterIntegrationSpec.scala
@@ -1,0 +1,102 @@
+package fr.acinq.eclair.router
+
+import akka.testkit.{TestFSMRef, TestProbe}
+import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.WatchFundingDeeplyBuriedTriggered
+import fr.acinq.eclair.blockchain.bitcoind.{ZmqWatcher, ZmqWatcherSpec}
+import fr.acinq.eclair.channel.DATA_NORMAL
+import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
+import fr.acinq.eclair.io.Peer.PeerRoutingMessage
+import fr.acinq.eclair.wire.protocol.AnnouncementSignatures
+import fr.acinq.eclair.{BlockHeight, TestKitBaseClass}
+import org.scalatest.funsuite.FixtureAnyFunSuiteLike
+import org.scalatest.{Outcome, Tag}
+
+/**
+ * This test checks the integration between Channel and Router (events, etc.)
+ */
+class ChannelRouterIntegrationSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ChannelStateTestsBase {
+
+  case class FixtureParam(router: TestFSMRef[Router.State, Router.Data, Router], channels: SetupFixture, testTags: Set[String])
+
+  implicit val log: akka.event.LoggingAdapter = akka.event.NoLogging
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val channels = init(tags = test.tags)
+    val router: TestFSMRef[Router.State, Router.Data, Router] = TestFSMRef(new Router(channels.alice.underlyingActor.nodeParams, channels.alice.underlyingActor.blockchain, initialized = None, eventStream_opt = Some(channels.alice.underlyingActor.eventStream)))
+    withFixture(test.toNoArgTest(FixtureParam(router, channels, test.tags)))
+  }
+
+  test("private local channel") { f =>
+    import f._
+
+    reachNormal(channels, testTags)
+
+    awaitCond(router.stateData.privateChannels.size == 1)
+
+    {
+      // only the local channel_update is known
+      val pc = router.stateData.privateChannels.head._2
+      assert(pc.update_1_opt.isDefined ^ pc.update_2_opt.isDefined)
+    }
+
+    val peerConnection = TestProbe()
+    val bobChannelUpdate = channels.bob.stateData.asInstanceOf[DATA_NORMAL].channelUpdate
+    router ! PeerRoutingMessage(peerConnection.ref, channels.bob.underlyingActor.nodeParams.nodeId, bobChannelUpdate)
+
+    awaitCond {
+      // only the local channel_update is known
+      val pc = router.stateData.privateChannels.head._2
+      pc.update_1_opt.isDefined && pc.update_2_opt.isDefined
+    }
+
+  }
+
+  test("public local channel", Tag(ChannelStateTestsTags.ChannelsPublic)) { f =>
+    import f._
+
+    val fundingTx = reachNormal(channels, testTags)
+
+    awaitCond(router.stateData.privateChannels.size == 1)
+
+    {
+      val pc = router.stateData.privateChannels.head._2
+      // only the local channel_update is known
+      assert(pc.update_1_opt.isDefined ^ pc.update_2_opt.isDefined)
+    }
+
+    val peerConnection = TestProbe()
+    val bobChannelUpdate = channels.bob.stateData.asInstanceOf[DATA_NORMAL].channelUpdate
+    router ! PeerRoutingMessage(peerConnection.ref, channels.bob.underlyingActor.nodeParams.nodeId, bobChannelUpdate)
+
+    awaitCond {
+      val pc = router.stateData.privateChannels.head._2
+      // both channel_updates are known
+      pc.update_1_opt.isDefined && pc.update_2_opt.isDefined
+    }
+
+    // funding tx reaches 6 blocks, announcements are exchanged
+    channels.alice ! WatchFundingDeeplyBuriedTriggered(BlockHeight(400000), 42, null)
+    channels.alice2bob.expectMsgType[AnnouncementSignatures]
+    channels.alice2bob.forward(channels.bob)
+
+    channels.bob ! WatchFundingDeeplyBuriedTriggered(BlockHeight(400000), 42, null)
+    channels.bob2alice.expectMsgType[AnnouncementSignatures]
+    channels.bob2alice.forward(channels.alice)
+
+    // router gets notified and attempts to validate the local channel
+    val vr = channels.alice2blockchain.expectMsgType[ZmqWatcher.ValidateRequest]
+    vr.replyTo ! ZmqWatcher.ValidateResult(vr.ann, Right((fundingTx, ZmqWatcher.UtxoStatus.Unspent)))
+
+    awaitCond {
+      router.stateData.privateChannels.isEmpty && router.stateData.channels.size == 1
+    }
+
+    awaitCond {
+      val pc = router.stateData.channels.head._2
+      // both channel updates are preserved
+      pc.update_1_opt.isDefined && pc.update_2_opt.isDefined
+    }
+
+  }
+
+}

--- a/eclair-front/src/test/scala/fr/acinq/eclair/router/FrontRouterSpec.scala
+++ b/eclair-front/src/test/scala/fr/acinq/eclair/router/FrontRouterSpec.scala
@@ -131,12 +131,14 @@ class FrontRouterSpec extends TestKit(ActorSystem("test")) with AnyFunSuiteLike 
     peerConnection1b.expectMsg(GossipDecision.Accepted(chan_ab))
     peerConnection2a.expectMsg(GossipDecision.Accepted(chan_ab))
 
-    // we have to wait 2 times the broadcast interval because there is an additional per-peer delay
-    val maxBroadcastDelay = 2 * nodeParams.routerConf.routerBroadcastInterval + 1.second
-    peerConnection1a.expectMsg(maxBroadcastDelay, Rebroadcast(channels = Map(chan_ab -> Set(origin1a, origin1b)), updates = Map.empty, nodes = Map.empty))
-    peerConnection1b.expectMsg(maxBroadcastDelay, Rebroadcast(channels = Map(chan_ab -> Set(origin1a, origin1b)), updates = Map.empty, nodes = Map.empty))
-    peerConnection2a.expectMsg(maxBroadcastDelay, Rebroadcast(channels = Map(chan_ab -> Set(origin2a)), updates = Map.empty, nodes = Map.empty))
-    peerConnection3a.expectMsg(maxBroadcastDelay, Rebroadcast(channels = Map(chan_ab -> Set.empty), updates = Map.empty, nodes = Map.empty))
+    // manual rebroadcast
+    front1 ! Router.TickBroadcast
+    peerConnection1a.expectMsg(Rebroadcast(channels = Map(chan_ab -> Set(origin1a, origin1b)), updates = Map.empty, nodes = Map.empty))
+    peerConnection1b.expectMsg(Rebroadcast(channels = Map(chan_ab -> Set(origin1a, origin1b)), updates = Map.empty, nodes = Map.empty))
+    front2 ! Router.TickBroadcast
+    peerConnection2a.expectMsg(Rebroadcast(channels = Map(chan_ab -> Set(origin2a)), updates = Map.empty, nodes = Map.empty))
+    front3 ! Router.TickBroadcast
+    peerConnection3a.expectMsg(Rebroadcast(channels = Map(chan_ab -> Set.empty), updates = Map.empty, nodes = Map.empty))
   }
 
   test("aggregate gossip") {
@@ -207,12 +209,14 @@ class FrontRouterSpec extends TestKit(ActorSystem("test")) with AnyFunSuiteLike 
     peerConnection3a.expectMsg(TransportHandler.ReadAck(ann_b))
     peerConnection3a.expectMsg(GossipDecision.Accepted(ann_b))
 
-    // we have to wait 2 times the broadcast interval because there is an additional per-peer delay
-    val maxBroadcastDelay = 2 * nodeParams.routerConf.routerBroadcastInterval + 1.second
-    peerConnection1a.expectMsg(maxBroadcastDelay, Rebroadcast(channels = Map(chan_ab -> Set(origin1a, origin1b)), updates = Map(channelUpdate_ab -> Set(origin1b), channelUpdate_ba -> Set.empty), nodes = Map(ann_a -> Set.empty, ann_b -> Set.empty)))
-    peerConnection1b.expectMsg(maxBroadcastDelay, Rebroadcast(channels = Map(chan_ab -> Set(origin1a, origin1b)), updates = Map(channelUpdate_ab -> Set(origin1b), channelUpdate_ba -> Set.empty), nodes = Map(ann_a -> Set.empty, ann_b -> Set.empty)))
-    peerConnection2a.expectMsg(maxBroadcastDelay, Rebroadcast(channels = Map(chan_ab -> Set(origin2a)), updates = Map(channelUpdate_ab -> Set.empty, channelUpdate_ba -> Set.empty), nodes = Map(ann_a -> Set.empty, ann_b -> Set.empty)))
-    peerConnection3a.expectMsg(maxBroadcastDelay, Rebroadcast(channels = Map(chan_ab -> Set.empty), updates = Map(channelUpdate_ab -> Set.empty, channelUpdate_ba -> Set(origin3a)), nodes = Map(ann_a -> Set(origin3a), ann_b -> Set(origin3a))))
+    // manual rebroadcast
+    front1 ! Router.TickBroadcast
+    peerConnection1a.expectMsg(Rebroadcast(channels = Map(chan_ab -> Set(origin1a, origin1b)), updates = Map(channelUpdate_ab -> Set(origin1b), channelUpdate_ba -> Set.empty), nodes = Map(ann_a -> Set.empty, ann_b -> Set.empty)))
+    peerConnection1b.expectMsg(Rebroadcast(channels = Map(chan_ab -> Set(origin1a, origin1b)), updates = Map(channelUpdate_ab -> Set(origin1b), channelUpdate_ba -> Set.empty), nodes = Map(ann_a -> Set.empty, ann_b -> Set.empty)))
+    front2 ! Router.TickBroadcast
+    peerConnection2a.expectMsg(Rebroadcast(channels = Map(chan_ab -> Set(origin2a)), updates = Map(channelUpdate_ab -> Set.empty, channelUpdate_ba -> Set.empty), nodes = Map(ann_a -> Set.empty, ann_b -> Set.empty)))
+    front3 ! Router.TickBroadcast
+    peerConnection3a.expectMsg(Rebroadcast(channels = Map(chan_ab -> Set.empty), updates = Map(channelUpdate_ab -> Set.empty, channelUpdate_ba -> Set(origin3a)), nodes = Map(ann_a -> Set(origin3a), ann_b -> Set(origin3a))))
   }
 
   test("do not forward duplicate gossip") {


### PR DESCRIPTION
In this PR we add a basic integration test between `Channel` and `Router` that checks the proper handling of local announcements.

This test found two bugs, fixed in two separate commits.