### PR TITLE
Prune channels if any update is stale

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/StaleChannels.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/StaleChannels.scala
@@ -21,7 +21,7 @@ import akka.event.LoggingAdapter
 import fr.acinq.eclair.db.NetworkDb
 import fr.acinq.eclair.router.Router.{ChannelDesc, Data, PublicChannel, hasChannels}
 import fr.acinq.eclair.wire.protocol.{ChannelAnnouncement, ChannelUpdate}
-import fr.acinq.eclair.{BlockHeight, RealShortChannelId, ShortChannelId, TimestampSecond, TxCoordinates}
+import fr.acinq.eclair.{BlockHeight, ShortChannelId, TimestampSecond, TxCoordinates}
 
 import scala.collection.mutable
 import scala.concurrent.duration._
@@ -79,21 +79,23 @@ object StaleChannels {
   }
 
   /**
-   * Is stale a channel that:
-   * (1) is older than 2 weeks (2*7*144 = 2016 blocks)
-   * AND
-   * (2) has no channel_update younger than 2 weeks
+   * A channel is stale if:
+   *  - it is older than 2 weeks (2*7*144 = 2016 blocks): we don't want to prune brand new channels for which we didn't
+   *    yet receive a channel update
+   *  - and has a channel update that is older than 2 weeks
+   *
+   * Note that we should not wait for *both* channel updates to be stale: as long as one of the peers is inactive, it's
+   * very likely that we won't be able to route payments through that channel, so we should ignore it.
    *
    * @param update1_opt update corresponding to one side of the channel, if we have it
    * @param update2_opt update corresponding to the other side of the channel, if we have it
-   * @return
    */
   def isStale(channel: ChannelAnnouncement, update1_opt: Option[ChannelUpdate], update2_opt: Option[ChannelUpdate], currentBlockHeight: BlockHeight): Boolean = {
-    // BOLT 7: "nodes MAY prune channels should the timestamp of the latest channel_update be older than 2 weeks (1209600 seconds)"
-    // but we don't want to prune brand new channels for which we didn't yet receive a channel update, so we keep them as long as they are less than 2 weeks (2016 blocks) old
     val staleThresholdBlocks = currentBlockHeight - 2016
     val TxCoordinates(blockHeight, _, _) = ShortChannelId.coordinates(channel.shortChannelId)
-    blockHeight < staleThresholdBlocks && update1_opt.forall(isStale) && update2_opt.forall(isStale)
+    val channelIsOldEnough = blockHeight < staleThresholdBlocks
+    val channelUpdateIsStale = update1_opt.forall(isStale) || update2_opt.forall(isStale)
+    channelIsOldEnough && channelUpdateIsStale
   }
 
   def getStaleChannels(channels: Iterable[PublicChannel], currentBlockHeight: BlockHeight): Iterable[PublicChannel] = channels.filter(data => isStale(data.ann, data.update_1_opt, data.update_2_opt, currentBlockHeight))


### PR DESCRIPTION
We previously incorrectly pruned only once both channel updates were stale. This was incorrect, we must prune channels as soon as one side becomes stale.

There are ~100 channels on the network today that have one inactive side, while the other side regularly refreshes their channel update, but those channels won't be usable for routing. They should eventually be closed, but the active side is probably hoping for the inactive side to come back online to get the opportunity to do a mutual close.