### PR TITLE
Small improvements to balance estimation

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/StaleChannels.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/StaleChannels.scala
@@ -53,14 +53,14 @@ object StaleChannels {
       staleChannelsToRemove += ChannelDesc(ca.ann.shortChannelId, ca.ann.nodeId2, ca.ann.nodeId1)
     })
 
-    val graph1 = d.graph.removeEdges(staleChannelsToRemove)
+    val graphWithBalances1 = d.graphWithBalances.removeEdges(staleChannelsToRemove)
     staleNodes.foreach {
       nodeId =>
         log.info("pruning nodeId={} (stale)", nodeId)
         db.removeNode(nodeId)
         ctx.system.eventStream.publish(NodeLost(nodeId))
     }
-    d.copy(nodes = d.nodes -- staleNodes, channels = channels1, graph = graph1)
+    d.copy(nodes = d.nodes -- staleNodes, channels = channels1, graphWithBalances = graphWithBalances1)
   }
 
   def isStale(u: ChannelUpdate): Boolean = isStale(u.timestamp)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -19,7 +19,6 @@ package fr.acinq.eclair.router
 import akka.actor.typed.scaladsl.adapter.actorRefAdapter
 import akka.actor.{ActorContext, ActorRef, typed}
 import akka.event.{DiagnosticLoggingAdapter, LoggingAdapter}
-import com.softwaremill.quicklens.ModifyPimp
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.Script.{pay2wsh, write}
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
@@ -195,7 +194,7 @@ object Validation {
     log.info("pruning shortChannelId={} (spent)", shortChannelId)
     db.removeChannel(shortChannelId) // NB: this also removes channel updates
     // we also need to remove updates from the graph
-    val BalancesAndGraph(balances1, graph1) = BalancesAndGraph(d.balances, d.graph)
+    val graphWithBalances1 = d.graphWithBalances
       .removeEdge(ChannelDesc(lostChannel.shortChannelId, lostChannel.nodeId1, lostChannel.nodeId2))
       .removeEdge(ChannelDesc(lostChannel.shortChannelId, lostChannel.nodeId2, lostChannel.nodeId1))
 
@@ -206,7 +205,7 @@ object Validation {
         db.removeNode(nodeId)
         ctx.system.eventStream.publish(NodeLost(nodeId))
     }
-    d.copy(nodes = d.nodes -- lostNodes, channels = d.channels - shortChannelId, graph = graph1, balances = balances1)
+    d.copy(nodes = d.nodes -- lostNodes, channels = d.channels - shortChannelId, graphWithBalances = graphWithBalances1)
   }
 
   def handleNodeAnnouncement(d: Data, db: NetworkDb, origins: Set[GossipOrigin], n: NodeAnnouncement, wasStashed: Boolean = false)(implicit ctx: ActorContext, log: LoggingAdapter): Data = {
@@ -285,8 +284,8 @@ object Validation {
           val origins1 = d.rebroadcast.updates(u) ++ origins
           // NB: we update the channels because the balances may have changed even if the channel_update is the same.
           val pc1 = pc.applyChannelUpdate(update)
-          val BalancesAndGraph(balances1, graph1) = BalancesAndGraph(d.balances, d.graph).addEdge(GraphEdge(u, pc1))
-          d.copy(rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins1)), channels = d.channels + (pc.shortChannelId -> pc1), graph = graph1, balances = balances1)
+          val graphWithBalances1 = d.graphWithBalances.addEdge(GraphEdge(u, pc1))
+          d.copy(rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins1)), channels = d.channels + (pc.shortChannelId -> pc1), graphWithBalances = graphWithBalances1)
         } else if (StaleChannels.isStale(u)) {
           log.debug("ignoring {} (stale)", u)
           sendDecision(origins, GossipDecision.Stale(u))
@@ -298,8 +297,8 @@ object Validation {
             case Left(_) =>
               // NB: we update the graph because the balances may have changed even if the channel_update is the same.
               val pc1 = pc.applyChannelUpdate(update)
-              val BalancesAndGraph(balances1, graph1) = BalancesAndGraph(d.balances, d.graph).addEdge(GraphEdge(u, pc1))
-              d.copy(channels = d.channels + (pc.shortChannelId -> pc1), graph = graph1, balances = balances1)
+              val graphWithBalances1 = d.graphWithBalances.addEdge(GraphEdge(u, pc1))
+              d.copy(channels = d.channels + (pc.shortChannelId -> pc1), graphWithBalances = graphWithBalances1)
             case Right(_) => d
           }
         } else if (!Announcements.checkSig(u, pc.getNodeIdSameSideAs(u))) {
@@ -314,14 +313,14 @@ object Validation {
           db.updateChannel(u)
           // update the graph
           val pc1 = pc.applyChannelUpdate(update)
-          val BalancesAndGraph(balances1, graph1) = if (u.channelFlags.isEnabled) {
+          val graphWithBalances1 = if (u.channelFlags.isEnabled) {
             update.left.foreach(_ => log.info("added local shortChannelId={} public={} to the network graph", u.shortChannelId, publicChannel))
-            BalancesAndGraph(d.balances, d.graph).addEdge(GraphEdge(u, pc1))
+            d.graphWithBalances.addEdge(GraphEdge(u, pc1))
           } else {
             update.left.foreach(_ => log.info("removed local shortChannelId={} public={} from the network graph", u.shortChannelId, publicChannel))
-            BalancesAndGraph(d.balances, d.graph).removeEdge(ChannelDesc(u, pc1.ann))
+            d.graphWithBalances.removeEdge(ChannelDesc(u, pc1.ann))
           }
-          d.copy(channels = d.channels + (pc.shortChannelId -> pc1), rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins)), graph = graph1, balances = balances1)
+          d.copy(channels = d.channels + (pc.shortChannelId -> pc1), rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins)), graphWithBalances = graphWithBalances1)
         } else {
           log.debug("added channel_update for shortChannelId={} public={} flags={} {}", u.shortChannelId, publicChannel, u.channelFlags, u)
           sendDecision(origins, GossipDecision.Accepted(u))
@@ -329,9 +328,9 @@ object Validation {
           db.updateChannel(u)
           // we also need to update the graph
           val pc1 = pc.applyChannelUpdate(update)
-          val BalancesAndGraph(balances1, graph1) = BalancesAndGraph(d.balances, d.graph).addEdge(GraphEdge(u, pc1))
+          val graphWithBalances1 = d.graphWithBalances.addEdge(GraphEdge(u, pc1))
           update.left.foreach(_ => log.info("added local shortChannelId={} public={} to the network graph", u.shortChannelId, publicChannel))
-          d.copy(channels = d.channels + (pc.shortChannelId -> pc1), privateChannels = d.privateChannels - pc1.channelId, rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins)), graph = graph1, balances = balances1)
+          d.copy(channels = d.channels + (pc.shortChannelId -> pc1), privateChannels = d.privateChannels - pc1.channelId, rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins)), graphWithBalances = graphWithBalances1)
         }
       case Some(pc: PrivateChannel) =>
         val publicChannel = false
@@ -354,23 +353,23 @@ object Validation {
           ctx.system.eventStream.publish(ChannelUpdatesReceived(u :: Nil))
           // we also need to update the graph
           val pc1 = pc.applyChannelUpdate(update)
-          val BalancesAndGraph(balances1, graph1) = if (u.channelFlags.isEnabled) {
+          val graphWithBalances1 = if (u.channelFlags.isEnabled) {
             update.left.foreach(_ => log.info("added local channelId={} public={} to the network graph", pc.channelId, publicChannel))
-            BalancesAndGraph(d.balances, d.graph).addEdge(GraphEdge(u, pc1))
+            d.graphWithBalances.addEdge(GraphEdge(u, pc1))
           } else {
             update.left.foreach(_ => log.info("removed local channelId={} public={} from the network graph", pc.channelId, publicChannel))
-            BalancesAndGraph(d.balances, d.graph).removeEdge(ChannelDesc(u, pc1))
+            d.graphWithBalances.removeEdge(ChannelDesc(u, pc1))
           }
-          d.copy(privateChannels = d.privateChannels + (pc.channelId -> pc1), graph = graph1, balances = balances1)
+          d.copy(privateChannels = d.privateChannels + (pc.channelId -> pc1), graphWithBalances = graphWithBalances1)
         } else {
           log.debug("added channel_update for channelId={} public={} flags={} {}", pc.channelId, publicChannel, u.channelFlags, u)
           sendDecision(origins, GossipDecision.Accepted(u))
           ctx.system.eventStream.publish(ChannelUpdatesReceived(u :: Nil))
           // we also need to update the graph
           val pc1 = pc.applyChannelUpdate(update)
-          val BalancesAndGraph(balances1, graph1) = BalancesAndGraph(d.balances, d.graph).addEdge(GraphEdge(u, pc1))
+          val graphWithBalances1 = d.graphWithBalances.addEdge(GraphEdge(u, pc1))
           update.left.foreach(_ => log.info("added local channelId={} public={} to the network graph", pc.channelId, publicChannel))
-          d.copy(privateChannels = d.privateChannels + (pc.channelId -> pc1), graph = graph1, balances = balances1)
+          d.copy(privateChannels = d.privateChannels + (pc.channelId -> pc1), graphWithBalances = graphWithBalances1)
         }
       case None if d.awaiting.keys.exists(c => c.shortChannelId == u.shortChannelId) =>
         // channel is currently being validated
@@ -467,39 +466,38 @@ object Validation {
       val desc1 = ChannelDesc(shortChannelId, localNodeId, remoteNodeId)
       val desc2 = ChannelDesc(shortChannelId, remoteNodeId, localNodeId)
       // we remove the corresponding updates from the graph
-      val BalancesAndGraph(balances1, graph1) = BalancesAndGraph(d.balances, d.graph)
+      val graphWithBalances1 = d.graphWithBalances
         .removeEdge(desc1)
         .removeEdge(desc2)
       // and we remove the channel and channel_update from our state
-      d.copy(privateChannels = d.privateChannels - channelId, graph = graph1, balances = balances1)
+      d.copy(privateChannels = d.privateChannels - channelId, graphWithBalances = graphWithBalances1)
     } else {
       d
     }
   }
 
   def handleAvailableBalanceChanged(d: Data, e: AvailableBalanceChanged)(implicit log: LoggingAdapter): Data = {
-    val balancesAndGraph0 = BalancesAndGraph(d.balances, d.graph)
-    val (publicChannels1, balancesAndGraph1) = d.channels.get(e.shortChannelId) match {
+    val (publicChannels1, graphWithBalances1) = d.channels.get(e.shortChannelId) match {
       case Some(pc) =>
         val pc1 = pc.updateBalances(e.commitments)
         log.debug("public channel balance updated: {}", pc1)
         val update_opt = if (e.commitments.localNodeId == pc1.ann.nodeId1) pc1.update_1_opt else pc1.update_2_opt
-        val balancesAndGraph1 = update_opt.map(u => balancesAndGraph0.addEdge(GraphEdge(u, pc1))).getOrElse(balancesAndGraph0)
-        (d.channels + (pc.ann.shortChannelId -> pc1), balancesAndGraph1)
+        val graphWithBalances1 = update_opt.map(u => d.graphWithBalances.addEdge(GraphEdge(u, pc1))).getOrElse(d.graphWithBalances)
+        (d.channels + (pc.ann.shortChannelId -> pc1), graphWithBalances1)
       case None =>
-        (d.channels, balancesAndGraph0)
+        (d.channels, d.graphWithBalances)
     }
-    val (privateChannels1, BalancesAndGraph(balances2, graph2)) = d.privateChannels.get(e.channelId) match {
+    val (privateChannels1, graphWithBalances2) = d.privateChannels.get(e.channelId) match {
       case Some(pc) =>
         val pc1 = pc.updateBalances(e.commitments)
         log.debug("private channel balance updated: {}", pc1)
         val update_opt = if (e.commitments.localNodeId == pc1.nodeId1) pc1.update_1_opt else pc1.update_2_opt
-        val balancesAndGraph2 = update_opt.map(u => balancesAndGraph1.addEdge(GraphEdge(u, pc1))).getOrElse(balancesAndGraph1)
-        (d.privateChannels + (e.channelId -> pc1), balancesAndGraph2)
+        val graphWithBalances2 = update_opt.map(u => graphWithBalances1.addEdge(GraphEdge(u, pc1))).getOrElse(graphWithBalances1)
+        (d.privateChannels + (e.channelId -> pc1), graphWithBalances2)
       case None =>
-        (d.privateChannels, balancesAndGraph1)
+        (d.privateChannels, graphWithBalances1)
     }
-    d.copy(channels = publicChannels1, privateChannels = privateChannels1, graph = graph2, balances = balances2)
+    d.copy(channels = publicChannels1, privateChannels = privateChannels1, graphWithBalances = graphWithBalances2)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
@@ -28,6 +28,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import scala.concurrent.duration.DurationInt
 
 class BalanceEstimateSpec extends AnyFunSuite {
+
   def isValid(balance: BalanceEstimate): Boolean = {
     balance.low >= 0.msat &&
       balance.low <= balance.high &&
@@ -201,7 +202,8 @@ class BalanceEstimateSpec extends AnyFunSuite {
       makeEdge(b, c, 6L, 150 sat),
     ))
 
-    val balances = BalancesEstimates.baseline(g, 1 day)
-    assert(balances.get(makeEdge(a, b, 1L, 100 sat)).canSend(55000 msat) === 0.5 +- 0.01)
+    val graphWithBalances = GraphWithBalanceEstimates(g, 1 day)
+    assert(graphWithBalances.canSend(55000 msat, makeEdge(a, b, 1L, 100 sat)) === 0.5 +- 0.01)
   }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
@@ -49,18 +49,19 @@ class BalanceEstimateSpec extends AnyFunSuite {
     assert(isValid(balance))
     assert(balance.canSend(0 msat) === 1.0 +- 0.001)
     assert(balance.canSend(1 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(25000 msat) === 0.75 +- 0.001)
     assert(balance.canSend(50000 msat) === 0.5 +- 0.001)
+    assert(balance.canSend(75000 msat) === 0.25 +- 0.001)
     assert(balance.canSend(99999 msat) === 0.0 +- 0.001)
     assert(balance.canSend(100000 msat) === 0.0 +- 0.001)
   }
 
   test("add and remove channels") {
-    val (a, b, c, d, e) =
-      (makeEdge(0, 200 sat),
-        makeEdge(1, 100 sat),
-        makeEdge(2, 800 sat),
-        makeEdge(3, 120 sat),
-        makeEdge(4, 190 sat))
+    val a = makeEdge(0, 200 sat)
+    val b = makeEdge(1, 100 sat)
+    val c = makeEdge(2, 800 sat)
+    val d = makeEdge(3, 120 sat)
+    val e = makeEdge(4, 190 sat)
     val balance = BalanceEstimate.empty(1 day)
       .addEdge(a)
       .addEdge(b)
@@ -75,21 +76,23 @@ class BalanceEstimateSpec extends AnyFunSuite {
       .addEdge(e)
     assert(isValid(balance1))
     assert(balance1.maxCapacity == 190.sat)
-    val balance2 = balance1.removeEdge(d.desc)
+    val balance2 = balance1
+      .removeEdge(d.desc)
       .removeEdge(e.desc)
     assert(isValid(balance2))
     assert(balance2.maxCapacity == 0.sat)
     assert(balance2.capacities.isEmpty)
   }
 
-  test("can send balance info bounds") {
+  test("update bounds based on what could then could not be sent (increasing amounts)") {
     val now = TimestampSecond.now()
-    val balance =
-      BalanceEstimate.empty(1 day).addEdge(makeEdge(0, 100 sat))
-        .couldSend(24000 msat, now)
-        .couldNotSend(30000 msat, now)
+    val balance = BalanceEstimate.empty(1 day)
+      // NB: the number of channels has no impact here
+      .addEdge(makeEdge(0, 100 sat))
+      .addEdge(makeEdge(1, 100 sat))
+      .couldSend(24000 msat, now)
+      .couldNotSend(30000 msat, now)
     assert(balance.canSend(0 msat) === 1.0 +- 0.001)
-    assert(balance.canSend(1 msat) === 1.0 +- 0.001)
     assert(balance.canSend(23999 msat) === 1.0 +- 0.001)
     assert(balance.canSend(24000 msat) === 1.0 +- 0.001)
     assert(balance.canSend(24001 msat) === 1.0 +- 0.001)
@@ -97,46 +100,68 @@ class BalanceEstimateSpec extends AnyFunSuite {
     assert(balance.canSend(29999 msat) === 0.0 +- 0.001)
     assert(balance.canSend(30000 msat) === 0.0 +- 0.001)
     assert(balance.canSend(30001 msat) === 0.0 +- 0.001)
-    assert(balance.canSend(99999 msat) === 0.0 +- 0.001)
     assert(balance.canSend(100000 msat) === 0.0 +- 0.001)
   }
 
-  test("could and couldn't send at the same time") {
+  test("update bounds based on what could then could not be sent (decreasing amounts)") {
     val now = TimestampSecond.now()
-    val balance =
-      BalanceEstimate.empty(1 day).addEdge(makeEdge(0, 100 sat))
-        .couldSend(26000 msat, now)
-        .couldNotSend(26000 msat, now)
+    val balance = BalanceEstimate.empty(1 day)
+      // NB: the number of channels has no impact here
+      .addEdge(makeEdge(0, 75 sat))
+      .addEdge(makeEdge(1, 100 sat))
+      .couldSend(26000 msat, now)
+      .couldNotSend(14000 msat, now)
     assert(isValid(balance))
     assert(balance.canSend(0 msat) === 1.0 +- 0.001)
     assert(balance.canSend(1 msat) === 1.0 +- 0.001)
-    assert(balance.canSend(26000 msat) >= 0)
-    assert(balance.canSend(26000 msat) <= 1)
+    assert(balance.canSend(7000 msat) === 0.5 +- 0.001)
+    assert(balance.canSend(14000 msat) === 0.0 +- 0.001)
+    assert(balance.canSend(26000 msat) === 0.0 +- 0.001)
     assert(balance.canSend(99999 msat) === 0.0 +- 0.001)
     assert(balance.canSend(100000 msat) === 0.0 +- 0.001)
   }
 
-  test("couldn't and could send at the same time") {
+  test("update bounds based on what could not then could be sent (increasing amounts)") {
     val now = TimestampSecond.now()
-    val balance =
-      BalanceEstimate.empty(1 day).addEdge(makeEdge(0, 100 sat))
-        .couldNotSend(26000 msat, now)
-        .couldSend(26000 msat, now)
+    val balance = BalanceEstimate.empty(1 day)
+      // NB: the number of channels has no impact here
+      .addEdge(makeEdge(0, 100 sat))
+      .addEdge(makeEdge(1, 50 sat))
+      .couldNotSend(26000 msat, now)
+      .couldSend(30000 msat, now)
     assert(isValid(balance))
     assert(balance.canSend(0 msat) === 1.0 +- 0.001)
     assert(balance.canSend(1 msat) === 1.0 +- 0.001)
-    assert(balance.canSend(26000 msat) >= 0)
-    assert(balance.canSend(26000 msat) <= 1)
+    assert(balance.canSend(30000 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(65000 msat) === 0.5 +- 0.001)
     assert(balance.canSend(99999 msat) === 0.0 +- 0.001)
     assert(balance.canSend(100000 msat) === 0.0 +- 0.001)
   }
 
-  test("decay") {
-    val longAgo = TimestampSecond.now() - 1.day
-    val balance =
-      BalanceEstimate.empty(1 second).addEdge(makeEdge(0, 100 sat))
-        .couldNotSend(32000 msat, longAgo)
-        .couldSend(28000 msat, longAgo)
+  test("update bounds based on what could not then could be sent (decreasing amounts)") {
+    val now = TimestampSecond.now()
+    val balance = BalanceEstimate.empty(1 day)
+      // NB: the number of channels has no impact here
+      .addEdge(makeEdge(0, 100 sat))
+      .addEdge(makeEdge(1, 50 sat))
+      .couldNotSend(30000 msat, now)
+      .couldSend(20000 msat, now)
+    assert(isValid(balance))
+    assert(balance.canSend(0 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(1 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(20000 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(25000 msat) === 0.5 +- 0.001)
+    assert(balance.canSend(30000 msat) === 0.0 +- 0.001)
+    assert(balance.canSend(99999 msat) === 0.0 +- 0.001)
+    assert(balance.canSend(100000 msat) === 0.0 +- 0.001)
+  }
+
+  test("decay restores baseline bounds") {
+    val longAgo = TimestampSecond.now() - 30.seconds
+    val balance = BalanceEstimate.empty(1 second)
+      .addEdge(makeEdge(0, 100 sat))
+      .couldNotSend(32000 msat, longAgo)
+      .couldSend(28000 msat, longAgo)
     assert(isValid(balance))
     assert(balance.canSend(1 msat) === 1.0 +- 0.01)
     assert(balance.canSend(33333 msat) === 0.666 +- 0.01)
@@ -146,64 +171,122 @@ class BalanceEstimateSpec extends AnyFunSuite {
 
   test("sending on single channel shifts amounts") {
     val now = TimestampSecond.now()
-    val balance =
-      BalanceEstimate.empty(1 day).addEdge(makeEdge(0, 100 sat))
-        .couldNotSend(80000 msat, now)
-        .couldSend(50000 msat, now)
+    val balance = BalanceEstimate.empty(1 day)
+      .addEdge(makeEdge(0, 100 sat))
+      .couldNotSend(80000 msat, now)
+      .couldSend(50000 msat, now)
     assert(isValid(balance))
     assert(balance.canSend(50000 msat) === 1.0 +- 0.001)
     assert(balance.canSend(80000 msat) === 0.0 +- 0.001)
     val balanceAfterSend = balance.didSend(20000 msat, now)
     assert(isValid(balanceAfterSend))
     assert(balanceAfterSend.canSend(30000 msat) === 1.0 +- 0.001)
+    assert(balanceAfterSend.canSend(45000 msat) === 0.5 +- 0.001)
     assert(balanceAfterSend.canSend(60000 msat) === 0.0 +- 0.001)
   }
 
   test("sending on single channel after decay") {
-    val longAgo = TimestampSecond.now() - 1.day
+    val longAgo = TimestampSecond.now() - 60.seconds
     val now = TimestampSecond.now()
-    val balance =
-      BalanceEstimate.empty(1 second).addEdge(makeEdge(0, 100 sat))
-        .couldNotSend(80000 msat, longAgo)
-        .couldSend(50000 msat, longAgo)
-        .didSend(40000 msat, now)
+    val balance = BalanceEstimate.empty(1 second)
+      .addEdge(makeEdge(0, 100 sat))
+      .couldNotSend(80000 msat, longAgo)
+      .couldSend(50000 msat, longAgo)
+      .didSend(40000 msat, now)
     assert(isValid(balance))
+    assert(balance.canSend(0 msat) === 1.0 +- 0.01)
+    assert(balance.canSend(10000 msat) <= 0.9)
+    assert(balance.canSend(50000 msat) >= 0.1)
     assert(balance.canSend(60000 msat) === 0.0 +- 0.01)
   }
 
   test("sending on parallel channels shifts low only") {
     val now = TimestampSecond.now()
-    val balance =
-      BalanceEstimate.empty(1 day)
-        .addEdge(makeEdge(0, 100 sat))
-        .addEdge(makeEdge(1, 100 sat))
-        .couldNotSend(80000 msat, now)
-        .couldSend(50000 msat, now)
+    val balance = BalanceEstimate.empty(1 day)
+      .addEdge(makeEdge(0, 100 sat))
+      .addEdge(makeEdge(1, 80 sat))
+      .couldNotSend(80000 msat, now)
+      .couldSend(50000 msat, now)
     assert(isValid(balance))
     assert(balance.canSend(50000 msat) === 1.0 +- 0.001)
     assert(balance.canSend(80000 msat) === 0.0 +- 0.001)
     val balanceAfterSend = balance.didSend(20000 msat, now)
     assert(isValid(balanceAfterSend))
     assert(balanceAfterSend.canSend(30000 msat) === 1.0 +- 0.001)
-    assert(balanceAfterSend.canSend(60000 msat) > 0.1)
+    assert(balanceAfterSend.canSend(70000 msat) > 0.1)
+  }
+
+  test("receiving on single channel shifts amounts") {
+    val now = TimestampSecond.now()
+    val balance = BalanceEstimate.empty(1 day)
+      .addEdge(makeEdge(0, 100 sat))
+      .couldNotSend(80000 msat, now)
+      .couldSend(50000 msat, now)
+      .didReceive(10000 msat, now)
+    assert(isValid(balance))
+    assert(balance.canSend(60000 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(75000 msat) === 0.5 +- 0.001)
+    assert(balance.canSend(90000 msat) === 0.0 +- 0.001)
+  }
+
+  test("receiving on single channel after decay") {
+    val longAgo = TimestampSecond.now() - 60.seconds
+    val now = TimestampSecond.now()
+    val balance = BalanceEstimate.empty(1 second)
+      .addEdge(makeEdge(0, 100 sat))
+      .couldNotSend(80000 msat, longAgo)
+      .couldSend(50000 msat, longAgo)
+      .didReceive(10000 msat, now)
+    assert(isValid(balance))
+    assert(balance.canSend(10000 msat) >= 0.9)
+    assert(balance.canSend(20000 msat) <= 0.9)
+    assert(balance.canSend(80000 msat) >= 0.1)
+    assert(balance.canSend(90000 msat) <= 0.1)
+  }
+
+  test("receiving on parallel channels shifts high only") {
+    val now = TimestampSecond.now()
+    val balance = BalanceEstimate.empty(1 day)
+      .addEdge(makeEdge(0, 100 sat))
+      .addEdge(makeEdge(1, 80 sat))
+      .couldNotSend(70000 msat, now)
+      .couldSend(50000 msat, now)
+      .didReceive(20000 msat, now)
+    assert(isValid(balance))
+    assert(balance.canSend(50000 msat) === 1.0 +- 0.001)
+    assert(balance.canSend(70000 msat) === 0.5 +- 0.001)
+    assert(balance.canSend(90000 msat) === 0.0 +- 0.001)
   }
 
   test("baseline from graph") {
     val (a, b, c) = (randomKey().publicKey, randomKey().publicKey, randomKey().publicKey)
     val g = DirectedGraph(Seq(
-      makeEdge(a, b, 1L, 100 sat),
-      makeEdge(b, a, 1L, 100 sat),
-      makeEdge(a, b, 2L, 110 sat),
-      makeEdge(b, a, 3L, 120 sat),
-      makeEdge(a, c, 4L, 130 sat),
-      makeEdge(c, a, 4L, 130 sat),
-      makeEdge(a, c, 5L, 140 sat),
-      makeEdge(c, a, 5L, 140 sat),
-      makeEdge(b, c, 6L, 150 sat),
+      makeEdge(a, b, 1, 100 sat),
+      makeEdge(b, a, 1, 100 sat),
+      makeEdge(a, b, 2, 110 sat),
+      makeEdge(b, a, 3, 120 sat),
+      makeEdge(a, c, 4, 130 sat),
+      makeEdge(c, a, 4, 130 sat),
+      makeEdge(a, c, 5, 140 sat),
+      makeEdge(c, a, 5, 140 sat),
+      makeEdge(b, c, 6, 150 sat),
     ))
 
     val graphWithBalances = GraphWithBalanceEstimates(g, 1 day)
-    assert(graphWithBalances.canSend(55000 msat, makeEdge(a, b, 1L, 100 sat)) === 0.5 +- 0.01)
+    // NB: it doesn't matter which edge is selected, the balance estimation takes all existing edges into account.
+    val edge_ab = makeEdge(a, b, 1, 10 sat)
+    val edge_ba = makeEdge(b, a, 1, 10 sat)
+    val edge_bc = makeEdge(b, c, 6, 10 sat)
+    assert(graphWithBalances.canSend(27500 msat, edge_ab) === 0.75 +- 0.01)
+    assert(graphWithBalances.canSend(55000 msat, edge_ab) === 0.5 +- 0.01)
+    assert(graphWithBalances.canSend(30000 msat, edge_ba) === 0.75 +- 0.01)
+    assert(graphWithBalances.canSend(60000 msat, edge_ba) === 0.5 +- 0.01)
+    assert(graphWithBalances.canSend(75000 msat, edge_bc) === 0.5 +- 0.01)
+    assert(graphWithBalances.canSend(100000 msat, edge_bc) === 0.33 +- 0.01)
+    val unknownEdge = makeEdge(42, 40 sat)
+    assert(graphWithBalances.canSend(10000 msat, unknownEdge) === 0.75 +- 0.01)
+    assert(graphWithBalances.canSend(20000 msat, unknownEdge) === 0.5 +- 0.01)
+    assert(graphWithBalances.canSend(30000 msat, unknownEdge) === 0.25 +- 0.01)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -617,7 +617,7 @@ class RouterSpec extends BaseRouterSpec {
       assert(Set(channel_ab.meta_opt.map(_.balance1), channel_ab.meta_opt.map(_.balance2)) === balances)
       // And the graph should be updated too.
       sender.send(router, Router.GetRouterData)
-      val g = sender.expectMsgType[Data].graph
+      val g = sender.expectMsgType[Data].graphWithBalances.graph
       val edge_ab = g.getEdge(ChannelDesc(scid_ab, a, b)).get
       val edge_ba = g.getEdge(ChannelDesc(scid_ab, b, a)).get
       assert(edge_ab.capacity == channel_ab.capacity && edge_ba.capacity == channel_ab.capacity)
@@ -640,7 +640,7 @@ class RouterSpec extends BaseRouterSpec {
       assert(Set(channel_ab.meta_opt.map(_.balance1), channel_ab.meta_opt.map(_.balance2)) === balances)
       // And the graph should be updated too.
       sender.send(router, Router.GetRouterData)
-      val g = sender.expectMsgType[Data].graph
+      val g = sender.expectMsgType[Data].graphWithBalances.graph
       val edge_ab = g.getEdge(ChannelDesc(scid_ab, a, b)).get
       val edge_ba = g.getEdge(ChannelDesc(scid_ab, b, a)).get
       assert(edge_ab.capacity == channel_ab.capacity && edge_ba.capacity == channel_ab.capacity)
@@ -658,7 +658,7 @@ class RouterSpec extends BaseRouterSpec {
       assert(Set(channel_ab.meta_opt.map(_.balance1), channel_ab.meta_opt.map(_.balance2)) === balances)
       // And the graph should be updated too.
       sender.send(router, Router.GetRouterData)
-      val g = sender.expectMsgType[Data].graph
+      val g = sender.expectMsgType[Data].graphWithBalances.graph
       val edge_ab = g.getEdge(ChannelDesc(scid_ab, a, b)).get
       val edge_ba = g.getEdge(ChannelDesc(scid_ab, b, a)).get
       assert(edge_ab.capacity == channel_ab.capacity && edge_ba.capacity == channel_ab.capacity)
@@ -676,7 +676,7 @@ class RouterSpec extends BaseRouterSpec {
       val channel_ag = data.privateChannels(channelId_ag_private)
       assert(Set(channel_ag.meta.balance1, channel_ag.meta.balance2) === balances)
       // And the graph should be updated too.
-      val edge_ag = data.graph.getEdge(ChannelDesc(scid_ag_private, a, g)).get
+      val edge_ag = data.graphWithBalances.graph.getEdge(ChannelDesc(scid_ag_private, a, g)).get
       assert(edge_ag.capacity == channel_ag.capacity)
       assert(edge_ag.balance_opt === Some(33000000 msat))
     }


### PR DESCRIPTION
This is a PR on #2272 
It contains two commits that should be reviewed separately.
Please read the commit messages, they contain more details about each commit.

This first commit doesn't contain any meaningful logic changes, it's mostly refactoring and code clean-up, it should be quite straight-forward even though it contains many line changes.

The second commit focuses on the balance estimation business logic, and I'm curious to get your thoughts. It does two things: add a `didReceive` (symmetric to `didSend`) and fix a division by zero. I spent a lot of time trying to figure out if we could do a more meaningful update in the parallel channels case of `didSend`, it feels like we're not doing enough, but I didn't find a better solution...