### PR TITLE
Accept payments to zero-hop blinded route

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -408,6 +408,7 @@ object PaymentOnion {
       override val amount = records.get[AmountToForward].get.amount
       override val totalAmount = records.get[TotalAmount].map(_.totalAmount).getOrElse(amount)
       override val expiry = records.get[OutgoingCltv].get.cltv
+      val blinding_opt: Option[PublicKey] = records.get[BlindingPoint].map(_.publicKey)
       val pathId = blindedRecords.get[RouteBlindingEncryptedDataTlv.PathId].get.data
       val paymentConstraints = blindedRecords.get[RouteBlindingEncryptedDataTlv.PaymentConstraints].get
       val allowedFeatures = blindedRecords.get[RouteBlindingEncryptedDataTlv.AllowedFeatures].map(_.features).getOrElse(Features.empty)


### PR DESCRIPTION
In case of a zero-hop blinded route, the final blinding point is not in the `UpdateAddHtlc` but in the payload itself.