### PR TITLE
Additive per-node feature override

### DIFF
--- a/docs/Configure.md
+++ b/docs/Configure.md
@@ -102,22 +102,50 @@ When experimenting with non-default features, we recommend using this to scope t
 This is done with the `override-init-features` configuration parameter in your `eclair.conf`:
 
 ```conf
+eclair.features {
+  var_onion_optin = mandatory
+  payment_secret = mandatory
+  option_support_large_channel = optional
+  option_static_remotekey = optional
+  option_channel_type = optional
+}
 eclair.override-init-features = [
     {
-        nodeId = "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+        nodeId = "<alice_node_id>"
         features {
             option_support_large_channel = disabled
-            option_static_remotekey = optional
+            option_static_remotekey = mandatory
+            option_anchors_zero_fee_htlc_tx = optional
         }
     },
     {
-        nodeId = "<another nodeId>"
+        nodeId = "<bob_node_id>"
         features {
-            option_static_remotekey = optional
-            option_support_large_channel = optional
+            option_support_large_channel = mandatory
+            option_static_remotekey = disabled
+            option_channel_type = mandatory
         }
     },
 ]
+```
+
+In this example, the features that will be activated with Alice are:
+
+```conf
+var_onion_optin = mandatory
+payment_secret = mandatory
+option_static_remotekey = mandatory
+option_anchors_zero_fee_htlc_tx = optional
+option_channel_type = optional
+```
+
+The features that will be activated with Bob are:
+
+```conf
+var_onion_optin = mandatory
+payment_secret = mandatory
+option_support_large_channel = mandatory
+option_channel_type = mandatory
 ```
 
 ## Customize feerate tolerance

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -34,10 +34,6 @@ override-init-features = [
   {
     nodeid = "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f",
     features = {
-      // these features need to be enabled
-      var_onion_optin = mandatory
-      payment_secret = mandatory
-      option_channel_type = optional
       // dependencies of zeroconf
       option_static_remotekey = optional
       option_anchors_zero_fee_htlc_tx = optional
@@ -76,6 +72,12 @@ $ ./eclair-cli open --nodeId=03864e... --fundingSatoshis=100000 --channelType=an
 ```shell
 $ ./eclair-cli open --nodeId=03864e... --fundingSatoshis=100000 --channelType=anchor_outputs_zero_fee_htlc_tx+scid_alias+zeroconf --announceChannel=false
 ```
+
+### Changes to features override
+
+Eclair supports overriding features on a per-peer basis, using the `eclair.override-init-features` field in `eclair.conf`.
+These overrides will now be applied on top of the default features, whereas the previous behavior was to completely ignore default features.
+We provide detailed examples in the [documentation](../Configure.md#customize-features).
 
 ### Remove support for Tor v2
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -68,9 +68,11 @@ eclair {
     keysend = disabled
     trampoline_payment_prototype = disabled
   }
+  // The following section lets you customize features for specific nodes.
+  // The overrides will be applied on top of the default features settings.
   override-init-features = [ // optional per-node features
     #  {
-    #    nodeid = "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    #    nodeid = "02aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     #    features { }
     #  }
   ]

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -313,7 +313,7 @@ object NodeParams extends Logging {
 
     val overrideInitFeatures: Map[PublicKey, Features[InitFeature]] = config.getConfigList("override-init-features").asScala.map { e =>
       val p = PublicKey(ByteVector.fromValidHex(e.getString("nodeid")))
-      val f = Features.fromConfiguration[InitFeature](e.getConfig("features"), Features.knownFeatures.collect { case f: InitFeature => f })
+      val f = Features.fromConfiguration[InitFeature](e.getConfig("features"), Features.knownFeatures.collect { case f: InitFeature => f }, features.initFeatures())
       validateFeatures(f.unscoped())
       p -> (f.copy(unknown = f.unknown ++ pluginMessageParams.map(_.pluginFeature)): Features[InitFeature])
     }.toMap


### PR DESCRIPTION
The `override-init-features` field in `eclair.conf` was not previously applied on top of the `features` field, so node operators were usually copy-pasting their `features` overrides in every `override-init-features`.

The overrides are now applied on top of the base `features` configuration, which makes it easier and more intuitive to configure per-node features.