### PR TITLE
Remove redundant log messages

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
@@ -287,7 +287,7 @@ private class ZmqWatcher(nodeParams: NodeParams, blockHeight: AtomicLong, client
 
       case TriggerEvent(replyTo, watch, event) =>
         if (watches.contains(watch)) {
-          log.info("triggering {}", watch)
+          log.debug("triggering {}", watch)
           replyTo ! event
           watch match {
             case _: WatchSpent[_] =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/watchdogs/BlockchainWatchdog.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/watchdogs/BlockchainWatchdog.scala
@@ -119,8 +119,6 @@ object BlockchainWatchdog {
               context.log.warn("{}: we are {} blocks late: we may be eclipsed from the bitcoin network", source, missingBlocks)
               context.system.eventStream ! EventStream.Publish(DangerousBlocksSkew(headers))
               context.system.eventStream ! EventStream.Publish(NotifyNodeOperator(NotificationsLogger.Warning, s"we are $missingBlocks late according to $source: we may be eclipsed from the bitcoin network, check your bitcoind node."))
-            } else if (missingBlocks > 0) {
-              context.log.info("{}: we are {} blocks late", source, missingBlocks)
             } else {
               context.log.debug("{}: we are {} blocks late", source, missingBlocks)
             }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -698,7 +698,7 @@ object Helpers {
         val closingTx = Transactions.makeClosingTx(commitInput, actualLocalScript, actualRemoteScript, localParams.isInitiator, dustLimit, closingFees.preferred, localCommit.spec)
         val localClosingSig = keyManager.sign(closingTx, keyManager.fundingPublicKey(commitments.localParams.fundingKeyPath), TxOwner.Local, commitmentFormat)
         val closingSigned = ClosingSigned(channelId, closingFees.preferred, localClosingSig, TlvStream(ClosingSignedTlv.FeeRange(closingFees.min, closingFees.max)))
-        log.info(s"signed closing txid=${closingTx.tx.txid} with closing fee=${closingSigned.feeSatoshis}")
+        log.debug(s"signed closing txid=${closingTx.tx.txid} with closing fee=${closingSigned.feeSatoshis}")
         log.debug(s"closingTxid=${closingTx.tx.txid} closingTx=${closingTx.tx}}")
         (closingTx, closingSigned)
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/InteractiveTxBuilder.scala
@@ -402,7 +402,7 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
               case None => Nil
             }
           }
-          log.info("added {} inputs and {} outputs to interactive tx", inputDetails.usableInputs.length, outputs.length)
+          log.debug("added {} inputs and {} outputs to interactive tx", inputDetails.usableInputs.length, outputs.length)
           // We unlock the unusable inputs from previous iterations (if any) as they can be used outside of this session.
           unlock(unusableInputs.map(_.outpoint))
           // The initiator's serial IDs must use even values and the non-initiator odd values.
@@ -686,7 +686,7 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
         val remoteInputsUnchanged = previousTx.tx.remoteInputs.map(_.outPoint).toSet == sharedTx.remoteInputs.map(_.outPoint).toSet
         val remoteOutputsUnchanged = previousTx.tx.remoteOutputs.map(o => TxOut(o.amount, o.pubkeyScript)).toSet == sharedTx.remoteOutputs.map(o => TxOut(o.amount, o.pubkeyScript)).toSet
         if (remoteInputsUnchanged && remoteOutputsUnchanged) {
-          log.info("peer did not contribute to the feerate increase to {}: they used the same inputs and outputs", fundingParams.targetFeerate)
+          log.debug("peer did not contribute to the feerate increase to {}: they used the same inputs and outputs", fundingParams.targetFeerate)
         }
         val previousUnsignedTx = previousTx.tx.buildUnsignedTx()
         val previousMinimumWeight = previousUnsignedTx.weight() + previousUnsignedTx.txIn.length * minimumWitnessWeight

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -331,7 +331,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
       stay()
 
     case Event(channelReady: ChannelReady, d: DATA_WAIT_FOR_DUAL_FUNDING_CREATED) =>
-      log.info("received their channel_ready, deferring message")
+      log.debug("received their channel_ready, deferring message")
       stay() using d.copy(deferred = Some(channelReady))
 
     case Event(msg: InteractiveTxBuilder.Response, d: DATA_WAIT_FOR_DUAL_FUNDING_CREATED) => msg match {
@@ -403,7 +403,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
               stay()
             case _ =>
               // Signatures are retransmitted on reconnection, but we may have already received them.
-              log.info("ignoring duplicate tx_signatures for txid={}", txSigs.txId)
+              log.debug("ignoring duplicate tx_signatures for txid={}", txSigs.txId)
               stay()
           }
       }
@@ -609,7 +609,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
         // NB: we will receive a WatchFundingConfirmedTriggered later that will simply be ignored
         goto(WAIT_FOR_DUAL_FUNDING_READY) using DATA_WAIT_FOR_DUAL_FUNDING_READY(d.commitments, shortIds, localChannelReady) storing() sending localChannelReady
       } else {
-        log.info("received their channel_ready, deferring message")
+        log.debug("received their channel_ready, deferring message")
         stay() using d.copy(deferred = Some(remoteChannelReady)) // no need to store, they will re-send if we get disconnected
       }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
@@ -382,7 +382,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
         // NB: we will receive a WatchFundingConfirmedTriggered later that will simply be ignored
         goto(WAIT_FOR_CHANNEL_READY) using DATA_WAIT_FOR_CHANNEL_READY(d.commitments, shortIds, localChannelReady) storing() sending localChannelReady
       } else {
-        log.info("received their channel_ready, deferring message")
+        log.debug("received their channel_ready, deferring message")
         stay() using d.copy(deferred = Some(remoteChannelReady)) // no need to store, they will re-send if we get disconnected
       }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
@@ -62,10 +62,7 @@ trait CommonFundingHandlers extends CommonHandlers {
 
   def receiveChannelReady(shortIds: ShortIds, channelReady: ChannelReady, commitments: Commitments): DATA_NORMAL = {
     val shortIds1 = shortIds.copy(remoteAlias_opt = channelReady.alias_opt)
-    shortIds1.remoteAlias_opt.foreach { remoteAlias =>
-      log.info("received remoteAlias={}", remoteAlias)
-      context.system.eventStream.publish(ShortChannelIdAssigned(self, commitments.channelId, shortIds = shortIds1, remoteNodeId = remoteNodeId))
-    }
+    shortIds1.remoteAlias_opt.foreach(_ => context.system.eventStream.publish(ShortChannelIdAssigned(self, commitments.channelId, shortIds = shortIds1, remoteNodeId = remoteNodeId)))
     log.info("shortIds: real={} localAlias={} remoteAlias={}", shortIds1.real.toOption.getOrElse("none"), shortIds1.localAlias, shortIds1.remoteAlias_opt.getOrElse("none"))
     // we create a channel_update early so that we can use it to send payments through this channel, but it won't be propagated to other nodes since the channel is not yet announced
     val scidForChannelUpdate = Helpers.scidForChannelUpdate(channelAnnouncement_opt = None, shortIds1.localAlias)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/TxPublisher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/TxPublisher.scala
@@ -209,7 +209,7 @@ private class TxPublisher(nodeParams: NodeParams, factory: TxPublisher.ChildFact
         val attempts = pending.getOrElse(cmd.input, PublishAttempts.empty)
         val alreadyPublished = attempts.finalAttempts.exists(_.cmd.tx.txid == cmd.tx.txid)
         if (alreadyPublished) {
-          log.info("not publishing {} txid={} spending {}:{}, publishing is already in progress", cmd.desc, cmd.tx.txid, cmd.input.txid, cmd.input.index)
+          log.debug("not publishing {} txid={} spending {}:{}, publishing is already in progress", cmd.desc, cmd.tx.txid, cmd.input.txid, cmd.input.index)
           Behaviors.same
         } else {
           val publishId = UUID.randomUUID()
@@ -229,7 +229,7 @@ private class TxPublisher(nodeParams: NodeParams, factory: TxPublisher.ChildFact
             }
             val currentConfirmationTarget = currentAttempt.confirmBefore
             if (currentConfirmationTarget <= proposedConfirmationTarget) {
-              log.info("not publishing replaceable {} spending {}:{} with confirmation target={}, publishing is already in progress with confirmation target={}", cmd.desc, cmd.input.txid, cmd.input.index, proposedConfirmationTarget, currentConfirmationTarget)
+              log.debug("not publishing replaceable {} spending {}:{} with confirmation target={}, publishing is already in progress with confirmation target={}", cmd.desc, cmd.input.txid, cmd.input.index, proposedConfirmationTarget, currentConfirmationTarget)
               Behaviors.same
             } else {
               log.info("replaceable {} spending {}:{} has new confirmation target={} (previous={})", cmd.desc, cmd.input.txid, cmd.input.index, proposedConfirmationTarget, currentConfirmationTarget)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/TxTimeLocksMonitor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/TxTimeLocksMonitor.scala
@@ -115,7 +115,7 @@ private class TxTimeLocksMonitor(nodeParams: NodeParams,
   def waitForParentsToConfirm(parentTxIds: Set[ByteVector32]): Behavior[Command] = {
     Behaviors.receiveMessagePartial {
       case ParentTxConfirmed(parentTxId) =>
-        log.info("parent tx of {} has been confirmed (parent txid={})", cmd.desc, parentTxId)
+        log.debug("parent tx of {} has been confirmed (parent txid={})", cmd.desc, parentTxId)
         val remainingParentTxIds = parentTxIds - parentTxId
         if (remainingParentTxIds.isEmpty) {
           log.info("all parent txs of {} have been confirmed", cmd.desc)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/TransportHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/TransportHandler.scala
@@ -103,9 +103,9 @@ class TransportHandler[T: ClassTag](keyPair: KeyPair, rs: Option[ByteVector], co
         listener ! message
         m += (message -> (m.getOrElse(message, 0) + 1))
       case Success(Attempt.Failure(err)) =>
-        log.error(s"cannot deserialize $plaintext: $err")
+        log.error(s"cannot deserialize ${plaintext.toHex}: $err")
       case Failure(t) =>
-        log.error(s"cannot deserialize $plaintext: ${t.getMessage}")
+        log.error(s"cannot deserialize ${plaintext.toHex}: ${t.getMessage}")
     })
     log.debug("decoded {} messages", m.values.sum)
     m
@@ -250,11 +250,11 @@ class TransportHandler[T: ClassTag](keyPair: KeyPair, rs: Option[ByteVector], co
   whenUnhandled {
     handleExceptions {
       case Event(closed: Tcp.ConnectionClosed, _) =>
-        log.info(s"connection closed: $closed")
+        log.debug(s"connection closed: $closed")
         stop(FSM.Normal)
 
       case Event(Terminated(actor), _) if actor == connection =>
-        log.info("connection actor died")
+        log.debug("connection actor died")
         // this can be the connection or the listener, either way it is a cause of death
         stop(FSM.Normal)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -246,14 +246,14 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnChainA
         stay() using d.copy(channels = d.channels + (FinalChannelId(channelId) -> channel))
 
       case Event(Disconnect(nodeId), d: ConnectedData) if nodeId == remoteNodeId =>
-        log.info("disconnecting")
+        log.debug("disconnecting")
         sender() ! "disconnecting"
         d.peerConnection ! PeerConnection.Kill(KillReason.UserRequest)
         stay()
 
       case Event(ConnectionDown(peerConnection), d: ConnectedData) if peerConnection == d.peerConnection =>
         Logs.withMdc(diagLog)(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
-          log.info("connection lost")
+          log.debug("connection lost")
         }
         if (d.channels.isEmpty) {
           // we have no existing channels, we can forget about this peer
@@ -276,7 +276,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnChainA
         stay() using d.copy(channels = channels1)
 
       case Event(connectionReady: PeerConnection.ConnectionReady, d: ConnectedData) =>
-        log.info(s"got new connection, killing current one and switching")
+        log.debug(s"got new connection, killing current one and switching")
         d.peerConnection ! PeerConnection.Kill(KillReason.ConnectionReplaced)
         d.channels.values.toSet[ActorRef].foreach(_ ! INPUT_DISCONNECTED) // we deduplicate with toSet because there might be two entries per channel (tmp id and final id)
         gotoConnected(connectionReady, d.channels)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -265,7 +265,6 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
             c + 1
         }
 
-        log.info("sending the full routing table")
         val channelsSent = send(channels.map(_.ann))
         val nodesSent = send(nodes)
         val updatesSent = send(channels.flatMap(c => c.update_1_opt.toSeq ++ c.update_2_opt.toSeq))
@@ -394,7 +393,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
         val canUseChannelRangeQueriesEx = Features.canUseFeature(d.localInit.features, d.remoteInit.features, Features.ChannelRangeQueriesExtended)
         if (canUseChannelRangeQueries || canUseChannelRangeQueriesEx) {
           val flags_opt = if (canUseChannelRangeQueriesEx) Some(QueryChannelRangeTlv.QueryFlags(QueryChannelRangeTlv.QueryFlags.WANT_ALL)) else None
-          log.info(s"sending sync channel range query with flags_opt=$flags_opt replacePrevious=$replacePrevious")
+          log.debug(s"sending sync channel range query with flags_opt=$flags_opt replacePrevious=$replacePrevious")
           router ! SendChannelQuery(d.chainHash, d.remoteNodeId, self, replacePrevious, flags_opt)
         }
         stay()
@@ -422,7 +421,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
 
     case Event(Terminated(actor), d: HasTransport) if actor == d.transport =>
       Logs.withMdc(diagLog)(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
-        log.info("transport died, stopping")
+        log.debug("transport died, stopping")
       }
       d match {
         case a: AuthenticatingData => a.pendingAuth.origin_opt.foreach(_ ! ConnectionResult.AuthenticationFailed("connection aborted while authenticating"))
@@ -434,7 +433,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
 
     case Event(Kill(reason), _) =>
       Logs.withMdc(diagLog)(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
-        log.info(s"stopping with reason=$reason")
+        log.debug(s"stopping with reason=$reason")
         stop(FSM.Normal)
       }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
@@ -56,7 +56,7 @@ class ReconnectionTask(nodeParams: NodeParams, remoteNodeId: PublicKey) extends 
       goto(WAITING) using WaitingData(nextReconnectionDelay(d.nextReconnectionDelay, nodeParams.maxReconnectInterval))
 
     case Event(Peer.Transition(_, _: Peer.ConnectedData), d) =>
-      log.info("peer is connected")
+      log.debug("peer is connected")
       goto(IDLE) using IdleData(d)
   }
 
@@ -73,7 +73,7 @@ class ReconnectionTask(nodeParams: NodeParams, remoteNodeId: PublicKey) extends 
       }
 
     case Event(Peer.Transition(_, _: Peer.ConnectedData), d) =>
-      log.info("peer is connected")
+      log.debug("peer is connected")
       cancelTimer(RECONNECT_TIMER)
       goto(IDLE) using IdleData(d)
   }
@@ -119,7 +119,7 @@ class ReconnectionTask(nodeParams: NodeParams, remoteNodeId: PublicKey) extends 
       }
 
     case Event(Peer.Transition(_, _: Peer.ConnectedData), _) =>
-      log.info("peer is connected")
+      log.debug("peer is connected")
       stay()
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentPacket.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentPacket.scala
@@ -17,7 +17,6 @@
 package fr.acinq.eclair.payment
 
 import akka.actor.ActorRef
-import akka.event.LoggingAdapter
 import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.eclair.channel.{CMD_ADD_HTLC, CMD_FAIL_HTLC, CannotExtractSharedSecret, Origin}
@@ -108,7 +107,7 @@ object IncomingPaymentPacket {
    * @param privateKey this node's private key
    * @return whether the payment is to be relayed or if our node is the final recipient (or an error).
    */
-  def decrypt(add: UpdateAddHtlc, privateKey: PrivateKey, features: Features[Feature])(implicit log: LoggingAdapter): Either[FailureMessage, IncomingPaymentPacket] = {
+  def decrypt(add: UpdateAddHtlc, privateKey: PrivateKey, features: Features[Feature]): Either[FailureMessage, IncomingPaymentPacket] = {
     // We first derive the decryption key used to peel the onion.
     val outerOnionDecryptionKey = add.blinding_opt match {
       case Some(blinding) => Sphinx.RouteBlinding.derivePrivateKey(privateKey, blinding)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
@@ -128,7 +128,7 @@ class ChannelRelay private(nodeParams: NodeParams,
         if (previousFailures.isEmpty) {
           context.log.info(s"relaying htlc #${r.add.id} from channelId={} to requestedShortChannelId={} nextNode={}", r.add.channelId, r.payload.outgoingChannelId, nextNodeId_opt.getOrElse(""))
         }
-        context.log.info("attempting relay previousAttempts={}", previousFailures.size)
+        context.log.debug("attempting relay previousAttempts={}", previousFailures.size)
         handleRelay(previousFailures) match {
           case RelayFailure(cmdFail) =>
             Metrics.recordPaymentRelayFailed(Tags.FailureType(cmdFail), Tags.RelayType.Channel)
@@ -163,13 +163,13 @@ class ChannelRelay private(nodeParams: NodeParams,
   def waitForAddSettled(): Behavior[Command] =
     Behaviors.receiveMessagePartial {
       case WrappedAddResponse(RES_ADD_SETTLED(o: Origin.ChannelRelayedHot, htlc, fulfill: HtlcResult.Fulfill)) =>
-        context.log.info("relaying fulfill to upstream")
+        context.log.debug("relaying fulfill to upstream")
         val cmd = CMD_FULFILL_HTLC(o.originHtlcId, fulfill.paymentPreimage, commit = true)
         context.system.eventStream ! EventStream.Publish(ChannelPaymentRelayed(o.amountIn, o.amountOut, htlc.paymentHash, o.originChannelId, htlc.channelId))
         safeSendAndStop(o.originChannelId, cmd)
 
       case WrappedAddResponse(RES_ADD_SETTLED(o: Origin.ChannelRelayedHot, _, fail: HtlcResult.Fail)) =>
-        context.log.info("relaying fail to upstream")
+        context.log.debug("relaying fail to upstream")
         Metrics.recordPaymentRelayFailed(Tags.FailureType.Remote, Tags.RelayType.Channel)
         val cmd = translateRelayFailure(o.originHtlcId, fail, Some(r))
         safeSendAndStop(o.originChannelId, cmd)
@@ -256,7 +256,7 @@ class ChannelRelay private(nodeParams: NodeParams,
           context.log.debug("requested short channel id is our preferred channel")
           Some(channel)
         } else {
-          context.log.info("replacing requestedShortChannelId={} by preferredShortChannelId={} with availableBalanceMsat={}", requestedShortChannelId, channel.channelUpdate.shortChannelId, channel.commitments.availableBalanceForSend)
+          context.log.debug("replacing requestedShortChannelId={} by preferredShortChannelId={} with availableBalanceMsat={}", requestedShortChannelId, channel.channelUpdate.shortChannelId, channel.commitments.availableBalanceForSend)
           Some(channel)
         }
       case None =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -95,7 +95,7 @@ object NodeRelay {
         category_opt = Some(Logs.LogCategory.PAYMENT),
         parentPaymentId_opt = Some(relayId), // for a node relay, we use the same identifier for the whole relay itself, and the outgoing payment
         paymentHash_opt = Some(paymentHash))) {
-        context.log.info("relaying payment relayId={}", relayId)
+        context.log.debug("relaying payment relayId={}", relayId)
         val mppFsmAdapters = {
           context.messageAdapter[MultiPartPaymentFSM.ExtraPaymentReceived[HtlcPart]](WrappedMultiPartExtraPaymentReceived)
           context.messageAdapter[MultiPartPaymentFSM.MultiPartPaymentFailed](WrappedMultiPartPaymentFailed)
@@ -244,7 +244,7 @@ class NodeRelay private(nodeParams: NodeParams,
   }
 
   private def doSend(upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay.Standard, nextPacket: OnionRoutingPacket): Behavior[Command] = {
-    context.log.info(s"relaying trampoline payment (amountIn=${upstream.amountIn} expiryIn=${upstream.expiryIn} amountOut=${nextPayload.amountToForward} expiryOut=${nextPayload.outgoingCltv})")
+    context.log.debug(s"relaying trampoline payment (amountIn=${upstream.amountIn} expiryIn=${upstream.expiryIn} amountOut=${nextPayload.amountToForward} expiryOut=${nextPayload.outgoingCltv})")
     relay(upstream, nextPayload, nextPacket)
     sending(upstream, nextPayload, fulfilledUpstream = false)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -87,7 +87,6 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
       }
 
     case Event(Status.Failure(t), WaitingForRoute(request, failures, _)) =>
-      log.warning("router error: {}", t.getMessage)
       Metrics.PaymentError.withTag(Tags.Failure, Tags.FailureType(LocalFailure(request.amount, Nil, t))).increment()
       myStop(request, Left(PaymentFailed(id, paymentHash, failures :+ LocalFailure(request.amount, Nil, t))))
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -145,7 +145,7 @@ class Router(val nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Comm
         .foreach(listener ! _)
       listener ! RoutingStateStreamingUpToDate
       context.actorOf(Props(new Actor with ActorLogging {
-        log.info(s"subscribing listener=$listener to network events")
+        log.debug(s"subscribing listener=$listener to network events")
         context.system.eventStream.subscribe(listener, classOf[NetworkEvent])
         context.watch(listener)
 
@@ -162,7 +162,6 @@ class Router(val nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Comm
       if (d.rebroadcast.channels.isEmpty && d.rebroadcast.updates.isEmpty && d.rebroadcast.nodes.isEmpty) {
         stay()
       } else {
-        log.debug("broadcasting routing messages")
         log.debug("staggered broadcast details: channels={} updates={} nodes={}", d.rebroadcast.channels.size, d.rebroadcast.updates.size, d.rebroadcast.nodes.size)
         context.system.eventStream.publish(d.rebroadcast)
         stay() using d.copy(rebroadcast = Rebroadcast(channels = Map.empty, updates = Map.empty, nodes = Map.empty))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Sync.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Sync.scala
@@ -64,7 +64,7 @@ object Sync {
       // reset our sync state for this peer: we create an entry to ensure we reject duplicate queries and unsolicited reply_channel_range
       d.copy(sync = d.sync + (s.remoteNodeId -> Syncing(Nil, 0)))
     } else {
-      log.info("not sending query_channel_range: sync already in progress")
+      log.debug("not sending query_channel_range: sync already in progress")
       d
     }
   }
@@ -198,7 +198,7 @@ object Sync {
       case Some(sync) =>
         sync.remainingQueries match {
           case nextRequest :: rest =>
-            log.info(s"asking for the next slice of short_channel_ids (remaining=${sync.remainingQueries.size}/${sync.totalQueries})")
+            log.debug(s"asking for the next slice of short_channel_ids (remaining=${sync.remainingQueries.size}/${sync.totalQueries})")
             origin.peerConnection ! nextRequest
             d.sync + (origin.nodeId -> sync.copy(remainingQueries = rest))
           case Nil =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -72,7 +72,7 @@ object Validation {
       sendDecision(origin.peerConnection, GossipDecision.InvalidSignature(c))
       d
     } else {
-      log.info("validating shortChannelId={}", c.shortChannelId)
+      log.debug("validating shortChannelId={}", c.shortChannelId)
       watcher ! ValidateRequest(ctx.self, c)
       // we don't acknowledge the message just yet
       d.copy(awaiting = d.awaiting + (c -> Seq(origin)))
@@ -447,7 +447,7 @@ object Validation {
                 val prunedChannels1 = d.prunedChannels + (pc1.shortChannelId -> pc1)
                 d.copy(prunedChannels = prunedChannels1)
               } else {
-                log.info("channel shortChannelId={} is back from the dead", u.shortChannelId)
+                log.debug("channel shortChannelId={} is back from the dead", u.shortChannelId)
                 // We notify front nodes that the channel is back.
                 ctx.system.eventStream.publish(ChannelsDiscovered(SingleChannelDiscovered(pc1.ann, pc1.capacity, pc1.update_1_opt, pc1.update_2_opt) :: Nil))
                 sendDecision(origins, GossipDecision.Accepted(u))


### PR DESCRIPTION
Reduce the amount of logs generated by default by moving logs that are redundant or only used for targeted debugging to `debug` level or removing them entirely.

I focused on logs that generate some volume and that I never personnally use for day-to-day log browsing, but let me know if some of these logs are important for you and it would be annoying to have to turn on `debug` level for their respective component.