### PR TITLE
Update to bitcoind 23.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more information please visit the [API documentation website](https://acinq.
 ## Documentation
 
 Please visit our [docs](./docs) folder to find detailed instructions on how to [configure](./docs/Configure.md) your
-node, connect to other nodes, open channels, send and receive payments, and help with more advanced scenarios. 
+node, connect to other nodes, open channels, send and receive payments, and help with more advanced scenarios.
 
 You will also find detailed [guides](./docs/Guides.md) and [frequently asked questions](./docs/FAQ.md) there.
 
@@ -57,11 +57,11 @@ Eclair relies on Bitcoin Core to interface with and monitor the blockchain and t
 
 This means that instead of re-implementing them, Eclair benefits from the verifications and optimisations (including fee management with RBF/CPFP, ...) that are implemented by Bitcoin Core. Eclair uses our own [bitcoin library](https://github.com/ACINQ/bitcoin-kmp) to verify data provided by Bitcoin Core.
 
-:warning: This also means that Eclair has strong requirements on how your Bitcoin Core node is configured (see below), and that you must back up your Bitcoin Core wallet as well as your Eclair node (see [here](#configure-bitcoin-core-wallet)): 
-- Eclair needs a _synchronized_, _segwit-ready_, 
-**_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node. 
-- You must configure your Bitcoin node to use `bech32` (segwit) addresses. If your wallet has "non-segwit UTXOs" (outputs that are neither `p2sh-segwit` or `bech32`), you must send them to a `bech32` address before running Eclair.
-- Eclair requires Bitcoin Core 0.20.1 or 0.21.1. (other versions of Bitcoin Core are *not* actively tested - use at your own risk).  If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
+:warning: This also means that Eclair has strong requirements on how your Bitcoin Core node is configured (see below), and that you must back up your Bitcoin Core wallet as well as your Eclair node (see [here](#configure-bitcoin-core-wallet)):
+
+* Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
+* You must configure your Bitcoin node to use `bech32` (segwit) addresses. If your wallet has "non-segwit UTXOs" (outputs that are neither `p2sh-segwit` or `bech32`), you must send them to a `bech32` address before running Eclair.
+* Eclair requires Bitcoin Core 23.0 or higher. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
 
 Run bitcoind with the following minimal `bitcoin.conf`:
 
@@ -181,11 +181,12 @@ eclair-node-<version>-<commit_id>/bin/eclair-node.sh -Dlogback.configurationFile
 ### Backup
 
 You need to backup:
-- your Bitcoin Core wallet
-- your Eclair channels
 
-For Bitcoin Core, you need to backup the wallet file for the wallet that Eclair is using. You only need to do this once, when the wallet is 
-created. See [Managing Wallets](https://github.com/bitcoin/bitcoin/blob/master/doc/managing-wallets.md) in the Bitcoin Core documentation for more information. 
+* your Bitcoin Core wallet
+* your Eclair channels
+
+For Bitcoin Core, you need to backup the wallet file for the wallet that Eclair is using. You only need to do this once, when the wallet is
+created. See [Managing Wallets](https://github.com/bitcoin/bitcoin/blob/master/doc/managing-wallets.md) in the Bitcoin Core documentation for more information.
 
 For Eclair, the files that you need to backup are located in your data directory. You must backup:
 
@@ -210,7 +211,7 @@ before copying that file to your final backup location.
 ## Docker
 
 A [Dockerfile](Dockerfile) x86_64 image is built on each commit on [docker hub](https://hub.docker.com/r/acinq/eclair) for running a dockerized eclair-node.
-For arm64 platforms you can use an [arm64 Dockerfile](contrib/arm64v8.Dockerfile) to build your own arm64 container. 
+For arm64 platforms you can use an [arm64 Dockerfile](contrib/arm64v8.Dockerfile) to build your own arm64 container.
 
 You can use the `JAVA_OPTS` environment variable to set arguments to `eclair-node`.
 

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -4,6 +4,11 @@
 
 ## Major changes
 
+### Bitcoin Core 23 or higher required
+
+This release adds support for Bitcoin Core 23.x and removes support for previous Bitcoin Core versions.
+Please make sure you have updated your Bitcoin Core node before updating eclair, as eclair won't start when connected to older versions of `bitcoind`.
+
 ### Add support for channel aliases and zeroconf channels
 
 #### Channel aliases
@@ -145,7 +150,7 @@ Expired incoming invoices that are unpaid will be searched for and purged from t
 Thereafter searches for expired unpaid invoices to purge will run once every 24 hours. You can disable this feature, or
 change the search interval with two new settings:
 
-- `eclair.purge-expired-invoices.enabled = true
+- `eclair.purge-expired-invoices.enabled = true`
 - `eclair.purge-expired-invoices.interval = 24 hours`
 
 #### Skip anchor CPFP for empty commitment
@@ -163,7 +168,8 @@ If the mempool becomes congested and the feerate is too low, the commitment tran
 
 #### Public IP addresses can be DNS host names
 
-You can now specify a DNS host name as one of your `server.public-ips` addresses (see PR [#911](https://github.com/lightning/bolts/pull/911)). Note: you can not specify more than one DNS host name.
+You can now specify a DNS host name as one of your `server.public-ips` addresses (see PR [#911](https://github.com/lightning/bolts/pull/911)).
+Note: you can not specify more than one DNS host name.
 
 #### Support for testing on the signet network
 

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -88,9 +88,9 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.21.1/bitcoin-0.21.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
-                <bitcoind.md5>e283a98b5e9f0b58e625e1dde661201d</bitcoind.md5>
-                <bitcoind.sha1>5101e29b39c33cc8e40d5f3b46dda37991b037a0</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-x86_64-linux-gnu.tar.gz</bitcoind.url>
+                <bitcoind.md5>fc4427b26a72fcc1556a9b07f3444013</bitcoind.md5>
+                <bitcoind.sha1>0fe0028a996909a46fbdde7e43aa842e419d29ce</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -101,9 +101,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.21.1/bitcoin-0.21.1-osx64.tar.gz</bitcoind.url>
-                <bitcoind.md5>dfd1f323678eede14ae2cf6afb26ff6a</bitcoind.md5>
-                <bitcoind.sha1>4273696f90a2648f90142438221f5d1ade16afa2</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-x86_64-apple-darwin.tar.gz</bitcoind.url>
+                <bitcoind.md5>64f1ee12dd5da0607bfadabfa62ec8f1</bitcoind.md5>
+                <bitcoind.sha1>a0d14de1363df370dca1d31b4adecdf12a40e384</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -114,9 +114,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-0.21.1/bitcoin-0.21.1-win64.zip</bitcoind.url>
-                <bitcoind.md5>1c6f5081ea68dcec7eddb9e6cdfc508d</bitcoind.md5>
-                <bitcoind.sha1>a782cd413fc736f05fad3831d6a9f59dde779520</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-23.0/bitcoin-23.0-win64.zip</bitcoind.url>
+                <bitcoind.md5>000e6536eaca6c76bc518bed34cba599</bitcoind.md5>
+                <bitcoind.sha1>1f14bb55f43ffc91185853e0240c5ef78da191be</bitcoind.sha1>
             </properties>
         </profile>
     </profiles>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -191,7 +191,7 @@ class Setup(val datadir: File,
     } yield (progress, ibd, chainHash, bitcoinVersion, unspentAddresses, blocks, headers)
     // blocking sanity checks
     val (progress, initialBlockDownload, chainHash, bitcoinVersion, unspentAddresses, blocks, headers) = await(future, 30 seconds, "bicoind did not respond after 30 seconds")
-    assert(bitcoinVersion >= 180000, "Eclair requires Bitcoin Core 0.18.0 or higher")
+    assert(bitcoinVersion >= 230000, "Eclair requires Bitcoin Core 23.0 or higher")
     assert(chainHash == nodeParams.chainHash, s"chainHash mismatch (conf=${nodeParams.chainHash} != bitcoind=$chainHash)")
     assert(unspentAddresses.forall(address => !isPay2PubkeyHash(address)), "Your wallet contains non-segwit UTXOs. You must send those UTXOs to a bech32 address to use Eclair (check out our README for more details).")
     if (chainHash != Block.RegtestGenesisBlock.hash) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/ReplaceableTxFunder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/ReplaceableTxFunder.scala
@@ -22,7 +22,7 @@ import akka.actor.typed.{ActorRef, Behavior}
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, OutPoint, Satoshi, Script, Transaction, TxOut}
 import fr.acinq.eclair.NotificationsLogger.NotifyNodeOperator
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
-import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.FundTransactionOptions
+import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.{FundTransactionOptions, InputWeight}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.Commitments
 import fr.acinq.eclair.channel.publish.ReplaceableTxPrePublisher._
@@ -83,49 +83,9 @@ object ReplaceableTxFunder {
     }
   }
 
-  /**
-   * Adjust the amount of the change output of an anchor tx to match our target feerate.
-   * We need this because fundrawtransaction doesn't allow us to leave non-wallet inputs, so we have to add them
-   * afterwards which may bring the resulting feerate below our target.
-   */
-  def adjustAnchorOutputChange(unsignedTx: ClaimLocalAnchorWithWitnessData, commitTx: Transaction, amountIn: Satoshi, commitFeerate: FeeratePerKw, targetFeerate: FeeratePerKw, dustLimit: Satoshi): ClaimLocalAnchorWithWitnessData = {
-    require(unsignedTx.txInfo.tx.txOut.size == 1, "funded transaction should have a single change output")
-    // We take into account witness weight and adjust the fee to match our desired feerate.
-    val dummySignedClaimAnchorTx = addSigs(unsignedTx.txInfo, PlaceHolderSig)
-    // NB: we assume that our bitcoind wallet uses only P2WPKH inputs when funding txs.
-    val estimatedWeight = commitTx.weight() + dummySignedClaimAnchorTx.tx.weight() + claimP2WPKHOutputWitnessWeight * (dummySignedClaimAnchorTx.tx.txIn.size - 1)
-    val targetFee = weight2fee(targetFeerate, estimatedWeight) - weight2fee(commitFeerate, commitTx.weight())
-    val amountOut = dustLimit.max(amountIn - targetFee)
-    val updatedAnchorTx = unsignedTx.updateTx(unsignedTx.txInfo.tx.copy(txOut = Seq(unsignedTx.txInfo.tx.txOut.head.copy(amount = amountOut))))
-    updatedAnchorTx
-  }
-
   private def dummySignedCommitTx(commitments: Commitments): CommitTx = {
     val unsignedCommitTx = commitments.localCommit.commitTxAndRemoteSig.commitTx
     addSigs(unsignedCommitTx, PlaceHolderPubKey, PlaceHolderPubKey, PlaceHolderSig, PlaceHolderSig)
-  }
-
-  /**
-   * Adjust the change output of an htlc tx to match our target feerate.
-   * We need this because fundrawtransaction doesn't allow us to leave non-wallet inputs, so we have to add them
-   * afterwards which may bring the resulting feerate below our target.
-   */
-  def adjustHtlcTxChange(unsignedTx: HtlcWithWitnessData, amountIn: Satoshi, targetFeerate: FeeratePerKw, dustLimit: Satoshi, commitmentFormat: CommitmentFormat): HtlcWithWitnessData = {
-    require(unsignedTx.txInfo.tx.txOut.size <= 2, "funded transaction should have at most one change output")
-    val dummySignedTx = unsignedTx.txInfo match {
-      case tx: HtlcSuccessTx => addSigs(tx, PlaceHolderSig, PlaceHolderSig, ByteVector32.Zeroes, commitmentFormat)
-      case tx: HtlcTimeoutTx => addSigs(tx, PlaceHolderSig, PlaceHolderSig, commitmentFormat)
-    }
-    // We adjust the change output to obtain the targeted feerate.
-    val estimatedWeight = dummySignedTx.tx.weight() + claimP2WPKHOutputWitnessWeight * (dummySignedTx.tx.txIn.size - 1)
-    val targetFee = weight2fee(targetFeerate, estimatedWeight)
-    val changeAmount = amountIn - dummySignedTx.tx.txOut.head.amount - targetFee
-    val updatedHtlcTx = if (dummySignedTx.tx.txOut.length == 2 && changeAmount >= dustLimit) {
-      unsignedTx.updateTx(unsignedTx.txInfo.tx.copy(txOut = Seq(unsignedTx.txInfo.tx.txOut.head, unsignedTx.txInfo.tx.txOut.last.copy(amount = changeAmount))))
-    } else {
-      unsignedTx.updateTx(unsignedTx.txInfo.tx.copy(txOut = Seq(unsignedTx.txInfo.tx.txOut.head)))
-    }
-    updatedHtlcTx
   }
 
   /**
@@ -174,7 +134,8 @@ object ReplaceableTxFunder {
         val commitTx = dummySignedCommitTx(commitments)
         val totalWeight = previousTx.signedTx.weight() + commitTx.tx.weight()
         weight2fee(targetFeerate, totalWeight) - commitTx.fee
-      case _ => weight2fee(targetFeerate, previousTx.signedTx.weight())
+      case _ =>
+        weight2fee(targetFeerate, previousTx.signedTx.weight())
     }
     previousTx.signedTxWithWitnessData match {
       case claimLocalAnchor: ClaimLocalAnchorWithWitnessData =>
@@ -353,23 +314,10 @@ private class ReplaceableTxFunder(nodeParams: NodeParams,
   }
 
   def signWalletInputs(locallySignedTx: ReplaceableTxWithWalletInputs, txFeerate: FeeratePerKw, amountIn: Satoshi): Behavior[Command] = {
-    locallySignedTx match {
-      case ClaimLocalAnchorWithWitnessData(anchorTx) =>
-        val commitInfo = BitcoinCoreClient.PreviousTx(anchorTx.input, anchorTx.tx.txIn.head.witness)
-        context.pipeToSelf(bitcoinClient.signTransaction(anchorTx.tx, Seq(commitInfo))) {
-          case Success(signedTx) => SignWalletInputsOk(signedTx.tx)
-          case Failure(reason) => SignWalletInputsFailed(reason)
-        }
-      case htlcTx: HtlcWithWitnessData =>
-        val inputInfo = BitcoinCoreClient.PreviousTx(htlcTx.txInfo.input, htlcTx.txInfo.tx.txIn.head.witness)
-        context.pipeToSelf(bitcoinClient.signTransaction(htlcTx.txInfo.tx, Seq(inputInfo), allowIncomplete = true).map(signTxResponse => {
-          // NB: bitcoind versions older than 0.21.1 messes up the witness stack for our htlc input, so we need to restore it.
-          // See https://github.com/bitcoin/bitcoin/issues/21151
-          htlcTx.txInfo.tx.copy(txIn = htlcTx.txInfo.tx.txIn.head +: signTxResponse.tx.txIn.tail)
-        })) {
-          case Success(signedTx) => SignWalletInputsOk(signedTx)
-          case Failure(reason) => SignWalletInputsFailed(reason)
-        }
+    val inputInfo = BitcoinCoreClient.PreviousTx(locallySignedTx.txInfo.input, locallySignedTx.txInfo.tx.txIn.head.witness)
+    context.pipeToSelf(bitcoinClient.signTransaction(locallySignedTx.txInfo.tx, Seq(inputInfo))) {
+      case Success(signedTx) => SignWalletInputsOk(signedTx.tx)
+      case Failure(reason) => SignWalletInputsFailed(reason)
     }
     Behaviors.receiveMessagePartial {
       case SignWalletInputsOk(signedTx) =>
@@ -405,75 +353,46 @@ private class ReplaceableTxFunder(nodeParams: NodeParams,
 
   private def addInputs(anchorTx: ClaimLocalAnchorWithWitnessData, targetFeerate: FeeratePerKw, commitments: Commitments): Future[(ClaimLocalAnchorWithWitnessData, Satoshi)] = {
     val dustLimit = commitments.localParams.dustLimit
-    val commitFeerate = commitments.localCommit.spec.commitTxFeerate
     val commitTx = dummySignedCommitTx(commitments).tx
-    // We want the feerate of the package (commit tx + tx spending anchor) to equal targetFeerate.
-    // Thus we have: anchorFeerate = targetFeerate + (weight-commit-tx / weight-anchor-tx) * (targetFeerate - commitTxFeerate)
-    // If we use the smallest weight possible for the anchor tx, the feerate we use will thus be greater than what we want,
-    // and we can adjust it afterwards by raising the change output amount.
-    val anchorFeerate = targetFeerate + FeeratePerKw(targetFeerate.feerate - commitFeerate.feerate) * commitTx.weight() / claimAnchorOutputMinWeight
     // NB: fundrawtransaction requires at least one output, and may add at most one additional change output.
     // Since the purpose of this transaction is just to do a CPFP, the resulting tx should have a single change output
-    // (note that bitcoind doesn't let us publish a transaction with no outputs).
-    // To work around these limitations, we start with a dummy output and later merge that dummy output with the optional
-    // change output added by bitcoind.
-    // NB: fundrawtransaction doesn't support non-wallet inputs, so we have to remove our anchor input and re-add it later.
-    // That means bitcoind will not take our anchor input's weight into account when adding inputs to set the fee.
-    // That's ok, we can increase the fee later by decreasing the output amount. But we need to ensure we'll have enough
-    // to cover the weight of our anchor input, which is why we set it to the following value.
-    val dummyChangeAmount = weight2fee(anchorFeerate, claimAnchorOutputMinWeight) + dustLimit
-    val txNotFunded = Transaction(2, Nil, TxOut(dummyChangeAmount, Script.pay2wpkh(PlaceHolderPubKey)) :: Nil, 0)
-    bitcoinClient.fundTransaction(txNotFunded, FundTransactionOptions(anchorFeerate, lockUtxos = true)).flatMap(fundTxResponse => {
+    // (note that bitcoind doesn't let us publish a transaction with no outputs). To work around these limitations, we
+    // start with a dummy output and later merge that dummy output with the optional change output added by bitcoind.
+    val txNotFunded = anchorTx.txInfo.tx.copy(txOut = TxOut(dustLimit, Script.pay2wpkh(PlaceHolderPubKey)) :: Nil)
+    // The anchor transaction is paying for the weight of the commitment transaction.
+    val anchorWeight = Seq(InputWeight(anchorTx.txInfo.input.outPoint, anchorInputWeight + commitTx.weight()))
+    bitcoinClient.fundTransaction(txNotFunded, FundTransactionOptions(targetFeerate, lockUtxos = true, inputWeights = anchorWeight)).flatMap(fundTxResponse => {
       // We merge the outputs if there's more than one.
       fundTxResponse.changePosition match {
         case Some(changePos) =>
           val changeOutput = fundTxResponse.tx.txOut(changePos)
-          val txSingleOutput = fundTxResponse.tx.copy(txOut = Seq(changeOutput.copy(amount = changeOutput.amount + dummyChangeAmount)))
-          Future.successful(fundTxResponse.copy(tx = txSingleOutput))
+          val txSingleOutput = fundTxResponse.tx.copy(txOut = Seq(changeOutput))
+          // We ask bitcoind to sign the wallet inputs to learn their final weight and adjust the change amount.
+          bitcoinClient.signTransaction(txSingleOutput, allowIncomplete = true).map(signTxResponse => {
+            val dummySignedTx = addSigs(anchorTx.updateTx(signTxResponse.tx).txInfo, PlaceHolderSig)
+            val packageWeight = commitTx.weight() + dummySignedTx.tx.weight()
+            val anchorTxFee = weight2fee(targetFeerate, packageWeight) - weight2fee(commitments.localCommit.spec.commitTxFeerate, commitTx.weight())
+            val changeAmount = dustLimit.max(fundTxResponse.amountIn - anchorTxFee)
+            val fundedTx = fundTxResponse.tx.copy(txOut = Seq(changeOutput.copy(amount = changeAmount)))
+            (anchorTx.updateTx(fundedTx), fundTxResponse.amountIn)
+          })
         case None =>
           bitcoinClient.getChangeAddress().map(pubkeyHash => {
-            val txSingleOutput = fundTxResponse.tx.copy(txOut = Seq(TxOut(dummyChangeAmount, Script.pay2wpkh(pubkeyHash))))
-            fundTxResponse.copy(tx = txSingleOutput)
+            val fundedTx = fundTxResponse.tx.copy(txOut = Seq(TxOut(dustLimit, Script.pay2wpkh(pubkeyHash))))
+            (anchorTx.updateTx(fundedTx), fundTxResponse.amountIn)
           })
       }
-    }).map(fundTxResponse => {
-      require(fundTxResponse.tx.txOut.size == 1, "funded transaction should have a single change output")
-      // NB: we insert the anchor input in the *first* position because our signing helpers only sign input #0.
-      val unsignedTx = anchorTx.updateTx(fundTxResponse.tx.copy(txIn = anchorTx.txInfo.tx.txIn.head +: fundTxResponse.tx.txIn))
-      val totalAmountIn = fundTxResponse.amountIn + AnchorOutputsCommitmentFormat.anchorAmount
-      (adjustAnchorOutputChange(unsignedTx, commitTx, totalAmountIn, commitFeerate, targetFeerate, dustLimit), totalAmountIn)
     })
   }
 
   private def addInputs(htlcTx: HtlcWithWitnessData, targetFeerate: FeeratePerKw, commitments: Commitments): Future[(HtlcWithWitnessData, Satoshi)] = {
-    // NB: fundrawtransaction doesn't support non-wallet inputs, so we clear the input and re-add it later.
-    val txNotFunded = htlcTx.txInfo.tx.copy(txIn = Nil, txOut = htlcTx.txInfo.tx.txOut.head.copy(amount = commitments.localParams.dustLimit) :: Nil)
-    val htlcTxWeight = htlcTx.txInfo match {
-      case _: HtlcSuccessTx => commitments.commitmentFormat.htlcSuccessWeight
-      case _: HtlcTimeoutTx => commitments.commitmentFormat.htlcTimeoutWeight
-    }
-    // We want the feerate of our final HTLC tx to equal targetFeerate. However, we removed the HTLC input from what we
-    // send to fundrawtransaction, so bitcoind will not know the total weight of the final tx. In order to make up for
-    // this difference, we need to tell bitcoind to target a higher feerate that takes into account the weight of the
-    // input we removed.
-    // That feerate will satisfy the following equality:
-    // feerate * weight_seen_by_bitcoind = target_feerate * (weight_seen_by_bitcoind + htlc_input_weight)
-    // So: feerate = target_feerate * (1 + htlc_input_weight / weight_seen_by_bitcoind)
-    // Because bitcoind will add at least one P2WPKH input, weight_seen_by_bitcoind >= htlc_tx_weight + p2wpkh_weight
-    // Thus: feerate <= target_feerate * (1 + htlc_input_weight / (htlc_tx_weight + p2wpkh_weight))
-    // NB: we don't take into account the fee paid by our HTLC input: we will take it into account when we adjust the
-    // change output amount (unless bitcoind didn't add any change output, in that case we will overpay the fee slightly).
-    val weightRatio = 1.0 + (htlcInputMaxWeight.toDouble / (htlcTxWeight + claimP2WPKHOutputWeight))
-    bitcoinClient.fundTransaction(txNotFunded, FundTransactionOptions(targetFeerate * weightRatio, lockUtxos = true, changePosition = Some(1))).map(fundTxResponse => {
-      // We add the HTLC input (from the commit tx) and restore the HTLC output.
-      // NB: we can't modify them because they are signed by our peer (with SIGHASH_SINGLE | SIGHASH_ANYONECANPAY).
-      val txWithHtlcInput = fundTxResponse.tx.copy(
-        txIn = htlcTx.txInfo.tx.txIn ++ fundTxResponse.tx.txIn,
-        txOut = htlcTx.txInfo.tx.txOut ++ fundTxResponse.tx.txOut.tail
-      )
-      val unsignedTx = htlcTx.updateTx(txWithHtlcInput)
-      val totalAmountIn = fundTxResponse.amountIn + unsignedTx.txInfo.amountIn
-      (adjustHtlcTxChange(unsignedTx, totalAmountIn, targetFeerate, commitments.localParams.dustLimit, commitments.commitmentFormat), totalAmountIn)
+    val htlcInputWeight = Seq(InputWeight(htlcTx.txInfo.input.outPoint, htlcTx.txInfo match {
+      case _: HtlcSuccessTx => commitments.commitmentFormat.htlcSuccessInputWeight
+      case _: HtlcTimeoutTx => commitments.commitmentFormat.htlcTimeoutInputWeight
+    }))
+    bitcoinClient.fundTransaction(htlcTx.txInfo.tx, FundTransactionOptions(targetFeerate, lockUtxos = true, changePosition = Some(1), inputWeights = htlcInputWeight)).map(fundTxResponse => {
+      val unsignedTx = htlcTx.updateTx(fundTxResponse.tx)
+      (unsignedTx, fundTxResponse.amountIn)
     })
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
@@ -16,12 +16,12 @@
 
 package fr.acinq.eclair.transactions
 
+import fr.acinq.bitcoin.Script.LOCKTIME_THRESHOLD
+import fr.acinq.bitcoin.SigHash._
+import fr.acinq.bitcoin.TxIn.{SEQUENCE_LOCKTIME_DISABLE_FLAG, SEQUENCE_LOCKTIME_MASK, SEQUENCE_LOCKTIME_TYPE_FLAG}
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.Script._
 import fr.acinq.bitcoin.scalacompat._
-import fr.acinq.bitcoin.SigHash._
-import fr.acinq.bitcoin.TxIn.{SEQUENCE_LOCKTIME_DISABLE_FLAG, SEQUENCE_LOCKTIME_TYPE_FLAG, SEQUENCE_LOCKTIME_MASK}
-import fr.acinq.bitcoin.Script.LockTimeThreshold
 import fr.acinq.eclair.transactions.Transactions.{AnchorOutputsCommitmentFormat, CommitmentFormat, DefaultCommitmentFormat}
 import fr.acinq.eclair.{BlockHeight, CltvExpiry, CltvExpiryDelta}
 import scodec.bits.ByteVector
@@ -85,7 +85,7 @@ object Scripts {
    * @return the block height before which this tx cannot be published.
    */
   def cltvTimeout(tx: Transaction): BlockHeight =
-    if (tx.lockTime <= LockTimeThreshold) {
+    if (tx.lockTime <= LOCKTIME_THRESHOLD) {
       // locktime is a number of blocks
       BlockHeight(tx.lockTime)
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -56,7 +56,7 @@ trait BitcoindService extends Logging {
 
   val PATH_BITCOIND = sys.env.get("BITCOIND_DIR") match {
     case Some(customBitcoinDir) => new File(customBitcoinDir, "bitcoind")
-    case None => new File(TestUtils.BUILD_DIRECTORY, "bitcoin-0.21.1/bin/bitcoind")
+    case None => new File(TestUtils.BUILD_DIRECTORY, "bitcoin-23.0/bin/bitcoind")
   }
   logger.info(s"using bitcoind: $PATH_BITCOIND")
   val PATH_BITCOIND_DATADIR = new File(INTEGRATION_TMP_DIR, "datadir-bitcoin")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
@@ -694,10 +694,6 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       f.forwardAlice2Bob[TxAddOutput]
       // Alice <-- tx_complete --- Bob
       f.forwardBob2Alice[TxComplete]
-      // Alice --- tx_add_output --> Bob
-      f.forwardAlice2Bob[TxAddOutput]
-      // Alice <-- tx_complete --- Bob
-      f.forwardBob2Alice[TxComplete]
       // Alice --- tx_complete --> Bob
       f.forwardAlice2Bob[TxComplete]
       // Alice --- commit_sig --> Bob
@@ -708,7 +704,8 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       val txB1 = bob2alice.expectMsgType[Succeeded].sharedTx.asInstanceOf[PartiallySignedSharedTransaction]
       alice ! ReceiveTxSigs(txB1.localSigs)
       val txA1 = alice2bob.expectMsgType[Succeeded].sharedTx.asInstanceOf[FullySignedSharedTransaction]
-      assert(targetFeerate * 0.9 <= txA1.feerate && txA1.feerate <= targetFeerate * 1.25)
+      // Bitcoin Core didn't add a change output, which results in a bigger over-payment of the on-chain fees.
+      assert(targetFeerate * 0.9 <= txA1.feerate && txA1.feerate <= targetFeerate * 1.5)
       val probe = TestProbe()
       walletA.publishTransaction(txA1.signedTx).pipeTo(probe.ref)
       probe.expectMsg(txA1.signedTx.txid)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -16,10 +16,10 @@
 
 package fr.acinq.eclair.transactions
 
+import fr.acinq.bitcoin.SigHash._
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, ripemd160, sha256}
 import fr.acinq.bitcoin.scalacompat.Script.{pay2wpkh, pay2wsh, write}
 import fr.acinq.bitcoin.scalacompat.{Btc, ByteVector32, Crypto, MilliBtc, MilliBtcDouble, OutPoint, Protocol, Satoshi, SatoshiLong, Script, ScriptWitness, Transaction, TxIn, TxOut, millibtc2satoshi}
-import fr.acinq.bitcoin.SigHash._
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.Helpers.Funding
@@ -208,9 +208,12 @@ class TransactionsSpec extends AnyFunSuite with Logging {
         txIn = claimAnchorOutputTx.tx.txIn :+ TxIn(OutPoint(randomBytes32(), 3), ByteVector.empty, 0, p2wpkhWitness),
         txOut = Seq(TxOut(1500 sat, Script.pay2wpkh(randomKey().publicKey)))
       ))
-      val weight = Transaction.weight(addSigs(claimAnchorOutputTxWithFees, PlaceHolderSig).tx)
+      val signedTx = addSigs(claimAnchorOutputTxWithFees, PlaceHolderSig).tx
+      val weight = Transaction.weight(signedTx)
       assert(weight == 717)
       assert(weight >= claimAnchorOutputMinWeight)
+      val inputWeight = Transaction.weight(signedTx) - Transaction.weight(signedTx.copy(txIn = signedTx.txIn.tail))
+      assert(inputWeight == anchorInputWeight)
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <akka.version>2.6.18</akka.version>
         <akka.http.version>10.2.7</akka.http.version>
         <sttp.version>3.4.1</sttp.version>
-        <bitcoinlib.version>0.24</bitcoinlib.version>
+        <bitcoinlib.version>0.25</bitcoinlib.version>
         <guava.version>31.1-jre</guava.version>
         <kamon.version>2.4.6</kamon.version>
     </properties>


### PR DESCRIPTION
This release of bitcoind contains several bug fixes that let us simplify our fee bumping logic:

- fixed a bug where bitcoind dropped non-wallet signatures
- added an option to fund transactions containing non-wallet inputs

It also has support for Taproot, which we obviously love.