### PR TITLE
Call `resolve()` on configuration

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -114,6 +114,7 @@ object NodeParams extends Logging {
     ConfigFactory.systemProperties()
       .withFallback(ConfigFactory.parseFile(new File(datadir, "eclair.conf")))
       .withFallback(ConfigFactory.load())
+      .resolve()
 
   private def readSeedFromFile(seedPath: File): ByteVector = {
     logger.info(s"use seed file: ${seedPath.getCanonicalPath}")


### PR DESCRIPTION
Calling `ConfigFactory.load()` automatically resolves the config (that is, processes substitutions), but that's not the case for `ConfigFactory.parseFile`, which means that substitutions don't work in `eclair.conf`.

We could resolve each of config separately, but the library's doc recommends one global `resolve()`, and frankly it makes more sense:
> A given Config must be resolved before using it to retrieve config values, but ideally should be resolved one time for your entire stack of fallbacks (see withFallback)

https://github.com/lightbend/config/blob/4458ea947a7a2a668bb811a122455f1f05975172/config/src/main/java/com/typesafe/config/Config.java#L204-L206

Fixes #2336.