### PR TITLE
Avoid locking inputs during interactive-tx

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -268,12 +268,12 @@ class Setup(val datadir: File,
       //  - the only case where double-spending a funding transaction causes a loss of funds is when we accept a 0-conf
       //    channel and our peer double-spends it, but we should never accept 0-conf channels from peers we don't trust
       lockedUtxosBehavior = config.getString("bitcoind.startup-locked-utxos-behavior").toLowerCase
-      _ <- bitcoinClient.listLockedOutpoints().flatMap { lockedOutpoints =>
+      _ <- bitcoinClient.listLockedInputs().flatMap { lockedOutpoints =>
         if (lockedOutpoints.isEmpty) {
           Future.successful(true)
         } else if (lockedUtxosBehavior == "unlock") {
           logger.info(s"unlocking utxos: ${lockedOutpoints.map(o => s"${o.txid}:${o.index}").mkString(", ")}")
-          bitcoinClient.unlockOutpoints(lockedOutpoints.toSeq)
+          bitcoinClient.unlockInputs(lockedOutpoints)
         } else if (lockedUtxosBehavior == "stop") {
           logger.warn(s"cannot start eclair with locked utxos: ${lockedOutpoints.map(o => s"${o.txid}:${o.index}").mkString(", ")}")
           NotificationsLogger.logFatalError(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.blockchain
 
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, Transaction}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, OutPoint, Satoshi, Transaction}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import scodec.bits.ByteVector
 
@@ -65,8 +65,11 @@ trait OnChainChannelFunder {
   /** Get the number of confirmations of a given transaction. */
   def getTxConfirmations(txid: ByteVector32)(implicit ec: ExecutionContext): Future[Option[Int]]
 
-  /** Rollback a transaction that we failed to commit: this probably translates to "release locks on utxos". */
-  def rollback(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean]
+  /** Lock wallet inputs to ensure they're not concurrently used, to avoid accidentally creating conflicting transactions. */
+  def lockInputs(outpoints: Set[OutPoint])(implicit  ec: ExecutionContext): Future[Boolean]
+
+  /** Unlock wallet inputs. */
+  def unlockInputs(outpoints: Set[OutPoint])(implicit ec: ExecutionContext): Future[Boolean]
 
   /**
    * Tests whether the inputs of the provided transaction have been spent by another transaction.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -1279,7 +1279,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder, val 
     case Event(MakeFundingTxResponse(fundingTx, _, _), _) =>
       // this may happen if connection is lost, or remote sends an error while we were waiting for the funding tx to be created by our wallet
       // in that case we rollback the tx
-      wallet.rollback(fundingTx)
+      wallet.unlockInputs(fundingTx.txIn.map(_.outPoint).toSet)
       stay()
 
     case Event(INPUT_DISCONNECTED, _) => stay() // we are disconnected, but it doesn't matter anymore

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
@@ -320,7 +320,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
       Transactions.checkSpendable(signedLocalCommitTx) match {
         case Failure(cause) =>
           // we rollback the funding tx, it will never be published
-          wallet.rollback(fundingTx)
+          wallet.unlockInputs(fundingTx.txIn.map(_.outPoint).toSet)
           channelOpenReplyToUser(Left(LocalError(cause)))
           handleLocalError(InvalidCommitmentSignature(channelId, signedLocalCommitTx.tx.txid), d, Some(msg))
         case Success(_) =>
@@ -350,25 +350,25 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
 
     case Event(c: CloseCommand, d: DATA_WAIT_FOR_FUNDING_SIGNED) =>
       // we rollback the funding tx, it will never be published
-      wallet.rollback(d.fundingTx)
+      wallet.unlockInputs(d.fundingTx.txIn.map(_.outPoint).toSet)
       channelOpenReplyToUser(Right(ChannelOpenResponse.ChannelClosed(d.channelId)))
       handleFastClose(c, d.channelId)
 
     case Event(e: Error, d: DATA_WAIT_FOR_FUNDING_SIGNED) =>
       // we rollback the funding tx, it will never be published
-      wallet.rollback(d.fundingTx)
+      wallet.unlockInputs(d.fundingTx.txIn.map(_.outPoint).toSet)
       channelOpenReplyToUser(Left(RemoteError(e)))
       handleRemoteError(e, d)
 
     case Event(INPUT_DISCONNECTED, d: DATA_WAIT_FOR_FUNDING_SIGNED) =>
       // we rollback the funding tx, it will never be published
-      wallet.rollback(d.fundingTx)
+      wallet.unlockInputs(d.fundingTx.txIn.map(_.outPoint).toSet)
       channelOpenReplyToUser(Left(LocalError(new RuntimeException("disconnected"))))
       goto(CLOSED)
 
     case Event(TickChannelOpenTimeout, d: DATA_WAIT_FOR_FUNDING_SIGNED) =>
       // we rollback the funding tx, it will never be published
-      wallet.rollback(d.fundingTx)
+      wallet.unlockInputs(d.fundingTx.txIn.map(_.outPoint).toSet)
       channelOpenReplyToUser(Left(LocalError(new RuntimeException("open channel cancelled, took too long"))))
       goto(CLOSED)
   })

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/ReplaceableTxFunder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/ReplaceableTxFunder.scala
@@ -333,9 +333,9 @@ private class ReplaceableTxFunder(nodeParams: NodeParams,
   }
 
   def unlockAndStop(input: OutPoint, tx: Transaction, failure: TxPublisher.TxRejectedReason): Behavior[Command] = {
-    val toUnlock = tx.txIn.filterNot(_.outPoint == input).map(_.outPoint)
+    val toUnlock = tx.txIn.filterNot(_.outPoint == input).map(_.outPoint).toSet
     log.debug("unlocking utxos={}", toUnlock.mkString(", "))
-    context.pipeToSelf(bitcoinClient.unlockOutpoints(toUnlock))(_ => UtxosUnlocked)
+    context.pipeToSelf(bitcoinClient.unlockInputs(toUnlock))(_ => UtxosUnlocked)
     Behaviors.receiveMessagePartial {
       case UtxosUnlocked =>
         log.debug("utxos unlocked")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/ReplaceableTxPublisher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/ReplaceableTxPublisher.scala
@@ -313,12 +313,8 @@ private class ReplaceableTxPublisher(nodeParams: NodeParams,
     Behaviors.receiveMessagePartial {
       case UnlockUtxos =>
         val toUnlock = failedTx.txIn.map(_.outPoint).toSet -- mempoolTx.signedTx.txIn.map(_.outPoint).toSet
-        if (toUnlock.isEmpty) {
-          context.self ! UtxosUnlocked
-        } else {
-          log.debug("unlocking utxos={}", toUnlock.mkString(", "))
-          context.pipeToSelf(bitcoinClient.unlockOutpoints(toUnlock.toSeq))(_ => UtxosUnlocked)
-        }
+        log.debug("unlocking utxos={}", toUnlock.mkString(", "))
+        context.pipeToSelf(bitcoinClient.unlockInputs(toUnlock))(_ => UtxosUnlocked)
         Behaviors.same
       case UtxosUnlocked =>
         // Now that we've cleaned up the failed transaction, we can go back to waiting for the current mempool transaction
@@ -358,12 +354,8 @@ private class ReplaceableTxPublisher(nodeParams: NodeParams,
     Behaviors.receiveMessagePartial {
       case UnlockUtxos =>
         val toUnlock = txs.flatMap(_.txIn).filterNot(_.outPoint == input).map(_.outPoint).toSet
-        if (toUnlock.isEmpty) {
-          context.self ! UtxosUnlocked
-        } else {
-          log.debug("unlocking utxos={}", toUnlock.mkString(", "))
-          context.pipeToSelf(bitcoinClient.unlockOutpoints(toUnlock.toSeq))(_ => UtxosUnlocked)
-        }
+        log.debug("unlocking utxos={}", toUnlock.mkString(", "))
+        context.pipeToSelf(bitcoinClient.unlockInputs(toUnlock))(_ => UtxosUnlocked)
         Behaviors.same
       case UtxosUnlocked =>
         log.debug("utxos unlocked")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
@@ -220,12 +220,12 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       // Utxos are locked for the duration of the protocol.
       val probe = TestProbe()
       val bitcoinClientA = new BitcoinCoreClient(rpcClientA)
-      bitcoinClientA.listLockedOutpoints().pipeTo(probe.ref)
+      bitcoinClientA.listLockedInputs().pipeTo(probe.ref)
       val locksA = probe.expectMsgType[Set[OutPoint]]
       assert(locksA.size == 3)
       assert(locksA == Set(inputA1, inputA2, inputA3).map(toOutPoint))
       val bitcoinClientB = new BitcoinCoreClient(rpcClientB)
-      bitcoinClientB.listLockedOutpoints().pipeTo(probe.ref)
+      bitcoinClientB.listLockedInputs().pipeTo(probe.ref)
       val locksB = probe.expectMsgType[Set[OutPoint]]
       assert(locksB.size == 1)
       assert(locksB == Set(toOutPoint(inputB1)))
@@ -533,7 +533,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       assert(alice2bob.expectMsgType[LocalFailure].cause == ChannelFundingError(aliceParams.channelId))
       // Alice's utxos shouldn't be locked after the failed funding attempt.
       awaitAssert({
-        bitcoinClient.listLockedOutpoints().pipeTo(probe.ref)
+        bitcoinClient.listLockedInputs().pipeTo(probe.ref)
         assert(probe.expectMsgType[Set[OutPoint]].isEmpty)
       }, max = 10 seconds, interval = 100 millis)
     }
@@ -581,7 +581,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       assert(alice2bob.expectMsgType[LocalFailure].cause == ChannelFundingError(aliceParams.channelId))
       // Utxos shouldn't be locked after a failure.
       awaitAssert({
-        bitcoinClient.listLockedOutpoints().pipeTo(probe.ref)
+        bitcoinClient.listLockedInputs().pipeTo(probe.ref)
         assert(probe.expectMsgType[Set[OutPoint]].isEmpty)
       }, max = 10 seconds, interval = 100 millis)
     }
@@ -649,7 +649,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       legacyTxIds.foreach(txid => assert(!txA.signedTx.txIn.exists(_.outPoint.txid == txid)))
       // Only used utxos should be locked.
       awaitAssert({
-        bitcoinClient.listLockedOutpoints().pipeTo(probe.ref)
+        bitcoinClient.listLockedInputs().pipeTo(probe.ref)
         val locks = probe.expectMsgType[Set[OutPoint]]
         assert(locks == txA.signedTx.txIn.map(_.outPoint).toSet)
       }, max = 10 seconds, interval = 100 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/ReplaceableTxPublisherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/ReplaceableTxPublisherSpec.scala
@@ -651,7 +651,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
       // our parent will stop us when receiving the TxRejected message.
       publisher2 ! Stop
       awaitAssert({
-        wallet.listLockedOutpoints().pipeTo(probe.ref)
+        wallet.listLockedInputs().pipeTo(probe.ref)
         assert(!probe.expectMsgType[Set[OutPoint]].exists(_.txid != commitTx.tx.txid))
       })
 
@@ -678,7 +678,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
       // we unlock utxos before stopping
       publisher ! Stop
       awaitAssert({
-        wallet.listLockedOutpoints().pipeTo(probe.ref)
+        wallet.listLockedInputs().pipeTo(probe.ref)
         assert(probe.expectMsgType[Set[OutPoint]].isEmpty)
       })
     }
@@ -1125,7 +1125,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
       // our parent will stop us when receiving the TxRejected message.
       publisher2 ! Stop
       awaitAssert({
-        wallet.listLockedOutpoints().pipeTo(probe.ref)
+        wallet.listLockedInputs().pipeTo(probe.ref)
         assert(!probe.expectMsgType[Set[OutPoint]].exists(_.txid != commitTx.txid))
       })
 
@@ -1151,7 +1151,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
       // We unlock utxos before stopping.
       publisher ! Stop
       awaitAssert({
-        wallet.listLockedOutpoints().pipeTo(probe.ref)
+        wallet.listLockedInputs().pipeTo(probe.ref)
         assert(probe.expectMsgType[Set[OutPoint]].isEmpty)
       })
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -149,10 +149,10 @@ class WaitForFundingSignedStateSpec extends TestKitBaseClass with FixtureAnyFunS
   test("recv INPUT_DISCONNECTED") { f =>
     import f._
     val fundingTx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_SIGNED].fundingTx
-    assert(alice.underlyingActor.wallet.asInstanceOf[DummyOnChainWallet].rolledback.isEmpty)
+    assert(alice.underlyingActor.wallet.asInstanceOf[DummyOnChainWallet].unlocked.isEmpty)
     alice ! INPUT_DISCONNECTED
     awaitCond(alice.stateName == CLOSED)
-    assert(alice.underlyingActor.wallet.asInstanceOf[DummyOnChainWallet].rolledback.contains(fundingTx))
+    assert(alice.underlyingActor.wallet.asInstanceOf[DummyOnChainWallet].unlocked == fundingTx.txIn.map(_.outPoint).toSet)
     aliceOrigin.expectMsgType[Status.Failure]
   }
 


### PR DESCRIPTION
Unless it's necessary (e.g. when using 0-conf), we avoid locking inputs during interactive-tx sessions as it can be abused by malicious peers to lock some of our liquidity (griefing attack).

This PR is best reviewed commit-by-commit.

Builds on top of #2553