### PR TITLE
Fix collision bug in local alias generation

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -70,7 +70,7 @@ object ShortChannelId {
    *
    * (*) https://en.wikipedia.org/wiki/Birthday_attack
    */
-  private val aliasUpperBound = 2^58
+  private val aliasUpperBound = Math.pow(2, 58).toLong
 
   def generateLocalAlias(): Alias = {
     // modulo won't skew the distribution because 2^64 is a multiple of 2^58

--- a/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/ShortChannelIdSpec.scala
@@ -71,9 +71,11 @@ class ShortChannelIdSpec extends AnyFunSuite {
   }
 
   test("basic check on random alias generation") {
-    for(_ <- 0 until 100) {
-      val alias = ShortChannelId.generateLocalAlias()
-      assert(alias.toLong >= 0 && alias.toLong <= 384_829_069_721_665_536L)
+    (0 until 1000).foldLeft(Set.empty[Alias]) {
+      case (aliases, _) =>
+        val alias = ShortChannelId.generateLocalAlias()
+        assert(alias.toLong >= 0 && alias.toLong <= 384_829_069_721_665_536L && !aliases.contains(alias))
+        aliases + alias
     }
   }
 


### PR DESCRIPTION
The bug is due to mistakingly using the `^` as power operator, while it instead is a `xor`. As a result, the available space for local alias was tiny, resulting in collisions. This in turns causes the `relayer` to forward `UpdateAddHtlc` to the wrong node, which results in `UpdateFailMalformed` error due to the peers being unable to decrypt the onion that wasn't meant for them.

Nice catch @robbiehanson!