### PR TITLE
Remove warning for pruned local channel update

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -533,8 +533,11 @@ object Validation {
         }
       case None =>
         lcu.shortIds.real.toOption match {
-          case Some(realScid) if d.prunedChannels.contains(realScid) => log.debug("created local channel update for pruned channelId={} scid={}", lcu.channelId, realScid)
-          case _ => log.warning("unrecognized local channel update for channelId={} localAlias={}", lcu.channelId, lcu.shortIds.localAlias)
+          case Some(realScid) if d.prunedChannels.contains(realScid) =>
+            log.debug("this is a known pruned local channel, processing channel_update for channelId={} scid={}", lcu.channelId, realScid)
+          case _ =>
+            // should never happen
+            log.warning("unrecognized local channel update for channelId={} localAlias={}", lcu.channelId, lcu.shortIds.localAlias)
         }
         // handle the update: it will be rejected if there is no related channel
         handleChannelUpdate(d, db, nodeParams.currentBlockHeight, Left(lcu))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -532,8 +532,11 @@ object Validation {
             handleChannelUpdate(d1, db, nodeParams.currentBlockHeight, Left(lcu))
         }
       case None =>
-        // should never happen, we log a warning and handle the update, it will be rejected since there is no related channel
-        log.warning("unrecognized local channel update for channelId={} localAlias={}", lcu.channelId, lcu.shortIds.localAlias)
+        lcu.shortIds.real.toOption match {
+          case Some(realScid) if d.prunedChannels.contains(realScid) => log.debug("created local channel update for pruned channelId={} scid={}", lcu.channelId, realScid)
+          case _ => log.warning("unrecognized local channel update for channelId={} localAlias={}", lcu.channelId, lcu.shortIds.localAlias)
+        }
+        // handle the update: it will be rejected if there is no related channel
         handleChannelUpdate(d, db, nodeParams.currentBlockHeight, Left(lcu))
     }
   }


### PR DESCRIPTION
When a channel is pruned, it is removed from our graph and thus isn't found by `d.resolve()`, but it shouldn't create a warning in the logs, this isn't an unknown channel.