### PR TITLE
Implement correct ordering of `tx_signatures`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/InteractiveTxBuilder.scala
@@ -763,14 +763,12 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
   }
 
   def signFundingTx(completeTx: SharedTransaction, commitments: Commitments): Behavior[Command] = {
-    val shouldSignFirst = if (completeTx.localAmountIn < completeTx.remoteAmountIn) {
-      // The peer with the lowest total of input amount must transmit its `tx_signatures` first.
-      true
-    } else if (completeTx.localAmountIn == completeTx.remoteAmountIn) {
+    val shouldSignFirst = if (completeTx.localAmountIn == completeTx.remoteAmountIn) {
       // When both peers contribute the same amount, the peer with the lowest pubkey must transmit its `tx_signatures` first.
       LexicographicalOrdering.isLessThan(commitments.localParams.nodeId.value, commitments.remoteNodeId.value)
     } else {
-      false
+      // The peer with the lowest total of input amount must transmit its `tx_signatures` first.
+      completeTx.localAmountIn < completeTx.remoteAmountIn
     }
     if (shouldSignFirst) {
       signTx(completeTx, None)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/InteractiveTxBuilder.scala
@@ -763,10 +763,10 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
   }
 
   def signFundingTx(completeTx: SharedTransaction, commitments: Commitments): Behavior[Command] = {
-    val shouldSignFirst = if (fundingParams.localAmount < fundingParams.remoteAmount) {
+    val shouldSignFirst = if (completeTx.localAmountIn < completeTx.remoteAmountIn) {
       // The peer with the lowest total of input amount must transmit its `tx_signatures` first.
       true
-    } else if (fundingParams.localAmount == fundingParams.remoteAmount) {
+    } else if (completeTx.localAmountIn == completeTx.remoteAmountIn) {
       // When both peers contribute the same amount, the peer with the lowest pubkey must transmit its `tx_signatures` first.
       LexicographicalOrdering.isLessThan(commitments.localParams.nodeId.value, commitments.remoteNodeId.value)
     } else {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -357,7 +357,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
         }
       case f: InteractiveTxBuilder.Failed =>
         channelOpenReplyToUser(Left(LocalError(f.cause)))
-        goto(CLOSED) sending TxAbort(d.channelId, f.cause.getMessage)
+        goto(CLOSED) sending Error(d.channelId, f.cause.getMessage)
     }
 
     case Event(c: CloseCommand, d: DATA_WAIT_FOR_DUAL_FUNDING_CREATED) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForDualFundingCreatedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForDualFundingCreatedStateSpec.scala
@@ -228,13 +228,13 @@ class WaitForDualFundingCreatedStateSpec extends TestKitBaseClass with FixtureAn
 
     // Invalid serial_id.
     alice2bob.forward(bob, inputA.copy(serialId = UInt64(1)))
-    bob2alice.expectMsgType[TxAbort]
+    bob2alice.expectMsgType[Error]
     awaitCond(wallet.rolledback.length == 1)
     awaitCond(bob.stateName == CLOSED)
 
     // Below dust.
     bob2alice.forward(alice, TxAddOutput(channelId(bob), UInt64(1), 150 sat, Script.write(Script.pay2wpkh(randomKey().publicKey))))
-    alice2bob.expectMsgType[TxAbort]
+    alice2bob.expectMsgType[Error]
     awaitCond(wallet.rolledback.length == 2)
     awaitCond(alice.stateName == CLOSED)
     aliceOrigin.expectMsgType[Status.Failure]
@@ -261,13 +261,13 @@ class WaitForDualFundingCreatedStateSpec extends TestKitBaseClass with FixtureAn
     val aliceCommitSig = alice2bob.expectMsgType[CommitSig]
 
     bob2alice.forward(alice, bobCommitSig.copy(signature = ByteVector64.Zeroes))
-    alice2bob.expectMsgType[TxAbort]
+    alice2bob.expectMsgType[Error]
     awaitCond(wallet.rolledback.length == 1)
     awaitCond(alice.stateName == CLOSED)
     aliceOrigin.expectMsgType[Status.Failure]
 
     alice2bob.forward(bob, aliceCommitSig.copy(signature = ByteVector64.Zeroes))
-    bob2alice.expectMsgType[TxAbort]
+    bob2alice.expectMsgType[Error]
     awaitCond(wallet.rolledback.length == 2)
     awaitCond(bob.stateName == CLOSED)
   }
@@ -297,7 +297,7 @@ class WaitForDualFundingCreatedStateSpec extends TestKitBaseClass with FixtureAn
     val bobSigs = bob2alice.expectMsgType[TxSignatures]
     bob2blockchain.expectMsgType[WatchFundingConfirmed]
     bob2alice.forward(alice, bobSigs.copy(txHash = randomBytes32(), witnesses = Nil))
-    alice2bob.expectMsgType[TxAbort]
+    alice2bob.expectMsgType[Error]
     awaitCond(wallet.rolledback.size == 1)
     awaitCond(alice.stateName == CLOSED)
     aliceOrigin.expectMsgType[Status.Failure]


### PR DESCRIPTION
According to the dual funding specification, the peer that has [contributed the smaller amount](https://github.com/niftynei/lightning-rfc/blob/nifty/dual-fund/02-peer-protocol.md#requirements-4) of `tx_add_input` must sign first. We incorrectly used the contributions to the funding output instead of the sum of the inputs values. This requirement guarantees that there can be no deadlocks when nodes are batching multiple `interactive-tx` sessions.

When building the first version of a dual-funded transaction, we should use `error` instead of `tx_abort` if we encounter a failure. It makes it more explicit to our peer that the channel should be closed at that point, whereas `tx_abort` can be used in RBF attempts to abort a secondary `interactive-tx` sessions without closing the channel. However, our peer may need to wait for the funding transaction to be double-spent before actually forgetting the channel if they have already sent us their `tx_signatures`.