### PR TITLE
Refactor routing hint failure updates

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/Invoice.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/Invoice.scala
@@ -55,17 +55,20 @@ trait Invoice {
 }
 
 object Invoice {
+  /** An extra edge that can be used to pay a given invoice and may not be part of the public graph. */
   sealed trait ExtraEdge {
+    // @formatter:off
     def sourceNodeId: PublicKey
     def feeBase: MilliSatoshi
     def feeProportionalMillionths: Long
     def cltvExpiryDelta: CltvExpiryDelta
     def htlcMinimum: MilliSatoshi
     def htlcMaximum_opt: Option[MilliSatoshi]
-
     def relayFees: Relayer.RelayFees = Relayer.RelayFees(feeBase = feeBase, feeProportionalMillionths = feeProportionalMillionths)
+    // @formatter:on
   }
 
+  /** A normal graph edge, that should be handled exactly like public graph edges. */
   case class BasicEdge(sourceNodeId: PublicKey,
                        targetNodeId: PublicKey,
                        shortChannelId: ShortChannelId,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -264,24 +264,24 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
   private def handleUpdate(nodeId: PublicKey, failure: Update, data: WaitingForComplete): Seq[ExtraEdge] = {
     val extraEdges1 = data.route.hops.find(_.nodeId == nodeId) match {
       case Some(hop) => hop.params match {
-        case ChannelRelayParams.FromAnnouncement(u) =>
-          if (u.shortChannelId != failure.update.shortChannelId) {
+        case ann: ChannelRelayParams.FromAnnouncement =>
+          if (ann.channelUpdate.shortChannelId != failure.update.shortChannelId) {
             // it is possible that nodes in the route prefer using a different channel (to the same N+1 node) than the one we requested, that's fine
-            log.info("received an update for a different channel than the one we asked: requested={} actual={} update={}", u.shortChannelId, failure.update.shortChannelId, failure.update)
-          } else if (Announcements.areSame(u, failure.update)) {
+            log.info("received an update for a different channel than the one we asked: requested={} actual={} update={}", ann.channelUpdate.shortChannelId, failure.update.shortChannelId, failure.update)
+          } else if (Announcements.areSame(ann.channelUpdate, failure.update)) {
             // node returned the exact same update we used, this can happen e.g. if the channel is imbalanced
             // in that case, let's temporarily exclude the channel from future routes, giving it time to recover
             log.info("received exact same update from nodeId={}, excluding the channel from futures routes", nodeId)
-            router ! ExcludeChannel(ChannelDesc(u.shortChannelId, nodeId, hop.nextNodeId), Some(nodeParams.routerConf.channelExcludeDuration))
+            router ! ExcludeChannel(ChannelDesc(ann.channelUpdate.shortChannelId, nodeId, hop.nextNodeId), Some(nodeParams.routerConf.channelExcludeDuration))
           } else if (PaymentFailure.hasAlreadyFailedOnce(nodeId, data.failures)) {
             // this node had already given us a new channel update and is still unhappy, it is probably messing with us, let's exclude it
-            log.warning("it is the second time nodeId={} answers with a new update, excluding it: old={} new={}", nodeId, u, failure.update)
-            router ! ExcludeChannel(ChannelDesc(u.shortChannelId, nodeId, hop.nextNodeId), Some(nodeParams.routerConf.channelExcludeDuration))
+            log.warning("it is the second time nodeId={} answers with a new update, excluding it: old={} new={}", nodeId, ann.channelUpdate, failure.update)
+            router ! ExcludeChannel(ChannelDesc(ann.channelUpdate.shortChannelId, nodeId, hop.nextNodeId), Some(nodeParams.routerConf.channelExcludeDuration))
           } else {
-            log.info("got a new update for shortChannelId={}: old={} new={}", u.shortChannelId, u, failure.update)
+            log.info("got a new update for shortChannelId={}: old={} new={}", ann.channelUpdate.shortChannelId, ann.channelUpdate, failure.update)
           }
           data.c.extraEdges
-        case ChannelRelayParams.FromHint(_) =>
+        case _: ChannelRelayParams.FromHint =>
           log.info("received an update for a routing hint (shortChannelId={} nodeId={} enabled={} update={})", failure.update.shortChannelId, nodeId, failure.update.channelFlags.isEnabled, failure.update)
           if (failure.update.channelFlags.isEnabled) {
             data.c.extraEdges.map {
@@ -304,6 +304,7 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
         data.c.extraEdges
     }
     // in all cases, we forward the update to the router: if the channel is disabled, the router will remove it from its routing table
+    // if the channel is not announced (e.g. was from a hint), the router will simply ignore the update
     router ! failure.update
     // we return updated assisted routes: they take precedence over the router's routing table
     extraEdges1

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -545,9 +545,6 @@ object Router {
       amountToSend - amount
     }
 
-    /** This method retrieves the channel update that we used when we built the route. */
-    def getChannelUpdateForNode(nodeId: PublicKey): Option[ChannelUpdate] = hops.find(_.nodeId == nodeId).map(_.params).collect { case s: ChannelRelayParams.FromAnnouncement => s.channelUpdate }
-
     def printNodes(): String = hops.map(_.nextNodeId).mkString("->")
 
     def printChannels(): String = hops.map(_.shortChannelId).mkString("->")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -629,7 +629,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.send(paymentFSM, addCompleted(HtlcResult.RemoteFail(UpdateFailHtlc(ByteVector32.Zeroes, 0, failureOnion))))
 
     assert(routerForwarder.expectMsgType[RouteCouldRelay].route.hops.map(_.shortChannelId) == Seq(update_ab, update_bc).map(_.shortChannelId))
-    routerForwarder.expectMsg(ExcludeChannel(ChannelDesc(update_cd.shortChannelId, c, d), Some(nodeParams.routerConf.channelExcludeDuration))))
+    routerForwarder.expectMsg(ExcludeChannel(ChannelDesc(update_cd.shortChannelId, c, d), Some(nodeParams.routerConf.channelExcludeDuration)))
     routerForwarder.expectMsg(channelUpdate_cd_disabled)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -629,8 +629,8 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
     sender.send(paymentFSM, addCompleted(HtlcResult.RemoteFail(UpdateFailHtlc(ByteVector32.Zeroes, 0, failureOnion))))
 
     assert(routerForwarder.expectMsgType[RouteCouldRelay].route.hops.map(_.shortChannelId) == Seq(update_ab, update_bc).map(_.shortChannelId))
+    routerForwarder.expectMsg(ExcludeChannel(ChannelDesc(update_cd.shortChannelId, c, d), Some(nodeParams.routerConf.channelExcludeDuration))))
     routerForwarder.expectMsg(channelUpdate_cd_disabled)
-    routerForwarder.expectMsg(ExcludeChannel(ChannelDesc(update_cd.shortChannelId, c, d), Some(nodeParams.routerConf.channelExcludeDuration)))
   }
 
   def testPermanentFailure(router: ActorRef, failure: FailureMessage): Unit = {


### PR DESCRIPTION
This is a follow up of #2264 where we refactor handling of channel updates in failures coming from routing hints.
For failures in one of the routing hints, we use the `node_id` pair (source, destination) instead of the `short_channel_id` to identify the failing edge.