### PR TITLE
Make creation of first commit tx more generic

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -565,7 +565,11 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
 
   private def signCommitTx(completeTx: SharedTransaction, fundingOutputIndex: Int): Behavior[Command] = {
     val fundingTx = completeTx.buildUnsignedTx()
-    Funding.makeFirstCommitTxs(keyManager, channelConfig, channelFeatures, fundingParams.channelId, localParams, remoteParams, fundingParams.localAmount, fundingParams.remoteAmount, localPushAmount, remotePushAmount, commitTxFeerate, fundingTx.hash, fundingOutputIndex, remoteFirstPerCommitmentPoint) match {
+    Funding.makeCommitTxsWithoutHtlcs(keyManager, channelConfig, channelFeatures, fundingParams.channelId, localParams, remoteParams,
+      fundingAmount = fundingParams.fundingAmount,
+      toLocal = fundingParams.localAmount - localPushAmount + remotePushAmount,
+      toRemote = fundingParams.remoteAmount - remotePushAmount + localPushAmount,
+      commitTxFeerate, fundingTx.hash, fundingOutputIndex, remoteFirstPerCommitmentPoint, commitmentIndex = 0) match {
       case Left(cause) =>
         replyTo ! RemoteFailure(cause)
         unlockAndStop(completeTx)


### PR DESCRIPTION
In preparation for splices, we make `makeFirstCommitTxs` more generic:
- expose the `commitmentIndex`, which was hardcoded to `0`
- take the funding/push amounts arithmetic out

We rename the existing method to `makeCommitTxsWithoutHtlcs` and define a new `makeFirstCommitTxs` with the exact same signature as before, making the change transparent from the outside.