### PR TITLE
Reuse postgres instance in tests

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
@@ -104,7 +104,7 @@ object TestDatabases {
 
   case class TestPgDatabases() extends TestDatabases {
 
-    val datasource: DataSource = getNewDatabase
+    val datasource: DataSource = getNewDatabase()
     val hikariConfig = new HikariConfig
     hikariConfig.setDataSource(datasource)
     val lock: PgLock.LeaseLock = PgLock.LeaseLock(UUID.randomUUID(), 10 minutes, 8 minute, LockFailureHandler.logAndThrow, autoReleaseAtShutdown = false)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
@@ -130,7 +130,7 @@ object TestDatabases {
     /** single instance */
     private val pg = EmbeddedPostgres.start()
 
-    def getNewDatabase: DataSource = {
+    def getNewDatabase(): DataSource = {
       implicit val datasource: DataSource = pg.getPostgresDatabase
       val dbName = s"db_${randomBytes(8).toHex}"
       JdbcUtils.withConnection { connection =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
@@ -3,8 +3,11 @@ package fr.acinq.eclair
 import akka.actor.ActorSystem
 import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import com.zaxxer.hikari.HikariConfig
+import fr.acinq.eclair.TestDatabases.TestPgDatabases.getNewDatabase
 import fr.acinq.eclair.channel._
+import fr.acinq.eclair.db.Databases.PostgresDatabases
 import fr.acinq.eclair.db._
+import fr.acinq.eclair.db.jdbc.JdbcUtils
 import fr.acinq.eclair.db.pg.PgUtils.PgLock.LockFailureHandler
 import fr.acinq.eclair.db.pg.PgUtils.{PgLock, getVersion, using}
 import fr.acinq.eclair.db.sqlite.SqliteChannelsDb
@@ -95,13 +98,13 @@ object TestDatabases {
       val dbs = Databases.SqliteDatabases(connection, connection, connection, jdbcUrlFile_opt = Some(jdbcUrlFile))
       dbs.copy(channels = new SqliteChannelsDbWithValidation(dbs.channels))
     }
-    override def close(): Unit = ()
+    override def close(): Unit = connection.close()
     // @formatter:on
   }
 
   case class TestPgDatabases() extends TestDatabases {
-    private val pg = EmbeddedPostgres.start()
-    val datasource: DataSource = pg.getPostgresDatabase
+
+    val datasource: DataSource = getNewDatabase
     val hikariConfig = new HikariConfig
     hikariConfig.setDataSource(datasource)
     val lock: PgLock.LeaseLock = PgLock.LeaseLock(UUID.randomUUID(), 10 minutes, 8 minute, LockFailureHandler.logAndThrow, autoReleaseAtShutdown = false)
@@ -112,11 +115,32 @@ object TestDatabases {
     implicit val system: ActorSystem = ActorSystem()
 
     // @formatter:off
-    override val connection: PgConnection = pg.getPostgresDatabase.getConnection.asInstanceOf[PgConnection]
+    override val connection: PgConnection = datasource.getConnection.asInstanceOf[PgConnection]
     // NB: we use a lazy val here: databases won't be initialized until we reference that variable
     override lazy val db: Databases = Databases.PostgresDatabases(hikariConfig, UUID.randomUUID(), lock, jdbcUrlFile_opt = Some(jdbcUrlFile), readOnlyUser_opt = None, resetJsonColumns = false, safetyChecks_opt = None)
-    override def close(): Unit = pg.close()
+    override def close(): Unit = {
+      db.asInstanceOf[PostgresDatabases].dataSource.close()
+      connection.close()
+      system.terminate()
+    }
     // @formatter:on
+  }
+
+  object TestPgDatabases {
+    /** single instance */
+    private val pg = EmbeddedPostgres.start()
+
+    def getNewDatabase: DataSource = {
+      implicit val datasource: DataSource = pg.getPostgresDatabase
+      val dbName = s"db_${randomBytes(8).toHex}"
+      JdbcUtils.withConnection { connection =>
+        connection
+          .createStatement()
+          .executeUpdate(s"CREATE DATABASE $dbName")
+      }
+      pg.getDatabase("postgres", dbName)
+    }
+
   }
 
   def forAllDbs(f: TestDatabases => Unit): Unit = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/ThreeNodesIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/ThreeNodesIntegrationSpec.scala
@@ -46,7 +46,7 @@ class ThreeNodesIntegrationSpec extends FixtureSpec with IntegrationPatience {
     // alice now knows about bob-carol
     eventually {
       val routerData = getRouterData(alice)
-      prettyPrint(routerData, alice, bob, carol)
+      //prettyPrint(routerData, alice, bob, carol)
       assert(routerData.channels.size == 2) // 2 channels
       assert(routerData.channels.values.flatMap(c => c.update_1_opt.toSeq ++ c.update_2_opt.toSeq).size == 4) // 2 channel_updates per channel
     }


### PR DESCRIPTION
Create new database for each unit test instead of spawning a new db instance.