### PR TITLE
Add tests for invoice feature validation

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt11InvoiceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt11InvoiceSpec.scala
@@ -645,13 +645,13 @@ class Bolt11InvoiceSpec extends AnyFunSuite {
   test("filter non-invoice features when parsing invoices") {
     // The following invoice has feature bit 20 activated (option_anchor_outputs) without feature bit 12 (option_static_remotekey).
     // This doesn't satisfy the feature dependency graph, but since those aren't invoice features, we should ignore it.
-    val bin = "lntb250u1p3jxdmwpp5mnjuf5zwkndq4e29lmvqen8cnwc57aqr0658jlfl3q42667q3lgsdpqdehkuttfdemx76trv5sxvetpw36hyetncqpxsp5a0epznfadhwjrtsrqykjpxu97800grzzjv3kuq3xnlsdgaytqn3s9pqzqqqqqqzqqqqqqqqqqqqqqqqqqqqqsgqk243r3nnm92d8qaam7hgwc5yhupq4wvmnufyyt6kk6hww98a4vtrzxy0pqrpj7dyffykdfx326k0ggcw4l2d08xkknes4unt6vu3ptgqk9zn8r"
     val features = Features(
-      Map(VariableLengthOnion -> FeatureSupport.Mandatory, PaymentSecret -> FeatureSupport.Mandatory),
+      Map(VariableLengthOnion -> FeatureSupport.Mandatory, PaymentSecret -> FeatureSupport.Mandatory, AnchorOutputs -> Mandatory),
       Set(UnknownFeature(121), UnknownFeature(156))
     )
-    val Success(pr) = Bolt11Invoice.fromString(bin)
-    assert(features == pr.features)
+    val invoice = createInvoiceUnsafe(Block.LivenetGenesisBlock.hash, None, randomBytes32(), priv, Left("non-invoice features"), CltvExpiryDelta(6), features = features.unscoped()).toString
+    val Success(pr) = Bolt11Invoice.fromString(invoice)
+    assert(pr.features == features.remove(AnchorOutputs))
   }
 
   test("invoices can't have high features") {


### PR DESCRIPTION
Add non-reg tests to ensure that we only validate invoice features, and correctly refuse to pay invoices containing unsupported mandatory features.