### PR TITLE
Fix dual funding flaky test

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingConfirmedStateSpec.scala
@@ -678,9 +678,7 @@ class WaitForDualFundingConfirmedStateSpec extends TestKitBaseClass with Fixture
     bobData.previousFundingTxs.foreach(f => bob2blockchain.expectMsgType[WatchFundingConfirmed].txId == f.commitments.fundingTxId)
     awaitCond(bob2.stateName == OFFLINE)
 
-    alice2.underlying.system.eventStream.subscribe(aliceListener.ref, classOf[TransactionPublished])
     alice2.underlying.system.eventStream.subscribe(aliceListener.ref, classOf[TransactionConfirmed])
-    bob2.underlying.system.eventStream.subscribe(bobListener.ref, classOf[TransactionPublished])
     bob2.underlying.system.eventStream.subscribe(bobListener.ref, classOf[TransactionConfirmed])
 
     (alice2, bob2)


### PR DESCRIPTION
Nodes also asynchronously republish funding txs after a restart, but we want to test the closing behavior so we ignore these events.