### PR TITLE
Emit event when receiving `Pong`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -247,7 +247,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
           case Some(ExpectedPong(ping, timestamp)) if ping.pongLength == data.length =>
             // we use the pong size to correlate between pings and pongs
             val latency = TimestampMilli.now() - timestamp
-			context.system.eventStream.publish(receivedPong(latency, d.remoteNodeId))
+			context.system.eventStream.publish(PongReceived(d.remoteNodeId, latency))
             log.debug(s"received pong with latency=$latency")
             cancelTimer(PingTimeout.toString())
           // we don't need to call scheduleNextPing here, the next ping was already scheduled when we received that pong

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -247,6 +247,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
           case Some(ExpectedPong(ping, timestamp)) if ping.pongLength == data.length =>
             // we use the pong size to correlate between pings and pongs
             val latency = TimestampMilli.now() - timestamp
+			context.system.eventStream.publish(receivedPong(latency, d.remoteNodeId))
             log.debug(s"received pong with latency=$latency")
             cancelTimer(PingTimeout.toString())
           // we don't need to call scheduleNextPing here, the next ping was already scheduled when we received that pong

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerEvents.scala
@@ -31,4 +31,6 @@ case class PeerDisconnected(peer: ActorRef, nodeId: PublicKey) extends PeerEvent
 
 case class LastChannelClosed(peer: ActorRef, nodeId: PublicKey) extends PeerEvent
 
+case class receivedPong(latency: FiniteDuration, nodeId: PublicKey) extends PeerEvent
+
 case class UnknownMessageReceived(peer: ActorRef, nodeId: PublicKey, message: UnknownMessage, connectionInfo: ConnectionInfo) extends PeerEvent

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerEvents.scala
@@ -21,6 +21,8 @@ import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.wire.protocol
 import fr.acinq.eclair.wire.protocol.{NodeAddress, UnknownMessage}
 
+import scala.concurrent.duration._
+
 sealed trait PeerEvent
 
 case class ConnectionInfo(address: NodeAddress, peerConnection: ActorRef, localInit: protocol.Init, remoteInit: protocol.Init)
@@ -31,6 +33,6 @@ case class PeerDisconnected(peer: ActorRef, nodeId: PublicKey) extends PeerEvent
 
 case class LastChannelClosed(peer: ActorRef, nodeId: PublicKey) extends PeerEvent
 
-case class receivedPong(latency: FiniteDuration, nodeId: PublicKey) extends PeerEvent
+case class PongReceived(nodeId: PublicKey, latency: FiniteDuration) extends PeerEvent
 
 case class UnknownMessageReceived(peer: ActorRef, nodeId: PublicKey, message: UnknownMessage, connectionInfo: ConnectionInfo) extends PeerEvent


### PR DESCRIPTION
create pong event and publish pongs, so plugins can subscribe to the latency of the peers