### PR TITLE
Close SQL statements during migrations

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/jdbc/JdbcUtils.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/jdbc/JdbcUtils.scala
@@ -109,7 +109,7 @@ trait JdbcUtils {
                    migrate: (ResultSet, PreparedStatement) => Unit)(implicit logger: Logger): Int = {
     val insertStatement = destination.prepareStatement(migrateSql)
     val batchSize = 50
-    JdbcUtils.using(source.prepareStatement(s"SELECT * FROM $sourceTable")) { queryStatement =>
+    using(source.prepareStatement(s"SELECT * FROM $sourceTable")) { queryStatement =>
       val rs = queryStatement.executeQuery()
       var inserted = 0
       var batchCount = 0
@@ -192,11 +192,6 @@ trait JdbcUtils {
     def getLongNullable(columnLabel: String): Option[Long] = {
       val result = rs.getLong(columnLabel)
       if (rs.wasNull()) None else Some(result)
-    }
-
-    def getUUIDNullable(label: String): Option[UUID] = {
-      val result = rs.getString(label)
-      if (rs.wasNull()) None else Some(UUID.fromString(result))
     }
 
     def getMilliSatoshiNullable(label: String): Option[MilliSatoshi] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/CompareDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/CompareDb.scala
@@ -2,7 +2,7 @@ package fr.acinq.eclair.db.migration
 
 import fr.acinq.eclair.db.Databases.{PostgresDatabases, SqliteDatabases}
 import fr.acinq.eclair.db.DualDatabases
-import fr.acinq.eclair.db.jdbc.JdbcUtils
+import fr.acinq.eclair.db.jdbc.JdbcUtils.using
 import fr.acinq.eclair.db.pg.PgUtils
 import grizzled.slf4j.Logging
 import scodec.bits.ByteVector
@@ -18,13 +18,13 @@ object CompareDb extends Logging {
                    hash1: ResultSet => ByteVector,
                    hash2: ResultSet => ByteVector): Boolean = {
     var hashes1 = List.empty[ByteVector]
-    JdbcUtils.using(conn1.prepareStatement(s"SELECT * FROM $table1")) { statement =>
+    using(conn1.prepareStatement(s"SELECT * FROM $table1")) { statement =>
       val rs = statement.executeQuery()
       while (rs.next()) hashes1 = hash1(rs) +: hashes1
     }
 
     var hashes2 = List.empty[ByteVector]
-    JdbcUtils.using(conn2.prepareStatement(s"SELECT * FROM $table2")) { statement =>
+    using(conn2.prepareStatement(s"SELECT * FROM $table2")) { statement =>
       val rs = statement.executeQuery()
       while (rs.next()) hashes2 = hash2(rs) +: hashes2
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/CompareDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/CompareDb.scala
@@ -2,6 +2,7 @@ package fr.acinq.eclair.db.migration
 
 import fr.acinq.eclair.db.Databases.{PostgresDatabases, SqliteDatabases}
 import fr.acinq.eclair.db.DualDatabases
+import fr.acinq.eclair.db.jdbc.JdbcUtils
 import fr.acinq.eclair.db.pg.PgUtils
 import grizzled.slf4j.Logging
 import scodec.bits.ByteVector
@@ -16,30 +17,27 @@ object CompareDb extends Logging {
                    table2: String,
                    hash1: ResultSet => ByteVector,
                    hash2: ResultSet => ByteVector): Boolean = {
-    val rs1 = conn1.prepareStatement(s"SELECT * FROM $table1").executeQuery()
-    val rs2 = conn2.prepareStatement(s"SELECT * FROM $table2").executeQuery()
-
     var hashes1 = List.empty[ByteVector]
-    while (rs1.next()) {
-      hashes1 = hash1(rs1) +: hashes1
+    JdbcUtils.using(conn1.prepareStatement(s"SELECT * FROM $table1")) { statement =>
+      val rs = statement.executeQuery()
+      while (rs.next()) hashes1 = hash1(rs) +: hashes1
     }
 
     var hashes2 = List.empty[ByteVector]
-    while (rs2.next()) {
-      hashes2 = hash2(rs2) +: hashes2
+    JdbcUtils.using(conn2.prepareStatement(s"SELECT * FROM $table2")) { statement =>
+      val rs = statement.executeQuery()
+      while (rs.next()) hashes2 = hash2(rs) +: hashes2
     }
 
-    val res = hashes1.sorted == hashes2.sorted
-
-    if (res) {
+    if (hashes1.sorted == hashes2.sorted) {
       logger.info(s"tables $table1/$table2 are identical")
+      true
     } else {
       val diff1 = hashes1 diff hashes2
       val diff2 = hashes2 diff hashes1
       logger.warn(s"tables $table1/$table2 are different diff1=${diff1.take(3).map(_.toHex.take(128))} diff2=${diff2.take(3).map(_.toHex.take(128))}")
+      false
     }
-
-    res
   }
 
   // @formatter:off

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/MigrateDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/MigrateDb.scala
@@ -10,12 +10,12 @@ import java.sql.{Connection, PreparedStatement, ResultSet}
 
 object MigrateDb extends Logging {
 
-  private def getVersion(conn: Connection,
-                         dbName: String): Int = {
-    val statement = conn.prepareStatement(s"SELECT version FROM versions WHERE db_name='$dbName'")
-    val res = statement.executeQuery()
-    res.next()
-    res.getInt("version")
+  private def getVersion(conn: Connection, dbName: String): Int = {
+    JdbcUtils.using(conn.prepareStatement(s"SELECT version FROM versions WHERE db_name='$dbName'")) { statement =>
+      val res = statement.executeQuery()
+      res.next()
+      res.getInt("version")
+    }
   }
 
   def checkVersions(source: Connection,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/MigrateDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/migration/MigrateDb.scala
@@ -3,6 +3,7 @@ package fr.acinq.eclair.db.migration
 import fr.acinq.eclair.db.Databases.{PostgresDatabases, SqliteDatabases}
 import fr.acinq.eclair.db.DualDatabases
 import fr.acinq.eclair.db.jdbc.JdbcUtils
+import fr.acinq.eclair.db.jdbc.JdbcUtils.using
 import fr.acinq.eclair.db.pg.PgUtils
 import grizzled.slf4j.Logging
 
@@ -11,7 +12,7 @@ import java.sql.{Connection, PreparedStatement, ResultSet}
 object MigrateDb extends Logging {
 
   private def getVersion(conn: Connection, dbName: String): Int = {
-    JdbcUtils.using(conn.prepareStatement(s"SELECT version FROM versions WHERE db_name='$dbName'")) { statement =>
+    using(conn.prepareStatement(s"SELECT version FROM versions WHERE db_name='$dbName'")) { statement =>
       val res = statement.executeQuery()
       res.next()
       res.getInt("version")


### PR DESCRIPTION
We weren't correctly closing SQL statements when comparing DBs and migrating them. All the DB handlers for normal operation (read/write channels, payments, etc) are already correctly closed after execution.

@DerEwige the issue was only in those migration handlers, otherwise we correctly use `using` everywhere which closes DB statements and their corresponding `ResultSet`.

Fixes #2425