### PR TITLE
Delete `ChaCha20.decrypt`, rename `encrypt` to `xor`.

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Sphinx.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/Sphinx.scala
@@ -50,7 +50,7 @@ object Sphinx extends Logging {
 
   def zeroes(length: Int): ByteVector = ByteVector.fill(length)(0)
 
-  def generateStream(key: ByteVector, length: Int): ByteVector = ChaCha20.encrypt(zeroes(length), key, zeroes(12))
+  def generateStream(key: ByteVector, length: Int): ByteVector = ChaCha20.xor(zeroes(length), key, zeroes(12))
 
   def computeSharedSecret(pub: PublicKey, secret: PrivateKey): ByteVector32 = Crypto.sha256(pub.multiply(secret).value)
 


### PR DESCRIPTION
This changes nothing because the two functions do exactly the same thing, I just thought it would be clearer this way.

Protocol description: https://www.rfc-editor.org/rfc/rfc7539#section-2.4

>    Decryption is done in the same way.  The ChaCha20 block function is
>    used to expand the key into a keystream, which is XORed with the
>    ciphertext giving back the plaintext.

About the boolean parameter passed to `engine.init`: https://github.com/bcgit/bc-java/blob/36e75a9a26479420d44008cefd28de2f2db083c3/core/src/main/java/org/bouncycastle/crypto/engines/Salsa20Engine.java#L88-L96 (`ChaCha7539Engine` extends `Salsa20` Engine and also does not use `forEncryption`)

>        /* 
>        * Salsa20 encryption and decryption is completely
>        * symmetrical, so the 'forEncryption' is 
>        * irrelevant. (Like 90% of stream ciphers)
>        */