### PR TITLE
Update otj-pg-embedded to 1.0.1

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -313,7 +313,7 @@
         <dependency>
             <groupId>com.opentable.components</groupId>
             <artifactId>otj-pg-embedded</artifactId>
-            <version>0.13.3</version>
+            <version>1.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR improves compatibility of the Postgres tests across different OS's, but requires Docker up and running on a developer's computer.

See https://github.com/opentable/otj-pg-embedded