### PR TITLE
Switch to io.zonky.test.db.postgres.embedded.EmbeddedPostgres

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -311,9 +311,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.opentable.components</groupId>
-            <artifactId>otj-pg-embedded</artifactId>
-            <version>0.13.3</version>
+            <groupId>io.zonky.test</groupId>
+            <artifactId>embedded-postgres</artifactId>
+            <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
@@ -1,7 +1,6 @@
 package fr.acinq.eclair
 
 import akka.actor.ActorSystem
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import com.zaxxer.hikari.HikariConfig
 import fr.acinq.eclair.TestDatabases.TestPgDatabases.getNewDatabase
 import fr.acinq.eclair.channel._
@@ -128,6 +127,8 @@ object TestDatabases {
   }
 
   object TestPgDatabases {
+    import _root_.io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+
     /** single instance */
     private val pg = EmbeddedPostgres.start()
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/DbMigrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/DbMigrationSpec.scala
@@ -1,12 +1,12 @@
 package fr.acinq.eclair.db
 
 import akka.actor.ActorSystem
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import com.zaxxer.hikari.HikariConfig
 import fr.acinq.eclair.db.Databases.{PostgresDatabases, SqliteDatabases}
 import fr.acinq.eclair.db.migration._
 import fr.acinq.eclair.db.pg.PgUtils.PgLock
 import fr.acinq.eclair.db.pg._
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import org.scalatest.Ignore
 import org.scalatest.funsuite.AnyFunSuite
 import org.sqlite.SQLiteConfig

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/DualDatabasesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/DualDatabasesSpec.scala
@@ -1,9 +1,9 @@
 package fr.acinq.eclair.db
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import com.typesafe.config.{Config, ConfigFactory}
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecsSpec
 import fr.acinq.eclair.{TestKitBaseClass, TestUtils}
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 import java.io.File

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PgUtilsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PgUtilsSpec.scala
@@ -1,6 +1,5 @@
 package fr.acinq.eclair.db
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres
 import com.typesafe.config.{Config, ConfigFactory}
 import fr.acinq.eclair.db.Databases.JdbcUrlChanged
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
@@ -13,6 +12,7 @@ import fr.acinq.eclair.wire.internal.channel.ChannelCodecsSpec
 import fr.acinq.eclair.wire.protocol.Color
 import fr.acinq.eclair.{Features, MilliSatoshiLong, TestKitBaseClass, TestUtils, TimestampMilli, TimestampSecond, randomBytes32, randomKey}
 import grizzled.slf4j.{Logger, Logging}
+import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import org.postgresql.jdbc.PgConnection
 import org.postgresql.util.PGInterval
 import org.scalatest.concurrent.Eventually


### PR DESCRIPTION
This PR improves compatibility of the Postgres tests across different OS's without Docker.