### PR TITLE
Offline commands plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,12 +245,15 @@ Here is how to run Eclair with plugins:
 eclair-node-<version>-<commit_id>/bin/eclair-node.sh <plugin1.jar> <plugin2.jar> <...>
 ```
 
-### Non-exhaustive plugins list
+We maintain some plugins in the [plugins](./plugins/) directory.
+The [offline commands plugin](./plugins/offline-commands/) is a good example of how to write a plugin that interacts with various features of eclair.
 
-Here are some plugins created by the Eclair community.
+There are also plugins provided by external contributors from the Eclair community.
+We provide a non-exhaustive list of these plugins below.
 If you need support for these plugins, head over to their respective github repository.
 
 * [Telegram Bot for Eclair alerts](https://github.com/engenegr/eclair-alarmbot-plugin)
+* [Hosted Channels](https://github.com/btcontract/plugin-hosted-channels)
 
 ## Testnet usage
 

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -11,6 +11,7 @@
 - `audit` now accepts `--count` and `--skip` parameters to limit the number of retrieved items (#2474, #2487)
 - `sendtoroute` removes the `--trampolineNodes` argument and implicitly uses a single trampoline hop (#2480)
 - `payinvoice` always returns the payment result when used with `--blocking`, even when using MPP (#2525)
+- the [offline commands plugin](/plugins/offline-commands/README.md) adds an `offlineclose` API (#2359)
 
 ### Miscellaneous improvements and bug fixes
 

--- a/plugins/offline-commands/README.md
+++ b/plugins/offline-commands/README.md
@@ -1,0 +1,11 @@
+# Offline commands plugin
+
+This plugin allows node operators to prepare commands that will be executed once the target peer is online.
+
+## Build
+
+To build this plugin, run the following command in this directory:
+
+```sh
+mvn package
+```

--- a/plugins/offline-commands/README.md
+++ b/plugins/offline-commands/README.md
@@ -17,3 +17,18 @@ To run eclair with this plugin, start eclair with the following command:
 ```sh
 eclair-node-<version>/bin/eclair-node.sh <path-to-plugin-jar>/offline-commands-plugin-<version>.jar
 ```
+
+## Usage
+
+This plugin adds a new API to `eclair` called `offlineclose`, with the following arguments:
+
+```sh
+eclair-cli offlineclose --channelIds=<comma-separated list of channels to close>
+    --scriptPubKey=<optional closing script>
+    --preferredFeerateSatByte=<closing tx feerate>
+    --minFeerateSatByte=<closing tx min feerate>
+    --maxFeerateSatByte=<closing tx max feerate>
+```
+
+The `channelIds` argument is mandatory; all other arguments are optional.
+The plugin will attempt to close the requested channels once they're online and will write a line in the logs when it succeeds.

--- a/plugins/offline-commands/README.md
+++ b/plugins/offline-commands/README.md
@@ -24,6 +24,7 @@ This plugin adds a new API to `eclair` called `offlineclose`, with the following
 
 ```sh
 eclair-cli offlineclose --channelIds=<comma-separated list of channels to close>
+    --forceCloseAfterHours=<force close after this delay if peer is unresponsive>
     --scriptPubKey=<optional closing script>
     --preferredFeerateSatByte=<closing tx feerate>
     --minFeerateSatByte=<closing tx min feerate>

--- a/plugins/offline-commands/README.md
+++ b/plugins/offline-commands/README.md
@@ -9,3 +9,11 @@ To build this plugin, run the following command in this directory:
 ```sh
 mvn package
 ```
+
+## Run
+
+To run eclair with this plugin, start eclair with the following command:
+
+```sh
+eclair-node-<version>/bin/eclair-node.sh <path-to-plugin-jar>/offline-commands-plugin-<version>.jar
+```

--- a/plugins/offline-commands/README.md
+++ b/plugins/offline-commands/README.md
@@ -33,3 +33,9 @@ eclair-cli offlineclose --channelIds=<comma-separated list of channels to close>
 
 The `channelIds` argument is mandatory; all other arguments are optional.
 The plugin will attempt to close the requested channels once they're online and will write a line in the logs when it succeeds.
+
+## Persistence
+
+This plugin stores its data into a sqlite database named `offline-commands.sqlite`.
+It uses that database to ensure commands are correctly executed even after a restart of the node.
+You can check the status of pending commands by reading directly from that database.

--- a/plugins/offline-commands/pom.xml
+++ b/plugins/offline-commands/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2022 ACINQ SAS
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>fr.acinq.eclair</groupId>
+        <artifactId>eclair_2.13</artifactId>
+        <version>0.7.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>offline-commands-plugin_2.13</artifactId>
+    <packaging>jar</packaging>
+    <name>offline-commands-plugin</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <transformers>
+                        <!-- Add a manifest entry for Main-Class with the FQDN of the implementation. -->
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Main-Class>fr.acinq.eclair.plugins.offlinecommands.OfflineCommandsPlugin</Main-Class>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-core_${scala.version.short}</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-node_${scala.version.short}</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/plugins/offline-commands/pom.xml
+++ b/plugins/offline-commands/pom.xml
@@ -75,6 +75,27 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- TESTS -->
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-testkit_${scala.version.short}</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-actor-testkit-typed_${scala.version.short}</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-core_${scala.version.short}</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/plugins/offline-commands/pom.xml
+++ b/plugins/offline-commands/pom.xml
@@ -22,6 +22,7 @@
         <groupId>fr.acinq.eclair</groupId>
         <artifactId>eclair_2.13</artifactId>
         <version>0.7.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>offline-commands-plugin_2.13</artifactId>

--- a/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/ApiHandlers.scala
+++ b/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/ApiHandlers.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.offlinecommands
+
+import akka.actor.typed.scaladsl.AskPattern.Askable
+import akka.actor.typed.scaladsl.adapter.ClassicSchedulerOps
+import akka.http.scaladsl.server.{MalformedFormFieldRejection, Route}
+import akka.util.Timeout
+import fr.acinq.bitcoin.scalacompat.Script
+import fr.acinq.eclair.api.directives.EclairDirectives
+import fr.acinq.eclair.api.serde.FormParamExtractors._
+import fr.acinq.eclair.blockchain.fee.{FeeratePerByte, FeeratePerKw}
+import fr.acinq.eclair.channel.ClosingFeerates
+import fr.acinq.eclair.plugins.offlinecommands.OfflineChannelsCloser.CloseChannels
+import scodec.bits.ByteVector
+
+import scala.concurrent.duration._
+
+object ApiHandlers {
+
+  import fr.acinq.eclair.api.serde.JsonSupport.{marshaller, serialization}
+  import fr.acinq.eclair.plugins.offlinecommands.ApiSerializers.formats
+
+  def registerRoutes(kit: OfflineCommandsKit, eclairDirectives: EclairDirectives): Route = {
+    import eclairDirectives._
+
+    val close: Route = postRequest("offlineclose") { implicit t =>
+      formFields(channelIdsFormParam, "scriptPubKey".as[ByteVector](binaryDataUnmarshaller).?, "preferredFeerateSatByte".as[FeeratePerByte].?, "minFeerateSatByte".as[FeeratePerByte].?, "maxFeerateSatByte".as[FeeratePerByte].?) {
+        (channelIds, scriptPubKey_opt, preferredFeerate_opt, minFeerate_opt, maxFeerate_opt) =>
+          val closingFeerates_opt = preferredFeerate_opt.map(preferredPerByte => {
+            val preferredFeerate = FeeratePerKw(preferredPerByte)
+            val minFeerate = minFeerate_opt.map(feerate => FeeratePerKw(feerate)).getOrElse(preferredFeerate / 2)
+            val maxFeerate = maxFeerate_opt.map(feerate => FeeratePerKw(feerate)).getOrElse(preferredFeerate * 2)
+            ClosingFeerates(preferredFeerate, minFeerate, maxFeerate)
+          })
+          if (scriptPubKey_opt.forall(Script.isNativeWitnessScript)) {
+            val res = kit.closer.ask(ref => CloseChannels(ref, channelIds, scriptPubKey_opt, closingFeerates_opt))(Timeout(30 seconds), kit.system.scheduler.toTyped)
+            complete(res)
+          } else {
+            reject(MalformedFormFieldRejection("scriptPubKey", "Non-segwit scripts are not allowed"))
+          }
+      }
+    }
+
+    close
+  }
+
+}
+
+

--- a/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/ApiSerializers.scala
+++ b/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/ApiSerializers.scala
@@ -17,14 +17,15 @@
 package fr.acinq.eclair.plugins.offlinecommands
 
 import fr.acinq.eclair.json.MinimalSerializer
-import fr.acinq.eclair.plugins.offlinecommands.OfflineChannelsCloser.ClosingStatus
 import org.json4s.{Formats, JString}
 
 object ApiSerializers {
 
   object ClosingStatusSerializer extends MinimalSerializer({
     case status: ClosingStatus => status match {
-      case OfflineChannelsCloser.WaitingForPeer => JString("waiting-for-peer")
+      case ClosingStatus.Pending => JString("pending")
+      case ClosingStatus.ChannelNotFound => JString("unknown-channel")
+      case ClosingStatus.ChannelClosed => JString("closed")
     }
   })
 

--- a/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/ApiSerializers.scala
+++ b/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/ApiSerializers.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.offlinecommands
+
+import fr.acinq.eclair.json.MinimalSerializer
+import fr.acinq.eclair.plugins.offlinecommands.OfflineChannelsCloser.ClosingStatus
+import org.json4s.{Formats, JString}
+
+object ApiSerializers {
+
+  object ClosingStatusSerializer extends MinimalSerializer({
+    case status: ClosingStatus => status match {
+      case OfflineChannelsCloser.WaitingForPeer => JString("waiting-for-peer")
+    }
+  })
+
+  implicit val formats: Formats = fr.acinq.eclair.api.serde.JsonSupport.formats + ClosingStatusSerializer
+
+}

--- a/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineChannelsCloser.scala
+++ b/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineChannelsCloser.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.offlinecommands
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
+import akka.actor.{ActorRef, typed}
+import fr.acinq.bitcoin.scalacompat.ByteVector32
+import fr.acinq.eclair.NodeParams
+import fr.acinq.eclair.channel.{CMD_CLOSE, ClosingFeerates}
+import scodec.bits.ByteVector
+
+object OfflineChannelsCloser {
+
+  // @formatter:off
+  sealed trait Command
+  case class CloseChannels(replyTo: typed.ActorRef[Response], channelIds: Seq[ByteVector32], scriptPubKey_opt: Option[ByteVector], closingFeerates_opt: Option[ClosingFeerates]) extends Command
+
+  sealed trait ClosingStatus
+  case object WaitingForPeer extends ClosingStatus
+
+  sealed trait Response
+  case class CloseCommandsRegistered(status: Map[ByteVector32, ClosingStatus]) extends Response
+  // @formatter:on
+
+  def apply(nodeParams: NodeParams, register: ActorRef): Behavior[Command] = {
+    Behaviors.setup { context =>
+      Behaviors.withTimers { timers =>
+        new OfflineChannelsCloser(nodeParams, register, context, timers).run(Map.empty)
+      }
+    }
+  }
+
+}
+
+private class OfflineChannelsCloser(nodeParams: NodeParams, register: ActorRef, context: ActorContext[OfflineChannelsCloser.Command], timers: TimerScheduler[OfflineChannelsCloser.Command]) {
+
+  import OfflineChannelsCloser._
+
+  private val log = context.log
+
+  def run(channels: Map[ByteVector32, CMD_CLOSE]): Behavior[Command] = {
+    Behaviors.receiveMessage {
+      case cmd: CloseChannels =>
+        cmd.replyTo ! CloseCommandsRegistered(cmd.channelIds.map(_ -> WaitingForPeer).toMap)
+        val channels1 = channels ++ cmd.channelIds.map(_ -> CMD_CLOSE(context.self.toClassic, cmd.scriptPubKey_opt, cmd.closingFeerates_opt))
+        run(channels1)
+    }
+  }
+
+}

--- a/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineChannelsCloser.scala
+++ b/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineChannelsCloser.scala
@@ -17,30 +17,38 @@
 package fr.acinq.eclair.plugins.offlinecommands
 
 import akka.actor.typed.Behavior
+import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
 import akka.actor.{ActorRef, typed}
 import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.eclair.NodeParams
-import fr.acinq.eclair.channel.{CMD_CLOSE, ClosingFeerates}
+import fr.acinq.eclair.channel._
 import scodec.bits.ByteVector
 
 object OfflineChannelsCloser {
 
   // @formatter:off
   sealed trait Command
-  case class CloseChannels(replyTo: typed.ActorRef[Response], channelIds: Seq[ByteVector32], scriptPubKey_opt: Option[ByteVector], closingFeerates_opt: Option[ClosingFeerates]) extends Command
+  case class CloseChannels(replyTo: typed.ActorRef[CloseCommandsRegistered], channelIds: Seq[ByteVector32], scriptPubKey_opt: Option[ByteVector], closingFeerates_opt: Option[ClosingFeerates]) extends Command
+  case class GetPendingCommands(replyTo: typed.ActorRef[PendingCommands]) extends Command
+  private case class WrappedChannelStateChanged(channelId: ByteVector32, state: ChannelState) extends Command
+  private case class WrappedCommandResponse(channelId: ByteVector32, response: CommandResponse[CloseCommand]) extends Command
+  private case class UnknownChannel(channelId: ByteVector32) extends Command
 
   sealed trait ClosingStatus
   case object WaitingForPeer extends ClosingStatus
 
-  sealed trait Response
-  case class CloseCommandsRegistered(status: Map[ByteVector32, ClosingStatus]) extends Response
+  case class CloseCommandsRegistered(status: Map[ByteVector32, ClosingStatus])
+  case class PendingCommands(channels: Map[ByteVector32, ClosingParams])
   // @formatter:on
+
+  case class ClosingParams(scriptPubKey_opt: Option[ByteVector], closingFeerates_opt: Option[ClosingFeerates])
 
   def apply(nodeParams: NodeParams, register: ActorRef): Behavior[Command] = {
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
+        context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelStateChanged](e => WrappedChannelStateChanged(e.channelId, e.currentState)))
         new OfflineChannelsCloser(nodeParams, register, context, timers).run(Map.empty)
       }
     }
@@ -54,13 +62,46 @@ private class OfflineChannelsCloser(nodeParams: NodeParams, register: ActorRef, 
 
   private val log = context.log
 
-  def run(channels: Map[ByteVector32, CMD_CLOSE]): Behavior[Command] = {
+  def run(channels: Map[ByteVector32, ClosingParams]): Behavior[Command] = {
     Behaviors.receiveMessage {
       case cmd: CloseChannels =>
+        val closingParams = ClosingParams(cmd.scriptPubKey_opt, cmd.closingFeerates_opt)
+        cmd.channelIds.foreach(channelId => sendCloseCommand(channelId, closingParams))
+        val channels1 = channels ++ cmd.channelIds.map(_ -> closingParams)
         cmd.replyTo ! CloseCommandsRegistered(cmd.channelIds.map(_ -> WaitingForPeer).toMap)
-        val channels1 = channels ++ cmd.channelIds.map(_ -> CMD_CLOSE(context.self.toClassic, cmd.scriptPubKey_opt, cmd.closingFeerates_opt))
         run(channels1)
+      case WrappedChannelStateChanged(channelId, state) =>
+        channels.get(channelId) match {
+          case Some(closingParams) => state match {
+            case NORMAL =>
+              log.info(s"channel $channelId is back online: initiating mutual close")
+              sendCloseCommand(channelId, closingParams)
+              Behaviors.same
+            case CLOSED =>
+              log.info(s"channel $channelId has been closed")
+              run(channels - channelId)
+            case _ => Behaviors.same
+          }
+          case None => Behaviors.same
+        }
+      case WrappedCommandResponse(channelId, response) =>
+        response match {
+          case _: CommandSuccess[_] => log.debug(s"close command received by channel $channelId")
+          case failure: CommandFailure[_, _] => log.debug(s"close command rejected by channel $channelId: ${failure.t.getMessage}")
+        }
+        Behaviors.same
+      case UnknownChannel(channelId) =>
+        log.warn(s"cannot close unknown channel $channelId")
+        run(channels - channelId)
+      case GetPendingCommands(replyTo) =>
+        replyTo ! PendingCommands(channels)
+        Behaviors.same
     }
+  }
+
+  private def sendCloseCommand(channelId: ByteVector32, closingParams: ClosingParams): Unit = {
+    val close = CMD_CLOSE(context.messageAdapter[CommandResponse[CMD_CLOSE]](r => WrappedCommandResponse(channelId, r)).toClassic, closingParams.scriptPubKey_opt, closingParams.closingFeerates_opt)
+    register ! Register.Forward(context.messageAdapter[Register.ForwardFailure[CMD_CLOSE]](r => UnknownChannel(r.fwd.channelId)), channelId, close)
   }
 
 }

--- a/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineCommandsDb.scala
+++ b/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineCommandsDb.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.offlinecommands
+
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi}
+import fr.acinq.eclair.TimestampSecond
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
+import fr.acinq.eclair.channel.ClosingFeerates
+import scodec.bits.ByteVector
+
+import java.sql.{Connection, ResultSet}
+
+// @formatter:off
+sealed trait ClosingStatus
+object ClosingStatus {
+  case object Pending extends ClosingStatus
+  case object ChannelNotFound extends ClosingStatus
+  case object ChannelClosed extends ClosingStatus
+}
+// @formatter:on
+
+case class ClosingParams(forceCloseAfter_opt: Option[TimestampSecond], scriptPubKey_opt: Option[ByteVector], closingFeerates_opt: Option[ClosingFeerates])
+
+trait OfflineCloseCommandsDb {
+  // @formatter:off
+  def addCloseCommand(channelId: ByteVector32, closingParams: ClosingParams): Unit
+  def updateCloseCommand(channelId: ByteVector32, status: ClosingStatus): Unit
+  def listPendingCloseCommands(): Map[ByteVector32, ClosingParams]
+  // @formatter:on
+}
+
+trait OfflineCommandsDb extends OfflineCloseCommandsDb
+
+object SqliteOfflineCommandsDb {
+  val CURRENT_VERSION = 1
+  val DB_NAME = "offline_commands"
+}
+
+class SqliteOfflineCommandsDb(sqlite: Connection) extends OfflineCommandsDb {
+
+  import SqliteOfflineCommandsDb._
+  import fr.acinq.eclair.db.jdbc.JdbcUtils.ExtendedResultSet._
+  import fr.acinq.eclair.db.sqlite.SqliteUtils._
+
+  using(sqlite.createStatement(), inTransaction = true) { statement =>
+    getVersion(statement, DB_NAME) match {
+      case None =>
+        statement.executeUpdate("CREATE TABLE close_commands (channel_id TEXT NOT NULL PRIMARY KEY, status TEXT NOT NULL, force_close_timestamp INTEGER, script_pubkey TEXT, preferred_feerate_sat_kw INTEGER, min_feerate_sat_kw INTEGER, max_feerate_sat_kw INTEGER, created_timestamp INTEGER NOT NULL, closed_timestamp INTEGER)")
+        statement.executeUpdate("CREATE INDEX status_idx ON close_commands(status)")
+        statement.executeUpdate("CREATE INDEX created_timestamp_idx ON close_commands(created_timestamp)")
+      case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
+      case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
+    }
+    setVersion(statement, DB_NAME, CURRENT_VERSION)
+  }
+
+  override def addCloseCommand(channelId: ByteVector32, closingParams: ClosingParams): Unit = {
+    using(sqlite.prepareStatement("UPDATE close_commands SET status=?, force_close_timestamp=?, script_pubkey=?, preferred_feerate_sat_kw=?, min_feerate_sat_kw=?, max_feerate_sat_kw=?, created_timestamp=? WHERE channel_id=?")) { update =>
+      update.setString(1, ClosingStatus.Pending.toString)
+      update.setObject(2, closingParams.forceCloseAfter_opt.map(_.toLong).orNull)
+      update.setString(3, closingParams.scriptPubKey_opt.map(_.toHex).orNull)
+      update.setObject(4, closingParams.closingFeerates_opt.map(_.preferred.toLong).orNull)
+      update.setObject(5, closingParams.closingFeerates_opt.map(_.min.toLong).orNull)
+      update.setObject(6, closingParams.closingFeerates_opt.map(_.max.toLong).orNull)
+      update.setLong(7, TimestampSecond.now().toLong)
+      update.setString(8, channelId.toHex)
+      if (update.executeUpdate() == 0) {
+        using(sqlite.prepareStatement("INSERT INTO close_commands (channel_id, status, force_close_timestamp, script_pubkey, preferred_feerate_sat_kw, min_feerate_sat_kw, max_feerate_sat_kw, created_timestamp) VALUES (?, ?, ?, ?, ?, ?, ?, ?)")) { statement =>
+          statement.setString(1, channelId.toHex)
+          statement.setString(2, ClosingStatus.Pending.toString)
+          statement.setObject(3, closingParams.forceCloseAfter_opt.map(_.toLong).orNull)
+          statement.setString(4, closingParams.scriptPubKey_opt.map(_.toHex).orNull)
+          statement.setObject(5, closingParams.closingFeerates_opt.map(_.preferred.toLong).orNull)
+          statement.setObject(6, closingParams.closingFeerates_opt.map(_.min.toLong).orNull)
+          statement.setObject(7, closingParams.closingFeerates_opt.map(_.max.toLong).orNull)
+          statement.setLong(8, TimestampSecond.now().toLong)
+          statement.executeUpdate()
+        }
+      }
+    }
+  }
+
+  override def updateCloseCommand(channelId: ByteVector32, status: ClosingStatus): Unit = {
+    using(sqlite.prepareStatement("UPDATE close_commands SET status=?, closed_timestamp=? WHERE channel_id=?")) { update =>
+      update.setString(1, status.toString)
+      update.setLong(2, TimestampSecond.now().toLong)
+      update.setString(3, channelId.toHex)
+      update.executeUpdate()
+    }
+  }
+
+  override def listPendingCloseCommands(): Map[ByteVector32, ClosingParams] = {
+    using(sqlite.prepareStatement("SELECT * FROM close_commands WHERE status = ? ORDER BY created_timestamp")) { statement =>
+      statement.setString(1, ClosingStatus.Pending.toString)
+      statement.executeQuery().map(parseCloseCommand).toMap
+    }
+  }
+
+  private def parseCloseCommand(rs: ResultSet): (ByteVector32, ClosingParams) = {
+    val channelId = ByteVector32.fromValidHex(rs.getString("channel_id"))
+    val closingParams = ClosingParams(
+      rs.getLongNullable("force_close_timestamp").map(TimestampSecond(_)),
+      rs.getStringNullable("script_pubkey").map(ByteVector.fromValidHex(_)),
+      rs.getLongNullable("preferred_feerate_sat_kw").map(preferred => ClosingFeerates(
+        FeeratePerKw(Satoshi(preferred)),
+        FeeratePerKw(Satoshi(rs.getLong("min_feerate_sat_kw"))),
+        FeeratePerKw(Satoshi(rs.getLong("max_feerate_sat_kw"))),
+      ))
+    )
+    (channelId, closingParams)
+  }
+
+}

--- a/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineCommandsPlugin.scala
+++ b/plugins/offline-commands/src/main/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineCommandsPlugin.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.offlinecommands
+
+import fr.acinq.eclair.{Kit, Plugin, PluginParams, Setup}
+import grizzled.slf4j.Logging
+
+/**
+ * Created by t-bast on 28/07/2022.
+ */
+
+/**
+ * This plugin allows node operators to prepare commands that will be executed once the target peer is online.
+ */
+class OfflineCommandsPlugin extends Plugin with Logging {
+
+  override def onSetup(setup: Setup): Unit = {
+    // TODO
+  }
+
+  override def onKit(kit: Kit): Unit = {
+    // TODO
+  }
+
+  override def params: PluginParams = new PluginParams {
+    override def name: String = "OfflineCommands"
+  }
+
+}

--- a/plugins/offline-commands/src/test/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineChannelsCloserSpec.scala
+++ b/plugins/offline-commands/src/test/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineChannelsCloserSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.offlinecommands
+
+import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
+import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
+import com.typesafe.config.ConfigFactory
+import fr.acinq.eclair.channel.{CMD_CLOSE, Register}
+import fr.acinq.eclair.plugins.offlinecommands.OfflineChannelsCloser.{CloseChannels, CloseCommandsRegistered, Response, WaitingForPeer}
+import fr.acinq.eclair.{TestConstants, randomBytes32}
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+class OfflineChannelsCloserSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with AnyFunSuiteLike {
+
+  test("receive command to close channels") {
+    val probe = TestProbe[Response]()
+    val register = TestProbe[Register.Forward[CMD_CLOSE]]()
+    val channelsCloser = testKit.spawn(OfflineChannelsCloser(TestConstants.Alice.nodeParams, register.ref.toClassic))
+    val channel1 = randomBytes32()
+    val channel2 = randomBytes32()
+    channelsCloser ! CloseChannels(probe.ref, Seq(channel1, channel2), None, None)
+    probe.expectMessage(CloseCommandsRegistered(Map(channel1 -> WaitingForPeer, channel2 -> WaitingForPeer)))
+  }
+
+}

--- a/plugins/offline-commands/src/test/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineChannelsCloserSpec.scala
+++ b/plugins/offline-commands/src/test/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineChannelsCloserSpec.scala
@@ -19,58 +19,66 @@ package fr.acinq.eclair.plugins.offlinecommands
 import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
 import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
+import fr.acinq.bitcoin.scalacompat.SatoshiLong
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.plugins.offlinecommands.OfflineChannelsCloser._
 import fr.acinq.eclair.{TestConstants, randomBytes32, randomKey}
+import org.scalatest.OptionValues.convertOptionToValuable
 import org.scalatest.funsuite.AnyFunSuiteLike
 import scodec.bits.HexStringSyntax
 
+import java.sql.DriverManager
 import scala.concurrent.duration.DurationInt
 
 class OfflineChannelsCloserSpec extends ScalaTestWithActorTestKit with AnyFunSuiteLike {
 
   test("close channels when online") {
-    val channel1 = randomBytes32()
-    val channel2 = randomBytes32()
+    val db = new SqliteOfflineCommandsDb(DriverManager.getConnection("jdbc:sqlite::memory:"))
+    val (channelId1, channelId2) = (randomBytes32(), randomBytes32())
     val senderProbe = TestProbe[CloseCommandsRegistered]()
     val statusProbe = TestProbe[PendingCommands]()
     val register = TestProbe[Register.Forward[CMD_CLOSE]]()
-    val channelsCloser = testKit.spawn(OfflineChannelsCloser(TestConstants.Alice.nodeParams, register.ref.toClassic))
+    val channelsCloser = testKit.spawn(OfflineChannelsCloser(TestConstants.Alice.nodeParams, db, register.ref.toClassic))
 
-    channelsCloser ! CloseChannels(senderProbe.ref, Seq(channel1, channel2), None, Some(hex"001436f83c329274e04b104000fbb27fcfe20a47cdaf"), None)
+    channelsCloser ! CloseChannels(senderProbe.ref, Seq(channelId1, channelId2), None, Some(hex"001436f83c329274e04b104000fbb27fcfe20a47cdaf"), None)
     val commands = Seq(
       register.expectMessageType[Register.Forward[CMD_CLOSE]],
       register.expectMessageType[Register.Forward[CMD_CLOSE]]
     )
-    assert(commands.map(_.channelId).toSet == Set(channel1, channel2))
+    assert(commands.map(_.channelId).toSet == Set(channelId1, channelId2))
     commands.foreach(c => assert(c.message.scriptPubKey.contains(hex"001436f83c329274e04b104000fbb27fcfe20a47cdaf")))
-    senderProbe.expectMessage(CloseCommandsRegistered(Map(channel1 -> WaitingForPeer, channel2 -> WaitingForPeer)))
+    senderProbe.expectMessage(CloseCommandsRegistered(Map(channelId1 -> ClosingStatus.Pending, channelId2 -> ClosingStatus.Pending)))
+    assert(db.listPendingCloseCommands().keySet == Set(channelId1, channelId2))
 
     // The first channel was online and successfully closes.
-    testKit.system.eventStream ! EventStream.Publish(ChannelStateChanged(null, channel1, null, randomKey().publicKey, CLOSING, CLOSED, None))
+    testKit.system.eventStream ! EventStream.Publish(ChannelStateChanged(null, channelId1, null, randomKey().publicKey, CLOSING, CLOSED, None))
     statusProbe.awaitAssert {
       channelsCloser ! GetPendingCommands(statusProbe.ref)
-      assert(statusProbe.expectMessageType[PendingCommands].channels.keySet == Set(channel2))
+      assert(statusProbe.expectMessageType[PendingCommands].channels.keySet == Set(channelId2))
     }
+    assert(db.listPendingCloseCommands().keySet == Set(channelId2))
 
     // The second channel was offline and comes back online.
-    testKit.system.eventStream ! EventStream.Publish(ChannelStateChanged(null, channel2, null, randomKey().publicKey, SYNCING, NORMAL, None))
-    assert(register.expectMessageType[Register.Forward[CMD_CLOSE]].channelId == channel2)
+    testKit.system.eventStream ! EventStream.Publish(ChannelStateChanged(null, channelId2, null, randomKey().publicKey, SYNCING, NORMAL, None))
+    assert(register.expectMessageType[Register.Forward[CMD_CLOSE]].channelId == channelId2)
     register.expectNoMessage(100 millis)
     channelsCloser ! GetPendingCommands(statusProbe.ref)
-    assert(statusProbe.expectMessageType[PendingCommands].channels.keySet == Set(channel2))
+    assert(statusProbe.expectMessageType[PendingCommands].channels.keySet == Set(channelId2))
 
-    testKit.system.eventStream ! EventStream.Publish(ChannelStateChanged(null, channel2, null, randomKey().publicKey, CLOSING, CLOSED, None))
+    testKit.system.eventStream ! EventStream.Publish(ChannelStateChanged(null, channelId2, null, randomKey().publicKey, CLOSING, CLOSED, None))
     statusProbe.awaitAssert {
       channelsCloser ! GetPendingCommands(statusProbe.ref)
       assert(statusProbe.expectMessageType[PendingCommands].channels.isEmpty)
     }
+    assert(db.listPendingCloseCommands().isEmpty)
   }
 
   test("force-close after delay") {
+    val db = new SqliteOfflineCommandsDb(DriverManager.getConnection("jdbc:sqlite::memory:"))
     val channel = randomBytes32()
     val register = TestProbe[Register.Forward[CloseCommand]]()
-    val channelsCloser = testKit.spawn(OfflineChannelsCloser(TestConstants.Alice.nodeParams, register.ref.toClassic))
+    val channelsCloser = testKit.spawn(OfflineChannelsCloser(TestConstants.Alice.nodeParams, db, register.ref.toClassic))
 
     channelsCloser ! CloseChannels(TestProbe[CloseCommandsRegistered]().ref, Seq(channel), Some(50 millis), None, None)
     assert(register.expectMessageType[Register.Forward[CloseCommand]].message.isInstanceOf[CMD_CLOSE])
@@ -87,6 +95,50 @@ class OfflineChannelsCloserSpec extends ScalaTestWithActorTestKit with AnyFunSui
     statusProbe.awaitAssert {
       channelsCloser ! GetPendingCommands(statusProbe.ref)
       assert(statusProbe.expectMessageType[PendingCommands].channels.isEmpty)
+    }
+  }
+
+  test("replay previous commands stored in db") {
+    val db = new SqliteOfflineCommandsDb(DriverManager.getConnection("jdbc:sqlite::memory:"))
+    val (channelId1, channelId2, channelId3) = (randomBytes32(), randomBytes32(), randomBytes32())
+    val feerates = ClosingFeerates(FeeratePerKw(750 sat), FeeratePerKw(500 sat), FeeratePerKw(800 sat))
+    val senderProbe = TestProbe[CloseCommandsRegistered]()
+    val register = TestProbe[Register.Forward[CloseCommand]]()
+
+    {
+      // We run the plugin a first time.
+      val channelsCloser = testKit.spawn(OfflineChannelsCloser(TestConstants.Alice.nodeParams, db, register.ref.toClassic))
+      channelsCloser ! CloseChannels(senderProbe.ref, Seq(channelId1), Some(1 hour), Some(hex"001436f83c329274e04b104000fbb27fcfe20a47cdaf"), Some(feerates))
+      assert(register.expectMessageType[Register.Forward[CloseCommand]].message.isInstanceOf[CMD_CLOSE])
+      senderProbe.expectMessage(CloseCommandsRegistered(Map(channelId1 -> ClosingStatus.Pending)))
+      assert(db.listPendingCloseCommands().keySet == Set(channelId1))
+
+      channelsCloser ! CloseChannels(senderProbe.ref, Seq(channelId2), Some(50 millis), None, None)
+      assert(register.expectMessageType[Register.Forward[CloseCommand]].message.isInstanceOf[CMD_CLOSE])
+      assert(register.expectMessageType[Register.Forward[CloseCommand]].message.isInstanceOf[CMD_FORCECLOSE])
+      senderProbe.expectMessage(CloseCommandsRegistered(Map(channelId2 -> ClosingStatus.Pending)))
+      assert(db.listPendingCloseCommands().keySet == Set(channelId1, channelId2))
+    }
+    {
+      // After restarting our node, pending commands are automatically replayed.
+      val channelsCloser = testKit.spawn(OfflineChannelsCloser(TestConstants.Alice.nodeParams, db, register.ref.toClassic))
+      val previousCmds = Seq(
+        register.expectMessageType[Register.Forward[CloseCommand]],
+        register.expectMessageType[Register.Forward[CloseCommand]],
+      )
+      assert(previousCmds.map(_.channelId).toSet == Set(channelId1, channelId2))
+      val cmd1 = previousCmds.find(_.channelId == channelId1).value.message.asInstanceOf[CMD_CLOSE]
+      assert(cmd1.scriptPubKey.contains(hex"001436f83c329274e04b104000fbb27fcfe20a47cdaf"))
+      assert(cmd1.feerates.contains(feerates))
+      val cmd2 = previousCmds.find(_.channelId == channelId2).value
+      assert(cmd2.message.isInstanceOf[CMD_FORCECLOSE])
+
+      channelsCloser ! CloseChannels(senderProbe.ref, Seq(channelId3), None, None, Some(feerates))
+      val cmd3 = register.expectMessageType[Register.Forward[CloseCommand]]
+      assert(cmd3.channelId == channelId3)
+      assert(cmd3.message.asInstanceOf[CMD_CLOSE].scriptPubKey.isEmpty)
+      assert(cmd3.message.asInstanceOf[CMD_CLOSE].feerates.contains(feerates))
+      senderProbe.expectMessage(CloseCommandsRegistered(Map(channelId3 -> ClosingStatus.Pending)))
     }
   }
 

--- a/plugins/offline-commands/src/test/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineCommandsDbSpec.scala
+++ b/plugins/offline-commands/src/test/scala/fr/acinq/eclair/plugins/offlinecommands/OfflineCommandsDbSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.offlinecommands
+
+import fr.acinq.bitcoin.scalacompat.SatoshiLong
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
+import fr.acinq.eclair.channel.ClosingFeerates
+import fr.acinq.eclair.{TimestampSecond, randomBytes32}
+import org.scalatest.funsuite.AnyFunSuiteLike
+import scodec.bits.HexStringSyntax
+
+import java.sql.DriverManager
+
+class OfflineCommandsDbSpec extends AnyFunSuiteLike {
+
+  test("add/update/list close commands") {
+    val db = new SqliteOfflineCommandsDb(DriverManager.getConnection("jdbc:sqlite::memory:"))
+    assert(db.listPendingCloseCommands().isEmpty)
+
+    val feerates = ClosingFeerates(FeeratePerKw(1000 sat), FeeratePerKw(500 sat), FeeratePerKw(1200 sat))
+    val channelId1 = randomBytes32()
+    db.addCloseCommand(channelId1, ClosingParams(None, None, None))
+    val channelId2 = randomBytes32()
+    db.addCloseCommand(channelId2, ClosingParams(Some(TimestampSecond(150)), Some(hex"0102030405"), Some(feerates)))
+
+    assert(db.listPendingCloseCommands() == Map(
+      channelId1 -> ClosingParams(None, None, None),
+      channelId2 -> ClosingParams(Some(TimestampSecond(150)), Some(hex"0102030405"), Some(feerates)),
+    ))
+
+    db.addCloseCommand(channelId1, ClosingParams(Some(TimestampSecond(250)), Some(hex"deadbeef"), None))
+    assert(db.listPendingCloseCommands() == Map(
+      channelId1 -> ClosingParams(Some(TimestampSecond(250)), Some(hex"deadbeef"), None),
+      channelId2 -> ClosingParams(Some(TimestampSecond(150)), Some(hex"0102030405"), Some(feerates)),
+    ))
+
+    db.updateCloseCommand(channelId1, ClosingStatus.ChannelNotFound)
+    assert(db.listPendingCloseCommands() == Map(
+      channelId2 -> ClosingParams(Some(TimestampSecond(150)), Some(hex"0102030405"), Some(feerates)),
+    ))
+
+    db.updateCloseCommand(channelId2, ClosingStatus.ChannelClosed)
+    assert(db.listPendingCloseCommands().isEmpty)
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <module>eclair-core</module>
         <module>eclair-front</module>
         <module>eclair-node</module>
+        <module>plugins/offline-commands</module>
     </modules>
 
     <description>A scala implementation of the Lightning Network</description>


### PR DESCRIPTION
This PR introduces a new `plugins` directory to maintain official eclair plugins. It contains our first official plugin, the offline commands plugin. This plugin lets a node operator issue commands regardless of whether the target peer is online.
The plugin will store these commands and execute them once the target comes back online.

Its main use-case is to request closing a given channel with a timeout after which we should force-close. This feature has been requested several times by various node operators (most recently by @viaj3ro).

The PR is split in several independent commits, which can act as guidelines for future plugin writers (and should be converted to better documentation at some point).

The main point I'd like to discuss is whether those official plugins (which will contain `PeerSwap` as well) should directly be in the `eclair` repository or in a dedicated `eclair-plugins` repository. Here are the advantages and drawbacks that I see for each approach:

- Include plugins in the `eclair` repository:
  - Advantages: changes to eclair that break plugins are automatically detected and cannot be added to `master` without fixing the plugin first
  - Drawbacks: the build and tests are longer, which is painful for day-to-day development
- Create a new `eclair-plugins` repository:
  - Advantages: the `eclair` repository stays small with a fast build/test
  - Drawbacks: some changes to `eclair` may be merged that break plugins: we can add a nightly CI run on the `eclair-plugins` repository to build and test using the latest `eclair` master, which ensures we catch those quickly, but if they require completely re-working an `eclair` PR this isn't ideal. But maybe in practice that would happen often and we would just need to update the plugin code, which is ok?

I'm tempted to start with a separate repository for plugins, and later move them inside `eclair` if that turns out to be too painful in practice, what do you think?