### PR TITLE
Remove compatibility code for waitingSince

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -284,12 +284,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, val 
               }
           }
           // no need to go OFFLINE, we can directly switch to CLOSING
-          if (closing.waitingSince.toLong > 1_500_000_000) {
-            // we were using timestamps instead of block heights when the channel was created: we reset it *and* we use block heights
-            goto(CLOSING) using closing.copy(waitingSince = nodeParams.currentBlockHeight) storing()
-          } else {
-            goto(CLOSING) using closing
-          }
+          goto(CLOSING) using closing
 
         case normal: DATA_NORMAL =>
           watchFundingTx(data.commitments)
@@ -314,12 +309,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, val 
           watchFundingTx(funding.commitments)
           // we make sure that the funding tx has been published
           blockchain ! GetTxWithMeta(self, funding.commitments.fundingTxId)
-          if (funding.waitingSince.toLong > 1_500_000_000) {
-            // we were using timestamps instead of block heights when the channel was created: we reset it *and* we use block heights
-            goto(OFFLINE) using funding.copy(waitingSince = nodeParams.currentBlockHeight) storing()
-          } else {
-            goto(OFFLINE) using funding
-          }
+          goto(OFFLINE) using funding
 
         case funding: DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED =>
           // we make sure that the funding tx with the highest feerate has been published

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.channel.publish.TxPublisher.PublishFinalTx
 import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
 import fr.acinq.eclair.transactions.Scripts.multiSig2of2
 import fr.acinq.eclair.wire.protocol.{AcceptChannel, ChannelReady, Error, FundingCreated, FundingSigned, Init, OpenChannel, TlvStream}
-import fr.acinq.eclair.{BlockHeight, MilliSatoshiLong, TestConstants, TestKitBaseClass, TimestampSecond, randomKey}
+import fr.acinq.eclair.{BlockHeight, MilliSatoshiLong, TestConstants, TestKitBaseClass, randomKey}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.{Outcome, Tag}
 
@@ -222,18 +222,6 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     bob ! CurrentBlockHeight(initialState.waitingSince + Channel.FUNDING_TIMEOUT_FUNDEE + 1)
     bob2alice.expectMsgType[Error]
     awaitCond(bob.stateName == CLOSED)
-  }
-
-  test("migrate waitingSince to waitingSinceBlocks") { f =>
-    import f._
-    // Before version 0.5.1, eclair used an absolute timestamp instead of a block height for funding timeouts.
-    val beforeMigration = bob.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].copy(waitingSince = BlockHeight(TimestampSecond.now().toLong))
-    bob.setState(WAIT_FOR_INIT_INTERNAL, Nothing)
-    bob ! INPUT_RESTORED(beforeMigration)
-    awaitCond(bob.stateName == OFFLINE)
-    // We reset the waiting period to the current block height when starting up after updating eclair.
-    val currentBlockHeight = bob.underlyingActor.nodeParams.currentBlockHeight
-    assert(bob.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].waitingSince == currentBlockHeight)
   }
 
   test("recv WatchFundingSpentTriggered (remote commit)") { f =>


### PR DESCRIPTION
We used to store UNIX timestamps in the waitingSince field before moving to block count. In order to ensure backward compatibility, we converted from timestamps to blockheight based on the value.

This code has shipped more than a year ago, so we can safely remove that compatibility code since it only applies during the channel open or close period, which cannot last long anyway.

Fixes #2125