### PR TITLE
Add `PeerReadyNotifier` actor

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/MessageRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/MessageRelay.scala
@@ -73,7 +73,7 @@ object MessageRelay {
 
   def waitForPreviousPeer(messageId: ByteVector32, switchboard: ActorRef, nextNodeId: PublicKey, msg: OnionMessage, replyTo_opt: Option[typed.ActorRef[Status]]): Behavior[Command] = {
     Behaviors.receivePartial {
-      case (context, WrappedPeerInfo(PeerInfo(_, _, _, _, channels))) if channels > 0 =>
+      case (context, WrappedPeerInfo(PeerInfo(_, _, _, _, channels))) if channels.nonEmpty =>
         switchboard ! GetPeerInfo(context.messageAdapter(WrappedPeerInfo), nextNodeId)
         waitForNextPeer(messageId, msg, replyTo_opt)
       case _ =>
@@ -84,7 +84,7 @@ object MessageRelay {
 
   def waitForNextPeer(messageId: ByteVector32, msg: OnionMessage, replyTo_opt: Option[typed.ActorRef[Status]]): Behavior[Command] = {
     Behaviors.receiveMessagePartial {
-      case WrappedPeerInfo(PeerInfo(peer, _, _, _, channels)) if channels > 0 =>
+      case WrappedPeerInfo(PeerInfo(peer, _, _, _, channels)) if channels.nonEmpty =>
         peer ! Peer.RelayOnionMessage(messageId, msg, replyTo_opt)
         Behaviors.stopped
       case _ =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -324,7 +324,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnChainA
       replyTo ! PeerInfo(self, remoteNodeId, stateName, d match {
         case c: ConnectedData => Some(c.address)
         case _ => None
-      }, d.channels.values.toSet.size) // we use toSet to dedup because a channel can have a TemporaryChannelId + a ChannelId
+      }, d.channels.values.toSet)
       stay()
 
     case Event(_: Peer.OutgoingMessage, _) => stay() // we got disconnected or reconnected and this message was for the previous connection
@@ -548,7 +548,7 @@ object Peer {
   sealed trait PeerInfoResponse {
     def nodeId: PublicKey
   }
-  case class PeerInfo(peer: ActorRef, nodeId: PublicKey, state: State, address: Option[NodeAddress], channels: Int) extends PeerInfoResponse
+  case class PeerInfo(peer: ActorRef, nodeId: PublicKey, state: State, address: Option[NodeAddress], channels: Set[ActorRef]) extends PeerInfoResponse
   case class PeerNotFound(nodeId: PublicKey) extends PeerInfoResponse { override def toString: String = s"peer $nodeId not found" }
 
   case class PeerRoutingMessage(peerConnection: ActorRef, remoteNodeId: PublicKey, message: RoutingMessage) extends RemoteTypes

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerReadyNotifier.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerReadyNotifier.scala
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.io
+
+import akka.actor.typed.eventstream.EventStream
+import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors, TimerScheduler}
+import akka.actor.typed.{ActorRef, Behavior}
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.eclair.blockchain.CurrentBlockHeight
+import fr.acinq.eclair.{BlockHeight, Logs, channel}
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+/**
+ * This actor waits for a given peer to be online and ready to process payments.
+ * It automatically stops after the timeout provided.
+ */
+object PeerReadyNotifier {
+
+  // @formatter:off
+  sealed trait Command
+  case class NotifyWhenPeerReady(replyTo: ActorRef[Result]) extends Command
+  private case object PeerNotConnected extends Command
+  private case class SomePeerConnected(nodeId: PublicKey) extends Command
+  private case class PeerChannels(channels: Set[akka.actor.ActorRef]) extends Command
+  private case class NewBlockNotTimedOut(currentBlockHeight: BlockHeight) extends Command
+  private case object CheckChannelsReady extends Command
+  private case class ChannelStates(states: Seq[channel.ChannelState]) extends Command
+  private case object Timeout extends Command
+
+  sealed trait Result
+  case class PeerReady(remoteNodeId: PublicKey, channelsCount: Int) extends Result
+  case class PeerUnavailable(remoteNodeId: PublicKey) extends Result
+  // @formatter:on
+
+  def apply(remoteNodeId: PublicKey, switchboard: ActorRef[Switchboard.GetPeerInfo], timeout_opt: Option[Either[FiniteDuration, BlockHeight]]): Behavior[Command] = {
+    Behaviors.setup { context =>
+      Behaviors.withTimers { timers =>
+        Behaviors.withMdc(Logs.mdc(remoteNodeId_opt = Some(remoteNodeId))) {
+          Behaviors.receiveMessagePartial {
+            case NotifyWhenPeerReady(replyTo) =>
+              timeout_opt.foreach {
+                case Left(d) => timers.startSingleTimer(Timeout, d)
+                case Right(h) => context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[CurrentBlockHeight] {
+                  case cbc if h <= cbc.blockHeight => Timeout
+                  case cbc => NewBlockNotTimedOut(cbc.blockHeight)
+                })
+              }
+              waitForPeerConnected(replyTo, remoteNodeId, switchboard, context, timers)
+          }
+        }
+      }
+    }
+  }
+
+  def waitForPeerConnected(replyTo: ActorRef[Result], remoteNodeId: PublicKey, switchboard: ActorRef[Switchboard.GetPeerInfo], context: ActorContext[Command], timers: TimerScheduler[Command]): Behavior[Command] = {
+    // In case the peer is not currently connected, we will wait for them to connect instead of regularly polling the
+    // switchboard. This makes more sense for long timeouts such as the ones used for async payments.
+    val peerConnectedAdapter = context.messageAdapter[PeerConnected](pc => SomePeerConnected(pc.nodeId))
+    context.system.eventStream ! EventStream.Subscribe(peerConnectedAdapter)
+    val peerInfoAdapter = context.messageAdapter[Peer.PeerInfoResponse] {
+      // We receive this when we don't have any channel to the given peer and are not currently connected to them.
+      // In that case we still want to wait for a connection, because we may want to open a channel to them.
+      case _: Peer.PeerNotFound => PeerNotConnected
+      case info: Peer.PeerInfo if info.state != Peer.CONNECTED => PeerNotConnected
+      case info: Peer.PeerInfo => PeerChannels(info.channels)
+    }
+    // We check whether the peer is already connected.
+    switchboard ! Switchboard.GetPeerInfo(peerInfoAdapter, remoteNodeId)
+    Behaviors.receiveMessagePartial {
+      case PeerNotConnected =>
+        context.log.debug("peer is not connected yet")
+        Behaviors.same
+      case SomePeerConnected(nodeId) =>
+        if (nodeId == remoteNodeId) {
+          switchboard ! Switchboard.GetPeerInfo(peerInfoAdapter, remoteNodeId)
+        }
+        Behaviors.same
+      case PeerChannels(channels) =>
+        if (channels.isEmpty) {
+          context.log.info("peer is ready with {} channels", channels.size)
+          replyTo ! PeerReady(remoteNodeId, 0)
+          Behaviors.stopped
+        } else {
+          context.log.debug("peer is connected with {} channels", channels.size)
+          waitForChannelsReady(replyTo, remoteNodeId, channels, context, timers)
+        }
+      case NewBlockNotTimedOut(currentBlockHeight) =>
+        context.log.debug("waiting for peer to connect at block {}", currentBlockHeight)
+        Behaviors.same
+      case Timeout =>
+        context.log.info("timed out waiting for peer to be ready")
+        replyTo ! PeerUnavailable(remoteNodeId)
+        Behaviors.stopped
+    }
+  }
+
+  def waitForChannelsReady(replyTo: ActorRef[Result], remoteNodeId: PublicKey, channels: Set[akka.actor.ActorRef], context: ActorContext[Command], timers: TimerScheduler[Command]): Behavior[Command] = {
+    timers.startTimerWithFixedDelay(CheckChannelsReady, initialDelay = 50 millis, delay = 1 second)
+    Behaviors.receiveMessagePartial {
+      case CheckChannelsReady =>
+        context.spawnAnonymous(ChannelStatesCollector(context.self, channels))
+        Behaviors.same
+      case ChannelStates(states) =>
+        if (states.forall(isChannelReady)) {
+          replyTo ! PeerReady(remoteNodeId, channels.size)
+          Behaviors.stopped
+        } else {
+          context.log.debug("peer has {} channels that are not ready", states.count(s => !isChannelReady(s)))
+          Behaviors.same
+        }
+      case NewBlockNotTimedOut(currentBlockHeight) =>
+        context.log.debug("waiting for channels to be ready at block {}", currentBlockHeight)
+        Behaviors.same
+      case SomePeerConnected(_) =>
+        Behaviors.same
+      case Timeout =>
+        context.log.info("timed out waiting for channels to be ready")
+        replyTo ! PeerUnavailable(remoteNodeId)
+        Behaviors.stopped
+    }
+  }
+
+  // We use an exhaustive pattern matching here to ensure we explicitly handle future new channel states.
+  private def isChannelReady(state: channel.ChannelState): Boolean = state match {
+    case channel.WAIT_FOR_INIT_INTERNAL => false
+    case channel.WAIT_FOR_INIT_SINGLE_FUNDED_CHANNEL => false
+    case channel.WAIT_FOR_INIT_DUAL_FUNDED_CHANNEL => false
+    case channel.OFFLINE => false
+    case channel.SYNCING => false
+    case channel.WAIT_FOR_OPEN_CHANNEL => true
+    case channel.WAIT_FOR_ACCEPT_CHANNEL => true
+    case channel.WAIT_FOR_FUNDING_INTERNAL => true
+    case channel.WAIT_FOR_FUNDING_CREATED => true
+    case channel.WAIT_FOR_FUNDING_SIGNED => true
+    case channel.WAIT_FOR_FUNDING_CONFIRMED => true
+    case channel.WAIT_FOR_CHANNEL_READY => true
+    case channel.WAIT_FOR_OPEN_DUAL_FUNDED_CHANNEL => true
+    case channel.WAIT_FOR_ACCEPT_DUAL_FUNDED_CHANNEL => true
+    case channel.WAIT_FOR_DUAL_FUNDING_CREATED => true
+    case channel.WAIT_FOR_DUAL_FUNDING_CONFIRMED => true
+    case channel.WAIT_FOR_DUAL_FUNDING_READY => true
+    case channel.NORMAL => true
+    case channel.SHUTDOWN => true
+    case channel.NEGOTIATING => true
+    case channel.CLOSING => true
+    case channel.CLOSED => true
+    case channel.WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT => true
+    case channel.ERR_INFORMATION_LEAK => true
+  }
+
+  object ChannelStatesCollector {
+
+    // @formatter:off
+    sealed trait Command
+    private final case class WrappedChannelState(wrapped: channel.RES_GET_CHANNEL_STATE) extends Command
+    // @formatter:on
+
+    def apply(replyTo: ActorRef[ChannelStates], channels: Set[akka.actor.ActorRef]): Behavior[Command] = {
+      Behaviors.setup { context =>
+        val channelStateAdapter = context.messageAdapter[channel.RES_GET_CHANNEL_STATE](WrappedChannelState)
+        channels.foreach(c => c ! channel.CMD_GET_CHANNEL_STATE(channelStateAdapter.toClassic))
+        collect(replyTo, Nil, channels.size)
+      }
+    }
+
+    private def collect(replyTo: ActorRef[ChannelStates], received: Seq[channel.ChannelState], remaining: Int): Behavior[Command] = {
+      Behaviors.receiveMessage {
+        case WrappedChannelState(wrapped) => remaining match {
+          case 1 =>
+            replyTo ! ChannelStates(received :+ wrapped.state)
+            Behaviors.stopped
+          case _ =>
+            collect(replyTo, received :+ wrapped.state, remaining - 1)
+        }
+      }
+    }
+
+  }
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -462,7 +462,7 @@ private case class GlobalBalanceJson(total: Btc, onChain: CorrectedOnChainBalanc
 object GlobalBalanceSerializer extends ConvertClassSerializer[GlobalBalance](b => GlobalBalanceJson(b.total, b.onChain, b.offChain))
 
 private case class PeerInfoJson(nodeId: PublicKey, state: String, address: Option[String], channels: Int)
-object PeerInfoSerializer extends ConvertClassSerializer[Peer.PeerInfo](peerInfo => PeerInfoJson(peerInfo.nodeId, peerInfo.state.toString, peerInfo.address.map(_.toString), peerInfo.channels))
+object PeerInfoSerializer extends ConvertClassSerializer[Peer.PeerInfo](peerInfo => PeerInfoJson(peerInfo.nodeId, peerInfo.state.toString, peerInfo.address.map(_.toString), peerInfo.channels.size))
 
 private[json] case class MessageReceivedJson(pathId: Option[ByteVector], encodedReplyPath: Option[String], replyPath: Option[BlindedRoute], unknownTlvs: Map[String, ByteVector])
 object OnionMessageReceivedSerializer extends ConvertClassSerializer[OnionMessages.ReceiveMessage](m => MessageReceivedJson(m.finalPayload.pathId_opt, m.finalPayload.replyPath_opt.map(route => blindedRouteCodec.encode(route.blindedRoute).require.bytes.toHex), m.finalPayload.replyPath_opt.map(_.blindedRoute), m.finalPayload.records.unknown.map(tlv => tlv.tag.toString -> tlv.value).toMap))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/MessageRelaySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/MessageRelaySpec.scala
@@ -103,7 +103,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     val getPeerInfo = switchboard.expectMsgType[GetPeerInfo]
     assert(getPeerInfo.remoteNodeId == previousNodeId)
-    getPeerInfo.replyTo ! PeerInfo(peer.ref.toClassic, previousNodeId, Peer.CONNECTED, None, 0)
+    getPeerInfo.replyTo ! PeerInfo(peer.ref.toClassic, previousNodeId, Peer.CONNECTED, None, Set.empty)
 
     probe.expectMessage(AgainstPolicy(messageId, RelayChannelsOnly))
     peer.expectNoMessage(100 millis)
@@ -119,7 +119,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     val getPeerInfo1 = switchboard.expectMsgType[GetPeerInfo]
     assert(getPeerInfo1.remoteNodeId == previousNodeId)
-    getPeerInfo1.replyTo ! PeerInfo(peer.ref.toClassic, previousNodeId, Peer.CONNECTED, None, 1)
+    getPeerInfo1.replyTo ! PeerInfo(peer.ref.toClassic, previousNodeId, Peer.CONNECTED, None, Set(TestProbe()(system.classicSystem).ref))
 
     val getPeerInfo2 = switchboard.expectMsgType[GetPeerInfo]
     assert(getPeerInfo2.remoteNodeId == bobId)
@@ -139,11 +139,11 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     val getPeerInfo1 = switchboard.expectMsgType[GetPeerInfo]
     assert(getPeerInfo1.remoteNodeId == previousNodeId)
-    getPeerInfo1.replyTo ! PeerInfo(TestProbe()(system.classicSystem).ref, previousNodeId, Peer.CONNECTED, None, 1)
+    getPeerInfo1.replyTo ! PeerInfo(TestProbe()(system.classicSystem).ref, previousNodeId, Peer.CONNECTED, None, Set(TestProbe()(system.classicSystem).ref))
 
     val getPeerInfo2 = switchboard.expectMsgType[GetPeerInfo]
     assert(getPeerInfo2.remoteNodeId == bobId)
-    getPeerInfo2.replyTo ! PeerInfo(peer.ref.toClassic, bobId, Peer.CONNECTED, None, 2)
+    getPeerInfo2.replyTo ! PeerInfo(peer.ref.toClassic, bobId, Peer.CONNECTED, None, Set(0, 1).map(_ => TestProbe()(system.classicSystem).ref))
 
     assert(peer.expectMessageType[Peer.RelayOnionMessage].msg == message)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerReadyNotifierSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerReadyNotifierSpec.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2022 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.io
+
+import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
+import akka.actor.typed.eventstream.EventStream
+import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
+import com.typesafe.config.ConfigFactory
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.eclair.blockchain.CurrentBlockHeight
+import fr.acinq.eclair.channel._
+import fr.acinq.eclair.io.PeerReadyNotifier.{NotifyWhenPeerReady, PeerReady, PeerUnavailable}
+import fr.acinq.eclair.{BlockHeight, randomKey}
+import org.scalatest.Outcome
+import org.scalatest.funsuite.FixtureAnyFunSuiteLike
+
+import scala.concurrent.duration.DurationInt
+
+class PeerReadyNotifierSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with FixtureAnyFunSuiteLike {
+
+  case class FixtureParam(remoteNodeId: PublicKey, switchboard: TestProbe[Switchboard.GetPeerInfo], channelProbes: Seq[TestProbe[CMD_GET_CHANNEL_STATE]], probe: TestProbe[PeerReadyNotifier.Result]) {
+    def channels: Set[akka.actor.ActorRef] = channelProbes.map(_.ref.toClassic).toSet
+  }
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val remoteNodeId = randomKey().publicKey
+    val switchboard = TestProbe[Switchboard.GetPeerInfo]("switchboard")
+    val channelProbes = Seq(TestProbe[CMD_GET_CHANNEL_STATE]("channel1"), TestProbe[CMD_GET_CHANNEL_STATE]("channel2"))
+    val probe = TestProbe[PeerReadyNotifier.Result]()
+    withFixture(test.toNoArgTest(FixtureParam(remoteNodeId, switchboard, channelProbes, probe)))
+  }
+
+  test("peer not connected (duration timeout)") { f =>
+    import f._
+
+    val notifier = testKit.spawn(PeerReadyNotifier(remoteNodeId, switchboard.ref, timeout_opt = Some(Left(10 millis))))
+    notifier ! NotifyWhenPeerReady(probe.ref)
+    assert(switchboard.expectMessageType[Switchboard.GetPeerInfo].remoteNodeId == remoteNodeId)
+    probe.expectMessage(PeerUnavailable(remoteNodeId))
+  }
+
+  test("peer not connected (block timeout)") { f =>
+    import f._
+
+    val notifier = testKit.spawn(PeerReadyNotifier(remoteNodeId, switchboard.ref, timeout_opt = Some(Right(BlockHeight(100)))))
+    notifier ! NotifyWhenPeerReady(probe.ref)
+    assert(switchboard.expectMessageType[Switchboard.GetPeerInfo].remoteNodeId == remoteNodeId)
+
+    // We haven't reached the timeout yet.
+    system.eventStream ! EventStream.Publish(CurrentBlockHeight(BlockHeight(99)))
+    probe.expectNoMessage(100 millis)
+
+    // We exceed the timeout (we've missed blocks).
+    system.eventStream ! EventStream.Publish(CurrentBlockHeight(BlockHeight(110)))
+    probe.expectMessage(PeerUnavailable(remoteNodeId))
+  }
+
+  test("peer connected (without channels)") { f =>
+    import f._
+
+    val notifier = testKit.spawn(PeerReadyNotifier(remoteNodeId, switchboard.ref, timeout_opt = Some(Right(BlockHeight(500)))))
+    notifier ! NotifyWhenPeerReady(probe.ref)
+    val request = switchboard.expectMessageType[Switchboard.GetPeerInfo]
+    request.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.CONNECTED, None, Set.empty)
+    probe.expectMessage(PeerReady(remoteNodeId, 0))
+  }
+
+  test("peer connected (with channels)") { f =>
+    import f._
+
+    val notifier = testKit.spawn(PeerReadyNotifier(remoteNodeId, switchboard.ref, timeout_opt = Some(Right(BlockHeight(500)))))
+    notifier ! NotifyWhenPeerReady(probe.ref)
+    val request = switchboard.expectMessageType[Switchboard.GetPeerInfo]
+    request.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.CONNECTED, None, channels)
+
+    // Channels are not ready yet.
+    channelProbes.foreach(_.expectMessageType[CMD_GET_CHANNEL_STATE].replyTo ! RES_GET_CHANNEL_STATE(SYNCING))
+    probe.expectNoMessage(100 millis)
+
+    // After the first retry, one of the channels is ready but not the second one.
+    channelProbes.head.expectMessageType[CMD_GET_CHANNEL_STATE].replyTo ! RES_GET_CHANNEL_STATE(NORMAL)
+    channelProbes.last.expectMessageType[CMD_GET_CHANNEL_STATE].replyTo ! RES_GET_CHANNEL_STATE(SYNCING)
+    probe.expectNoMessage(100 millis)
+
+    // After the second retry, both channels are ready.
+    channelProbes.head.expectMessageType[CMD_GET_CHANNEL_STATE].replyTo ! RES_GET_CHANNEL_STATE(NORMAL)
+    channelProbes.last.expectMessageType[CMD_GET_CHANNEL_STATE].replyTo ! RES_GET_CHANNEL_STATE(SHUTDOWN)
+    probe.expectMessage(PeerReady(remoteNodeId, 2))
+  }
+
+  test("peer connects after initial request") { f =>
+    import f._
+
+    val notifier = testKit.spawn(PeerReadyNotifier(remoteNodeId, switchboard.ref, timeout_opt = Some(Right(BlockHeight(500)))))
+    notifier ! NotifyWhenPeerReady(probe.ref)
+    val request1 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
+    request1.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.DISCONNECTED, None, channels)
+    channelProbes.head.expectNoMessage(100 millis)
+
+    // An unrelated peer connects.
+    system.eventStream ! EventStream.Publish(PeerConnected(TestProbe().ref.toClassic, randomKey().publicKey, null))
+    switchboard.expectNoMessage(100 millis)
+
+    // The target peer connects.
+    system.eventStream ! EventStream.Publish(PeerConnected(TestProbe().ref.toClassic, remoteNodeId, null))
+    val request2 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
+    request2.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.CONNECTED, None, channels)
+    channelProbes.foreach(_.expectMessageType[CMD_GET_CHANNEL_STATE].replyTo ! RES_GET_CHANNEL_STATE(NEGOTIATING))
+    probe.expectMessage(PeerReady(remoteNodeId, 2))
+  }
+
+  test("peer connects then disconnects") { f =>
+    import f._
+
+    val notifier = testKit.spawn(PeerReadyNotifier(remoteNodeId, switchboard.ref, timeout_opt = None))
+    notifier ! NotifyWhenPeerReady(probe.ref)
+    val request1 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
+    request1.replyTo ! Peer.PeerNotFound(remoteNodeId)
+    channelProbes.head.expectNoMessage(100 millis)
+
+    // The target peer connects and instantly disconnects.
+    system.eventStream ! EventStream.Publish(PeerConnected(TestProbe().ref.toClassic, remoteNodeId, null))
+    val request2 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
+    request2.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.DISCONNECTED, None, channels)
+    channelProbes.head.expectNoMessage(100 millis)
+
+    // The target peer reconnects and stays connected.
+    system.eventStream ! EventStream.Publish(PeerConnected(TestProbe().ref.toClassic, remoteNodeId, null))
+    val request3 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
+    request3.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.CONNECTED, None, channels)
+    channelProbes.foreach(_.expectMessageType[CMD_GET_CHANNEL_STATE].replyTo ! RES_GET_CHANNEL_STATE(NEGOTIATING))
+    probe.expectMessage(PeerReady(remoteNodeId, 2))
+  }
+
+  test("peer connected (duration timeout)") { f =>
+    import f._
+
+    val notifier = testKit.spawn(PeerReadyNotifier(remoteNodeId, switchboard.ref, timeout_opt = Some(Left(100 millis))))
+    notifier ! NotifyWhenPeerReady(probe.ref)
+    val request = switchboard.expectMessageType[Switchboard.GetPeerInfo]
+    request.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.CONNECTED, None, channels)
+    channelProbes.foreach(_.expectMessageType[CMD_GET_CHANNEL_STATE])
+    probe.expectMessage(PeerUnavailable(remoteNodeId))
+  }
+
+  test("peer connected (block timeout)") { f =>
+    import f._
+
+    val notifier = testKit.spawn(PeerReadyNotifier(remoteNodeId, switchboard.ref, timeout_opt = Some(Right(BlockHeight(100)))))
+    notifier ! NotifyWhenPeerReady(probe.ref)
+    val request = switchboard.expectMessageType[Switchboard.GetPeerInfo]
+    request.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.CONNECTED, None, channels)
+    channelProbes.foreach(_.expectMessageType[CMD_GET_CHANNEL_STATE])
+    system.eventStream ! EventStream.Publish(CurrentBlockHeight(BlockHeight(100)))
+    probe.expectMessage(PeerUnavailable(remoteNodeId))
+  }
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -114,7 +114,12 @@ class PeerSpec extends FixtureSpec {
     val probe = TestProbe()
     connect(remoteNodeId, peer, peerConnection, switchboard, channels = Set(ChannelCodecsSpec.normal))
     probe.send(peer, Peer.GetPeerInfo(None))
-    probe.expectMsg(PeerInfo(peer, remoteNodeId, Peer.CONNECTED, Some(fakeIPAddress), 1))
+    val peerInfo = probe.expectMsgType[PeerInfo]
+    assert(peerInfo.peer == peer)
+    assert(peerInfo.nodeId == remoteNodeId)
+    assert(peerInfo.state == Peer.CONNECTED)
+    assert(peerInfo.address.contains(fakeIPAddress))
+    assert(peerInfo.channels.size == 1)
   }
 
   test("fail to connect if no address provided or found") { f =>
@@ -571,12 +576,12 @@ class PeerSpec extends FixtureSpec {
     probe.send(peer, Peer.GetPeerInfo(Some(probe.ref.toTyped)))
     val peerInfo1 = probe.expectMsgType[Peer.PeerInfo]
     assert(peerInfo1.state == Peer.DISCONNECTED)
-    assert(peerInfo1.channels == 1)
+    assert(peerInfo1.channels.size == 1)
     peer ! ChannelIdAssigned(probe.ref, remoteNodeId, randomBytes32(), randomBytes32())
     probe.send(peer, Peer.GetPeerInfo(Some(probe.ref.toTyped)))
     val peerInfo2 = probe.expectMsgType[Peer.PeerInfo]
     assert(peerInfo2.state == Peer.DISCONNECTED)
-    assert(peerInfo2.channels == 2)
+    assert(peerInfo2.channels.size == 2)
   }
 
   test("notify when last channel is closed") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
@@ -43,7 +43,7 @@ class SwitchboardSpec extends TestKitBaseClass with AnyFunSuiteLike {
     peer.expectMsg(Peer.Init(Set.empty))
     val connect = peer.expectMsgType[Peer.Connect]
     assert(connect.nodeId == remoteNodeId)
-    assert(connect.address_opt == None)
+    assert(connect.address_opt.isEmpty)
   }
 
   test("disconnect from peers") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
@@ -106,8 +106,8 @@ class JsonSerializersSpec extends AnyFunSuite with Matchers {
   }
 
   test("PeerInfo serialization") {
-    val peerInfo = PeerInfo(ActorRef.noSender, PublicKey(hex"0270685ca81a8e4d4d01beec5781f4cc924684072ae52c507f8ebe9daf0caaab7b"), Peer.CONNECTED, None, 5)
-    val expected = """{"nodeId":"0270685ca81a8e4d4d01beec5781f4cc924684072ae52c507f8ebe9daf0caaab7b","state":"CONNECTED","channels":5}"""
+    val peerInfo = PeerInfo(ActorRef.noSender, PublicKey(hex"0270685ca81a8e4d4d01beec5781f4cc924684072ae52c507f8ebe9daf0caaab7b"), Peer.CONNECTED, None, Set(ActorRef.noSender))
+    val expected = """{"nodeId":"0270685ca81a8e4d4d01beec5781f4cc924684072ae52c507f8ebe9daf0caaab7b","state":"CONNECTED","channels":1}"""
     JsonSerializers.serialization.write(peerInfo)(JsonSerializers.formats) shouldBe expected
   }
 

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -170,13 +170,13 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         nodeId = aliceNodeId,
         state = Peer.CONNECTED,
         address = Some(NodeAddress.fromParts("127.0.0.1", 9731).get),
-        channels = 1),
+        channels = Set(ActorRef.noSender)),
       PeerInfo(
         ActorRef.noSender,
         nodeId = bobNodeId,
         state = Peer.DISCONNECTED,
         address = None,
-        channels = 1)))
+        channels = Set(ActorRef.noSender))))
 
     val mockService = mockApi(eclair)
     Post("/peers") ~>


### PR DESCRIPTION
We add an actor that waits for a given peer to be connected and ready to process payments.
This is useful in the context of async payments for the receiver's LSP.

@remyers you can start building the mechanism to trigger a pending async payment on top of that branch.