### PR TITLE
Fix duplicate SLF4J loggers in tests

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/FixtureUtils.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/FixtureUtils.scala
@@ -10,6 +10,8 @@ object FixtureUtils {
         s"""|  akka {
             |    logging-context = "$testName"
             |    loggers = ["fr.acinq.eclair.testutils.MySlf4jLogger"]
+            |    // akka-typed always uses slf4j and by default will remove custom loggers
+            |    use-slf4j = false
             |    actor.debug.event-stream = off
             |    }""".stripMargin
       }.withFallback(ConfigFactory.load())


### PR DESCRIPTION
When using a custom logger for log capture in tests (with `akka.loggers=["fr.acinq.eclair.testutils.MySlf4jLogger"]`), we need to explicitly disable the "hardcoded" slf4j logger for akka typed, otherwise we will end up with duplicate slf4j logging (one through our custom logger, the other one through the default slf4j logger).

See the rationale for this hardcoded sl4j logger here: https://doc.akka.io/docs/akka/current/typed/logging.html#event-bus.