### PR TITLE
Random values for `generateLocalAlias()`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -60,7 +60,7 @@ object ShortChannelId {
 
   /**
    * At block height 350 000 LN didn't exist, so all real scids less than that will never be used. This results in
-   * `384_829_069_721_665_536` possible values, greater than `2^58`.
+   * more than `2^58` values.
    *
    * The expected number of values before we have a collision can be approximated by (*):
    * `Q(H) ~= sqrt( Pi * H / 2) = sqrt(Pi * 2^57) = 673 000 000`
@@ -70,13 +70,11 @@ object ShortChannelId {
    *
    * (*) https://en.wikipedia.org/wiki/Birthday_attack
    */
-  private val aliasUpperBound = RealShortChannelId.apply(BlockHeight(350_000), 1, 0).toLong
+  private val aliasUpperBound = 2^58
 
   def generateLocalAlias(): Alias = {
-    var l = -1L
-    do {
-      l = randomLong()
-    } while (l < 0 || l > aliasUpperBound)
+    // modulo won't skew the distribution because 2^64 is a multiple of 2^58
+    val l = Math.abs(randomLong() % aliasUpperBound)
     Alias(l)
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -70,10 +70,13 @@ object ShortChannelId {
    *
    * (*) https://en.wikipedia.org/wiki/Birthday_attack
    */
-  private val aliasUpperBound = RealShortChannelId.apply(BlockHeight(350_000),1,0).toLong
+  private val aliasUpperBound = RealShortChannelId.apply(BlockHeight(350_000), 1, 0).toLong
 
   def generateLocalAlias(): Alias = {
-    val l = randomLong() % aliasUpperBound
+    var l = -1L
+    do {
+      l = randomLong()
+    } while (l < 0 || l > aliasUpperBound)
     Alias(l)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
@@ -70,4 +70,11 @@ class ShortChannelIdSpec extends AnyFunSuite {
     Seq(-561L, 0xffffffffffffffffL, 0x2affffffffffffffL).foreach(id => assert(Alias(id) == UnspecifiedShortChannelId(id)))
   }
 
+  test("basic check on random alias generation") {
+    for(_ <- 0 until 100) {
+      val alias = ShortChannelId.generateLocalAlias()
+      assert(alias.toLong >= 0 && alias.toLong <= 384_829_069_721_665_536L)
+    }
+  }
+
 }


### PR DESCRIPTION
This is an alternative to #2316.

Turns out the value space is large enough to not have to worry about duplicates.