### PR TITLE
Don't RBF anchor if commit is confirmed

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitor.scala
@@ -44,6 +44,7 @@ object MempoolTxMonitor {
   private case class InputStatus(spentConfirmed: Boolean, spentUnconfirmed: Boolean) extends Command
   private case class CheckInputFailed(reason: Throwable) extends Command
   private case class TxConfirmations(confirmations: Int, blockHeight: BlockHeight) extends Command
+  private case class ParentTxStatus(confirmed: Boolean, blockHeight: BlockHeight) extends Command
   private case object TxNotFound extends Command
   private case class GetTxConfirmationsFailed(reason: Throwable) extends Command
   private case class WrappedCurrentBlockHeight(currentBlockHeight: BlockHeight) extends Command
@@ -58,7 +59,7 @@ object MempoolTxMonitor {
   sealed trait TxResult
   sealed trait IntermediateTxResult extends TxResult
   /** The transaction is still unconfirmed and available in the mempool. */
-  case class TxInMempool(txid: ByteVector32, blockHeight: BlockHeight) extends IntermediateTxResult
+  case class TxInMempool(txid: ByteVector32, blockHeight: BlockHeight, parentConfirmed: Boolean) extends IntermediateTxResult
   /** The transaction is confirmed, but hasn't reached min depth yet, we should wait for more confirmations. */
   case class TxRecentlyConfirmed(txid: ByteVector32, confirmations: Int) extends IntermediateTxResult
   sealed trait FinalTxResult extends TxResult
@@ -147,7 +148,10 @@ private class MempoolTxMonitor(nodeParams: NodeParams,
         Behaviors.same
       case TxConfirmations(confirmations, currentBlockHeight) =>
         if (confirmations == 0) {
-          cmd.replyTo ! TxInMempool(cmd.tx.txid, currentBlockHeight)
+          context.pipeToSelf(bitcoinClient.getTxConfirmations(cmd.input.txid)) {
+            case Success(parentConfirmations_opt) => ParentTxStatus(parentConfirmations_opt.exists(_ >= 1), currentBlockHeight)
+            case Failure(reason) => GetTxConfirmationsFailed(reason)
+          }
           Behaviors.same
         } else if (confirmations < nodeParams.channelConf.minDepthBlocks) {
           log.info("txid={} has {} confirmations, waiting to reach min depth", cmd.tx.txid, confirmations)
@@ -158,6 +162,9 @@ private class MempoolTxMonitor(nodeParams: NodeParams,
           context.system.eventStream ! EventStream.Publish(TransactionConfirmed(txPublishContext.channelId_opt.getOrElse(ByteVector32.Zeroes), txPublishContext.remoteNodeId, cmd.tx))
           sendFinalResult(TxDeeplyBuried(cmd.tx), Some(messageAdapter))
         }
+      case ParentTxStatus(confirmed, currentBlockHeight) =>
+        cmd.replyTo ! TxInMempool(cmd.tx.txid, currentBlockHeight, confirmed)
+        Behaviors.same
       case TxNotFound =>
         log.warn("txid={} has been evicted from the mempool", cmd.tx.txid)
         checkInputStatus(cmd.input)


### PR DESCRIPTION
Even though we use our anchor to CPFP our commit tx, the commit tx could confirm on its own. If that happens, we don't care about the anchor tx so we shouldn't RBF it. Ideally we'd like to cancel it but that's impossible, so we just wait for it to either confirm or drop out of mempools after a while.

I couldn't easily add a unit test for this, because the test would need to be able to publish the commit tx and our anchor tx, and then generate a block that includes the commit tx but not our anchor tx. Unfortunately the `bitcoind` RPCs on `regtest` don't easily allow such granularity, so please review carefully (it's quite a simple `if` so I think we're ok).
