### PR TITLE
Fix pruned channels coming back online

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/NetworkDb.scala
@@ -18,10 +18,10 @@ package fr.acinq.eclair.db
 
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi}
-import fr.acinq.eclair.ShortChannelId
-import fr.acinq.eclair.RealShortChannelId
 import fr.acinq.eclair.router.Router.PublicChannel
+import fr.acinq.eclair.router.StaleChannels
 import fr.acinq.eclair.wire.protocol.{ChannelAnnouncement, ChannelUpdate, NodeAnnouncement}
+import fr.acinq.eclair.{RealShortChannelId, ShortChannelId}
 
 import scala.collection.immutable.SortedMap
 
@@ -47,10 +47,12 @@ trait NetworkDb {
 
   def listChannels(): SortedMap[RealShortChannelId, PublicChannel]
 
-  def addToPruned(shortChannelIds: Iterable[RealShortChannelId]): Unit
+  def addToPruned(channels: Iterable[StaleChannels.LatestUpdates]): Unit
 
   def removeFromPruned(shortChannelId: RealShortChannelId): Unit
 
-  def isPruned(shortChannelId: ShortChannelId): Boolean
+  def getPrunedChannel(shortChannelId: ShortChannelId): Option[StaleChannels.LatestUpdates]
+
+  def updatePrunedChannel(u: ChannelUpdate): Unit
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgNetworkDb.scala
@@ -77,7 +77,9 @@ class PgNetworkDb(implicit ds: DataSource) extends NetworkDb with Logging {
           val validChannelUpdate2 = rs.getBitVectorOpt("channel_update_2").forall(channelUpdateCodec.decode(_).isSuccessful)
           (shortChannelId, validChannelUpdate1 && validChannelUpdate2)
         }).collect {
-          case (scid, false) => statement.executeUpdate(s"DELETE FROM network.public_channels WHERE short_channel_id=$scid")
+          case (scid, false) =>
+            logger.warn(s"removing channel update with scid=$scid from the network DB (update cannot be decoded)")
+            statement.executeUpdate(s"DELETE FROM network.public_channels WHERE short_channel_id=$scid")
         }
       }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteNetworkDb.scala
@@ -64,7 +64,9 @@ class SqliteNetworkDb(val sqlite: Connection) extends NetworkDb with Logging {
         val validChannelUpdate2 = rs.getBitVectorOpt("channel_update_2").forall(channelUpdateCodec.decode(_).isSuccessful)
         (shortChannelId, validChannelUpdate1 && validChannelUpdate2)
       }).collect {
-        case (scid, false) => statement.executeUpdate(s"DELETE FROM channels WHERE short_channel_id=$scid")
+        case (scid, false) =>
+          logger.warn(s"removing channel update with scid=$scid from the network DB (update cannot be decoded)")
+          statement.executeUpdate(s"DELETE FROM channels WHERE short_channel_id=$scid")
       }
     }
 


### PR DESCRIPTION
When a channel was pruned and we receive a valid channel update for it, we need to wait until we're sure both sides of the channel are back online: a channel that has only one side available will most likely not be able to relay payments.

Once both sides have created fresh, valid channel updates, we need to re-request the corresponding channel announcement that we previously deleted. We also need to request the corresponding channel updates: if we don't receive them, we will just prune the channel again.

@sstone can you try that on your node and see if that fully fixes the issue?

Fixes #2388