### PR TITLE
Explicitly request bech32 static remotekey

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
@@ -84,11 +84,8 @@ trait OnChainAddressGenerator {
    */
   def getReceiveAddress(label: String = "")(implicit ec: ExecutionContext): Future[String]
 
-  /**
-   * @param receiveAddress if provided, will extract the public key from this address, otherwise will generate a new
-   *                       address and return the underlying public key.
-   */
-  def getReceivePubkey(receiveAddress: Option[String] = None)(implicit ec: ExecutionContext): Future[PublicKey]
+  /** Generate a p2wpkh wallet address and return the corresponding public key. */
+  def getReceivePubkey()(implicit ec: ExecutionContext): Future[PublicKey]
 
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -362,8 +362,8 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient) extends OnChainWall
     JString(address) <- rpcClient.invoke("getnewaddress", label)
   } yield address
 
-  def getReceivePubkey(receiveAddress: Option[String] = None)(implicit ec: ExecutionContext): Future[Crypto.PublicKey] = for {
-    address <- receiveAddress.map(Future.successful).getOrElse(getReceiveAddress())
+  def getReceivePubkey()(implicit ec: ExecutionContext): Future[Crypto.PublicKey] = for {
+    address <- rpcClient.invoke("getnewaddress", "", "bech32")
     JString(rawKey) <- rpcClient.invoke("getaddressinfo", address).map(_ \ "pubkey")
   } yield PublicKey(ByteVector.fromValidHex(rawKey))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
@@ -42,7 +42,7 @@ class DummyOnChainWallet extends OnChainWallet {
 
   override def getReceiveAddress(label: String)(implicit ec: ExecutionContext): Future[String] = Future.successful(dummyReceiveAddress)
 
-  override def getReceivePubkey(receiveAddress: Option[String] = None)(implicit ec: ExecutionContext): Future[Crypto.PublicKey] = Future.successful(dummyReceivePubkey)
+  override def getReceivePubkey()(implicit ec: ExecutionContext): Future[Crypto.PublicKey] = Future.successful(dummyReceivePubkey)
 
   override def fundTransaction(tx: Transaction, feeRate: FeeratePerKw, replaceable: Boolean, lockUtxos: Boolean)(implicit ec: ExecutionContext): Future[FundTransactionResponse] = Future.successful(FundTransactionResponse(tx, 0 sat, None))
 
@@ -82,7 +82,7 @@ class NoOpOnChainWallet extends OnChainWallet {
 
   override def getReceiveAddress(label: String)(implicit ec: ExecutionContext): Future[String] = Future.successful(dummyReceiveAddress)
 
-  override def getReceivePubkey(receiveAddress: Option[String] = None)(implicit ec: ExecutionContext): Future[Crypto.PublicKey] = Future.successful(dummyReceivePubkey)
+  override def getReceivePubkey()(implicit ec: ExecutionContext): Future[Crypto.PublicKey] = Future.successful(dummyReceivePubkey)
 
   override def fundTransaction(tx: Transaction, feeRate: FeeratePerKw, replaceable: Boolean, lockUtxos: Boolean)(implicit ec: ExecutionContext): Future[FundTransactionResponse] = Promise().future // will never be completed
 
@@ -119,7 +119,7 @@ class SingleKeyOnChainWallet extends OnChainWallet {
 
   override def getReceiveAddress(label: String)(implicit ec: ExecutionContext): Future[String] = Future.successful(Bech32.encodeWitnessAddress("bcrt", 0, pubkey.hash160.toArray))
 
-  override def getReceivePubkey(receiveAddress: Option[String] = None)(implicit ec: ExecutionContext): Future[Crypto.PublicKey] = Future.successful(pubkey)
+  override def getReceivePubkey()(implicit ec: ExecutionContext): Future[Crypto.PublicKey] = Future.successful(pubkey)
 
   override def fundTransaction(tx: Transaction, feeRate: FeeratePerKw, replaceable: Boolean, lockUtxos: Boolean)(implicit ec: ExecutionContext): Future[FundTransactionResponse] = synchronized {
     val currentAmountIn = tx.txIn.flatMap(txIn => inputs.find(_.txid == txIn.outPoint.txid)).map(_.txOut.head.amount).sum


### PR DESCRIPTION
When using `static_remotekey`, we ask `bitcoind` to generate a receiving address and send the corresponding public key to our peer. We previously assumed that `bitcoind` used `bech32`, which may change since #2466.

We need to explicitly tell `bitcoind` that we want to use a p2wpkh address in that case, otherwise it may generate a `p2tr` address, we will use that public key to get our funds back, but `bitcoind` will not detect that it can spend this output (because it only expects this public key to be used for a taproot address).

Thanks @sstone for hinting at this problem.