### PR TITLE
Remove watch-confirmed with depth 0 in zero-conf

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -39,7 +39,7 @@ case class UnspecifiedShortChannelId(private val id: Long) extends ShortChannelI
   override def toLong: Long = id
   override def toString: String = toCoordinatesString // for backwards compatibility, because ChannelUpdate have an unspecified scid
 }
-case class RealShortChannelId private (private val id: Long) extends ShortChannelId {
+case class RealShortChannelId private(private val id: Long) extends ShortChannelId {
   override def toLong: Long = id
   override def toString: String = toCoordinatesString
   def blockHeight: BlockHeight = ShortChannelId.blockHeight(this)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
@@ -20,18 +20,17 @@ import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
 import akka.actor.typed.{ActorRef, Behavior, SupervisorStrategy}
 import fr.acinq.bitcoin.scalacompat._
-import fr.acinq.eclair.RealShortChannelId
 import fr.acinq.eclair.blockchain.Monitoring.Metrics
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
 import fr.acinq.eclair.blockchain.watchdogs.BlockchainWatchdog
 import fr.acinq.eclair.wire.protocol.ChannelAnnouncement
-import fr.acinq.eclair.{BlockHeight, KamonExt, NodeParams, ShortChannelId, TimestampSecond}
+import fr.acinq.eclair.{BlockHeight, KamonExt, NodeParams, RealShortChannelId, TimestampSecond}
 
 import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Random, Success}
+import scala.util.{Failure, Success}
 
 /**
  * Created by PM on 21/02/2016.
@@ -237,11 +236,6 @@ private class ZmqWatcher(nodeParams: NodeParams, blockHeight: AtomicLong, client
             case _: WatchConfirmed[_] => // nothing to do
             case _: WatchFundingLost => // nothing to do
           }
-        watches
-          .collect {
-            case w: WatchFundingConfirmed if w.minDepth == 0 && w.txId == tx.txid =>
-              checkConfirmed(w)
-          }
         Behaviors.same
 
       case ProcessNewBlock(blockHash) =>
@@ -412,21 +406,13 @@ private class ZmqWatcher(nodeParams: NodeParams, blockHeight: AtomicLong, client
     client.getTxConfirmations(w.txId).flatMap {
       case Some(confirmations) if confirmations >= w.minDepth =>
         client.getTransaction(w.txId).flatMap { tx =>
-          w match {
-            case w: WatchFundingConfirmed if confirmations == 0 =>
-              // if the tx doesn't have confirmations but we don't require any, we reply with a fake block index
-              // otherwise, we get the real short id
-              context.self ! TriggerEvent(w.replyTo, w, WatchFundingConfirmedTriggered(BlockHeight(0), 0, tx))
-              Future.successful((): Unit)
-            case _ =>
-              client.getTransactionShortId(w.txId).map {
-                case (height, index) => w match {
-                  case w: WatchFundingConfirmed => context.self ! TriggerEvent(w.replyTo, w, WatchFundingConfirmedTriggered(height, index, tx))
-                  case w: WatchFundingDeeplyBuried => context.self ! TriggerEvent(w.replyTo, w, WatchFundingDeeplyBuriedTriggered(height, index, tx))
-                  case w: WatchTxConfirmed => context.self ! TriggerEvent(w.replyTo, w, WatchTxConfirmedTriggered(height, index, tx))
-                  case w: WatchParentTxConfirmed => context.self ! TriggerEvent(w.replyTo, w, WatchParentTxConfirmedTriggered(height, index, tx))
-                }
-              }
+          client.getTransactionShortId(w.txId).map {
+            case (height, index) => w match {
+              case w: WatchFundingConfirmed => context.self ! TriggerEvent(w.replyTo, w, WatchFundingConfirmedTriggered(height, index, tx))
+              case w: WatchFundingDeeplyBuried => context.self ! TriggerEvent(w.replyTo, w, WatchFundingDeeplyBuriedTriggered(height, index, tx))
+              case w: WatchTxConfirmed => context.self ! TriggerEvent(w.replyTo, w, WatchTxConfirmedTriggered(height, index, tx))
+              case w: WatchParentTxConfirmed => context.self ! TriggerEvent(w.replyTo, w, WatchParentTxConfirmedTriggered(height, index, tx))
+            }
           }
         }
       case _ => Future.successful((): Unit)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -429,10 +429,14 @@ final case class DATA_WAIT_FOR_FUNDING_CONFIRMED(commitments: Commitments,
 final case class DATA_WAIT_FOR_CHANNEL_READY(commitments: Commitments,
                                              shortIds: ShortIds,
                                              lastSent: ChannelReady) extends PersistentChannelData
+
 sealed trait RealScidStatus { def toOption: Option[RealShortChannelId] }
 object RealScidStatus {
+  /** The funding transaction has been confirmed but hasn't reached min_depth, we must be ready for a reorg. */
   case class Temporary(realScid: RealShortChannelId) extends RealScidStatus { override def toOption: Option[RealShortChannelId] = Some(realScid) }
+  /** The funding transaction has been deeply confirmed. */
   case class Final(realScid: RealShortChannelId) extends RealScidStatus { override def toOption: Option[RealShortChannelId] = Some(realScid) }
+  /** We don't know the status of the funding transaction. */
   case object Unknown extends RealScidStatus { override def toOption: Option[RealShortChannelId] = None }
 }
 
@@ -441,7 +445,7 @@ object RealScidStatus {
  *
  * @param real            the real scid, it may change if a reorg happens before the channel reaches 6 conf
  * @param localAlias      we must remember the alias that we sent to our peer because we use it to:
- *                          - identify incoming [[ChannelUpdate]]
+ *                          - identify incoming [[ChannelUpdate]] at the connection level
  *                          - route outgoing payments to that channel
  * @param remoteAlias_opt we only remember the last alias received from our peer, we use this to generate
  *                        routing hints in [[fr.acinq.eclair.payment.Bolt11Invoice]]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelFeatures.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelFeatures.scala
@@ -115,7 +115,7 @@ object ChannelTypes {
     ).flatten
     override def paysDirectlyToWallet: Boolean = false
     override def commitmentFormat: CommitmentFormat = ZeroFeeHtlcTxAnchorOutputsCommitmentFormat
-    override def toString: String = s"anchor_outputs_zero_fee_htlc_tx${if (scidAlias) "+scid_alias" else ""}${if (zeroConf) "+zeroconf" else ""}"
+    override def toString: String = s"anchor_outputs_zero_fee_htlc_tx${if (scidAlias) "+scid_alias" else ""}${if (zeroConf) "+zero_conf" else ""}"
   }
   case class UnsupportedChannelType(featureBits: Features[InitFeature]) extends ChannelType {
     override def features: Set[InitFeature] = featureBits.activated.keySet

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -291,11 +291,11 @@ object Helpers {
      * wait for one conf, except if the channel has the zero-conf feature (because presumably the peer will send an
      * alias in that case).
      */
-    def minDepthFunder(channelFeatures: ChannelFeatures): Long = {
+    def minDepthFunder(channelFeatures: ChannelFeatures): Option[Long] = {
       if (channelFeatures.hasFeature(Features.ZeroConf)) {
-        0
+        None
       } else {
-        1
+        Some(1)
       }
     }
 
@@ -306,14 +306,14 @@ object Helpers {
      * @param fundingSatoshis funding amount of the channel
      * @return number of confirmations needed
      */
-    def minDepthFundee(channelConf: ChannelConf, channelFeatures: ChannelFeatures, fundingSatoshis: Satoshi): Long = fundingSatoshis match {
-      case _ if channelFeatures.hasFeature(Features.ZeroConf) => 0 // zero-conf stay zero-conf, whatever the funding amount is
-      case funding if funding <= Channel.MAX_FUNDING => channelConf.minDepthBlocks
+    def minDepthFundee(channelConf: ChannelConf, channelFeatures: ChannelFeatures, fundingSatoshis: Satoshi): Option[Long] = fundingSatoshis match {
+      case _ if channelFeatures.hasFeature(Features.ZeroConf) => None // zero-conf stay zero-conf, whatever the funding amount is
+      case funding if funding <= Channel.MAX_FUNDING => Some(channelConf.minDepthBlocks)
       case funding =>
         val blockReward = 6.25 // this is true as of ~May 2020, but will be too large after 2024
         val scalingFactor = 15
         val blocksToReachFunding = (((scalingFactor * funding.toBtc.toDouble) / blockReward).ceil + 1).toInt
-        channelConf.minDepthBlocks.max(blocksToReachFunding)
+        Some(channelConf.minDepthBlocks.max(blocksToReachFunding))
     }
 
     def makeFundingInputInfo(fundingTxId: ByteVector32, fundingTxOutputIndex: Int, fundingSatoshis: Satoshi, fundingPubkey1: PublicKey, fundingPubkey2: PublicKey): InputInfo = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -21,6 +21,7 @@ import fr.acinq.bitcoin.ScriptFlags
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey, sha256}
 import fr.acinq.bitcoin.scalacompat.Script._
 import fr.acinq.bitcoin.scalacompat._
+import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.OnChainAddressGenerator
 import fr.acinq.eclair.blockchain.fee.{FeeEstimator, FeeTargets, FeeratePerKw}
 import fr.acinq.eclair.channel.fsm.Channel
@@ -35,7 +36,6 @@ import fr.acinq.eclair.transactions.Scripts._
 import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.transactions._
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{RealShortChannelId, _}
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration._
@@ -196,17 +196,17 @@ object Helpers {
    *    - before channel announcement: use remote_alias
    *    - after channel announcement: use real scid
    *  - no remote_alias from peer
-   *    - min_depth > 0 : use real scid (may change if reorg between min_depth and 6 conf)
-   *    - min_depth = 0 (zero-conf) : unsupported
+   *    - min_depth > 0: use real scid (may change if reorg between min_depth and 6 conf)
+   *    - min_depth = 0 (zero-conf): spec violation, our peer MUST send an alias when using zero-conf
    */
-  def scidForChannelUpdate(channelAnnouncement_opt: Option[ChannelAnnouncement], shortIds: ShortIds)(implicit log: DiagnosticLoggingAdapter): ShortChannelId = {
+  def scidForChannelUpdate(channelAnnouncement_opt: Option[ChannelAnnouncement], shortIds: ShortIds): ShortChannelId = {
     channelAnnouncement_opt.map(_.shortChannelId) // we use the real "final" scid when it is publicly announced
       .orElse(shortIds.remoteAlias_opt) // otherwise the remote alias
       .orElse(shortIds.real.toOption) // if we don't have a remote alias, we use the real scid (which could change because the funding tx possibly has less than 6 confs here)
       .getOrElse(throw new RuntimeException("this is a zero-conf channel and no alias was provided in channel_ready")) // if we don't have a real scid, it means this is a zero-conf channel and our peer must have sent an alias
   }
 
-  def scidForChannelUpdate(d: DATA_NORMAL)(implicit log: DiagnosticLoggingAdapter): ShortChannelId = scidForChannelUpdate(d.channelAnnouncement, d.shortIds)
+  def scidForChannelUpdate(d: DATA_NORMAL): ShortChannelId = scidForChannelUpdate(d.channelAnnouncement, d.shortIds)
 
   /**
    * Compute the delay until we need to refresh the channel_update for our channel not to be considered stale by

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -304,7 +304,7 @@ object Helpers {
      * we make sure the cumulative block reward largely exceeds the channel size.
      *
      * @param fundingSatoshis funding amount of the channel
-     * @return number of confirmations needed
+     * @return number of confirmations needed, if any
      */
     def minDepthFundee(channelConf: ChannelConf, channelFeatures: ChannelFeatures, fundingSatoshis: Satoshi): Option[Long] = fundingSatoshis match {
       case _ if channelFeatures.hasFeature(Features.ZeroConf) => None // zero-conf stay zero-conf, whatever the funding amount is

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -49,7 +49,7 @@ class Register extends Actor with ActorLogging {
 
     case scidAssigned: ShortChannelIdAssigned =>
       // We map all known scids (real or alias) to the channel_id. The relayer is in charge of deciding whether a real
-      // scid can be used or not for routing (see option_scid_privacy), but the register is neutral.
+      // scid can be used or not for routing (see option_scid_alias), but the register is neutral.
       val m = (scidAssigned.shortIds.real.toOption.toSeq :+ scidAssigned.shortIds.localAlias).map(_ -> scidAssigned.channelId).toMap
       context become main(channels, shortIds ++ m, channelsTo)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/FundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/FundingHandlers.scala
@@ -19,12 +19,12 @@ package fr.acinq.eclair.channel.fsm
 import akka.actor.Status
 import akka.actor.typed.scaladsl.adapter.{TypedActorRefOps, actorRefAdapter}
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, SatoshiLong, Transaction}
-import fr.acinq.eclair.BlockHeight
-import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{GetTxWithMeta, GetTxWithMetaResponse, WatchFundingSpent}
+import fr.acinq.eclair.{Alias, BlockHeight, ShortChannelId}
+import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{GetTxWithMeta, GetTxWithMetaResponse, WatchFundingLost, WatchFundingSpent}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.fsm.Channel.{BITCOIN_FUNDING_PUBLISH_FAILED, BITCOIN_FUNDING_TIMEOUT, FUNDING_TIMEOUT_FUNDEE}
 import fr.acinq.eclair.channel.publish.TxPublisher.PublishFinalTx
-import fr.acinq.eclair.wire.protocol.Error
+import fr.acinq.eclair.wire.protocol.{ChannelReady, ChannelReadyTlv, Error, TlvStream}
 
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success}
@@ -58,6 +58,17 @@ trait FundingHandlers extends CommonHandlers {
     blockchain ! WatchFundingSpent(self, commitments.commitInput.outPoint.txid, commitments.commitInput.outPoint.index.toInt, knownSpendingTxs)
     // TODO: implement this? (not needed if we use a reasonable min_depth)
     //blockchain ! WatchLost(self, commitments.commitInput.outPoint.txid, nodeParams.channelConf.minDepthBlocks, BITCOIN_FUNDING_LOST)
+  }
+
+  /** When using 0-conf, we don't wait for the funding tx to confirm and instantly send channel_ready. */
+  def skipFundingConfirmation(commitments: Commitments, remoteAlias_opt: Option[Alias], emitEvent: Boolean): (ShortIds, ChannelReady) = {
+    blockchain ! WatchFundingLost(self, commitments.commitInput.outPoint.txid, nodeParams.channelConf.minDepthBlocks)
+    val channelKeyPath = keyManager.keyPath(commitments.localParams, commitments.channelConfig)
+    val nextPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 1)
+    val shortIds = ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), remoteAlias_opt)
+    if (emitEvent) context.system.eventStream.publish(ShortChannelIdAssigned(self, commitments.channelId, shortIds, remoteNodeId))
+    val channelReady = ChannelReady(commitments.channelId, nextPerCommitmentPoint, TlvStream(ChannelReadyTlv.ShortChannelIdTlv(shortIds.localAlias)))
+    (shortIds, channelReady)
   }
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -311,9 +311,7 @@ object Graph {
 
         // Every edge is weighted by funding block height where older blocks add less weight. The window considered is 1 year.
         val ageFactor = edge.desc.shortChannelId match {
-          case real: RealShortChannelId =>
-            val channelBlockHeight = ShortChannelId.coordinates(real).blockHeight
-            normalize(channelBlockHeight.toDouble, min = (currentBlockHeight - BLOCK_TIME_ONE_YEAR).toDouble, max = currentBlockHeight.toDouble)
+          case real: RealShortChannelId => normalize(real.blockHeight.toDouble, min = (currentBlockHeight - BLOCK_TIME_ONE_YEAR).toDouble, max = currentBlockHeight.toDouble)
           // for local channels or route hints we don't easily have access to the channel block height, but we want to
           // give them the best score anyway
           case _: Alias => 1

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -399,10 +399,10 @@ object Router {
       val scid_opt = shortIds.remoteAlias_opt.orElse(shortIds.real.toOption)
       // we override the remote update's scid, because it contains either the real scid or our local alias
       scid_opt.flatMap { scid =>
-        remoteUpdate_opt.map {remoteUpdate =>
+        remoteUpdate_opt.map { remoteUpdate =>
           ExtraHop(remoteNodeId, scid, remoteUpdate.feeBaseMsat, remoteUpdate.feeProportionalMillionths, remoteUpdate.cltvExpiryDelta)
-          }
         }
+      }
     }
   }
   // @formatter:on

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
@@ -410,7 +410,7 @@ private[channel] object ChannelCodecs3 {
 
   // Order matters!
   val channelDataCodec: Codec[PersistentChannelData] = discriminated[PersistentChannelData].by(uint16)
-    .typecase(0x10, Codecs.DATA_WAIT_FOR_CHANNEL_READY_Codec)
+    .typecase(0x0a, Codecs.DATA_WAIT_FOR_CHANNEL_READY_Codec)
     .typecase(0x09, Codecs.DATA_NORMAL_Codec)
     .typecase(0x08, Codecs.DATA_SHUTDOWN_Codec)
     .typecase(0x07, Codecs.DATA_NORMAL_COMPAT_07_Codec)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
@@ -20,11 +20,9 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import scala.util.Try
 
-
-
 class ShortChannelIdSpec extends AnyFunSuite {
 
-  test("handle values from 0 to 0xffffffffffff") {
+  test("handle real short channel ids from 0 to 0xffffffffffff") {
     val expected = Map(
       TxCoordinates(BlockHeight(0), 0, 0) -> RealShortChannelId(0),
       TxCoordinates(BlockHeight(42000), 27, 3) -> RealShortChannelId(0x0000a41000001b0003L),
@@ -44,7 +42,7 @@ class ShortChannelIdSpec extends AnyFunSuite {
     assert(RealShortChannelId(0x0000a41000001b0003L).toString == "42000x27x3")
   }
 
-  test("parse a short channel it") {
+  test("parse a short channel id") {
     assert(ShortChannelId("42000x27x3").toLong == 0x0000a41000001b0003L)
   }
 
@@ -58,17 +56,18 @@ class ShortChannelIdSpec extends AnyFunSuite {
     assert(Try(ShortChannelId("42000x")).isFailure)
   }
 
-  test("scids key space") {
-
+  test("compare different types of short channel ids") {
     val id = 123456
     val alias = Alias(id)
     val realScid = RealShortChannelId(id)
     val scid = ShortChannelId(id)
-
+    assert(alias == realScid)
+    assert(realScid == scid)
     val m = Map(alias -> "alias", realScid -> "real", scid -> "unknown")
-
     // all scids are in the same key space
     assert(m.size == 1)
-
+    // Values outside of the range [0;0xffffffffffff] can be used for aliases.
+    Seq(-561L, 0xffffffffffffffffL, 0x2affffffffffffffL).foreach(id => assert(Alias(id) == UnspecifiedShortChannelId(id)))
   }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
@@ -40,14 +40,14 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
   implicit val log: akka.event.LoggingAdapter = akka.event.NoLogging
 
   test("compute the funding tx min depth according to funding amount") {
-    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(1)) == 4)
-    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf.copy(minDepthBlocks = 6), ChannelFeatures(), Btc(1)) == 6) // 4 conf would be enough but we use min-depth=6
-    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(6.25)) == 16) // we use scaling_factor=15 and a fixed block reward of 6.25BTC
-    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(12.50)) == 31)
-    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(12.60)) == 32)
-    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(30)) == 73)
-    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(50)) == 121)
-    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(Features.ZeroConf), Btc(50)) == 0)
+    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(1)).contains(4))
+    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf.copy(minDepthBlocks = 6), ChannelFeatures(), Btc(1)).contains(6)) // 4 conf would be enough but we use min-depth=6
+    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(6.25)).contains(16)) // we use scaling_factor=15 and a fixed block reward of 6.25BTC
+    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(12.50)).contains(31))
+    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(12.60)).contains(32))
+    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(30)).contains(73))
+    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(), Btc(50)).contains(121))
+    assert(Helpers.Funding.minDepthFundee(nodeParams.channelConf, ChannelFeatures(Features.ZeroConf), Btc(50)).isEmpty)
   }
 
   test("compute refresh delay") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -100,10 +100,11 @@ class WaitForFundingSignedStateSpec extends TestKitBaseClass with FixtureAnyFunS
     import f._
     bob2alice.expectMsgType[FundingSigned]
     bob2alice.forward(alice)
-    awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
+    awaitCond(alice.stateName == WAIT_FOR_CHANNEL_READY)
+    // alice doesn't watch for the funding tx to confirm
     alice2blockchain.expectMsgType[WatchFundingSpent]
-    val watchConfirmed = alice2blockchain.expectMsgType[WatchFundingConfirmed]
-    assert(watchConfirmed.minDepth == 0) // zeroconf
+    alice2blockchain.expectMsgType[WatchFundingLost]
+    alice2blockchain.expectNoMessage(100 millis)
     aliceOrigin.expectMsgType[ChannelOpenResponse.ChannelOpened]
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -3468,7 +3468,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     // we create a new listener that registers after alice has published the funding tx
     val listener = TestProbe()
     alice.underlying.system.eventStream.subscribe(listener.ref, classOf[TransactionConfirmed])
-    // zero-conf channel : the funding tx isn't confirmed
+    // zero-conf channel: the funding tx isn't confirmed
     assert(alice.stateData.asInstanceOf[DATA_NORMAL].shortIds.real == RealScidStatus.Unknown)
     alice ! WatchFundingDeeplyBuriedTriggered(BlockHeight(42000), 42, null)
     val realShortChannelId = RealShortChannelId(BlockHeight(42000), 42, 0)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3Spec.scala
@@ -257,7 +257,7 @@ class ChannelCodecs3Spec extends AnyFunSuite {
       assert(data.shortIds.localAlias == ShortChannelId(123456789L))
       assert(data.shortIds.real == RealScidStatus.Temporary(RealShortChannelId(123456789L)))
       val binMigrated = channelDataCodec.encode(data).require.toHex
-      assert(binMigrated.startsWith("0010")) // NB: 01 -> 10
+      assert(binMigrated.startsWith("000a")) // NB: 01 -> 0a
     }
 
     {


### PR DESCRIPTION
This is a PR on #2224, best reviewed commit-by-commit.

The first commit contains only some clean-up and nits.

The second commit removes the use a depth 0 watch-confirmed (which is quite hacky) and instead skips the `WAIT_FOR_FUNDING_CONFIRMED` state entirely, which fits better with our model, at the cost of duplication a few lines of code (which we could refactor to a dedicated function, but I'd rather have them explicitly in each event handlers as they vary slightly depending on the case).

The third commit contains a few small changes to `Validation.scala`. The most important change is that we lost a call to `updateBalances` in #2224 by moving the initialization of private channels in the handler of `ShortChannelIdAssigned`, which we restore in `handleLocalChannelUpdate`, otherwise path-finding would ignore all newly created channels.