### PR TITLE
Increase `CLOSED` timeout from 10s to 1min

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -1586,7 +1586,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, val 
 
       if (nextState == CLOSED) {
         // channel is closed, scheduling this actor for self destruction
-        context.system.scheduler.scheduleOnce(10 seconds, self, Symbol("shutdown"))
+        context.system.scheduler.scheduleOnce(1 minute, self, Symbol("shutdown"))
       }
       if (nextState == OFFLINE) {
         // we can cancel the timer, we are not expecting anything when disconnected


### PR DESCRIPTION
This gives more time to rollback the funding tx in case where we moved from `WAIT_FOR_FUNDING_INTERNAL`->`CLOSED` and unlock utxos.

We could do it differently, with an additional state, or by only sending the "shutdown" symbol after we receive the wallet response for this specific transition, but it would be more complicated.