### PR TITLE
Channels can be excluded several times

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -99,7 +99,7 @@ object RouteCalculation {
       implicit val sender: ActorRef = ctx.self // necessary to preserve origin when sending messages to other actors
 
       val extraEdges = r.extraEdges.map(GraphEdge(_)).filterNot(_.desc.a == r.source).toSet // we ignore routing hints for our own channels, we have more accurate information
-      val ignoredEdges = r.ignore.channels ++ d.excludedChannels
+      val ignoredEdges = r.ignore.channels ++ d.excludedChannels.keySet
       val params = r.routeParams
       val routesToFind = if (params.randomize) DEFAULT_ROUTES_COUNT else 1
 


### PR DESCRIPTION
Instead of exclusion being a binary state, we stack exclusions and only use the channel again once every individual exclusion has been lifted. 