### PR TITLE
Add option to require confirmed inputs in interactive-tx

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
@@ -62,6 +62,9 @@ trait OnChainChannelFunder {
   /** Return the transaction if it exists, either in the blockchain or in the mempool. */
   def getTransaction(txId: ByteVector32)(implicit ec: ExecutionContext): Future[Transaction]
 
+  /** Get the number of confirmations of a given transaction. */
+  def getTxConfirmations(txid: ByteVector32)(implicit ec: ExecutionContext): Future[Option[Int]]
+
   /** Rollback a transaction that we failed to commit: this probably translates to "release locks on utxos". */
   def rollback(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -35,7 +35,6 @@ case class RemoteError(e: Error) extends ChannelOpenError
 class ChannelException(val channelId: ByteVector32, message: String) extends RuntimeException(message)
 
 // @formatter:off
-case class DebugTriggeredException                 (override val channelId: ByteVector32) extends ChannelException(channelId, "debug-mode triggered failure")
 case class InvalidChainHash                        (override val channelId: ByteVector32, local: ByteVector32, remote: ByteVector32) extends ChannelException(channelId, s"invalid chainHash (local=$local remote=$remote)")
 case class InvalidFundingAmount                    (override val channelId: ByteVector32, fundingAmount: Satoshi, min: Satoshi, max: Satoshi) extends ChannelException(channelId, s"invalid funding_satoshis=$fundingAmount (min=$min max=$max)")
 case class InvalidPushAmount                       (override val channelId: ByteVector32, pushAmount: MilliSatoshi, max: MilliSatoshi) extends ChannelException(channelId, s"invalid pushAmount=$pushAmount (max=$max)")
@@ -58,6 +57,7 @@ case class InputOutOfBounds                        (override val channelId: Byte
 case class NonSegwitInput                          (override val channelId: ByteVector32, serialId: UInt64, previousTxId: ByteVector32, previousTxOutput: Long) extends ChannelException(channelId, s"$previousTxId:$previousTxOutput is not a native segwit input (serial_id=${serialId.toByteVector.toHex})")
 case class OutputBelowDust                         (override val channelId: ByteVector32, serialId: UInt64, amount: Satoshi, dustLimit: Satoshi) extends ChannelException(channelId, s"invalid output amount=$amount below dust=$dustLimit (serial_id=${serialId.toByteVector.toHex})")
 case class NonSegwitOutput                         (override val channelId: ByteVector32, serialId: UInt64) extends ChannelException(channelId, s"output with serial_id=${serialId.toByteVector.toHex} is not a native segwit output")
+case class UnconfirmedInteractiveTxInputs          (override val channelId: ByteVector32) extends ChannelException(channelId, "the completed interactive tx contains unconfirmed inputs")
 case class InvalidCompleteInteractiveTx            (override val channelId: ByteVector32) extends ChannelException(channelId, "the completed interactive tx is invalid")
 case class TooManyInteractiveTxRounds              (override val channelId: ByteVector32) extends ChannelException(channelId, "too many messages exchanged during interactive tx construction")
 case class DualFundingAborted                      (override val channelId: ByteVector32) extends ChannelException(channelId, "dual funding aborted")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -188,7 +188,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
           context.system.eventStream.publish(ChannelIdAssigned(self, remoteNodeId, accept.temporaryChannelId, channelId))
           // We start the interactive-tx funding protocol.
           val fundingPubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey, remoteParams.fundingPubKey)))
-          val fundingParams = InteractiveTxParams(channelId, localParams.isInitiator, accept.fundingAmount, open.fundingAmount, fundingPubkeyScript, open.lockTime, open.dustLimit.max(accept.dustLimit), open.fundingFeerate)
+          val fundingParams = InteractiveTxParams(channelId, localParams.isInitiator, accept.fundingAmount, open.fundingAmount, fundingPubkeyScript, open.lockTime, open.dustLimit.max(accept.dustLimit), open.fundingFeerate, requireConfirmedRemoteInputs = false)
           val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
             remoteNodeId, fundingParams, keyManager,
             localParams, remoteParams,
@@ -240,7 +240,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
           // We start the interactive-tx funding protocol.
           val localFundingPubkey = keyManager.fundingPublicKey(localParams.fundingKeyPath)
           val fundingPubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey.publicKey, remoteParams.fundingPubKey)))
-          val fundingParams = InteractiveTxParams(channelId, localParams.isInitiator, d.lastSent.fundingAmount, accept.fundingAmount, fundingPubkeyScript, d.lastSent.lockTime, d.lastSent.dustLimit.max(accept.dustLimit), d.lastSent.fundingFeerate)
+          val fundingParams = InteractiveTxParams(channelId, localParams.isInitiator, d.lastSent.fundingAmount, accept.fundingAmount, fundingPubkeyScript, d.lastSent.lockTime, d.lastSent.dustLimit.max(accept.dustLimit), d.lastSent.fundingFeerate, requireConfirmedRemoteInputs = false)
           val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
             remoteNodeId, fundingParams, keyManager,
             localParams, remoteParams,
@@ -418,7 +418,8 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
             d.fundingParams.fundingPubkeyScript,
             msg.lockTime,
             d.fundingParams.dustLimit,
-            msg.feerate
+            msg.feerate,
+            d.fundingParams.requireConfirmedRemoteInputs,
           )
           val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
             remoteNodeId, fundingParams, keyManager,
@@ -445,7 +446,8 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
             d.fundingParams.fundingPubkeyScript,
             cmd.lockTime,
             d.fundingParams.dustLimit,
-            cmd.targetFeerate
+            cmd.targetFeerate,
+            d.fundingParams.requireConfirmedRemoteInputs,
           )
           val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
             remoteNodeId, fundingParams, keyManager,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
@@ -16,7 +16,6 @@
 
 package fr.acinq.eclair.wire.internal.channel.version3
 
-import akka.actor.typed
 import fr.acinq.bitcoin.scalacompat.DeterministicWallet.{ExtendedPrivateKey, KeyPath}
 import fr.acinq.bitcoin.scalacompat.{OutPoint, Transaction, TxOut}
 import fr.acinq.eclair.channel.InteractiveTxBuilder._
@@ -381,7 +380,8 @@ private[channel] object ChannelCodecs3 {
         ("fundingPubkeyScript" | lengthDelimited(bytes)) ::
         ("lockTime" | uint32) ::
         ("dustLimit" | satoshi) ::
-        ("targetFeerate" | feeratePerKw)).as[InteractiveTxParams]
+        ("targetFeerate" | feeratePerKw) ::
+        ("requireConfirmedRemoteInputs" | bool8)).as[InteractiveTxParams]
 
     val DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED_0b_Codec: Codec[DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED] = (
       ("commitments" | commitmentsCodec) ::

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
@@ -60,6 +60,8 @@ class DummyOnChainWallet extends OnChainWallet {
 
   override def getTransaction(txId: ByteVector32)(implicit ec: ExecutionContext): Future[Transaction] = Future.failed(new RuntimeException("transaction not found"))
 
+  override def getTxConfirmations(txid: ByteVector32)(implicit ec: ExecutionContext): Future[Option[Int]] = Future.failed(new RuntimeException("transaction not found"))
+
   override def rollback(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean] = {
     rolledback = rolledback + tx
     Future.successful(true)
@@ -93,6 +95,8 @@ class NoOpOnChainWallet extends OnChainWallet {
   override def commit(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean] = Future.successful(true)
 
   override def getTransaction(txId: ByteVector32)(implicit ec: ExecutionContext): Future[Transaction] = Promise().future // will never be completed
+
+  override def getTxConfirmations(txid: ByteVector32)(implicit ec: ExecutionContext): Future[Option[Int]] = Promise().future // will never be completed
 
   override def rollback(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean] = {
     rolledback = rolledback :+ tx
@@ -168,6 +172,8 @@ class SingleKeyOnChainWallet extends OnChainWallet {
       case None => Future.failed(new RuntimeException("tx not found"))
     }
   }
+
+  override def getTxConfirmations(txid: ByteVector32)(implicit ec: ExecutionContext): Future[Option[Int]] = Future.successful(None)
 
   override def rollback(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean] = {
     rolledback = rolledback :+ tx

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
@@ -93,7 +93,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       ChannelFlags.Public, ChannelConfig.standard, channelFeatures, wallet))
   }
 
-  private def createChannelParams(fundingAmountA: Satoshi, fundingAmountB: Satoshi, targetFeerate: FeeratePerKw, dustLimit: Satoshi, lockTime: Long): ChannelParams = {
+  private def createChannelParams(fundingAmountA: Satoshi, fundingAmountB: Satoshi, targetFeerate: FeeratePerKw, dustLimit: Satoshi, lockTime: Long, requireConfirmedInputs: Boolean = false): ChannelParams = {
     val channelFeatures = ChannelFeatures(ChannelTypes.AnchorOutputsZeroFeeHtlcTx(scidAlias = false, zeroConf = false), Features[InitFeature](Features.DualFunding -> FeatureSupport.Optional), Features[InitFeature](Features.DualFunding -> FeatureSupport.Optional), announceChannel = true)
     val Seq(nodeParamsA, nodeParamsB) = Seq(TestConstants.Alice.nodeParams, TestConstants.Bob.nodeParams).map(_.copy(features = Features(channelFeatures.features.map(f => f -> FeatureSupport.Optional).toMap[Feature, FeatureSupport])))
     val localParamsA = Peer.makeChannelParams(nodeParamsA, nodeParamsA.features.initFeatures(), ByteVector.empty, None, isInitiator = true, fundingAmountA)
@@ -119,8 +119,8 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
 
     val channelId = randomBytes32()
     val fundingScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(remoteParamsA.fundingPubKey, remoteParamsB.fundingPubKey)))
-    val fundingParamsA = InteractiveTxParams(channelId, isInitiator = true, fundingAmountA, fundingAmountB, fundingScript, lockTime, dustLimit, targetFeerate)
-    val fundingParamsB = InteractiveTxParams(channelId, isInitiator = false, fundingAmountB, fundingAmountA, fundingScript, lockTime, dustLimit, targetFeerate)
+    val fundingParamsA = InteractiveTxParams(channelId, isInitiator = true, fundingAmountA, fundingAmountB, fundingScript, lockTime, dustLimit, targetFeerate, requireConfirmedInputs)
+    val fundingParamsB = InteractiveTxParams(channelId, isInitiator = false, fundingAmountB, fundingAmountA, fundingScript, lockTime, dustLimit, targetFeerate, requireConfirmedInputs)
     ChannelParams(fundingParamsA, nodeParamsA, localParamsA, remoteParamsA, firstPerCommitmentPointA, fundingParamsB, nodeParamsB, localParamsB, remoteParamsB, firstPerCommitmentPointB, channelFeatures)
   }
 
@@ -130,9 +130,9 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
                      bobRbf: ActorRef[InteractiveTxBuilder.Command],
                      aliceParams: InteractiveTxParams,
                      bobParams: InteractiveTxParams,
-                     walletA: OnChainWallet,
+                     walletA: BitcoinCoreClient,
                      rpcClientA: BitcoinJsonRPCClient,
-                     walletB: OnChainWallet,
+                     walletB: BitcoinCoreClient,
                      rpcClientB: BitcoinJsonRPCClient,
                      alice2bob: TestProbe,
                      bob2alice: TestProbe) {
@@ -158,7 +158,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     }
   }
 
-  private def withFixture(fundingAmountA: Satoshi, utxosA: Seq[Satoshi], fundingAmountB: Satoshi, utxosB: Seq[Satoshi], targetFeerate: FeeratePerKw, dustLimit: Satoshi, lockTime: Long)(testFun: Fixture => Any): Unit = {
+  private def withFixture(fundingAmountA: Satoshi, utxosA: Seq[Satoshi], fundingAmountB: Satoshi, utxosB: Seq[Satoshi], targetFeerate: FeeratePerKw, dustLimit: Satoshi, lockTime: Long, requireConfirmedInputs: Boolean)(testFun: Fixture => Any): Unit = {
     // Initialize wallets with a few confirmed utxos.
     val probe = TestProbe()
     val rpcClientA = createWallet(UUID.randomUUID().toString)
@@ -169,7 +169,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     utxosB.foreach(amount => addUtxo(walletB, amount, probe))
     generateBlocks(1)
 
-    val channelParams = createChannelParams(fundingAmountA, fundingAmountB, targetFeerate, dustLimit, lockTime)
+    val channelParams = createChannelParams(fundingAmountA, fundingAmountB, targetFeerate, dustLimit, lockTime, requireConfirmedInputs)
     val commitFeerate = TestConstants.anchorOutputsFeeratePerKw
     val alice = channelParams.spawnTxBuilderAlice(channelParams.fundingParamsA, commitFeerate, walletA)
     val aliceRbf = channelParams.spawnTxBuilderAlice(channelParams.fundingParamsA.copy(targetFeerate = targetFeerate * 1.5), commitFeerate, walletA)
@@ -184,7 +184,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     val utxosA = Seq(50_000 sat, 35_000 sat, 60_000 sat)
     val fundingB = 40_000 sat
     val utxosB = Seq(100_000 sat)
-    withFixture(fundingA, utxosA, fundingB, utxosB, targetFeerate, 660 sat, 42) { f =>
+    withFixture(fundingA, utxosA, fundingB, utxosB, targetFeerate, 660 sat, 42, requireConfirmedInputs = false) { f =>
       import f._
 
       alice ! Start(alice2bob.ref, Nil)
@@ -261,7 +261,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     val utxosA = Seq(50_000 sat)
     val fundingB = 50_000 sat
     val utxosB = Seq(80_000 sat)
-    withFixture(fundingA, utxosA, fundingB, utxosB, targetFeerate, 660 sat, 0) { f =>
+    withFixture(fundingA, utxosA, fundingB, utxosB, targetFeerate, 660 sat, 0, requireConfirmedInputs = true) { f =>
       import f._
 
       alice ! Start(alice2bob.ref, Nil)
@@ -318,7 +318,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     val targetFeerate = FeeratePerKw(2500 sat)
     val fundingA = 150_000 sat
     val utxosA = Seq(80_000 sat, 120_000 sat)
-    withFixture(fundingA, utxosA, 0 sat, Nil, targetFeerate, 660 sat, 0) { f =>
+    withFixture(fundingA, utxosA, 0 sat, Nil, targetFeerate, 660 sat, 0, requireConfirmedInputs = false) { f =>
       import f._
 
       alice ! Start(alice2bob.ref, Nil)
@@ -374,7 +374,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
   }
 
   test("remove input/output") {
-    withFixture(100_000 sat, Seq(150_000 sat), 0 sat, Nil, FeeratePerKw(2500 sat), 330 sat, 0) { f =>
+    withFixture(100_000 sat, Seq(150_000 sat), 0 sat, Nil, FeeratePerKw(2500 sat), 330 sat, 0, requireConfirmedInputs = false) { f =>
       import f._
 
       alice ! Start(alice2bob.ref, Nil)
@@ -424,7 +424,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
   test("not enough funds (unusable utxos)") {
     val fundingA = 140_000 sat
     val utxosA = Seq(75_000 sat, 60_000 sat)
-    withFixture(fundingA, utxosA, 0 sat, Nil, FeeratePerKw(5000 sat), 660 sat, 0) { f =>
+    withFixture(fundingA, utxosA, 0 sat, Nil, FeeratePerKw(5000 sat), 660 sat, 0, requireConfirmedInputs = false) { f =>
       import f._
 
       // Add some unusable utxos to Alice's wallet.
@@ -469,7 +469,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
   test("skip unusable utxos") {
     val fundingA = 140_000 sat
     val utxosA = Seq(55_000 sat, 65_000 sat, 50_000 sat)
-    withFixture(fundingA, utxosA, 0 sat, Nil, FeeratePerKw(5000 sat), 660 sat, 0) { f =>
+    withFixture(fundingA, utxosA, 0 sat, Nil, FeeratePerKw(5000 sat), 660 sat, 0, requireConfirmedInputs = false) { f =>
       import f._
 
       // Add some unusable utxos to Alice's wallet.
@@ -538,7 +538,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     val targetFeerate = FeeratePerKw(7500 sat)
     val fundingA = 85_000 sat
     val utxosA = Seq(120_000 sat)
-    withFixture(fundingA, utxosA, 0 sat, Nil, targetFeerate, 660 sat, 0) { f =>
+    withFixture(fundingA, utxosA, 0 sat, Nil, targetFeerate, 660 sat, 0, requireConfirmedInputs = false) { f =>
       import f._
 
       alice ! Start(alice2bob.ref, Nil)
@@ -613,7 +613,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     val targetFeerate = FeeratePerKw(10_000 sat)
     val fundingA = 100_000 sat
     val utxosA = Seq(55_000 sat, 55_000 sat, 55_000 sat)
-    withFixture(fundingA, utxosA, 0 sat, Nil, targetFeerate, 660 sat, 0) { f =>
+    withFixture(fundingA, utxosA, 0 sat, Nil, targetFeerate, 660 sat, 0, requireConfirmedInputs = false) { f =>
       import f._
 
       alice ! Start(alice2bob.ref, Nil)
@@ -702,7 +702,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     val utxosA = Seq(70_000 sat, 60_000 sat)
     val fundingB = 25_000 sat
     val utxosB = Seq(27_500 sat)
-    withFixture(fundingA, utxosA, fundingB, utxosB, initialFeerate, 660 sat, 0) { f =>
+    withFixture(fundingA, utxosA, fundingB, utxosB, initialFeerate, 660 sat, 0, requireConfirmedInputs = false) { f =>
       import f._
 
       alice ! Start(alice2bob.ref, Nil)
@@ -788,7 +788,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     val targetFeerate = FeeratePerKw(10_000 sat)
     val fundingA = 80_000 sat
     val utxosA = Seq(85_000 sat)
-    withFixture(fundingA, utxosA, 0 sat, Nil, targetFeerate, 660 sat, 0) { f =>
+    withFixture(fundingA, utxosA, 0 sat, Nil, targetFeerate, 660 sat, 0, requireConfirmedInputs = false) { f =>
       import f._
 
       alice ! Start(alice2bob.ref, Nil)
@@ -816,6 +816,78 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
 
       aliceRbf ! Start(alice2bob.ref, Seq(txA))
       assert(alice2bob.expectMsgType[LocalFailure].cause == ChannelFundingError(aliceParams.channelId))
+    }
+  }
+
+  test("allow unconfirmed remote inputs") {
+    withFixture(120_000 sat, Seq(150_000 sat), 50_000 sat, Seq(100_000 sat), FeeratePerKw(4000 sat), 660 sat, 0, requireConfirmedInputs = false) { f =>
+      import f._
+
+      // Bob's available utxo is unconfirmed.
+      val probe = TestProbe()
+      walletB.getReceiveAddress().pipeTo(probe.ref)
+      walletB.sendToAddress(probe.expectMsgType[String], 75_000 sat, 1).pipeTo(probe.ref)
+      probe.expectMsgType[ByteVector32]
+
+      alice ! Start(alice2bob.ref, Nil)
+      bob ! Start(bob2alice.ref, Nil)
+
+      // Alice --- tx_add_input --> Bob
+      f.forwardAlice2Bob[TxAddInput]
+      // Alice <-- tx_add_input --- Bob
+      f.forwardBob2Alice[TxAddInput]
+      // Alice --- tx_add_output --> Bob
+      f.forwardAlice2Bob[TxAddOutput]
+      // Alice <-- tx_add_output --- Bob
+      f.forwardBob2Alice[TxAddOutput]
+      // Alice --- tx_add_output --> Bob
+      f.forwardAlice2Bob[TxAddOutput]
+      // Alice <-- tx_complete --- Bob
+      f.forwardBob2Alice[TxComplete]
+      // Alice --- tx_complete --> Bob
+      f.forwardAlice2Bob[TxComplete]
+      // Alice <-- commit_sig --- Bob
+      f.forwardBob2Alice[CommitSig]
+      // Alice --- commit_sig --> Bob
+      f.forwardAlice2Bob[CommitSig]
+      // Alice <-- tx_signatures --- Bob
+      val txB1 = bob2alice.expectMsgType[Succeeded].sharedTx.asInstanceOf[PartiallySignedSharedTransaction]
+      alice ! ReceiveTxSigs(txB1.localSigs)
+      val txA1 = alice2bob.expectMsgType[Succeeded].sharedTx.asInstanceOf[FullySignedSharedTransaction]
+      walletA.publishTransaction(txA1.signedTx).pipeTo(probe.ref)
+      probe.expectMsg(txA1.signedTx.txid)
+    }
+  }
+
+  test("reject unconfirmed remote inputs") {
+    withFixture(120_000 sat, Seq(150_000 sat), 50_000 sat, Seq(100_000 sat), FeeratePerKw(4000 sat), 660 sat, 0, requireConfirmedInputs = true) { f =>
+      import f._
+
+      // Bob's available utxo is unconfirmed.
+      val probe = TestProbe()
+      walletB.getReceiveAddress().pipeTo(probe.ref)
+      walletB.sendToAddress(probe.expectMsgType[String], 75_000 sat, 1).pipeTo(probe.ref)
+      probe.expectMsgType[ByteVector32]
+
+      alice ! Start(alice2bob.ref, Nil)
+      bob ! Start(bob2alice.ref, Nil)
+
+      // Alice --- tx_add_input --> Bob
+      f.forwardAlice2Bob[TxAddInput]
+      // Alice <-- tx_add_input --- Bob
+      f.forwardBob2Alice[TxAddInput]
+      // Alice --- tx_add_output --> Bob
+      f.forwardAlice2Bob[TxAddOutput]
+      // Alice <-- tx_add_output --- Bob
+      f.forwardBob2Alice[TxAddOutput]
+      // Alice --- tx_add_output --> Bob
+      f.forwardAlice2Bob[TxAddOutput]
+      // Alice <-- tx_complete --- Bob
+      f.forwardBob2Alice[TxComplete]
+      // Alice --- tx_complete --> Bob
+      f.forwardAlice2Bob[TxComplete]
+      // Alice detects that Bob's inputs are unconfirmed and aborts.
+      assert(alice2bob.expectMsgType[RemoteFailure].cause == UnconfirmedInteractiveTxInputs(aliceParams.channelId))
     }
   }
 
@@ -1176,7 +1248,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     val nonInitiatorInput = TxAddInput(channelId, UInt64(11), parentTx, 2, 4294967293L)
     val nonInitiatorOutput = TxAddOutput(channelId, UInt64(33), 49999900 sat, hex"001444cb0c39f93ecc372b5851725bd29d865d333b10")
 
-    val initiatorParams = InteractiveTxParams(channelId, isInitiator = true, 200_000_000 sat, 200_000_000 sat, hex"0020297b92c238163e820b82486084634b4846b86a3c658d87b9384192e6bea98ec5", 120, 330 sat, FeeratePerKw(253 sat))
+    val initiatorParams = InteractiveTxParams(channelId, isInitiator = true, 200_000_000 sat, 200_000_000 sat, hex"0020297b92c238163e820b82486084634b4846b86a3c658d87b9384192e6bea98ec5", 120, 330 sat, FeeratePerKw(253 sat), requireConfirmedRemoteInputs = false)
     val initiatorTx = SharedTransaction(List(initiatorInput), List(nonInitiatorInput).map(i => RemoteTxAddInput(i)), List(initiatorOutput, sharedOutput), List(nonInitiatorOutput).map(o => RemoteTxAddOutput(o)), lockTime = 120)
     assert(initiatorTx.localFees(initiatorParams) == 155.sat)
     val nonInitiatorParams = initiatorParams.copy(isInitiator = false)


### PR DESCRIPTION
If your peer uses unconfirmed inputs in the `interactive-tx` protocol, you will end up paying for the fees of their unconfirmed previous transactions. This may be undesirable in some cases, so we allow requiring confirmed inputs only. This is currently set to false, but can be tweaked based on custom tlvs or values in the open/accept messages.