### PR TITLE
Run channel state tests sequentially

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
@@ -20,9 +20,9 @@ import akka.actor.typed.scaladsl.adapter.actorRefAdapter
 import akka.actor.{ActorContext, ActorRef}
 import akka.testkit.{TestFSMRef, TestKitBase, TestProbe}
 import com.softwaremill.quicklens.ModifyPimp
+import fr.acinq.bitcoin.ScriptFlags
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, Crypto, SatoshiLong, Transaction}
-import fr.acinq.bitcoin.ScriptFlags
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
@@ -39,7 +39,7 @@ import fr.acinq.eclair.router.Router.ChannelHop
 import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.wire.protocol._
-import org.scalatest.{FixtureTestSuite, ParallelTestExecution}
+import org.scalatest.FixtureTestSuite
 
 import java.util.UUID
 import scala.concurrent.duration._
@@ -47,7 +47,7 @@ import scala.concurrent.duration._
 /**
  * Created by PM on 23/08/2016.
  */
-trait ChannelStateTestsBase extends ChannelStateTestsHelperMethods with FixtureTestSuite with ParallelTestExecution {
+trait ChannelStateTestsBase extends ChannelStateTestsHelperMethods with FixtureTestSuite {
 
   implicit class ChannelWithTestFeeConf(a: TestFSMRef[ChannelState, ChannelData, Channel]) {
     // @formatter:off

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -52,7 +52,7 @@ import scala.concurrent.duration._
  * Created by PM on 05/07/2016.
  */
 
-class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ChannelStateTestsBase {
+abstract class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ChannelStateTestsBase {
 
   type FixtureParam = SetupFixture
 
@@ -68,8 +68,11 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
       withFixture(test.toNoArgTest(setup))
     }
   }
+}
 
-  test("recv CMD_ADD_HTLC (empty origin)") { f =>
+class Chunk1NormalStateSpec extends NormalStateSpec {
+
+   test("recv CMD_ADD_HTLC (empty origin)") { f =>
     import f._
     val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
     val sender = TestProbe()
@@ -1915,6 +1918,10 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     // We should rectify the packet length before forwarding upstream.
     assert(fail.reason.length === Sphinx.FailurePacket.PacketLength)
   }
+
+}
+
+class Chunk2NormalStateSpec extends NormalStateSpec {
 
   private def testCmdUpdateFee(f: FixtureParam): Unit = {
     import f._


### PR DESCRIPTION
From scalatest's `ParallelTestExecution` doc:

> ScalaTest's normal approach for running suites of tests in parallel is to run different suites in parallel, but the tests of any one suite sequentially.
> [...]
> To make it easier for users to write tests that run in parallel, this trait runs each test in its own instance of the class. Running each test in its own instance enables tests to use the same instance vars and mutable objects referenced from instance variables without needing to synchronize. Although ScalaTest provides functional approaches to factoring out common test code that can help avoid such issues, running each test in its own instance is an insurance policy that makes running tests in parallel easier and less error prone.

This means that for each single test of the `channel.states` package, we instantiate one actor system, which contains two thread pools. With default settings, that's a minimum of 2*8 threads per individual test.

That's already pretty bad, and with 65cf238 (#2270) we add a factor of 3 on top of that, which makes us go past the OS limits on github CI.

setup | peak thread count | memory used | run time
-------|---------------------|-----------------|----
baseline | 5447 | 622M | 5m 44s
sequential | 1927 | 561M | 5m 9s (*)
sequential + split | 1724 | 525M | 5m 20s (**)


(*) It's actually so bad, that tests run actually faster without parallelization!

(**) I tried to split large test files (e.g. `NormalStateSpec`, `ClosingStateSpec`) in order to still preserve some parallelization. In theory it should have been faster and used a bit more threads than the full sequential, but I guess it depends on the run.