### PR TITLE
Allow receiving to blinded routes

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/ShortChannelId.scala
@@ -95,6 +95,9 @@ object ShortChannelId {
     }
     case _ => Failure(new IllegalArgumentException(s"Invalid short channel id: $s"))
   }
+
+  // A special alias for a virtual channel to ourselves. Used to add extra hops at the end of a blinded route.
+  val toSelf: Alias = Alias(aliasUpperBound)
 }
 
 /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
@@ -299,10 +299,10 @@ object MultiPartHandler {
                   invoice
                 case r: ReceiveOfferPayment =>
                   // TODO: get blinded paths from the router instead
-                  val pathId = RouteBlindingEncryptedDataTlv.PathId(randomBytes(32))
+                  val pathId = RouteBlindingEncryptedDataTlv.PathId(randomBytes32())
                   val dummyConstraints = RouteBlindingEncryptedDataTlv.PaymentConstraints(CltvExpiry(nodeParams.currentBlockHeight + 144), 1 msat)
                   val dummyRelay = RouteBlindingEncryptedDataTlv.PaymentRelay(CltvExpiryDelta(0), 0, 0 msat)
-                  val dummyScid = RouteBlindingEncryptedDataTlv.OutgoingChannelId(ShortChannelId(0))
+                  val dummyScid = RouteBlindingEncryptedDataTlv.OutgoingChannelId(ShortChannelId.toSelf)
                   val dummyPath = Seq(
                     (nodeParams.nodeId, RouteBlindingEncryptedDataCodecs.blindedRouteDataCodec.encode(TlvStream(dummyScid, dummyRelay, dummyConstraints)).require.bytes),
                     (nodeParams.nodeId, RouteBlindingEncryptedDataCodecs.blindedRouteDataCodec.encode(TlvStream(dummyConstraints, pathId)).require.bytes),


### PR DESCRIPTION
Enable receiving blinded payments.
Unroll the dummy hops at the end of a blinded route.