### PR TITLE
Add initial support for async payment trampoline relay

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -70,6 +70,7 @@ eclair {
     option_zeroconf = disabled
     keysend = disabled
     trampoline_payment_prototype = disabled
+    async_payment_prototype = disabled
   }
   // The following section lets you customize features for specific nodes.
   // The overrides will be applied on top of the default features settings.
@@ -150,10 +151,8 @@ eclair {
       enforcement-delay = 10 minutes
     }
 
-    async-payments {
-        enabled = false
-        timeout = 1 day // maximum time to hold an async payment while waiting for the receiver to come online
-    }
+    // Maximum time to hold an async payment while waiting for the receiver to come online
+    timeout = 1 day
   }
 
   on-chain-fees {

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -151,8 +151,12 @@ eclair {
       enforcement-delay = 10 minutes
     }
 
-    // Maximum time to hold an async payment while waiting for the receiver to come online
-    timeout = 1 day
+    async-payments {
+      // Maximum number of blocks to hold an async payment while waiting to receive a trigger from the receiver
+      hold-timeout-blocks = 1008
+      // Number of blocks before the incoming HTLC expires that an async payment must be triggered by the receiver
+      cancel-safety-before-timeout-blocks = 144
+    }
   }
 
   on-chain-fees {

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -149,6 +149,11 @@ eclair {
       // Delay enforcement of channel fee updates
       enforcement-delay = 10 minutes
     }
+
+    async-payments {
+        enabled = false
+        timeout = 1 day // maximum time to hold an async payment while waiting for the receiver to come online
+    }
   }
 
   on-chain-fees {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -323,7 +323,7 @@ object Features {
     RouteBlinding -> (VariableLengthOnion :: Nil),
     TrampolinePaymentPrototype -> (PaymentSecret :: Nil),
     KeySend -> (VariableLengthOnion :: Nil),
-    AsyncPaymentPrototype -> (VariableLengthOnion :: TrampolinePaymentPrototype :: Nil)
+    AsyncPaymentPrototype -> (TrampolinePaymentPrototype :: Nil)
   )
 
   case class FeatureException(message: String) extends IllegalArgumentException(message)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -282,7 +282,7 @@ object Features {
   }
 
   // TODO: @remyers update feature bits once spec-ed (currently reserved here: https://github.com/lightning/bolts/pull/989)
-  case object AsyncPaymentPrototype extends Feature with InvoiceFeature {
+  case object AsyncPaymentPrototype extends Feature with InitFeature with InvoiceFeature {
     val rfcName = "async_payment_prototype"
     val mandatory = 152
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -281,6 +281,12 @@ object Features {
     val mandatory = 148
   }
 
+  // TODO: @remyers update feature bits once spec-ed (currently reserved here: https://github.com/lightning/bolts/pull/989)
+  case object AsyncPaymentPrototype extends Feature with InvoiceFeature {
+    val rfcName = "async_payment_prototype"
+    val mandatory = 52
+  }
+
   val knownFeatures: Set[Feature] = Set(
     DataLossProtect,
     InitialRoutingSync,
@@ -303,7 +309,8 @@ object Features {
     PaymentMetadata,
     ZeroConf,
     KeySend,
-    TrampolinePaymentPrototype
+    TrampolinePaymentPrototype,
+    AsyncPaymentPrototype
   )
 
   // Features may depend on other features, as specified in Bolt 9.
@@ -315,7 +322,8 @@ object Features {
     AnchorOutputsZeroFeeHtlcTx -> (StaticRemoteKey :: Nil),
     RouteBlinding -> (VariableLengthOnion :: Nil),
     TrampolinePaymentPrototype -> (PaymentSecret :: Nil),
-    KeySend -> (VariableLengthOnion :: Nil)
+    KeySend -> (VariableLengthOnion :: Nil),
+    AsyncPaymentPrototype -> (VariableLengthOnion :: TrampolinePaymentPrototype :: Nil)
   )
 
   case class FeatureException(message: String) extends IllegalArgumentException(message)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -284,7 +284,7 @@ object Features {
   // TODO: @remyers update feature bits once spec-ed (currently reserved here: https://github.com/lightning/bolts/pull/989)
   case object AsyncPaymentPrototype extends Feature with InvoiceFeature {
     val rfcName = "async_payment_prototype"
-    val mandatory = 52
+    val mandatory = 152
   }
 
   val knownFeatures: Set[Feature] = Set(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -83,8 +83,7 @@ case class NodeParams(nodeKeyManager: NodeKeyManager,
                       blockchainWatchdogThreshold: Int,
                       blockchainWatchdogSources: Seq[String],
                       onionMessageConfig: OnionMessageConfig,
-                      purgeInvoicesInterval: Option[FiniteDuration],
-                      asyncPaymentsTimeout: Option[FiniteDuration]) {
+                      purgeInvoicesInterval: Option[FiniteDuration]) {
   val privateKey: Crypto.PrivateKey = nodeKeyManager.nodeKey.privateKey
 
   val nodeId: PublicKey = nodeKeyManager.nodeId
@@ -420,12 +419,6 @@ object NodeParams extends Logging {
       None
     }
 
-    val asyncPaymentsTimeout = if (config.getBoolean("relay.async-payments.enabled")) {
-      Some(FiniteDuration(config.getDuration("relay.async-payments.timeout").toMinutes, TimeUnit.MINUTES))
-    } else {
-      None
-    }
-
     NodeParams(
       nodeKeyManager = nodeKeyManager,
       channelKeyManager = channelKeyManager,
@@ -495,7 +488,8 @@ object NodeParams extends Logging {
         publicChannelFees = getRelayFees(config.getConfig("relay.fees.public-channels")),
         privateChannelFees = getRelayFees(config.getConfig("relay.fees.private-channels")),
         minTrampolineFees = getRelayFees(config.getConfig("relay.fees.min-trampoline")),
-        enforcementDelay = FiniteDuration(config.getDuration("relay.fees.enforcement-delay").getSeconds, TimeUnit.SECONDS)
+        enforcementDelay = FiniteDuration(config.getDuration("relay.fees.enforcement-delay").getSeconds, TimeUnit.SECONDS),
+        timeout = FiniteDuration(config.getDuration("relay.timeout").toMinutes, TimeUnit.MINUTES)
       ),
       db = database,
       autoReconnect = config.getBoolean("auto-reconnect"),
@@ -536,8 +530,7 @@ object NodeParams extends Logging {
         relayPolicy = onionMessageRelayPolicy,
         timeout = FiniteDuration(config.getDuration("onion-messages.reply-timeout").getSeconds, TimeUnit.SECONDS),
       ),
-      purgeInvoicesInterval = purgeInvoicesInterval,
-      asyncPaymentsTimeout = asyncPaymentsTimeout
+      purgeInvoicesInterval = purgeInvoicesInterval
     )
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -83,7 +83,8 @@ case class NodeParams(nodeKeyManager: NodeKeyManager,
                       blockchainWatchdogThreshold: Int,
                       blockchainWatchdogSources: Seq[String],
                       onionMessageConfig: OnionMessageConfig,
-                      purgeInvoicesInterval: Option[FiniteDuration]) {
+                      purgeInvoicesInterval: Option[FiniteDuration],
+                      asyncPaymentsTimeout: Option[FiniteDuration]) {
   val privateKey: Crypto.PrivateKey = nodeKeyManager.nodeKey.privateKey
 
   val nodeId: PublicKey = nodeKeyManager.nodeId
@@ -419,6 +420,12 @@ object NodeParams extends Logging {
       None
     }
 
+    val asyncPaymentsTimeout = if (config.getBoolean("relay.async-payments.enabled")) {
+      Some(FiniteDuration(config.getDuration("relay.async-payments.timeout").toMinutes, TimeUnit.MINUTES))
+    } else {
+      None
+    }
+
     NodeParams(
       nodeKeyManager = nodeKeyManager,
       channelKeyManager = channelKeyManager,
@@ -529,7 +536,8 @@ object NodeParams extends Logging {
         relayPolicy = onionMessageRelayPolicy,
         timeout = FiniteDuration(config.getDuration("onion-messages.reply-timeout").getSeconds, TimeUnit.SECONDS),
       ),
-      purgeInvoicesInterval = purgeInvoicesInterval
+      purgeInvoicesInterval = purgeInvoicesInterval,
+      asyncPaymentsTimeout = asyncPaymentsTimeout
     )
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -120,6 +120,8 @@ case class PaymentMetadataReceived(paymentHash: ByteVector32, paymentMetadata: B
 
 case class PaymentSettlingOnChain(id: UUID, amount: MilliSatoshi, paymentHash: ByteVector32, timestamp: TimestampMilli = TimestampMilli.now()) extends PaymentEvent
 
+case class WaitingToRelayPayment(remoteNodeId: PublicKey, paymentHash: ByteVector32, timestamp: TimestampMilli = TimestampMilli.now()) extends PaymentEvent
+
 sealed trait PaymentFailure {
   // @formatter:off
   def amount: MilliSatoshi

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -209,8 +209,6 @@ class NodeRelay private(nodeParams: NodeParams,
               doSend(upstream, nextPayload, nextPacket)
             }
         }
-      case RelayAsyncPayment => context.log.debug("received async payment trigger while waiting to receive all incoming payment packets")
-        receiving(htlcs, nextPayload, nextPacket, handler)
     }
 
   private def waitForTrigger(upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay.Standard, nextPacket: OnionRoutingPacket): Behavior[Command] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -54,7 +54,7 @@ object NodeRelay {
   sealed trait Command
   case class Relay(nodeRelayPacket: IncomingPaymentPacket.NodeRelayPacket) extends Command
   case object Stop extends Command
-  case object AsyncPaymentTrigger extends Command
+  case object RelayAsyncPayment extends Command
   private case class WrappedMultiPartExtraPaymentReceived(mppExtraReceived: MultiPartPaymentFSM.ExtraPaymentReceived[HtlcPart]) extends Command
   private case class WrappedMultiPartPaymentFailed(mppFailed: MultiPartPaymentFSM.MultiPartPaymentFailed) extends Command
   private case class WrappedMultiPartPaymentSucceeded(mppSucceeded: MultiPartPaymentFSM.MultiPartPaymentSucceeded) extends Command
@@ -208,7 +208,7 @@ class NodeRelay private(nodeParams: NodeParams,
               doSend(upstream, nextPayload, nextPacket)
             }
         }
-      case AsyncPaymentTrigger => context.log.debug("received async payment trigger while waiting to receive all incoming payment packets")
+      case RelayAsyncPayment => context.log.debug("received async payment trigger while waiting to receive all incoming payment packets")
         receiving(htlcs, nextPayload, nextPacket, handler)
     }
 
@@ -221,7 +221,7 @@ class NodeRelay private(nodeParams: NodeParams,
           context.log.warn(s"rejecting async payment that was not triggered before relay timeout: ${nodeParams.relayParams.timeout}")
           rejectPayment(upstream, Some(PaymentTimeout))
           stopping()
-        case AsyncPaymentTrigger =>
+        case RelayAsyncPayment =>
           // check cltv timeouts again before forwarding the payment
           validateRelay(nodeParams, upstream, nextPayload) match {
           case Some(failure) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -43,6 +43,7 @@ import fr.acinq.eclair.{CltvExpiry, Features, Logs, MilliSatoshi, NodeParams, UI
 
 import java.util.UUID
 import scala.collection.immutable.Queue
+import scala.concurrent.duration.FiniteDuration
 
 /**
  * It [[NodeRelay]] aggregates incoming HTLCs (in case multi-part was used upstream) and then forwards the requested amount (using the
@@ -54,12 +55,14 @@ object NodeRelay {
   sealed trait Command
   case class Relay(nodeRelayPacket: IncomingPaymentPacket.NodeRelayPacket) extends Command
   case object Stop extends Command
+  case object AsyncPaymentTrigger extends Command
   private case class WrappedMultiPartExtraPaymentReceived(mppExtraReceived: MultiPartPaymentFSM.ExtraPaymentReceived[HtlcPart]) extends Command
   private case class WrappedMultiPartPaymentFailed(mppFailed: MultiPartPaymentFSM.MultiPartPaymentFailed) extends Command
   private case class WrappedMultiPartPaymentSucceeded(mppSucceeded: MultiPartPaymentFSM.MultiPartPaymentSucceeded) extends Command
   private case class WrappedPreimageReceived(preimageReceived: PreimageReceived) extends Command
   private case class WrappedPaymentSent(paymentSent: PaymentSent) extends Command
   private case class WrappedPaymentFailed(paymentFailed: PaymentFailed) extends Command
+  private case object AsyncPaymentTimeout extends Command
   // @formatter:on
 
   trait OutgoingPaymentFactory {
@@ -178,14 +181,15 @@ class NodeRelay private(nodeParams: NodeParams,
    * @param nextPayload relay instructions (should be identical across HTLCs in this set).
    * @param nextPacket  trampoline onion to relay to the next trampoline node.
    * @param handler     actor handling the aggregation of the incoming HTLC set.
+   * @param triggered   async payment trigger received
    */
-  private def receiving(htlcs: Queue[UpdateAddHtlc], nextPayload: IntermediatePayload.NodeRelay.Standard, nextPacket: OnionRoutingPacket, handler: ActorRef): Behavior[Command] =
+  private def receiving(htlcs: Queue[UpdateAddHtlc], nextPayload: IntermediatePayload.NodeRelay.Standard, nextPacket: OnionRoutingPacket, handler: ActorRef, triggered: Boolean = false): Behavior[Command] =
     Behaviors.receiveMessagePartial {
       case Relay(IncomingPaymentPacket.NodeRelayPacket(add, outer, _, _)) =>
         require(outer.paymentSecret == paymentSecret, "payment secret mismatch")
         context.log.debug("forwarding incoming htlc #{} from channel {} to the payment FSM", add.id, add.channelId)
         handler ! MultiPartPaymentFSM.HtlcPart(outer.totalAmount, add)
-        receiving(htlcs :+ add, nextPayload, nextPacket, handler)
+        receiving(htlcs :+ add, nextPayload, nextPacket, handler, triggered)
       case WrappedMultiPartPaymentFailed(MultiPartPaymentFSM.MultiPartPaymentFailed(_, failure, parts)) =>
         context.log.warn("could not complete incoming multi-part payment (parts={} paidAmount={} failure={})", parts.size, parts.map(_.amount).sum, failure)
         Metrics.recordPaymentRelayFailed(failure.getClass.getSimpleName, Tags.RelayType.Trampoline)
@@ -200,9 +204,42 @@ class NodeRelay private(nodeParams: NodeParams,
             rejectPayment(upstream, Some(failure))
             stopping()
           case None =>
+            if (!triggered && nextPayload.isAsyncPayment && nodeParams.asyncPaymentsTimeout.isDefined) {
+              waitForTrigger(upstream, nextPayload, nextPacket, nodeParams.asyncPaymentsTimeout.get)
+            } else {
+              doSend(upstream, nextPayload, nextPacket)
+            }
+        }
+      case AsyncPaymentTrigger => context.log.debug("received async payment trigger while waiting to receive all incoming payment packets")
+        receiving(htlcs, nextPayload, nextPacket, handler, triggered = true)
+    }
+
+  private def waitForTrigger(upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay.Standard, nextPacket: OnionRoutingPacket, asyncPaymentsTimeout: FiniteDuration): Behavior[Command] = {
+    context.log.info(s"waiting for async payment to trigger before relaying trampoline payment (amountIn=${upstream.amountIn} expiryIn=${upstream.expiryIn} amountOut=${nextPayload.amountToForward} expiryOut=${nextPayload.outgoingCltv}, asyncPaymentsTimeout=$asyncPaymentsTimeout)")
+    Behaviors.withTimers { timers =>
+      timers.startSingleTimer(AsyncPaymentTimeout, asyncPaymentsTimeout)
+      Behaviors.receiveMessagePartial {
+        case AsyncPaymentTimeout =>
+          context.log.warn(s"rejecting async payment that was not triggered before timeout: $asyncPaymentsTimeout")
+          rejectPayment(upstream, Some(PaymentTimeout))
+          stopping()
+        case AsyncPaymentTrigger =>
+          // check cltv timeouts again before forwarding the payment
+          validateRelay(nodeParams, upstream, nextPayload) match {
+          case Some(failure) =>
+            context.log.warn(s"rejecting async payment, reason=$failure")
+            rejectPayment(upstream, Some(failure))
+            stopping()
+          case None =>
             doSend(upstream, nextPayload, nextPacket)
         }
+        case Stop =>
+          context.log.warn(s"async payment stopped while waiting for trigger")
+          rejectPayment(upstream, Some(PaymentTimeout))
+          stopping()
+      }
     }
+  }
 
   private def doSend(upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay.Standard, nextPacket: OnionRoutingPacket): Behavior[Command] = {
     context.log.info(s"relaying trampoline payment (amountIn=${upstream.amountIn} expiryIn=${upstream.expiryIn} amountOut=${nextPayload.amountToForward} expiryOut=${nextPayload.outgoingCltv})")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -232,6 +232,8 @@ class NodeRelay private(nodeParams: NodeParams,
         context.log.warn(s"rejecting async payment at block $blockHeight; was not triggered after waiting ${nodeParams.relayParams.asyncPaymentsParams.holdTimeoutBlocks} blocks")
         rejectPayment(upstream, Some(TemporaryNodeFailure)) // TODO: replace failure type when async payment spec is finalized
         stopping()
+      case WrappedCurrentBlockHeight(blockHeight) =>
+        Behaviors.same
       case CancelAsyncPayment =>
         context.log.warn(s"payment sender canceled a waiting async payment")
         rejectPayment(upstream, Some(TemporaryNodeFailure)) // TODO: replace failure type when async payment spec is finalized

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -129,7 +129,8 @@ object Relayer extends Logging {
   case class RelayParams(publicChannelFees: RelayFees,
                          privateChannelFees: RelayFees,
                          minTrampolineFees: RelayFees,
-                         enforcementDelay: FiniteDuration) {
+                         enforcementDelay: FiniteDuration,
+                         timeout: FiniteDuration) {
     def defaultFees(announceChannel: Boolean): RelayFees = {
       if (announceChannel) {
         publicChannelFees

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -29,7 +29,7 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.PendingCommandsDb
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{Logs, MilliSatoshi, NodeParams}
+import fr.acinq.eclair.{CltvExpiryDelta, Logs, MilliSatoshi, NodeParams}
 import grizzled.slf4j.Logging
 
 import scala.concurrent.Promise
@@ -126,11 +126,13 @@ object Relayer extends Logging {
     require(feeProportionalMillionths >= 0.0, "feeProportionalMillionths must be nonnegative")
   }
 
+  case class AsyncPaymentsParams(holdTimeoutBlocks: Int, cancelSafetyBeforeTimeout: CltvExpiryDelta)
+
   case class RelayParams(publicChannelFees: RelayFees,
                          privateChannelFees: RelayFees,
                          minTrampolineFees: RelayFees,
                          enforcementDelay: FiniteDuration,
-                         timeout: FiniteDuration) {
+                         asyncPaymentsParams: AsyncPaymentsParams) {
     def defaultFees(announceChannel: Boolean): RelayFees = {
       if (announceChannel) {
         publicChannelFees

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -507,8 +507,8 @@ object PaymentOnionCodecs {
     .typecase(UInt64(66098), outgoingNodeId)
     .typecase(UInt64(66099), invoiceRoutingInfo)
     .typecase(UInt64(66100), trampolineOnion)
-    .typecase(UInt64(5482373484L), keySend)
     .typecase(UInt64(181324718L), asyncPayment)
+    .typecase(UInt64(5482373484L), keySend)
 
   val perHopPayloadCodec: Codec[TlvStream[OnionPaymentPayloadTlv]] = TlvCodecs.lengthPrefixedTlvStream[OnionPaymentPayloadTlv](onionTlvCodec).complete
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -22,7 +22,7 @@ import fr.acinq.eclair.payment.Bolt11Invoice
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
 import fr.acinq.eclair.wire.protocol.OnionRoutingCodecs.{ForbiddenTlv, InvalidTlvPayload, MissingRequiredTlv}
 import fr.acinq.eclair.wire.protocol.TlvCodecs._
-import fr.acinq.eclair.{CltvExpiry, Features, MilliSatoshi, MilliSatoshiLong, ShortChannelId, UInt64}
+import fr.acinq.eclair.{CltvExpiry, Features, InvoiceFeature, MilliSatoshi, MilliSatoshiLong, ShortChannelId, UInt64}
 import scodec.bits.{BitVector, ByteVector}
 
 /**
@@ -181,6 +181,9 @@ object OnionPaymentPayloadTlv {
 
   /** Pre-image included by the sender of a payment in case of a donation */
   case class KeySend(paymentPreimage: ByteVector32) extends OnionPaymentPayloadTlv
+
+  /** Invoice feature bits. Only included for intermediate trampoline nodes that should wait before forwarding this payment */
+  case class AsyncPaymentFeatures(features: ByteVector) extends OnionPaymentPayloadTlv
 }
 
 object PaymentOnion {
@@ -301,6 +304,8 @@ object PaymentOnion {
         val paymentMetadata = records.get[PaymentMetadata].map(_.data)
         val invoiceFeatures = records.get[InvoiceFeatures].map(_.features)
         val invoiceRoutingInfo = records.get[InvoiceRoutingInfo].map(_.extraHops)
+        // The following fields are only included in the async payment case.
+        val isAsyncPayment: Boolean = records.get[AsyncPaymentFeatures].isDefined
       }
 
       object Standard {
@@ -328,6 +333,17 @@ object PaymentOnion {
             Some(OutgoingNodeId(targetNodeId)),
             Some(InvoiceFeatures(invoice.features.toByteVector)),
             Some(InvoiceRoutingInfo(invoice.routingInfo.toList.map(_.toList)))
+          ).flatten
+          Standard(TlvStream(tlvs))
+        }
+
+        /** Create a standard trampoline inner payload instructing the trampoline node to wait for a trigger before sending an async payment. */
+        def createNodeRelayForAsyncPayment(amount: MilliSatoshi, expiry: CltvExpiry, nextNodeId: PublicKey, invoiceFeatures: Features[InvoiceFeature]): Standard = {
+          val tlvs = Seq(
+            Some(AmountToForward(amount)),
+            Some(OutgoingCltv(expiry)),
+            Some(OutgoingNodeId(nextNodeId)),
+            Some(AsyncPaymentFeatures(invoiceFeatures.toByteVector))
           ).flatten
           Standard(TlvStream(tlvs))
         }
@@ -475,6 +491,8 @@ object PaymentOnionCodecs {
 
   private val keySend: Codec[KeySend] = variableSizeBytesLong(varintoverflow, bytes32).as[KeySend]
 
+  private val asyncPayment: Codec[AsyncPaymentFeatures] = variableSizeBytesLong(varintoverflow, bytes).as[AsyncPaymentFeatures]
+
   private val onionTlvCodec = discriminated[OnionPaymentPayloadTlv].by(varint)
     .typecase(UInt64(2), amountToForward)
     .typecase(UInt64(4), outgoingCltv)
@@ -490,6 +508,7 @@ object PaymentOnionCodecs {
     .typecase(UInt64(66099), invoiceRoutingInfo)
     .typecase(UInt64(66100), trampolineOnion)
     .typecase(UInt64(5482373484L), keySend)
+    .typecase(UInt64(181324718L), asyncPayment)
 
   val perHopPayloadCodec: Codec[TlvStream[OnionPaymentPayloadTlv]] = TlvCodecs.lengthPrefixedTlvStream[OnionPaymentPayloadTlv](onionTlvCodec).complete
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -485,7 +485,7 @@ object PaymentOnionCodecs {
 
   private val keySend: Codec[KeySend] = variableSizeBytesLong(varintoverflow, bytes32).as[KeySend]
 
-  private val asyncPayment: Codec[AsyncPayment] = provide(AsyncPayment())
+  private val asyncPayment: Codec[AsyncPayment] = variableSizeBytesLong(varintoverflow, provide(AsyncPayment())).as[AsyncPayment]
 
   private val onionTlvCodec = discriminated[OnionPaymentPayloadTlv].by(varint)
     .typecase(UInt64(2), amountToForward)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -203,6 +203,7 @@ object TestConstants {
         timeout = 1 minute
       ),
       purgeInvoicesInterval = None,
+      asyncPaymentsTimeout = None
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(
@@ -344,7 +345,8 @@ object TestConstants {
         relayPolicy = RelayAll,
         timeout = 1 minute
       ),
-      purgeInvoicesInterval = None
+      purgeInvoicesInterval = None,
+      asyncPaymentsTimeout = None
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -142,7 +142,8 @@ object TestConstants {
         minTrampolineFees = RelayFees(
           feeBase = 548000 msat,
           feeProportionalMillionths = 30),
-        enforcementDelay = 10 minutes),
+        enforcementDelay = 10 minutes,
+        timeout = 1 day),
       db = TestDatabases.inMemoryDb(),
       autoReconnect = false,
       initialRandomReconnectDelay = 5 seconds,
@@ -202,8 +203,7 @@ object TestConstants {
         relayPolicy = RelayAll,
         timeout = 1 minute
       ),
-      purgeInvoicesInterval = None,
-      asyncPaymentsTimeout = None
+      purgeInvoicesInterval = None
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(
@@ -285,7 +285,8 @@ object TestConstants {
         minTrampolineFees = RelayFees(
           feeBase = 548000 msat,
           feeProportionalMillionths = 30),
-        enforcementDelay = 10 minutes),
+        enforcementDelay = 10 minutes,
+        timeout = 1 day),
       db = TestDatabases.inMemoryDb(),
       autoReconnect = false,
       initialRandomReconnectDelay = 5 seconds,
@@ -345,8 +346,7 @@ object TestConstants {
         relayPolicy = RelayAll,
         timeout = 1 minute
       ),
-      purgeInvoicesInterval = None,
-      asyncPaymentsTimeout = None
+      purgeInvoicesInterval = None
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -26,7 +26,7 @@ import fr.acinq.eclair.crypto.keymanager.{LocalChannelKeyManager, LocalNodeKeyMa
 import fr.acinq.eclair.io.MessageRelay.RelayAll
 import fr.acinq.eclair.io.{Peer, PeerConnection}
 import fr.acinq.eclair.message.OnionMessages.OnionMessageConfig
-import fr.acinq.eclair.payment.relay.Relayer.{RelayFees, RelayParams}
+import fr.acinq.eclair.payment.relay.Relayer.{AsyncPaymentsParams, RelayFees, RelayParams}
 import fr.acinq.eclair.router.Graph.WeightRatios
 import fr.acinq.eclair.router.PathFindingExperimentConf
 import fr.acinq.eclair.router.Router.{MultiPartParams, PathFindingConf, RouterConf, SearchBoundaries}
@@ -143,7 +143,7 @@ object TestConstants {
           feeBase = 548000 msat,
           feeProportionalMillionths = 30),
         enforcementDelay = 10 minutes,
-        timeout = 1 day),
+       asyncPaymentsParams = AsyncPaymentsParams(1008, CltvExpiryDelta(144))),
       db = TestDatabases.inMemoryDb(),
       autoReconnect = false,
       initialRandomReconnectDelay = 5 seconds,
@@ -286,7 +286,7 @@ object TestConstants {
           feeBase = 548000 msat,
           feeProportionalMillionths = 30),
         enforcementDelay = 10 minutes,
-        timeout = 1 day),
+        asyncPaymentsParams = AsyncPaymentsParams(1008, CltvExpiryDelta(144))),
       db = TestDatabases.inMemoryDb(),
       autoReconnect = false,
       initialRandomReconnectDelay = 5 seconds,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -347,7 +347,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     val g = f.copy(nodeParams = f.nodeParams.copy(features = f.nodeParams.features.add(AsyncPaymentPrototype, Optional), relayParams = f.nodeParams.relayParams.copy(timeout = 5 seconds)))
     import g._
 
-    val (nodeRelayer, parent) = g.createNodeRelay(incomingAsyncPayment.head)
+    val (nodeRelayer, _) = g.createNodeRelay(incomingAsyncPayment.head)
     incomingAsyncPayment.dropRight(1).foreach { p =>
       nodeRelayer ! NodeRelay.Relay(p)
       relayMonitor.expectMessageType[NodeRelay.Relay]
@@ -355,8 +355,8 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     mockPayFSM.expectNoMessage(100 millis) // we should NOT trigger a downstream payment before we received a complete upstream payment
 
     // trigger before last incoming part received
-    nodeRelayer ! NodeRelay.AsyncPaymentTrigger
-    relayMonitor.expectMessage(NodeRelay.AsyncPaymentTrigger)
+    nodeRelayer ! NodeRelay.RelayAsyncPayment
+    relayMonitor.expectMessage(NodeRelay.RelayAsyncPayment)
 
     // receive last incoming part
     nodeRelayer ! NodeRelay.Relay(incomingAsyncPayment.last)
@@ -394,7 +394,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     blockHeight.set(outgoingExpiry.toLong - 1)
 
     // trigger the node relay to forward the payment
-    nodeRelayer ! NodeRelay.AsyncPaymentTrigger
+    nodeRelayer ! NodeRelay.RelayAsyncPayment
 
     // upstream payment relayed
     val outgoingCfg = mockPayFSM.expectMessageType[SendPaymentConfig]
@@ -426,7 +426,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     val g = f.copy(nodeParams = f.nodeParams.copy(features = f.nodeParams.features.add(AsyncPaymentPrototype, Optional), relayParams = f.nodeParams.relayParams.copy(timeout = 5 seconds)))
     import g._
 
-    val (nodeRelayer, parent) = g.createNodeRelay(incomingAsyncPayment.head)
+    val (nodeRelayer, _) = g.createNodeRelay(incomingAsyncPayment.head)
 
     incomingAsyncPayment.foreach { p =>
       nodeRelayer ! NodeRelay.Relay(p)
@@ -441,7 +441,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     blockHeight.set(outgoingExpiry.toLong)
 
     // trigger the node relay to forward the payment
-    nodeRelayer ! NodeRelay.AsyncPaymentTrigger
+    nodeRelayer ! NodeRelay.RelayAsyncPayment
 
     incomingAsyncPayment.foreach { p =>
       val fwd = register.expectMessageType[Register.Forward[CMD_FAIL_HTLC]]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -401,7 +401,7 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     incomingAsyncPayment.foreach(p => nodeRelayer ! NodeRelay.Relay(p))
     mockPayFSM.expectNoMessage(100 millis) // we should NOT trigger a downstream payment before we received a complete upstream payment
 
-    // publish block height one block before the cancel-safety-before-timeout-block interval before the current incoming payment expiry
+    // publish block height at the cancel-safety-before-timeout-block threshold before the current incoming payment expiry
     assert(asyncTimeoutHeight(nodeParams) > asyncSafetyHeight(incomingAsyncPayment, nodeParams))
     system.eventStream ! EventStream.Publish(CurrentBlockHeight(asyncSafetyHeight(incomingAsyncPayment, nodeParams)))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -858,7 +858,7 @@ object NodeRelayerSpec {
     createValidIncomingPacket(1000000 msat, incomingAmount, CltvExpiry(499999), outgoingAmount, outgoingExpiry)
   )
   val incomingSinglePart = createValidIncomingPacket(incomingAmount, incomingAmount, CltvExpiry(500000), outgoingAmount, outgoingExpiry)
-  val incomingAsyncPayment: Seq[NodeRelayPacket] = incomingMultiPart.map(p => p.copy(innerPayload = IntermediatePayload.NodeRelay.Standard.createNodeRelayForAsyncPayment(p.innerPayload.amountToForward, p.innerPayload.outgoingCltv, outgoingNodeId, Features.empty)))
+  val incomingAsyncPayment: Seq[NodeRelayPacket] = incomingMultiPart.map(p => p.copy(innerPayload = IntermediatePayload.NodeRelay.Standard.createNodeRelayForAsyncPayment(p.innerPayload.amountToForward, p.innerPayload.outgoingCltv, outgoingNodeId)))
 
   def createSuccessEvent(): PaymentSent =
     PaymentSent(relayId, paymentHash, paymentPreimage, outgoingAmount, outgoingNodeId, Seq(PaymentSent.PartialPayment(UUID.randomUUID(), outgoingAmount, 10 msat, randomBytes32(), None)))
@@ -870,7 +870,7 @@ object NodeRelayerSpec {
       FinalPayload.Standard.createMultiPartPayload(amountIn, totalAmountIn, expiryIn, incomingSecret, None)
     }
     val innerPayload = if (isAsyncPayment) {
-      IntermediatePayload.NodeRelay.Standard.createNodeRelayForAsyncPayment(amountOut, expiryOut, outgoingNodeId, Features.empty)
+      IntermediatePayload.NodeRelay.Standard.createNodeRelayForAsyncPayment(amountOut, expiryOut, outgoingNodeId)
     } else {
       IntermediatePayload.NodeRelay.Standard(amountOut, expiryOut, outgoingNodeId)
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/PaymentOnionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/PaymentOnionSpec.scala
@@ -343,4 +343,13 @@ class PaymentOnionSpec extends AnyFunSuite {
     }
   }
 
+  test("encode/decode empty AsyncPayment TLV") {
+    val tlvs = TlvStream[OnionPaymentPayloadTlv](AsyncPayment())
+    val bin = hex"06 fe0acecbae00"
+
+    val encoded = perHopPayloadCodec.encode(tlvs).require.bytes
+    assert(encoded == bin)
+    assert(perHopPayloadCodec.decode(bin.bits).require.value == tlvs)
+  }
+
 }


### PR DESCRIPTION
This is the first step in adding "async payments" as described in issue #2424 .