### PR TITLE
Add `tlvField` codec

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/ChannelTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/ChannelTlv.scala
@@ -19,7 +19,7 @@ package fr.acinq.eclair.wire.protocol
 import fr.acinq.bitcoin.scalacompat.Satoshi
 import fr.acinq.eclair.channel.{ChannelType, ChannelTypes}
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
-import fr.acinq.eclair.wire.protocol.TlvCodecs.{tlvStream, tmillisatoshi}
+import fr.acinq.eclair.wire.protocol.TlvCodecs.{tlvField, tlvStream, tmillisatoshi}
 import fr.acinq.eclair.{Alias, FeatureSupport, Features, MilliSatoshi, UInt64}
 import scodec.Codec
 import scodec.bits.ByteVector
@@ -40,19 +40,19 @@ object ChannelTlv {
     val isEmpty: Boolean = script.isEmpty
   }
 
-  val upfrontShutdownScriptCodec: Codec[UpfrontShutdownScriptTlv] = variableSizeBytesLong(varintoverflow, bytes).as[UpfrontShutdownScriptTlv]
+  val upfrontShutdownScriptCodec: Codec[UpfrontShutdownScriptTlv] = tlvField(bytes.as[UpfrontShutdownScriptTlv])
 
   /** A channel type is a set of even feature bits that represent persistent features which affect channel operations. */
   case class ChannelTypeTlv(channelType: ChannelType) extends OpenChannelTlv with AcceptChannelTlv with OpenDualFundedChannelTlv with AcceptDualFundedChannelTlv
 
-  val channelTypeCodec: Codec[ChannelTypeTlv] = variableSizeBytesLong(varintoverflow, bytes).xmap(
+  val channelTypeCodec: Codec[ChannelTypeTlv] = tlvField(bytes.xmap(
     b => ChannelTypeTlv(ChannelTypes.fromFeatures(Features(b).initFeatures())),
     tlv => Features(tlv.channelType.features.map(f => f -> FeatureSupport.Mandatory).toMap).toByteVector
-  )
+  ))
 
   case class PushAmountTlv(amount: MilliSatoshi) extends OpenDualFundedChannelTlv with AcceptDualFundedChannelTlv
 
-  val pushAmountCodec: Codec[PushAmountTlv] = variableSizeBytesLong(varintoverflow, tmillisatoshi).as[PushAmountTlv]
+  val pushAmountCodec: Codec[PushAmountTlv] = tlvField(tmillisatoshi.as[PushAmountTlv])
 
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/InteractiveTxTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/InteractiveTxTlv.scala
@@ -18,10 +18,10 @@ package fr.acinq.eclair.wire.protocol
 
 import fr.acinq.bitcoin.scalacompat.Satoshi
 import fr.acinq.eclair.UInt64
-import fr.acinq.eclair.wire.protocol.CommonCodecs.{varint, varintoverflow}
-import fr.acinq.eclair.wire.protocol.TlvCodecs.{tlvStream, tsatoshi}
+import fr.acinq.eclair.wire.protocol.CommonCodecs.varint
+import fr.acinq.eclair.wire.protocol.TlvCodecs.{tlvField, tlvStream, tsatoshi}
 import scodec.Codec
-import scodec.codecs.{discriminated, variableSizeBytesLong}
+import scodec.codecs.discriminated
 
 /**
  * Created by t-bast on 08/04/2022.
@@ -77,7 +77,7 @@ object TxInitRbfTlv {
   import TxRbfTlv._
 
   val txInitRbfTlvCodec: Codec[TlvStream[TxInitRbfTlv]] = tlvStream(discriminated[TxInitRbfTlv].by(varint)
-    .typecase(UInt64(0), variableSizeBytesLong(varintoverflow, tsatoshi).as[SharedOutputContributionTlv])
+    .typecase(UInt64(0), tlvField(tsatoshi.as[SharedOutputContributionTlv]))
   )
 
 }
@@ -87,7 +87,7 @@ object TxAckRbfTlv {
   import TxRbfTlv._
 
   val txAckRbfTlvCodec: Codec[TlvStream[TxAckRbfTlv]] = tlvStream(discriminated[TxAckRbfTlv].by(varint)
-    .typecase(UInt64(0), variableSizeBytesLong(varintoverflow, tsatoshi).as[SharedOutputContributionTlv])
+    .typecase(UInt64(0), tlvField(tsatoshi.as[SharedOutputContributionTlv]))
   )
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/OfferCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/OfferCodecs.scala
@@ -21,43 +21,43 @@ import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.{BlindedNode, BlindedRoute}
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
 import fr.acinq.eclair.wire.protocol.LightningMessageCodecs.lengthPrefixedFeaturesCodec
 import fr.acinq.eclair.wire.protocol.OfferTypes._
-import fr.acinq.eclair.wire.protocol.TlvCodecs.{tmillisatoshi, tu32, tu64overflow}
+import fr.acinq.eclair.wire.protocol.TlvCodecs.{tlvField, tmillisatoshi, tu32, tu64overflow}
 import fr.acinq.eclair.{CltvExpiryDelta, Feature, Features, MilliSatoshi, TimestampSecond, UInt64}
 import scodec.Codec
 import scodec.codecs._
 
 object OfferCodecs {
-  private val chains: Codec[Chains] = variableSizeBytesLong(varintoverflow, list(bytes32)).xmap[Seq[ByteVector32]](_.toSeq, _.toList).as[Chains]
+  private val chains: Codec[Chains] = tlvField(list(bytes32).xmap[Seq[ByteVector32]](_.toSeq, _.toList).as[Chains])
 
-  private val currency: Codec[Currency] = variableSizeBytesLong(varintoverflow, utf8).as[Currency]
+  private val currency: Codec[Currency] = tlvField(utf8.as[Currency])
 
-  private val amount: Codec[Amount] = variableSizeBytesLong(varintoverflow, tmillisatoshi).as[Amount]
+  private val amount: Codec[Amount] = tlvField(tmillisatoshi.as[Amount])
 
-  private val description: Codec[Description] = variableSizeBytesLong(varintoverflow, utf8).as[Description]
+  private val description: Codec[Description] = tlvField(utf8.as[Description])
 
-  private val features: Codec[FeaturesTlv] = variableSizeBytesLong(varintoverflow, bytes).xmap[Features[Feature]](Features(_), _.toByteVector).as[FeaturesTlv]
+  private val features: Codec[FeaturesTlv] = tlvField(bytes.xmap[Features[Feature]](Features(_), _.toByteVector).as[FeaturesTlv])
 
-  private val absoluteExpiry: Codec[AbsoluteExpiry] = variableSizeBytesLong(varintoverflow, tu64overflow).as[TimestampSecond].as[AbsoluteExpiry]
+  private val absoluteExpiry: Codec[AbsoluteExpiry] = tlvField(tu64overflow.as[TimestampSecond].as[AbsoluteExpiry])
 
   private val blindedNodeCodec: Codec[BlindedNode] = (("nodeId" | publicKey) :: ("encryptedData" | variableSizeBytes(uint16, bytes))).as[BlindedNode]
 
   private val pathCodec: Codec[BlindedRoute] = (("firstNodeId" | publicKey) :: ("blinding" | publicKey) :: ("path" | listOfN(uint8, blindedNodeCodec).xmap[Seq[BlindedNode]](_.toSeq, _.toList))).as[BlindedRoute]
 
-  private val paths: Codec[Paths] = variableSizeBytesLong(varintoverflow, list(pathCodec)).xmap[Seq[BlindedRoute]](_.toSeq, _.toList).as[Paths]
+  private val paths: Codec[Paths] = tlvField(list(pathCodec).xmap[Seq[BlindedRoute]](_.toSeq, _.toList).as[Paths])
 
-  private val issuer: Codec[Issuer] = variableSizeBytesLong(varintoverflow, utf8).as[Issuer]
+  private val issuer: Codec[Issuer] = tlvField(utf8.as[Issuer])
 
-  private val quantityMin: Codec[QuantityMin] = variableSizeBytesLong(varintoverflow, tu64overflow).as[QuantityMin]
+  private val quantityMin: Codec[QuantityMin] = tlvField(tu64overflow.as[QuantityMin])
 
-  private val quantityMax: Codec[QuantityMax] = variableSizeBytesLong(varintoverflow, tu64overflow).as[QuantityMax]
+  private val quantityMax: Codec[QuantityMax] = tlvField(tu64overflow.as[QuantityMax])
 
-  private val nodeId: Codec[NodeId] = variableSizeBytesLong(varintoverflow, publicKey).as[NodeId]
+  private val nodeId: Codec[NodeId] = tlvField(publicKey.as[NodeId])
 
-  private val sendInvoice: Codec[SendInvoice] = variableSizeBytesLong(varintoverflow, provide(SendInvoice()))
+  private val sendInvoice: Codec[SendInvoice] = tlvField(provide(SendInvoice()))
 
-  private val refundFor: Codec[RefundFor] = variableSizeBytesLong(varintoverflow, bytes32).as[RefundFor]
+  private val refundFor: Codec[RefundFor] = tlvField(bytes32.as[RefundFor])
 
-  private val signature: Codec[Signature] = variableSizeBytesLong(varintoverflow, bytes64).as[Signature]
+  private val signature: Codec[Signature] = tlvField(bytes64.as[Signature])
 
   val offerTlvCodec: Codec[TlvStream[OfferTlv]] = TlvCodecs.tlvStream[OfferTlv](discriminated[OfferTlv].by(varint)
     .typecase(UInt64(2), chains)
@@ -75,19 +75,19 @@ object OfferCodecs {
     .typecase(UInt64(54), sendInvoice)
     .typecase(UInt64(240), signature)).complete
 
-  private val chain: Codec[Chain] = variableSizeBytesLong(varintoverflow, bytes32).as[Chain]
+  private val chain: Codec[Chain] = tlvField(bytes32.as[Chain])
 
-  private val offerId: Codec[OfferId] = variableSizeBytesLong(varintoverflow, bytes32).as[OfferId]
+  private val offerId: Codec[OfferId] = tlvField(bytes32.as[OfferId])
 
-  private val quantity: Codec[Quantity] = variableSizeBytesLong(varintoverflow, tu64overflow).as[Quantity]
+  private val quantity: Codec[Quantity] = tlvField(tu64overflow.as[Quantity])
 
-  private val payerKey: Codec[PayerKey] = variableSizeBytesLong(varintoverflow, bytes32).as[PayerKey]
+  private val payerKey: Codec[PayerKey] = tlvField(bytes32.as[PayerKey])
 
-  private val payerNote: Codec[PayerNote] = variableSizeBytesLong(varintoverflow, utf8).as[PayerNote]
+  private val payerNote: Codec[PayerNote] = tlvField(utf8.as[PayerNote])
 
-  private val payerInfo: Codec[PayerInfo] = variableSizeBytesLong(varintoverflow, bytes).as[PayerInfo]
+  private val payerInfo: Codec[PayerInfo] = tlvField(bytes.as[PayerInfo])
 
-  private val replaceInvoice: Codec[ReplaceInvoice] = variableSizeBytesLong(varintoverflow, bytes32).as[ReplaceInvoice]
+  private val replaceInvoice: Codec[ReplaceInvoice] = tlvField(bytes32.as[ReplaceInvoice])
 
   val invoiceRequestTlvCodec: Codec[TlvStream[InvoiceRequestTlv]] = TlvCodecs.tlvStream[InvoiceRequestTlv](discriminated[InvoiceRequestTlv].by(varint)
     .typecase(UInt64(3), chain)
@@ -108,25 +108,23 @@ object OfferCodecs {
     ("htlc_maximum_msat" | millisatoshi) ::
     ("features" | lengthPrefixedFeaturesCodec)).as[PaymentInfo]
 
-  private val paymentPathsInfo: Codec[PaymentPathsInfo] = variableSizeBytesLong(varintoverflow, list(paymentInfo)).xmap[Seq[PaymentInfo]](_.toSeq, _.toList).as[PaymentPathsInfo]
+  private val paymentPathsInfo: Codec[PaymentPathsInfo] = tlvField(list(paymentInfo).xmap[Seq[PaymentInfo]](_.toSeq, _.toList).as[PaymentPathsInfo])
 
-  private val paymentPathsCapacities: Codec[PaymentPathsCapacities] = variableSizeBytesLong(varintoverflow, list(millisatoshi)).xmap[Seq[MilliSatoshi]](_.toSeq, _.toList).as[PaymentPathsCapacities]
+  private val paymentPathsCapacities: Codec[PaymentPathsCapacities] = tlvField(list(millisatoshi).xmap[Seq[MilliSatoshi]](_.toSeq, _.toList).as[PaymentPathsCapacities])
 
-  private val createdAt: Codec[CreatedAt] = variableSizeBytesLong(varintoverflow, tu64overflow).as[TimestampSecond].as[CreatedAt]
+  private val createdAt: Codec[CreatedAt] = tlvField(tu64overflow.as[TimestampSecond].as[CreatedAt])
 
-  private val paymentHash: Codec[PaymentHash] = variableSizeBytesLong(varintoverflow, bytes32).as[PaymentHash]
+  private val paymentHash: Codec[PaymentHash] = tlvField(bytes32.as[PaymentHash])
 
-  private val relativeExpiry: Codec[RelativeExpiry] = variableSizeBytesLong(varintoverflow, tu32).as[RelativeExpiry]
+  private val relativeExpiry: Codec[RelativeExpiry] = tlvField(tu32.as[RelativeExpiry])
 
-  private val cltv: Codec[Cltv] = variableSizeBytesLong(varintoverflow, uint16).as[CltvExpiryDelta].as[Cltv]
+  private val cltv: Codec[Cltv] = tlvField(uint16.as[CltvExpiryDelta].as[Cltv])
 
-  private val fallbackAddress: Codec[FallbackAddress] = variableSizeBytesLong(varintoverflow,
-    ("version" | byte) ::
-      ("address" | variableSizeBytes(uint16, bytes))).as[FallbackAddress]
+  private val fallbackAddress: Codec[FallbackAddress] = variableSizeBytesLong(varintoverflow, ("version" | byte) :: ("address" | variableSizeBytes(uint16, bytes))).as[FallbackAddress]
 
-  private val fallbacks: Codec[Fallbacks] = variableSizeBytesLong(varintoverflow, list(fallbackAddress)).xmap[Seq[FallbackAddress]](_.toSeq, _.toList).as[Fallbacks]
+  private val fallbacks: Codec[Fallbacks] = tlvField(list(fallbackAddress).xmap[Seq[FallbackAddress]](_.toSeq, _.toList).as[Fallbacks])
 
-  private val refundSignature: Codec[RefundSignature] = variableSizeBytesLong(varintoverflow, bytes64).as[RefundSignature]
+  private val refundSignature: Codec[RefundSignature] = tlvField(bytes64.as[RefundSignature])
 
   val invoiceTlvCodec: Codec[TlvStream[InvoiceTlv]] = TlvCodecs.tlvStream[InvoiceTlv](discriminated[InvoiceTlv].by(varint)
     .typecase(UInt64(3), chain)
@@ -156,9 +154,9 @@ object OfferCodecs {
   ).complete
 
   val invoiceErrorTlvCodec: Codec[TlvStream[InvoiceErrorTlv]] = TlvCodecs.tlvStream[InvoiceErrorTlv](discriminated[InvoiceErrorTlv].by(varint)
-    .typecase(UInt64(1), variableSizeBytesLong(varintoverflow, tu64overflow).as[ErroneousField])
-    .typecase(UInt64(3), variableSizeBytesLong(varintoverflow, bytes).as[SuggestedValue])
-    .typecase(UInt64(5), variableSizeBytesLong(varintoverflow, utf8).as[Error])
+    .typecase(UInt64(1), tlvField(tu64overflow.as[ErroneousField]))
+    .typecase(UInt64(3), tlvField(bytes.as[SuggestedValue]))
+    .typecase(UInt64(5), tlvField(utf8.as[Error]))
   ).complete
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/SetupAndControlTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/SetupAndControlTlv.scala
@@ -19,9 +19,9 @@ package fr.acinq.eclair.wire.protocol
 import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.eclair.UInt64
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
-import fr.acinq.eclair.wire.protocol.TlvCodecs.tlvStream
+import fr.acinq.eclair.wire.protocol.TlvCodecs.{tlvField, tlvStream}
 import scodec.Codec
-import scodec.codecs.{discriminated, list, variableSizeBytesLong}
+import scodec.codecs.{discriminated, list}
 
 /**
  * Created by t-bast on 13/12/2019.
@@ -47,8 +47,8 @@ object InitTlvCodecs {
 
   import InitTlv._
 
-  private val networks: Codec[Networks] = variableSizeBytesLong(varintoverflow, list(bytes32)).as[Networks]
-  private val remoteAddress: Codec[RemoteAddress] = variableSizeBytesLong(varintoverflow, nodeaddress).as[RemoteAddress]
+  private val networks: Codec[Networks] = tlvField(list(bytes32).as[Networks])
+  private val remoteAddress: Codec[RemoteAddress] = tlvField(nodeaddress.as[RemoteAddress])
 
   val initTlvCodec = tlvStream(discriminated[InitTlv].by(varint)
     .typecase(UInt64(1), networks)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/TlvCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/TlvCodecsSpec.scala
@@ -36,95 +36,80 @@ class TlvCodecsSpec extends AnyFunSuite {
 
   test("encode/decode truncated uint16") {
     val testCases = Seq(
-      (hex"", hex"00", 0),
-      (hex"01", hex"01 01", 1),
-      (hex"2a", hex"01 2a", 42),
-      (hex"ff", hex"01 ff", 255),
-      (hex"0100", hex"02 0100", 256),
-      (hex"0231", hex"02 0231", 561),
-      (hex"ffff", hex"02 ffff", 65535)
+      (hex"", 0),
+      (hex"01", 1),
+      (hex"2a", 42),
+      (hex"ff", 255),
+      (hex"0100", 256),
+      (hex"0231", 561),
+      (hex"ffff", 65535)
     )
 
-    for ((bin, lengthPrefixedBin, expected) <- testCases) {
+    for ((bin, expected) <- testCases) {
       val decoded = tu16.decode(bin.bits).require.value
-      val decoded1 = ltu16.decode(lengthPrefixedBin.bits).require.value
       assert(decoded == expected)
-      assert(decoded1 == expected)
-
       val encoded = tu16.encode(expected).require.bytes
-      val encoded1 = ltu16.encode(expected).require.bytes
       assert(encoded == bin)
-      assert(encoded1 == lengthPrefixedBin)
     }
   }
 
   test("encode/decode truncated uint32") {
     val testCases = Seq(
-      (hex"", hex"00", 0L),
-      (hex"01", hex"01 01", 1L),
-      (hex"2a", hex"01 2a", 42L),
-      (hex"ff", hex"01 ff", 255L),
-      (hex"0100", hex"02 0100", 256L),
-      (hex"0231", hex"02 0231", 561L),
-      (hex"ffff", hex"02 ffff", 65535L),
-      (hex"010000", hex"03 010000", 65536L),
-      (hex"ffffff", hex"03 ffffff", 16777215L),
-      (hex"01000000", hex"04 01000000", 16777216L),
-      (hex"01020304", hex"04 01020304", 16909060L),
-      (hex"ffffffff", hex"04 ffffffff", 4294967295L)
+      (hex"", 0L),
+      (hex"01", 1L),
+      (hex"2a", 42L),
+      (hex"ff", 255L),
+      (hex"0100", 256L),
+      (hex"0231", 561L),
+      (hex"ffff", 65535L),
+      (hex"010000", 65536L),
+      (hex"ffffff", 16777215L),
+      (hex"01000000", 16777216L),
+      (hex"01020304", 16909060L),
+      (hex"ffffffff", 4294967295L)
     )
 
-    for ((bin, lengthPrefixedBin, expected) <- testCases) {
+    for ((bin, expected) <- testCases) {
       val decoded = tu32.decode(bin.bits).require.value
-      val decoded1 = ltu32.decode(lengthPrefixedBin.bits).require.value
       assert(decoded == expected)
-      assert(decoded1 == expected)
-
       val encoded = tu32.encode(expected).require.bytes
-      val encoded1 = ltu32.encode(expected).require.bytes
       assert(encoded == bin)
-      assert(encoded1 == lengthPrefixedBin)
     }
   }
 
   test("encode/decode truncated uint64") {
     val testCases = Seq(
-      (hex"", hex"00", UInt64(0)),
-      (hex"01", hex"01 01", UInt64(1)),
-      (hex"2a", hex"01 2a", UInt64(42)),
-      (hex"ff", hex"01 ff", UInt64(255)),
-      (hex"0100", hex"02 0100", UInt64(256)),
-      (hex"0231", hex"02 0231", UInt64(561)),
-      (hex"ffff", hex"02 ffff", UInt64(65535)),
-      (hex"010000", hex"03 010000", UInt64(65536)),
-      (hex"ffffff", hex"03 ffffff", UInt64(16777215)),
-      (hex"01000000", hex"04 01000000", UInt64(16777216)),
-      (hex"01020304", hex"04 01020304", UInt64(16909060)),
-      (hex"ffffffff", hex"04 ffffffff", UInt64(4294967295L)),
-      (hex"0100000000", hex"05 0100000000", UInt64(4294967296L)),
-      (hex"0102030405", hex"05 0102030405", UInt64(4328719365L)),
-      (hex"ffffffffff", hex"05 ffffffffff", UInt64(1099511627775L)),
-      (hex"010000000000", hex"06 010000000000", UInt64(1099511627776L)),
-      (hex"010203040506", hex"06 010203040506", UInt64(1108152157446L)),
-      (hex"ffffffffffff", hex"06 ffffffffffff", UInt64(281474976710655L)),
-      (hex"01000000000000", hex"07 01000000000000", UInt64(281474976710656L)),
-      (hex"01020304050607", hex"07 01020304050607", UInt64(283686952306183L)),
-      (hex"ffffffffffffff", hex"07 ffffffffffffff", UInt64(72057594037927935L)),
-      (hex"0100000000000000", hex"08 0100000000000000", UInt64(72057594037927936L)),
-      (hex"0102030405060708", hex"08 0102030405060708", UInt64(72623859790382856L)),
-      (hex"ffffffffffffffff", hex"08 ffffffffffffffff", UInt64.MaxValue)
+      (hex"", UInt64(0)),
+      (hex"01", UInt64(1)),
+      (hex"2a", UInt64(42)),
+      (hex"ff", UInt64(255)),
+      (hex"0100", UInt64(256)),
+      (hex"0231", UInt64(561)),
+      (hex"ffff", UInt64(65535)),
+      (hex"010000", UInt64(65536)),
+      (hex"ffffff", UInt64(16777215)),
+      (hex"01000000", UInt64(16777216)),
+      (hex"01020304", UInt64(16909060)),
+      (hex"ffffffff", UInt64(4294967295L)),
+      (hex"0100000000", UInt64(4294967296L)),
+      (hex"0102030405", UInt64(4328719365L)),
+      (hex"ffffffffff", UInt64(1099511627775L)),
+      (hex"010000000000", UInt64(1099511627776L)),
+      (hex"010203040506", UInt64(1108152157446L)),
+      (hex"ffffffffffff", UInt64(281474976710655L)),
+      (hex"01000000000000", UInt64(281474976710656L)),
+      (hex"01020304050607", UInt64(283686952306183L)),
+      (hex"ffffffffffffff", UInt64(72057594037927935L)),
+      (hex"0100000000000000", UInt64(72057594037927936L)),
+      (hex"0102030405060708", UInt64(72623859790382856L)),
+      (hex"ffffffffffffffff", UInt64.MaxValue)
     )
 
-    for ((bin, lengthPrefixedBin, expected) <- testCases) {
+    for ((bin, expected) <- testCases) {
       val decoded = tu64.decode(bin.bits).require.value
-      val decoded1 = ltu64.decode(lengthPrefixedBin.bits).require.value
       assert(decoded == expected)
-      assert(decoded1 == expected)
-
       val encoded = tu64.encode(expected).require.bytes
-      val encoded1 = ltu64.encode(expected).require.bytes
       assert(encoded == bin)
-      assert(encoded1 == lengthPrefixedBin)
     }
   }
 
@@ -137,13 +122,6 @@ class TlvCodecsSpec extends AnyFunSuite {
 
     assert(tu64overflow.encode(-1L).isFailure)
     assert(tu64overflow.decode(hex"8000000000000000".bits).isFailure)
-  }
-
-  test("decode length-prefixed truncated uint64 ignores trailing bytes") {
-    assert(ltu64.decode(hex"00 1234".bits).require.value == UInt64(0))
-    assert(ltu64.decode(hex"01 2a ff".bits).require.value == UInt64(42))
-    assert(ltu64.decode(hex"02 0451 1234".bits).require.value == UInt64(1105))
-    assert(ltu64.decode(hex"03 010000 0000".bits).require.value == UInt64(65536))
   }
 
   test("decode invalid truncated integers") {
@@ -334,9 +312,9 @@ class TlvCodecsSpec extends AnyFunSuite {
 
   test("get optional TLV field") {
     val stream = TlvStream[TestTlv](Seq(TestType254(42), TestType1(42)), Seq(GenericTlv(13, hex"2a"), GenericTlv(11, hex"2b")))
-    assert(stream.get[TestType254] == Some(TestType254(42)))
-    assert(stream.get[TestType1] == Some(TestType1(42)))
-    assert(stream.get[TestType2] == None)
+    assert(stream.get[TestType254].contains(TestType254(42)))
+    assert(stream.get[TestType1].contains(TestType1(42)))
+    assert(stream.get[TestType2].isEmpty)
   }
 }
 
@@ -351,10 +329,10 @@ object TlvCodecsSpec {
   case class TestType3(nodeId: PublicKey, value1: UInt64, value2: UInt64) extends TestTlv
   case class TestType254(intValue: Int) extends TestTlv
 
-  private val testCodec1: Codec[TestType1] = ("value" | ltu64).as[TestType1]
-  private val testCodec2: Codec[TestType2] = (("length" | constant(hex"08")) :: ("short_channel_id" | shortchannelid)).as[TestType2]
-  private val testCodec3: Codec[TestType3] = (("length" | constant(hex"31")) :: ("node_id" | publicKey) :: ("value_1" | uint64) :: ("value_2" | uint64)).as[TestType3]
-  private val testCodec254: Codec[TestType254] = (("length" | constant(hex"02")) :: ("value" | uint16)).as[TestType254]
+  private val testCodec1: Codec[TestType1] = tlvField(tu64.as[TestType1])
+  private val testCodec2: Codec[TestType2] = fixedLengthTlvField(8, shortchannelid.as[TestType2])
+  private val testCodec3: Codec[TestType3] = fixedLengthTlvField(49, (("node_id" | publicKey) :: ("value_1" | uint64) :: ("value_2" | uint64)).as[TestType3])
+  private val testCodec254: Codec[TestType254] = fixedLengthTlvField(2, uint16.as[TestType254])
 
   private val testTlvCodec = discriminated[TestTlv].by(varint)
     .typecase(1, testCodec1)
@@ -369,8 +347,8 @@ object TlvCodecsSpec {
   case class OtherType1(uintValue: UInt64) extends OtherTlv
   case class OtherType2(smallValue: Long) extends OtherTlv
 
-  val otherCodec1: Codec[OtherType1] = ("value" | ltu64).as[OtherType1]
-  val otherCodec2: Codec[OtherType2] = ("value" | ltu32).as[OtherType2]
+  val otherCodec1: Codec[OtherType1] = tlvField(tu64.as[OtherType1])
+  val otherCodec2: Codec[OtherType2] = tlvField(tu32.as[OtherType2])
   val otherTlvStreamCodec = tlvStream(discriminated[OtherTlv].by(varint)
     .typecase(10, otherCodec1)
     .typecase(11, otherCodec2))


### PR DESCRIPTION
We previously duplicated `variableSizeBytesLong(varintoverflow, ...)` whenever we wanted to work with a tlv field.

This was confusing and error-prone, so it's now factored into a specific helper codec. We also remove the length-prefixed truncated int codecs, as they are always used in tlvs and should simply use this new tlv field codec instead.