### PR TITLE
Fix minimal node fixture flakyness

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/TwoNodesIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/TwoNodesIntegrationSpec.scala
@@ -9,7 +9,6 @@ import org.scalatest.TestData
 import org.scalatest.concurrent.IntegrationPatience
 import scodec.bits.HexStringSyntax
 
-
 /**
  * This test checks the integration between Channel and Router (events, etc.)
  */

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
@@ -24,6 +24,7 @@ import fr.acinq.eclair.router.Router
 import fr.acinq.eclair.wire.protocol.IPAddress
 import fr.acinq.eclair.{BlockHeight, MilliSatoshi, MilliSatoshiLong, NodeParams, ShortChannelId, TestBitcoinCoreClient, TestDatabases, TestFeeEstimator}
 import org.scalatest.Assertions
+import org.scalatest.concurrent.Eventually.eventually
 
 import java.net.InetAddress
 import java.util.UUID
@@ -162,8 +163,10 @@ object MinimalNodeFixture extends Assertions {
     watch1.replyTo ! WatchFundingConfirmedTriggered(blockHeight, txIndex, fundingTx)
     watch2.replyTo ! WatchFundingConfirmedTriggered(blockHeight, txIndex, fundingTx)
 
-    waitReady(node1, channelId)
-    waitReady(node2, channelId)
+    eventually {
+      assert(getChannelState(node1, channelId) == NORMAL)
+      assert(getChannelState(node2, channelId) == NORMAL)
+    }
 
     val data1After = getChannelData(node1, channelId).asInstanceOf[DATA_NORMAL]
     val data2After = getChannelData(node2, channelId).asInstanceOf[DATA_NORMAL]


### PR DESCRIPTION
There was a race condition between the `wait_for_funding_locked` state and the `normal` state. By only waiting for the channel to have handled the last message it could either be still in `waiting_for_funding_locked` or already in `normal.