### PR TITLE
Fix blinded path amount to forward calculation

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/RouteBlinding.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/RouteBlinding.scala
@@ -22,7 +22,7 @@ import fr.acinq.eclair.wire.protocol.CommonCodecs.{cltvExpiry, cltvExpiryDelta, 
 import fr.acinq.eclair.wire.protocol.LightningMessageCodecs.featuresCodec
 import fr.acinq.eclair.wire.protocol.OnionRoutingCodecs.{ForbiddenTlv, MissingRequiredTlv}
 import fr.acinq.eclair.wire.protocol.TlvCodecs.tmillisatoshi32
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Feature, Features, MilliSatoshi, ShortChannelId, UInt64}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Feature, Features, MilliSatoshi, MilliSatoshiLong, ShortChannelId, UInt64}
 import scodec.Attempt
 import scodec.bits.ByteVector
 
@@ -94,7 +94,7 @@ object BlindedRouteData {
     val outgoingChannelId: ShortChannelId = records.get[OutgoingChannelId].get.shortChannelId
 
     def amountToForward(amountReceived: MilliSatoshi): MilliSatoshi =
-      MilliSatoshi(((amountReceived - paymentRelay.feeBase).toLong.toDouble / (1.0 + paymentRelay.feeProportionalMillionths.toDouble / 1e-6)).ceil.toLong)
+      ((amountReceived - paymentRelay.feeBase).toLong * 1_000_000 + 1_000_000 + paymentRelay.feeProportionalMillionths - 1).msat / (1_000_000 + paymentRelay.feeProportionalMillionths)
 
     def outgoingCltv(incomingCltv: CltvExpiry): CltvExpiry = incomingCltv - paymentRelay.cltvExpiryDelta
   }


### PR DESCRIPTION
Apply @rustyrussell's neat truncating integer arithmetic formula to calculate the amount that should be forwarded by blinded path nodes instead of our previous approximation.

This simply expands `ceil(a/b)` as `(a+b-1)/b` and provides better results in practice (I ran a simulation with many values for fees and amount).