### PR TITLE
Register can forward messages to specific nodes

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -232,8 +232,8 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
 
   override def channelsInfo(toRemoteNode_opt: Option[PublicKey])(implicit timeout: Timeout): Future[Iterable[RES_GET_CHANNEL_INFO]] = {
     val futureResponse = toRemoteNode_opt match {
-      case Some(pk) => (appKit.register ? Symbol("channelsTo")).mapTo[Map[ByteVector32, PublicKey]].map(_.filter(_._2 == pk).keys)
-      case None => (appKit.register ? Symbol("channels")).mapTo[Map[ByteVector32, ActorRef]].map(_.keys)
+      case Some(pk) => (appKit.register ? Register.GetChannelsTo).mapTo[Map[ByteVector32, PublicKey]].map(_.filter(_._2 == pk).keys)
+      case None => (appKit.register ? Register.GetChannels).mapTo[Map[ByteVector32, ActorRef]].map(_.keys)
     }
 
     for {
@@ -478,7 +478,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
   /** Send a request to multiple channels using node ids */
   private def sendToNodes[C <: Command, R <: CommandResponse[C]](nodeids: List[PublicKey], request: C)(implicit timeout: Timeout): Future[Map[ApiTypes.ChannelIdentifier, Either[Throwable, R]]] = {
     for {
-      channelIds <- (appKit.register ? Symbol("channelsTo")).mapTo[Map[ByteVector32, PublicKey]].map(_.filter(kv => nodeids.contains(kv._2)).keys)
+      channelIds <- (appKit.register ? Register.GetChannelsTo).mapTo[Map[ByteVector32, PublicKey]].map(_.filter(kv => nodeids.contains(kv._2)).keys)
       res <- sendToChannels[C, R](channelIds.map(Left(_)).toList, request)
     } yield res
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Register.scala
@@ -21,7 +21,8 @@ import akka.actor.{Actor, ActorLogging, ActorRef, Props}
 import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.channel.Register._
-import fr.acinq.eclair.{SubscriptionsComplete, ShortChannelId}
+import fr.acinq.eclair.io.PeerCreated
+import fr.acinq.eclair.{ShortChannelId, SubscriptionsComplete}
 
 /**
  * Created by PM on 26/01/2016.
@@ -29,31 +30,32 @@ import fr.acinq.eclair.{SubscriptionsComplete, ShortChannelId}
 
 class Register() extends Actor with ActorLogging {
 
+  context.system.eventStream.subscribe(self, classOf[PeerCreated])
   context.system.eventStream.subscribe(self, classOf[ChannelCreated])
   context.system.eventStream.subscribe(self, classOf[AbstractChannelRestored])
   context.system.eventStream.subscribe(self, classOf[ChannelIdAssigned])
   context.system.eventStream.subscribe(self, classOf[ShortChannelIdAssigned])
   context.system.eventStream.publish(SubscriptionsComplete(this.getClass))
 
-  // @formatter:off
-  private case class ChannelTerminated(channel: ActorRef, channelId: ByteVector32)
-  // @formatter:on
+  override def receive: Receive = main(Map.empty, Map.empty, Map.empty, Map.empty)
 
-  override def receive: Receive = main(Map.empty, Map.empty, Map.empty)
+  def main(channels: Map[ByteVector32, ActorRef], shortIds: Map[ShortChannelId, ByteVector32], channelsTo: Map[ByteVector32, PublicKey], nodeIdToPeer: Map[PublicKey, ActorRef]): Receive = {
+    case PeerCreated(peer, remoteNodeId) =>
+      context.watchWith(peer, PeerTerminated(peer, remoteNodeId))
+      context become main(channels, shortIds, channelsTo, nodeIdToPeer + (remoteNodeId -> peer))
 
-  def main(channels: Map[ByteVector32, ActorRef], shortIds: Map[ShortChannelId, ByteVector32], channelsTo: Map[ByteVector32, PublicKey]): Receive = {
     case ChannelCreated(channel, _, remoteNodeId, _, temporaryChannelId, _, _) =>
       context.watchWith(channel, ChannelTerminated(channel, temporaryChannelId))
-      context become main(channels + (temporaryChannelId -> channel), shortIds, channelsTo + (temporaryChannelId -> remoteNodeId))
+      context become main(channels + (temporaryChannelId -> channel), shortIds, channelsTo + (temporaryChannelId -> remoteNodeId), nodeIdToPeer)
 
     case event: AbstractChannelRestored =>
       context.watchWith(event.channel, ChannelTerminated(event.channel, event.channelId))
-      context become main(channels + (event.channelId -> event.channel), shortIds, channelsTo + (event.channelId -> event.remoteNodeId))
+      context become main(channels + (event.channelId -> event.channel), shortIds, channelsTo + (event.channelId -> event.remoteNodeId), nodeIdToPeer)
 
     case ChannelIdAssigned(channel, remoteNodeId, temporaryChannelId, channelId) =>
       context.unwatch(channel)
       context.watchWith(channel, ChannelTerminated(channel, channelId))
-      context become main(channels + (channelId -> channel) - temporaryChannelId, shortIds, channelsTo + (channelId -> remoteNodeId) - temporaryChannelId)
+      context become main(channels + (channelId -> channel) - temporaryChannelId, shortIds, channelsTo + (channelId -> remoteNodeId) - temporaryChannelId, nodeIdToPeer)
 
     case scidAssigned: ShortChannelIdAssigned =>
       // We map all known scids (real or alias) to the channel_id. The relayer is in charge of deciding whether a real
@@ -65,17 +67,27 @@ class Register() extends Actor with ActorLogging {
           log.error("duplicate alias={} for channelIds={},{} this should never happen!", scidAssigned.shortIds.localAlias, channelId, scidAssigned.channelId)
         case _ => ()
       }
-      context become main(channels, shortIds ++ m, channelsTo)
+      context become main(channels, shortIds ++ m, channelsTo, nodeIdToPeer)
+
+    case PeerTerminated(peer, nodeId) =>
+      // Peer actors can be stopped and recreated, which leads to race conditions between PeerTerminated and PeerCreated
+      // messages, so we need to compare the actor reference to ensure we don't remove a newly created Peer.
+      nodeIdToPeer.get(nodeId) match {
+        case Some(current) if current == peer => context become main(channels, shortIds, channelsTo, nodeIdToPeer - nodeId)
+        case _ => ()
+      }
 
     case ChannelTerminated(_, channelId) =>
       val shortChannelIds = shortIds.collect { case (key, value) if value == channelId => key }
-      context become main(channels - channelId, shortIds -- shortChannelIds, channelsTo - channelId)
+      context become main(channels - channelId, shortIds -- shortChannelIds, channelsTo - channelId, nodeIdToPeer)
 
-    case Symbol("channels") => sender() ! channels
+    case GetChannels => sender() ! channels
 
-    case Symbol("shortIds") => sender() ! shortIds
+    case GetShortIds => sender() ! shortIds
 
-    case Symbol("channelsTo") => sender() ! channelsTo
+    case GetChannelsTo => sender() ! channelsTo
+
+    case GetNodes => sender() ! nodeIdToPeer
 
     case fwd@Forward(replyTo, channelId, msg) =>
       // for backward compatibility with legacy ask, we use the replyTo as sender
@@ -92,6 +104,14 @@ class Register() extends Actor with ActorLogging {
         case Some(channel) => channel.tell(msg, compatReplyTo)
         case None => compatReplyTo ! ForwardShortIdFailure(fwd)
       }
+
+    case fwd@ForwardNodeId(replyTo, nodeId, msg) =>
+      // for backward compatibility with legacy ask, we use the replyTo as sender
+      val compatReplyTo = if (replyTo == null) sender() else replyTo.toClassic
+      nodeIdToPeer.get(nodeId) match {
+        case Some(peer) => peer.tell(msg, compatReplyTo)
+        case None => compatReplyTo ! ForwardNodeIdFailure(fwd)
+      }
   }
 }
 
@@ -100,10 +120,20 @@ object Register {
   def props(): Props = Props(new Register())
 
   // @formatter:off
+  case object GetChannels
+  case object GetShortIds
+  case object GetChannelsTo
+  case object GetNodes
+
+  case class PeerTerminated(peer: ActorRef, nodeId: PublicKey)
+  case class ChannelTerminated(channel: ActorRef, channelId: ByteVector32)
+
   case class Forward[T](replyTo: akka.actor.typed.ActorRef[ForwardFailure[T]], channelId: ByteVector32, message: T)
   case class ForwardShortId[T](replyTo: akka.actor.typed.ActorRef[ForwardShortIdFailure[T]], shortChannelId: ShortChannelId, message: T)
+  case class ForwardNodeId[T](replyTo: akka.actor.typed.ActorRef[ForwardNodeIdFailure[T]], nodeId: PublicKey, message: T)
 
   case class ForwardFailure[T](fwd: Forward[T])
   case class ForwardShortIdFailure[T](fwd: ForwardShortId[T])
+  case class ForwardNodeIdFailure[T](fwd: ForwardNodeId[T])
   // @formatter:on
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -59,6 +59,8 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnChainA
 
   import Peer._
 
+  context.system.eventStream.publish(PeerCreated(self, remoteNodeId))
+
   startWith(INSTANTIATING, Nothing)
 
   when(INSTANTIATING) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerEvents.scala
@@ -25,6 +25,8 @@ import scala.concurrent.duration._
 
 sealed trait PeerEvent
 
+case class PeerCreated(peer: ActorRef, nodeId: PublicKey) extends PeerEvent
+
 case class ConnectionInfo(address: NodeAddress, peerConnection: ActorRef, localInit: protocol.Init, remoteInit: protocol.Init)
 
 case class PeerConnected(peer: ActorRef, nodeId: PublicKey, connectionInfo: ConnectionInfo) extends PeerEvent

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -432,7 +432,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     eclair.channelsInfo(toRemoteNode_opt = None).pipeTo(sender.ref)
 
-    register.expectMsg(Symbol("channels"))
+    register.expectMsg(Register.GetChannels)
     register.reply(map)
 
     val c1 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
@@ -463,7 +463,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     eclair.channelsInfo(toRemoteNode_opt = Some(a)).pipeTo(sender.ref)
 
-    register.expectMsg(Symbol("channelsTo"))
+    register.expectMsg(Register.GetChannelsTo)
     register.reply(channels2Nodes)
 
     val c1 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
@@ -595,7 +595,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
 
     eclair.updateRelayFee(List(a, b), 999 msat, 1234).pipeTo(sender.ref)
 
-    register.expectMsg(Symbol("channelsTo"))
+    register.expectMsg(Register.GetChannelsTo)
     register.reply(map)
 
     val u1 = register.expectMsgType[Register.Forward[CMD_UPDATE_RELAY_FEE]]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/RegisterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/RegisterSpec.scala
@@ -1,24 +1,59 @@
 package fr.acinq.eclair.channel
 
-import fr.acinq.eclair._
-
-import akka.actor.{ActorRef, Props}
+import akka.actor.ActorRef
+import akka.actor.typed.scaladsl.adapter.ClassicActorRefOps
 import akka.testkit.TestProbe
 import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import org.scalatest.funsuite.AnyFunSuiteLike
+import fr.acinq.eclair._
+import fr.acinq.eclair.channel.Register._
+import fr.acinq.eclair.io.PeerCreated
 import org.scalatest.ParallelTestExecution
+import org.scalatest.funsuite.AnyFunSuiteLike
 
 class RegisterSpec extends TestKitBaseClass with AnyFunSuiteLike with ParallelTestExecution {
 
   case class CustomChannelRestored(channel: ActorRef, channelId: ByteVector32, peer: ActorRef, remoteNodeId: PublicKey) extends AbstractChannelRestored
 
-  test("register processes custom restored events") {
+  test("process custom restored events") {
     val sender = TestProbe()
-    val registerRef = system.actorOf(Register.props())
+    val register = system.actorOf(Register.props())
     val customRestoredEvent = CustomChannelRestored(TestProbe().ref, randomBytes32(), TestProbe().ref, randomKey().publicKey)
-    registerRef ! customRestoredEvent
-    sender.send(registerRef, Symbol("channels"))
-    sender.expectMsgType[Map[ByteVector32, ActorRef]] == Map(customRestoredEvent.channelId -> customRestoredEvent.channel)
+    register ! customRestoredEvent
+    sender.send(register, GetChannels)
+    assert(sender.expectMsgType[Map[ByteVector32, ActorRef]] == Map(customRestoredEvent.channelId -> customRestoredEvent.channel))
   }
+
+  test("map nodeIds to peers") {
+    val sender = TestProbe()
+    val register = system.actorOf(Register.props())
+    val (nodeId1, peer1a, peer1b) = (randomKey().publicKey, TestProbe(), TestProbe())
+    val (nodeId2, peer2) = (randomKey().publicKey, TestProbe())
+    register ! PeerCreated(peer1a.ref, nodeId1)
+    register ! PeerCreated(peer2.ref, nodeId2)
+    sender.send(register, GetNodes)
+    assert(sender.expectMsgType[Map[PublicKey, ActorRef]] == Map(nodeId1 -> peer1a.ref, nodeId2 -> peer2.ref))
+    // The first peer is stopped and recreated, the corresponding messages arrive out of order.
+    register ! PeerCreated(peer1b.ref, nodeId1)
+    register ! PeerTerminated(peer1a.ref, nodeId1)
+    sender.send(register, GetNodes)
+    assert(sender.expectMsgType[Map[PublicKey, ActorRef]] == Map(nodeId1 -> peer1b.ref, nodeId2 -> peer2.ref))
+    // The second peer is stopped.
+    register ! PeerTerminated(peer2.ref, nodeId2)
+    sender.send(register, GetNodes)
+    assert(sender.expectMsgType[Map[PublicKey, ActorRef]] == Map(nodeId1 -> peer1b.ref))
+  }
+
+  test("forward messages to nodes") {
+    val sender = TestProbe()
+    val register = system.actorOf(Register.props())
+    val (nodeId, peer) = (randomKey().publicKey, TestProbe())
+    register ! PeerCreated(peer.ref, nodeId)
+    register ! ForwardNodeId(sender.ref.toTyped, nodeId, "hello")
+    peer.expectMsg("hello")
+    val fwd = ForwardNodeId(sender.ref.toTyped, randomKey().publicKey, "hello")
+    register ! fwd
+    sender.expectMsg(ForwardNodeIdFailure(fwd))
+  }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
@@ -499,7 +499,7 @@ class StandardChannelIntegrationSpec extends ChannelIntegrationSpec {
     // mine the funding tx
     generateBlocks(2)
     // get the channelId
-    sender.send(fundee.register, Symbol("channels"))
+    sender.send(fundee.register, Register.GetChannels)
     val Some((_, fundeeChannel)) = sender.expectMsgType[Map[ByteVector32, ActorRef]].find(_._1 == tempChannelId)
 
     sender.send(fundeeChannel, CMD_GET_CHANNEL_DATA(ActorRef.noSender))
@@ -674,7 +674,7 @@ abstract class AnchorChannelIntegrationSpec extends ChannelIntegrationSpec {
 
     // initially all the balance is on C side and F doesn't have an output
     val sender = TestProbe()
-    sender.send(nodes("F").register, Symbol("channelsTo"))
+    sender.send(nodes("F").register, Register.GetChannelsTo)
     // retrieve the channelId of C <--> F
     val Some(channelId) = sender.expectMsgType[Map[ByteVector32, PublicKey]].find(_._2 == nodes("C").nodeParams.nodeId).map(_._1)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.TestUtils.waitEventStreamSynced
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{Watch, WatchFundingConfirmed}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
-import fr.acinq.eclair.channel.{CMD_CLOSE, RES_SUCCESS}
+import fr.acinq.eclair.channel.{CMD_CLOSE, RES_SUCCESS, Register}
 import fr.acinq.eclair.io.Switchboard
 import fr.acinq.eclair.message.OnionMessages
 import fr.acinq.eclair.router.Router
@@ -299,10 +299,10 @@ class MessageIntegrationSpec extends IntegrationSpec {
     // We close the channels A -> B -> C but we keep channels with D
     // This ensures nodes still have an unrelated channel so we keep them in the network DB.
     val probe = TestProbe()
-    probe.send(nodes("B").register, Symbol("channels"))
+    probe.send(nodes("B").register, Register.GetChannels)
     val channelsB = probe.expectMsgType[Map[ByteVector32, ActorRef]]
     assert(channelsB.size == 3)
-    probe.send(nodes("D").register, Symbol("channels"))
+    probe.send(nodes("D").register, Register.GetChannels)
     val channelsD = probe.expectMsgType[Map[ByteVector32, ActorRef]]
     assert(channelsD.size == 3)
     channelsB.foreach {


### PR DESCRIPTION
The register contains the mapping from channel IDs to the corresponding actors and acts as a routing table. It can be useful to have the same feature to send messages to given nodes, outside of the context of any given channel.

But I'm wondering if that change is really necessary, or if we should instead use the `Switchboard` and the `GetPeerInfo` command when we want to send a message to a given peer? That also lets the sender get connection information for that peer, which probably makes more sense?

@remyers this should be useful for the peer-swap plugin.