### PR TITLE
Wait for tx to be published for zero-conf

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -70,6 +70,7 @@ case class InvalidRbfFeerate                       (override val channelId: Byte
 case class InvalidRbfAlreadyInProgress             (override val channelId: ByteVector32) extends ChannelException(channelId, "invalid rbf attempt: the current rbf attempt must be completed or aborted first")
 case class InvalidRbfTxConfirmed                   (override val channelId: ByteVector32) extends ChannelException(channelId, "no need to rbf, transaction is already confirmed")
 case class InvalidRbfNonInitiator                  (override val channelId: ByteVector32) extends ChannelException(channelId, "cannot initiate rbf: we're not the initiator of this interactive-tx attempt")
+case class InvalidRbfZeroConf                      (override val channelId: ByteVector32) extends ChannelException(channelId, "cannot initiate rbf: we're using zero-conf for this interactive-tx attempt")
 case class InvalidRbfAttempt                       (override val channelId: ByteVector32) extends ChannelException(channelId, "invalid rbf attempt")
 case class NoMoreHtlcsClosingInProgress            (override val channelId: ByteVector32) extends ChannelException(channelId, "cannot send new htlcs, closing in progress")
 case class NoMoreFeeUpdateClosingInProgress        (override val channelId: ByteVector32) extends ChannelException(channelId, "cannot send new update_fee, closing in progress")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/FuzzySpec.scala
@@ -93,8 +93,6 @@ class FuzzySpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Channe
       val fundingTx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].fundingTx_opt.get
       alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx)
       bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx)
-      alice2blockchain.expectMsgType[WatchFundingLost]
-      bob2blockchain.expectMsgType[WatchFundingLost]
       awaitCond(alice.stateName == NORMAL, 1 minute)
       awaitCond(bob.stateName == NORMAL, 1 minute)
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -100,10 +100,10 @@ class WaitForFundingSignedStateSpec extends TestKitBaseClass with FixtureAnyFunS
     import f._
     bob2alice.expectMsgType[FundingSigned]
     bob2alice.forward(alice)
-    awaitCond(alice.stateName == WAIT_FOR_CHANNEL_READY)
-    // alice doesn't watch for the funding tx to confirm
+    awaitCond(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
+    // alice doesn't watch for the funding tx to confirm, she only waits for the transaction to be published
     alice2blockchain.expectMsgType[WatchFundingSpent]
-    alice2blockchain.expectMsgType[WatchFundingLost]
+    alice2blockchain.expectMsgType[WatchPublished]
     alice2blockchain.expectNoMessage(100 millis)
     aliceOrigin.expectMsgType[ChannelOpenResponse.ChannelOpened]
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
@@ -81,19 +81,22 @@ class WaitForDualFundingReadyStateSpec extends TestKitBaseClass with FixtureAnyF
       bob2alice.forward(alice)
       alice2bob.expectMsgType[TxSignatures]
       alice2bob.forward(bob)
-      if (!test.tags.contains(ChannelStateTestsTags.ZeroConf)) {
-        awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
-        awaitCond(bob.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
-        val fundingTx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED].fundingTx.asInstanceOf[FullySignedSharedTransaction].signedTx
+      awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
+      awaitCond(bob.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
+      val fundingTx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED].fundingTx.asInstanceOf[FullySignedSharedTransaction].signedTx
+      if (test.tags.contains(ChannelStateTestsTags.ZeroConf)) {
+        assert(alice2blockchain.expectMsgType[WatchPublished].txId == fundingTx.txid)
+        assert(bob2blockchain.expectMsgType[WatchPublished].txId == fundingTx.txid)
+        alice ! WatchPublishedTriggered(fundingTx)
+        bob ! WatchPublishedTriggered(fundingTx)
+      } else {
         assert(alice2blockchain.expectMsgType[WatchFundingConfirmed].txId == fundingTx.txid)
         assert(bob2blockchain.expectMsgType[WatchFundingConfirmed].txId == fundingTx.txid)
         alice ! WatchFundingConfirmedTriggered(BlockHeight(TestConstants.defaultBlockHeight), 42, fundingTx)
         bob ! WatchFundingConfirmedTriggered(BlockHeight(TestConstants.defaultBlockHeight), 42, fundingTx)
       }
       alice2blockchain.expectMsgType[WatchFundingSpent]
-      alice2blockchain.expectMsgType[WatchFundingLost]
       bob2blockchain.expectMsgType[WatchFundingSpent]
-      bob2blockchain.expectMsgType[WatchFundingLost]
       awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_READY)
       awaitCond(bob.stateName == WAIT_FOR_DUAL_FUNDING_READY)
       withFixture(test.toNoArgTest(FixtureParam(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -89,7 +89,8 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     // test starts here
     bob2alice.forward(alice)
     // alice stops waiting for confirmations since bob is accepting the channel
-    alice2blockchain.expectMsgType[WatchFundingLost]
+    assert(alice2blockchain.expectMsgType[WatchPublished].txId == fundingTx.txid)
+    alice ! WatchPublishedTriggered(fundingTx)
     alice2blockchain.expectMsgType[WatchFundingDeeplyBuried]
     val aliceChannelReady = alice2bob.expectMsgType[ChannelReady]
     assert(aliceChannelReady.alias_opt.nonEmpty)
@@ -137,7 +138,6 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     alice ! WatchFundingConfirmedTriggered(BlockHeight(42000), 42, fundingTx)
     assert(listener.expectMsgType[TransactionConfirmed].tx == fundingTx)
     awaitCond(alice.stateName == WAIT_FOR_CHANNEL_READY)
-    alice2blockchain.expectMsgType[WatchFundingLost]
     val channelReady = alice2bob.expectMsgType[ChannelReady]
     // we always send an alias
     assert(channelReady.alias_opt.isDefined)
@@ -157,7 +157,6 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     assert(txPublished.miningFee == 0.sat) // bob is fundee
     assert(listener.expectMsgType[TransactionConfirmed].tx == fundingTx)
     awaitCond(bob.stateName == WAIT_FOR_CHANNEL_READY)
-    bob2blockchain.expectMsgType[WatchFundingLost]
     val channelReady = bob2alice.expectMsgType[ChannelReady]
     // we always send an alias
     assert(channelReady.alias_opt.isDefined)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/interop/rustytests/RustyTestsSpec.scala
@@ -91,8 +91,6 @@ class RustyTestsSpec extends TestKitBaseClass with Matchers with FixtureAnyFunSu
       val fundingTx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_CONFIRMED].fundingTx_opt.get
       alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx)
       bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx)
-      alice2blockchain.expectMsgType[WatchFundingLost]
-      bob2blockchain.expectMsgType[WatchFundingLost]
       awaitCond(alice.stateName == NORMAL)
       awaitCond(bob.stateName == NORMAL)
       pipe ! new File(getClass.getResource(s"/scenarii/${test.name}.script").getFile)


### PR DESCRIPTION
When using zero-conf, we wait for the transaction to be published before using a channel. This guarantees that the bitcoind wallet has successfully recorded the transaction and won't double-spend it.

Otherwise if the transaction fails to publish and the utxos are unlocked, or if bitcoind is restarted, we may accidentally double-spend it which would break the channel and be very painful to recover.