### PR TITLE
Fix mempool flaky tests

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/MempoolTxMonitor.scala
@@ -47,7 +47,7 @@ object MempoolTxMonitor {
   private case class ParentTxStatus(confirmed: Boolean, blockHeight: BlockHeight) extends Command
   private case object TxNotFound extends Command
   private case class GetTxConfirmationsFailed(reason: Throwable) extends Command
-  private case class WrappedCurrentBlockHeight(currentBlockHeight: BlockHeight) extends Command
+  final case class WrappedCurrentBlockHeight(currentBlockHeight: BlockHeight) extends Command
   private case class CheckTxConfirmations(currentBlockHeight: BlockHeight) extends Command
   // @formatter:on
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/message/OnionMessagesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/message/OnionMessagesSpec.scala
@@ -230,8 +230,6 @@ class OnionMessagesSpec extends AnyFunSuite {
 
     val Success((_, messageForAlice)) = buildMessage(sessionKey, blindingSecret, IntermediateNode(alice.publicKey) :: IntermediateNode(bob.publicKey) :: Nil, Recipient(carol.publicKey, Some(pathId)), Nil)
 
-    println(messageForAlice.onionRoutingPacket.payload.length)
-
     // Checking that the onion is relayed properly
     process(alice, messageForAlice) match {
       case SendMessage(nextNodeId, onionForBob) =>


### PR DESCRIPTION
As usual, there was a race related to `EventStream` subscriptions.

There are still remaining issues, including:

- I can't figure out how this can possibly happen cc @t-bast 
```
- transaction confirmed *** FAILED ***
  java.lang.AssertionError: assertion failed: timeout (15 seconds) during expectMsg while waiting for TxInMempool(272f5128df6c1e9c4c233fc29906468c2b0616b0a43f5ded5eb8cc9ce2d5b218,151,true)
  at scala.Predef$.assert(Predef.scala:279)
  at akka.testkit.TestKitBase.expectMsg_internal(TestKit.scala:461)
  at akka.testkit.TestKitBase.expectMsg(TestKit.scala:438)
  at akka.testkit.TestKitBase.expectMsg$(TestKit.scala:438)
  at akka.testkit.TestKit.expectMsg(TestKit.scala:973)
  at fr.acinq.eclair.channel.publish.MempoolTxMonitorSpec.$anonfun$new$2(MempoolTxMonitorSpec.scala:99)
  at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
  at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
  at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
  at org.scalatest.Transformer.apply(Transformer.scala:22)
```
- not investigated
```
- watch for spent transactions *** FAILED ***
  java.lang.AssertionError: assertion failed: expected WatchOutputSpentTriggered(02000000000101fc7435dfcdff35ba9a8b99f92db7d3ab7da5e63a763838331dd6cdd262c457ad0000000000ffffffff01e092f50500000000160014bccdc183e25f188d20367432f52217ff843529be0248304502210091a58bb2891d025ff623d3612db827aeae950790d500be647847fd31891905770220431302161092d68994a281f2dc91452f662a463c41280a44e3aa97e38ed652bb0121033fa4cf3f450b0ec0c034eda6b3a170018ec07949d12626893882d8ebe76f36de00000000), found WatchFundingSpentTriggered(02000000000101fc7435dfcdff35ba9a8b99f92db7d3ab7da5e63a763838331dd6cdd262c457ad0000000000ffffffff01e092f50500000000160014bccdc183e25f188d20367432f52217ff843529be0248304502210091a58bb2891d025ff623d3612db827aeae950790d500be647847fd31891905770220431302161092d68994a281f2dc91452f662a463c41280a44e3aa97e38ed652bb0121033fa4cf3f450b0ec0c034eda6b3a170018ec07949d12626893882d8ebe76f36de00000000)
  at scala.Predef$.assert(Predef.scala:279)
  at akka.testkit.TestKitBase.expectMsg_internal(TestKit.scala:462)
  at akka.testkit.TestKitBase.expectMsg(TestKit.scala:438)
  at akka.testkit.TestKitBase.expectMsg$(TestKit.scala:438)
  at akka.testkit.TestKit.expectMsg(TestKit.scala:973)
  at fr.acinq.eclair.blockchain.bitcoind.ZmqWatcherSpec.$anonfun$new$17(ZmqWatcherSpec.scala:263)
  at fr.acinq.eclair.blockchain.bitcoind.ZmqWatcherSpec.withWatcher(ZmqWatcherSpec.scala:82)
  at fr.acinq.eclair.blockchain.bitcoind.ZmqWatcherSpec.$anonfun$new$16(ZmqWatcherSpec.scala:205)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
  at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
```