### PR TITLE
(Minor) Postgres: use write instead of writePretty

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/MigrateChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/MigrateChannelsDb.scala
@@ -20,7 +20,7 @@ object MigrateChannelsDb {
       insertStatement.setString(1, rs.getByteVector32("channel_id").toHex)
       insertStatement.setBytes(2, rs.getBytes("data"))
       val state = channelDataCodec.decode(BitVector(rs.getBytes("data"))).require.value
-      val json = serialization.writePretty(state)
+      val json = serialization.write(state)
       insertStatement.setString(3, json)
       insertStatement.setBoolean(4, rs.getBoolean("is_closed"))
       insertStatement.setTimestamp(5, rs.getLongNullable("created_timestamp").map(l => Timestamp.from(Instant.ofEpochMilli(l))).orNull)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/MigrateNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/MigrateNetworkDb.scala
@@ -19,7 +19,7 @@ object MigrateNetworkDb {
       insertStatement.setString(1, rs.getByteVector("node_id").toHex)
       insertStatement.setBytes(2, rs.getBytes("data"))
       val state = nodeAnnouncementCodec.decode(BitVector(rs.getBytes("data"))).require.value
-      val json = serialization.writePretty(state)
+      val json = serialization.write(state)
       insertStatement.setString(3, json)
     }
 
@@ -42,9 +42,9 @@ object MigrateNetworkDb {
       val ann = channelAnnouncementCodec.decode(rs.getBitVectorOpt("channel_announcement").get).require.value
       val channel_update_1_opt = rs.getBitVectorOpt("channel_update_1").map(channelUpdateCodec.decode(_).require.value)
       val channel_update_2_opt = rs.getBitVectorOpt("channel_update_2").map(channelUpdateCodec.decode(_).require.value)
-      val json = serialization.writePretty(ann)
-      val u1_json = channel_update_1_opt.map(serialization.writePretty(_)).orNull
-      val u2_json = channel_update_2_opt.map(serialization.writePretty(_)).orNull
+      val json = serialization.write(ann)
+      val u1_json = channel_update_1_opt.map(serialization.write(_)).orNull
+      val u2_json = channel_update_2_opt.map(serialization.write(_)).orNull
       insertStatement.setString(7, json)
       insertStatement.setString(8, u1_json)
       insertStatement.setString(9, u2_json)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
@@ -91,7 +91,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
             // store local commitment signatures anymore, and we want to clean up existing data
             val state = channelDataCodec.decode(BitVector(rs.getBytes("data"))).require.value
             val data = channelDataCodec.encode(state).require.toByteArray
-            val json = serialization.writePretty(state)
+            val json = serialization.write(state)
             statement.setBytes(1, data)
             statement.setString(2, json)
             statement.setString(3, state.channelId.toHex)
@@ -141,7 +141,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
       s"UPDATE $table SET json=?::JSONB WHERE channel_id=?",
       (rs, statement) => {
         val state = channelDataCodec.decode(BitVector(rs.getBytes("data"))).require.value
-        val json = serialization.writePretty(state)
+        val json = serialization.write(state)
         statement.setString(1, json)
         statement.setString(2, state.channelId.toHex)
       }
@@ -160,7 +160,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
           | """.stripMargin)) { statement =>
         statement.setString(1, data.channelId.toHex)
         statement.setBytes(2, encoded)
-        statement.setString(3, serialization.writePretty(data))
+        statement.setString(3, serialization.write(data))
         statement.executeUpdate()
       }
     }


### PR DESCRIPTION
There is no point in formatting the json since the `JSONB` data type that we use in postgres do not preserve formatting.