### PR TITLE
Update final onchain address when possible

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
@@ -148,7 +148,7 @@ object CheckBalance {
     val toLocal = if (c.channelFeatures.paysDirectlyToWallet) {
       // If static remote key is enabled, the commit tx directly pays to our wallet
       // We use the pubkeyscript to retrieve our output
-      Transactions.findPubKeyScriptIndex(remoteCommitPublished.commitTx, c.localParams.defaultFinalScriptPubKey) match {
+      Transactions.findPubKeyScriptIndex(remoteCommitPublished.commitTx, c.localParams.actualFinalScriptPubKey) match {
         case Right(outputIndex) => Map(remoteCommitPublished.commitTx.txid -> remoteCommitPublished.commitTx.txOut(outputIndex).amount.toBtc)
         case _ => Map.empty[ByteVector32, Btc] // either we don't have an output (below dust), or we have used a non-default pubkey script
       }
@@ -225,7 +225,7 @@ object CheckBalance {
                   // Normally this would mean that we don't actually have an output, but due to a migration
                   // the data might not be accurate, see [[ChannelTypes0.migrateClosingTx]]
                   // As a (hackish) workaround, we use the pubkeyscript to retrieve our output
-                  Transactions.findPubKeyScriptIndex(mutualClose.tx, d.commitments.localParams.defaultFinalScriptPubKey) match {
+                  Transactions.findPubKeyScriptIndex(mutualClose.tx, d.commitments.localParams.actualFinalScriptPubKey) match {
                     case Right(outputIndex) => mutualClose.tx.txOut(outputIndex).amount
                     case _ => 0.sat // either we don't have an output (below dust), or we have used a non-default pubkey script
                   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -564,6 +564,7 @@ case class LocalParams(nodeId: PublicKey,
                        maxAcceptedHtlcs: Int,
                        isInitiator: Boolean,
                        defaultFinalScriptPubKey: ByteVector,
+                       actualFinalScriptPubKey: ByteVector,
                        walletStaticPaymentBasepoint: Option[PublicKey],
                        initFeatures: Features[InitFeature])
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -595,6 +595,7 @@ object Peer {
       maxAcceptedHtlcs = nodeParams.channelConf.maxAcceptedHtlcs,
       isInitiator = isInitiator,
       defaultFinalScriptPubKey = defaultFinalScriptPubkey,
+      actualFinalScriptPubKey = defaultFinalScriptPubkey,
       walletStaticPaymentBasepoint = walletStaticPaymentBasepoint,
       initFeatures = initFeatures)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -84,6 +84,10 @@ package object eclair {
     Bitcoin.addressToPublicKeyScript(chainHash, address).asScala.toSeq.map(kmp2scala)
   }
 
+  def addressFromPublicKeyScript(pubKeyScript: ByteVector, chainHash: ByteVector32): String = {
+    Bitcoin.addressFromPublicKeyScript(chainHash, pubKeyScript.toArray)
+  }
+
   implicit class MilliSatoshiLong(private val n: Long) extends AnyVal {
     def msat = MilliSatoshi(n)
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/ChannelCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/ChannelCodecs.scala
@@ -21,6 +21,7 @@ import fr.acinq.eclair.wire.internal.channel.version0.ChannelCodecs0
 import fr.acinq.eclair.wire.internal.channel.version1.ChannelCodecs1
 import fr.acinq.eclair.wire.internal.channel.version2.ChannelCodecs2
 import fr.acinq.eclair.wire.internal.channel.version3.ChannelCodecs3
+import fr.acinq.eclair.wire.internal.channel.version4.ChannelCodecs4
 import grizzled.slf4j.Logging
 import scodec.Codec
 import scodec.codecs.{byte, discriminated}
@@ -66,7 +67,8 @@ object ChannelCodecs extends Logging {
    * More info here: https://github.com/scodec/scodec/issues/122
    */
   val channelDataCodec: Codec[PersistentChannelData] = discriminated[PersistentChannelData].by(byte)
-    .typecase(3, ChannelCodecs3.channelDataCodec)
+    .typecase(4, ChannelCodecs4.channelDataCodec)
+    .typecase(3, ChannelCodecs3.channelDataCodec.decodeOnly)
     .typecase(2, ChannelCodecs2.channelDataCodec.decodeOnly)
     .typecase(1, ChannelCodecs1.channelDataCodec.decodeOnly)
     .typecase(0, ChannelCodecs0.channelDataCodec.decodeOnly)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelCodecs0.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelCodecs0.scala
@@ -75,7 +75,9 @@ private[channel] object ChannelCodecs0 {
         ("isInitiator" | bool) ::
         ("defaultFinalScriptPubKey" | varsizebinarydata) ::
         ("walletStaticPaymentBasepoint" | optional(provide(channelVersion.paysDirectlyToWallet), publicKey)) ::
-        ("features" | combinedFeaturesCodec)).as[LocalParams].decodeOnly
+        ("features" | combinedFeaturesCodec)).map { case nodeId :: channelPath :: dustLimit :: maxHtlcValueInFlightMsat :: channelReserve :: htlcMinimum :: toSelfDelay :: maxAcceptedHtlcs :: isInitiator :: defaultFinalScriptPubKey :: walletStaticPaymentBasepoint :: features :: HNil =>
+      LocalParams(nodeId, channelPath, dustLimit, maxHtlcValueInFlightMsat, channelReserve, htlcMinimum, toSelfDelay, maxAcceptedHtlcs, isInitiator, defaultFinalScriptPubKey, defaultFinalScriptPubKey, walletStaticPaymentBasepoint, features)
+    }.decodeOnly
 
     val remoteParamsCodec: Codec[RemoteParams] = (
       ("nodeId" | publicKey) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version1/ChannelCodecs1.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version1/ChannelCodecs1.scala
@@ -62,7 +62,12 @@ private[channel] object ChannelCodecs1 {
         ("isInitiator" | bool8) ::
         ("defaultFinalScriptPubKey" | lengthDelimited(bytes)) ::
         ("walletStaticPaymentBasepoint" | optional(provide(channelVersion.paysDirectlyToWallet), publicKey)) ::
-        ("features" | combinedFeaturesCodec)).as[LocalParams]
+        ("features" | combinedFeaturesCodec)).xmap(
+      {
+        case nodeId :: channelPath :: dustLimit :: maxHtlcValueInFlightMsat :: channelReserve :: htlcMinimum :: toSelfDelay :: maxAcceptedHtlcs :: isInitiator :: defaultFinalScriptPubKey :: walletStaticPaymentBasepoint :: features :: HNil =>
+          LocalParams(nodeId, channelPath, dustLimit, maxHtlcValueInFlightMsat, channelReserve, htlcMinimum, toSelfDelay, maxAcceptedHtlcs, isInitiator, defaultFinalScriptPubKey, defaultFinalScriptPubKey, walletStaticPaymentBasepoint, features)
+
+      }, (lp => lp.nodeId :: lp.fundingKeyPath :: lp.dustLimit :: lp.maxHtlcValueInFlightMsat :: lp.requestedChannelReserve_opt :: lp.htlcMinimum :: lp.toSelfDelay :: lp.maxAcceptedHtlcs :: lp.isInitiator :: lp.defaultFinalScriptPubKey :: lp.walletStaticPaymentBasepoint :: lp.initFeatures :: HNil))
 
     val remoteParamsCodec: Codec[RemoteParams] = (
       ("nodeId" | publicKey) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2.scala
@@ -62,7 +62,9 @@ private[channel] object ChannelCodecs2 {
         ("isInitiator" | bool8) ::
         ("defaultFinalScriptPubKey" | lengthDelimited(bytes)) ::
         ("walletStaticPaymentBasepoint" | optional(provide(channelVersion.paysDirectlyToWallet), publicKey)) ::
-        ("features" | combinedFeaturesCodec)).as[LocalParams]
+        ("features" | combinedFeaturesCodec)).map { case nodeId :: channelPath :: dustLimit :: maxHtlcValueInFlightMsat :: channelReserve :: htlcMinimum :: toSelfDelay :: maxAcceptedHtlcs :: isInitiator :: defaultFinalScriptPubKey :: walletStaticPaymentBasepoint :: features :: HNil =>
+      LocalParams(nodeId, channelPath, dustLimit, maxHtlcValueInFlightMsat, channelReserve, htlcMinimum, toSelfDelay, maxAcceptedHtlcs, isInitiator, defaultFinalScriptPubKey, defaultFinalScriptPubKey, walletStaticPaymentBasepoint, features)
+    }.decodeOnly
 
     val remoteParamsCodec: Codec[RemoteParams] = (
       ("nodeId" | publicKey) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version4/ChannelCodecs4.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version4/ChannelCodecs4.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package fr.acinq.eclair.wire.internal.channel.version3
+package fr.acinq.eclair.wire.internal.channel.version4
 
 import fr.acinq.bitcoin.scalacompat.DeterministicWallet.KeyPath
 import fr.acinq.bitcoin.scalacompat.{OutPoint, Transaction, TxOut}
@@ -32,9 +32,9 @@ import scodec.codecs._
 import scodec.{Attempt, Codec}
 import shapeless.{::, HNil}
 
-private[channel] object ChannelCodecs3 {
+private[channel] object ChannelCodecs4 {
 
-  private[version3] object Codecs {
+  private[version4] object Codecs {
 
     val keyPathCodec: Codec[KeyPath] = ("path" | listOfN(uint16, uint32)).xmap[KeyPath](l => KeyPath(l), keyPath => keyPath.path.toList).as[KeyPath]
 
@@ -72,12 +72,9 @@ private[channel] object ChannelCodecs3 {
         ("maxAcceptedHtlcs" | uint16) ::
         ("isInitiator" | bool8) ::
         ("defaultFinalScriptPubKey" | lengthDelimited(bytes)) ::
+        ("actualFinalScriptPubKey" | lengthDelimited(bytes)) ::
         ("walletStaticPaymentBasepoint" | optional(provide(channelFeatures.paysDirectlyToWallet), publicKey)) ::
-        ("features" | combinedFeaturesCodec)).xmap({
-      case nodeId :: channelPath :: dustLimit :: maxHtlcValueInFlightMsat :: channelReserve :: htlcMinimum :: toSelfDelay :: maxAcceptedHtlcs :: isInitiator :: defaultFinalScriptPubKey :: walletStaticPaymentBasepoint :: features :: HNil =>
-        LocalParams(nodeId, channelPath, dustLimit, maxHtlcValueInFlightMsat, channelReserve, htlcMinimum, toSelfDelay, maxAcceptedHtlcs, isInitiator, defaultFinalScriptPubKey, defaultFinalScriptPubKey, walletStaticPaymentBasepoint, features)
-
-    }, (lp => lp.nodeId :: lp.fundingKeyPath :: lp.dustLimit :: lp.maxHtlcValueInFlightMsat :: lp.requestedChannelReserve_opt :: lp.htlcMinimum :: lp.toSelfDelay :: lp.maxAcceptedHtlcs :: lp.isInitiator :: lp.defaultFinalScriptPubKey :: lp.walletStaticPaymentBasepoint :: lp.initFeatures :: HNil))
+        ("features" | combinedFeaturesCodec)).as[LocalParams]
 
     def remoteParamsCodec(channelFeatures: ChannelFeatures): Codec[RemoteParams] = (
       ("nodeId" | publicKey) ::

--- a/eclair-core/src/test/resources/nonreg/codecs/000003-DATA_NORMAL/fundee-announced/data.json
+++ b/eclair-core/src/test/resources/nonreg/codecs/000003-DATA_NORMAL/fundee-announced/data.json
@@ -17,6 +17,7 @@
       "maxAcceptedHtlcs" : 30,
       "isInitiator" : false,
       "defaultFinalScriptPubKey" : "a9144805d016e47885dc7c852710cdd8cd0d576f57ec87",
+      "actualFinalScriptPubKey" : "a9144805d016e47885dc7c852710cdd8cd0d576f57ec87",
       "initFeatures" : {
         "activated" : {
           "option_data_loss_protect" : "optional",

--- a/eclair-core/src/test/resources/nonreg/codecs/000003-DATA_NORMAL/funder/data.json
+++ b/eclair-core/src/test/resources/nonreg/codecs/000003-DATA_NORMAL/funder/data.json
@@ -17,6 +17,7 @@
       "maxAcceptedHtlcs" : 30,
       "isInitiator" : true,
       "defaultFinalScriptPubKey" : "a91445e990148599176534ec9b75df92ace9263f7d3487",
+      "actualFinalScriptPubKey" : "a91445e990148599176534ec9b75df92ace9263f7d3487",
       "initFeatures" : {
         "activated" : {
           "option_data_loss_protect" : "optional",

--- a/eclair-core/src/test/resources/nonreg/codecs/020002-DATA_NORMAL/funder-announced/data.json
+++ b/eclair-core/src/test/resources/nonreg/codecs/020002-DATA_NORMAL/funder-announced/data.json
@@ -17,6 +17,7 @@
       "maxAcceptedHtlcs" : 30,
       "isInitiator" : true,
       "defaultFinalScriptPubKey" : "00148061b7fbd2d84ed1884177ea785faecb2080b103",
+      "actualFinalScriptPubKey" : "00148061b7fbd2d84ed1884177ea785faecb2080b103",
       "walletStaticPaymentBasepoint" : "02e56c8eca8d4f00df84ac34c23f49c006d57d316b7ada5c346e9d4211e11604b3",
       "initFeatures" : {
         "activated" : {

--- a/eclair-core/src/test/resources/nonreg/codecs/030000-DATA_WAIT_FOR_FUNDING_CONFIRMED/funder/data.json
+++ b/eclair-core/src/test/resources/nonreg/codecs/030000-DATA_WAIT_FOR_FUNDING_CONFIRMED/funder/data.json
@@ -17,6 +17,7 @@
       "maxAcceptedHtlcs" : 100,
       "isInitiator" : true,
       "defaultFinalScriptPubKey" : "0014fec406ef7a0258cb503fe1f1803787d971eeb4d1",
+      "actualFinalScriptPubKey" : "0014fec406ef7a0258cb503fe1f1803787d971eeb4d1",
       "initFeatures" : {
         "activated" : {
           "payment_secret" : "mandatory",

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -17,8 +17,8 @@
 package fr.acinq.eclair
 
 import com.typesafe.config.{Config, ConfigFactory}
-import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.bitcoin.scalacompat.{Block, SatoshiLong}
+import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
+import fr.acinq.bitcoin.scalacompat.{Block, SatoshiLong, Script}
 import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
 import fr.acinq.eclair.Features._
 import fr.acinq.eclair.blockchain.fee.{DustTolerance, FeeratePerByte, FeeratePerKw, FeerateTolerance}
@@ -27,7 +27,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits.{ByteVector, HexStringSyntax}
 
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
@@ -37,11 +37,12 @@ class StartupSpec extends AnyFunSuite {
 
   def makeNodeParamsWithDefaults(conf: Config): NodeParams = {
     val blockCount = new AtomicLong(0)
+    val finalScriptPubKey = new AtomicReference[ByteVector](Script.write(Script.pay2wpkh(PrivateKey(ByteVector.fromValidHex("01" * 32)).publicKey)))
     val nodeKeyManager = new LocalNodeKeyManager(randomBytes32(), chainHash = Block.TestnetGenesisBlock.hash)
     val channelKeyManager = new LocalChannelKeyManager(randomBytes32(), chainHash = Block.TestnetGenesisBlock.hash)
     val feeEstimator = new TestFeeEstimator()
     val db = TestDatabases.inMemoryDb()
-    NodeParams.makeNodeParams(conf, UUID.fromString("01234567-0123-4567-89ab-0123456789ab"), nodeKeyManager, channelKeyManager, None, db, blockCount, feeEstimator)
+    NodeParams.makeNodeParams(conf, UUID.fromString("01234567-0123-4567-89ab-0123456789ab"), nodeKeyManager, channelKeyManager, None, db, blockCount, feeEstimator, finalScriptPubKey)
   }
 
   test("check configuration") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -16,6 +16,7 @@
 
 package fr.acinq.eclair
 
+import fr.acinq.bitcoin.scalacompat.Crypto.PrivateKey
 import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, Satoshi, SatoshiLong, Script}
 import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
 import fr.acinq.eclair.Features._
@@ -35,7 +36,7 @@ import org.scalatest.Tag
 import scodec.bits.{ByteVector, HexStringSyntax}
 
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 import scala.concurrent.duration._
 
 /**
@@ -208,7 +209,8 @@ object TestConstants {
         relayPolicy = RelayAll,
         timeout = 1 minute
       ),
-      purgeInvoicesInterval = None
+      purgeInvoicesInterval = None,
+      finalScriptPubKey = new AtomicReference[ByteVector](Script.write(Script.pay2wpkh(PrivateKey(ByteVector.fromValidHex("01" * 32)).publicKey)))
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(
@@ -357,7 +359,8 @@ object TestConstants {
         relayPolicy = RelayAll,
         timeout = 1 minute
       ),
-      purgeInvoicesInterval = None
+      purgeInvoicesInterval = None,
+      finalScriptPubKey = new AtomicReference[ByteVector](Script.write(Script.pay2wpkh(PrivateKey(ByteVector.fromValidHex("02" * 32)).publicKey)))
     )
 
     def channelParams: LocalParams = Peer.makeChannelParams(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -486,7 +486,7 @@ object CommitmentsSpec {
 
   def makeCommitments(toLocal: MilliSatoshi, toRemote: MilliSatoshi, feeRatePerKw: FeeratePerKw = FeeratePerKw(0 sat), dustLimit: Satoshi = 0 sat, isInitiator: Boolean = true, announceChannel: Boolean = true): Commitments = {
     val channelReserve = (toLocal + toRemote).truncateToSatoshi * 0.01
-    val localParams = LocalParams(randomKey().publicKey, DeterministicWallet.KeyPath(Seq(42L)), dustLimit, Long.MaxValue.msat, Some(channelReserve), 1 msat, CltvExpiryDelta(144), 50, isInitiator, ByteVector.empty, None, Features.empty)
+    val localParams = LocalParams(randomKey().publicKey, DeterministicWallet.KeyPath(Seq(42L)), dustLimit, Long.MaxValue.msat, Some(channelReserve), 1 msat, CltvExpiryDelta(144), 50, isInitiator, ByteVector.empty, ByteVector.empty, None, Features.empty)
     val remoteParams = RemoteParams(randomKey().publicKey, dustLimit, UInt64.MaxValue, Some(channelReserve), 1 msat, CltvExpiryDelta(144), 50, randomKey().publicKey, randomKey().publicKey, randomKey().publicKey, randomKey().publicKey, randomKey().publicKey, Features.empty, None)
     val commitmentInput = Funding.makeFundingInputInfo(randomBytes32(), 0, (toLocal + toRemote).truncateToSatoshi, randomKey().publicKey, remoteParams.fundingPubKey)
     Commitments(
@@ -510,7 +510,7 @@ object CommitmentsSpec {
 
   def makeCommitments(toLocal: MilliSatoshi, toRemote: MilliSatoshi, localNodeId: PublicKey, remoteNodeId: PublicKey, announceChannel: Boolean): Commitments = {
     val channelReserve = (toLocal + toRemote).truncateToSatoshi * 0.01
-    val localParams = LocalParams(localNodeId, DeterministicWallet.KeyPath(Seq(42L)), 0 sat, Long.MaxValue.msat, Some(channelReserve), 1 msat, CltvExpiryDelta(144), 50, isInitiator = true, ByteVector.empty, None, Features.empty)
+    val localParams = LocalParams(localNodeId, DeterministicWallet.KeyPath(Seq(42L)), 0 sat, Long.MaxValue.msat, Some(channelReserve), 1 msat, CltvExpiryDelta(144), 50, isInitiator = true, ByteVector.empty, ByteVector.empty, None, Features.empty)
     val remoteParams = RemoteParams(remoteNodeId, 0 sat, UInt64.MaxValue, Some(channelReserve), 1 msat, CltvExpiryDelta(144), 50, randomKey().publicKey, randomKey().publicKey, randomKey().publicKey, randomKey().publicKey, randomKey().publicKey, Features.empty, None)
     val commitmentInput = Funding.makeFundingInputInfo(randomBytes32(), 0, (toLocal + toRemote).truncateToSatoshi, randomKey().publicKey, remoteParams.fundingPubKey)
     Commitments(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
@@ -7,7 +7,8 @@ import akka.actor.{ActorRef, ActorSystem}
 import akka.testkit.{TestActor, TestProbe}
 import com.softwaremill.quicklens.ModifyPimp
 import com.typesafe.config.ConfigFactory
-import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, Satoshi, SatoshiLong, Transaction}
+import fr.acinq.bitcoin.scalacompat.Crypto.PrivateKey
+import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, Satoshi, SatoshiLong, Script, Transaction}
 import fr.acinq.eclair.ShortChannelId.txIndex
 import fr.acinq.eclair.blockchain.DummyOnChainWallet
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
@@ -30,10 +31,11 @@ import fr.acinq.eclair.wire.protocol.IPAddress
 import fr.acinq.eclair.{BlockHeight, MilliSatoshi, NodeParams, RealShortChannelId, SubscriptionsComplete, TestBitcoinCoreClient, TestDatabases, TestFeeEstimator}
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{Assertions, EitherValues}
+import scodec.bits.ByteVector
 
 import java.net.InetAddress
 import java.util.UUID
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
 import scala.concurrent.duration.DurationInt
 import scala.util.Random
 
@@ -68,7 +70,8 @@ object MinimalNodeFixture extends Assertions with Eventually with IntegrationPat
       torAddress_opt = None,
       database = TestDatabases.inMemoryDb(),
       blockHeight = new AtomicLong(400_000),
-      feeEstimator = new TestFeeEstimator(FeeratePerKw(253 sat))
+      feeEstimator = new TestFeeEstimator(FeeratePerKw(253 sat)),
+      finalScriptPubKey = new AtomicReference[ByteVector](Script.write(Script.pay2wpkh(PrivateKey(seed).publicKey)))
     ).modify(_.alias).setTo(alias)
       .modify(_.chainHash).setTo(Block.RegtestGenesisBlock.hash)
       .modify(_.routerConf.routerBroadcastInterval).setTo(1 second)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
@@ -699,7 +699,7 @@ object PaymentPacketSpec {
 
   def makeCommitments(channelId: ByteVector32, testAvailableBalanceForSend: MilliSatoshi = 50000000 msat, testAvailableBalanceForReceive: MilliSatoshi = 50000000 msat, testCapacity: Satoshi = 100000 sat, channelFeatures: ChannelFeatures = ChannelFeatures()): Commitments = {
     val channelReserve = testCapacity * 0.01
-    val params = LocalParams(null, null, null, Long.MaxValue.msat, Some(channelReserve), null, null, 0, isInitiator = true, null, None, null)
+    val params = LocalParams(null, null, null, Long.MaxValue.msat, Some(channelReserve), null, null, 0, isInitiator = true, null, null, None, null)
     val remoteParams = RemoteParams(randomKey().publicKey, null, UInt64.MaxValue, Some(channelReserve), null, null, maxAcceptedHtlcs = 0, null, null, null, null, null, null, None)
     val commitInput = InputInfo(OutPoint(randomBytes32(), 1), TxOut(testCapacity, Nil), Nil)
     val channelFlags = ChannelFlags.Private

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/ChannelCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/ChannelCodecsSpec.scala
@@ -93,7 +93,7 @@ class ChannelCodecsSpec extends AnyFunSuite {
     // and re-encode it with the new codec
     val bin_new = ByteVector(channelDataCodec.encode(data_new).require.toByteVector.toArray)
     // data should now be encoded under the new format
-    assert(bin_new.startsWith(hex"030000"))
+    assert(bin_new.startsWith(hex"040000"))
     // now let's decode it again
     val data_new2 = channelDataCodec.decode(bin_new.toBitVector).require.value
     // data should match perfectly
@@ -177,7 +177,7 @@ class ChannelCodecsSpec extends AnyFunSuite {
       // and we encode with the new codec
       val newBin = channelDataCodec.encode(decoded1).require.bytes
       // make sure that encoding used the new codec
-      assert(newBin.startsWith(hex"0300"))
+      assert(newBin.startsWith(hex"0400"))
       // make sure that round-trip yields the same data
       val decoded2 = channelDataCodec.decode(newBin.bits).require.value
       assert(decoded1 == decoded2)
@@ -262,6 +262,7 @@ object ChannelCodecsSpec {
     toSelfDelay = CltvExpiryDelta(144),
     maxAcceptedHtlcs = 50,
     defaultFinalScriptPubKey = ByteVector.empty,
+    actualFinalScriptPubKey = ByteVector.empty,
     walletStaticPaymentBasepoint = None,
     isInitiator = true,
     initFeatures = Features.empty)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version1/ChannelCodecs1Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version1/ChannelCodecs1Spec.scala
@@ -58,6 +58,7 @@ class ChannelCodecs1Spec extends AnyFunSuite {
       assert(localParams == decoded.value)
     }
 
+    val finalScriptPubKey = Script.write(Script.pay2wpkh(PrivateKey(randomBytes32()).publicKey))
     val o = LocalParams(
       nodeId = randomKey().publicKey,
       fundingKeyPath = DeterministicWallet.KeyPath(Seq(42L)),
@@ -67,7 +68,8 @@ class ChannelCodecs1Spec extends AnyFunSuite {
       htlcMinimum = MilliSatoshi(Random.nextInt(Int.MaxValue)),
       toSelfDelay = CltvExpiryDelta(Random.nextInt(Short.MaxValue)),
       maxAcceptedHtlcs = Random.nextInt(Short.MaxValue),
-      defaultFinalScriptPubKey = Script.write(Script.pay2wpkh(PrivateKey(randomBytes32()).publicKey)),
+      defaultFinalScriptPubKey = finalScriptPubKey,
+      actualFinalScriptPubKey = finalScriptPubKey,
       walletStaticPaymentBasepoint = None,
       isInitiator = Random.nextBoolean(),
       initFeatures = Features(randomBytes(256)).initFeatures())

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3Spec.scala
@@ -118,6 +118,7 @@ class ChannelCodecs3Spec extends AnyFunSuite {
       50,
       Random.nextBoolean(),
       hex"deadbeef",
+      hex"deadbeef",
       None,
       Features().initFeatures())
     val remoteParams = RemoteParams(


### PR DESCRIPTION
When a channel gets closed, and when possible, we send all onchain funds to a recent onchain address and not to an address that was generated when the channel was created. This is possible in all cases except when mutual-closing a channel that sets `upfront-shutdown-script`.