### PR TITLE
Add an optional API key

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Boot.scala
@@ -74,6 +74,7 @@ object Boot extends App with Logging {
       val service: Service = new Service {
         override val actorSystem: ActorSystem = system
         override val password: String = apiPassword
+        override val apiKey: Option[String] = if (config.hasPath("api.key")) Some(config.getString("api.key")) else None
         override val eclairApi: Eclair = new EclairImpl(kit)
       }
       Http().newServerAt(config.getString("api.binding-ip"), config.getInt("api.port")).bindFlow(service.finalRoutes(providers)).recover {

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/Service.scala
@@ -30,6 +30,7 @@ trait Service extends EclairDirectives with WebSocket with Node with Channel wit
    */
   def password: String
 
+  def apiKey: Option[String]
   /**
    * The API of Eclair core.
    */

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/AuthDirective.scala
@@ -39,4 +39,7 @@ trait AuthDirective {
     case _ => akka.pattern.after(1 second, using = actorSystem.scheduler)(Future.successful(None))(actorSystem.dispatcher) // force a 1 sec pause to deter brute force
   }
 
+  def withValidApiKey: Directive0 = formFields("apiKey".as[String].?).flatMap { key =>
+    authorize(apiKey.forall(k => key.contains(k)))
+  }
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Fees.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Fees.scala
@@ -34,9 +34,11 @@ trait Fees {
   }
 
   val updateRelayFee: Route = postRequest("updaterelayfee") { implicit t =>
-    withNodesIdentifier { nodes =>
-      formFields("feeBaseMsat".as[MilliSatoshi], "feeProportionalMillionths".as[Long]) { (feeBase, feeProportional) =>
-        complete(eclairApi.updateRelayFee(nodes, feeBase, feeProportional))
+    withValidApiKey {
+      withNodesIdentifier { nodes =>
+        formFields("feeBaseMsat".as[MilliSatoshi], "feeProportionalMillionths".as[Long]) { (feeBase, feeProportional) =>
+          complete(eclairApi.updateRelayFee(nodes, feeBase, feeProportional))
+        }
       }
     }
   }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/OnChain.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/OnChain.scala
@@ -32,9 +32,11 @@ trait OnChain {
   }
 
   val sendOnChain: Route = postRequest("sendonchain") { implicit t =>
-    formFields("address".as[String], "amountSatoshis".as[Satoshi], "confirmationTarget".as[Long]) {
-      (address, amount, confirmationTarget) =>
-        complete(eclairApi.sendOnChain(address, amount, confirmationTarget))
+    withValidApiKey {
+      formFields("address".as[String], "amountSatoshis".as[Satoshi], "confirmationTarget".as[Long]) {
+        (address, amount, confirmationTarget) =>
+          complete(eclairApi.sendOnChain(address, amount, confirmationTarget))
+      }
     }
   }
 


### PR DESCRIPTION
Add an optional API key that can be set in eclair.conf.  If set, methods that modify channel states will require to be called with an additional apiKey parameter that must match the value set in eclair.conf.

These methods are: open, rbfopen, close, forceclose, updatefees, payinvoice, sendonchain, sendtoroute.