### PR TITLE
Fix `availableForSend` fuzz tests

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -432,7 +432,7 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
         val (_, cmdAdd) = makeCmdAdd(amount, randomKey().publicKey, f.currentBlockHeight)
         sendAdd(c, cmdAdd, f.currentBlockHeight, feeConfNoMismatch) match {
           case Right((cc, _)) => c = cc
-          case Left(e) => fail(s"$t -> could not setup initial htlcs: $e")
+          case Left(e) => ignore(s"$t -> could not setup initial htlcs: $e")
         }
       }
       val (_, cmdAdd) = makeCmdAdd(c.availableBalanceForSend, randomKey().publicKey, f.currentBlockHeight)
@@ -460,7 +460,7 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
         val add = UpdateAddHtlc(randomBytes32(), c.remoteNextHtlcId, amount, randomBytes32(), CltvExpiry(f.currentBlockHeight), TestConstants.emptyOnionPacket, None)
         receiveAdd(c, add, feeConfNoMismatch) match {
           case Right(cc) => c = cc
-          case Left(e) => fail(s"$t -> could not setup initial htlcs: $e")
+          case Left(e) => ignore(s"$t -> could not setup initial htlcs: $e")
         }
       }
       val add = UpdateAddHtlc(randomBytes32(), c.remoteNextHtlcId, c.availableBalanceForReceive, randomBytes32(), CltvExpiry(f.currentBlockHeight), TestConstants.emptyOnionPacket, None)


### PR DESCRIPTION
These two fuzz tests setup a random set of HTLCs and then try to send or receive the maximum available amount. The initial HTLC setup may fail, if the initial balances are too low.

It is hard to set those initial balances to ensure this will always work, but since this will only rarely randomly happen, we should simply ignore it (instead of failing the test).