### PR TITLE
Fix flaky `ZeroConfAliasIntegrationSpec`

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/ThreeNodesIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/ThreeNodesIntegrationSpec.scala
@@ -46,7 +46,7 @@ class ThreeNodesIntegrationSpec extends FixtureSpec with IntegrationPatience {
     // alice now knows about bob-carol
     eventually {
       val routerData = getRouterData(alice)
-      prettyPrint(routerData, alice, bob, carol)
+      //prettyPrint(routerData, alice, bob, carol)
       assert(routerData.channels.size == 2) // 2 channels
       assert(routerData.channels.values.flatMap(c => c.update_1_opt.toSeq ++ c.update_2_opt.toSeq).size == 4) // 2 channel_updates per channel
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/ZeroConfAliasIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/ZeroConfAliasIntegrationSpec.scala
@@ -98,44 +98,48 @@ class ZeroConfAliasIntegrationSpec extends FixtureSpec with IntegrationPatience 
       }
     }
 
-    if (bcPublic && deepConfirm) {
-      // if channel bob-carol is public, we wait for alice to learn about it
-      eventually {
+    eventually {
+      if (bcPublic && deepConfirm) {
+        // if channel bob-carol is public, we wait for alice to learn about it
         val data = getRouterData(alice)
         assert(data.channels.size == 2)
         assert(data.channels.values.forall(pc => pc.update_1_opt.isDefined && pc.update_2_opt.isDefined))
       }
     }
 
-    if (paymentWorksWithoutHint) {
-      sendPaymentAliceToCarol(f)
-    } else {
-      intercept[AssertionError] {
+    eventually {
+      if (paymentWorksWithoutHint) {
         sendPaymentAliceToCarol(f)
+      } else {
+        intercept[AssertionError] {
+          sendPaymentAliceToCarol(f)
+        }
       }
     }
 
-    paymentWorksWithHint_opt match {
-      case Some(true) => sendPaymentAliceToCarol(f, useHint = true)
-      case Some(false) => intercept[AssertionError] {
-        sendPaymentAliceToCarol(f, useHint = true)
+    eventually {
+      paymentWorksWithHint_opt match {
+        case Some(true) => sendPaymentAliceToCarol(f, useHint = true)
+        case Some(false) => intercept[AssertionError] {
+          sendPaymentAliceToCarol(f, useHint = true)
+        }
+        case None => // skipped
       }
-      case None => // skipped
     }
 
-    paymentWorksWithRealScidHint_opt match {
-      // if alice uses the real scid instead of the bob-carol alias, it still works
-      case Some(true) => sendPaymentAliceToCarol(f, useHint = true, overrideHintScid_opt = Some(getChannelData(bob, channelId_bc).asInstanceOf[DATA_NORMAL].shortIds.real.toOption.value))
-      case Some(false) => intercept[AssertionError] {
-        sendPaymentAliceToCarol(f, useHint = true, overrideHintScid_opt = Some(getChannelData(bob, channelId_bc).asInstanceOf[DATA_NORMAL].shortIds.real.toOption.value))
+    eventually {
+      paymentWorksWithRealScidHint_opt match {
+        // if alice uses the real scid instead of the bob-carol alias, it still works
+        case Some(true) => sendPaymentAliceToCarol(f, useHint = true, overrideHintScid_opt = Some(getChannelData(bob, channelId_bc).asInstanceOf[DATA_NORMAL].shortIds.real.toOption.value))
+        case Some(false) => intercept[AssertionError] {
+          sendPaymentAliceToCarol(f, useHint = true, overrideHintScid_opt = Some(getChannelData(bob, channelId_bc).asInstanceOf[DATA_NORMAL].shortIds.real.toOption.value))
+        }
+        case None => // skipped
       }
-      case None => // skipped
     }
   }
 
   test("a->b->c (b-c private)") { f =>
-    import f._
-
     internalTest(f,
       deepConfirm = true,
       bcPublic = false,
@@ -148,8 +152,6 @@ class ZeroConfAliasIntegrationSpec extends FixtureSpec with IntegrationPatience 
   }
 
   test("a->b->c (b-c scid-alias private)", Tag(ScidAliasBobCarol)) { f =>
-    import f._
-
     internalTest(f,
       deepConfirm = true,
       bcPublic = false,
@@ -162,8 +164,6 @@ class ZeroConfAliasIntegrationSpec extends FixtureSpec with IntegrationPatience 
   }
 
   test("a->b->c (b-c zero-conf unconfirmed private)", Tag(ZeroConfBobCarol)) { f =>
-    import f._
-
     internalTest(f,
       deepConfirm = false,
       bcPublic = false,


### PR DESCRIPTION
This build failure: https://github.com/ACINQ/eclair/runs/6901214111 was possibly caused by the register not yet having been notified of the real scid.