### PR TITLE
Properly quote in bash scripts

### DIFF
--- a/eclair-front/src/main/resources/eclair-front.sh
+++ b/eclair-front/src/main/resources/eclair-front.sh
@@ -282,7 +282,7 @@ java_version_check() {
   if [[ "$java_version" == "" ]]; then
     echo
     echo No java installations was detected.
-    echo Please go to https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot and download
+    echo Please go to 'https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot' and download
     echo
     exit 1
   else

--- a/eclair-node/src/main/resources/eclair-node.sh
+++ b/eclair-node/src/main/resources/eclair-node.sh
@@ -282,7 +282,7 @@ java_version_check() {
   if [[ "$java_version" == "" ]]; then
     echo
     echo No java installations was detected.
-    echo Please go to https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot and download
+    echo Please go to 'https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot' and download
     echo
     exit 1
   else


### PR DESCRIPTION
To avoid bash interpreting '&' as background job metacharacter, properly quote the string containing it.

Otherwise you get output like the following:
eclair-node[3517981]: No java installations was detected.
eclair-node[3518011]: Please go to https://adoptopenjdk.net/?variant=openjdk11
eclair-node[3518012]: /usr/bin/eclair-node: line 285: and: command not found