### PR TITLE
Improve `findRoute` ignored channels behavior

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -53,7 +53,6 @@ import scodec.{Attempt, DecodeResult, codecs}
 
 import java.nio.charset.StandardCharsets
 import java.util.UUID
-import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
@@ -535,14 +534,12 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
       Future.successful(Set.empty)
     } else {
       for {
-        channelsMap <- (appKit.router ? GetChannelsMap).mapTo[SortedMap[ShortChannelId, PublicChannel]]
+        routerData <- (appKit.router ? GetRouterData).mapTo[Router.Data]
       } yield {
-        shortChannelIds.flatMap { id =>
-          val c = channelsMap.getOrElse(id, throw new IllegalArgumentException(s"unknown channel: $id"))
-          Set(
-            ChannelDesc(c.ann.shortChannelId, c.ann.nodeId1, c.ann.nodeId2),
-            ChannelDesc(c.ann.shortChannelId, c.ann.nodeId2, c.ann.nodeId1))
-        }
+        shortChannelIds.flatMap(scid => routerData.resolve(scid) match {
+          case Some(c) => Set(ChannelDesc(scid, c.nodeId1, c.nodeId2), ChannelDesc(scid, c.nodeId2, c.nodeId1))
+          case None => Set.empty
+        })
       }
     }
   }


### PR DESCRIPTION
We use router data to resolve both private and public channels, even when scid-alias is used.
When a channel cannot be found, we simply skip it since adding it to the ignore list wouldn't have any impact.

@rorp @DerEwige can you verify that this is what you expect?

Supersedes #2483

Fixes #2346 and #2426