### PR TITLE
Add trait for permanent optional channel features

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -56,6 +56,18 @@ trait InitFeature extends Feature
 trait NodeFeature extends Feature
 /** Feature that should be advertised in invoices. */
 trait InvoiceFeature extends Feature
+/**
+ * Feature negotiated when opening a channel that will apply for all of the channel's lifetime.
+ * This doesn't include features that can be safely activated/deactivated without impacting the channel's operation such
+ * as option_dataloss_protect or option_shutdown_anysegwit.
+ */
+trait PermanentChannelFeature extends InitFeature // <- not in the spec
+/**
+ * Permanent channel feature negotiated in the channel type. Those features take precedence over permanent channel
+ * features negotiated in init messages. For example, if the channel type is option_static_remotekey, then even if
+ * the option_anchor_outputs feature is supported by both peers, it won't apply to the channel.
+ */
+trait ChannelTypeFeature extends PermanentChannelFeature
 // @formatter:on
 
 case class UnknownFeature(bitIndex: Int)
@@ -158,7 +170,7 @@ object Features {
     val mandatory = 2
   }
 
-  case object UpfrontShutdownScript extends Feature with InitFeature with NodeFeature {
+  case object UpfrontShutdownScript extends Feature with InitFeature with NodeFeature with PermanentChannelFeature {
     val rfcName = "option_upfront_shutdown_script"
     val mandatory = 4
   }
@@ -178,7 +190,7 @@ object Features {
     val mandatory = 10
   }
 
-  case object StaticRemoteKey extends Feature with InitFeature with NodeFeature {
+  case object StaticRemoteKey extends Feature with InitFeature with NodeFeature with ChannelTypeFeature {
     val rfcName = "option_static_remotekey"
     val mandatory = 12
   }
@@ -193,17 +205,17 @@ object Features {
     val mandatory = 16
   }
 
-  case object Wumbo extends Feature with InitFeature with NodeFeature {
+  case object Wumbo extends Feature with InitFeature with NodeFeature with PermanentChannelFeature {
     val rfcName = "option_support_large_channel"
     val mandatory = 18
   }
 
-  case object AnchorOutputs extends Feature with InitFeature with NodeFeature {
+  case object AnchorOutputs extends Feature with InitFeature with NodeFeature with ChannelTypeFeature {
     val rfcName = "option_anchor_outputs"
     val mandatory = 20
   }
 
-  case object AnchorOutputsZeroFeeHtlcTx extends Feature with InitFeature with NodeFeature {
+  case object AnchorOutputsZeroFeeHtlcTx extends Feature with InitFeature with NodeFeature with ChannelTypeFeature {
     val rfcName = "option_anchors_zero_fee_htlc_tx"
     val mandatory = 22
   }
@@ -213,7 +225,7 @@ object Features {
     val mandatory = 26
   }
 
-  case object DualFunding extends Feature with InitFeature with NodeFeature {
+  case object DualFunding extends Feature with InitFeature with NodeFeature with PermanentChannelFeature {
     val rfcName = "option_dual_fund"
     val mandatory = 28
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelTypes0.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelTypes0.scala
@@ -23,7 +23,7 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.ShaChain
 import fr.acinq.eclair.transactions.CommitmentSpec
 import fr.acinq.eclair.transactions.Transactions._
-import fr.acinq.eclair.{BlockHeight, Features, Feature, channel}
+import fr.acinq.eclair.{BlockHeight, ChannelTypeFeature, Features, PermanentChannelFeature, channel}
 import scodec.bits.BitVector
 
 private[channel] object ChannelTypes0 {
@@ -196,8 +196,8 @@ private[channel] object ChannelTypes0 {
         ChannelConfig()
       }
       val isWumboChannel = commitInput.txOut.amount > Satoshi(16777215)
-      val baseChannelFeatures: Set[Feature] = if (isWumboChannel) Set(Features.Wumbo) else Set.empty
-      val commitmentFeatures: Set[Feature] = if (channelVersion.hasAnchorOutputs) {
+      val baseChannelFeatures: Set[PermanentChannelFeature] = if (isWumboChannel) Set(Features.Wumbo) else Set.empty
+      val commitmentFeatures: Set[ChannelTypeFeature] = if (channelVersion.hasAnchorOutputs) {
         Set(Features.StaticRemoteKey, Features.AnchorOutputs)
       } else if (channelVersion.hasStaticRemotekey) {
         Set(Features.StaticRemoteKey)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.wire.internal.channel.version3
 
 import fr.acinq.bitcoin.scalacompat.DeterministicWallet.{ExtendedPrivateKey, KeyPath}
-import fr.acinq.bitcoin.scalacompat.{OutPoint, Satoshi, Transaction, TxOut}
+import fr.acinq.bitcoin.scalacompat.{OutPoint, Transaction, TxOut}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.ShaChain
 import fr.acinq.eclair.transactions.Transactions._
@@ -25,7 +25,7 @@ import fr.acinq.eclair.transactions.{CommitmentSpec, DirectedHtlc, IncomingHtlc,
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
 import fr.acinq.eclair.wire.protocol.LightningMessageCodecs._
 import fr.acinq.eclair.wire.protocol.UpdateMessage
-import fr.acinq.eclair.{BlockHeight, FeatureSupport, Features}
+import fr.acinq.eclair.{BlockHeight, FeatureSupport, Features, PermanentChannelFeature}
 import scodec.bits.{BitVector, ByteVector}
 import scodec.codecs._
 import scodec.{Attempt, Codec}
@@ -66,7 +66,7 @@ private[channel] object ChannelCodecs3 {
 
     /** We use the same encoding as init features, even if we don't need the distinction between mandatory and optional */
     val channelFeaturesCodec: Codec[ChannelFeatures] = lengthDelimited(bytes).xmap(
-      (b: ByteVector) => ChannelFeatures(Features(b).activated.keySet), // we make no difference between mandatory/optional, both are considered activated
+      (b: ByteVector) => ChannelFeatures(Features(b).activated.keySet.collect { case f: PermanentChannelFeature => f }), // we make no difference between mandatory/optional, both are considered activated
       (cf: ChannelFeatures) => Features(cf.features.map(f => f -> FeatureSupport.Mandatory).toMap).toByteVector // we encode features as mandatory, by convention
     )
 


### PR DESCRIPTION
We create a new feature trait for permanent channel features that aren't part of the channel type. These features must be included in our `ChannelFeatures` at channel creation time.

It's important to separate them from features that belong to the `channel_type`, otherwise we couldn't use a `channel_type` that's different from the one we'd pick based on init features alone. Let's provide an example to explain this:

- Alice and Bob's `init` contain `option_static_remotekey` and `option_anchors_zero_fee_htlc_tx`
- Alice wants to open an `option_static_remotekey` channel that doesn't use anchor outputs
- That's perfectly acceptable, and in that case the `channelFeatures` must not contain `option_anchors_zero_fee_htlc_tx`