### PR TITLE
Unlock utxos at startup

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -14,7 +14,15 @@
 
 ### Miscellaneous improvements and bug fixes
 
-<insert changes>
+#### Strategies to handle locked utxos at start-up (#2278)
+
+If some utxos are locked when eclair starts, it is likely because eclair was previously stopped in the middle of funding a transaction.
+While this doesn't create any risk of loss of funds, these utxos will stay locked for no good reason and won't be used to fund future transactions.
+Eclair offers three strategies to handle that scenario, that node operators can configure by setting `eclair.bitcoind.startup-locked-utxos-behavior` in their `eclair.conf`:
+
+- `stop`: eclair won't start until the corresponding utxos are unlocked by the node operator
+- `unlock`: eclair will automatically unlock the corresponding utxos
+- `ignore`: eclair will leave these utxos locked and start
 
 ## Verifying signatures
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -33,6 +33,12 @@ eclair {
     // which can generate a lot of requests to validate channels, iterate over blocks to find a spending tx, etc.
     // You may want to disable this when bitcoin is running on a remote machine with an unreliable network.
     batch-watcher-requests = true
+    // If some utxos are locked when eclair starts, it is likely because it was previously stopped in the middle of
+    // funding a transaction. The supported behaviors to handle this case are:
+    //  - stop: eclair won't start until the corresponding utxos are unlocked by the node operator
+    //  - unlock: eclair will automatically unlock the corresponding utxos
+    //  - ignore: eclair will leave these utxos locked and start
+    startup-locked-utxos-behavior = "stop"
   }
 
   node-alias = "eclair"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -351,7 +351,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient) extends OnChainWall
           case Success(JBool(result)) => Future.successful(result)
           case Failure(JsonRPCError(error)) if error.message.contains("expected locked output") =>
             Future.successful(true) // we consider that the outpoint was successfully unlocked (since it was not locked to begin with)
-          case Failure(t) =>
+          case Failure(_) =>
             Future.successful(false)
         })
     val future = Future.sequence(futures)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -20,7 +20,7 @@ import akka.actor.{Actor, ActorRef, ActorSystem, Props}
 import akka.pattern.pipe
 import akka.testkit.{TestKitBase, TestProbe}
 import fr.acinq.bitcoin.scalacompat.Crypto.PrivateKey
-import fr.acinq.bitcoin.scalacompat.{Block, Btc, BtcAmount, ByteVector32, MilliBtc, OutPoint, Satoshi, Transaction, computeP2WpkhAddress}
+import fr.acinq.bitcoin.scalacompat.{Block, Btc, BtcAmount, MilliBtc, Satoshi, Transaction, computeP2WpkhAddress}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinJsonRPCAuthMethod.{SafeCookie, UserPassword}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, BitcoinJsonRPCAuthMethod, BitcoinJsonRPCClient}
 import fr.acinq.eclair.integration.IntegrationSpec
@@ -203,17 +203,6 @@ trait BitcoindService extends Logging {
     rpcClient.invoke("getrawtransaction", txid).pipeTo(sender.ref)
     val JString(rawTx) = sender.expectMsgType[JString]
     Transaction.read(rawTx)
-  }
-
-  /** Get locked utxos. */
-  def getLocks(sender: TestProbe = TestProbe(), rpcClient: BitcoinJsonRPCClient = bitcoinrpcclient): Set[OutPoint] = {
-    rpcClient.invoke("listlockunspent").pipeTo(sender.ref)
-    val JArray(locks) = sender.expectMsgType[JValue]
-    locks.map(item => {
-      val JString(txid) = item \ "txid"
-      val JInt(vout) = item \ "vout"
-      OutPoint(ByteVector32.fromValidHex(txid).reverse, vout.toInt)
-    }).toSet
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
@@ -21,7 +21,7 @@ import akka.actor.typed.scaladsl.adapter.{ClassicActorSystemOps, actorRefAdapter
 import akka.pattern.pipe
 import akka.testkit.TestProbe
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, OP_1, Satoshi, SatoshiLong, Script, ScriptWitness, Transaction, TxOut}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, OP_1, OutPoint, Satoshi, SatoshiLong, Script, ScriptWitness, Transaction, TxOut}
 import fr.acinq.eclair.blockchain.OnChainWallet.{FundTransactionResponse, SignTransactionResponse}
 import fr.acinq.eclair.blockchain.bitcoind.BitcoindService
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.{MempoolTx, Utxo}
@@ -219,10 +219,14 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
 
       // Utxos are locked for the duration of the protocol.
       val probe = TestProbe()
-      val locksA = getLocks(probe, rpcClientA)
+      val bitcoinClientA = new BitcoinCoreClient(rpcClientA)
+      bitcoinClientA.listLockedOutpoints().pipeTo(probe.ref)
+      val locksA = probe.expectMsgType[Set[OutPoint]]
       assert(locksA.size == 3)
       assert(locksA == Set(inputA1, inputA2, inputA3).map(toOutPoint))
-      val locksB = getLocks(probe, rpcClientB)
+      val bitcoinClientB = new BitcoinCoreClient(rpcClientB)
+      bitcoinClientB.listLockedOutpoints().pipeTo(probe.ref)
+      val locksB = probe.expectMsgType[Set[OutPoint]]
       assert(locksB.size == 1)
       assert(locksB == Set(toOutPoint(inputB1)))
 
@@ -528,7 +532,10 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       alice ! Start(alice2bob.ref, Nil)
       assert(alice2bob.expectMsgType[LocalFailure].cause == ChannelFundingError(aliceParams.channelId))
       // Alice's utxos shouldn't be locked after the failed funding attempt.
-      awaitCond(getLocks(probe, rpcClientA).isEmpty)
+      awaitAssert({
+        bitcoinClient.listLockedOutpoints().pipeTo(probe.ref)
+        assert(probe.expectMsgType[Set[OutPoint]].isEmpty)
+      }, max = 10 seconds, interval = 100 millis)
     }
   }
 
@@ -573,7 +580,10 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       alice ! Start(alice2bob.ref, Nil)
       assert(alice2bob.expectMsgType[LocalFailure].cause == ChannelFundingError(aliceParams.channelId))
       // Utxos shouldn't be locked after a failure.
-      awaitCond(getLocks(probe, rpcClientA).isEmpty, max = 10 seconds, interval = 100 millis)
+      awaitAssert({
+        bitcoinClient.listLockedOutpoints().pipeTo(probe.ref)
+        assert(probe.expectMsgType[Set[OutPoint]].isEmpty)
+      }, max = 10 seconds, interval = 100 millis)
     }
   }
 
@@ -638,9 +648,10 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       // Unusable utxos should be skipped.
       legacyTxIds.foreach(txid => assert(!txA.signedTx.txIn.exists(_.outPoint.txid == txid)))
       // Only used utxos should be locked.
-      awaitCond({
-        val locks = getLocks(probe, rpcClientA)
-        locks == txA.signedTx.txIn.map(_.outPoint).toSet
+      awaitAssert({
+        bitcoinClient.listLockedOutpoints().pipeTo(probe.ref)
+        val locks = probe.expectMsgType[Set[OutPoint]]
+        assert(locks == txA.signedTx.txIn.map(_.outPoint).toSet)
       }, max = 10 seconds, interval = 100 millis)
     }
   }


### PR DESCRIPTION
We remove utxos locks that were previously set, otherwise we may have utxos that stay locked indefinitely. This may happen if we started funding a channel and restarted before completing the funding flow: the channel will be safely forgotten but the corresponding utxos stay locked.

The only drawback that this may have is if we have funded and signed a funding transaction but didn't publish it and we accidentally double-spend it after a restart. This shouldn't be an issue because:

- locks are automatically removed when the transaction is published anyway
- funding transactions are republished at startup if they aren't in the blockchain or in the mempool
- funding transactions detect when they are double-spent and abort the channel creation
- the only case where double-spending a funding transaction causes  a loss of funds is when we accept a 0-conf channel and our peer double-spends it, but we should never accept 0-conf channels from peers we don't trust