### PR TITLE
Clean up scid parsing from coordinates string

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -98,13 +98,13 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     // standard conversion
     eclair.open(nodeId, fundingAmount = 10000000L sat, pushAmount_opt = None, channelType_opt = None, fundingFeeratePerByte_opt = Some(FeeratePerByte(5 sat)), announceChannel_opt = None, openTimeout_opt = None)
     val open = switchboard.expectMsgType[OpenChannel]
-    assert(open.fundingTxFeeratePerKw_opt == Some(FeeratePerKw(1250 sat)))
+    assert(open.fundingTxFeeratePerKw_opt.contains(FeeratePerKw(1250 sat)))
 
     // check that minimum fee rate of 253 sat/bw is used
     eclair.open(nodeId, fundingAmount = 10000000L sat, pushAmount_opt = None, channelType_opt = Some(ChannelTypes.StaticRemoteKey), fundingFeeratePerByte_opt = Some(FeeratePerByte(1 sat)), announceChannel_opt = None, openTimeout_opt = None)
     val open1 = switchboard.expectMsgType[OpenChannel]
-    assert(open1.fundingTxFeeratePerKw_opt == Some(FeeratePerKw.MinimumFeeratePerKw))
-    assert(open1.channelType_opt == Some(ChannelTypes.StaticRemoteKey))
+    assert(open1.fundingTxFeeratePerKw_opt.contains(FeeratePerKw.MinimumFeeratePerKw))
+    assert(open1.channelType_opt.contains(ChannelTypes.StaticRemoteKey))
   }
 
   test("call send with passing correct arguments") { f =>
@@ -115,7 +115,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     val invoice0 = Bolt11Invoice(Block.RegtestGenesisBlock.hash, Some(123 msat), ByteVector32.Zeroes, nodePrivKey, Left("description"), CltvExpiryDelta(18))
     eclair.send(None, 123 msat, invoice0)
     val send = paymentInitiator.expectMsgType[SendPaymentToNode]
-    assert(send.externalId == None)
+    assert(send.externalId.isEmpty)
     assert(send.recipientNodeId == nodePrivKey.publicKey)
     assert(send.recipientAmount == 123.msat)
     assert(send.paymentHash == ByteVector32.Zeroes)
@@ -124,11 +124,11 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     // with assisted routes
     val externalId1 = "030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87"
-    val hints = List(List(ExtraHop(Bob.nodeParams.nodeId, ShortChannelId("569178x2331x1"), feeBase = 10 msat, feeProportionalMillionths = 1, cltvExpiryDelta = CltvExpiryDelta(12))))
+    val hints = List(List(ExtraHop(Bob.nodeParams.nodeId, ShortChannelId.fromCoordinates("569178x2331x1").get, feeBase = 10 msat, feeProportionalMillionths = 1, cltvExpiryDelta = CltvExpiryDelta(12))))
     val invoice1 = Bolt11Invoice(Block.RegtestGenesisBlock.hash, Some(123 msat), ByteVector32.Zeroes, nodePrivKey, Left("description"), CltvExpiryDelta(18), None, None, hints)
     eclair.send(Some(externalId1), 123 msat, invoice1)
     val send1 = paymentInitiator.expectMsgType[SendPaymentToNode]
-    assert(send1.externalId == Some(externalId1))
+    assert(send1.externalId.contains(externalId1))
     assert(send1.recipientNodeId == nodePrivKey.publicKey)
     assert(send1.recipientAmount == 123.msat)
     assert(send1.paymentHash == ByteVector32.Zeroes)
@@ -140,7 +140,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     val invoice2 = Bolt11Invoice("lntb", Some(123 msat), TimestampSecond.now(), nodePrivKey.publicKey, List(Bolt11Invoice.MinFinalCltvExpiry(96), Bolt11Invoice.PaymentHash(ByteVector32.Zeroes), Bolt11Invoice.Description("description")), ByteVector.empty)
     eclair.send(Some(externalId2), 123 msat, invoice2)
     val send2 = paymentInitiator.expectMsgType[SendPaymentToNode]
-    assert(send2.externalId == Some(externalId2))
+    assert(send2.externalId.contains(externalId2))
     assert(send2.recipientNodeId == nodePrivKey.publicKey)
     assert(send2.recipientAmount == 123.msat)
     assert(send2.paymentHash == ByteVector32.Zeroes)
@@ -149,7 +149,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     // with custom route fees parameters
     eclair.send(None, 123 msat, invoice0, maxFeeFlat_opt = Some(123 sat), maxFeePct_opt = Some(4.20))
     val send3 = paymentInitiator.expectMsgType[SendPaymentToNode]
-    assert(send3.externalId == None)
+    assert(send3.externalId.isEmpty)
     assert(send3.recipientNodeId == nodePrivKey.publicKey)
     assert(send3.recipientAmount == 123.msat)
     assert(send3.paymentHash == ByteVector32.Zeroes)
@@ -261,13 +261,13 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     eclair.forceClose(Left(ByteVector32.Zeroes) :: Nil)
     register.expectMsg(Register.Forward(ActorRef.noSender, ByteVector32.Zeroes, CMD_FORCECLOSE(ActorRef.noSender)))
 
-    eclair.forceClose(Right(ShortChannelId("568749x2597x0")) :: Nil)
-    register.expectMsg(Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x0"), CMD_FORCECLOSE(ActorRef.noSender)))
+    eclair.forceClose(Right(ShortChannelId.fromCoordinates("568749x2597x0").get) :: Nil)
+    register.expectMsg(Register.ForwardShortId(ActorRef.noSender, ShortChannelId.fromCoordinates("568749x2597x0").get, CMD_FORCECLOSE(ActorRef.noSender)))
 
-    eclair.forceClose(Left(ByteVector32.Zeroes) :: Right(ShortChannelId("568749x2597x0")) :: Nil)
+    eclair.forceClose(Left(ByteVector32.Zeroes) :: Right(ShortChannelId.fromCoordinates("568749x2597x0").get) :: Nil)
     register.expectMsgAllOf(
       Register.Forward(ActorRef.noSender, ByteVector32.Zeroes, CMD_FORCECLOSE(ActorRef.noSender)),
-      Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x0"), CMD_FORCECLOSE(ActorRef.noSender))
+      Register.ForwardShortId(ActorRef.noSender, ShortChannelId.fromCoordinates("568749x2597x0").get, CMD_FORCECLOSE(ActorRef.noSender))
     )
 
     eclair.close(Left(ByteVector32.Zeroes) :: Nil, None, None)
@@ -277,17 +277,17 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     eclair.close(Left(ByteVector32.Zeroes) :: Nil, None, Some(customClosingFees))
     register.expectMsg(Register.Forward(ActorRef.noSender, ByteVector32.Zeroes, CMD_CLOSE(ActorRef.noSender, None, Some(customClosingFees))))
 
-    eclair.close(Right(ShortChannelId("568749x2597x0")) :: Nil, None, None)
-    register.expectMsg(Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x0"), CMD_CLOSE(ActorRef.noSender, None, None)))
+    eclair.close(Right(ShortChannelId.fromCoordinates("568749x2597x0").get) :: Nil, None, None)
+    register.expectMsg(Register.ForwardShortId(ActorRef.noSender, ShortChannelId.fromCoordinates("568749x2597x0").get, CMD_CLOSE(ActorRef.noSender, None, None)))
 
-    eclair.close(Right(ShortChannelId("568749x2597x0")) :: Nil, Some(ByteVector.empty), Some(customClosingFees))
-    register.expectMsg(Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x0"), CMD_CLOSE(ActorRef.noSender, Some(ByteVector.empty), Some(customClosingFees))))
+    eclair.close(Right(ShortChannelId.fromCoordinates("568749x2597x0").get) :: Nil, Some(ByteVector.empty), Some(customClosingFees))
+    register.expectMsg(Register.ForwardShortId(ActorRef.noSender, ShortChannelId.fromCoordinates("568749x2597x0").get, CMD_CLOSE(ActorRef.noSender, Some(ByteVector.empty), Some(customClosingFees))))
 
-    eclair.close(Right(ShortChannelId("568749x2597x0")) :: Left(ByteVector32.One) :: Right(ShortChannelId("568749x2597x1")) :: Nil, None, None)
+    eclair.close(Right(ShortChannelId.fromCoordinates("568749x2597x0").get) :: Left(ByteVector32.One) :: Right(ShortChannelId.fromCoordinates("568749x2597x1").get) :: Nil, None, None)
     register.expectMsgAllOf(
-      Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x0"), CMD_CLOSE(ActorRef.noSender, None, None)),
+      Register.ForwardShortId(ActorRef.noSender, ShortChannelId.fromCoordinates("568749x2597x0").get, CMD_CLOSE(ActorRef.noSender, None, None)),
       Register.Forward(ActorRef.noSender, ByteVector32.One, CMD_CLOSE(ActorRef.noSender, None, None)),
-      Register.ForwardShortId(ActorRef.noSender, ShortChannelId("568749x2597x1"), CMD_CLOSE(ActorRef.noSender, None, None))
+      Register.ForwardShortId(ActorRef.noSender, ShortChannelId.fromCoordinates("568749x2597x1").get, CMD_CLOSE(ActorRef.noSender, None, None))
     )
   }
 
@@ -299,9 +299,9 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     eclair.receive(Left("some desc"), Some(123 msat), Some(456), Some(fallBackAddressRaw), None)
     val receive = paymentHandler.expectMsgType[ReceivePayment]
 
-    assert(receive.amount_opt == Some(123 msat))
-    assert(receive.expirySeconds_opt == Some(456))
-    assert(receive.fallbackAddress_opt == Some(fallBackAddressRaw))
+    assert(receive.amount_opt.contains(123 msat))
+    assert(receive.expirySeconds_opt.contains(456))
+    assert(receive.fallbackAddress_opt.contains(fallBackAddressRaw))
 
     // try with wrong address format
     assertThrows[IllegalArgumentException](eclair.receive(Left("some desc"), Some(123 msat), Some(456), Some("wassa wassa"), None))
@@ -339,7 +339,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     eclair.sendWithPreimage(None, nodeId, 12345 msat)
     val send = paymentInitiator.expectMsgType[SendSpontaneousPayment]
-    assert(send.externalId == None)
+    assert(send.externalId.isEmpty)
     assert(send.recipientNodeId == nodeId)
     assert(send.recipientAmount == 12345.msat)
     assert(send.paymentHash == Crypto.sha256(send.paymentPreimage))
@@ -356,7 +356,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     eclair.sendWithPreimage(None, nodeId, 12345 msat, paymentPreimage = expectedPaymentPreimage)
     val send = paymentInitiator.expectMsgType[SendSpontaneousPayment]
-    assert(send.externalId == None)
+    assert(send.externalId.isEmpty)
     assert(send.recipientNodeId == nodeId)
     assert(send.recipientAmount == 12345.msat)
     assert(send.paymentPreimage == expectedPaymentPreimage)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair
 
 import org.scalatest.funsuite.AnyFunSuite
 
-import scala.util.Try
+import scala.util.Success
 
 class ShortChannelIdSpec extends AnyFunSuite {
 
@@ -43,17 +43,17 @@ class ShortChannelIdSpec extends AnyFunSuite {
   }
 
   test("parse a short channel id") {
-    assert(ShortChannelId("42000x27x3").toLong == 0x0000a41000001b0003L)
+    assert(ShortChannelId.fromCoordinates("42000x27x3").map(_.toLong) == Success(0x0000a41000001b0003L))
   }
 
   test("fail parsing a short channel id if not in the required form") {
-    assert(Try(ShortChannelId("42000x27x3.1")).isFailure)
-    assert(Try(ShortChannelId("4200aa0x27x3")).isFailure)
-    assert(Try(ShortChannelId("4200027x3")).isFailure)
-    assert(Try(ShortChannelId("42000x27ax3")).isFailure)
-    assert(Try(ShortChannelId("42000x27x")).isFailure)
-    assert(Try(ShortChannelId("42000x27")).isFailure)
-    assert(Try(ShortChannelId("42000x")).isFailure)
+    assert(ShortChannelId.fromCoordinates("42000x27x3.1").isFailure)
+    assert(ShortChannelId.fromCoordinates("4200aa0x27x3").isFailure)
+    assert(ShortChannelId.fromCoordinates("4200027x3").isFailure)
+    assert(ShortChannelId.fromCoordinates("42000x27ax3").isFailure)
+    assert(ShortChannelId.fromCoordinates("42000x27x").isFailure)
+    assert(ShortChannelId.fromCoordinates("42000x27").isFailure)
+    assert(ShortChannelId.fromCoordinates("42000x").isFailure)
   }
 
   test("compare different types of short channel ids") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt11InvoiceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt11InvoiceSpec.scala
@@ -22,6 +22,7 @@ import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
 import fr.acinq.eclair.Features.{PaymentMetadata, PaymentSecret, _}
 import fr.acinq.eclair.payment.Bolt11Invoice._
 import fr.acinq.eclair.{CltvExpiryDelta, Feature, FeatureSupport, Features, MilliSatoshi, MilliSatoshiLong, ShortChannelId, TestConstants, TimestampSecond, TimestampSecondLong, ToMilliSatoshiConversion, UnknownFeature, randomBytes32}
+import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.DecodeResult
 import scodec.bits._
@@ -218,8 +219,8 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     assert(invoice.description == Right(Crypto.sha256(ByteVector.view("One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon".getBytes))))
     assert(invoice.fallbackAddress().contains("1RustyRX2oai4EYYDpQGWvEL62BBGqN9T"))
     assert(invoice.routingInfo == List(List(
-      ExtraHop(PublicKey(hex"029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"), ShortChannelId.fromCoordinates("66051x263430x1800").get, 1 msat, 20, CltvExpiryDelta(3)),
-      ExtraHop(PublicKey(hex"039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"), ShortChannelId.fromCoordinates("197637x395016x2314").get, 2 msat, 30, CltvExpiryDelta(4))
+      ExtraHop(PublicKey(hex"029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"), ShortChannelId.fromCoordinates("66051x263430x1800").success.value, 1 msat, 20, CltvExpiryDelta(3)),
+      ExtraHop(PublicKey(hex"039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"), ShortChannelId.fromCoordinates("197637x395016x2314").success.value, 2 msat, 30, CltvExpiryDelta(4))
     )))
     assert(invoice.tags.size == 6)
     assert(invoice.sign(priv).toString == ref)
@@ -348,7 +349,7 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     assert(invoice.fallbackAddress().isEmpty)
     assert(invoice.relativeExpiry == 604800.seconds)
     assert(invoice.minFinalCltvExpiryDelta == CltvExpiryDelta(10))
-    assert(invoice.routingInfo == Seq(Seq(ExtraHop(PublicKey(hex"03d06758583bb5154774a6eb221b1276c9e82d65bbaceca806d90e20c108f4b1c7"), ShortChannelId.fromCoordinates("589390x3312x1").get, 1000 msat, 2500, CltvExpiryDelta(40)))))
+    assert(invoice.routingInfo == Seq(Seq(ExtraHop(PublicKey(hex"03d06758583bb5154774a6eb221b1276c9e82d65bbaceca806d90e20c108f4b1c7"), ShortChannelId.fromCoordinates("589390x3312x1").success.value, 1000 msat, 2500, CltvExpiryDelta(40)))))
     assert(invoice.sign(priv).toString == ref)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt11InvoiceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt11InvoiceSpec.scala
@@ -136,12 +136,12 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     assert(invoice.prefix == "lnbc")
     assert(invoice.amount_opt.isEmpty)
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
-    assert(invoice.paymentSecret.map(_.bytes) == Some(hex"1111111111111111111111111111111111111111111111111111111111111111"))
+    assert(invoice.paymentSecret.map(_.bytes).contains(hex"1111111111111111111111111111111111111111111111111111111111111111"))
     assert(invoice.features == Features(Features.VariableLengthOnion -> Mandatory, Features.PaymentSecret -> Mandatory))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Left("Please consider supporting this project"))
-    assert(invoice.fallbackAddress() == None)
+    assert(invoice.fallbackAddress().isEmpty)
     assert(invoice.tags.size == 4)
     assert(invoice.sign(priv).toString == ref)
   }
@@ -150,13 +150,13 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpu9qrsgquk0rl77nj30yxdy8j9vdx85fkpmdla2087ne0xh8nhedh8w27kyke0lp53ut353s06fv3qfegext0eh0ymjpf39tuven09sam30g4vgpfna3rh"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(250000000 msat))
+    assert(invoice.amount_opt.contains(250000000 msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
     assert(invoice.features == Features(Features.VariableLengthOnion -> Mandatory, Features.PaymentSecret -> Mandatory))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Left("1 cup coffee"))
-    assert(invoice.fallbackAddress() == None)
+    assert(invoice.fallbackAddress().isEmpty)
     assert(invoice.tags.size == 5)
     assert(invoice.sign(priv).toString == ref)
   }
@@ -165,13 +165,13 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc2500u1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpquwpc4curk03c9wlrswe78q4eyqc7d8d0xqzpu9qrsgqhtjpauu9ur7fw2thcl4y9vfvh4m9wlfyz2gem29g5ghe2aak2pm3ps8fdhtceqsaagty2vph7utlgj48u0ged6a337aewvraedendscp573dxr"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(250000000 msat))
+    assert(invoice.amount_opt.contains(250000000 msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
     assert(invoice.features == Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Left("ナンセンス 1杯"))
-    assert(invoice.fallbackAddress() == None)
+    assert(invoice.fallbackAddress().isEmpty)
     assert(invoice.tags.size == 5)
     assert(invoice.sign(priv).toString == ref)
   }
@@ -180,13 +180,13 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqs9qrsgq7ea976txfraylvgzuxs8kgcw23ezlrszfnh8r6qtfpr6cxga50aj6txm9rxrydzd06dfeawfk6swupvz4erwnyutnjq7x39ymw6j38gp7ynn44"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(2000000000 msat))
+    assert(invoice.amount_opt.contains(2000000000 msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
     assert(invoice.features == Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Right(Crypto.sha256(ByteVector("One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon".getBytes))))
-    assert(invoice.fallbackAddress() == None)
+    assert(invoice.fallbackAddress().isEmpty)
     assert(invoice.tags.size == 4)
     assert(invoice.sign(priv).toString == ref)
   }
@@ -195,13 +195,13 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lntb20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfpp3x9et2e20v6pu37c5d9vax37wxq72un989qrsgqdj545axuxtnfemtpwkc45hx9d2ft7x04mt8q7y6t0k2dge9e7h8kpy9p34ytyslj3yu569aalz2xdk8xkd7ltxqld94u8h2esmsmacgpghe9k8"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lntb")
-    assert(invoice.amount_opt == Some(2000000000 msat))
+    assert(invoice.amount_opt.contains(2000000000 msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
     assert(invoice.features == Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Right(Crypto.sha256(ByteVector.view("One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon".getBytes))))
-    assert(invoice.fallbackAddress() == Some("mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP"))
+    assert(invoice.fallbackAddress().contains("mk2QpYatsKicvFVuTAQLBryyccRXMUaGHP"))
     assert(invoice.tags.size == 5)
     assert(invoice.sign(priv).toString == ref)
   }
@@ -210,16 +210,16 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfpp3qjmp7lwpagxun9pygexvgpjdc4jdj85fr9yq20q82gphp2nflc7jtzrcazrra7wwgzxqc8u7754cdlpfrmccae92qgzqvzq2ps8pqqqqqqpqqqqq9qqqvpeuqafqxu92d8lr6fvg0r5gv0heeeqgcrqlnm6jhphu9y00rrhy4grqszsvpcgpy9qqqqqqgqqqqq7qqzq9qrsgqdfjcdk6w3ak5pca9hwfwfh63zrrz06wwfya0ydlzpgzxkn5xagsqz7x9j4jwe7yj7vaf2k9lqsdk45kts2fd0fkr28am0u4w95tt2nsq76cqw0"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(2000000000 msat))
+    assert(invoice.amount_opt.contains(2000000000 msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
     assert(invoice.features == Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Right(Crypto.sha256(ByteVector.view("One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon".getBytes))))
-    assert(invoice.fallbackAddress() == Some("1RustyRX2oai4EYYDpQGWvEL62BBGqN9T"))
+    assert(invoice.fallbackAddress().contains("1RustyRX2oai4EYYDpQGWvEL62BBGqN9T"))
     assert(invoice.routingInfo == List(List(
-      ExtraHop(PublicKey(hex"029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"), ShortChannelId("66051x263430x1800"), 1 msat, 20, CltvExpiryDelta(3)),
-      ExtraHop(PublicKey(hex"039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"), ShortChannelId("197637x395016x2314"), 2 msat, 30, CltvExpiryDelta(4))
+      ExtraHop(PublicKey(hex"029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"), ShortChannelId.fromCoordinates("66051x263430x1800").get, 1 msat, 20, CltvExpiryDelta(3)),
+      ExtraHop(PublicKey(hex"039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255"), ShortChannelId.fromCoordinates("197637x395016x2314").get, 2 msat, 30, CltvExpiryDelta(4))
     )))
     assert(invoice.tags.size == 6)
     assert(invoice.sign(priv).toString == ref)
@@ -229,13 +229,13 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfppj3a24vwu6r8ejrss3axul8rxldph2q7z99qrsgqz6qsgww34xlatfj6e3sngrwfy3ytkt29d2qttr8qz2mnedfqysuqypgqex4haa2h8fx3wnypranf3pdwyluftwe680jjcfp438u82xqphf75ym"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(2000000000 msat))
+    assert(invoice.amount_opt.contains(2000000000 msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
     assert(invoice.features == Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Right(Crypto.sha256(ByteVector.view("One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon".getBytes))))
-    assert(invoice.fallbackAddress() == Some("3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX"))
+    assert(invoice.fallbackAddress().contains("3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX"))
     assert(invoice.tags.size == 5)
     assert(invoice.sign(priv).toString == ref)
   }
@@ -244,13 +244,13 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfppqw508d6qejxtdg4y5r3zarvary0c5xw7k9qrsgqt29a0wturnys2hhxpner2e3plp6jyj8qx7548zr2z7ptgjjc7hljm98xhjym0dg52sdrvqamxdezkmqg4gdrvwwnf0kv2jdfnl4xatsqmrnsse"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(2000000000 msat))
+    assert(invoice.amount_opt.contains(2000000000 msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
     assert(invoice.features == Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Right(Crypto.sha256(ByteVector.view("One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon".getBytes))))
-    assert(invoice.fallbackAddress() == Some("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"))
+    assert(invoice.fallbackAddress().contains("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"))
     assert(invoice.tags.size == 5)
     assert(invoice.sign(priv).toString == ref)
   }
@@ -259,14 +259,14 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygshp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfp4qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q9qrsgq9vlvyj8cqvq6ggvpwd53jncp9nwc47xlrsnenq2zp70fq83qlgesn4u3uyf4tesfkkwwfg3qs54qe426hp3tz7z6sweqdjg05axsrjqp9yrrwc"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(2000000000 msat))
+    assert(invoice.amount_opt.contains(2000000000 msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
     assert(invoice.features == Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory))
     assert(!invoice.features.hasFeature(BasicMultiPartPayment))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Right(Crypto.sha256(ByteVector.view("One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon".getBytes))))
-    assert(invoice.fallbackAddress() == Some("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"))
+    assert(invoice.fallbackAddress().contains("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"))
     assert(invoice.tags.size == 5)
     assert(invoice.sign(priv).toString == ref)
   }
@@ -275,14 +275,14 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc20m1pvjluezsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygscqpvpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqsfp4qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q9qrsgq999fraffdzl6c8j7qd325dfurcq7vl0mfkdpdvve9fy3hy4lw0x9j3zcj2qdh5e5pyrp6cncvmxrhchgey64culwmjtw9wym74xm6xqqevh9r0"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(2000000000 msat))
+    assert(invoice.amount_opt.contains(2000000000 msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
     assert(invoice.features == Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory))
     assert(!invoice.features.hasFeature(BasicMultiPartPayment))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Right(Crypto.sha256(ByteVector.view("One piece of chocolate cake, one icecream cone, one pickle, one slice of swiss cheese, one slice of salami, one lollypop, one piece of cherry pie, one sausage, one cupcake, and one slice of watermelon".getBytes))))
-    assert(invoice.fallbackAddress() == Some("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"))
+    assert(invoice.fallbackAddress().contains("bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"))
     assert(invoice.minFinalCltvExpiryDelta == CltvExpiryDelta(12))
     assert(invoice.tags.size == 6)
     assert(invoice.sign(priv).toString == ref)
@@ -300,9 +300,9 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     for (ref <- refs) {
       val Success(invoice) = Bolt11Invoice.fromString(ref)
       assert(invoice.prefix == "lnbc")
-      assert(invoice.amount_opt == Some(2500000000L msat))
+      assert(invoice.amount_opt.contains(2500000000L msat))
       assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
-      assert(invoice.paymentSecret == Some(ByteVector32(hex"1111111111111111111111111111111111111111111111111111111111111111")))
+      assert(invoice.paymentSecret.contains(ByteVector32(hex"1111111111111111111111111111111111111111111111111111111111111111")))
       assert(invoice.createdAt == TimestampSecond(1496314658L))
       assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
       assert(invoice.description == Left("coffee beans"))
@@ -319,9 +319,9 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc25m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5vdhkven9v5sxyetpdeessp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q4psqqqqqqqqqqqqqqqqsgqtqyx5vggfcsll4wu246hz02kp85x4katwsk9639we5n5yngc3yhqkm35jnjw4len8vrnqnf5ejh0mzj9n3vz2px97evektfm2l6wqccp3y7372"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(2500000000L msat))
+    assert(invoice.amount_opt.contains(2500000000L msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
-    assert(invoice.paymentSecret == Some(ByteVector32(hex"1111111111111111111111111111111111111111111111111111111111111111")))
+    assert(invoice.paymentSecret.contains(ByteVector32(hex"1111111111111111111111111111111111111111111111111111111111111111")))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
     assert(invoice.description == Left("coffee beans"))
@@ -338,7 +338,7 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc9678785340p1pwmna7lpp5gc3xfm08u9qy06djf8dfflhugl6p7lgza6dsjxq454gxhj9t7a0sd8dgfkx7cmtwd68yetpd5s9xar0wfjn5gpc8qhrsdfq24f5ggrxdaezqsnvda3kkum5wfjkzmfqf3jkgem9wgsyuctwdus9xgrcyqcjcgpzgfskx6eqf9hzqnteypzxz7fzypfhg6trddjhygrcyqezcgpzfysywmm5ypxxjemgw3hxjmn8yptk7untd9hxwg3q2d6xjcmtv4ezq7pqxgsxzmnyyqcjqmt0wfjjq6t5v4khxsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygsxqyjw5qcqp2rzjq0gxwkzc8w6323m55m4jyxcjwmy7stt9hwkwe2qxmy8zpsgg7jcuwz87fcqqeuqqqyqqqqlgqqqqn3qq9q9qrsgqrvgkpnmps664wgkp43l22qsgdw4ve24aca4nymnxddlnp8vh9v2sdxlu5ywdxefsfvm0fq3sesf08uf6q9a2ke0hc9j6z6wlxg5z5kqpu2v9wz"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(967878534 msat))
+    assert(invoice.amount_opt.contains(967878534 msat))
     assert(invoice.paymentHash.bytes == hex"462264ede7e14047e9b249da94fefc47f41f7d02ee9b091815a5506bc8abf75f")
     assert(invoice.features == Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory))
     assert(TestConstants.Alice.nodeParams.features.invoiceFeatures().areSupported(invoice.features))
@@ -348,7 +348,7 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     assert(invoice.fallbackAddress().isEmpty)
     assert(invoice.relativeExpiry == 604800.seconds)
     assert(invoice.minFinalCltvExpiryDelta == CltvExpiryDelta(10))
-    assert(invoice.routingInfo == Seq(Seq(ExtraHop(PublicKey(hex"03d06758583bb5154774a6eb221b1276c9e82d65bbaceca806d90e20c108f4b1c7"), ShortChannelId("589390x3312x1"), 1000 msat, 2500, CltvExpiryDelta(40)))))
+    assert(invoice.routingInfo == Seq(Seq(ExtraHop(PublicKey(hex"03d06758583bb5154774a6eb221b1276c9e82d65bbaceca806d90e20c108f4b1c7"), ShortChannelId.fromCoordinates("589390x3312x1").get, 1000 msat, 2500, CltvExpiryDelta(40)))))
     assert(invoice.sign(priv).toString == ref)
   }
 
@@ -356,14 +356,14 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     val ref = "lnbc10m1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdp9wpshjmt9de6zqmt9w3skgct5vysxjmnnd9jx2mq8q8a04uqsp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygs9q2gqqqqqqsgq7hf8he7ecf7n4ffphs6awl9t6676rrclv9ckg3d3ncn7fct63p6s365duk5wrk202cfy3aj5xnnp5gs3vrdvruverwwq7yzhkf5a3xqpd05wjc"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
     assert(invoice.prefix == "lnbc")
-    assert(invoice.amount_opt == Some(1000000000 msat))
+    assert(invoice.amount_opt.contains(1000000000 msat))
     assert(invoice.paymentHash.bytes == hex"0001020304050607080900010203040506070809000102030405060708090102")
     assert(invoice.features == Features(VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory, PaymentMetadata -> Mandatory))
     assert(invoice.createdAt == TimestampSecond(1496314658L))
     assert(invoice.nodeId == PublicKey(hex"03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad"))
-    assert(invoice.paymentSecret == Some(ByteVector32(hex"1111111111111111111111111111111111111111111111111111111111111111")))
+    assert(invoice.paymentSecret.contains(ByteVector32(hex"1111111111111111111111111111111111111111111111111111111111111111")))
     assert(invoice.description == Left("payment metadata inside"))
-    assert(invoice.paymentMetadata == Some(hex"01fafaf0"))
+    assert(invoice.paymentMetadata.contains(hex"01fafaf0"))
     assert(invoice.tags.size == 5)
     assert(invoice.sign(priv).toString == ref)
   }
@@ -457,7 +457,7 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
   test("Pay 1 BTC without multiplier") {
     val ref = "lnbc1000m1pdkmqhusp5zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zyg3zygspp5n2ees808r98m0rh4472yyth0c5fptzcxmexcjznrzmq8xald0cgqdqsf4ujqarfwqsxymmccqp2pv37ezvhth477nu0yhhjlcry372eef57qmldhreqnr0kx82jkupp3n7nw42u3kdyyjskdr8jhjy2vugr3skdmy8ersft36969xplkxsp2v7c58"
     val Success(invoice) = Bolt11Invoice.fromString(ref)
-    assert(invoice.amount_opt == Some(100000000000L msat))
+    assert(invoice.amount_opt.contains(100000000000L msat))
     assert(features2bits(invoice.features) == BitVector.empty)
   }
 
@@ -519,7 +519,7 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
 
     val Success(pr2) = Bolt11Invoice.fromString("lnbc40n1pw9qjvwpp5qq3w2ln6krepcslqszkrsfzwy49y0407hvks30ec6pu9s07jur3sdpstfshq5n9v9jzucm0d5s8vmm5v5s8qmmnwssyj3p6yqenwdencqzysxqrrss7ju0s4dwx6w8a95a9p2xc5vudl09gjl0w2n02sjrvffde632nxwh2l4w35nqepj4j5njhh4z65wyfc724yj6dn9wajvajfn5j7em6wsq2elakl")
     assert(!pr2.features.hasFeature(PaymentSecret, Some(Mandatory)))
-    assert(pr2.paymentSecret == None)
+    assert(pr2.paymentSecret.isEmpty)
 
     // An invoice that sets the payment secret feature bit must provide a payment secret.
     assert(Bolt11Invoice.fromString("lnbc1230p1pwljzn3pp5qyqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqdq52dhk6efqd9h8vmmfvdjs9qypqsqylvwhf7xlpy6xpecsnpcjjuuslmzzgeyv90mh7k7vs88k2dkxgrkt75qyfjv5ckygw206re7spga5zfd4agtdvtktxh5pkjzhn9dq2cqz9upw7").isFailure)
@@ -627,7 +627,7 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
     assert(Bolt11Invoice.fromString(invoice.toString).get == invoice)
   }
 
-  test("Invoices can't have high features"){
+  test("Invoices can't have high features") {
     assertThrows[Exception](createInvoiceUnsafe(Block.LivenetGenesisBlock.hash, Some(123 msat), ByteVector32.One, priv, Left("Some invoice"), CltvExpiryDelta(18), features = Features[Feature](Map[Feature, FeatureSupport](VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory), Set(UnknownFeature(424242)))))
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -19,7 +19,6 @@ package fr.acinq.eclair.router
 import com.softwaremill.quicklens.ModifyPimp
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, ByteVector64, Satoshi, SatoshiLong}
-import fr.acinq.eclair.RealShortChannelId
 import fr.acinq.eclair.payment.Bolt11Invoice.ExtraHop
 import fr.acinq.eclair.payment.relay.Relayer.RelayFees
 import fr.acinq.eclair.router.BaseRouterSpec.channelHopFromUpdate
@@ -30,7 +29,7 @@ import fr.acinq.eclair.router.RouteCalculation._
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{BlockHeight, CltvExpiryDelta, Features, MilliSatoshi, MilliSatoshiLong, RealShortChannelId, ShortChannelId, TimestampSecond, TimestampSecondLong, ToMilliSatoshiConversion, randomKey}
+import fr.acinq.eclair.{BlockHeight, CltvExpiryDelta, Features, MilliSatoshi, MilliSatoshiLong, RealShortChannelId, ShortChannelId, ShortChannelIdSpec, TimestampSecond, TimestampSecondLong, ToMilliSatoshiConversion, randomKey}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.{ParallelTestExecution, Tag}
 import scodec.bits._
@@ -849,12 +848,12 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     val currentBlockHeight = BlockHeight(554000)
 
     val g = DirectedGraph(List(
-      makeEdge(ShortChannelId(s"${currentBlockHeight.toLong}x0x1").toLong, a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeEdge(ShortChannelId(s"${currentBlockHeight.toLong}x0x4").toLong, a, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeEdge(ShortChannelId(s"${currentBlockHeight.toLong - 3000}x0x2").toLong, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)), // younger channel
-      makeEdge(ShortChannelId(s"${currentBlockHeight.toLong - 3000}x0x3").toLong, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeEdge(ShortChannelId(s"${currentBlockHeight.toLong}x0x5").toLong, e, f, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
-      makeEdge(ShortChannelId(s"${currentBlockHeight.toLong}x0x6").toLong, f, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144))
+      makeEdge(ShortChannelId.fromCoordinates(s"${currentBlockHeight.toLong}x0x1").get.toLong, a, b, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(ShortChannelId.fromCoordinates(s"${currentBlockHeight.toLong}x0x4").get.toLong, a, e, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(ShortChannelId.fromCoordinates(s"${currentBlockHeight.toLong - 3000}x0x2").get.toLong, b, c, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)), // younger channel
+      makeEdge(ShortChannelId.fromCoordinates(s"${currentBlockHeight.toLong - 3000}x0x3").get.toLong, c, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(ShortChannelId.fromCoordinates(s"${currentBlockHeight.toLong}x0x5").get.toLong, e, f, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144)),
+      makeEdge(ShortChannelId.fromCoordinates(s"${currentBlockHeight.toLong}x0x6").get.toLong, f, d, feeBase = 1 msat, 0, minHtlc = 0 msat, maxHtlc = None, cltvDelta = CltvExpiryDelta(144))
     ))
 
     val Success(routeScoreOptimized :: Nil) = findRoute(g, a, d, DEFAULT_AMOUNT_MSAT / 2, DEFAULT_MAX_FEE, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS.copy(heuristics = Left(WeightRatios(
@@ -917,27 +916,27 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     // then if the cost function is not monotonic the path-finding breaks because the result path contains a loop.
     val updates = SortedMap(
       RealShortChannelId(BlockHeight(565643), 1216, 0) -> PublicChannel(
-        ann = makeChannel(ShortChannelId("565643x1216x0").toLong, PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"), PublicKey(hex"024655b768ef40951b20053a5c4b951606d4d86085d51238f2c67c7dec29c792ca")),
+        ann = makeChannel(ShortChannelId.fromCoordinates("565643x1216x0").get.toLong, PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"), PublicKey(hex"024655b768ef40951b20053a5c4b951606d4d86085d51238f2c67c7dec29c792ca")),
         fundingTxid = ByteVector32.Zeroes,
         capacity = DEFAULT_CAPACITY,
-        update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565643x1216x0"), 0 unixsec, ChannelUpdate.ChannelFlags.DUMMY, CltvExpiryDelta(14), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 10, Some(4294967295L msat))),
-        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565643x1216x0"), 0 unixsec, ChannelUpdate.ChannelFlags(isEnabled = true, isNode1 = false), CltvExpiryDelta(144), htlcMinimumMsat = 0 msat, feeBaseMsat = 1000 msat, 100, Some(15000000000L msat))),
+        update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId.fromCoordinates("565643x1216x0").get, 0 unixsec, ChannelUpdate.ChannelFlags.DUMMY, CltvExpiryDelta(14), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 10, Some(4294967295L msat))),
+        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId.fromCoordinates("565643x1216x0").get, 0 unixsec, ChannelUpdate.ChannelFlags(isEnabled = true, isNode1 = false), CltvExpiryDelta(144), htlcMinimumMsat = 0 msat, feeBaseMsat = 1000 msat, 100, Some(15000000000L msat))),
         meta_opt = None
       ),
       RealShortChannelId(BlockHeight(542280), 2156, 0) -> PublicChannel(
-        ann = makeChannel(ShortChannelId("542280x2156x0").toLong, PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"), PublicKey(hex"03cb7983dc247f9f81a0fa2dfa3ce1c255365f7279c8dd143e086ca333df10e278")),
+        ann = makeChannel(ShortChannelId.fromCoordinates("542280x2156x0").get.toLong, PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"), PublicKey(hex"03cb7983dc247f9f81a0fa2dfa3ce1c255365f7279c8dd143e086ca333df10e278")),
         fundingTxid = ByteVector32.Zeroes,
         capacity = DEFAULT_CAPACITY,
-        update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("542280x2156x0"), 0 unixsec, ChannelUpdate.ChannelFlags.DUMMY, CltvExpiryDelta(144), htlcMinimumMsat = 1000 msat, feeBaseMsat = 1000 msat, 100, Some(16777000000L msat))),
-        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("542280x2156x0"), 0 unixsec, ChannelUpdate.ChannelFlags(isEnabled = true, isNode1 = false), CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 667 msat, 1, Some(16777000000L msat))),
+        update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId.fromCoordinates("542280x2156x0").get, 0 unixsec, ChannelUpdate.ChannelFlags.DUMMY, CltvExpiryDelta(144), htlcMinimumMsat = 1000 msat, feeBaseMsat = 1000 msat, 100, Some(16777000000L msat))),
+        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId.fromCoordinates("542280x2156x0").get, 0 unixsec, ChannelUpdate.ChannelFlags(isEnabled = true, isNode1 = false), CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 667 msat, 1, Some(16777000000L msat))),
         meta_opt = None
       ),
       RealShortChannelId(BlockHeight(565779), 2711, 0) -> PublicChannel(
-        ann = makeChannel(ShortChannelId("565779x2711x0").toLong, PublicKey(hex"036d65409c41ab7380a43448f257809e7496b52bf92057c09c4f300cbd61c50d96"), PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f")),
+        ann = makeChannel(ShortChannelId.fromCoordinates("565779x2711x0").get.toLong, PublicKey(hex"036d65409c41ab7380a43448f257809e7496b52bf92057c09c4f300cbd61c50d96"), PublicKey(hex"03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f")),
         fundingTxid = ByteVector32.Zeroes,
         capacity = DEFAULT_CAPACITY,
-        update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565779x2711x0"), 0 unixsec, ChannelUpdate.ChannelFlags.DUMMY, CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 100, Some(230000000L msat))),
-        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId("565779x2711x0"), 0 unixsec, ChannelUpdate.ChannelFlags(isEnabled = false, isNode1 = false), CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 100, Some(230000000L msat))),
+        update_1_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId.fromCoordinates("565779x2711x0").get, 0 unixsec, ChannelUpdate.ChannelFlags.DUMMY, CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 100, Some(230000000L msat))),
+        update_2_opt = Some(ChannelUpdate(ByteVector64.Zeroes, ByteVector32.Zeroes, ShortChannelId.fromCoordinates("565779x2711x0").get, 0 unixsec, ChannelUpdate.ChannelFlags(isEnabled = false, isNode1 = false), CltvExpiryDelta(144), htlcMinimumMsat = 1 msat, feeBaseMsat = 1000 msat, 100, Some(230000000L msat))),
         meta_opt = None
       )
     )
@@ -1871,7 +1870,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
   test("use direct channel when available") {
     // A ===> B ===> C
     //  \___________/
-    val recentChannelId = ShortChannelId("399990x1x2").toLong
+    val recentChannelId = ShortChannelId.fromCoordinates("399990x1x2").get.toLong
     val g = DirectedGraph(List(
       makeEdge(1L, a, b, 1 msat, 1, capacity = 100_000_000 sat),
       makeEdge(2L, b, c, 1 msat, 1, capacity = 100_000_000 sat),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/ExtendedQueriesCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/ExtendedQueriesCodecsSpec.scala
@@ -17,12 +17,10 @@
 package fr.acinq.eclair.wire.protocol
 
 import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, ByteVector64}
-import fr.acinq.eclair.RealShortChannelId
-import fr.acinq.eclair.RealShortChannelId
 import fr.acinq.eclair.router.Sync
 import fr.acinq.eclair.wire.protocol.LightningMessageCodecs._
 import fr.acinq.eclair.wire.protocol.ReplyChannelRangeTlv._
-import fr.acinq.eclair.{BlockHeight, CltvExpiryDelta, MilliSatoshiLong, ShortChannelId, TimestampSecond, TimestampSecondLong, UInt64}
+import fr.acinq.eclair.{BlockHeight, CltvExpiryDelta, MilliSatoshiLong, RealShortChannelId, ShortChannelId, TimestampSecond, TimestampSecondLong, UInt64}
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits._
 
@@ -152,7 +150,7 @@ class ExtendedQueriesCodecsSpec extends AnyFunSuite {
     val update = ChannelUpdate(
       chainHash = ByteVector32.fromValidHex("06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f"),
       signature = ByteVector64.fromValidHex("76df7e70c63cc2b63ef1c062b99c6d934a80ef2fd4dae9e1d86d277f47674af3255a97fa52ade7f129263f591ed784996eba6383135896cc117a438c80293282"),
-      shortChannelId = ShortChannelId("103x1x0"),
+      shortChannelId = ShortChannelId.fromCoordinates("103x1x0").get,
       timestamp = TimestampSecond(1565587763L),
       channelFlags = ChannelUpdate.ChannelFlags.DUMMY,
       cltvExpiryDelta = CltvExpiryDelta(144),
@@ -172,7 +170,7 @@ class ExtendedQueriesCodecsSpec extends AnyFunSuite {
     val update = ChannelUpdate(
       chainHash = ByteVector32.fromValidHex("06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f"),
       signature = ByteVector64.fromValidHex("06737e9e18d3e4d0ab4066ccaecdcc10e648c5f1c5413f1610747e0d463fa7fa39c1b02ea2fd694275ecfefe4fe9631f24afd182ab75b805e16cd550941f858c"),
-      shortChannelId = ShortChannelId("109x1x0"),
+      shortChannelId = ShortChannelId.fromCoordinates("109x1x0").get,
       timestamp = TimestampSecond(1565587765L),
       channelFlags = ChannelUpdate.ChannelFlags.DUMMY,
       cltvExpiryDelta = CltvExpiryDelta(48),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/ExtendedQueriesCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/ExtendedQueriesCodecsSpec.scala
@@ -21,6 +21,7 @@ import fr.acinq.eclair.router.Sync
 import fr.acinq.eclair.wire.protocol.LightningMessageCodecs._
 import fr.acinq.eclair.wire.protocol.ReplyChannelRangeTlv._
 import fr.acinq.eclair.{BlockHeight, CltvExpiryDelta, MilliSatoshiLong, RealShortChannelId, ShortChannelId, TimestampSecond, TimestampSecondLong, UInt64}
+import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits._
 
@@ -150,7 +151,7 @@ class ExtendedQueriesCodecsSpec extends AnyFunSuite {
     val update = ChannelUpdate(
       chainHash = ByteVector32.fromValidHex("06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f"),
       signature = ByteVector64.fromValidHex("76df7e70c63cc2b63ef1c062b99c6d934a80ef2fd4dae9e1d86d277f47674af3255a97fa52ade7f129263f591ed784996eba6383135896cc117a438c80293282"),
-      shortChannelId = ShortChannelId.fromCoordinates("103x1x0").get,
+      shortChannelId = ShortChannelId.fromCoordinates("103x1x0").success.value,
       timestamp = TimestampSecond(1565587763L),
       channelFlags = ChannelUpdate.ChannelFlags.DUMMY,
       cltvExpiryDelta = CltvExpiryDelta(144),
@@ -170,7 +171,7 @@ class ExtendedQueriesCodecsSpec extends AnyFunSuite {
     val update = ChannelUpdate(
       chainHash = ByteVector32.fromValidHex("06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f"),
       signature = ByteVector64.fromValidHex("06737e9e18d3e4d0ab4066ccaecdcc10e648c5f1c5413f1610747e0d463fa7fa39c1b02ea2fd694275ecfefe4fe9631f24afd182ab75b805e16cd550941f858c"),
-      shortChannelId = ShortChannelId.fromCoordinates("109x1x0").get,
+      shortChannelId = ShortChannelId.fromCoordinates("109x1x0").success.value,
       timestamp = TimestampSecond(1565587765L),
       channelFlags = ChannelUpdate.ChannelFlags.DUMMY,
       cltvExpiryDelta = CltvExpiryDelta(48),

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/serde/FormParamExtractors.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/serde/FormParamExtractors.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.Bolt11Invoice
 import fr.acinq.eclair.wire.protocol.MessageOnionCodecs.blindedRouteCodec
-import fr.acinq.eclair.{UnspecifiedShortChannelId, MilliSatoshi, ShortChannelId, TimestampSecond}
+import fr.acinq.eclair.{MilliSatoshi, ShortChannelId, TimestampSecond}
 import scodec.bits.ByteVector
 
 import java.util.UUID
@@ -46,9 +46,9 @@ object FormParamExtractors {
 
   implicit val bolt11Unmarshaller: Unmarshaller[String, Bolt11Invoice] = Unmarshaller.strict { rawRequest => Bolt11Invoice.fromString(rawRequest).get }
 
-  implicit val shortChannelIdUnmarshaller: Unmarshaller[String, ShortChannelId] = Unmarshaller.strict { str => ShortChannelId(str) }
+  implicit val shortChannelIdUnmarshaller: Unmarshaller[String, ShortChannelId] = Unmarshaller.strict { str => ShortChannelId.fromCoordinates(str).get }
 
-  implicit val shortChannelIdsUnmarshaller: Unmarshaller[String, List[ShortChannelId]] = listUnmarshaller(str => ShortChannelId(str))
+  implicit val shortChannelIdsUnmarshaller: Unmarshaller[String, List[ShortChannelId]] = listUnmarshaller(str => ShortChannelId.fromCoordinates(str).get)
 
   implicit val javaUUIDUnmarshaller: Unmarshaller[String, UUID] = Unmarshaller.strict { str => UUID.fromString(str) }
 

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -50,6 +50,7 @@ import fr.acinq.eclair.router.Router.{ChannelRelayParams, PredefinedNodeRoute}
 import fr.acinq.eclair.wire.protocol._
 import org.json4s.{Formats, Serialization}
 import org.mockito.scalatest.IdiomaticMockito
+import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import scodec.bits._
@@ -380,7 +381,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
 
   test("'close' method should accept shortChannelIds") {
     val shortChannelIdSerialized = "42000x27x3"
-    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
     val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
     val channelIdSerialized = channelId.toHex
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
@@ -408,7 +409,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
 
   test("'close' method should accept channelIds") {
     val shortChannelIdSerialized = "42000x27x3"
-    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
     val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
     val channelIdSerialized = channelId.toHex
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
@@ -436,7 +437,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
 
   test("'close' method should accept channelIds and shortChannelIds") {
     val shortChannelIdSerialized = "42000x27x3"
-    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
     val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
     val channelIdSerialized = channelId.toHex
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
@@ -457,14 +458,14 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == OK)
         val resp = entityAs[String]
-        eclair.close(Left(channelId) :: Right(ShortChannelId.fromCoordinates("42000x27x3").get) :: Right(ShortChannelId.fromCoordinates("42000x561x1").get) :: Nil, None, None)(any[Timeout]).wasCalled(once)
+        eclair.close(Left(channelId) :: Right(ShortChannelId.fromCoordinates("42000x27x3").success.value) :: Right(ShortChannelId.fromCoordinates("42000x561x1").success.value) :: Nil, None, None)(any[Timeout]).wasCalled(once)
         matchTestJson("close", resp)
       }
   }
 
   test("'close' accepts custom closing feerates 1") {
     val shortChannelIdSerialized = "1701x42x3"
-    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
@@ -487,7 +488,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
 
   test("'close' accepts custom closing feerates 2") {
     val shortChannelIdSerialized = "1701x42x3"
-    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
@@ -510,7 +511,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
 
   test("'close' accepts custom closing feerates 3") {
     val shortChannelIdSerialized = "1701x42x3"
-    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
@@ -533,7 +534,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
 
   test("'close' accepts custom closing feerates 4") {
     val shortChannelIdSerialized = "1701x42x3"
-    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -380,12 +380,13 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
 
   test("'close' method should accept shortChannelIds") {
     val shortChannelIdSerialized = "42000x27x3"
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
     val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
     val channelIdSerialized = channelId.toHex
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
       Left(channelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), channelId)),
       Left(channelId.reverse) -> Left(new RuntimeException("channel not found")),
-      Right(ShortChannelId(shortChannelIdSerialized)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
+      Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
     )
 
     val eclair = mock[Eclair]
@@ -400,19 +401,20 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == OK)
         val resp = entityAs[String]
-        eclair.close(Right(ShortChannelId(shortChannelIdSerialized)) :: Nil, None, None)(any[Timeout]).wasCalled(once)
+        eclair.close(Right(shortChannelId) :: Nil, None, None)(any[Timeout]).wasCalled(once)
         matchTestJson("close", resp)
       }
   }
 
   test("'close' method should accept channelIds") {
     val shortChannelIdSerialized = "42000x27x3"
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
     val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
     val channelIdSerialized = channelId.toHex
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
       Left(channelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), channelId)),
       Left(channelId.reverse) -> Left(new RuntimeException("channel not found")),
-      Right(ShortChannelId(shortChannelIdSerialized)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
+      Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
     )
 
     val eclair = mock[Eclair]
@@ -434,12 +436,13 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
 
   test("'close' method should accept channelIds and shortChannelIds") {
     val shortChannelIdSerialized = "42000x27x3"
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
     val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
     val channelIdSerialized = channelId.toHex
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
       Left(channelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), channelId)),
       Left(channelId.reverse) -> Left(new RuntimeException("channel not found")),
-      Right(ShortChannelId(shortChannelIdSerialized)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
+      Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
     )
 
     val eclair = mock[Eclair]
@@ -454,22 +457,23 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == OK)
         val resp = entityAs[String]
-        eclair.close(Left(channelId) :: Right(ShortChannelId("42000x27x3")) :: Right(ShortChannelId("42000x561x1")) :: Nil, None, None)(any[Timeout]).wasCalled(once)
+        eclair.close(Left(channelId) :: Right(ShortChannelId.fromCoordinates("42000x27x3").get) :: Right(ShortChannelId.fromCoordinates("42000x561x1").get) :: Nil, None, None)(any[Timeout]).wasCalled(once)
         matchTestJson("close", resp)
       }
   }
 
   test("'close' accepts custom closing feerates 1") {
-    val shortChannelId = "1701x42x3"
+    val shortChannelIdSerialized = "1701x42x3"
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
-      Right(ShortChannelId(shortChannelId)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
+      Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
 
     val eclair = mock[Eclair]
     eclair.close(any, any, any)(any[Timeout]) returns Future.successful(response)
     val mockService = new MockService(eclair)
 
-    Post("/close", FormData("shortChannelId" -> shortChannelId, "preferredFeerateSatByte" -> "10", "minFeerateSatByte" -> "2", "maxFeerateSatByte" -> "50").toEntity) ~>
+    Post("/close", FormData("shortChannelId" -> shortChannelIdSerialized, "preferredFeerateSatByte" -> "10", "minFeerateSatByte" -> "2", "maxFeerateSatByte" -> "50").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
       addHeader("Content-Type", "application/json") ~>
       Route.seal(mockService.close) ~>
@@ -477,21 +481,22 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == OK)
         val expectedFeerates = ClosingFeerates(FeeratePerKw(2500 sat), FeeratePerKw(500 sat), FeeratePerKw(12500 sat))
-        eclair.close(Right(ShortChannelId(shortChannelId)) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
+        eclair.close(Right(shortChannelId) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
       }
   }
 
   test("'close' accepts custom closing feerates 2") {
-    val shortChannelId = "1701x42x3"
+    val shortChannelIdSerialized = "1701x42x3"
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
-      Right(ShortChannelId(shortChannelId)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
+      Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
 
     val eclair = mock[Eclair]
     eclair.close(any, any, any)(any[Timeout]) returns Future.successful(response)
     val mockService = new MockService(eclair)
 
-    Post("/close", FormData("shortChannelId" -> shortChannelId, "preferredFeerateSatByte" -> "10").toEntity) ~>
+    Post("/close", FormData("shortChannelId" -> shortChannelIdSerialized, "preferredFeerateSatByte" -> "10").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
       addHeader("Content-Type", "application/json") ~>
       Route.seal(mockService.close) ~>
@@ -499,21 +504,22 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == OK)
         val expectedFeerates = ClosingFeerates(FeeratePerKw(2500 sat), FeeratePerKw(1250 sat), FeeratePerKw(5000 sat))
-        eclair.close(Right(ShortChannelId(shortChannelId)) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
+        eclair.close(Right(shortChannelId) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
       }
   }
 
   test("'close' accepts custom closing feerates 3") {
-    val shortChannelId = "1701x42x3"
+    val shortChannelIdSerialized = "1701x42x3"
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
-      Right(ShortChannelId(shortChannelId)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
+      Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
 
     val eclair = mock[Eclair]
     eclair.close(any, any, any)(any[Timeout]) returns Future.successful(response)
     val mockService = new MockService(eclair)
 
-    Post("/close", FormData("shortChannelId" -> shortChannelId, "preferredFeerateSatByte" -> "10", "minFeerateSatByte" -> "2").toEntity) ~>
+    Post("/close", FormData("shortChannelId" -> shortChannelIdSerialized, "preferredFeerateSatByte" -> "10", "minFeerateSatByte" -> "2").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
       addHeader("Content-Type", "application/json") ~>
       Route.seal(mockService.close) ~>
@@ -521,21 +527,22 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == OK)
         val expectedFeerates = ClosingFeerates(FeeratePerKw(2500 sat), FeeratePerKw(500 sat), FeeratePerKw(5000 sat))
-        eclair.close(Right(ShortChannelId(shortChannelId)) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
+        eclair.close(Right(shortChannelId) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
       }
   }
 
   test("'close' accepts custom closing feerates 4") {
-    val shortChannelId = "1701x42x3"
+    val shortChannelIdSerialized = "1701x42x3"
+    val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).get
     val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
-      Right(ShortChannelId(shortChannelId)) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
+      Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
 
     val eclair = mock[Eclair]
     eclair.close(any, any, any)(any[Timeout]) returns Future.successful(response)
     val mockService = new MockService(eclair)
 
-    Post("/close", FormData("shortChannelId" -> shortChannelId, "preferredFeerateSatByte" -> "10", "maxFeerateSatByte" -> "50").toEntity) ~>
+    Post("/close", FormData("shortChannelId" -> shortChannelIdSerialized, "preferredFeerateSatByte" -> "10", "maxFeerateSatByte" -> "50").toEntity) ~>
       addCredentials(BasicHttpCredentials("", mockApi().password)) ~>
       addHeader("Content-Type", "application/json") ~>
       Route.seal(mockService.close) ~>
@@ -543,7 +550,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         assert(handled)
         assert(status == OK)
         val expectedFeerates = ClosingFeerates(FeeratePerKw(2500 sat), FeeratePerKw(1250 sat), FeeratePerKw(12500 sat))
-        eclair.close(Right(ShortChannelId(shortChannelId)) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
+        eclair.close(Right(shortChannelId) :: Nil, None, Some(expectedFeerates))(any[Timeout]).wasCalled(once)
       }
   }
 
@@ -1004,7 +1011,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
       htlcMaximumMsat = None
     )
     val mockChannelUpdate2 = mockChannelUpdate1.copy(shortChannelId = RealShortChannelId(BlockHeight(1), 2, 4))
-    val mockChannelUpdate3 = mockChannelUpdate1.copy(shortChannelId = RealShortChannelId (BlockHeight(1), 2, 5))
+    val mockChannelUpdate3 = mockChannelUpdate1.copy(shortChannelId = RealShortChannelId(BlockHeight(1), 2, 5))
 
     val mockHop1 = Router.ChannelHop(mockChannelUpdate1.shortChannelId, PublicKey.fromBin(ByteVector.fromValidHex("03007e67dc5a8fd2b2ef21cb310ab6359ddb51f3f86a8b79b8b1e23bc3a6ea150a")), PublicKey.fromBin(ByteVector.fromValidHex("026105f6cb4862810be989385d16f04b0f748f6f2a14040338b1a534d45b4be1c1")), ChannelRelayParams.FromAnnouncement(mockChannelUpdate1))
     val mockHop2 = Router.ChannelHop(mockChannelUpdate2.shortChannelId, mockHop1.nextNodeId, PublicKey.fromBin(ByteVector.fromValidHex("038cfa2b5857843ee90cff91b06f692c0d8fe201921ee6387aee901d64f43699f0")), ChannelRelayParams.FromAnnouncement(mockChannelUpdate2))


### PR DESCRIPTION
This is a conversion that can fail by throwing an exception, which is dangerous.
It's only used in tests, so we're moving this to a test file to ensure we don't accidentally use it in non-test code.