### PR TITLE
Add option to disable sending remote address in init

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -209,6 +209,9 @@ eclair {
     ping-interval = 30 seconds
     ping-timeout = 20 seconds // will disconnect if peer takes longer than that to respond
     ping-disconnect = true // disconnect if no answer to our pings
+    // When enabled, if we receive an incoming connection, we will echo the source IP address in our init message.
+    // This should be disabled if your node is behind a load balancer that doesn't preserve source IP addresses.
+    send-remote-address-init = true
   }
 
   auto-reconnect = true

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -482,7 +482,8 @@ object NodeParams extends Logging {
         pingDisconnect = config.getBoolean("peer-connection.ping-disconnect"),
         maxRebroadcastDelay = FiniteDuration(config.getDuration("router.broadcast-interval").getSeconds, TimeUnit.SECONDS), // it makes sense to not delay rebroadcast by more than the rebroadcast period
         killIdleDelay = FiniteDuration(config.getDuration("onion-messages.kill-transient-connection-after").getSeconds, TimeUnit.SECONDS),
-        maxOnionMessagesPerSecond = config.getInt("onion-messages.max-per-peer-per-second")
+        maxOnionMessagesPerSecond = config.getInt("onion-messages.max-per-peer-per-second"),
+        sendRemoteAddressInit = config.getBoolean("peer-connection.send-remote-address-init"),
       ),
       routerConf = RouterConf(
         watchSpentWindow = watchSpentWindow,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.remote.EclairInternalsSerializer.RemoteTypes
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.wire.protocol
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{FSMDiagnosticActorLogging, Feature, Features, InitFeature, Logs, TimestampMilli, TimestampSecond}
+import fr.acinq.eclair.{FSMDiagnosticActorLogging, Features, InitFeature, Logs, TimestampMilli, TimestampSecond}
 import scodec.Attempt
 import scodec.bits.ByteVector
 
@@ -103,7 +103,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
       Metrics.PeerConnectionsConnecting.withTag(Tags.ConnectionState, Tags.ConnectionStates.Initializing).increment()
       log.info(s"using features=$localFeatures")
       val localInit = d.pendingAuth.address match {
-        case remoteAddress if !d.pendingAuth.outgoing && NodeAddress.isPublicIPAddress(remoteAddress) => protocol.Init(localFeatures, TlvStream(InitTlv.Networks(chainHash :: Nil), InitTlv.RemoteAddress(remoteAddress)))
+        case remoteAddress if !d.pendingAuth.outgoing && conf.sendRemoteAddressInit && NodeAddress.isPublicIPAddress(remoteAddress) => protocol.Init(localFeatures, TlvStream(InitTlv.Networks(chainHash :: Nil), InitTlv.RemoteAddress(remoteAddress)))
         case _ => protocol.Init(localFeatures, TlvStream(InitTlv.Networks(chainHash :: Nil)))
       }
       d.transport ! localInit
@@ -528,7 +528,8 @@ object PeerConnection {
                   pingDisconnect: Boolean,
                   maxRebroadcastDelay: FiniteDuration,
                   killIdleDelay: FiniteDuration,
-                  maxOnionMessagesPerSecond: Int)
+                  maxOnionMessagesPerSecond: Int,
+                  sendRemoteAddressInit: Boolean)
 
   // @formatter:off
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -31,7 +31,7 @@ import fr.acinq.eclair.wire.protocol.CommonCodecs._
 import fr.acinq.eclair.wire.protocol.LightningMessageCodecs._
 import fr.acinq.eclair.wire.protocol.QueryChannelRangeTlv.queryFlagsCodec
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{CltvExpiryDelta, Feature, Features, InitFeature}
+import fr.acinq.eclair.{CltvExpiryDelta, Feature, Features}
 import scodec._
 import scodec.codecs._
 
@@ -108,7 +108,8 @@ object EclairInternalsSerializer {
       ("pingDisconnect" | bool(8)) ::
       ("maxRebroadcastDelay" | finiteDurationCodec) ::
       ("killIdleDelay" | finiteDurationCodec) ::
-      ("maxOnionMessagesPerSecond" | int32)).as[PeerConnection.Conf]
+      ("maxOnionMessagesPerSecond" | int32) ::
+      ("sendRemoteAddressInit" | bool(8))).as[PeerConnection.Conf]
 
   val peerConnectionDoSyncCodec: Codec[PeerConnection.DoSync] = bool(8).as[PeerConnection.DoSync]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -156,7 +156,8 @@ object TestConstants {
         pingDisconnect = true,
         maxRebroadcastDelay = 5 seconds,
         killIdleDelay = 1 seconds,
-        maxOnionMessagesPerSecond = 10
+        maxOnionMessagesPerSecond = 10,
+        sendRemoteAddressInit = true,
       ),
       routerConf = RouterConf(
         watchSpentWindow = 1 second,
@@ -294,7 +295,8 @@ object TestConstants {
         pingDisconnect = true,
         maxRebroadcastDelay = 5 seconds,
         killIdleDelay = 10 seconds,
-        maxOnionMessagesPerSecond = 10
+        maxOnionMessagesPerSecond = 10,
+        sendRemoteAddressInit = true,
       ),
       routerConf = RouterConf(
         watchSpentWindow = 1 second,


### PR DESCRIPTION
When running behind a load balancer that doesn't preserve the client source IP address, it doesn't make sense to include the `remote-address` tlv in our `init` message, it will contain an IP address that is completely unrelated to our peer.

Fixes #2256