### PR TITLE
Add more GraphSpec tests (#2292)

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
@@ -265,7 +265,8 @@ class GraphSpec extends AnyFunSuite {
 
   test("fees less along C->D->E than C->E") {
     /*
-    The channel C -> D is large enough for the payment and associated fees to go through, but C -> E is not.
+    The channel going through C -> D -> E  (fee = 1001 + 1 = 1002) is considered shorter than going
+    through C -> E (fee = 1003) because the fees are less.
     A --> B --> C <-> D
                  \   /
                   \ /
@@ -285,7 +286,7 @@ class GraphSpec extends AnyFunSuite {
       BlockHeight(714930), _ => true, includeLocalChannelCost = true)
 
     assert(paths.length == 2)
-    assert(paths.head.path == Seq(edgeAB, edgeBC, edgeCD, edgeDE))
+    assert(paths(0).path == Seq(edgeAB, edgeBC, edgeCD, edgeDE))
     assert(paths(1).path == Seq(edgeAB, edgeBC, edgeCE))
   }
 
@@ -317,25 +318,25 @@ class GraphSpec extends AnyFunSuite {
 
   /**
    * Find all the shortest paths using the example described in
-   * https://en.wikipedia.org/wiki/Yen%27s_algorithm#:~:text=Yen's%20algorithm
+   * https://en.wikipedia.org/wiki/Yen's_algorithm#Example
    */
   test("all shortest paths are found") {
     // There will be 3 shortest paths.
     // Edge capacities are set to be the same so that only feeBase will affect the RichWeight.
-    //  C --> D --> F
-    //   \    ^    /|\
-    //    \   |  /  | \
-    //     \ | /    |  \
-    //       E----->G-->H
-    val edgeCD = makeEdge(1L, c, d, 301 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
-    val edgeDF = makeEdge(2L, d, f, 401 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
-    val edgeCE = makeEdge(3L, c, e, 201 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
-    val edgeED = makeEdge(4L, e, d, 101 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
-    val edgeEF = makeEdge(5L, e, f, 201 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
-    val edgeFG = makeEdge(6L, f, g, 201 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
-    val edgeFH = makeEdge(7L, f, h, 101 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
-    val edgeEG = makeEdge(8L, e, g, 301 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
-    val edgeGH = makeEdge(9L, g, h, 201 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
+    // C --> D --> F
+    //   \   ^   / | \
+    //    \  |  /  |  \
+    //     \ | /   |   \
+    //       E --> G --> H
+    val edgeCD = makeEdge(1L, c, d, 3 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
+    val edgeDF = makeEdge(2L, d, f, 4 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
+    val edgeCE = makeEdge(3L, c, e, 2 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
+    val edgeED = makeEdge(4L, e, d, 1 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
+    val edgeEF = makeEdge(5L, e, f, 2 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
+    val edgeFG = makeEdge(6L, f, g, 2 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
+    val edgeFH = makeEdge(7L, f, h, 1 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
+    val edgeEG = makeEdge(8L, e, g, 3 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
+    val edgeGH = makeEdge(9L, g, h, 2 msat, 0, capacity = 100000 sat, minHtlc = 1000 msat)
     val graph = DirectedGraph(Seq(edgeCD, edgeDF, edgeCE, edgeED, edgeEF, edgeFG, edgeFH, edgeEG, edgeGH))
 
     val paths = yenKshortestPaths(graph, c, h, 10000000 msat,
@@ -343,7 +344,7 @@ class GraphSpec extends AnyFunSuite {
       Left(WeightRatios(1, 0, 0, 0, RelayFees(0 msat, 0))),
       BlockHeight(714930), _ => true, includeLocalChannelCost = true)
     assert(paths.length == 3)
-    assert(paths.head.path == Seq(edgeCE, edgeEF, edgeFH))
+    assert(paths(0).path == Seq(edgeCE, edgeEF, edgeFH))
     assert(paths(1).path == Seq(edgeCE, edgeEG, edgeGH))
     assert(paths(2).path == Seq(edgeCD, edgeDF, edgeFH))
   }


### PR DESCRIPTION
I added the 2 tests that I suggested but noticed something surprising.

The test for the [wikipedia example](https://en.wikipedia.org/wiki/Yen%27s_algorithm#:~:text=Yen's%20algorithm) is not returning the expected results. I suspect that there is at least one bug. I'm reluctant to make the change in the production code because of my current lack of understanding, but if I remove the `reverse` from [this line](https://github.com/ACINQ/eclair/blob/9c7ddcd8745bbea9c7113457e1a1f378435347c7/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala#L227), then at least the call to `dijkstraShortestPath` returns the shortest path that was expected. But even after making that fix, assuming that it is a correct fix, the next 2 shortest paths also do not match what is in the wikipedia article and I have not tried to debug that yet.

