### PR TITLE
Remove invalid channel updates from DB at startup

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
@@ -41,7 +41,7 @@ trait NetworkDb {
 
   def updateChannel(u: ChannelUpdate): Unit
 
-  def removeChannel(shortChannelId: ShortChannelId) = removeChannels(Set(shortChannelId)): Unit
+  def removeChannel(shortChannelId: ShortChannelId): Unit = removeChannels(Set(shortChannelId))
 
   def removeChannels(shortChannelIds: Iterable[ShortChannelId]): Unit
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
@@ -17,8 +17,7 @@
 package fr.acinq.eclair.db.pg
 
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, Crypto, Satoshi}
-import fr.acinq.eclair.ShortChannelId
-import fr.acinq.eclair.RealShortChannelId
+import fr.acinq.eclair.{RealShortChannelId, ShortChannelId}
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db.Monitoring.Tags.DbBackends
 import fr.acinq.eclair.db.NetworkDb
@@ -80,7 +79,17 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
           if (v < 4) {
             migration34(statement)
           }
-        case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
+        case Some(CURRENT_VERSION) =>
+          // We clean up channels that contain an invalid channel update (e.g. missing htlc_maximum_msat).
+          val invalidChannels = statement.executeQuery("SELECT short_channel_id, channel_update_1, channel_update_2 FROM network.public_channels").map(rs => {
+            val shortChannelId = rs.getLong("short_channel_id")
+            val validChannelUpdate1 = rs.getBitVectorOpt("channel_update_1").forall(channelUpdateCodec.decode(_).isSuccessful)
+            val validChannelUpdate2 = rs.getBitVectorOpt("channel_update_2").forall(channelUpdateCodec.decode(_).isSuccessful)
+            (shortChannelId, validChannelUpdate1 && validChannelUpdate2)
+          }).filter { case (_, isValid) => !isValid }.map { case (scid, _) => scid }.toSeq
+          invalidChannels.foreach(scid => {
+            statement.executeUpdate(s"DELETE FROM network.public_channels WHERE short_channel_id=$scid")
+          })
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
       }
       setVersion(statement, DB_NAME, CURRENT_VERSION)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -17,8 +17,7 @@
 package fr.acinq.eclair.db.sqlite
 
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, Crypto, Satoshi}
-import fr.acinq.eclair.ShortChannelId
-import fr.acinq.eclair.RealShortChannelId
+import fr.acinq.eclair.{RealShortChannelId, ShortChannelId}
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db.Monitoring.Tags.DbBackends
 import fr.acinq.eclair.db.NetworkDb
@@ -61,7 +60,17 @@ class SqliteNetworkDb(val sqlite: Connection) extends NetworkDb with Logging {
       case Some(v@1) =>
         logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
         migration12(statement)
-      case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
+      case Some(CURRENT_VERSION) =>
+        // We clean up channels that contain an invalid channel update (e.g. missing htlc_maximum_msat).
+        val invalidChannels = statement.executeQuery("SELECT short_channel_id, channel_update_1, channel_update_2 FROM channels").map(rs => {
+          val shortChannelId = rs.getLong("short_channel_id")
+          val validChannelUpdate1 = rs.getBitVectorOpt("channel_update_1").forall(channelUpdateCodec.decode(_).isSuccessful)
+          val validChannelUpdate2 = rs.getBitVectorOpt("channel_update_2").forall(channelUpdateCodec.decode(_).isSuccessful)
+          (shortChannelId, validChannelUpdate1 && validChannelUpdate2)
+        }).filter { case (_, isValid) => !isValid }.map { case (scid, _) => scid }.toSeq
+        invalidChannels.foreach(scid => {
+          statement.executeUpdate(s"DELETE FROM channels WHERE short_channel_id=$scid")
+        })
       case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
     }
     setVersion(statement, DB_NAME, CURRENT_VERSION)
@@ -129,12 +138,12 @@ class SqliteNetworkDb(val sqlite: Connection) extends NetworkDb with Logging {
     using(sqlite.createStatement()) { statement =>
       statement.executeQuery("SELECT channel_announcement, txid, capacity_sat, channel_update_1, channel_update_2 FROM channels")
         .foldLeft(SortedMap.empty[RealShortChannelId, PublicChannel]) { (m, rs) =>
-            val ann = channelAnnouncementCodec.decode(rs.getBitVectorOpt("channel_announcement").get).require.value
-            val txId = ByteVector32.fromValidHex(rs.getString("txid"))
-            val capacity = rs.getLong("capacity_sat")
-            val channel_update_1_opt = rs.getBitVectorOpt("channel_update_1").map(channelUpdateCodec.decode(_).require.value)
-            val channel_update_2_opt = rs.getBitVectorOpt("channel_update_2").map(channelUpdateCodec.decode(_).require.value)
-            m + (ann.shortChannelId -> PublicChannel(ann, txId, Satoshi(capacity), channel_update_1_opt, channel_update_2_opt, None))
+          val ann = channelAnnouncementCodec.decode(rs.getBitVectorOpt("channel_announcement").get).require.value
+          val txId = ByteVector32.fromValidHex(rs.getString("txid"))
+          val capacity = rs.getLong("capacity_sat")
+          val channel_update_1_opt = rs.getBitVectorOpt("channel_update_1").map(channelUpdateCodec.decode(_).require.value)
+          val channel_update_2_opt = rs.getBitVectorOpt("channel_update_2").map(channelUpdateCodec.decode(_).require.value)
+          m + (ann.shortChannelId -> PublicChannel(ann, txId, Satoshi(capacity), channel_update_1_opt, channel_update_2_opt, None))
         }
     }
   }
@@ -166,7 +175,7 @@ class SqliteNetworkDb(val sqlite: Connection) extends NetworkDb with Logging {
   }
 
   override def removeFromPruned(shortChannelId: RealShortChannelId): Unit = withMetrics("network/remove-from-pruned", DbBackends.Sqlite) {
-    using(sqlite.prepareStatement(s"DELETE FROM pruned WHERE short_channel_id=?")) { statement =>
+    using(sqlite.prepareStatement("DELETE FROM pruned WHERE short_channel_id=?")) { statement =>
       statement.setLong(1, shortChannelId.toLong)
       statement.executeUpdate()
     }


### PR DESCRIPTION
Following #2361, we reject channel updates that don't contain the `htlc_maximum_msat` field. However, the network DB may contain such channel updates, that we need to remove when starting up.

I've checked what we have in our network DB on the ACINQ node before opening that PR. We have ~100 channel updates that don't contain an `htlc_maximum_msat`, but all of them except one are completely outdated (from before 2020), which indicates that we have a pruning bug that I'll fix in a separate PR. The only non-outdated invalid channel update that we have is a 22,222 sat channel between a node called `dontconnect` and a node called `Sybil`: https://1ml.com/channel/588047405915373568

So we can pretty much ignore it.
