### PR TITLE
Update dependencies

### DIFF
--- a/docs/Monitoring.md
+++ b/docs/Monitoring.md
@@ -53,7 +53,7 @@ To enable monitoring with Prometheus, add the following to your `eclair.conf`:
 ```config
 eclair.enable-kamon=true
 
-// The Kamon APM reporter is enabled by default, but it won't work with Prometheus, so we disable it.
+# The Kamon APM reporter is enabled by default, but it won't work with Prometheus, so we disable it.
 kamon.modules {
   apm-reporter {
     enabled = false

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -272,11 +272,6 @@
         <!-- MONITORING -->
         <dependency>
             <groupId>io.kamon</groupId>
-            <artifactId>kamon-prometheus_${scala.version.short}</artifactId>
-            <version>2.5.4</version>
-        </dependency>
-        <dependency>
-            <groupId>io.kamon</groupId>
             <artifactId>kamon-core_${scala.version.short}</artifactId>
             <version>${kamon.version}</version>
         </dependency>

--- a/eclair-front/pom.xml
+++ b/eclair-front/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>kamon-system-metrics_${scala.version.short}</artifactId>
             <version>${kamon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.kamon</groupId>
+            <artifactId>kamon-prometheus_${scala.version.short}</artifactId>
+            <version>${kamon.version}</version>
+        </dependency>
         <!-- agents -->
         <dependency>
             <groupId>io.kamon</groupId>

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -119,6 +119,11 @@
             <artifactId>kamon-jdbc_${scala.version.short}</artifactId>
             <version>${kamon.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.kamon</groupId>
+            <artifactId>kamon-prometheus_${scala.version.short}</artifactId>
+            <version>${kamon.version}</version>
+        </dependency>
         <!-- test dependencies -->
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,14 +67,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <scala.version>2.13.9</scala.version>
+        <scala.version>2.13.10</scala.version>
         <scala.version.short>2.13</scala.version.short>
-        <akka.version>2.6.18</akka.version>
+        <akka.version>2.6.20</akka.version>
         <akka.http.version>10.2.7</akka.http.version>
-        <sttp.version>3.4.1</sttp.version>
+        <sttp.version>3.8.5</sttp.version>
         <bitcoinlib.version>0.25</bitcoinlib.version>
         <guava.version>31.1-jre</guava.version>
-        <kamon.version>2.4.6</kamon.version>
+        <kamon.version>2.5.12</kamon.version>
     </properties>
 
     <build>


### PR DESCRIPTION
And move kamon-prometheus to eclair-node/eclair-front.

I wanted to update `akka.http.version` to `10.2.10` but couldn't because `akka-http-json4s` hasn't been updated yet to 
support that version.