### PR TITLE
Complete codec for TLV fields

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/ChannelTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/ChannelTlv.scala
@@ -45,7 +45,7 @@ object ChannelTlv {
   /** A channel type is a set of even feature bits that represent persistent features which affect channel operations. */
   case class ChannelTypeTlv(channelType: ChannelType) extends OpenChannelTlv with AcceptChannelTlv with OpenDualFundedChannelTlv with AcceptDualFundedChannelTlv
 
-  val channelTypeCodec: Codec[ChannelTypeTlv] = tlvField(bytes.xmap(
+  val channelTypeCodec: Codec[ChannelTypeTlv] = tlvField(bytes.xmap[ChannelTypeTlv](
     b => ChannelTypeTlv(ChannelTypes.fromFeatures(Features(b).initFeatures())),
     tlv => Features(tlv.channelType.features.map(f => f -> FeatureSupport.Mandatory).toMap).toByteVector
   ))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/ChannelTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/ChannelTlv.scala
@@ -40,7 +40,7 @@ object ChannelTlv {
     val isEmpty: Boolean = script.isEmpty
   }
 
-  val upfrontShutdownScriptCodec: Codec[UpfrontShutdownScriptTlv] = tlvField(bytes.as[UpfrontShutdownScriptTlv])
+  val upfrontShutdownScriptCodec: Codec[UpfrontShutdownScriptTlv] = tlvField(bytes)
 
   /** A channel type is a set of even feature bits that represent persistent features which affect channel operations. */
   case class ChannelTypeTlv(channelType: ChannelType) extends OpenChannelTlv with AcceptChannelTlv with OpenDualFundedChannelTlv with AcceptDualFundedChannelTlv
@@ -52,7 +52,7 @@ object ChannelTlv {
 
   case class PushAmountTlv(amount: MilliSatoshi) extends OpenDualFundedChannelTlv with AcceptDualFundedChannelTlv
 
-  val pushAmountCodec: Codec[PushAmountTlv] = tlvField(tmillisatoshi.as[PushAmountTlv])
+  val pushAmountCodec: Codec[PushAmountTlv] = tlvField(tmillisatoshi)
 
 }
 
@@ -119,7 +119,7 @@ object ChannelReadyTlv {
 
   case class ShortChannelIdTlv(alias: Alias) extends ChannelReadyTlv
 
-  val channelAliasTlvCodec: Codec[ShortChannelIdTlv] = variableSizeBytesLong(varintoverflow, "alias" | alias).as[ShortChannelIdTlv]
+  val channelAliasTlvCodec: Codec[ShortChannelIdTlv] = tlvField("alias" | alias)
 
   val channelReadyTlvCodec: Codec[TlvStream[ChannelReadyTlv]] = tlvStream(discriminated[ChannelReadyTlv].by(varint)
     .typecase(UInt64(1), channelAliasTlvCodec)
@@ -150,10 +150,10 @@ object ClosingSignedTlv {
 
   case class FeeRange(min: Satoshi, max: Satoshi) extends ClosingSignedTlv
 
-  private val feeRange: Codec[FeeRange] = (("min_fee_satoshis" | satoshi) :: ("max_fee_satoshis" | satoshi)).as[FeeRange]
+  private val feeRange: Codec[FeeRange] = tlvField(("min_fee_satoshis" | satoshi) :: ("max_fee_satoshis" | satoshi))
 
   val closingSignedTlvCodec: Codec[TlvStream[ClosingSignedTlv]] = tlvStream(discriminated[ClosingSignedTlv].by(varint)
-    .typecase(UInt64(1), variableSizeBytesLong(varintoverflow, feeRange))
+    .typecase(UInt64(1), feeRange)
   )
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/MessageOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/MessageOnion.scala
@@ -128,9 +128,9 @@ object MessageOnionCodecs {
 
   val blindedRouteCodec: Codec[BlindedRoute] = (("firstNodeId" | publicKey) :: ("blinding" | publicKey) :: ("path" | list(replyHopCodec).xmap[Seq[BlindedNode]](_.toSeq, _.toList))).as[BlindedRoute]
 
-  private val replyPathCodec: Codec[ReplyPath] = tlvField(blindedRouteCodec.as[ReplyPath])
+  private val replyPathCodec: Codec[ReplyPath] = tlvField(blindedRouteCodec)
 
-  private val encryptedDataCodec: Codec[EncryptedData] = tlvField(bytes.as[EncryptedData])
+  private val encryptedDataCodec: Codec[EncryptedData] = tlvField(bytes)
 
   private val onionTlvCodec = discriminated[OnionMessagePayloadTlv].by(varint)
     .typecase(UInt64(2), replyPathCodec)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -464,7 +464,7 @@ object PaymentOnionCodecs {
 
   private val outgoingChannelId: Codec[OutgoingChannelId] = tlvField(shortchannelid)
 
-  private val paymentData: Codec[PaymentData] = tlvField((("payment_secret" | bytes32) :: ("total_msat" | tmillisatoshi)))
+  private val paymentData: Codec[PaymentData] = tlvField(("payment_secret" | bytes32) :: ("total_msat" | tmillisatoshi))
 
   private val encryptedRecipientData: Codec[EncryptedRecipientData] = tlvField(bytes)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -458,33 +458,33 @@ object PaymentOnionCodecs {
   val payloadLengthDecoder = Decoder[Long]((bits: BitVector) =>
     varintoverflow.decode(bits).map(d => DecodeResult(d.value + (bits.length - d.remainder.length) / 8, d.remainder)))
 
-  private val amountToForward: Codec[AmountToForward] = tlvField(tmillisatoshi.as[AmountToForward])
+  private val amountToForward: Codec[AmountToForward] = tlvField(tmillisatoshi)
 
   private val outgoingCltv: Codec[OutgoingCltv] = tlvField(tu32.xmap(cltv => OutgoingCltv(CltvExpiry(cltv)), (c: OutgoingCltv) => c.cltv.toLong))
 
-  private val outgoingChannelId: Codec[OutgoingChannelId] = tlvField(shortchannelid.as[OutgoingChannelId])
+  private val outgoingChannelId: Codec[OutgoingChannelId] = tlvField(shortchannelid)
 
-  private val paymentData: Codec[PaymentData] = tlvField((("payment_secret" | bytes32) :: ("total_msat" | tmillisatoshi)).as[PaymentData])
+  private val paymentData: Codec[PaymentData] = tlvField((("payment_secret" | bytes32) :: ("total_msat" | tmillisatoshi)))
 
-  private val encryptedRecipientData: Codec[EncryptedRecipientData] = tlvField(bytes.as[EncryptedRecipientData])
+  private val encryptedRecipientData: Codec[EncryptedRecipientData] = tlvField(bytes)
 
-  private val blindingPoint: Codec[BlindingPoint] = fixedLengthTlvField(33, publicKey.as[BlindingPoint])
+  private val blindingPoint: Codec[BlindingPoint] = fixedLengthTlvField(33, publicKey)
 
-  private val outgoingNodeId: Codec[OutgoingNodeId] = fixedLengthTlvField(33, publicKey.as[OutgoingNodeId])
+  private val outgoingNodeId: Codec[OutgoingNodeId] = fixedLengthTlvField(33, publicKey)
 
-  private val paymentMetadata: Codec[PaymentMetadata] = tlvField(bytes.as[PaymentMetadata])
+  private val paymentMetadata: Codec[PaymentMetadata] = tlvField(bytes)
 
-  private val totalAmount: Codec[TotalAmount] = tlvField(tmillisatoshi.as[TotalAmount])
+  private val totalAmount: Codec[TotalAmount] = tlvField(tmillisatoshi)
 
-  private val invoiceFeatures: Codec[InvoiceFeatures] = tlvField(bytes.as[InvoiceFeatures])
+  private val invoiceFeatures: Codec[InvoiceFeatures] = tlvField(bytes)
 
-  private val invoiceRoutingInfo: Codec[InvoiceRoutingInfo] = tlvField(list(listOfN(uint8, Bolt11Invoice.Codecs.extraHopCodec)).as[InvoiceRoutingInfo])
+  private val invoiceRoutingInfo: Codec[InvoiceRoutingInfo] = tlvField(list(listOfN(uint8, Bolt11Invoice.Codecs.extraHopCodec)))
 
-  private val trampolineOnion: Codec[TrampolineOnion] = tlvField(trampolineOnionPacketCodec.as[TrampolineOnion])
+  private val trampolineOnion: Codec[TrampolineOnion] = tlvField(trampolineOnionPacketCodec)
 
-  private val keySend: Codec[KeySend] = tlvField(bytes32.as[KeySend])
+  private val keySend: Codec[KeySend] = tlvField(bytes32)
 
-  private val asyncPayment: Codec[AsyncPayment] = tlvField(provide(AsyncPayment()).as[AsyncPayment])
+  private val asyncPayment: Codec[AsyncPayment] = tlvField(provide(AsyncPayment()))
 
   private val onionTlvCodec = discriminated[OnionPaymentPayloadTlv].by(varint)
     .typecase(UInt64(2), amountToForward)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -484,7 +484,7 @@ object PaymentOnionCodecs {
 
   private val keySend: Codec[KeySend] = tlvField(bytes32.as[KeySend])
 
-  private val asyncPayment: Codec[AsyncPayment] = variableSizeBytesLong(varintoverflow, provide(AsyncPayment())).as[AsyncPayment]
+  private val asyncPayment: Codec[AsyncPayment] = tlvField(provide(AsyncPayment()).as[AsyncPayment])
 
   private val onionTlvCodec = discriminated[OnionPaymentPayloadTlv].by(varint)
     .typecase(UInt64(2), amountToForward)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/RouteBlinding.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/RouteBlinding.scala
@@ -112,14 +112,14 @@ object RouteBlindingEncryptedDataCodecs {
   import scodec.codecs._
   import scodec.{Attempt, Codec, DecodeResult}
 
-  private val padding: Codec[Padding] = tlvField(bytes.as[Padding])
-  private val outgoingChannelId: Codec[OutgoingChannelId] = tlvField(shortchannelid.as[OutgoingChannelId])
-  private val outgoingNodeId: Codec[OutgoingNodeId] = fixedLengthTlvField(33, publicKey.as[OutgoingNodeId])
-  private val pathId: Codec[PathId] = tlvField(bytes.as[PathId])
-  private val nextBlinding: Codec[NextBlinding] = fixedLengthTlvField(33, publicKey.as[NextBlinding])
-  private val paymentRelay: Codec[PaymentRelay] = tlvField((("cltv_expiry_delta" | cltvExpiryDelta) :: ("fee_proportional_millionths" | uint32) :: ("fee_base_msat" | tmillisatoshi32)).as[PaymentRelay])
-  private val paymentConstraints: Codec[PaymentConstraints] = tlvField((("max_cltv_expiry" | cltvExpiry) :: ("htlc_minimum_msat" | tmillisatoshi)).as[PaymentConstraints])
-  private val allowedFeatures: Codec[AllowedFeatures] = tlvField(featuresCodec.as[AllowedFeatures])
+  private val padding: Codec[Padding] = tlvField(bytes)
+  private val outgoingChannelId: Codec[OutgoingChannelId] = tlvField(shortchannelid)
+  private val outgoingNodeId: Codec[OutgoingNodeId] = fixedLengthTlvField(33, publicKey)
+  private val pathId: Codec[PathId] = tlvField(bytes)
+  private val nextBlinding: Codec[NextBlinding] = fixedLengthTlvField(33, publicKey)
+  private val paymentRelay: Codec[PaymentRelay] = tlvField(("cltv_expiry_delta" | cltvExpiryDelta) :: ("fee_proportional_millionths" | uint32) :: ("fee_base_msat" | tmillisatoshi32))
+  private val paymentConstraints: Codec[PaymentConstraints] = tlvField(("max_cltv_expiry" | cltvExpiry) :: ("htlc_minimum_msat" | tmillisatoshi))
+  private val allowedFeatures: Codec[AllowedFeatures] = tlvField(featuresCodec)
 
   private val encryptedDataTlvCodec = discriminated[RouteBlindingEncryptedDataTlv].by(varint)
     .typecase(UInt64(1), padding)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/RoutingTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/RoutingTlv.scala
@@ -187,7 +187,7 @@ object QueryShortChannelIdsTlv {
 
 
   val codec: Codec[TlvStream[QueryShortChannelIdsTlv]] = TlvCodecs.tlvStream(discriminated.by(varint)
-    .typecase(UInt64(1), tlvField(encodedQueryFlagsCodec))
+    .typecase(UInt64(1), tlvField[EncodedQueryFlags, EncodedQueryFlags](encodedQueryFlagsCodec))
   )
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/RoutingTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/RoutingTlv.scala
@@ -138,7 +138,7 @@ object ReplyChannelRangeTlv {
       ("checksum2" | uint32)
     ).as[Checksums]
 
-  val encodedChecksumsCodec: Codec[EncodedChecksums] = tlvField(list(checksumsCodec).as[EncodedChecksums])
+  val encodedChecksumsCodec: Codec[EncodedChecksums] = tlvField(list(checksumsCodec))
 
   val innerCodec = discriminated[ReplyChannelRangeTlv].by(varint)
     .typecase(UInt64(1), encodedTimestampsCodec)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/SetupAndControlTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/SetupAndControlTlv.scala
@@ -47,8 +47,8 @@ object InitTlvCodecs {
 
   import InitTlv._
 
-  private val networks: Codec[Networks] = tlvField(list(bytes32).as[Networks])
-  private val remoteAddress: Codec[RemoteAddress] = tlvField(nodeaddress.as[RemoteAddress])
+  private val networks: Codec[Networks] = tlvField(list(bytes32))
+  private val remoteAddress: Codec[RemoteAddress] = tlvField(nodeaddress)
 
   val initTlvCodec = tlvStream(discriminated[InitTlv].by(varint)
     .typecase(UInt64(1), networks)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/TlvCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/TlvCodecs.scala
@@ -107,10 +107,10 @@ object TlvCodecs {
   }
 
   /** Codec for a tlv field that contains the field length and its value, without its tag. */
-  def tlvField[T <: Tlv](valueCodec: Codec[T]): Codec[T] = variableSizeBytesLong(varintoverflow, valueCodec.complete)
+  def tlvField[T <: Tlv, A](valueCodec: Codec[A])(implicit as: scodec.Transformer[A, T]): Codec[T] = variableSizeBytesLong(varintoverflow, valueCodec.as[T].complete)
 
   /** Codec for a tlv field that has a known, fixed length. */
-  def fixedLengthTlvField[T <: Tlv](length: Long, valueCodec: Codec[T]): Codec[T] = ("length" | constant(varintoverflow.encode(length).require)) ~> ("value" | valueCodec)
+  def fixedLengthTlvField[T <: Tlv, A](length: Long, valueCodec: Codec[A])(implicit as: scodec.Transformer[A, T]): Codec[T] = ("length" | constant(varintoverflow.encode(length).require)) ~> ("value" | valueCodec.as[T])
 
   val genericTlv: Codec[GenericTlv] = (("tag" | varint) :: variableSizeBytesLong(varintoverflow, bytes)).as[GenericTlv]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/TlvCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/TlvCodecs.scala
@@ -107,7 +107,7 @@ object TlvCodecs {
   }
 
   /** Codec for a tlv field that contains the field length and its value, without its tag. */
-  def tlvField[T <: Tlv](valueCodec: Codec[T]): Codec[T] = variableSizeBytesLong(varintoverflow, valueCodec)
+  def tlvField[T <: Tlv](valueCodec: Codec[T]): Codec[T] = variableSizeBytesLong(varintoverflow, valueCodec.complete)
 
   /** Codec for a tlv field that has a known, fixed length. */
   def fixedLengthTlvField[T <: Tlv](length: Long, valueCodec: Codec[T]): Codec[T] = ("length" | constant(varintoverflow.encode(length).require)) ~> ("value" | valueCodec)


### PR DESCRIPTION
We currently accept some malformed TLVs with additional data that we ignore. This means that decoding and reencoding may give a different result. With this change, we now reject such TLVs.