### PR TITLE
Remove redundant routing hint

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -342,7 +342,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
         externalId_opt match {
           case Some(externalId) if externalId.length > externalIdMaxLength => Left(new IllegalArgumentException(s"externalId is too long: cannot exceed $externalIdMaxLength characters"))
           case _ if invoice.isExpired() => Left(new IllegalArgumentException("invoice has expired"))
-          case _ => Right(SendPaymentToNode(amount, invoice, maxAttempts, externalId_opt, extraEdges = invoice.extraEdges, routeParams = routeParams))
+          case _ => Right(SendPaymentToNode(amount, invoice, maxAttempts, externalId_opt, routeParams = routeParams))
         }
       case Left(t) => Left(t)
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Invoice.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Invoice.scala
@@ -56,12 +56,12 @@ trait Invoice {
 
 object Invoice {
   sealed trait ExtraEdge {
-    val sourceNodeId: PublicKey
-    val feeBase: MilliSatoshi
-    val feeProportionalMillionths: Long
-    val cltvExpiryDelta: CltvExpiryDelta
-    val htlcMinimum: MilliSatoshi
-    val htlcMaximum_opt: Option[MilliSatoshi]
+    def sourceNodeId: PublicKey
+    def feeBase: MilliSatoshi
+    def feeProportionalMillionths: Long
+    def cltvExpiryDelta: CltvExpiryDelta
+    def htlcMinimum: MilliSatoshi
+    def htlcMaximum_opt: Option[MilliSatoshi]
 
     def relayFees: Relayer.RelayFees = Relayer.RelayFees(feeBase = feeBase, feeProportionalMillionths = feeProportionalMillionths)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -122,7 +122,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     assert(send.recipientAmount == 123.msat)
     assert(send.paymentHash == ByteVector32.Zeroes)
     assert(send.invoice == invoice0)
-    assert(send.extraEdges == Seq.empty)
+    assert(send.invoice.extraEdges == Seq.empty)
 
     // with assisted routes
     val externalId1 = "030bb6a5e0c6b203c7e2180fb78c7ba4bdce46126761d8201b91ddac089cdecc87"
@@ -135,13 +135,13 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     assert(send1.recipientAmount == 123.msat)
     assert(send1.paymentHash == ByteVector32.Zeroes)
     assert(send1.invoice == invoice1)
-    assert(send1.extraEdges.length == 1)
-    assert(send1.extraEdges.head.asInstanceOf[BasicEdge].shortChannelId == ShortChannelId.fromCoordinates("569178x2331x1").success.value)
-    assert(send1.extraEdges.head.asInstanceOf[BasicEdge].sourceNodeId == Bob.nodeParams.nodeId)
-    assert(send1.extraEdges.head.asInstanceOf[BasicEdge].targetNodeId == nodePrivKey.publicKey)
-    assert(send1.extraEdges.head.asInstanceOf[BasicEdge].feeBase == 10.msat)
-    assert(send1.extraEdges.head.asInstanceOf[BasicEdge].feeProportionalMillionths == 1)
-    assert(send1.extraEdges.head.asInstanceOf[BasicEdge].cltvExpiryDelta == CltvExpiryDelta(12))
+    assert(send1.invoice.extraEdges.length == 1)
+    assert(send1.invoice.extraEdges.head.asInstanceOf[BasicEdge].shortChannelId == ShortChannelId.fromCoordinates("569178x2331x1").success.value)
+    assert(send1.invoice.extraEdges.head.asInstanceOf[BasicEdge].sourceNodeId == Bob.nodeParams.nodeId)
+    assert(send1.invoice.extraEdges.head.asInstanceOf[BasicEdge].targetNodeId == nodePrivKey.publicKey)
+    assert(send1.invoice.extraEdges.head.asInstanceOf[BasicEdge].feeBase == 10.msat)
+    assert(send1.invoice.extraEdges.head.asInstanceOf[BasicEdge].feeProportionalMillionths == 1)
+    assert(send1.invoice.extraEdges.head.asInstanceOf[BasicEdge].cltvExpiryDelta == CltvExpiryDelta(12))
 
     // with finalCltvExpiry
     val externalId2 = "487da196-a4dc-4b1e-92b4-3e5e905e9f3f"


### PR DESCRIPTION
In `SendPaymentToNode`, the routing hints were present twice: once in `invoice` and once in `extraEdges`. I'm only keeping `invoice`.
Also make the `ExtraEdge` trait use `def` as there may be problems with `val`.