### PR TITLE
Expose scraping endpoint for prometheus metrics

### DIFF
--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -68,7 +68,7 @@ kamon {
       port = <port to expose to prometheus>
     }
   }
-}
+}```
 
 You should then configure your Prometheus process to scrape metrics from the exposed http server. 
 * Download Prometheus [here](https://prometheus.io/download/).

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -52,6 +52,14 @@ To enable monitoring with Prometheus, add the following to your `eclair.conf`:
 
 ```config
 eclair.enable-kamon=true
+
+// The Kamon APM reporter is enabled by default, but it won't work with Prometheus, so we disable it.
+kamon.modules {
+  apm-reporter {
+    enabled = false
+  }
+}
+
 kamon {
   prometheus {
     start-embedded-http-server = yes
@@ -61,16 +69,6 @@ kamon {
     }
   }
 }
-```
-Note: By default kamon apm reporter will initialize when you enable kamon in eclair.conf. To disable kamon apm-reporter, add following to your `eclair.conf`
-```disable
-eclair.enable-kamon=true
-kamon.modules {
-  apm-reporter {
-    enabled = false
-  }
-} 
-```
 
 You should then configure your Prometheus process to scrape metrics from the exposed http server. 
 * Download the Prometheus from [here](https://prometheus.io/download/).

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -69,7 +69,8 @@ kamon {
       port = <port to expose to prometheus>
     }
   }
-}```
+}
+```
 
 You should then configure your Prometheus process to scrape metrics from the exposed http server. 
 * Download Prometheus [here](https://prometheus.io/download/).
@@ -94,3 +95,4 @@ metrics are just a small sample of all the metrics we provide:
 * Number of connected peers
 * Bitcoin wallet balance
 * Various metrics about the public graph (nodes, channels, updates, etc)
+```

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -33,6 +33,7 @@ kamon {
 }
 ```
 
+
 When starting eclair, you should enable the Kanela agent:
 
 ```sh

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -83,7 +83,8 @@ global:
 scrape_configs:
   - job_name: 'eclair'
     static_configs:
-      - targets: ['<url of the eclair http embedded server>']```
+      - targets: ['<url of the eclair http embedded server>']
+ ```
 
 ## Example metrics
 
@@ -95,4 +96,4 @@ metrics are just a small sample of all the metrics we provide:
 * Number of connected peers
 * Bitcoin wallet balance
 * Various metrics about the public graph (nodes, channels, updates, etc)
-```
+

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -42,14 +42,61 @@ eclair.sh -with-kanela
 Your eclair node will start exporting monitoring data to Kamon.
 You can then start creating dashboards, graphs and alerts directly on Kamon's website.
 
-## Enabling monitoring with a different backend
+## Enabling monitoring with Prometheus
 
 Kamon supports many other monitoring [backends](https://kamon.io/docs/latest/reporters/).
 This can be useful for nodes that don't want to export any data to third-party servers.
 
-No specific work has been done yet in eclair to support these backends. If you'd like to use them,
-don't hesitate to ask around or send a PR.
+Eclair currently supports exporting metrics to [Prometheus](https://kamon.io/docs/latest/reporters/prometheus/).
+To enable monitoring with Prometheus, add the following to your `eclair.conf`:
 
+```config
+eclair.enable-kamon=true
+kamon {
+  prometheus {
+    start-embedded-http-server = yes
+    embedded-server {
+      hostname = 0.0.0.0
+      port = <port to expose to prometheus>
+    }
+  }
+}
+```
+Note: By default kamon apm reporter will initialize when you enable kamon in eclair.conf. To disable kamon apm-reporter, add following to your `eclair.conf`
+```disable
+eclair.enable-kamon=true
+kamon.modules {
+  apm-reporter {
+    enabled = false
+  }
+} 
+```
+
+You should then configure your Prometheus process to scrape metrics from the exposed http server. 
+* Download the Prometheus from [here](https://prometheus.io/download/).
+* Configure the `prometheus.yml` file present in prometheus repository and add following in it
+```prometheus.yml
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+
+  # Attach these labels to any time series or alerts when communicating with
+  # external systems (federation, remote storage, Alertmanager).
+  external_labels:
+    monitor: 'codelab-monitor'
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: 'eclair'
+
+    # Override the global default and scrape targets from this job every 5 seconds.
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['0.0.0.0:9090']
+```
+After making changes in the prometheus.yml file, start Prometheus and check the status of Prometheus by `sudo systemctl status prometheus`. If it is actively running, you can visit the Prometheus web interface at a specified target in `prometheus.yml`.
 ## Example metrics
 
 Apart from akka and system metrics, eclair generates a lot of lightning metrics. The following

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -30,7 +30,8 @@ kamon {
     sampler = "random"
   }
 
-}```
+}
+```
 
 When starting eclair, you should enable the Kanela agent:
 

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -80,8 +80,8 @@ global:
 scrape_configs:
   - job_name: 'eclair'
     static_configs:
-      - targets: ['<url of the eclair http embedded server>']
-After making changes in the prometheus.yml file, start Prometheus and check the status of Prometheus by `sudo systemctl status prometheus`. If it is actively running, you can visit the Prometheus web interface at a specified target in `prometheus.yml`.
+      - targets: ['<url of the eclair http embedded server>']```
+
 ## Example metrics
 
 Apart from akka and system metrics, eclair generates a lot of lightning metrics. The following

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -30,8 +30,7 @@ kamon {
     sampler = "random"
   }
 
-}
-```
+}```
 
 When starting eclair, you should enable the Kanela agent:
 

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -71,8 +71,9 @@ kamon {
 }
 
 You should then configure your Prometheus process to scrape metrics from the exposed http server. 
-* Download the Prometheus from [here](https://prometheus.io/download/).
-* Configure the `prometheus.yml` file present in prometheus repository and add following in it
+* Download Prometheus [here](https://prometheus.io/download/).
+* Add the following configuration to the `prometheus.yml` file (see the [Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/) for more details)
+
 ```prometheus.yml
 global:
   scrape_interval:     15s # By default, scrape targets every 15 seconds.

--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -78,23 +78,10 @@ You should then configure your Prometheus process to scrape metrics from the exp
 global:
   scrape_interval:     15s # By default, scrape targets every 15 seconds.
 
-  # Attach these labels to any time series or alerts when communicating with
-  # external systems (federation, remote storage, Alertmanager).
-  external_labels:
-    monitor: 'codelab-monitor'
-
-# A scrape configuration containing exactly one endpoint to scrape:
-# Here it's Prometheus itself.
 scrape_configs:
-  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
   - job_name: 'eclair'
-
-    # Override the global default and scrape targets from this job every 5 seconds.
-    scrape_interval: 5s
-
     static_configs:
-      - targets: ['0.0.0.0:9090']
-```
+      - targets: ['<url of the eclair http embedded server>']
 After making changes in the prometheus.yml file, start Prometheus and check the status of Prometheus by `sudo systemctl status prometheus`. If it is actively running, you can visit the Prometheus web interface at a specified target in `prometheus.yml`.
 ## Example metrics
 

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -272,6 +272,11 @@
         <!-- MONITORING -->
         <dependency>
             <groupId>io.kamon</groupId>
+            <artifactId>kamon-prometheus_${scala.version.short}</artifactId>
+            <version>2.5.4</version>
+        </dependency>
+        <dependency>
+            <groupId>io.kamon</groupId>
             <artifactId>kamon-core_${scala.version.short}</artifactId>
             <version>${kamon.version}</version>
         </dependency>

--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -43,6 +43,15 @@ kamon.instrumentation.akka {
     }
   }
 }
+// See documentation here: https://kamon.io/docs/latest/reporters/prometheus/
+kamon.prometheus {
+  // If you want to expose a scraping endpoint for Prometheus metrics, set this to true.
+  start-embedded-http-server = no
+  embedded-server {
+    hostname = 0.0.0.0
+    port = 9095
+  }
+}
 
 kanela.modules {
   jdbc {


### PR DESCRIPTION
In this PR I have made following additions:
- Added dependencies for exposing metrics for Prometheus.
- Added default configuration for kamon.prometheus in `application.conf` (eclair node).
- Update `Monitoring.md`.