### PR TITLE
Fix closing channel state when nothing at stake

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingConfirmedStateSpec.scala
@@ -649,8 +649,10 @@ class WaitForDualFundingConfirmedStateSpec extends TestKitBaseClass with Fixture
     val commitTx = bob.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED].commitments.localCommit.commitTxAndRemoteSig.commitTx.tx
     bob ! Error(ByteVector32.Zeroes, "please help me recover my funds")
     // We have nothing at stake, but we publish our commitment to help our peer recover their funds more quickly.
+    awaitCond(bob.stateName == CLOSING)
     assert(bob2blockchain.expectMsgType[PublishFinalTx].tx.txid == commitTx.txid)
-    bob2blockchain.expectNoMessage(100 millis)
+    assert(bob2blockchain.expectMsgType[WatchTxConfirmed].txId == commitTx.txid)
+    bob ! WatchTxConfirmedTriggered(BlockHeight(42), 1, commitTx)
     awaitCond(bob.stateName == CLOSED)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -270,8 +270,10 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     val tx = bob.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].commitments.localCommit.commitTxAndRemoteSig.commitTx.tx
     bob ! Error(ByteVector32.Zeroes, "please help me recover my funds")
     // We have nothing at stake, but we publish our commitment to help our peer recover their funds more quickly.
+    awaitCond(bob.stateName == CLOSING)
     assert(bob2blockchain.expectMsgType[PublishFinalTx].tx.txid == tx.txid)
-    bob2blockchain.expectNoMessage(100 millis)
+    assert(bob2blockchain.expectMsgType[WatchTxConfirmed].txId == tx.txid)
+    bob ! WatchTxConfirmedTriggered(BlockHeight(42), 1, tx)
     awaitCond(bob.stateName == CLOSED)
   }
 


### PR DESCRIPTION
This is a follow up to #2360 which was actually buggy: the channel actor doesn't stop itself immediately after going into the CLOSED state, so it received a `WatchFundingTxSpent` event that was handled in the global `whenUnhandled` block, logged a warning and went back to the CLOSING state.

We now go through the normal steps to close those channels, by waiting for the commit tx to be confirmed before actually going to CLOSED.