### PR TITLE
Don't send payment secret when using keysend

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Recipient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Recipient.scala
@@ -110,7 +110,7 @@ case class SpontaneousRecipient(nodeId: PublicKey,
 
   override def buildPayloads(paymentHash: ByteVector32, route: Route): Either[OutgoingPaymentError, PaymentPayloads] = {
     ClearRecipient.validateRoute(nodeId, route).map(_ => {
-      val finalPayload = NodePayload(nodeId, FinalPayload.Standard.createKeySendPayload(route.amount, totalAmount, expiry, preimage, customTlvs))
+      val finalPayload = NodePayload(nodeId, FinalPayload.Standard.createKeySendPayload(route.amount, expiry, preimage, customTlvs))
       Recipient.buildPayloads(totalAmount, expiry, Seq(finalPayload), route.hops)
     })
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -386,11 +386,10 @@ object PaymentOnion {
         Standard(TlvStream(tlvs, customTlvs))
       }
 
-      def createKeySendPayload(amount: MilliSatoshi, totalAmount: MilliSatoshi, expiry: CltvExpiry, preimage: ByteVector32, customTlvs: Seq[GenericTlv] = Nil): Standard = {
+      def createKeySendPayload(amount: MilliSatoshi, expiry: CltvExpiry, preimage: ByteVector32, customTlvs: Seq[GenericTlv] = Nil): Standard = {
         val tlvs = Seq(
           AmountToForward(amount),
           OutgoingCltv(expiry),
-          PaymentData(preimage, totalAmount),
           KeySend(preimage)
         )
         Standard(TlvStream(tlvs, customTlvs))


### PR DESCRIPTION
Apparently lnd rejects keysend payments that contain a payment secret, instead of simply ignoring that field.

The blip doesn't mention this requirement:
https://github.com/lightning/blips/blob/master/blip-0003.md

But we don't have a strong reason to send it either, so let's remove that.

Waiting for @kiwiidb to confirm that this fixes the lnd compatibility issues.