### PR TITLE
Create routes to self using remote alias

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -35,6 +35,19 @@ import scala.util.{Failure, Random, Success, Try}
 
 object RouteCalculation {
 
+  private def getEdgeRelayScid(d: Data, localNodeId: PublicKey, e: GraphEdge): ShortChannelId = {
+    if (e.desc.b == localNodeId) {
+      // We are the destination of that edge: local graph edges always use either the local alias or the real scid.
+      // We want to use the remote alias when available, because our peer won't understand our local alias.
+      d.resolve(e.desc.shortChannelId) match {
+        case Some(c: PrivateChannel) => c.shortIds.remoteAlias_opt.getOrElse(e.desc.shortChannelId)
+        case _ => e.desc.shortChannelId
+      }
+    } else {
+      e.desc.shortChannelId
+    }
+  }
+
   def finalizeRoute(d: Data, localNodeId: PublicKey, fr: FinalizeRoute)(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Data = {
     Logs.withMdc(log)(Logs.mdc(
       category_opt = Some(LogCategory.PAYMENT),
@@ -52,7 +65,7 @@ object RouteCalculation {
             case edges if edges.nonEmpty && edges.forall(_.nonEmpty) =>
               // select the largest edge (using balance when available, otherwise capacity).
               val selectedEdges = edges.map(es => es.maxBy(e => e.balance_opt.getOrElse(e.capacity.toMilliSatoshi)))
-              val hops = selectedEdges.map(e => ChannelHop(e.desc.shortChannelId, e.desc.a, e.desc.b, e.params))
+              val hops = selectedEdges.map(e => ChannelHop(getEdgeRelayScid(d, localNodeId, e), e.desc.a, e.desc.b, e.params))
               ctx.sender() ! RouteResponse(Route(fr.amount, hops) :: Nil)
             case _ =>
               // some nodes in the supplied route aren't connected in our graph
@@ -75,7 +88,7 @@ object RouteCalculation {
                 case None => fr.extraEdges.map(GraphEdge(_)).find(e => e.desc.shortChannelId == shortChannelId && e.desc.a == currentNode).map(_.desc)
               }
               channelDesc_opt.flatMap(c => g.getEdge(c)) match {
-                case Some(edge) => (edge.desc.b, previousHops :+ ChannelHop(edge.desc.shortChannelId, edge.desc.a, edge.desc.b, edge.params))
+                case Some(edge) => (edge.desc.b, previousHops :+ ChannelHop(getEdgeRelayScid(d, localNodeId, edge), edge.desc.a, edge.desc.b, edge.params))
                 case None => (currentNode, previousHops)
               }
           }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
@@ -50,7 +50,9 @@ case class MinimalNodeFixture private(nodeParams: NodeParams,
                                       paymentHandler: ActorRef,
                                       watcher: TestProbe,
                                       wallet: DummyOnChainWallet,
-                                      bitcoinClient: TestBitcoinCoreClient)
+                                      bitcoinClient: TestBitcoinCoreClient) {
+  val nodeId = nodeParams.nodeId
+}
 
 object MinimalNodeFixture extends Assertions with Eventually with IntegrationPatience with EitherValues {
 


### PR DESCRIPTION
The introduction of `scid-alias` broke the ability to create a valid route to our own node using `FinalizeRoute` for private or unconfirmed channels because we use our local alias as the shortChannelId of the graph edge in both directions.

Using the same identifier for both directions makes sense, because it's a stable identifier whereas the remote alias could be updated by our peer. It's generally not an issue, except when we are building a route, because our peer will not know how to route if we give them our local alias in a payment onion (they expect their own local alias, which from our point of view is the remote alias).

The only way to build routes to ourselves is by using `FinalizeRoute`, so we fix the issue only in this handler by looking at our private channels when we notice that we are the destination.