### PR TITLE
Add `GetNode` router API

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -11,6 +11,7 @@
 - `audit` now accepts `--count` and `--skip` parameters to limit the number of retrieved items (#2474, #2487)
 - `sendtoroute` removes the `--trampolineNodes` argument and implicitly uses a single trampoline hop (#2480)
 - `payinvoice` always returns the payment result when used with `--blocking`, even when using MPP (#2525)
+- `node` returns high-level information about a remote node (#2568)
 
 ### Miscellaneous improvements and bug fixes
 

--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -56,6 +56,7 @@ and COMMAND is one of the available commands:
     - findroute
     - findroutetonode
     - findroutebetweennodes
+    - node
     - nodes
 
   === Invoice ===

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -48,6 +48,50 @@ import scala.concurrent.duration._
 
 class RouterSpec extends BaseRouterSpec {
 
+  test("properly announce valid new nodes announcements and ignore invalid ones") { fixture =>
+    import fixture._
+    val eventListener = TestProbe()
+    system.eventStream.subscribe(eventListener.ref, classOf[NetworkEvent])
+    system.eventStream.subscribe(eventListener.ref, classOf[Rebroadcast])
+    val peerConnection = TestProbe()
+
+    {
+      // continue to rebroadcast node updates with deprecated Torv2 addresses
+      val torv2Address = List(NodeAddress.fromParts("hsmithsxurybd7uh.onion", 9735).get)
+      val node_c_torv2 = makeNodeAnnouncement(priv_c, "node-C", Color(123, 100, -40), torv2Address, TestConstants.Bob.nodeParams.features.nodeAnnouncementFeatures(), timestamp = TimestampSecond.now() + 1)
+      peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, node_c_torv2))
+      peerConnection.expectMsg(TransportHandler.ReadAck(node_c_torv2))
+      peerConnection.expectMsg(GossipDecision.Accepted(node_c_torv2))
+      eventListener.expectMsg(NodeUpdated(node_c_torv2))
+      router ! Router.TickBroadcast
+      val rebroadcast = eventListener.expectMsgType[Rebroadcast]
+      assert(rebroadcast.nodes.contains(node_c_torv2))
+    }
+    {
+      // rebroadcast node updates with a single DNS hostname addresses
+      val hostname = List(NodeAddress.fromParts("acinq.co", 9735).get)
+      val node_c_hostname = makeNodeAnnouncement(priv_c, "node-C", Color(123, 100, -40), hostname, TestConstants.Bob.nodeParams.features.nodeAnnouncementFeatures(), timestamp = TimestampSecond.now() + 10)
+      peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, node_c_hostname))
+      peerConnection.expectMsg(TransportHandler.ReadAck(node_c_hostname))
+      peerConnection.expectMsg(GossipDecision.Accepted(node_c_hostname))
+      eventListener.expectMsg(NodeUpdated(node_c_hostname))
+      router ! Router.TickBroadcast
+      val rebroadcast = eventListener.expectMsgType[Rebroadcast]
+      assert(rebroadcast.nodes.contains(node_c_hostname))
+    }
+    {
+      // do NOT rebroadcast node updates with more than one DNS hostname addresses
+      val multiHostnames = List(NodeAddress.fromParts("acinq.co", 9735).get, NodeAddress.fromParts("acinq.fr", 9735).get)
+      val node_c_noForward = makeNodeAnnouncement(priv_c, "node-C", Color(123, 100, -40), multiHostnames, TestConstants.Bob.nodeParams.features.nodeAnnouncementFeatures(), timestamp = TimestampSecond.now() + 20)
+      peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, node_c_noForward))
+      peerConnection.expectMsg(TransportHandler.ReadAck(node_c_noForward))
+      peerConnection.expectMsg(GossipDecision.Accepted(node_c_noForward))
+      eventListener.expectMsg(NodeUpdated(node_c_noForward))
+      router ! Router.TickBroadcast
+      eventListener.expectNoMessage(100 millis)
+    }
+  }
+
   test("properly announce valid new channels and ignore invalid ones") { fixture =>
     import fixture._
     val eventListener = TestProbe()
@@ -260,6 +304,17 @@ class RouterSpec extends BaseRouterSpec {
     }
 
     watcher.expectNoMessage(100 millis)
+  }
+
+  test("get nodes") { fixture =>
+    import fixture._
+
+    val probe = TestProbe()
+    val unknownNodeId = randomKey().publicKey
+    probe.send(router, GetNode(unknownNodeId))
+    probe.expectMsg(UnknownNode(unknownNodeId))
+    probe.send(router, GetNode(b))
+    probe.expectMsg(PublicNode(node_b, 2, publicChannelCapacity * 2))
   }
 
   test("properly announce lost channels and nodes") { fixture =>
@@ -1040,49 +1095,4 @@ class RouterSpec extends BaseRouterSpec {
     }
   }
 
-  test("properly announce valid new nodes announcements and ignore invalid ones") { fixture =>
-    import fixture._
-    val eventListener = TestProbe()
-    system.eventStream.subscribe(eventListener.ref, classOf[NetworkEvent])
-    system.eventStream.subscribe(eventListener.ref, classOf[Rebroadcast])
-    val peerConnection = TestProbe()
-
-    {
-      // continue to rebroadcast node updates with deprecated Torv2 addresses
-      val torv2Address = List(NodeAddress.fromParts("hsmithsxurybd7uh.onion", 9735).get)
-      val node_c_torv2 = makeNodeAnnouncement(priv_c, "node-C", Color(123, 100, -40), torv2Address, TestConstants.Bob.nodeParams.features.nodeAnnouncementFeatures(), timestamp = TimestampSecond.now() + 1)
-      peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, node_c_torv2))
-      peerConnection.expectMsg(TransportHandler.ReadAck(node_c_torv2))
-      peerConnection.expectMsg(GossipDecision.Accepted(node_c_torv2))
-      eventListener.expectMsg(NodeUpdated(node_c_torv2))
-      router ! Router.TickBroadcast
-      val rebroadcast = eventListener.expectMsgType[Rebroadcast]
-      assert(rebroadcast.nodes.contains(node_c_torv2))
-    }
-
-    {
-      // rebroadcast node updates with a single DNS hostname addresses
-      val hostname = List(NodeAddress.fromParts("acinq.co", 9735).get)
-      val node_c_hostname = makeNodeAnnouncement(priv_c, "node-C", Color(123, 100, -40), hostname, TestConstants.Bob.nodeParams.features.nodeAnnouncementFeatures(), timestamp = TimestampSecond.now() + 10)
-      peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, node_c_hostname))
-      peerConnection.expectMsg(TransportHandler.ReadAck(node_c_hostname))
-      peerConnection.expectMsg(GossipDecision.Accepted(node_c_hostname))
-      eventListener.expectMsg(NodeUpdated(node_c_hostname))
-      router ! Router.TickBroadcast
-      val rebroadcast = eventListener.expectMsgType[Rebroadcast]
-      assert(rebroadcast.nodes.contains(node_c_hostname))
-    }
-
-    {
-      // do NOT rebroadcast node updates with more than one DNS hostname addresses
-      val multiHostnames = List(NodeAddress.fromParts("acinq.co", 9735).get, NodeAddress.fromParts("acinq.fr", 9735).get)
-      val node_c_noForward = makeNodeAnnouncement(priv_c, "node-C", Color(123, 100, -40), multiHostnames, TestConstants.Bob.nodeParams.features.nodeAnnouncementFeatures(), timestamp = TimestampSecond.now() + 20)
-      peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, node_c_noForward))
-      peerConnection.expectMsg(TransportHandler.ReadAck(node_c_noForward))
-      peerConnection.expectMsg(GossipDecision.Accepted(node_c_noForward))
-      eventListener.expectMsg(NodeUpdated(node_c_noForward))
-      router ! Router.TickBroadcast
-      eventListener.expectNoMessage(100 millis)
-    }
-  }
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/PathFinding.scala
@@ -56,12 +56,18 @@ trait PathFinding {
     }
   }
 
+  val node: Route = postRequest("node") { implicit t =>
+    formFields(nodeIdFormParam) { nodeId =>
+      completeOrNotFound(eclairApi.node(nodeId))
+    }
+  }
+
   val nodes: Route = postRequest("nodes") { implicit t =>
     formFields(nodeIdsFormParam.?) { nodeIds_opt =>
       complete(eclairApi.nodes(nodeIds_opt.map(_.toSet)))
     }
   }
 
-  val pathFindingRoutes: Route = findRoute ~ findRouteToNode ~ findRouteBetweenNodes ~ nodes
+  val pathFindingRoutes: Route = findRoute ~ findRouteToNode ~ findRouteBetweenNodes ~ node ~ nodes
 
 }


### PR DESCRIPTION
Add a new API to return information about a specific node: its announcement, number of active channels and total capacity. This has been requested several times by node operators.