### PR TITLE
Read channels db only once at restart

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/DBChecker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/DBChecker.scala
@@ -16,6 +16,7 @@
 
 package fr.acinq.eclair
 
+import fr.acinq.eclair.channel.PersistentChannelData
 import grizzled.slf4j.Logging
 
 import scala.util.{Failure, Success, Try}
@@ -29,10 +30,11 @@ object DBChecker extends Logging {
    *
    * @param nodeParams node parameters
    */
-  def checkChannelsDB(nodeParams: NodeParams): Unit = {
+  def checkChannelsDB(nodeParams: NodeParams): Seq[PersistentChannelData] = {
     Try(nodeParams.db.channels.listLocalChannels()) match {
       case Success(channels) =>
-        channels.foreach(data => if (!data.metaCommitments.main.validateSeed(nodeParams.channelKeyManager)) throw InvalidChannelSeedException(data.channelId))
+        channels.foreach(data => if (!data.commitments.validateSeed(nodeParams.channelKeyManager)) throw InvalidChannelSeedException(data.channelId))
+        channels
       case Failure(_) => throw IncompatibleDBException
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -61,6 +61,7 @@ class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paym
   private val nodeRelayer = context.spawn(Behaviors.supervise(NodeRelayer(nodeParams, register, NodeRelay.SimpleOutgoingPaymentFactory(nodeParams, router, register), triggerer)).onFailure(SupervisorStrategy.resume), name = "node-relayer")
 
   def receive: Receive = {
+    case init: PostRestartHtlcCleaner.Init => postRestartCleaner forward init
     case RelayForward(add) =>
       log.debug(s"received forwarding request for htlc #${add.id} from channelId=${add.channelId}")
       IncomingPaymentPacket.decrypt(add, nodeParams.privateKey, nodeParams.features) match {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
@@ -37,7 +37,7 @@ import fr.acinq.eclair.router.BaseRouterSpec.channelHopFromUpdate
 import fr.acinq.eclair.router.Router.Route
 import fr.acinq.eclair.transactions.Transactions.{ClaimRemoteDelayedOutputTx, InputInfo}
 import fr.acinq.eclair.transactions.{DirectedHtlc, IncomingHtlc, OutgoingHtlc}
-import fr.acinq.eclair.wire.internal.channel.ChannelCodecsSpec
+import fr.acinq.eclair.wire.internal.channel.{ChannelCodecs, ChannelCodecsSpec}
 import fr.acinq.eclair.wire.protocol._
 import fr.acinq.eclair.{BlockHeight, CltvExpiry, CltvExpiryDelta, CustomCommitmentsPlugin, MilliSatoshi, MilliSatoshiLong, NodeParams, TestConstants, TestKitBaseClass, TimestampMilliLong, randomBytes32, randomKey}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
@@ -115,11 +115,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
       ChannelCodecsSpec.makeChannelDataNormal(htlc_ab_2, Map(4L -> trampolineRelayed))
     )
 
-    // Prepare channels state before restart.
-    channels.foreach(c => nodeParams.db.channels.addOrUpdateChannel(c))
-
     val channel = TestProbe()
-    f.createRelayer(nodeParams)
+    val (relayer, _) = f.createRelayer(nodeParams)
+    relayer ! PostRestartHtlcCleaner.Init(channels)
     register.expectNoMessage(100 millis) // nothing should happen while channels are still offline.
 
     // channel 1 goes to NORMAL state:
@@ -177,11 +175,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
       ChannelCodecsSpec.makeChannelDataNormal(htlc_ab_2, Map.empty)
     )
 
-    // Prepare channels state before restart.
-    channels.foreach(c => nodeParams.db.channels.addOrUpdateChannel(c))
-
     val channel = TestProbe()
-    f.createRelayer(nodeParams)
+    val (relayer, _) = f.createRelayer(nodeParams)
+    relayer ! PostRestartHtlcCleaner.Init(channels)
     register.expectNoMessage(100 millis) // nothing should happen while channels are still offline.
 
     // channel 1 goes to NORMAL state:
@@ -229,6 +225,7 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
 
     val testCase = setupLocalPayments(nodeParams)
     val (relayer, _) = createRelayer(nodeParams)
+    relayer ! PostRestartHtlcCleaner.Init(List(testCase.channel))
     register.expectNoMessage(100 millis)
 
     sender.send(relayer, testCase.fails(1))
@@ -258,6 +255,7 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
 
     val testCase = setupLocalPayments(nodeParams)
     val (relayer, _) = f.createRelayer(nodeParams)
+    relayer ! PostRestartHtlcCleaner.Init(List(testCase.channel))
     register.expectNoMessage(100 millis)
 
     sender.send(relayer, testCase.fulfills(1))
@@ -292,9 +290,10 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
   test("ignore htlcs in downstream channels that have already been settled upstream") { f =>
     import f._
 
-    val testCase = setupTrampolinePayments(nodeParams)
+    val testCase = setupTrampolinePayments()
     val initialized = Promise[Done]()
     val postRestart = system.actorOf(PostRestartHtlcCleaner.props(nodeParams, register.ref, Some(initialized)))
+    postRestart ! PostRestartHtlcCleaner.Init(testCase.channels)
     awaitCond(initialized.isCompleted)
     register.expectNoMessage(100 millis)
 
@@ -394,12 +393,10 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
       (alice.stateData.asInstanceOf[DATA_CLOSING], htlc_2_2)
     }
 
-    nodeParams.db.channels.addOrUpdateChannel(data_upstream_1)
-    nodeParams.db.channels.addOrUpdateChannel(data_upstream_2)
-    nodeParams.db.channels.addOrUpdateChannel(data_upstream_3)
-    nodeParams.db.channels.addOrUpdateChannel(data_downstream)
+    val channels = stored(data_upstream_1, data_upstream_2, data_upstream_3, data_downstream)
 
     val (relayer, _) = f.createRelayer(nodeParams)
+    relayer ! PostRestartHtlcCleaner.Init(channels)
     register.expectNoMessage(100 millis) // nothing should happen while channels are still offline.
 
     val (channel_upstream_1, channel_upstream_2, channel_upstream_3) = (TestProbe(), TestProbe(), TestProbe())
@@ -435,11 +432,11 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
       buildHtlcIn(4, channelId_ab_1, randomBytes32()),
     )
     val channelData = ChannelCodecsSpec.makeChannelDataNormal(htlc_ab, Map.empty)
-    nodeParams.db.channels.addOrUpdateChannel(channelData)
     nodeParams.db.pendingCommands.addSettlementCommand(channelId_ab_1, CMD_FULFILL_HTLC(1, randomBytes32()))
     nodeParams.db.pendingCommands.addSettlementCommand(channelId_ab_1, CMD_FAIL_HTLC(4, Right(PermanentChannelFailure())))
 
     val (_, postRestart) = f.createRelayer(nodeParams)
+    postRestart ! PostRestartHtlcCleaner.Init(List(channelData))
     sender.send(postRestart, PostRestartHtlcCleaner.GetBrokenHtlcs)
     val brokenHtlcs = sender.expectMsgType[PostRestartHtlcCleaner.BrokenHtlcs]
     assert(brokenHtlcs.relayedOut.isEmpty)
@@ -479,11 +476,11 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
       DATA_CLOSING(normal.metaCommitments, BlockHeight(0), mutualCloseProposed = Nil, revokedCommitPublished = List(rcp))
     }
 
-    nodeParams.db.channels.addOrUpdateChannel(upstreamChannel)
-    nodeParams.db.channels.addOrUpdateChannel(downstreamChannel)
+    val channels = List(upstreamChannel, downstreamChannel)
     assert(Closing.isClosed(downstreamChannel, None).isEmpty)
 
     val (_, postRestart) = f.createRelayer(nodeParams)
+    postRestart ! PostRestartHtlcCleaner.Init(channels)
     sender.send(postRestart, PostRestartHtlcCleaner.GetBrokenHtlcs)
     val brokenHtlcs = sender.expectMsgType[PostRestartHtlcCleaner.BrokenHtlcs]
     assert(brokenHtlcs.relayedOut.isEmpty)
@@ -493,8 +490,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
   test("handle a channel relay htlc-fail") { f =>
     import f._
 
-    val testCase = setupChannelRelayedPayments(nodeParams)
+    val testCase = setupChannelRelayedPayments()
     val (relayer, _) = f.createRelayer(nodeParams)
+    relayer ! PostRestartHtlcCleaner.Init(testCase.channels)
     register.expectNoMessage(100 millis)
 
     sender.send(relayer, buildForwardFail(testCase.downstream, testCase.origin))
@@ -508,8 +506,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
   test("handle a channel relay htlc-fulfill") { f =>
     import f._
 
-    val testCase = setupChannelRelayedPayments(nodeParams)
+    val testCase = setupChannelRelayedPayments()
     val (relayer, _) = f.createRelayer(nodeParams)
+    relayer ! PostRestartHtlcCleaner.Init(testCase.channels)
     register.expectNoMessage(100 millis)
 
     sender.send(relayer, buildForwardFulfill(testCase.downstream, testCase.origin, preimage1))
@@ -524,8 +523,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
   test("handle a trampoline relay htlc-fail") { f =>
     import f._
 
-    val testCase = setupTrampolinePayments(nodeParams)
+    val testCase = setupTrampolinePayments()
     val (relayer, _) = f.createRelayer(nodeParams)
+    relayer ! PostRestartHtlcCleaner.Init(testCase.channels)
     register.expectNoMessage(100 millis)
 
     // This downstream HTLC has two upstream HTLCs.
@@ -554,8 +554,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
   test("handle a trampoline relay htlc-fulfill") { f =>
     import f._
 
-    val testCase = setupTrampolinePayments(nodeParams)
+    val testCase = setupTrampolinePayments()
     val (relayer, _) = f.createRelayer(nodeParams)
+    relayer ! PostRestartHtlcCleaner.Init(testCase.channels)
     register.expectNoMessage(100 millis)
 
     // This downstream HTLC has two upstream HTLCs.
@@ -583,8 +584,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
   test("handle a trampoline relay htlc-fail followed by htlc-fulfill") { f =>
     import f._
 
-    val testCase = setupTrampolinePayments(nodeParams)
+    val testCase = setupTrampolinePayments()
     val (relayer, _) = f.createRelayer(nodeParams)
+    relayer ! PostRestartHtlcCleaner.Init(testCase.channels)
     register.expectNoMessage(100 millis)
 
     sender.send(relayer, buildForwardFail(testCase.downstream_2_1, testCase.origin_2))
@@ -621,10 +623,10 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
 
     val nodeParams1 = nodeParams.copy(pluginParams = List(pluginParams))
     val c = ChannelCodecsSpec.makeChannelDataNormal(List(relayedHtlc1Out), Map(50L -> trampolineRelayed))
-    nodeParams1.db.channels.addOrUpdateChannel(c)
 
     val channel = TestProbe()
-    f.createRelayer(nodeParams1)
+    val (relayer, _) = f.createRelayer(nodeParams1)
+    relayer ! PostRestartHtlcCleaner.Init(List(c))
     register.expectNoMessage(100 millis) // nothing should happen while channels are still offline.
 
     // @formatter:off
@@ -671,10 +673,10 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
 
     val nodeParams1 = nodeParams.copy(pluginParams = List(pluginParams))
     val c = ChannelCodecsSpec.makeChannelDataNormal(List(relayedHtlcIn, nonRelayedHtlcIn), Map.empty)
-    nodeParams1.db.channels.addOrUpdateChannel(c)
 
     val channel = TestProbe()
-    f.createRelayer(nodeParams1)
+    val (relayer, _) = f.createRelayer(nodeParams1)
+    relayer ! PostRestartHtlcCleaner.Init(List(c))
     register.expectNoMessage(100 millis) // nothing should happen while channels are still offline.
 
     // Standard channel goes to NORMAL state:
@@ -702,7 +704,8 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
     val nodeParams1 = nodeParams.copy(pluginParams = List(pluginParams))
     nodeParams1.db.pendingCommands.addSettlementCommand(channelId_ab_1, cmd1)
     nodeParams1.db.pendingCommands.addSettlementCommand(channelId_ab_1, cmd2)
-    f.createRelayer(nodeParams1)
+    val (relayer, _) = f.createRelayer(nodeParams1)
+    relayer ! PostRestartHtlcCleaner.Init(Nil)
     register.expectNoMessage(100 millis)
     awaitCond(Seq(cmd1) == nodeParams1.db.pendingCommands.listSettlementCommands(channelId_ab_1))
   }
@@ -745,7 +748,7 @@ object PostRestartHtlcCleanerSpec {
   def buildForwardFulfill(add: UpdateAddHtlc, origin: Origin.Cold, preimage: ByteVector32): RES_ADD_SETTLED[Origin.Cold, HtlcResult.Fulfill] =
     RES_ADD_SETTLED(origin, add, HtlcResult.RemoteFulfill(UpdateFulfillHtlc(add.channelId, add.id, preimage)))
 
-  case class LocalPaymentTest(parentId: UUID, childIds: Seq[UUID], fails: Seq[RES_ADD_SETTLED[Origin.Cold, HtlcResult.Fail]], fulfills: Seq[RES_ADD_SETTLED[Origin.Cold, HtlcResult.Fulfill]])
+  case class LocalPaymentTest(channel: PersistentChannelData, parentId: UUID, childIds: Seq[UUID], fails: Seq[RES_ADD_SETTLED[Origin.Cold, HtlcResult.Fail]], fulfills: Seq[RES_ADD_SETTLED[Origin.Cold, HtlcResult.Fulfill]])
 
   /**
    * We setup two outgoing payments:
@@ -767,19 +770,19 @@ object PostRestartHtlcCleanerSpec {
     nodeParams.db.payments.addOutgoingPayment(OutgoingPayment(id1, id1, None, paymentHash1, PaymentType.Standard, add1.amountMsat, add1.amountMsat, c, 0 unixms, None, OutgoingPaymentStatus.Pending))
     nodeParams.db.payments.addOutgoingPayment(OutgoingPayment(id2, parentId, None, paymentHash2, PaymentType.Standard, add2.amountMsat, 2500 msat, c, 0 unixms, None, OutgoingPaymentStatus.Pending))
     nodeParams.db.payments.addOutgoingPayment(OutgoingPayment(id3, parentId, None, paymentHash2, PaymentType.Standard, add3.amountMsat, 2500 msat, c, 0 unixms, None, OutgoingPaymentStatus.Pending))
-    nodeParams.db.channels.addOrUpdateChannel(ChannelCodecsSpec.makeChannelDataNormal(
+    val channel = ChannelCodecsSpec.makeChannelDataNormal(
       Seq(add1, add2, add3).map(add => OutgoingHtlc(add)),
-      Map(add1.id -> origin1, add2.id -> origin2, add3.id -> origin3))
+      Map(add1.id -> origin1, add2.id -> origin2, add3.id -> origin3)
     )
 
     val fails = Seq(buildForwardFail(add1, origin1), buildForwardFail(add2, origin2), buildForwardFail(add3, origin3))
     val fulfills = Seq(buildForwardFulfill(add1, origin1, preimage1), buildForwardFulfill(add2, origin2, preimage2), buildForwardFulfill(add3, origin3, preimage2))
-    LocalPaymentTest(parentId, Seq(id1, id2, id3), fails, fulfills)
+    LocalPaymentTest(channel, parentId, Seq(id1, id2, id3), fails, fulfills)
   }
 
-  case class ChannelRelayedPaymentTest(origin: Origin.ChannelRelayedCold, downstream: UpdateAddHtlc, notRelayed: Set[(Long, ByteVector32)])
+  case class ChannelRelayedPaymentTest(channels: Seq[PersistentChannelData], origin: Origin.ChannelRelayedCold, downstream: UpdateAddHtlc, notRelayed: Set[(Long, ByteVector32)])
 
-  def setupChannelRelayedPayments(nodeParams: NodeParams): ChannelRelayedPaymentTest = {
+  def setupChannelRelayedPayments(): ChannelRelayedPaymentTest = {
     // Upstream HTLCs.
     val htlc_ab_1 = Seq(
       buildHtlcIn(0, channelId_ab_1, paymentHash1)
@@ -794,16 +797,15 @@ object PostRestartHtlcCleanerSpec {
     val data_ab_1 = ChannelCodecsSpec.makeChannelDataNormal(htlc_ab_1, Map.empty)
     val data_bc_1 = ChannelCodecsSpec.makeChannelDataNormal(htlc_bc_1, Map(6L -> origin_1))
 
-    // Prepare channels state before restart.
-    nodeParams.db.channels.addOrUpdateChannel(data_ab_1)
-    nodeParams.db.channels.addOrUpdateChannel(data_bc_1)
+    val channels = List(data_ab_1, data_bc_1)
 
     val downstream_1 = htlc_bc_1.head.add
 
-    ChannelRelayedPaymentTest(origin_1, downstream_1, Set.empty)
+    ChannelRelayedPaymentTest(channels, origin_1, downstream_1, Set.empty)
   }
 
-  case class TrampolinePaymentTest(origin_1: Origin.TrampolineRelayedCold,
+  case class TrampolinePaymentTest(channels: Seq[PersistentChannelData],
+                                   origin_1: Origin.TrampolineRelayedCold,
                                    downstream_1_1: UpdateAddHtlc,
                                    origin_2: Origin.TrampolineRelayedCold,
                                    downstream_2_1: UpdateAddHtlc,
@@ -823,7 +825,7 @@ object PostRestartHtlcCleanerSpec {
    *  - the downstream HTLC is stuck in a closing channel: the upstream HTLC has been correctly resolved, so we should
    *    ignore that payment (downstream will eventually settle on-chain).
    */
-  def setupTrampolinePayments(nodeParams: NodeParams): TrampolinePaymentTest = {
+  def setupTrampolinePayments(): TrampolinePaymentTest = {
     // Upstream HTLCs.
     val htlc_ab_1 = Seq(
       buildHtlcIn(0, channelId_ab_1, paymentHash1),
@@ -883,16 +885,16 @@ object PostRestartHtlcCleanerSpec {
     val data_bc_4 = ChannelCodecsSpec.makeChannelDataNormal(htlc_bc_4, Map(5L -> origin_3))
     val data_bc_5 = ChannelCodecsSpec.makeChannelDataNormal(htlc_bc_5, Map(2L -> origin_3, 4L -> origin_4))
 
-    // Prepare channels state before restart.
-    nodeParams.db.channels.addOrUpdateChannel(data_ab_1)
-    nodeParams.db.channels.addOrUpdateChannel(data_ab_2)
-    nodeParams.db.channels.addOrUpdateChannel(data_bc_1)
-    nodeParams.db.channels.addOrUpdateChannel(data_bc_2)
-    nodeParams.db.channels.addOrUpdateChannel(data_bc_3)
-    nodeParams.db.channels.addOrUpdateChannel(data_bc_4)
-    nodeParams.db.channels.addOrUpdateChannel(data_bc_5)
+    val channels = List(data_ab_1, data_ab_2, data_bc_1, data_bc_2, data_bc_3, data_bc_4, data_bc_5)
 
-    TrampolinePaymentTest(origin_1, downstream_1_1, origin_2, downstream_2_1, downstream_2_2, downstream_2_3, notRelayed)
+    TrampolinePaymentTest(channels, origin_1, downstream_1_1, origin_2, downstream_2_1, downstream_2_2, downstream_2_3, notRelayed)
   }
+
+  /**
+   * The [[PostRestartHtlcCleaner]] only deals with data that has been persisted, and has [[Origin.Cold]] origins. We
+   * simulate that by doing a codec roundtrip.
+   */
+  def stored(channels: PersistentChannelData*): Seq[PersistentChannelData] =
+    channels.map(c => ChannelCodecs.channelDataCodec.decode(ChannelCodecs.channelDataCodec.encode(c).require).require.value)
 
 }


### PR DESCRIPTION
Fixes #2478.

I tried to keep the changes minimal, but had to move the _read_ from `Setup` to `Setup.bootstrap`, otherwise we would have kept a reference of the initial channels list forever.

Checking the db now happens a bit further in the startup procedure, but it is still blocking, and before the actors are initiated.