### PR TITLE
Improve `payinvoice` API response

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -10,6 +10,7 @@
 
 - `audit` now accepts `--count` and `--skip` parameters to limit the number of retrieved items (#2474, #2487)
 - `sendtoroute` removes the `--trampolineNodes` argument and implicitly uses a single trampoline hop (#2480)
+- `payinvoice` always returns the payment result when used with `--blocking`, even when using MPP (#2525)
 
 ### Miscellaneous improvements and bug fixes
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -70,7 +70,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     val cfg = SendPaymentConfig(id, id, Some("42"), paymentHash, randomKey().publicKey, Upstream.Local(id), None, storeInDb = true, publishEvent = true, recordPathFindingMetrics = true)
     val nodeParams = TestConstants.Alice.nodeParams
     val (childPayFsm, router, sender, eventListener, metricsListener) = (TestProbe(), TestProbe(), TestProbe(), TestProbe(), TestProbe())
-    val paymentHandler = TestFSMRef(new MultiPartPaymentLifecycle(nodeParams, cfg, router.ref, FakePaymentFactory(childPayFsm)))
+    val paymentHandler = TestFSMRef(new MultiPartPaymentLifecycle(nodeParams, cfg, publishPreimage = true, router.ref, FakePaymentFactory(childPayFsm)))
     system.eventStream.subscribe(eventListener.ref, classOf[PaymentEvent])
     system.eventStream.subscribe(metricsListener.ref, classOf[PathFindingExperimentMetrics])
     withFixture(test.toNoArgTest(FixtureParam(cfg, nodeParams, paymentHandler, router, sender, childPayFsm, eventListener, metricsListener)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -90,7 +90,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
       payFsm.ref ! cfg
       payFsm.ref
     }
-    override def spawnOutgoingMultiPartPayment(context: ActorContext, cfg: SendPaymentConfig): ActorRef = {
+    override def spawnOutgoingMultiPartPayment(context: ActorContext, cfg: SendPaymentConfig, publishPreimage: Boolean): ActorRef = {
       multiPartPayFsm.ref ! cfg
       multiPartPayFsm.ref
     }


### PR DESCRIPTION
When sending an outgoing multi-part payment, we forward the preimage back to the sender as soon as we receive the first `update_fulfill_htlc`. This is particularly useful when relaying trampoline payments, to be able to propagate the fulfill upstream as early as possible.

However this meant that callers of the HTTP API would receive this preimage event instead of the final payment result, which was quite bad. We now disable this first event when used with the `--blocking` argument, which ensures that the API always returns the payment result.

Fixes #2389
