### PR TITLE
Never lock utxos when funding

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -17,16 +17,6 @@
 
 ### Miscellaneous improvements and bug fixes
 
-#### Strategies to handle locked utxos at start-up (#2278)
-
-If some utxos are locked when eclair starts, it is likely because eclair was previously stopped in the middle of funding a transaction.
-While this doesn't create any risk of loss of funds, these utxos will stay locked for no good reason and won't be used to fund future transactions.
-Eclair offers three strategies to handle that scenario, that node operators can configure by setting `eclair.bitcoind.startup-locked-utxos-behavior` in their `eclair.conf`:
-
-- `stop`: eclair won't start until the corresponding utxos are unlocked by the node operator
-- `unlock`: eclair will automatically unlock the corresponding utxos
-- `ignore`: eclair will leave these utxos locked and start
-
 ## Verifying signatures
 
 You will need `gpg` and our release signing key 7A73FE77DE2C4027. Note that you can get it:

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -33,12 +33,6 @@ eclair {
     // which can generate a lot of requests to validate channels, iterate over blocks to find a spending tx, etc.
     // You may want to disable this when bitcoin is running on a remote machine with an unreliable network.
     batch-watcher-requests = true
-    // If some utxos are locked when eclair starts, it is likely because it was previously stopped in the middle of
-    // funding a transaction. The supported behaviors to handle this case are:
-    //  - stop: eclair won't start until the corresponding utxos are unlocked by the node operator
-    //  - unlock: eclair will automatically unlock the corresponding utxos
-    //  - ignore: eclair will leave these utxos locked and start
-    startup-locked-utxos-behavior = "stop"
   }
 
   node-alias = "eclair"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -263,38 +263,14 @@ class Setup(val datadir: File,
 
       bitcoinClient = new BitcoinCoreClient(bitcoin)
 
-      // If we started funding a transaction and restarted before signing it, we may have utxos that stay locked forever.
-      // We want to do something about it: we can unlock them automatically, or let the node operator decide what to do.
-      //
-      // The only drawback that this may have is if we have funded and signed a funding transaction but didn't publish
-      // it and we accidentally double-spend it after a restart. This shouldn't be an issue because:
-      //  - locks are automatically removed when the transaction is published anyway
-      //  - funding transactions are republished at startup if they aren't in the blockchain or in the mempool
-      //  - funding transactions detect when they are double-spent and abort the channel creation
-      //  - the only case where double-spending a funding transaction causes a loss of funds is when we accept a 0-conf
-      //    channel and our peer double-spends it, but we should never accept 0-conf channels from peers we don't trust
-      lockedUtxosBehavior = config.getString("bitcoind.startup-locked-utxos-behavior").toLowerCase
-      _ <- bitcoinClient.listLockedOutpoints().flatMap { lockedOutpoints =>
-        if (lockedOutpoints.isEmpty) {
-          Future.successful(true)
-        } else if (lockedUtxosBehavior == "unlock") {
-          logger.info(s"unlocking utxos: ${lockedOutpoints.map(o => s"${o.txid}:${o.index}").mkString(", ")}")
-          bitcoinClient.unlockOutpoints(lockedOutpoints.toSeq)
-        } else if (lockedUtxosBehavior == "stop") {
-          logger.warn(s"cannot start eclair with locked utxos: ${lockedOutpoints.map(o => s"${o.txid}:${o.index}").mkString(", ")}")
-          NotificationsLogger.logFatalError(
-            """aborting startup as configured strategy for locked utxos
-              |
-              |If you want eclair to automatically unlock utxos at startup, set 'eclair.bitcoind.startup-locked-utxos-behavior = "unlock"' in your eclair.conf and restart.
-              |If you want to start eclair without unlocking those utxos, set 'eclair.bitcoind.startup-locked-utxos-behavior = "ignore"' in your eclair.conf and restart.
-              |
-              |Otherwise, run the following command to unlock them and restart eclair: 'bitcoin-cli lockunspent true'
-              |""".stripMargin, new RuntimeException("cannot start with locked utxos"))
-          throw new RuntimeException("cannot start with locked utxos: see notifications.log for detailed instructions to fix it")
-        } else {
-          logger.warn(s"ignoring locked utxos: ${lockedOutpoints.map(o => s"${o.txid}:${o.index}").mkString(", ")}")
-          Future.successful(true)
-        }
+      // If eclair stopped at the wrong time, we may have locked utxos and not unlocked them, which freezes some
+      // liquidity that could otherwise be useful. We warn the node operator when that happens.
+      _ <- bitcoinClient.listLockedOutpoints().map {
+        case lockedOutpoints if lockedOutpoints.nonEmpty =>
+          val message = s"some utxos are locked in the bitcoind wallet (${lockedOutpoints.map(o => s"${o.txid}:${o.index}").mkString(", ")}): if that is not intentional, run the following command to unlock them: 'bitcoin-cli lockunspent true'"
+          system.eventStream.publish(NotificationsLogger.NotifyNodeOperator(NotificationsLogger.Warning, message))
+          logger.warn(message)
+        case _ => // nothing to do
       }
 
       watcher = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.blockchain
 
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, Transaction}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, OutPoint, Satoshi, Transaction}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import scodec.bits.ByteVector
 
@@ -59,14 +59,17 @@ trait OnChainChannelFunder {
    */
   def commit(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean]
 
+  /** Lock some wallet inputs to avoid using them when funding a transaction. */
+  def lockOutpoints(outPoints: Seq[OutPoint])(implicit ec: ExecutionContext): Future[Boolean]
+
+  /** Unlock some wallet inputs. */
+  def unlockOutpoints(outPoints: Seq[OutPoint])(implicit ec: ExecutionContext): Future[Boolean]
+
   /** Return the transaction if it exists, either in the blockchain or in the mempool. */
   def getTransaction(txId: ByteVector32)(implicit ec: ExecutionContext): Future[Transaction]
 
   /** Get the number of confirmations of a given transaction. */
   def getTxConfirmations(txid: ByteVector32)(implicit ec: ExecutionContext): Future[Option[Int]]
-
-  /** Rollback a transaction that we failed to commit: this probably translates to "release locks on utxos". */
-  def rollback(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean]
 
   /**
    * Tests whether the inputs of the provided transaction have been spent by another transaction.

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -20,7 +20,6 @@ import akka.actor.Status
 import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.scalacompat.{Btc, ByteVector32, ByteVector64, SatoshiLong}
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
-import fr.acinq.eclair.blockchain.DummyOnChainWallet
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.fsm.Channel
@@ -148,11 +147,8 @@ class WaitForFundingSignedStateSpec extends TestKitBaseClass with FixtureAnyFunS
 
   test("recv INPUT_DISCONNECTED") { f =>
     import f._
-    val fundingTx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_SIGNED].fundingTx
-    assert(alice.underlyingActor.wallet.asInstanceOf[DummyOnChainWallet].rolledback.isEmpty)
     alice ! INPUT_DISCONNECTED
     awaitCond(alice.stateName == CLOSED)
-    assert(alice.underlyingActor.wallet.asInstanceOf[DummyOnChainWallet].rolledback.contains(fundingTx))
     aliceOrigin.expectMsgType[Status.Failure]
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingConfirmedStateSpec.scala
@@ -417,7 +417,6 @@ class WaitForDualFundingConfirmedStateSpec extends TestKitBaseClass with Fixture
     alice ! ProcessCurrentBlockHeight(CurrentBlockHeight(currentBlock))
     alice2bob.expectMsgType[Error]
     alice2blockchain.expectNoMessage(100 millis)
-    awaitCond(wallet.rolledback.map(_.txid) == Seq(fundingTx.txid))
     awaitCond(alice.stateName == CLOSED)
   }
 
@@ -431,7 +430,6 @@ class WaitForDualFundingConfirmedStateSpec extends TestKitBaseClass with Fixture
     alice ! ProcessCurrentBlockHeight(CurrentBlockHeight(currentBlock))
     alice2bob.expectMsgType[Error]
     alice2blockchain.expectNoMessage(100 millis)
-    awaitCond(wallet.rolledback.map(_.txid) == Seq(fundingTx.txid))
     awaitCond(alice.stateName == CLOSED)
   }
 


### PR DESCRIPTION
We previously locked utxos when funding transactions to avoid accidentally double-spending ourselves if an unrelated transaction was funded concurrently before the first one was published.

It didn't fully protect us against double-spending ourselves though. If bitcoind was restarted while eclair was running, it would clear existing locks and remove those guarantees. But that was an acceptable edge case.

However, dual funding and liquidity ads introduce griefing attacks if we lock our utxos: an attacker can waste our liquidity in funding attempts that will never be published, as explained here:
https://github.com/lightning/bolts/pull/851#discussion_r997537630

The easiest way to get rid of that griefing attack is to never lock our inputs: this ensures that honest users will double-spend the inputs used for sessions with malicious users, at no cost to us. It also greatly simplifies our code because we don't need to worry about unlocking utxos.

Note that once a transaction has been successfully published once, we are then guaranteed that bitcoind will never accidentally double-spend it: we have to call `abandontransaction` to tell bitcoind to forget that transaction and free its inputs.

There is one drawback with this approach: if we have concurrent sessions with honest peers, there is a risk that we will double-spend ourselves and only one of the sessions will succeed. This trade-off is acceptable because:

- the time window where such race condition may happen is small: honest peers will quickly complete the funding flow and publish the signed transaction, which protects against accidental double-spends
- funding on-chain transactions is an infrequent operation: block size is limited, so we have to rate-limit our funding attempts anyway
- to be perfectly safe, all funding code must handle the possibility of being double-spent before the transaction is published: the main danger here was zero-conf channels, but it has been fixed in #2558.
- all existing funding scenarios already handle the case where the transaction cannot be published and detect double-spends
- when a funding attempt fails, it can simply be restarted (e.g. LSP operations that open channels on-the-fly)

It's also important to note that bitcoind funding locks have to either be used all the time or never. We cannot use them in some scenarios and not others, because it wouldn't provide any meaningful guarantees for the scenarios that lock inputs, as shown by the following sample flow:

- fund a transaction for which we don't lock utxos
- fund another unrelated transaction for which we lock utxos
- the second transaction ends up using the same utxos as the first one, since they were unlocked and thus ready to be used
- but the first transaction confirms, invalidating the second one, which incorrectly thought it was safe from double-spends because it used locks