### PR TITLE
Clean up channel commands generic types

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
@@ -42,7 +42,7 @@ object ChannelRelay {
   sealed trait Command
   private case object DoRelay extends Command
   private case class WrappedForwardFailure(failure: Register.ForwardFailure[CMD_ADD_HTLC]) extends Command
-  private case class WrappedAddResponse(res: CommandResponse[CMD_ADD_HTLC]) extends Command
+  private case class WrappedAddResponse(res: CommandResponse) extends Command
   // @formatter:on
 
   // @formatter:off
@@ -115,7 +115,7 @@ class ChannelRelay private(nodeParams: NodeParams,
   import ChannelRelay._
 
   private val forwardFailureAdapter = context.messageAdapter[Register.ForwardFailure[CMD_ADD_HTLC]](WrappedForwardFailure)
-  private val addResponseAdapter = context.messageAdapter[CommandResponse[CMD_ADD_HTLC]](WrappedAddResponse)
+  private val addResponseAdapter = context.messageAdapter[CommandResponse](WrappedAddResponse)
 
   private case class PreviouslyTried(channelId: ByteVector32, failure: RES_ADD_FAILED[ChannelException])
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -569,7 +569,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     register.reply(RES_SUCCESS(c2.message, c2.channelId))
     register.expectNoMessage()
 
-    assert(sender.expectMsgType[Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]]] == Map(
+    assert(sender.expectMsgType[Map[ChannelIdentifier, Either[Throwable, CommandResponse]]] == Map(
       Left(a) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), a)),
       Left(b) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), b))
     ))
@@ -606,7 +606,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     register.reply(Register.ForwardFailure(u3))
     register.expectNoMessage()
 
-    assert(sender.expectMsgType[Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_UPDATE_RELAY_FEE]]]] == Map(
+    assert(sender.expectMsgType[Map[ChannelIdentifier, Either[Throwable, CommandResponse]]] == Map(
       Left(a1) -> Right(RES_SUCCESS(CMD_UPDATE_RELAY_FEE(ActorRef.noSender, 999 msat, 1234, None), a1)),
       Left(a2) -> Right(RES_FAILURE(CMD_UPDATE_RELAY_FEE(ActorRef.noSender, 999 msat, 1234, None), CommandUnavailableInThisState(a2, "CMD_UPDATE_RELAY_FEE", channel.CLOSING))),
       Left(b1) -> Left(ChannelNotFound(Left(b1)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/ChannelDataSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/ChannelDataSpec.scala
@@ -54,13 +54,13 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
 
     // Alice and Bob both know the preimage for only one of the two HTLCs they received.
     alice ! CMD_FULFILL_HTLC(htlcb1.id, rb1, replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
     bob ! CMD_FULFILL_HTLC(htlca1.id, ra1, replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
 
     // Alice publishes her commitment.
     alice ! CMD_FORCECLOSE(probe.ref)
-    probe.expectMsgType[CommandSuccess[CMD_FORCECLOSE]]
+    probe.expectMsgType[CommandSuccess]
     awaitCond(alice.stateName == CLOSING)
 
     // Bob detects it.
@@ -90,7 +90,7 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
     val htlcSuccessTxs = getHtlcSuccessTxs(lcp)
     assert(htlcSuccessTxs.length == 1) // we only have the preimage for 1 of the 2 non-dust htlcs
     val remainingHtlcOutpoint = lcp.htlcTxs.collect { case (outpoint, None) => outpoint }.head
-    assert(lcp.claimHtlcDelayedTxs.length == 0) // we will publish 3rd-stage txs once htlc txs confirm
+    assert(lcp.claimHtlcDelayedTxs.isEmpty) // we will publish 3rd-stage txs once htlc txs confirm
     assert(!lcp.isConfirmed)
     assert(!lcp.isDone)
 
@@ -153,7 +153,7 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
     assert(!lcp4.isDone)
 
     alice ! CMD_FULFILL_HTLC(alicePendingHtlc.htlc.id, alicePendingHtlc.preimage, replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
     val aliceClosing1 = alice.stateData.asInstanceOf[DATA_CLOSING]
     val lcp5 = aliceClosing1.localCommitPublished.get.copy(irrevocablySpent = lcp4.irrevocablySpent, claimHtlcDelayedTxs = lcp4.claimHtlcDelayedTxs)
     assert(lcp5.htlcTxs(remainingHtlcOutpoint) !== None)
@@ -246,10 +246,10 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
     assert(!lcp4.isDone)
 
     // at this point the pending incoming htlc is waiting for a preimage
-    assert(lcp4.htlcTxs(remainingHtlcOutpoint) == None)
+    assert(lcp4.htlcTxs(remainingHtlcOutpoint).isEmpty)
 
     alice ! CMD_FAIL_HTLC(1, Right(UnknownNextPeer), replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FAIL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
     val aliceClosing1 = alice.stateData.asInstanceOf[DATA_CLOSING]
     val lcp5 = aliceClosing1.localCommitPublished.get.copy(irrevocablySpent = lcp4.irrevocablySpent, claimHtlcDelayedTxs = lcp4.claimHtlcDelayedTxs)
     assert(!lcp5.htlcTxs.contains(remainingHtlcOutpoint))
@@ -321,7 +321,7 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
     assert(!rcp3.isDone)
 
     bob ! CMD_FULFILL_HTLC(bobPendingHtlc.htlc.id, bobPendingHtlc.preimage, replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
     val bobClosing1 = bob.stateData.asInstanceOf[DATA_CLOSING]
     val rcp4 = bobClosing1.remoteCommitPublished.get.copy(irrevocablySpent = rcp3.irrevocablySpent)
     assert(rcp4.claimHtlcTxs(remainingHtlcOutpoint) !== None)
@@ -379,7 +379,7 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
     assert(!rcp3.isDone)
 
     bob ! CMD_FAIL_HTLC(bobPendingHtlc.htlc.id, Right(UnknownNextPeer), replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FAIL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
     val bobClosing1 = bob.stateData.asInstanceOf[DATA_CLOSING]
     val rcp4 = bobClosing1.remoteCommitPublished.get.copy(irrevocablySpent = rcp3.irrevocablySpent)
     assert(!rcp4.claimHtlcTxs.contains(remainingHtlcOutpoint))
@@ -406,20 +406,20 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
     crossSign(bob, alice, bob2alice, alice2bob)
     addHtlc(18_000_000 msat, bob, alice, bob2alice, alice2bob)
     bob ! CMD_SIGN(Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_SIGN]]
+    probe.expectMsgType[CommandSuccess]
     bob2alice.expectMsgType[CommitSig]
     bob2alice.forward(alice)
     alice2bob.expectMsgType[RevokeAndAck]
 
     // Alice and Bob both know the preimage for only one of the two HTLCs they received.
     alice ! CMD_FULFILL_HTLC(htlcb1.id, rb1, replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
     bob ! CMD_FULFILL_HTLC(htlca1.id, ra1, replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
 
     // Alice publishes her last commitment.
     alice ! CMD_FORCECLOSE(probe.ref)
-    probe.expectMsgType[CommandSuccess[CMD_FORCECLOSE]]
+    probe.expectMsgType[CommandSuccess]
     awaitCond(alice.stateName == CLOSING)
     val aliceClosing = alice.stateData.asInstanceOf[DATA_CLOSING]
     val lcp = aliceClosing.localCommitPublished.get
@@ -483,7 +483,7 @@ class ChannelDataSpec extends TestKitBaseClass with AnyFunSuiteLike with Channel
     assert(!rcp3.isDone)
 
     bob ! CMD_FULFILL_HTLC(bobPendingHtlc.htlc.id, bobPendingHtlc.preimage, replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
     val bobClosing1 = bob.stateData.asInstanceOf[DATA_CLOSING]
     val rcp4 = bobClosing1.nextRemoteCommitPublished.get.copy(irrevocablySpent = rcp3.irrevocablySpent)
     assert(rcp4.claimHtlcTxs(remainingHtlcOutpoint) !== None)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -189,7 +189,8 @@ class FuzzySpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Channe
     awaitCond({
       val c = CMD_CLOSE(sender.ref, None, None)
       alice ! c
-      sender.expectMsgType[CommandResponse[CMD_CLOSE]].isInstanceOf[RES_SUCCESS[CMD_CLOSE]]
+      val res = sender.expectMsgType[CommandResponse]
+      res == RES_SUCCESS(c, channelId(alice))
     }, interval = 1 second, max = 30 seconds)
     awaitCond(alice.stateName == CLOSING, interval = 1 second, max = 3 minutes)
     awaitCond(bob.stateName == CLOSING, interval = 1 second, max = 3 minutes)
@@ -207,11 +208,11 @@ class FuzzySpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Channe
     awaitCond({
       val c = CMD_CLOSE(sender.ref, None, None)
       alice ! c
-      val resa = sender.expectMsgType[CommandResponse[CMD_CLOSE]]
+      val resa = sender.expectMsgType[CommandResponse]
       sender.send(bob, c)
-      val resb = sender.expectMsgType[CommandResponse[CMD_CLOSE]]
+      val resb = sender.expectMsgType[CommandResponse]
       // we only need that one of them succeeds
-      resa.isInstanceOf[RES_SUCCESS[CMD_CLOSE]] || resb.isInstanceOf[RES_SUCCESS[CMD_CLOSE]]
+      resa == RES_SUCCESS(c, channelId(alice)) || resb == RES_SUCCESS(c, channelId(bob))
     }, interval = 1 second, max = 30 seconds)
     awaitCond(alice.stateName == CLOSING, interval = 1 second, max = 3 minutes)
     awaitCond(bob.stateName == CLOSING, interval = 1 second, max = 3 minutes)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/HelpersSpec.scala
@@ -85,13 +85,13 @@ class HelpersSpec extends TestKitBaseClass with AnyFunSuiteLike with ChannelStat
 
     // Alice and Bob both know the preimage for only one of the two HTLCs they received.
     alice ! CMD_FULFILL_HTLC(htlcb2.id, rb2, replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
     bob ! CMD_FULFILL_HTLC(htlca2.id, ra2, replyTo_opt = Some(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
 
     // Alice publishes her commitment.
     alice ! CMD_FORCECLOSE(probe.ref)
-    probe.expectMsgType[CommandSuccess[CMD_FORCECLOSE]]
+    probe.expectMsgType[CommandSuccess]
     awaitCond(alice.stateName == CLOSING)
 
     // Bob detects it.

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/ReplaceableTxPublisherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/ReplaceableTxPublisherSpec.scala
@@ -154,7 +154,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
 
     val commitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.fullySignedLocalCommitTx(alice.underlyingActor.nodeParams.channelKeyManager)
     probe.send(alice, CMD_FORCECLOSE(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FORCECLOSE]]
+    probe.expectMsgType[CommandSuccess]
 
     // Forward the commit tx to the publisher.
     val publishCommitTx = alice2blockchain.expectMsg(PublishFinalTx(commitTx, commitTx.fee, None))
@@ -688,11 +688,11 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
       val (r, htlc) = addHtlc(4_000_000 msat, bob, alice, bob2alice, alice2bob)
       crossSign(bob, alice, bob2alice, alice2bob)
       probe.send(alice, CMD_FULFILL_HTLC(htlc.id, r, replyTo_opt = Some(probe.ref)))
-      probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+      probe.expectMsgType[CommandSuccess]
 
       // Force-close channel.
       probe.send(alice, CMD_FORCECLOSE(probe.ref))
-      probe.expectMsgType[CommandSuccess[CMD_FORCECLOSE]]
+      probe.expectMsgType[CommandSuccess]
       alice2blockchain.expectMsgType[PublishFinalTx]
       assert(alice2blockchain.expectMsgType[PublishReplaceableTx].txInfo.isInstanceOf[ClaimLocalAnchorOutputTx])
       alice2blockchain.expectMsgType[PublishFinalTx] // claim main output
@@ -734,13 +734,13 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
     val (r, htlc) = addHtlc(4_000_000 msat, bob, alice, bob2alice, alice2bob)
     crossSign(bob, alice, bob2alice, alice2bob)
     probe.send(alice, CMD_FULFILL_HTLC(htlc.id, r, replyTo_opt = Some(probe.ref)))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
 
     // Force-close channel and verify txs sent to watcher.
     val commitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.fullySignedLocalCommitTx(alice.underlyingActor.nodeParams.channelKeyManager)
     assert(commitTx.tx.txOut.size == 6)
     probe.send(alice, CMD_FORCECLOSE(probe.ref))
-    probe.expectMsgType[CommandSuccess[CMD_FORCECLOSE]]
+    probe.expectMsgType[CommandSuccess]
 
     // We make the commit tx confirm because htlc txs have a relative delay.
     alice2blockchain.expectMsg(PublishFinalTx(commitTx, commitTx.fee, None))
@@ -1155,7 +1155,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
       val (r, htlc) = addHtlc(20_000_000 msat, bob, alice, bob2alice, alice2bob)
       crossSign(bob, alice, bob2alice, alice2bob)
       probe.send(alice, CMD_FULFILL_HTLC(htlc.id, r, replyTo_opt = Some(probe.ref)))
-      probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+      probe.expectMsgType[CommandSuccess]
 
       // Force-close channel.
       val localCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.fullySignedLocalCommitTx(alice.underlyingActor.nodeParams.channelKeyManager)
@@ -1200,7 +1200,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
     val (r, htlc) = addHtlc(20_000_000 msat, bob, alice, bob2alice, alice2bob)
     crossSign(bob, alice, bob2alice, alice2bob)
     probe.send(alice, CMD_FULFILL_HTLC(htlc.id, r, replyTo_opt = Some(probe.ref)))
-    probe.expectMsgType[CommandSuccess[CMD_FULFILL_HTLC]]
+    probe.expectMsgType[CommandSuccess]
 
     // Force-close channel and verify txs sent to watcher.
     val remoteCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.fullySignedLocalCommitTx(bob.underlyingActor.nodeParams.channelKeyManager)

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -384,7 +384,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
     val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
     val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
     val channelIdSerialized = channelId.toHex
-    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse]](
       Left(channelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), channelId)),
       Left(channelId.reverse) -> Left(new RuntimeException("channel not found")),
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
@@ -412,7 +412,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
     val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
     val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
     val channelIdSerialized = channelId.toHex
-    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse]](
       Left(channelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), channelId)),
       Left(channelId.reverse) -> Left(new RuntimeException("channel not found")),
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
@@ -440,7 +440,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
     val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
     val channelId = ByteVector32(hex"56d7d6eda04d80138270c49709f1eadb5ab4939e5061309ccdacdb98ce637d0e")
     val channelIdSerialized = channelId.toHex
-    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse]](
       Left(channelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), channelId)),
       Left(channelId.reverse) -> Left(new RuntimeException("channel not found")),
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), ByteVector32.fromValidHex(channelIdSerialized.reverse)))
@@ -466,7 +466,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
   test("'close' accepts custom closing feerates 1") {
     val shortChannelIdSerialized = "1701x42x3"
     val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
-    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse]](
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
 
@@ -489,7 +489,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
   test("'close' accepts custom closing feerates 2") {
     val shortChannelIdSerialized = "1701x42x3"
     val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
-    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse]](
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
 
@@ -512,7 +512,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
   test("'close' accepts custom closing feerates 3") {
     val shortChannelIdSerialized = "1701x42x3"
     val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
-    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse]](
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
 
@@ -535,7 +535,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
   test("'close' accepts custom closing feerates 4") {
     val shortChannelIdSerialized = "1701x42x3"
     val shortChannelId = ShortChannelId.fromCoordinates(shortChannelIdSerialized).success.value
-    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse[CMD_CLOSE]]](
+    val response = Map[ChannelIdentifier, Either[Throwable, CommandResponse]](
       Right(shortChannelId) -> Right(RES_SUCCESS(CMD_CLOSE(ActorRef.noSender, None, None), randomBytes32()))
     )
 


### PR DESCRIPTION
Our channel commands had unused generic types, which were actually useless because of type erasure.
Removing them simplifies the types and removes a lot of redundant (and useless) test code.