### PR TITLE
Add support for splices

### DIFF
--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -39,6 +39,8 @@ and COMMAND is one of the available commands:
   === Channel ===
     - open
     - rbfopen
+    - splicein
+    - spliceout
     - close
     - forceclose
     - channel
@@ -143,7 +145,7 @@ jq_filter='if type=="object" and .error != null then .error else .';
 
 # apply special jq filter if we are in "short" ouput mode -- only for specific commands such as 'channels'
 if [ "$short" = true ]; then
-  jq_channel_filter="{ nodeId, shortChannelId: .data.shortIds.real.realScid, channelId, state, balanceSat: (try (.data.commitments.localCommit.spec.toLocal / 1000 | floor) catch null), capacitySat: .data.commitments.commitInput.amountSatoshis, channelPoint: .data.commitments.commitInput.outPoint }";
+  jq_channel_filter="{ nodeId, shortChannelId: .data.shortIds.real.realScid, channelId, state, commitments: (.data.commitments.active | map({balanceSat: (try (.localCommit.spec.toLocal / 1000 | floor) catch null), capacitySat: .fundingTx.amountSatoshis, fundingTxIndex: .fundingTxIndex, channelPoint: .fundingTx.outPoint})) }";
   case $api_endpoint in
     "channels")   jq_filter="$jq_filter | map( $jq_channel_filter )" ;;
     "channel")    jq_filter="$jq_filter | $jq_channel_filter" ;;

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -294,6 +294,12 @@ object Features {
     val mandatory = 152
   }
 
+  // TODO: @pm47 custom splices implementation for phoenix, to be replaced once splices is spec-ed (currently reserved here: https://github.com/lightning/bolts/issues/605)
+  case object SplicePrototype extends Feature with InitFeature {
+    val rfcName = "splice_prototype"
+    val mandatory = 154
+  }
+
   val knownFeatures: Set[Feature] = Set(
     DataLossProtect,
     InitialRoutingSync,
@@ -317,7 +323,8 @@ object Features {
     ZeroConf,
     KeySend,
     TrampolinePaymentPrototype,
-    AsyncPaymentPrototype
+    AsyncPaymentPrototype,
+    SplicePrototype,
   )
 
   // Features may depend on other features, as specified in Bolt 9.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -98,7 +98,7 @@ class Setup(val datadir: File,
   val Seeds(nodeSeed, channelSeed) = seeds_opt.getOrElse(NodeParams.getSeeds(datadir))
   val chain = config.getString("chain")
 
-  if (chain != "regtest") {
+  if (chain != "regtest" && chain != "testnet") {
     // TODO: database format is WIP, we want to be able to squash changes and not support intermediate unreleased versions
     throw new RuntimeException("this unreleased version of Eclair only works on regtest")
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/ZmqWatcher.scala
@@ -161,6 +161,9 @@ object ZmqWatcher {
   case class WatchParentTxConfirmed(replyTo: ActorRef[WatchParentTxConfirmedTriggered], txId: ByteVector32, minDepth: Long) extends WatchConfirmed[WatchParentTxConfirmedTriggered]
   case class WatchParentTxConfirmedTriggered(blockHeight: BlockHeight, txIndex: Int, tx: Transaction) extends WatchConfirmedTriggered
 
+  case class WatchAlternativeCommitTxConfirmed(replyTo: ActorRef[WatchAlternativeCommitTxConfirmedTriggered], txId: ByteVector32, minDepth: Long) extends WatchConfirmed[WatchAlternativeCommitTxConfirmedTriggered]
+  case class WatchAlternativeCommitTxConfirmedTriggered(blockHeight: BlockHeight, txIndex: Int, tx: Transaction) extends WatchConfirmedTriggered
+
   private sealed trait AddWatchResult
   private case object Keep extends AddWatchResult
   private case object Ignore extends AddWatchResult
@@ -423,6 +426,7 @@ private class ZmqWatcher(nodeParams: NodeParams, blockHeight: AtomicLong, client
               case w: WatchFundingDeeplyBuried => context.self ! TriggerEvent(w.replyTo, w, WatchFundingDeeplyBuriedTriggered(height, index, tx))
               case w: WatchTxConfirmed => context.self ! TriggerEvent(w.replyTo, w, WatchTxConfirmedTriggered(height, index, tx))
               case w: WatchParentTxConfirmed => context.self ! TriggerEvent(w.replyTo, w, WatchParentTxConfirmedTriggered(height, index, tx))
+              case w: WatchAlternativeCommitTxConfirmed => context.self ! TriggerEvent(w.replyTo, w, WatchAlternativeCommitTxConfirmedTriggered(height, index, tx))
             }
           }
         }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.channel
 
 import akka.actor.{ActorRef, PossiblyHarmful, typed}
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, DeterministicWallet, OutPoint, Satoshi, Transaction}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, DeterministicWallet, OutPoint, Satoshi, SatoshiLong, Transaction, TxOut}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.LocalFundingStatus.DualFundedUnconfirmedFundingTx
 import fr.acinq.eclair.channel.fund.InteractiveTxBuilder._
@@ -27,6 +27,8 @@ import fr.acinq.eclair.channel.fund.{InteractiveTxBuilder, InteractiveTxSigningS
 import fr.acinq.eclair.payment.OutgoingPaymentPacket.Upstream
 import fr.acinq.eclair.transactions.CommitmentSpec
 import fr.acinq.eclair.transactions.Transactions._
+import fr.acinq.eclair.wire.protocol.{ChannelAnnouncement, ChannelReady, ChannelReestablish, ChannelUpdate, ClosingSigned, FailureMessage, FundingCreated, FundingSigned, Init, OnionRoutingPacket, OpenChannel, OpenDualFundedChannel, Shutdown, SpliceInit, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFulfillHtlc}
+import fr.acinq.eclair.{Alias, BlockHeight, CltvExpiry, CltvExpiryDelta, Features, InitFeature, MilliSatoshi, MilliSatoshiLong, RealShortChannelId, UInt64}
 import fr.acinq.eclair.wire.protocol.{ChannelAnnouncement, ChannelReady, ChannelReestablish, ChannelUpdate, ClosingSigned, CommitSig, FailureMessage, FundingCreated, FundingSigned, Init, OnionRoutingPacket, OpenChannel, OpenDualFundedChannel, Shutdown, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFulfillHtlc}
 import fr.acinq.eclair.{Alias, BlockHeight, CltvExpiry, CltvExpiryDelta, Features, InitFeature, MilliSatoshi, RealShortChannelId, UInt64}
 import scodec.bits.ByteVector
@@ -186,13 +188,15 @@ sealed trait Command extends PossiblyHarmful
 sealed trait HasReplyToCommand extends Command { def replyTo: ActorRef }
 sealed trait HasOptionalReplyToCommand extends Command { def replyTo_opt: Option[ActorRef] }
 
-final case class CMD_ADD_HTLC(replyTo: ActorRef, amount: MilliSatoshi, paymentHash: ByteVector32, cltvExpiry: CltvExpiry, onion: OnionRoutingPacket, nextBlindingKey_opt: Option[PublicKey], origin: Origin.Hot, commit: Boolean = false) extends HasReplyToCommand
-sealed trait HtlcSettlementCommand extends HasOptionalReplyToCommand { def id: Long }
+sealed trait ForbiddenCommandDuringSplice extends Command
+
+final case class CMD_ADD_HTLC(replyTo: ActorRef, amount: MilliSatoshi, paymentHash: ByteVector32, cltvExpiry: CltvExpiry, onion: OnionRoutingPacket, nextBlindingKey_opt: Option[PublicKey], origin: Origin.Hot, commit: Boolean = false) extends HasReplyToCommand with ForbiddenCommandDuringSplice
+sealed trait HtlcSettlementCommand extends HasOptionalReplyToCommand with ForbiddenCommandDuringSplice { def id: Long }
 final case class CMD_FULFILL_HTLC(id: Long, r: ByteVector32, commit: Boolean = false, replyTo_opt: Option[ActorRef] = None) extends HtlcSettlementCommand
 final case class CMD_FAIL_HTLC(id: Long, reason: Either[ByteVector, FailureMessage], delay_opt: Option[FiniteDuration] = None, commit: Boolean = false, replyTo_opt: Option[ActorRef] = None) extends HtlcSettlementCommand
 final case class CMD_FAIL_MALFORMED_HTLC(id: Long, onionHash: ByteVector32, failureCode: Int, commit: Boolean = false, replyTo_opt: Option[ActorRef] = None) extends HtlcSettlementCommand
-final case class CMD_UPDATE_FEE(feeratePerKw: FeeratePerKw, commit: Boolean = false, replyTo_opt: Option[ActorRef] = None) extends HasOptionalReplyToCommand
-final case class CMD_SIGN(replyTo_opt: Option[ActorRef] = None) extends HasOptionalReplyToCommand
+final case class CMD_UPDATE_FEE(feeratePerKw: FeeratePerKw, commit: Boolean = false, replyTo_opt: Option[ActorRef] = None) extends HasOptionalReplyToCommand with ForbiddenCommandDuringSplice
+final case class CMD_SIGN(replyTo_opt: Option[ActorRef] = None) extends HasOptionalReplyToCommand with ForbiddenCommandDuringSplice
 
 final case class ClosingFees(preferred: Satoshi, min: Satoshi, max: Satoshi)
 final case class ClosingFeerates(preferred: FeeratePerKw, min: FeeratePerKw, max: FeeratePerKw) {
@@ -200,10 +204,18 @@ final case class ClosingFeerates(preferred: FeeratePerKw, min: FeeratePerKw, max
 }
 
 sealed trait CloseCommand extends HasReplyToCommand
-final case class CMD_CLOSE(replyTo: ActorRef, scriptPubKey: Option[ByteVector], feerates: Option[ClosingFeerates]) extends CloseCommand
+final case class CMD_CLOSE(replyTo: ActorRef, scriptPubKey: Option[ByteVector], feerates: Option[ClosingFeerates]) extends CloseCommand with ForbiddenCommandDuringSplice
 final case class CMD_FORCECLOSE(replyTo: ActorRef) extends CloseCommand
 
 final case class CMD_BUMP_FUNDING_FEE(replyTo: akka.actor.typed.ActorRef[CommandResponse[CMD_BUMP_FUNDING_FEE]], targetFeerate: FeeratePerKw, lockTime: Long) extends Command
+case class SpliceIn(additionalLocalFunding: Satoshi, pushAmount: MilliSatoshi = 0.msat)
+case class SpliceOut(amount: Satoshi, scriptPubKey: ByteVector)
+final case class CMD_SPLICE(replyTo: akka.actor.typed.ActorRef[CommandResponse[CMD_SPLICE]], spliceIn_opt: Option[SpliceIn], spliceOut_opt: Option[SpliceOut]) extends Command {
+  require(spliceIn_opt.isDefined || spliceOut_opt.isDefined, "there must be a splice-in or a splice-out")
+  val additionalLocalFunding: Satoshi = spliceIn_opt.map(_.additionalLocalFunding).getOrElse(0L.sat)
+  val pushAmount: MilliSatoshi = spliceIn_opt.map(_.pushAmount).getOrElse(0L.msat)
+  val spliceOutputs: List[TxOut] = spliceOut_opt.toList.map(s => TxOut(s.amount, s.scriptPubKey))
+}
 final case class CMD_UPDATE_RELAY_FEE(replyTo: ActorRef, feeBase: MilliSatoshi, feeProportionalMillionths: Long, cltvExpiryDelta_opt: Option[CltvExpiryDelta]) extends HasReplyToCommand
 final case class CMD_GET_CHANNEL_STATE(replyTo: ActorRef) extends HasReplyToCommand
 final case class CMD_GET_CHANNEL_DATA(replyTo: ActorRef) extends HasReplyToCommand
@@ -252,6 +264,7 @@ final case class RES_ADD_SETTLED[+O <: Origin, +R <: HtlcResult](origin: O, htlc
 
 /** other specific responses */
 final case class RES_BUMP_FUNDING_FEE(rbfIndex: Int, fundingTxId: ByteVector32, fee: Satoshi) extends CommandSuccess[CMD_BUMP_FUNDING_FEE]
+final case class RES_SPLICE(fundingTxIndex: Long, fundingTxId: ByteVector32, capacity: Satoshi, balance: MilliSatoshi) extends CommandSuccess[CMD_SPLICE]
 final case class RES_GET_CHANNEL_STATE(state: ChannelState) extends CommandSuccess[CMD_GET_CHANNEL_STATE]
 final case class RES_GET_CHANNEL_DATA[+D <: ChannelData](data: D) extends CommandSuccess[CMD_GET_CHANNEL_DATA]
 final case class RES_GET_CHANNEL_INFO(nodeId: PublicKey, channelId: ByteVector32, state: ChannelState, data: ChannelData) extends CommandSuccess[CMD_GET_CHANNEL_INFO]
@@ -401,6 +414,9 @@ case class ShortIds(real: RealScidStatus, localAlias: Alias, remoteAlias_opt: Op
 
 sealed trait LocalFundingStatus { def signedTx_opt: Option[Transaction] }
 object LocalFundingStatus {
+  sealed trait NotLocked extends LocalFundingStatus
+  sealed trait Locked extends LocalFundingStatus
+
   sealed trait UnconfirmedFundingTx extends LocalFundingStatus
   /**
    * In single-funding, fundees only know the funding txid.
@@ -408,14 +424,14 @@ object LocalFundingStatus {
    * didn't keep the funding tx at all, even as funder (e.g. NORMAL). However, right after restoring those channels we
    * retrieve the funding tx and update the funding status immediately.
    */
-  case class SingleFundedUnconfirmedFundingTx(signedTx_opt: Option[Transaction]) extends UnconfirmedFundingTx
-  case class DualFundedUnconfirmedFundingTx(sharedTx: SignedSharedTransaction, createdAt: BlockHeight, fundingParams: InteractiveTxParams) extends UnconfirmedFundingTx {
+  case class SingleFundedUnconfirmedFundingTx(signedTx_opt: Option[Transaction]) extends UnconfirmedFundingTx with NotLocked
+  case class DualFundedUnconfirmedFundingTx(sharedTx: SignedSharedTransaction, createdAt: BlockHeight, fundingParams: InteractiveTxParams) extends UnconfirmedFundingTx with NotLocked {
     override def signedTx_opt: Option[Transaction] = sharedTx.signedTx_opt
   }
-  case class ZeroconfPublishedFundingTx(tx: Transaction) extends UnconfirmedFundingTx {
+  case class ZeroconfPublishedFundingTx(tx: Transaction) extends UnconfirmedFundingTx with Locked {
     override val signedTx_opt: Option[Transaction] = Some(tx)
   }
-  case class ConfirmedFundingTx(tx: Transaction) extends LocalFundingStatus {
+  case class ConfirmedFundingTx(tx: Transaction) extends LocalFundingStatus with Locked {
     override val signedTx_opt: Option[Transaction] = Some(tx)
   }
 }
@@ -433,6 +449,15 @@ object RbfStatus {
   case class RbfInProgress(cmd_opt: Option[CMD_BUMP_FUNDING_FEE], rbf: typed.ActorRef[InteractiveTxBuilder.Command], remoteCommitSig: Option[CommitSig]) extends RbfStatus
   case class RbfWaitingForSigs(signingSession: InteractiveTxSigningSession.WaitingForSigs) extends RbfStatus
   case object RbfAborted extends RbfStatus
+}
+
+sealed trait SpliceStatus
+object SpliceStatus {
+  case object NoSplice extends SpliceStatus
+  case class SpliceRequested(cmd: CMD_SPLICE, init: SpliceInit) extends SpliceStatus
+  case class SpliceInProgress(cmd_opt: Option[CMD_SPLICE], splice: typed.ActorRef[InteractiveTxBuilder.Command], remoteCommitSig: Option[CommitSig]) extends SpliceStatus
+  case class SpliceWaitingForSigs(signingSession: InteractiveTxSigningSession.WaitingForSigs) extends SpliceStatus
+  case object SpliceAborted extends SpliceStatus
 }
 
 sealed trait ChannelData extends PossiblyHarmful {
@@ -537,7 +562,8 @@ final case class DATA_NORMAL(commitments: Commitments,
                              channelUpdate: ChannelUpdate,
                              localShutdown: Option[Shutdown],
                              remoteShutdown: Option[Shutdown],
-                             closingFeerates: Option[ClosingFeerates]) extends ChannelDataWithCommitments
+                             closingFeerates: Option[ClosingFeerates],
+                             spliceStatus: SpliceStatus) extends ChannelDataWithCommitments
 final case class DATA_SHUTDOWN(commitments: Commitments, localShutdown: Shutdown, remoteShutdown: Shutdown, closingFeerates: Option[ClosingFeerates]) extends ChannelDataWithCommitments
 final case class DATA_NEGOTIATING(commitments: Commitments,
                                   localShutdown: Shutdown, remoteShutdown: Shutdown,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -208,12 +208,12 @@ final case class CMD_CLOSE(replyTo: ActorRef, scriptPubKey: Option[ByteVector], 
 final case class CMD_FORCECLOSE(replyTo: ActorRef) extends CloseCommand
 
 final case class CMD_BUMP_FUNDING_FEE(replyTo: akka.actor.typed.ActorRef[CommandResponse[CMD_BUMP_FUNDING_FEE]], targetFeerate: FeeratePerKw, lockTime: Long) extends Command
-case class SpliceIn(additionalLocalFunding: Satoshi, pushAmount: MilliSatoshi = 0.msat)
+case class SpliceIn(additionalLocalFunding: Satoshi, pushAmount: MilliSatoshi = 0 msat)
 case class SpliceOut(amount: Satoshi, scriptPubKey: ByteVector)
 final case class CMD_SPLICE(replyTo: akka.actor.typed.ActorRef[CommandResponse[CMD_SPLICE]], spliceIn_opt: Option[SpliceIn], spliceOut_opt: Option[SpliceOut]) extends Command {
   require(spliceIn_opt.isDefined || spliceOut_opt.isDefined, "there must be a splice-in or a splice-out")
-  val additionalLocalFunding: Satoshi = spliceIn_opt.map(_.additionalLocalFunding).getOrElse(0L.sat)
-  val pushAmount: MilliSatoshi = spliceIn_opt.map(_.pushAmount).getOrElse(0L.msat)
+  val additionalLocalFunding: Satoshi = spliceIn_opt.map(_.additionalLocalFunding).getOrElse(0 sat)
+  val pushAmount: MilliSatoshi = spliceIn_opt.map(_.pushAmount).getOrElse(0 msat)
   val spliceOutputs: List[TxOut] = spliceOut_opt.toList.map(s => TxOut(s.amount, s.scriptPubKey))
 }
 final case class CMD_UPDATE_RELAY_FEE(replyTo: ActorRef, feeBase: MilliSatoshi, feeProportionalMillionths: Long, cltvExpiryDelta_opt: Option[CltvExpiryDelta]) extends HasReplyToCommand

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -22,6 +22,7 @@ import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.wire.protocol
 import fr.acinq.eclair.wire.protocol.{AnnouncementSignatures, InteractiveTxMessage, UpdateAddHtlc}
 import fr.acinq.eclair.{BlockHeight, CltvExpiry, CltvExpiryDelta, MilliSatoshi, UInt64}
+import scodec.bits.ByteVector
 
 /**
  * Created by PM on 11/04/2017.
@@ -64,20 +65,25 @@ case class PreviousTxMissing                       (override val channelId: Byte
 case class InvalidSharedInput                      (override val channelId: ByteVector32, serialId: UInt64) extends ChannelException(channelId, s"invalid shared tx_add_input (serial_id=${serialId.toByteVector.toHex})")
 case class OutputBelowDust                         (override val channelId: ByteVector32, serialId: UInt64, amount: Satoshi, dustLimit: Satoshi) extends ChannelException(channelId, s"invalid output amount=$amount below dust=$dustLimit (serial_id=${serialId.toByteVector.toHex})")
 case class InvalidSharedOutputAmount               (override val channelId: ByteVector32, serialId: UInt64, amount: Satoshi, expected: Satoshi) extends ChannelException(channelId, s"invalid shared output amount=$amount expected=$expected (serial_id=${serialId.toByteVector.toHex})")
+case class InvalidSpliceOutputScript               (override val channelId: ByteVector32, serialId: UInt64, publicKeyScript: ByteVector) extends ChannelException(channelId, s"invalid splice output publicKeyScript=$publicKeyScript (serial_id=${serialId.toByteVector.toHex})")
 case class UnconfirmedInteractiveTxInputs          (override val channelId: ByteVector32) extends ChannelException(channelId, "the completed interactive tx contains unconfirmed inputs")
 case class InvalidCompleteInteractiveTx            (override val channelId: ByteVector32) extends ChannelException(channelId, "the completed interactive tx is invalid")
 case class TooManyInteractiveTxRounds              (override val channelId: ByteVector32) extends ChannelException(channelId, "too many messages exchanged during interactive tx construction")
 case class RbfAttemptAborted                       (override val channelId: ByteVector32) extends ChannelException(channelId, "rbf attempt aborted")
+case class SpliceAttemptAborted                    (override val channelId: ByteVector32) extends ChannelException(channelId, "splice attempt aborted")
 case class DualFundingAborted                      (override val channelId: ByteVector32) extends ChannelException(channelId, "dual funding aborted")
 case class UnexpectedInteractiveTxMessage          (override val channelId: ByteVector32, msg: InteractiveTxMessage) extends ChannelException(channelId, s"unexpected interactive-tx message (${msg.getClass.getSimpleName})")
 case class UnexpectedFundingSignatures             (override val channelId: ByteVector32) extends ChannelException(channelId, "unexpected funding signatures (tx_signatures)")
 case class InvalidFundingFeerate                   (override val channelId: ByteVector32, targetFeerate: FeeratePerKw, actualFeerate: FeeratePerKw) extends ChannelException(channelId, s"invalid funding feerate: target=$targetFeerate actual=$actualFeerate")
 case class InvalidFundingSignature                 (override val channelId: ByteVector32, txId_opt: Option[ByteVector32]) extends ChannelException(channelId, s"invalid funding signature: txId=${txId_opt.map(_.toHex).getOrElse("n/a")}")
 case class InvalidRbfFeerate                       (override val channelId: ByteVector32, proposed: FeeratePerKw, expected: FeeratePerKw) extends ChannelException(channelId, s"invalid rbf attempt: the feerate must be at least $expected, you proposed $proposed")
+case class InvalidSpliceRequest                    (override val channelId: ByteVector32) extends ChannelException(channelId, "invalid splice request")
 case class InvalidRbfAlreadyInProgress             (override val channelId: ByteVector32) extends ChannelException(channelId, "invalid rbf attempt: the current rbf attempt must be completed or aborted first")
+case class InvalidSpliceAlreadyInProgress          (override val channelId: ByteVector32) extends ChannelException(channelId, "invalid splice attempt: the current splice attempt must be completed or aborted first")
 case class InvalidRbfTxAbortNotAcked               (override val channelId: ByteVector32) extends ChannelException(channelId, "invalid rbf attempt: our previous tx_abort has not been acked")
 case class InvalidRbfAttemptsExhausted             (override val channelId: ByteVector32, maxAttempts: Int) extends ChannelException(channelId, s"invalid rbf attempt: $maxAttempts/$maxAttempts attempts already published")
 case class InvalidRbfAttemptTooSoon                (override val channelId: ByteVector32, previousAttempt: BlockHeight, nextAttempt: BlockHeight) extends ChannelException(channelId, s"invalid rbf attempt: last attempt made at block=$previousAttempt, next attempt available after block=$nextAttempt")
+case class InvalidSpliceTxAbortNotAcked            (override val channelId: ByteVector32) extends ChannelException(channelId, "invalid splice attempt: our previous tx_abort has not been acked")
 case class InvalidRbfTxConfirmed                   (override val channelId: ByteVector32) extends ChannelException(channelId, "no need to rbf, transaction is already confirmed")
 case class InvalidRbfNonInitiator                  (override val channelId: ByteVector32) extends ChannelException(channelId, "cannot initiate rbf: we're not the initiator of this interactive-tx attempt")
 case class InvalidRbfZeroConf                      (override val channelId: ByteVector32) extends ChannelException(channelId, "cannot initiate rbf: we're using zero-conf for this interactive-tx attempt")
@@ -104,7 +110,7 @@ case class InvalidCloseSignature                   (override val channelId: Byte
 case class InvalidCloseFee                         (override val channelId: ByteVector32, fee: Satoshi) extends ChannelException(channelId, s"invalid close fee: fee_satoshis=$fee")
 case class InvalidCloseAmountBelowDust             (override val channelId: ByteVector32, txId: ByteVector32) extends ChannelException(channelId, s"invalid closing tx: some outputs are below dust: txId=$txId")
 case class CommitSigCountMismatch                  (override val channelId: ByteVector32, expected: Int, actual: Int) extends ChannelException(channelId, s"commit sig count mismatch: expected=$expected actual=$actual")
-case class HtlcSigCountMismatch                    (override val channelId: ByteVector32, expected: Int, actual: Int) extends ChannelException(channelId, s"htlc sig count mismatch: expected=$expected actual: $actual")
+case class HtlcSigCountMismatch                    (override val channelId: ByteVector32, expected: Int, actual: Int) extends ChannelException(channelId, s"htlc sig count mismatch: expected=$expected actual=$actual")
 case class ForcedLocalCommit                       (override val channelId: ByteVector32) extends ChannelException(channelId, s"forced local commit")
 case class UnexpectedHtlcId                        (override val channelId: ByteVector32, expected: Long, actual: Long) extends ChannelException(channelId, s"unexpected htlc id: expected=$expected actual=$actual")
 case class ExpiryTooSmall                          (override val channelId: ByteVector32, minimum: CltvExpiry, actual: CltvExpiry, blockHeight: BlockHeight) extends ChannelException(channelId, s"expiry too small: minimum=$minimum actual=$actual blockHeight=$blockHeight")
@@ -126,8 +132,8 @@ case class CannotSignWithoutChanges                (override val channelId: Byte
 case class CannotSignBeforeRevocation              (override val channelId: ByteVector32) extends ChannelException(channelId, "cannot sign until next revocation hash is received")
 case class UnexpectedRevocation                    (override val channelId: ByteVector32) extends ChannelException(channelId, "received unexpected RevokeAndAck message")
 case class InvalidRevocation                       (override val channelId: ByteVector32) extends ChannelException(channelId, "invalid revocation")
-case class InvalidRevokedCommitProof               (override val channelId: ByteVector32, ourLocalCommitmentNumber: Long, theirRemoteCommitmentNumber: Long, invalidPerCommitmentSecret: PrivateKey) extends ChannelException(channelId, s"counterparty claimed that we have a revoked commit but their proof doesn't check out: ourCommitmentNumber=$ourLocalCommitmentNumber theirCommitmentNumber=$theirRemoteCommitmentNumber perCommitmentSecret=$invalidPerCommitmentSecret")
 case class InvalidFailureCode                      (override val channelId: ByteVector32) extends ChannelException(channelId, "UpdateFailMalformedHtlc message doesn't have BADONION bit set")
 case class PleasePublishYourCommitment             (override val channelId: ByteVector32) extends ChannelException(channelId, "please publish your local commitment")
 case class CommandUnavailableInThisState           (override val channelId: ByteVector32, command: String, state: ChannelState) extends ChannelException(channelId, s"cannot execute command=$command in state=$state")
+case class ForbiddenDuringSplice                   (override val channelId: ByteVector32, command: String) extends ChannelException(channelId, s"cannot process $command while splicing")
 // @formatter:on

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -1094,7 +1094,7 @@ case class Commitments(params: ChannelParams,
   }
 
   /**
-   * We can prune inactive commitments in two cases:
+   * We can prune commitments in two cases:
    * - their funding tx has been permanently double-spent by the funding tx of a concurrent commitments (happens when using RBF)
    * - their funding tx has been permanently spent by a splice tx
    */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -1,8 +1,9 @@
 package fr.acinq.eclair.channel
 
 import akka.event.LoggingAdapter
+import com.softwaremill.quicklens.ModifyPimp
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, Crypto, Satoshi, SatoshiLong, Script}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, Crypto, Satoshi, SatoshiLong, Script, Transaction}
 import fr.acinq.eclair.blockchain.fee.{FeeratePerKw, OnChainFeeConf}
 import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel.Monitoring.Metrics
@@ -161,8 +162,16 @@ case class RemoteCommit(index: Long, spec: CommitmentSpec, txid: ByteVector32, r
 /** We have the next remote commit when we've sent our commit_sig but haven't yet received their revoke_and_ack. */
 case class NextRemoteCommit(sig: CommitSig, commit: RemoteCommit)
 
-/** A minimal commitment for a given funding tx. */
-case class Commitment(localFundingStatus: LocalFundingStatus, remoteFundingStatus: RemoteFundingStatus,
+/**
+ * A minimal commitment for a given funding tx.
+ *
+ * @param fundingTxIndex index of the funding tx in the life of the channel:
+ *                       - initial funding tx has index 0
+ *                       - splice txs have index 1, 2, ...
+ *                       - commitments that share the same index are rbfed
+ */
+case class Commitment(fundingTxIndex: Long,
+                      localFundingStatus: LocalFundingStatus, remoteFundingStatus: RemoteFundingStatus,
                       localCommit: LocalCommit, remoteCommit: RemoteCommit, nextRemoteCommit_opt: Option[NextRemoteCommit]) {
   val commitInput: InputInfo = localCommit.commitTxAndRemoteSig.commitTx.input
   val fundingTxId: ByteVector32 = commitInput.outPoint.txid
@@ -266,15 +275,14 @@ case class Commitment(localFundingStatus: LocalFundingStatus, remoteFundingStatu
 
   private def hasNoPendingHtlcs: Boolean = localCommit.spec.htlcs.isEmpty && remoteCommit.spec.htlcs.isEmpty && nextRemoteCommit_opt.isEmpty
 
-  def hasNoPendingHtlcsOrFeeUpdate(changes: CommitmentChanges): Boolean =
-    nextRemoteCommit_opt.isEmpty &&
-      localCommit.spec.htlcs.isEmpty &&
-      remoteCommit.spec.htlcs.isEmpty &&
-      (changes.localChanges.signed ++ changes.localChanges.acked ++ changes.remoteChanges.signed ++ changes.remoteChanges.acked).collectFirst { case _: UpdateFee => true }.isEmpty
+  def hasNoPendingHtlcsOrFeeUpdate(changes: CommitmentChanges): Boolean = hasNoPendingHtlcs &&
+    (changes.localChanges.signed ++ changes.localChanges.acked ++ changes.remoteChanges.signed ++ changes.remoteChanges.acked).collectFirst { case _: UpdateFee => true }.isEmpty
 
   def hasPendingOrProposedHtlcs(changes: CommitmentChanges): Boolean = !hasNoPendingHtlcs ||
     changes.localChanges.all.exists(_.isInstanceOf[UpdateAddHtlc]) ||
     changes.remoteChanges.all.exists(_.isInstanceOf[UpdateAddHtlc])
+
+  def isIdle(changes: CommitmentChanges): Boolean = hasNoPendingHtlcs && changes.localChanges.all.isEmpty && changes.remoteChanges.all.isEmpty
 
   def timedOutOutgoingHtlcs(currentHeight: BlockHeight): Set[UpdateAddHtlc] = {
     def expired(add: UpdateAddHtlc): Boolean = currentHeight >= add.cltvExpiry.blockHeight
@@ -622,6 +630,7 @@ object Commitment {
 
 /** Subset of Commitments when we want to work with a single, specific commitment. */
 case class FullCommitment(params: ChannelParams, changes: CommitmentChanges,
+                          fundingTxIndex: Long,
                           localFundingStatus: LocalFundingStatus, remoteFundingStatus: RemoteFundingStatus,
                           localCommit: LocalCommit, remoteCommit: RemoteCommit, nextRemoteCommit_opt: Option[NextRemoteCommit]) {
   val channelId = params.channelId
@@ -630,7 +639,7 @@ case class FullCommitment(params: ChannelParams, changes: CommitmentChanges,
   val commitInput = localCommit.commitTxAndRemoteSig.commitTx.input
   val fundingTxId = commitInput.outPoint.txid
   val capacity = commitInput.txOut.amount
-  val commitment = Commitment(localFundingStatus, remoteFundingStatus, localCommit, remoteCommit, nextRemoteCommit_opt)
+  val commitment = Commitment(fundingTxIndex, localFundingStatus, remoteFundingStatus, localCommit, remoteCommit, nextRemoteCommit_opt)
 
   def localChannelReserve: Satoshi = commitment.localChannelReserve(params)
 
@@ -662,11 +671,15 @@ case class WaitForRev(sentAfterLocalCommitIndex: Long)
 
 /**
  * @param active                all currently valid commitments
+ * @param inactive              commitments that can potentially end up on-chain, but shouldn't be taken into account
+ *                              when updating the channel state; they are zero-conf and have been superseded by a newer
+ *                              commitment, which funding tx is not yet confirmed, and will be pruned when it confirms
  * @param remoteChannelData_opt peer backup
  */
 case class Commitments(params: ChannelParams,
                        changes: CommitmentChanges,
                        active: Seq[Commitment],
+                       inactive: Seq[Commitment] = Nil,
                        remoteNextCommitInfo: Either[WaitForRev, PublicKey], // this one is tricky, it must be kept in sync with Commitment.nextRemoteCommit_opt
                        remotePerCommitmentSecrets: ShaChain,
                        originChannels: Map[Long, Origin], // for outgoing htlcs relayed through us, details about the corresponding incoming htlcs
@@ -690,12 +703,15 @@ case class Commitments(params: ChannelParams,
   lazy val availableBalanceForReceive: MilliSatoshi = active.map(_.availableBalanceForReceive(params, changes)).min
 
   // We always use the last commitment that was created, to make sure we never go back in time.
-  val latest = FullCommitment(params, changes, active.head.localFundingStatus, active.head.remoteFundingStatus, active.head.localCommit, active.head.remoteCommit, active.head.nextRemoteCommit_opt)
+  val latest = FullCommitment(params, changes, active.head.fundingTxIndex, active.head.localFundingStatus, active.head.remoteFundingStatus, active.head.localCommit, active.head.remoteCommit, active.head.nextRemoteCommit_opt)
+
+  val all: Seq[Commitment] = active ++ inactive
 
   def add(commitment: Commitment): Commitments = copy(active = commitment +: active)
 
   // @formatter:off
   // HTLCs and pending changes are the same for all active commitments, so we don't need to loop through all of them.
+  def isIdle: Boolean = active.head.isIdle(changes)
   def hasNoPendingHtlcsOrFeeUpdate: Boolean = active.head.hasNoPendingHtlcsOrFeeUpdate(changes)
   def hasPendingOrProposedHtlcs: Boolean = active.head.hasPendingOrProposedHtlcs(changes)
   def timedOutOutgoingHtlcs(currentHeight: BlockHeight): Set[UpdateAddHtlc] = active.head.timedOutOutgoingHtlcs(currentHeight)
@@ -875,7 +891,13 @@ case class Commitments(params: ChannelParams,
           active = active1,
           remoteNextCommitInfo = Left(WaitForRev(localCommitIndex))
         )
-        Right(commitments1, sigs)
+        val sigs1 = if (sigs.size > 1) {
+          // if there are more than one sig, we add a tlv to tell the receiver how many sigs are to be expected
+          sigs.map { sig => sig.modify(_.tlvStream.records).using(_ + CommitSigTlv.BatchTlv(sigs.size)) }
+        } else {
+          sigs
+        }
+        Right(commitments1, sigs1)
       case Left(_) => Left(CannotSignBeforeRevocation(channelId))
     }
   }
@@ -1010,37 +1032,94 @@ case class Commitments(params: ChannelParams,
     active.forall(_.commitInput.redeemScript == fundingScript)
   }
 
-  def updateLocalFundingStatus(txId: ByteVector32, status: LocalFundingStatus)(implicit log: LoggingAdapter): Either[Commitments, (Commitments, Commitment)] = {
-    if (!this.active.exists(_.fundingTxId == txId)) {
-      log.error(s"funding txid=$txId doesn't match any of our funding txs")
-      Left(this)
-    } else {
-      val commitments1 = copy(active = active.map {
-        case c if c.fundingTxId == txId =>
-          log.info(s"setting localFundingStatus=${status.getClass.getSimpleName} for funding txid=$txId")
-          c.copy(localFundingStatus = status)
-        case c => c
-      }).pruneCommitments()
-      val commitment = commitments1.active.find(_.fundingTxId == txId).get
-      Right(commitments1, commitment)
+  /**
+   * Update the local/remote funding status
+   *
+   * @param updateMethod This method is tricky: it passes the fundingTxIndex of the commitment corresponding to the
+   *                     fundingTxId, because in the remote case we may update several commitments.
+   */
+  private def updateFundingStatus(fundingTxId: ByteVector32, updateMethod: Long => PartialFunction[Commitment, Commitment])(implicit log: LoggingAdapter): Either[Commitments, (Commitments, Commitment)] = {
+    all.find(_.fundingTxId == fundingTxId) match {
+      case Some(commitment) =>
+        val commitments1 = copy(
+          active = active.map(updateMethod(commitment.fundingTxIndex)),
+          inactive = inactive.map(updateMethod(commitment.fundingTxIndex))
+        ).deactivateCommitments().pruneCommitments()
+        val commitment1 = commitments1.all.find(_.fundingTxId == fundingTxId).get
+        Right(commitments1, commitment1)
+      case None =>
+        log.warning(s"fundingTxId=$fundingTxId doesn't match any of our funding txs")
+        Left(this)
+    }
+  }
+
+  def updateLocalFundingStatus(fundingTxId: ByteVector32, status: LocalFundingStatus)(implicit log: LoggingAdapter): Either[Commitments, (Commitments, Commitment)] =
+    updateFundingStatus(fundingTxId, _ => {
+      case c if c.fundingTxId == fundingTxId =>
+        log.info(s"setting localFundingStatus=${status.getClass.getSimpleName} for fundingTxId=$fundingTxId fundingTxIndex=${c.fundingTxIndex}")
+        c.copy(localFundingStatus = status)
+      case c => c
+    })
+
+  def updateRemoteFundingStatus(fundingTxId: ByteVector32)(implicit log: LoggingAdapter): Either[Commitments, (Commitments, Commitment)] =
+    updateFundingStatus(fundingTxId, fundingTxIndex => {
+      // all funding older than this one are considered locked
+      case c if c.fundingTxId == fundingTxId || c.fundingTxIndex < fundingTxIndex =>
+        log.info(s"setting remoteFundingStatus=${RemoteFundingStatus.Locked.getClass.getSimpleName} for fundingTxId=$fundingTxId fundingTxIndex=${c.fundingTxIndex}")
+        c.copy(remoteFundingStatus = RemoteFundingStatus.Locked)
+      case c => c
+    })
+
+  /**
+   * Commitments are considered inactive when they have been superseded by a newer commitment, but can still potentially
+   * end up on-chain. This is a consequence of using zero-conf. Inactive commitments will be cleaned up by
+   * [[pruneCommitments()]], when the next funding tx confirms.
+   */
+  def deactivateCommitments()(implicit log: LoggingAdapter): Commitments = {
+    val lastLocalLockedIndex: Long = active.find(_.localFundingStatus.isInstanceOf[LocalFundingStatus.Locked]).map(_.fundingTxIndex).getOrElse(-1)
+    val lastRemoteLockedIndex: Long = active.find(_.remoteFundingStatus == RemoteFundingStatus.Locked).map(_.fundingTxIndex).getOrElse(-1)
+    val lastLockedIndex = Math.min(lastLocalLockedIndex, lastRemoteLockedIndex)
+    active.find(_.fundingTxIndex == lastLockedIndex) match {
+      case Some(lastLocked) =>
+        // all commitments older than this one are inactive
+        val inactive1 = active.filter(c => c.fundingTxId != lastLocked.fundingTxId && c.fundingTxIndex <= lastLocked.fundingTxIndex)
+        inactive1.foreach(c => log.info("deactivating commitment fundingTxIndex={} fundingTxid={}", c.fundingTxIndex, c.fundingTxId))
+        copy(
+          active = active diff inactive1,
+          inactive = inactive1 ++ inactive
+        )
+      case _ =>
+        this
     }
   }
 
   /**
-   * Current (pre-splice) implementation prune initial commitments. There can be several of them with RBF, but they all
-   * double-spend each other and can be pruned once one of them confirms.
+   * We can prune inactive commitments in two cases:
+   * - their funding tx has been permanently double-spent by the funding tx of a concurrent commitments (happens when using RBF)
+   * - their funding tx has been permanently spent by a splice tx
    */
   def pruneCommitments()(implicit log: LoggingAdapter): Commitments = {
-    active.find(_.localFundingStatus.isInstanceOf[LocalFundingStatus.ConfirmedFundingTx]) match {
+    all
+      .filter(_.localFundingStatus.isInstanceOf[LocalFundingStatus.ConfirmedFundingTx])
+      .sortBy(_.fundingTxIndex)
+      .lastOption match {
       case Some(lastConfirmed) =>
         // we can prune all other commitments with the same or lower funding index
-        val pruned = active.filter(c => c.fundingTxId != lastConfirmed.fundingTxId)
-        val active1 = active diff pruned
-        pruned.foreach(c => log.info("pruning commitment fundingTxid={}", c.fundingTxId))
-        copy(active = active1)
+        val pruned = inactive.filter(c => c.fundingTxId != lastConfirmed.fundingTxId && c.fundingTxIndex <= lastConfirmed.fundingTxIndex)
+        pruned.foreach(c => log.info("pruning commitment index={} fundingTxid={}", c.fundingTxIndex, c.fundingTxId))
+        copy(inactive = inactive diff pruned)
       case _ =>
         this
     }
+  }
+
+  /**
+   * Find the corresponding commitment, based on a spending transaction.
+   *
+   * @param spendingTx A transaction that may spend a current or former funding tx
+   */
+  def resolveCommitment(spendingTx: Transaction): Option[Commitment] = {
+    all.find(c => spendingTx.txIn.map(_.outPoint).contains(c.commitInput.outPoint))
   }
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -384,7 +384,7 @@ object Helpers {
      *  - our peer may also contribute to the funding transaction, even if they don't contribute to the channel funding amount
      *  - even if they don't, we may RBF the transaction and don't want to handle reorgs
      */
-    def minDepthDualFunding(channelConf: ChannelConf, localFeatures: Features[InitFeature], isInitiator: Boolean, remoteContribution: Satoshi): Option[Long] = {
+    def minDepthDualFunding(channelConf: ChannelConf, localFeatures: Features[InitFeature], isInitiator: Boolean,  localContribution: Satoshi, remoteContribution: Satoshi): Option[Long] = {
       if (isInitiator && remoteContribution <= 0.sat) {
         if (localFeatures.hasFeature(Features.ZeroConf)) {
           None
@@ -392,7 +392,7 @@ object Helpers {
           Some(channelConf.minDepthBlocks)
         }
       } else {
-        minDepthFundee(channelConf, localFeatures, remoteContribution)
+        minDepthFundee(channelConf, localFeatures, localContribution + remoteContribution)
       }
     }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -384,7 +384,7 @@ object Helpers {
      *  - our peer may also contribute to the funding transaction, even if they don't contribute to the channel funding amount
      *  - even if they don't, we may RBF the transaction and don't want to handle reorgs
      */
-    def minDepthDualFunding(channelConf: ChannelConf, localFeatures: Features[InitFeature], isInitiator: Boolean, localContribution: Satoshi, remoteContribution: Satoshi): Option[Long] = {
+    def minDepthDualFunding(channelConf: ChannelConf, localFeatures: Features[InitFeature], isInitiator: Boolean, remoteContribution: Satoshi): Option[Long] = {
       if (isInitiator && remoteContribution <= 0.sat) {
         if (localFeatures.hasFeature(Features.ZeroConf)) {
           None
@@ -392,7 +392,7 @@ object Helpers {
           Some(channelConf.minDepthBlocks)
         }
       } else {
-        minDepthFundee(channelConf, localFeatures, localContribution + remoteContribution)
+        minDepthFundee(channelConf, localFeatures, remoteContribution)
       }
     }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -774,7 +774,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
               spliceInAmount = cmd.additionalLocalFunding,
               spliceOut = cmd.spliceOutputs,
               targetFeerate = targetFeerate)
-            if (d.commitments.latest.localCommit.spec.toLocal + fundingContribution < 0.sat) {
+            if (d.commitments.latest.localCommit.spec.toLocal + fundingContribution < d.commitments.latest.localChannelReserve) {
               log.warning("cannot do splice: insufficient funds")
               cmd.replyTo ! RES_FAILURE(cmd, InvalidSpliceRequest(d.channelId))
               stay()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -827,7 +827,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
               lockTime = nodeParams.currentBlockHeight.toLong,
               dustLimit = d.commitments.params.localParams.dustLimit.max(d.commitments.params.remoteParams.dustLimit),
               targetFeerate = msg.feerate,
-              minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = false, localContribution = spliceAck.fundingContribution, remoteContribution = msg.fundingContribution),
+              minDepth_opt = d.commitments.params.minDepthSplices(nodeParams.channelConf.minDepthBlocks, isInitiator = false, localContribution = spliceAck.fundingContribution, remoteContribution = msg.fundingContribution),
               requireConfirmedInputs = RequireConfirmedInputs(forLocal = msg.requireConfirmedInputs, forRemote = spliceAck.requireConfirmedInputs)
             )
             val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
@@ -867,7 +867,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
             lockTime = spliceInit.lockTime,
             dustLimit = d.commitments.params.localParams.dustLimit.max(d.commitments.params.remoteParams.dustLimit),
             targetFeerate = spliceInit.feerate,
-            minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = true, localContribution = spliceInit.fundingContribution, remoteContribution = msg.fundingContribution),
+            minDepth_opt = d.commitments.params.minDepthSplices(nodeParams.channelConf.minDepthBlocks, isInitiator = true, localContribution = spliceInit.fundingContribution, remoteContribution = msg.fundingContribution),
             requireConfirmedInputs = RequireConfirmedInputs(forLocal = msg.requireConfirmedInputs, forRemote = spliceInit.requireConfirmedInputs)
           )
           val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -827,7 +827,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
               lockTime = nodeParams.currentBlockHeight.toLong,
               dustLimit = d.commitments.params.localParams.dustLimit.max(d.commitments.params.remoteParams.dustLimit),
               targetFeerate = msg.feerate,
-              minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = false, localContribution = spliceAck.fundingContribution, remoteContribution = msg.fundingContribution),
+              minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = false, remoteContribution = msg.fundingContribution),
               requireConfirmedInputs = RequireConfirmedInputs(forLocal = msg.requireConfirmedInputs, forRemote = spliceAck.requireConfirmedInputs)
             )
             val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
@@ -867,7 +867,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
             lockTime = spliceInit.lockTime,
             dustLimit = d.commitments.params.localParams.dustLimit.max(d.commitments.params.remoteParams.dustLimit),
             targetFeerate = spliceInit.feerate,
-            minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = true, localContribution = cmd.additionalLocalFunding, remoteContribution = msg.fundingContribution),
+            minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = true, remoteContribution = msg.fundingContribution),
             requireConfirmedInputs = RequireConfirmedInputs(forLocal = msg.requireConfirmedInputs, forRemote = spliceInit.requireConfirmedInputs)
           )
           val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -21,7 +21,8 @@ import akka.actor.typed.scaladsl.adapter.{ClassicActorContextOps, actorRefAdapte
 import akka.actor.{Actor, ActorContext, ActorRef, FSM, OneForOneStrategy, PossiblyHarmful, Props, SupervisorStrategy, typed}
 import akka.event.Logging.MDC
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, SatoshiLong, Transaction}
+import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, Satoshi, SatoshiLong, Transaction}
+import fr.acinq.eclair.Features.DualFunding
 import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.OnChainWallet.MakeFundingTxResponse
@@ -30,12 +31,14 @@ import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
 import fr.acinq.eclair.channel.Commitments.PostRevocationAction
+import fr.acinq.eclair.channel.Helpers.Closing.MutualClose
 import fr.acinq.eclair.channel.Helpers.Syncing.SyncResult
-import fr.acinq.eclair.channel.Helpers.{Closing, Syncing, getRelayFees, scidForChannelUpdate}
+import fr.acinq.eclair.channel.Helpers._
 import fr.acinq.eclair.channel.Monitoring.Metrics.ProcessMessage
 import fr.acinq.eclair.channel.Monitoring.{Metrics, Tags}
 import fr.acinq.eclair.channel._
-import fr.acinq.eclair.channel.fund.InteractiveTxBuilder
+import fr.acinq.eclair.channel.fund.InteractiveTxBuilder._
+import fr.acinq.eclair.channel.fund.{InteractiveTxBuilder, InteractiveTxSigningSession}
 import fr.acinq.eclair.channel.publish.TxPublisher
 import fr.acinq.eclair.channel.publish.TxPublisher.{PublishFinalTx, SetChannelId}
 import fr.acinq.eclair.crypto.keymanager.ChannelKeyManager
@@ -196,6 +199,8 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
   // choose to not make this an Option (that would be None before the first connection), and instead embrace the fact
   // that the active connection may point to dead letters at all time
   var activeConnection = context.system.deadLetters
+  // we aggregate sigs for splices before processing
+  var sigStash = Seq.empty[CommitSig]
 
   val txPublisher = txPublisherFactory.spawnTxPublisher(context, remoteNodeId)
 
@@ -250,7 +255,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
       // (there can be multiple funding txs due to rbf, and they can be unconfirmed in any state due to zero-conf)
       data match {
         case _: ChannelDataWithoutCommitments => ()
-        case data: ChannelDataWithCommitments => data.commitments.active.foreach { commitment =>
+        case data: ChannelDataWithCommitments => data.commitments.all.foreach { commitment =>
           commitment.localFundingStatus match {
             case _: LocalFundingStatus.SingleFundedUnconfirmedFundingTx =>
               // NB: in the case of legacy single-funded channels, the funding tx may actually be confirmed already (and
@@ -353,6 +358,20 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
    */
 
   when(NORMAL)(handleExceptions {
+    case Event(c: ForbiddenCommandDuringSplice, d: DATA_NORMAL) if d.spliceStatus.isInstanceOf[SpliceStatus.SpliceRequested] || d.spliceStatus.isInstanceOf[SpliceStatus.SpliceInProgress] =>
+      val error = ForbiddenDuringSplice(d.channelId, c.getClass.getSimpleName)
+      c match {
+        case c: CMD_ADD_HTLC => handleAddHtlcCommandError(c, error, Some(d.channelUpdate))
+        // NB: the command cannot be an htlc settlement (fail/fulfill), because if we are splicing it means the channel is idle and has no htlcs
+        case _ => handleCommandError(error, c)
+      }
+
+    case Event(msg: ForbiddenMessageDuringSplice, d: DATA_NORMAL) if d.spliceStatus.isInstanceOf[SpliceStatus.SpliceInProgress] =>
+      // In case of a race between our splice_init and a forbidden message from our peer, we accept their message, because
+      // we know they are going to reject our splice attempt
+      val error = ForbiddenDuringSplice(d.channelId, msg.getClass.getSimpleName)
+      handleLocalError(error, d, Some(msg))
+
     case Event(c: CMD_ADD_HTLC, d: DATA_NORMAL) if d.localShutdown.isDefined || d.remoteShutdown.isDefined =>
       // note: spec would allow us to keep sending new htlcs after having received their shutdown (and not sent ours)
       // but we want to converge as fast as possible and they would probably not route them anyway
@@ -485,20 +504,49 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
       }
 
     case Event(commit: CommitSig, d: DATA_NORMAL) =>
-      d.commitments.receiveCommit(Seq(commit), keyManager) match {
-        case Right((commitments1, revocation)) =>
-          log.debug("received a new sig, spec:\n{}", commitments1.latest.specs2String)
-          if (commitments1.changes.localHasChanges) {
-            // if we have newly acknowledged changes let's sign them
-            self ! CMD_SIGN()
+      aggregateSigs(commit) match {
+        case Some(sigs) =>
+          d.spliceStatus match {
+            case s: SpliceStatus.SpliceInProgress =>
+              log.debug("received their commit_sig, deferring message")
+              stay() using d.copy(spliceStatus = s.copy(remoteCommitSig = Some(commit)))
+            case SpliceStatus.SpliceWaitingForSigs(signingSession) =>
+              signingSession.receiveCommitSig(nodeParams, d.commitments.params, commit) match {
+                case Left(f) =>
+                  rollbackFundingAttempt(signingSession.fundingTx.tx, Nil)
+                  handleLocalError(f, d, Some(commit))
+                case Right(signingSession1) => signingSession1 match {
+                  case signingSession1: InteractiveTxSigningSession.WaitingForSigs =>
+                    // No need to store their commit_sig, they will re-send it if we disconnect.
+                    stay() using d.copy(spliceStatus = SpliceStatus.SpliceWaitingForSigs(signingSession1))
+                  case signingSession1: InteractiveTxSigningSession.SendingSigs =>
+                    // We don't have their tx_sigs, but they have ours, and could publish the funding tx without telling us.
+                    // That's why we move on immediately to the next step, and will update our unsigned funding tx when we
+                    // receive their tx_sigs.
+                    watchFundingConfirmed(signingSession.fundingTx.txId, signingSession.fundingParams.minDepth_opt)
+                    val commitments1 = d.commitments.add(signingSession1.commitment)
+                    val d1 = d.copy(commitments = commitments1, spliceStatus = SpliceStatus.NoSplice)
+                    stay() using d1 storing() sending signingSession1.localSigs
+                }
+              }
+            case _ =>
+              d.commitments.receiveCommit(sigs, keyManager) match {
+                case Right((commitments1, revocation)) =>
+                  log.debug("received a new sig, spec:\n{}", commitments1.latest.specs2String)
+                  if (commitments1.changes.localHasChanges) {
+                    // if we have newly acknowledged changes let's sign them
+                    self ! CMD_SIGN()
+                  }
+                  if (d.commitments.availableBalanceForSend != commitments1.availableBalanceForSend) {
+                    // we send this event only when our balance changes
+                    context.system.eventStream.publish(AvailableBalanceChanged(self, d.channelId, d.shortIds, commitments1))
+                  }
+                  context.system.eventStream.publish(ChannelSignatureReceived(self, commitments1))
+                  stay() using d.copy(commitments = commitments1) storing() sending revocation
+                case Left(cause) => handleLocalError(cause, d, Some(commit))
+              }
           }
-          if (d.commitments.availableBalanceForSend != commitments1.availableBalanceForSend) {
-            // we send this event only when our balance changes
-            context.system.eventStream.publish(AvailableBalanceChanged(self, d.channelId, d.shortIds, commitments1))
-          }
-          context.system.eventStream.publish(ChannelSignatureReceived(self, commitments1))
-          stay() using d.copy(commitments = commitments1) storing() sending revocation
-        case Left(cause) => handleLocalError(cause, d, Some(commit))
+        case None => stay()
       }
 
     case Event(revocation: RevokeAndAck, d: DATA_NORMAL) =>
@@ -715,9 +763,269 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
           goto(NORMAL) using d.copy(channelUpdate = channelUpdate1) storing()
       }
 
+    case Event(cmd: CMD_SPLICE, d: DATA_NORMAL) =>
+      d.spliceStatus match {
+        case SpliceStatus.NoSplice =>
+          if (d.commitments.isIdle && d.commitments.params.channelFeatures.hasFeature(DualFunding)) {
+            val targetFeerate = nodeParams.onChainFeeConf.feeEstimator.getFeeratePerKw(target = nodeParams.onChainFeeConf.feeTargets.fundingBlockTarget)
+            val fundingContribution = InteractiveTxBuilder.computeLocalContribution(
+              isInitiator = true,
+              commitment = d.commitments.active.head,
+              spliceInAmount = cmd.additionalLocalFunding,
+              spliceOut = cmd.spliceOutputs,
+              targetFeerate = targetFeerate)
+            if (d.commitments.latest.localCommit.spec.toLocal + fundingContribution < 0.sat) {
+              log.warning("cannot do splice: insufficient funds")
+              cmd.replyTo ! RES_FAILURE(cmd, InvalidSpliceRequest(d.channelId))
+              stay()
+            } else if (cmd.spliceOut_opt.map(_.scriptPubKey).exists(!MutualClose.isValidFinalScriptPubkey(_, allowAnySegwit = true))) {
+              log.warning("cannot do splice: invalid splice-out script")
+              cmd.replyTo ! RES_FAILURE(cmd, InvalidSpliceRequest(d.channelId))
+              stay()
+            } else {
+              log.info(s"initiating splice with local.in.amount=${cmd.additionalLocalFunding} local.in.push=${cmd.pushAmount} out.amount=${cmd.spliceOut_opt.map(_.amount).sum}")
+              val spliceInit = SpliceInit(d.channelId,
+                fundingContribution = fundingContribution,
+                lockTime = nodeParams.currentBlockHeight.toLong,
+                feerate = targetFeerate,
+                pushAmount = cmd.pushAmount,
+                requireConfirmedInputs = nodeParams.channelConf.requireConfirmedInputsForDualFunding
+              )
+              stay() using d.copy(spliceStatus = SpliceStatus.SpliceRequested(cmd, spliceInit)) sending spliceInit
+            }
+          } else {
+            log.warning("cannot do splice")
+            cmd.replyTo ! RES_FAILURE(cmd, CommandUnavailableInThisState(d.channelId, "splice", NORMAL))
+            stay()
+          }
+        case _ =>
+          log.warning("cannot initiate splice, another one is already in progress")
+          cmd.replyTo ! RES_FAILURE(cmd, InvalidSpliceAlreadyInProgress(d.channelId))
+          stay()
+      }
+
+    // NB: we only accept splices on regtest
+    case Event(msg: SpliceInit, d: DATA_NORMAL) if nodeParams.chainHash == Block.RegtestGenesisBlock.hash || nodeParams.chainHash == Block.TestnetGenesisBlock.hash =>
+      d.spliceStatus match {
+        case SpliceStatus.NoSplice =>
+          if (d.commitments.isIdle && d.commitments.params.channelFeatures.hasFeature(DualFunding)) {
+            log.info(s"accepting splice with remote.in.amount=${msg.fundingContribution} remote.in.push=${msg.pushAmount}")
+            val spliceAck = SpliceAck(d.channelId,
+              fundingContribution = 0.sat, // only remote contributes to the splice
+              pushAmount = 0.msat,
+              requireConfirmedInputs = nodeParams.channelConf.requireConfirmedInputsForDualFunding
+            )
+            val parentCommitments = d.commitments.latest
+            val fundingParams = InteractiveTxParams(
+              channelId = d.channelId,
+              isInitiator = false,
+              localContribution = spliceAck.fundingContribution,
+              remoteContribution = msg.fundingContribution,
+              sharedInput_opt = Some(Multisig2of2Input(keyManager, d.commitments.params, parentCommitments.commitment)),
+              fundingPubkeyScript = parentCommitments.commitment.commitInput.txOut.publicKeyScript, // same pubkey script as before
+              localOutputs = Nil,
+              lockTime = nodeParams.currentBlockHeight.toLong,
+              dustLimit = d.commitments.params.localParams.dustLimit.max(d.commitments.params.remoteParams.dustLimit),
+              targetFeerate = msg.feerate,
+              minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = false, localContribution = spliceAck.fundingContribution, remoteContribution = msg.fundingContribution),
+              requireConfirmedInputs = RequireConfirmedInputs(forLocal = msg.requireConfirmedInputs, forRemote = spliceAck.requireConfirmedInputs)
+            )
+            val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
+              nodeParams, fundingParams,
+              channelParams = d.commitments.params,
+              purpose = InteractiveTxBuilder.SpliceTx(parentCommitments.commitment),
+              localPushAmount = spliceAck.pushAmount, remotePushAmount = msg.pushAmount,
+              wallet
+            ))
+            txBuilder ! InteractiveTxBuilder.Start(self)
+            stay() using d.copy(spliceStatus = SpliceStatus.SpliceInProgress(cmd_opt = None, splice = txBuilder, remoteCommitSig = None)) sending spliceAck
+          } else {
+            log.info("rejecting splice request, channel not idle or not compatible")
+            stay() using d.copy(spliceStatus = SpliceStatus.SpliceAborted) sending TxAbort(d.channelId, InvalidSpliceRequest(d.channelId).getMessage)
+          }
+        case SpliceStatus.SpliceAborted =>
+          log.info("rejecting splice attempt: our previous tx_abort was not acked")
+          stay() sending Warning(d.channelId, InvalidSpliceTxAbortNotAcked(d.channelId).getMessage)
+        case _: SpliceStatus.SpliceRequested | _: SpliceStatus.SpliceInProgress | _: SpliceStatus.SpliceWaitingForSigs =>
+          log.info("rejecting splice attempt: the current splice attempt must be completed or aborted first")
+          stay() sending Warning(d.channelId, InvalidSpliceAlreadyInProgress(d.channelId).getMessage)
+      }
+
+    case Event(msg: SpliceAck, d: DATA_NORMAL) =>
+      d.spliceStatus match {
+        case SpliceStatus.SpliceRequested(cmd, spliceInit) =>
+          log.info("our peer accepted our splice request and will contribute {} to the funding transaction", msg.fundingContribution)
+          val parentCommitments = d.commitments.latest
+          val fundingParams = InteractiveTxParams(
+            channelId = d.channelId,
+            isInitiator = true,
+            localContribution = spliceInit.fundingContribution,
+            remoteContribution = msg.fundingContribution,
+            sharedInput_opt = Some(Multisig2of2Input(keyManager, d.commitments.params, parentCommitments.commitment)),
+            fundingPubkeyScript = parentCommitments.commitInput.txOut.publicKeyScript, // same pubkey script as before
+            localOutputs = cmd.spliceOutputs,
+            lockTime = spliceInit.lockTime,
+            dustLimit = d.commitments.params.localParams.dustLimit.max(d.commitments.params.remoteParams.dustLimit),
+            targetFeerate = spliceInit.feerate,
+            minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = true, localContribution = cmd.additionalLocalFunding, remoteContribution = msg.fundingContribution),
+            requireConfirmedInputs = RequireConfirmedInputs(forLocal = msg.requireConfirmedInputs, forRemote = spliceInit.requireConfirmedInputs)
+          )
+          val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
+            nodeParams, fundingParams,
+            channelParams = d.commitments.params,
+            purpose = InteractiveTxBuilder.SpliceTx(parentCommitments.commitment),
+            localPushAmount = cmd.pushAmount, remotePushAmount = msg.pushAmount,
+            wallet
+          ))
+          txBuilder ! InteractiveTxBuilder.Start(self)
+          stay() using d.copy(spliceStatus = SpliceStatus.SpliceInProgress(cmd_opt = Some(cmd), splice = txBuilder, remoteCommitSig = None))
+        case _ =>
+          log.info(s"ignoring unexpected splice_ack=$msg")
+          stay()
+      }
+
+    case Event(msg: InteractiveTxConstructionMessage, d: DATA_NORMAL) =>
+      d.spliceStatus match {
+        case SpliceStatus.SpliceInProgress(_, txBuilder, _) =>
+          txBuilder ! InteractiveTxBuilder.ReceiveMessage(msg)
+          stay()
+        case _ =>
+          log.info("ignoring unexpected interactive-tx message: {}", msg.getClass.getSimpleName)
+          stay() sending Warning(d.channelId, UnexpectedInteractiveTxMessage(d.channelId, msg).getMessage)
+      }
+
+    case Event(msg: TxAbort, d: DATA_NORMAL) =>
+      d.spliceStatus match {
+        case SpliceStatus.SpliceInProgress(cmd_opt, txBuilder, _) =>
+          log.info("our peer aborted the splice attempt: ascii='{}' bin={}", msg.toAscii, msg.data)
+          cmd_opt.foreach(cmd => cmd.replyTo ! RES_FAILURE(cmd, SpliceAttemptAborted(d.channelId)))
+          txBuilder ! InteractiveTxBuilder.Abort
+          stay() using d.copy(spliceStatus = SpliceStatus.NoSplice) sending TxAbort(d.channelId, SpliceAttemptAborted(d.channelId).getMessage)
+        case SpliceStatus.SpliceWaitingForSigs(signingSession) =>
+          log.info("our peer aborted the splice attempt: ascii='{}' bin={}", msg.toAscii, msg.data)
+          rollbackFundingAttempt(signingSession.fundingTx.tx, previousTxs = Seq.empty) // no splice rbf yet
+          stay() using d.copy(spliceStatus = SpliceStatus.NoSplice) sending TxAbort(d.channelId, SpliceAttemptAborted(d.channelId).getMessage)
+        case SpliceStatus.SpliceRequested(cmd, _) =>
+          log.info("our peer rejected our splice attempt: ascii='{}' bin={}", msg.toAscii, msg.data)
+          cmd.replyTo ! RES_FAILURE(cmd, new RuntimeException(s"splice attempt rejected by our peer: ${msg.toAscii}"))
+          stay() using d.copy(spliceStatus = SpliceStatus.NoSplice) sending TxAbort(d.channelId, SpliceAttemptAborted(d.channelId).getMessage)
+        case SpliceStatus.SpliceAborted =>
+          log.debug("our peer acked our previous tx_abort")
+          stay() using d.copy(spliceStatus = SpliceStatus.NoSplice)
+        case SpliceStatus.NoSplice =>
+          log.info("our peer wants to abort the splice, but we've already negotiated a splice transaction: ascii='{}' bin={}", msg.toAscii, msg.data)
+          // We ack their tx_abort but we keep monitoring the funding transaction until it's confirmed or double-spent.
+          stay() sending TxAbort(d.channelId, SpliceAttemptAborted(d.channelId).getMessage)
+      }
+
+    case Event(msg: InteractiveTxBuilder.Response, d: DATA_NORMAL) =>
+      d.spliceStatus match {
+        case SpliceStatus.SpliceInProgress(cmd_opt, _, remoteCommitSig_opt) =>
+          msg match {
+            case InteractiveTxBuilder.SendMessage(msg) => stay() sending msg
+            case InteractiveTxBuilder.Succeeded(signingSession, commitSig) =>
+              log.info(s"splice tx completed: new funding index=${signingSession.fundingTxIndex} txid=${signingSession.fundingTx.txId}")
+              cmd_opt.foreach(cmd => cmd.replyTo ! RES_SPLICE(fundingTxIndex = signingSession.fundingTxIndex, signingSession.fundingTx.txId, signingSession.fundingParams.fundingAmount, signingSession.localCommit.fold(_.spec, _.spec).toLocal))
+              remoteCommitSig_opt.foreach(self ! _)
+              val d1 = d.copy(spliceStatus = SpliceStatus.SpliceWaitingForSigs(signingSession))
+              stay() using d1 storing() sending commitSig
+            case f: InteractiveTxBuilder.Failed =>
+              log.info("splice attempt failed: {}", f.cause.getMessage)
+              cmd_opt.foreach(cmd => cmd.replyTo ! RES_FAILURE(cmd, f.cause))
+              stay() using d.copy(spliceStatus = SpliceStatus.SpliceAborted) sending TxAbort(d.channelId, f.cause.getMessage)
+          }
+        case _ =>
+          // This can happen if we received a tx_abort right before receiving the interactive-tx result.
+          log.warning("ignoring interactive-tx result with spliceStatus={}", d.spliceStatus.getClass.getSimpleName)
+          stay()
+      }
+
+    case Event(msg: TxSignatures, d: DATA_NORMAL) =>
+      d.commitments.latest.localFundingStatus match {
+        case dfu@LocalFundingStatus.DualFundedUnconfirmedFundingTx(fundingTx: PartiallySignedSharedTransaction, _, _) if fundingTx.txId == msg.txId =>
+          // we already sent our tx_signatures
+          InteractiveTxSigningSession.addRemoteSigs(dfu.fundingParams, fundingTx, msg) match {
+            case Left(cause) =>
+              val unsignedFundingTx = fundingTx.tx.buildUnsignedTx()
+              log.warning("received invalid tx_signatures for txid={} (current funding txid={}): {}", msg.txId, unsignedFundingTx.txid, cause.getMessage)
+              // The funding transaction may still confirm (since our peer should be able to generate valid signatures),
+              // so we cannot close the channel yet.
+              stay() sending Error(d.channelId, InvalidFundingSignature(d.channelId, Some(unsignedFundingTx.txid)).getMessage)
+            case Right(fundingTx) =>
+              val dfu1 = dfu.copy(sharedTx = fundingTx)
+              d.commitments.updateLocalFundingStatus(msg.txId, dfu1) match {
+                case Right((commitments1, _)) =>
+                  log.info("publishing funding tx for channelId={} fundingTxId={}", d.channelId, fundingTx.signedTx.txid)
+                  stay() using d.copy(commitments = commitments1) storing() calling publishFundingTx(dfu1)
+                case Left(_) =>
+                  stay()
+              }
+          }
+        case _ =>
+          d.spliceStatus match {
+            case SpliceStatus.SpliceWaitingForSigs(signingSession) =>
+              // we have not yet sent our tx_signatures
+              signingSession.receiveTxSigs(nodeParams, msg) match {
+                case Left(f) =>
+                  rollbackFundingAttempt(signingSession.fundingTx.tx, previousTxs = Seq.empty) // no splice rbf yet
+                  stay() using d.copy(spliceStatus = SpliceStatus.SpliceAborted) sending TxAbort(d.channelId, f.getMessage)
+                case Right(signingSession1) =>
+                  watchFundingConfirmed(signingSession.fundingTx.txId, signingSession.fundingParams.minDepth_opt)
+                  val commitments1 = d.commitments.add(signingSession1.commitment)
+                  val d1 = d.copy(commitments = commitments1, spliceStatus = SpliceStatus.NoSplice)
+                  log.info("publishing funding tx for channelId={} fundingTxId={}", d.channelId, signingSession1.fundingTx.sharedTx.txId)
+                  stay() using d1 storing() sending signingSession1.localSigs calling publishFundingTx(signingSession1.fundingTx)
+              }
+            case _ =>
+              log.debug("rejecting unexpected tx_signatures for txId={}", msg.txId)
+              reportSpliceFailure(d.spliceStatus, UnexpectedFundingSignatures(d.channelId))
+              stay() using d.copy(spliceStatus = SpliceStatus.SpliceAborted) sending TxAbort(d.channelId, UnexpectedFundingSignatures(d.channelId).getMessage)
+          }
+      }
+
+    case Event(w: WatchPublishedTriggered, d: DATA_NORMAL) =>
+      val fundingStatus = LocalFundingStatus.ZeroconfPublishedFundingTx(w.tx)
+      d.commitments.updateLocalFundingStatus(w.tx.txid, fundingStatus) match {
+        case Right((commitments1, _)) =>
+          watchFundingConfirmed(w.tx.txid, Some(nodeParams.channelConf.minDepthBlocks))
+          maybeEmitEventsPostSplice(d.shortIds, d.commitments, commitments1)
+          stay() using d.copy(commitments = commitments1) storing() sending SpliceLocked(d.channelId, w.tx.hash)
+        case Left(_) => stay()
+      }
+
+    case Event(w: WatchFundingConfirmedTriggered, d: DATA_NORMAL) =>
+      acceptFundingTxConfirmed(w, d) match {
+        case Right((commitments1, commitment)) =>
+          val toSend = if (d.commitments.all.exists(c => c.fundingTxId == commitment.fundingTxId && c.localFundingStatus.isInstanceOf[LocalFundingStatus.NotLocked])) {
+            // this commitment just moved from NotLocked to Locked
+            Some(SpliceLocked(d.channelId, w.tx.hash))
+          } else {
+            // this was a zero-conf splice and we already sent our splice_locked
+            None
+          }
+          maybeEmitEventsPostSplice(d.shortIds, d.commitments, commitments1)
+          stay() using d.copy(commitments = commitments1) storing() sending toSend.toSeq
+        case Left(_) => stay()
+      }
+
+    case Event(msg: SpliceLocked, d: DATA_NORMAL) =>
+      d.commitments.updateRemoteFundingStatus(msg.fundingTxid) match {
+        case Right((commitments1, _)) =>
+          maybeEmitEventsPostSplice(d.shortIds, d.commitments, commitments1)
+          stay() using d.copy(commitments = commitments1) storing()
+        case Left(_) => stay()
+      }
+
     case Event(INPUT_DISCONNECTED, d: DATA_NORMAL) =>
       // we cancel the timer that would have made us send the enabled update after reconnection (flappy channel protection)
       cancelTimer(Reconnected.toString)
+      // if we are splicing, we need to cancel it
+      reportSpliceFailure(d.spliceStatus, new RuntimeException("splice attempt failed: disconnected"))
+      val d1 = d.spliceStatus match {
+        // We keep track of the RBF status: we should be able to complete the signature steps on reconnection.
+        case _: SpliceStatus.SpliceWaitingForSigs => d
+        case _ => d.copy(spliceStatus = SpliceStatus.NoSplice)
+      }
       // if we have pending unsigned htlcs, then we cancel them and generate an update with the disabled flag set, that will be returned to the sender in a temporary channel failure
       if (d.commitments.changes.localChanges.proposed.collectFirst { case add: UpdateAddHtlc => add }.isDefined) {
         log.debug("updating channel_update announcement (reason=disabled)")
@@ -726,9 +1034,9 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
         d.commitments.changes.localChanges.proposed.collect {
           case add: UpdateAddHtlc => relayer ! RES_ADD_SETTLED(d.commitments.originChannels(add.id), add, HtlcResult.DisconnectedBeforeSigned(channelUpdate1))
         }
-        goto(OFFLINE) using d.copy(channelUpdate = channelUpdate1) storing()
+        goto(OFFLINE) using d1.copy(channelUpdate = channelUpdate1) storing()
       } else {
-        goto(OFFLINE) using d
+        goto(OFFLINE) using d1
       }
 
     case Event(e: Error, d: DATA_NORMAL) => handleRemoteError(e, d)
@@ -846,28 +1154,32 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
       }
 
     case Event(commit: CommitSig, d@DATA_SHUTDOWN(_, localShutdown, remoteShutdown, closingFeerates)) =>
-      d.commitments.receiveCommit(Seq(commit), keyManager) match {
-        case Right((commitments1, revocation)) =>
-          // we always reply with a revocation
-          log.debug("received a new sig:\n{}", commitments1.latest.specs2String)
-          context.system.eventStream.publish(ChannelSignatureReceived(self, commitments1))
-          if (commitments1.hasNoPendingHtlcsOrFeeUpdate) {
-            if (d.commitments.params.localParams.isInitiator) {
-              // we are the channel initiator, need to initiate the negotiation by sending the first closing_signed
-              val (closingTx, closingSigned) = Closing.MutualClose.makeFirstClosingTx(keyManager, commitments1.latest, localShutdown.scriptPubKey, remoteShutdown.scriptPubKey, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets, closingFeerates)
-              goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, List(List(ClosingTxProposed(closingTx, closingSigned))), bestUnpublishedClosingTx_opt = None) storing() sending revocation :: closingSigned :: Nil
-            } else {
-              // we are not the channel initiator, will wait for their closing_signed
-              goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, closingTxProposed = List(List()), bestUnpublishedClosingTx_opt = None) storing() sending revocation
-            }
-          } else {
-            if (commitments1.changes.localHasChanges) {
-              // if we have newly acknowledged changes let's sign them
-              self ! CMD_SIGN()
-            }
-            stay() using d.copy(commitments = commitments1) storing() sending revocation
+      aggregateSigs(commit) match {
+        case Some(sigs) =>
+          d.commitments.receiveCommit(sigs, keyManager) match {
+            case Right((commitments1, revocation)) =>
+              // we always reply with a revocation
+              log.debug("received a new sig:\n{}", commitments1.latest.specs2String)
+              context.system.eventStream.publish(ChannelSignatureReceived(self, commitments1))
+              if (commitments1.hasNoPendingHtlcsOrFeeUpdate) {
+                if (d.commitments.params.localParams.isInitiator) {
+                  // we are the channel initiator, need to initiate the negotiation by sending the first closing_signed
+                  val (closingTx, closingSigned) = Closing.MutualClose.makeFirstClosingTx(keyManager, commitments1.latest, localShutdown.scriptPubKey, remoteShutdown.scriptPubKey, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets, closingFeerates)
+                  goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, List(List(ClosingTxProposed(closingTx, closingSigned))), bestUnpublishedClosingTx_opt = None) storing() sending revocation :: closingSigned :: Nil
+                } else {
+                  // we are not the channel initiator, will wait for their closing_signed
+                  goto(NEGOTIATING) using DATA_NEGOTIATING(commitments1, localShutdown, remoteShutdown, closingTxProposed = List(List()), bestUnpublishedClosingTx_opt = None) storing() sending revocation
+                }
+              } else {
+                if (commitments1.changes.localHasChanges) {
+                  // if we have newly acknowledged changes let's sign them
+                  self ! CMD_SIGN()
+                }
+                stay() using d.copy(commitments = commitments1) storing() sending revocation
+              }
+            case Left(cause) => handleLocalError(cause, d, Some(commit))
           }
-        case Left(cause) => handleLocalError(cause, d, Some(commit))
+        case None => stay()
       }
 
     case Event(revocation: RevokeAndAck, d@DATA_SHUTDOWN(_, localShutdown, remoteShutdown, closingFeerates)) =>
@@ -1076,11 +1388,8 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
 
     case Event(w: WatchFundingConfirmedTriggered, d: DATA_CLOSING) =>
       acceptFundingTxConfirmed(w, d) match {
-        case Right((commitments1, _)) =>
-          if (d.commitments.latest.fundingTxId == w.tx.txid) {
-            // The best funding tx candidate has been confirmed, alternative commitments have been pruned
-            stay() using d.copy(commitments = commitments1) storing()
-          } else {
+        case Right((commitments1, commitment)) =>
+          if (d.commitments.latest.fundingTxIndex == commitment.fundingTxIndex && d.commitments.latest.fundingTxId != commitment.fundingTxId) {
             // This is a corner case where:
             //  - we are using dual funding
             //  - *and* the funding tx was RBF-ed
@@ -1094,14 +1403,24 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
             // Force-closing is our only option here, if we are in this state the channel was closing and it is too late
             // to negotiate a mutual close.
             log.info("channelId={} was confirmed at blockHeight={} txIndex={} with a previous funding txid={}", d.channelId, w.blockHeight, w.txIndex, w.tx.txid)
-            val d1 = d.copy(commitments = commitments1)
+            val commitments2 = commitments1.copy(
+              active = commitment +: Nil,
+              inactive = Nil
+            )
+            val d1 = d.copy(commitments = commitments2)
             spendLocalCurrent(d1)
+          } else {
+            // We're still on the same splice history, nothing to do
+            stay() using d.copy(commitments = commitments1) storing()
           }
         case Left(_) => stay()
       }
 
     case Event(WatchFundingSpentTriggered(tx), d: DATA_CLOSING) =>
-      if (d.mutualClosePublished.exists(_.tx.txid == tx.txid)) {
+      if (d.commitments.all.map(_.fundingTxId).contains(tx.txid)) {
+        // if the spending tx is itself a funding tx, this is a splice and there is nothing to do
+        stay()
+      } else if (d.mutualClosePublished.exists(_.tx.txid == tx.txid)) {
         // we already know about this tx, probably because we have published it ourselves after successful negotiation
         stay()
       } else if (d.mutualCloseProposed.exists(_.tx.txid == tx.txid)) {
@@ -1130,9 +1449,43 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
         // counterparty may attempt to spend a revoked commit tx at any time
         handleRemoteSpentOther(tx, d)
       } else {
-        log.warning(s"unrecognized tx=${tx.txid}")
-        // this was for another commitments
-        stay()
+        d.commitments.resolveCommitment(tx) match {
+          case Some(commitment) =>
+            log.warning(s"a commit tx for an older commitment has been published txid=${tx.txid} fundingTxIndex=${commitment.fundingTxIndex}")
+            blockchain ! WatchAlternativeCommitTxConfirmed(self, tx.txid, nodeParams.channelConf.minDepthBlocks)
+            stay()
+          case None =>
+            // This must be a former funding tx that has already been pruned, because watches are unordered.
+            stay()
+        }
+      }
+
+    case Event(WatchAlternativeCommitTxConfirmedTriggered(_, _, tx), d: DATA_CLOSING) =>
+      d.commitments.resolveCommitment(tx) match {
+        case Some(commitment) =>
+          log.warning("a commit tx for fundingTxIndex={} fundingTxid={} has been confirmed", commitment.fundingTxIndex, commitment.fundingTxId)
+          val commitments1 = d.commitments.copy(
+            active = commitment +: Nil,
+            inactive = Nil
+          )
+          // we reset the state
+          val d1 = d.copy(commitments = commitments1)
+          if (commitment.localCommit.commitTxAndRemoteSig.commitTx.tx.txid == tx.txid) {
+            // our local commit has been published from the outside, it's unexpected but let's deal with it anyway
+            spendLocalCurrent(d1)
+          } else if (commitment.remoteCommit.txid == tx.txid && commitment.remoteCommit.index == d.commitments.remoteCommitIndex) {
+            // counterparty may attempt to spend its last commit tx at any time
+            handleRemoteSpentCurrent(tx, d1)
+          } else if (commitment.nextRemoteCommit_opt.exists(_.commit.txid == tx.txid) && commitment.remoteCommit.index == d.commitments.remoteCommitIndex && d.commitments.remoteNextCommitInfo.isLeft) {
+            // counterparty may attempt to spend its last commit tx at any time
+            handleRemoteSpentNext(tx, d1)
+          } else {
+            // counterparty may attempt to spend a revoked commit tx at any time
+            handleRemoteSpentOther(tx, d1)
+          }
+        case None =>
+          log.warning(s"unrecognized alternative commit tx=${tx.txid}")
+          stay()
       }
 
     case Event(WatchOutputSpentTriggered(tx), d: DATA_CLOSING) =>
@@ -1355,9 +1708,9 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
       channelReestablish.nextFundingTxId_opt match {
         case Some(fundingTxId) =>
           d.rbfStatus match {
-            case RbfStatus.RbfWaitingForSigs(status) if status.fundingTx.txId == fundingTxId =>
+            case RbfStatus.RbfWaitingForSigs(signingSession) if signingSession.fundingTx.txId == fundingTxId =>
               // We retransmit our commit_sig, and will send our tx_signatures once we've received their commit_sig.
-              val commitSig = status.remoteCommit.sign(keyManager, d.commitments.params, status.commitInput)
+              val commitSig = signingSession.remoteCommit.sign(keyManager, d.commitments.params, signingSession.commitInput)
               goto(WAIT_FOR_DUAL_FUNDING_CONFIRMED) sending commitSig
             case _ if d.latestFundingTx.sharedTx.txId == fundingTxId =>
               val toSend = d.latestFundingTx.sharedTx match {
@@ -1396,13 +1749,65 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
           var sendQueue = Queue.empty[LightningMessage]
           // normal case, our data is up-to-date
 
-          if (channelReestablish.nextLocalCommitmentNumber == 1 && d.commitments.localCommitIndex == 0) {
+          // re-send channel_ready or splice_locked
+          if (d.commitments.latest.fundingTxIndex == 0 && channelReestablish.nextLocalCommitmentNumber == 1 && d.commitments.localCommitIndex == 0) {
             // If next_local_commitment_number is 1 in both the channel_reestablish it sent and received, then the node MUST retransmit channel_ready, otherwise it MUST NOT
             log.debug("re-sending channelReady")
             val channelKeyPath = keyManager.keyPath(d.commitments.params.localParams, d.commitments.params.channelConfig)
             val nextPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 1)
             val channelReady = ChannelReady(d.commitments.channelId, nextPerCommitmentPoint)
             sendQueue = sendQueue :+ channelReady
+          } else {
+            // NB: there is a key difference between channel_ready and splice_confirmed:
+            // - channel_ready: a non-zero commitment index implies that both sides have seen the channel_ready
+            // - splice_confirmed: the commitment index can be updated as long as it is compatible with all splices, so
+            //   we must keep sending our most recent splice_confirmed at each reconnection
+            val spliceConfirmed = d.commitments.active
+              .filter(c => c.fundingTxIndex > 0) // only consider splice txs
+              .collectFirst { case c if c.localFundingStatus.isInstanceOf[LocalFundingStatus.Locked] =>
+                log.debug(s"re-sending SpliceLocked for fundingTxid=${c.fundingTxId}")
+                SpliceLocked(d.channelId, c.fundingTxId.reverse)
+              }
+            sendQueue = sendQueue ++ spliceConfirmed
+          }
+
+          // resume splice signing session if any
+          val spliceStatus1 = channelReestablish.nextFundingTxId_opt match {
+            case Some(fundingTxId) =>
+              d.spliceStatus match {
+                case SpliceStatus.SpliceWaitingForSigs(signingSession) if signingSession.fundingTx.txId == fundingTxId =>
+                  // We retransmit our commit_sig, and will send our tx_signatures once we've received their commit_sig.
+                  log.info(s"re-sending commit_sig for splice attempt with fundingTxIndex=${signingSession.fundingTxIndex} fundingTxId=${signingSession.fundingTx.txId}")
+                  val commitSig = signingSession.remoteCommit.sign(keyManager, d.commitments.params, signingSession.commitInput)
+                  sendQueue = sendQueue :+ commitSig
+                  d.spliceStatus
+                case _ if d.commitments.latest.fundingTxId == fundingTxId =>
+                  d.commitments.latest.localFundingStatus match {
+                    case dfu: LocalFundingStatus.DualFundedUnconfirmedFundingTx =>
+                      dfu.sharedTx match {
+                        case fundingTx: InteractiveTxBuilder.PartiallySignedSharedTransaction =>
+                          // If we have not received their tx_signatures, we can't tell whether they had received our commit_sig, so we need to retransmit it
+                          log.info(s"re-sending commit_sig and tx_signatures for fundingTxIndex=${d.commitments.latest.fundingTxIndex} fundingTxId=${d.commitments.latest.fundingTxId}")
+                          val commitSig = d.commitments.latest.remoteCommit.sign(keyManager, d.commitments.params, d.commitments.latest.commitInput)
+                          sendQueue = sendQueue :+ commitSig :+ fundingTx.localSigs
+                        case _ => ()
+                      }
+                      log.info(s"re-sending tx_signatures for fundingTxIndex=${d.commitments.latest.fundingTxIndex} fundingTxId=${d.commitments.latest.fundingTxId}")
+                      sendQueue = sendQueue :+ dfu.sharedTx.localSigs
+                    case _ =>
+                    // The funding tx is published or confirmed, and they have not received our tx_signatures, but they must have received our commit_sig, otherwise they
+                    // would not have sent their tx_signatures and we would not have been able to publish the funding tx in the first place. We could in theory
+                    // recompute our tx_signatures, but instead we do nothing: they will be notified that the funding tx has confirmed.
+                  }
+                  d.spliceStatus
+                case _ =>
+                  // The fundingTxId must be for a splice attempt that we didn't store (we got disconnected before receiving
+                  // their tx_complete): we tell them to abort that splice attempt.
+                  log.info(s"aborting obsolete splice attempt for fundingTxId=$fundingTxId")
+                  sendQueue = sendQueue :+ TxAbort(d.channelId, RbfAttemptAborted(d.channelId).getMessage)
+                  SpliceStatus.SpliceAborted
+              }
+            case None => d.spliceStatus
           }
 
           // we may need to retransmit updates and/or commit_sig and/or revocation
@@ -1467,7 +1872,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
             }
           }
 
-          goto(NORMAL) using d.copy(commitments = commitments1) sending sendQueue
+          goto(NORMAL) using d.copy(commitments = commitments1, spliceStatus = spliceStatus1) sending sendQueue
       }
 
     case Event(c: CMD_ADD_HTLC, d: DATA_NORMAL) => handleAddDisconnected(c, d)
@@ -1536,15 +1941,9 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
     case Event(e: Error, d: PersistentChannelData) => handleRemoteError(e, d)
   })
 
-  when(WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT)(handleExceptions {
-    case Event(WatchFundingSpentTriggered(tx), d: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) => handleRemoteSpentFuture(tx, d)
-  })
+  when(WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT)(PartialFunction.empty[Event, State])
 
-  private def errorStateHandler: StateFunction = {
-    case Event(Symbol("nevermatches"), _) => stay() // we can't define a state with no event handler, so we put a dummy one here
-  }
-
-  when(ERR_INFORMATION_LEAK)(errorStateHandler)
+  when(ERR_INFORMATION_LEAK)(PartialFunction.empty[Event, State])
 
   whenUnhandled {
 
@@ -1592,6 +1991,10 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
 
     case Event(c: CMD_BUMP_FUNDING_FEE, d) =>
       c.replyTo ! RES_FAILURE(c, CommandUnavailableInThisState(d.channelId, "rbf", stateName))
+      stay()
+
+    case Event(c: CMD_SPLICE, d) =>
+      c.replyTo ! RES_FAILURE(c, CommandUnavailableInThisState(d.channelId, "splice", stateName))
       stay()
 
     // at restore, if the configuration has changed, the channel will send a command to itself to update the relay fees
@@ -1697,18 +2100,30 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
       // if we were in the process of closing and already received a closing sig from the counterparty, it's always better to use that
       handleMutualClose(d.bestUnpublishedClosingTx_opt.get, Left(d))
 
-    case Event(WatchFundingSpentTriggered(tx), d: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) => handleRemoteSpentFuture(tx, d)
-
     case Event(WatchFundingSpentTriggered(tx), d: ChannelDataWithCommitments) =>
-      if (tx.txid == d.commitments.latest.remoteCommit.txid) {
+      if (d.commitments.all.map(_.fundingTxId).contains(tx.txid)) {
+        // if the spending tx is itself a funding tx, this is a splice and there is nothing to do
+        stay()
+      } else if (tx.txid == d.commitments.latest.remoteCommit.txid) {
         handleRemoteSpentCurrent(tx, d)
       } else if (d.commitments.latest.nextRemoteCommit_opt.exists(_.commit.txid == tx.txid)) {
         handleRemoteSpentNext(tx, d)
       } else if (tx.txid == d.commitments.latest.localCommit.commitTxAndRemoteSig.commitTx.tx.txid) {
         log.warning(s"processing local commit spent from the outside")
         spendLocalCurrent(d)
-      } else {
+      } else if (tx.txIn.map(_.outPoint.txid).contains(d.commitments.latest.fundingTxId)) {
         handleRemoteSpentOther(tx, d)
+      } else {
+        d.commitments.resolveCommitment(tx) match {
+          case Some(commitment) =>
+            log.warning(s"a commit tx for an older commitment has been published txid=${tx.txid} fundingTxIndex=${commitment.fundingTxIndex}")
+            // we watch the commitment tx, in the meantime we force close using the latest commitment
+            blockchain ! WatchAlternativeCommitTxConfirmed(self, tx.txid, nodeParams.channelConf.minDepthBlocks)
+            spendLocalCurrent(d)
+          case None =>
+            // This must be a former funding tx that has already been pruned, because watches are unordered.
+            stay()
+        }
       }
   }
 
@@ -1833,6 +2248,12 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
       }
   }
 
+  /** On disconnection we clear up the sig stash */
+  onTransition {
+    case _ -> OFFLINE =>
+      sigStash = Nil
+  }
+
   /*
           888    888        d8888 888b    888 8888888b.  888      8888888888 8888888b.   .d8888b.
           888    888       d88888 8888b   888 888  "Y88b 888      888        888   Y88b d88P  Y88b
@@ -1843,6 +2264,19 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
           888    888  d8888888888 888   Y8888 888  .d88P 888      888        888  T88b  Y88b  d88P
           888    888 d88P     888 888    Y888 8888888P"  88888888 8888888888 888   T88b  "Y8888P"
    */
+
+  /** For splices we will send one commit_sig per active commitments. */
+  private def aggregateSigs(commit: CommitSig): Option[Seq[CommitSig]] = {
+    sigStash = sigStash :+ commit
+    log.debug("received sig for batch of size={}", commit.batchSize)
+    if (sigStash.size == commit.batchSize) {
+      val sigs = sigStash
+      sigStash = Nil
+      Some(sigs)
+    } else {
+      None
+    }
+  }
 
   private def handleCurrentFeerate(c: CurrentFeerates, d: ChannelDataWithCommitments) = {
     // TODO: we should consider *all* commitments
@@ -1978,9 +2412,9 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
         // we need to remember their commitment point in order to be able to claim our outputs
         handleOutdatedCommitment(channelReestablish, d)
       case res: Syncing.SyncResult.RemoteLying =>
-        log.error(s"counterparty is lying about us having an outdated commitment!!! ourLocalCommitmentNumber=${res.ourLocalCommitmentNumber} theirRemoteCommitmentNumber=${res.theirRemoteCommitmentNumber}")
-        // they are deliberately trying to fool us into thinking we have a late commitment
-        handleLocalError(InvalidRevokedCommitProof(d.channelId, res.ourLocalCommitmentNumber, res.theirRemoteCommitmentNumber, res.invalidPerCommitmentSecret), d, Some(channelReestablish))
+        log.error(s"counterparty claims that we have an outdated commitment, but they sent an invalid proof, so our commitment may or may not be revoked: ourLocalCommitmentNumber=${res.ourLocalCommitmentNumber} theirRemoteCommitmentNumber=${res.theirRemoteCommitmentNumber}")
+        // they are deliberately trying to fool us into thinking we have a late commitment, but we cannot risk publishing it ourselves, because it may really be revoked!
+        handleOutdatedCommitment(channelReestablish, d)
       case SyncResult.RemoteLate =>
         log.error("counterparty appears to be using an outdated commitment, they may request a force-close, standing by...")
         stay()
@@ -1990,6 +2424,19 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
   private def maybeEmitChannelUpdateChangedEvent(newUpdate: ChannelUpdate, oldUpdate_opt: Option[ChannelUpdate], d: DATA_NORMAL): Unit = {
     if (oldUpdate_opt.isEmpty || !Announcements.areSameIgnoreFlags(newUpdate, oldUpdate_opt.get)) {
       context.system.eventStream.publish(ChannelUpdateParametersChanged(self, d.channelId, d.commitments.remoteNodeId, newUpdate))
+    }
+  }
+
+  /** Splices change balances and capacity, we send events to notify other actors (router, relayer) */
+  private def maybeEmitEventsPostSplice(shortIds: ShortIds, oldCommitments: Commitments, newCommitments: Commitments): Unit = {
+    // NB: we consider the send and receive balance, because router tracks both
+    if (oldCommitments.availableBalanceForSend != newCommitments.availableBalanceForSend || oldCommitments.availableBalanceForReceive != newCommitments.availableBalanceForReceive) {
+      context.system.eventStream.publish(AvailableBalanceChanged(self, newCommitments.channelId, shortIds, newCommitments))
+    }
+    if (!Helpers.aboveReserve(oldCommitments) && Helpers.aboveReserve(newCommitments)) {
+      // we just went above reserve (can't go below), let's refresh our channel_update to enable/disable it accordingly
+      log.debug("updating channel_update aboveReserve={}", Helpers.aboveReserve(newCommitments))
+      self ! BroadcastChannelUpdate(AboveReserve)
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -827,7 +827,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
               lockTime = nodeParams.currentBlockHeight.toLong,
               dustLimit = d.commitments.params.localParams.dustLimit.max(d.commitments.params.remoteParams.dustLimit),
               targetFeerate = msg.feerate,
-              minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = false, remoteContribution = msg.fundingContribution),
+              minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = false, localContribution = spliceAck.fundingContribution, remoteContribution = msg.fundingContribution),
               requireConfirmedInputs = RequireConfirmedInputs(forLocal = msg.requireConfirmedInputs, forRemote = spliceAck.requireConfirmedInputs)
             )
             val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
@@ -867,7 +867,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
             lockTime = spliceInit.lockTime,
             dustLimit = d.commitments.params.localParams.dustLimit.max(d.commitments.params.remoteParams.dustLimit),
             targetFeerate = spliceInit.feerate,
-            minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = true, remoteContribution = msg.fundingContribution),
+            minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, isInitiator = true, localContribution = spliceInit.fundingContribution, remoteContribution = msg.fundingContribution),
             requireConfirmedInputs = RequireConfirmedInputs(forLocal = msg.requireConfirmedInputs, forRemote = spliceInit.requireConfirmedInputs)
           )
           val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -169,7 +169,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
           val channelParams = ChannelParams(channelId, d.init.channelConfig, channelFeatures, localParams, remoteParams, open.channelFlags)
           val localAmount = d.init.fundingContribution_opt.getOrElse(0 sat)
           val remoteAmount = open.fundingAmount
-          val minDepth_opt = channelParams.minDepthDualFunding(nodeParams.channelConf.minDepthBlocks, localContribution = localAmount, remoteContribution = remoteAmount)
+          val minDepth_opt = channelParams.minDepthDualFunding(nodeParams.channelConf.minDepthBlocks, localAmount + remoteAmount)
           val upfrontShutdownScript_opt = localParams.upfrontShutdownScript_opt.map(scriptPubKey => ChannelTlv.UpfrontShutdownScriptTlv(scriptPubKey))
           val tlvs: Set[AcceptDualFundedChannelTlv] = Set(
             upfrontShutdownScript_opt,
@@ -266,7 +266,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
           val channelParams = ChannelParams(channelId, d.init.channelConfig, channelFeatures, localParams, remoteParams, d.lastSent.channelFlags)
           val localAmount = d.lastSent.fundingAmount
           val remoteAmount = accept.fundingAmount
-          val minDepth_opt = channelParams.minDepthDualFunding(nodeParams.channelConf.minDepthBlocks, localContribution = localAmount, remoteContribution = remoteAmount)
+          val minDepth_opt = channelParams.minDepthDualFunding(nodeParams.channelConf.minDepthBlocks, localAmount + remoteAmount)
           val fundingParams = InteractiveTxParams(
             channelId = channelId,
             isInitiator = localParams.isInitiator,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -20,7 +20,6 @@ import akka.actor.typed.scaladsl.adapter.{ClassicActorContextOps, actorRefAdapte
 import com.softwaremill.quicklens.{ModifyPimp, QuicklensAt}
 import fr.acinq.bitcoin.scalacompat.{SatoshiLong, Script}
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
-import fr.acinq.eclair.channel.Helpers.Funding
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.fsm.Channel._
 import fr.acinq.eclair.channel.fund.InteractiveTxBuilder.{FullySignedSharedTransaction, InteractiveTxParams, PartiallySignedSharedTransaction, RequireConfirmedInputs}
@@ -146,11 +145,31 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
         case Left(t) => handleLocalError(t, d, Some(open))
         case Right((channelFeatures, remoteShutdownScript)) =>
           context.system.eventStream.publish(ChannelCreated(self, peer, remoteNodeId, isInitiator = false, open.temporaryChannelId, open.commitmentFeerate, Some(open.fundingFeerate)))
+          val remoteParams = RemoteParams(
+            nodeId = remoteNodeId,
+            dustLimit = open.dustLimit,
+            maxHtlcValueInFlightMsat = open.maxHtlcValueInFlightMsat,
+            requestedChannelReserve_opt = None, // channel reserve will be computed based on channel capacity
+            htlcMinimum = open.htlcMinimum,
+            toSelfDelay = open.toSelfDelay,
+            maxAcceptedHtlcs = open.maxAcceptedHtlcs,
+            fundingPubKey = open.fundingPubkey,
+            revocationBasepoint = open.revocationBasepoint,
+            paymentBasepoint = open.paymentBasepoint,
+            delayedPaymentBasepoint = open.delayedPaymentBasepoint,
+            htlcBasepoint = open.htlcBasepoint,
+            initFeatures = remoteInit.features,
+            upfrontShutdownScript_opt = remoteShutdownScript)
+          log.debug("remote params: {}", remoteParams)
           val localFundingPubkey = keyManager.fundingPublicKey(localParams.fundingKeyPath).publicKey
           val channelKeyPath = keyManager.keyPath(localParams, d.init.channelConfig)
+          val revocationBasePoint = keyManager.revocationPoint(channelKeyPath).publicKey
+          // We've exchanged open_channel2 and accept_channel2, we now know the final channelId.
+          val channelId = Helpers.computeChannelId(open.revocationBasepoint, revocationBasePoint)
+          val channelParams = ChannelParams(channelId, d.init.channelConfig, channelFeatures, localParams, remoteParams, open.channelFlags)
           val localAmount = d.init.fundingContribution_opt.getOrElse(0 sat)
           val remoteAmount = open.fundingAmount
-          val minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.init.localParams.initFeatures, isInitiator = localParams.isInitiator, localContribution = localAmount, remoteContribution = remoteAmount)
+          val minDepth_opt = channelParams.minDepthDualFunding(nodeParams.channelConf.minDepthBlocks, localContribution = localAmount, remoteContribution = remoteAmount)
           val upfrontShutdownScript_opt = localParams.upfrontShutdownScript_opt.map(scriptPubKey => ChannelTlv.UpfrontShutdownScriptTlv(scriptPubKey))
           val tlvs: Set[AcceptDualFundedChannelTlv] = Set(
             upfrontShutdownScript_opt,
@@ -168,31 +187,13 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
             toSelfDelay = localParams.toSelfDelay,
             maxAcceptedHtlcs = localParams.maxAcceptedHtlcs,
             fundingPubkey = localFundingPubkey,
-            revocationBasepoint = keyManager.revocationPoint(channelKeyPath).publicKey,
+            revocationBasepoint = revocationBasePoint,
             paymentBasepoint = localParams.walletStaticPaymentBasepoint.getOrElse(keyManager.paymentPoint(channelKeyPath).publicKey),
             delayedPaymentBasepoint = keyManager.delayedPaymentPoint(channelKeyPath).publicKey,
             htlcBasepoint = keyManager.htlcPoint(channelKeyPath).publicKey,
             firstPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 0),
             secondPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 1),
             tlvStream = TlvStream(tlvs))
-          val remoteParams = RemoteParams(
-            nodeId = remoteNodeId,
-            dustLimit = open.dustLimit,
-            maxHtlcValueInFlightMsat = open.maxHtlcValueInFlightMsat,
-            requestedChannelReserve_opt = None, // channel reserve will be computed based on channel capacity
-            htlcMinimum = open.htlcMinimum,
-            toSelfDelay = open.toSelfDelay,
-            maxAcceptedHtlcs = open.maxAcceptedHtlcs,
-            fundingPubKey = open.fundingPubkey,
-            revocationBasepoint = open.revocationBasepoint,
-            paymentBasepoint = open.paymentBasepoint,
-            delayedPaymentBasepoint = open.delayedPaymentBasepoint,
-            htlcBasepoint = open.htlcBasepoint,
-            initFeatures = remoteInit.features,
-            upfrontShutdownScript_opt = remoteShutdownScript)
-          log.debug("remote params: {}", remoteParams)
-          // We've exchanged open_channel2 and accept_channel2, we now know the final channelId.
-          val channelId = Helpers.computeChannelId(open, accept)
           peer ! ChannelIdAssigned(self, remoteNodeId, accept.temporaryChannelId, channelId) // we notify the peer asap so it knows how to route messages
           txPublisher ! SetChannelId(remoteNodeId, channelId)
           context.system.eventStream.publish(ChannelIdAssigned(self, remoteNodeId, accept.temporaryChannelId, channelId))
@@ -212,7 +213,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
             minDepth_opt = minDepth_opt,
             requireConfirmedInputs = RequireConfirmedInputs(forLocal = open.requireConfirmedInputs, forRemote = accept.requireConfirmedInputs)
           )
-          val channelParams = ChannelParams(channelId, d.init.channelConfig, channelFeatures, localParams, remoteParams, open.channelFlags)
+
           val purpose = InteractiveTxBuilder.FundingTx(open.commitmentFeerate, open.firstPerCommitmentPoint)
           val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
             nodeParams, fundingParams,
@@ -239,7 +240,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
           handleLocalError(t, d, Some(accept))
         case Right((channelFeatures, remoteShutdownScript)) =>
           // We've exchanged open_channel2 and accept_channel2, we now know the final channelId.
-          val channelId = Helpers.computeChannelId(d.lastSent, accept)
+          val channelId = Helpers.computeChannelId(d.lastSent.revocationBasepoint, accept.revocationBasepoint)
           peer ! ChannelIdAssigned(self, remoteNodeId, accept.temporaryChannelId, channelId) // we notify the peer asap so it knows how to route messages
           txPublisher ! SetChannelId(remoteNodeId, channelId)
           context.system.eventStream.publish(ChannelIdAssigned(self, remoteNodeId, accept.temporaryChannelId, channelId))
@@ -262,9 +263,10 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
           // We start the interactive-tx funding protocol.
           val localFundingPubkey = keyManager.fundingPublicKey(localParams.fundingKeyPath)
           val fundingPubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey.publicKey, remoteParams.fundingPubKey)))
+          val channelParams = ChannelParams(channelId, d.init.channelConfig, channelFeatures, localParams, remoteParams, d.lastSent.channelFlags)
           val localAmount = d.lastSent.fundingAmount
           val remoteAmount = accept.fundingAmount
-          val minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.init.localParams.initFeatures, isInitiator = localParams.isInitiator, localContribution = localAmount, remoteContribution = remoteAmount)
+          val minDepth_opt = channelParams.minDepthDualFunding(nodeParams.channelConf.minDepthBlocks, localContribution = localAmount, remoteContribution = remoteAmount)
           val fundingParams = InteractiveTxParams(
             channelId = channelId,
             isInitiator = localParams.isInitiator,
@@ -279,7 +281,6 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
             minDepth_opt = minDepth_opt,
             requireConfirmedInputs = RequireConfirmedInputs(forLocal = accept.requireConfirmedInputs, forRemote = d.lastSent.requireConfirmedInputs)
           )
-          val channelParams = ChannelParams(channelId, d.init.channelConfig, channelFeatures, localParams, remoteParams, d.lastSent.channelFlags)
           val purpose = InteractiveTxBuilder.FundingTx(d.lastSent.commitmentFeerate, accept.firstPerCommitmentPoint)
           val txBuilder = context.spawnAnonymous(InteractiveTxBuilder(
             nodeParams, fundingParams,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -150,7 +150,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
           val channelKeyPath = keyManager.keyPath(localParams, d.init.channelConfig)
           val localAmount = d.init.fundingContribution_opt.getOrElse(0 sat)
           val remoteAmount = open.fundingAmount
-          val minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.init.localParams.initFeatures, isInitiator = localParams.isInitiator, remoteContribution = remoteAmount)
+          val minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.init.localParams.initFeatures, isInitiator = localParams.isInitiator, localContribution = localAmount, remoteContribution = remoteAmount)
           val upfrontShutdownScript_opt = localParams.upfrontShutdownScript_opt.map(scriptPubKey => ChannelTlv.UpfrontShutdownScriptTlv(scriptPubKey))
           val tlvs: Set[AcceptDualFundedChannelTlv] = Set(
             upfrontShutdownScript_opt,
@@ -264,7 +264,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
           val fundingPubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey.publicKey, remoteParams.fundingPubKey)))
           val localAmount = d.lastSent.fundingAmount
           val remoteAmount = accept.fundingAmount
-          val minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.init.localParams.initFeatures, isInitiator = localParams.isInitiator, remoteContribution = remoteAmount)
+          val minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.init.localParams.initFeatures, isInitiator = localParams.isInitiator, localContribution = localAmount, remoteContribution = remoteAmount)
           val fundingParams = InteractiveTxParams(
             channelId = channelId,
             isInitiator = localParams.isInitiator,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -150,7 +150,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
           val channelKeyPath = keyManager.keyPath(localParams, d.init.channelConfig)
           val localAmount = d.init.fundingContribution_opt.getOrElse(0 sat)
           val remoteAmount = open.fundingAmount
-          val minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.init.localParams.initFeatures, isInitiator = localParams.isInitiator, localContribution = localAmount, remoteContribution = remoteAmount)
+          val minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.init.localParams.initFeatures, isInitiator = localParams.isInitiator, remoteContribution = remoteAmount)
           val upfrontShutdownScript_opt = localParams.upfrontShutdownScript_opt.map(scriptPubKey => ChannelTlv.UpfrontShutdownScriptTlv(scriptPubKey))
           val tlvs: Set[AcceptDualFundedChannelTlv] = Set(
             upfrontShutdownScript_opt,
@@ -264,7 +264,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
           val fundingPubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(localFundingPubkey.publicKey, remoteParams.fundingPubKey)))
           val localAmount = d.lastSent.fundingAmount
           val remoteAmount = accept.fundingAmount
-          val minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.init.localParams.initFeatures, isInitiator = localParams.isInitiator, localContribution = localAmount, remoteContribution = remoteAmount)
+          val minDepth_opt = Funding.minDepthDualFunding(nodeParams.channelConf, d.init.localParams.initFeatures, isInitiator = localParams.isInitiator, remoteContribution = remoteAmount)
           val fundingParams = InteractiveTxParams(
             channelId = channelId,
             isInitiator = localParams.isInitiator,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
@@ -278,6 +278,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
                 signature = localSigOfRemoteTx
               )
               val commitment = Commitment(
+                fundingTxIndex = 0,
                 localFundingStatus = SingleFundedUnconfirmedFundingTx(None),
                 remoteFundingStatus = RemoteFundingStatus.NotLocked,
                 localCommit = LocalCommit(0, localSpec, CommitTxAndRemoteSig(localCommitTx, remoteSig), htlcTxsAndRemoteSigs = Nil),
@@ -322,6 +323,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
           handleLocalError(InvalidCommitmentSignature(d.channelId, signedLocalCommitTx.tx.txid), d, Some(msg))
         case Success(_) =>
           val commitment = Commitment(
+            fundingTxIndex = 0,
             localFundingStatus = SingleFundedUnconfirmedFundingTx(Some(fundingTx)),
             remoteFundingStatus = RemoteFundingStatus.NotLocked,
             localCommit = LocalCommit(0, localSpec, CommitTxAndRemoteSig(localCommitTx, remoteSig), htlcTxsAndRemoteSigs = Nil),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.channel.fsm
 
 import akka.actor.typed.scaladsl.adapter.actorRefAdapter
-import com.softwaremill.quicklens.{ModifyPimp, QuicklensAt}
+import com.softwaremill.quicklens.ModifyPimp
 import fr.acinq.bitcoin.ScriptFlags
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, Transaction}
 import fr.acinq.eclair.ShortChannelId
@@ -112,9 +112,7 @@ trait CommonFundingHandlers extends CommonHandlers {
     context.system.scheduler.scheduleWithFixedDelay(initialDelay = REFRESH_CHANNEL_UPDATE_INTERVAL, delay = REFRESH_CHANNEL_UPDATE_INTERVAL, receiver = self, message = BroadcastChannelUpdate(PeriodicRefresh))
     // used to get the final shortChannelId, used in announcements (if minDepth >= ANNOUNCEMENTS_MINCONF this event will fire instantly)
     blockchain ! WatchFundingDeeplyBuried(self, commitments.latest.fundingTxId, ANNOUNCEMENTS_MINCONF)
-    val commitments1 = commitments
-      .modify(_.remoteNextCommitInfo).setTo(Right(channelReady.nextPerCommitmentPoint))
-      .modify(_.active.at(0).remoteFundingStatus).setTo(RemoteFundingStatus.Locked)
+    val commitments1 = commitments.modify(_.remoteNextCommitInfo).setTo(Right(channelReady.nextPerCommitmentPoint))
     DATA_NORMAL(commitments1, shortIds1, None, initialChannelUpdate, None, None, None, SpliceStatus.NoSplice)
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/DualFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/DualFundingHandlers.scala
@@ -146,4 +146,14 @@ trait DualFundingHandlers extends CommonFundingHandlers {
     }
   }
 
+  def reportSpliceFailure(spliceStatus: SpliceStatus, f: Throwable): Unit = {
+    spliceStatus match {
+      case SpliceStatus.SpliceRequested(cmd, _) => cmd.replyTo ! RES_FAILURE(cmd, f)
+      case SpliceStatus.SpliceInProgress(cmd_opt, txBuilder, _) =>
+        txBuilder ! InteractiveTxBuilder.Abort
+        cmd_opt.foreach(cmd => cmd.replyTo ! RES_FAILURE(cmd, f))
+      case _ => ()
+    }
+  }
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ErrorHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ErrorHandlers.scala
@@ -185,14 +185,16 @@ trait ErrorHandlers extends CommonHandlers {
       stay()
     } else {
       val finalScriptPubKey = getOrGenerateFinalScriptPubKey(d)
-      val commitTx = d.commitments.latest.fullySignedLocalCommitTx(keyManager).tx
-      val localCommitPublished = Closing.LocalClose.claimCommitTxOutputs(keyManager, d.commitments.latest, commitTx, nodeParams.currentBlockHeight, nodeParams.onChainFeeConf, finalScriptPubKey)
+      val commitment = d.commitments.latest
+      log.error(s"force-closing with fundingIndex=${commitment.fundingTxIndex}")
+      val commitTx = commitment.fullySignedLocalCommitTx(keyManager).tx
+      val localCommitPublished = Closing.LocalClose.claimCommitTxOutputs(keyManager, commitment, commitTx, nodeParams.currentBlockHeight, nodeParams.onChainFeeConf, finalScriptPubKey)
       val nextData = d match {
         case closing: DATA_CLOSING => closing.copy(localCommitPublished = Some(localCommitPublished))
         case negotiating: DATA_NEGOTIATING => DATA_CLOSING(d.commitments, waitingSince = nodeParams.currentBlockHeight, finalScriptPubKey = finalScriptPubKey, negotiating.closingTxProposed.flatten.map(_.unsignedTx), localCommitPublished = Some(localCommitPublished))
         case _ => DATA_CLOSING(d.commitments, waitingSince = nodeParams.currentBlockHeight, finalScriptPubKey = finalScriptPubKey, mutualCloseProposed = Nil, localCommitPublished = Some(localCommitPublished))
       }
-      goto(CLOSING) using nextData storing() calling doPublish(localCommitPublished, d.commitments.latest)
+      goto(CLOSING) using nextData storing() calling doPublish(localCommitPublished, commitment)
     }
   }
 
@@ -239,23 +241,6 @@ trait ErrorHandlers extends CommonHandlers {
     goto(CLOSING) using nextData storing() calling doPublish(remoteCommitPublished, commitments)
   }
 
-  def handleRemoteSpentFuture(commitTx: Transaction, d: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) = {
-    // It doesn't matter which commitment we use here, we'll only be able to claim our main outputs which is independent of the commitment.
-    val commitments = d.commitments.latest
-    log.warning(s"they published their future commit (because we asked them to) in txid=${commitTx.txid}")
-    context.system.eventStream.publish(TransactionPublished(d.channelId, remoteNodeId, commitTx, Closing.commitTxFee(commitments.commitInput, commitTx, d.commitments.params.localParams.isInitiator), "future-remote-commit"))
-    val finalScriptPubKey = getOrGenerateFinalScriptPubKey(d)
-    val remotePerCommitmentPoint = d.remoteChannelReestablish.myCurrentPerCommitmentPoint
-    val remoteCommitPublished = RemoteCommitPublished(
-      commitTx = commitTx,
-      claimMainOutputTx = Closing.RemoteClose.claimMainOutput(keyManager, d.commitments.params, remotePerCommitmentPoint, commitTx, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets, finalScriptPubKey),
-      claimHtlcTxs = Map.empty,
-      claimAnchorTxs = List.empty,
-      irrevocablySpent = Map.empty)
-    val nextData = DATA_CLOSING(d.commitments, waitingSince = nodeParams.currentBlockHeight, finalScriptPubKey = finalScriptPubKey, mutualCloseProposed = Nil, futureRemoteCommitPublished = Some(remoteCommitPublished))
-    goto(CLOSING) using nextData storing() calling doPublish(remoteCommitPublished, commitments)
-  }
-
   def handleRemoteSpentNext(commitTx: Transaction, d: ChannelDataWithCommitments) = {
     val commitment = d.commitments.latest
     log.warning(s"they published their next commit in txid=${commitTx.txid}")
@@ -297,8 +282,9 @@ trait ErrorHandlers extends CommonHandlers {
     val commitments = d.commitments.latest
     log.warning(s"funding tx spent in txid=${tx.txid}")
     val finalScriptPubKey = getOrGenerateFinalScriptPubKey(d)
-    Closing.RevokedClose.claimCommitTxOutputs(keyManager, d.commitments.params, d.commitments.remotePerCommitmentSecrets, tx, nodeParams.db.channels, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets, finalScriptPubKey) match {
-      case Some(revokedCommitPublished) =>
+    Closing.RevokedClose.getRemotePerCommitmentSecret(keyManager, d.commitments.params, d.commitments.remotePerCommitmentSecrets, tx) match {
+      case Some((commitmentNumber, remotePerCommitmentSecret)) =>
+        val revokedCommitPublished = Closing.RevokedClose.claimCommitTxOutputs(keyManager, d.commitments.params, tx, commitmentNumber, remotePerCommitmentSecret, nodeParams.db.channels, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets, finalScriptPubKey)
         log.warning(s"txid=${tx.txid} was a revoked commitment, publishing the penalty tx")
         context.system.eventStream.publish(TransactionPublished(d.channelId, remoteNodeId, tx, Closing.commitTxFee(commitments.commitInput, tx, d.commitments.params.localParams.isInitiator), "revoked-commit"))
         val exc = FundingTxSpent(d.channelId, tx.txid)
@@ -310,11 +296,25 @@ trait ErrorHandlers extends CommonHandlers {
           case _ => DATA_CLOSING(d.commitments, waitingSince = nodeParams.currentBlockHeight, finalScriptPubKey = finalScriptPubKey, mutualCloseProposed = Nil, revokedCommitPublished = revokedCommitPublished :: Nil)
         }
         goto(CLOSING) using nextData storing() calling doPublish(revokedCommitPublished) sending error
-      case None =>
-        // the published tx was neither their current commitment nor a revoked one
-        log.error(s"couldn't identify txid=${tx.txid}, something very bad is going on!!!")
-        context.system.eventStream.publish(NotifyNodeOperator(NotificationsLogger.Error, s"funding tx ${commitments.fundingTxId} of channel ${d.channelId} was spent by an unknown transaction, indicating that your DB has lost data or your node has been breached: please contact the dev team."))
-        goto(ERR_INFORMATION_LEAK)
+      case None => d match {
+        case d: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT =>
+          log.warning(s"they published a future commit (because we asked them to) in txid=${tx.txid}")
+          context.system.eventStream.publish(TransactionPublished(d.channelId, remoteNodeId, tx, Closing.commitTxFee(d.commitments.latest.commitInput, tx, d.commitments.latest.localParams.isInitiator), "future-remote-commit"))
+          val remotePerCommitmentPoint = d.remoteChannelReestablish.myCurrentPerCommitmentPoint
+          val remoteCommitPublished = RemoteCommitPublished(
+            commitTx = tx,
+            claimMainOutputTx = Closing.RemoteClose.claimMainOutput(keyManager, d.commitments.params, remotePerCommitmentPoint, tx, nodeParams.onChainFeeConf.feeEstimator, nodeParams.onChainFeeConf.feeTargets, finalScriptPubKey),
+            claimHtlcTxs = Map.empty,
+            claimAnchorTxs = List.empty,
+            irrevocablySpent = Map.empty)
+          val nextData = DATA_CLOSING(d.commitments, waitingSince = nodeParams.currentBlockHeight, finalScriptPubKey = finalScriptPubKey, mutualCloseProposed = Nil, futureRemoteCommitPublished = Some(remoteCommitPublished))
+          goto(CLOSING) using nextData storing() calling doPublish(remoteCommitPublished, d.commitments.latest)
+        case _ =>
+          // the published tx doesn't seem to be a valid commitment transaction
+          log.error(s"couldn't identify txid=${tx.txid}, something very bad is going on!!!")
+          context.system.eventStream.publish(NotifyNodeOperator(NotificationsLogger.Error, s"funding tx ${commitments.fundingTxId} of channel ${d.channelId} was spent by an unknown transaction, indicating that your DB has lost data or your node has been breached: please contact the dev team."))
+          goto(ERR_INFORMATION_LEAK)
+      }
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/SingleFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/SingleFundingHandlers.scala
@@ -116,10 +116,10 @@ trait SingleFundingHandlers extends CommonFundingHandlers {
 
   def singleFundingMinDepth(d: ChannelDataWithCommitments): Long = {
     val minDepth_opt = if (d.commitments.params.localParams.isInitiator) {
-      Helpers.Funding.minDepthFunder(d.commitments.params.localParams.initFeatures)
+      d.commitments.params.minDepthFunder
     } else {
       // when we're not the channel initiator we scale the min_depth confirmations depending on the funding amount
-      Helpers.Funding.minDepthFundee(nodeParams.channelConf, d.commitments.params.localParams.initFeatures, d.commitments.latest.commitInput.txOut.amount)
+      d.commitments.params.minDepthFundee(nodeParams.channelConf.minDepthBlocks, d.commitments.latest.commitInput.txOut.amount)
     }
     val minDepth = minDepth_opt.getOrElse {
       val defaultMinDepth = nodeParams.channelConf.minDepthBlocks

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/SingleFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/SingleFundingHandlers.scala
@@ -44,7 +44,7 @@ trait SingleFundingHandlers extends CommonFundingHandlers {
     wallet.commit(fundingTx).onComplete {
       case Success(true) =>
         context.system.eventStream.publish(TransactionPublished(channelId, remoteNodeId, fundingTx, fundingTxFee, "funding"))
-        replyTo ! OpenChannelResponse.Created(channelId, fundingTx.txid, fundingTxFee)
+        replyTo ! OpenChannelResponse.Created(channelId, fundingTxId = fundingTx.txid, fundingTxFee)
       case Success(false) =>
         replyTo ! OpenChannelResponse.Rejected("couldn't publish funding tx")
         self ! BITCOIN_FUNDING_PUBLISH_FAILED // fail-fast: this should be returned only when we are really sure the tx has *not* been published

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -21,7 +21,7 @@ import akka.actor.typed.{ActorRef, Behavior}
 import akka.event.LoggingAdapter
 import fr.acinq.bitcoin.ScriptFlags
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, KotlinUtils, LexicographicalOrdering, OutPoint, Satoshi, SatoshiLong, Script, ScriptWitness, Transaction, TxIn, TxOut}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, LexicographicalOrdering, OutPoint, Satoshi, SatoshiLong, Script, ScriptWitness, Transaction, TxIn, TxOut}
 import fr.acinq.eclair.blockchain.OnChainChannelFunder
 import fr.acinq.eclair.blockchain.OnChainWallet.SignTransactionResponse
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
@@ -101,13 +101,13 @@ object InteractiveTxBuilder {
   sealed trait SharedFundingInput {
     // @formatter:off
     def info: InputInfo
-    def weight: Long
+    def weight: Int
     def sign(keyManager: ChannelKeyManager, params: ChannelParams, tx: Transaction): ByteVector64
     // @formatter:on
   }
 
   case class Multisig2of2Input(info: InputInfo, localFundingPubkey: PublicKey, remoteFundingPubkey: PublicKey) extends SharedFundingInput {
-    override val weight: Long = Multisig2of2Input.weight
+    override val weight: Int = 388
 
     override def sign(keyManager: ChannelKeyManager, params: ChannelParams, tx: Transaction): ByteVector64 = {
       val fundingPubkey = keyManager.fundingPublicKey(params.localParams.fundingKeyPath)
@@ -116,8 +116,6 @@ object InteractiveTxBuilder {
   }
 
   object Multisig2of2Input {
-    val weight: Long = 388
-
     def apply(keyManager: ChannelKeyManager, params: ChannelParams, commitment: Commitment): Multisig2of2Input = Multisig2of2Input(
       info = commitment.commitInput,
       localFundingPubkey = keyManager.fundingPublicKey(params.localParams.fundingKeyPath).publicKey,
@@ -156,29 +154,6 @@ object InteractiveTxBuilder {
     val minNextFeerate: FeeratePerKw = targetFeerate * 25 / 24
     // BOLT 2: the initiator's serial IDs MUST use even values and the non-initiator odd values.
     val serialIdParity: Int = if (isInitiator) 0 else 1
-  }
-
-  def computeLocalContribution(isInitiator: Boolean, commitment: Commitment, spliceInAmount: Satoshi, spliceOut: List[TxOut], targetFeerate: FeeratePerKw): Satoshi = {
-    // If there is a splice-in, whatever the amount of the splice-in, fees will be paid for by bitcoind, when we call
-    // fundrawtransaction to pay the inputs. they won't change the contribution so we don't take them into account
-    val fees = if (spliceInAmount == 0.sat) {
-      val commonFieldsWeight = if (isInitiator) {
-        val dummyTx = Transaction(
-          version = 2,
-          txIn = Nil, // NB: we add the weight manually
-          txOut = commitment.commitInput.txOut +: Nil, // we're taking the previous output, it has the wrong amount but we don't care: only the weight matters to compute fees
-          lockTime = 0
-        )
-        dummyTx.weight() + Multisig2of2Input.weight
-      } else 0
-      val spliceOutputsWeight = spliceOut.map(KotlinUtils.scala2kmp).map(_.weight()).sum
-      val weight = commonFieldsWeight + spliceOutputsWeight
-      Transactions.weight2fee(targetFeerate, weight.toInt)
-    } else {
-      // if there is a splice-in, bitcoind will add fees when adding the input
-      0 sat
-    }
-    spliceInAmount - spliceOut.map(_.amount).sum - fees
   }
 
   // @formatter:off
@@ -670,10 +645,9 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
     }
 
     val sharedInput_opt = fundingParams.sharedInput_opt.map(_ => {
-      // To compute the remote reserve, we discard the local contribution. It's okay if they go below reserve because
-      // we added capacity to the channel with a splice-in.
-      val remoteReserve = ((fundingParams.fundingAmount - fundingParams.localContribution) / 100).max(channelParams.localParams.dustLimit)
-      if (sharedOutput.remoteAmount < remoteReserve && remoteOutputs.nonEmpty) {
+      val remoteReserve = (fundingParams.fundingAmount / 100).max(channelParams.localParams.dustLimit)
+      // We ignore the reserve requirement if we are splicing funds into the channel, which increases the size of the reserve.
+      if (sharedOutput.remoteAmount < remoteReserve && remoteOutputs.nonEmpty && localInputs.isEmpty) {
         log.warn("invalid interactive tx: peer takes too much funds out and falls below the channel reserve ({} < {})", sharedOutput.remoteAmount, remoteReserve)
         return Left(InvalidCompleteInteractiveTx(fundingParams.channelId))
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -670,7 +670,9 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
     }
 
     val sharedInput_opt = fundingParams.sharedInput_opt.map(_ => {
-      val remoteReserve = (fundingParams.fundingAmount / 100).max(channelParams.localParams.dustLimit)
+      // To compute the remote reserve, we discard the local contribution. It's okay if they go below reserve because
+      // we added capacity to the channel with a splice-in.
+      val remoteReserve = ((fundingParams.fundingAmount - fundingParams.localContribution) / 100).max(channelParams.localParams.dustLimit)
       if (sharedOutput.remoteAmount < remoteReserve && remoteOutputs.nonEmpty) {
         log.warn("invalid interactive tx: peer takes too much funds out and falls below the channel reserve ({} < {})", sharedOutput.remoteAmount, remoteReserve)
         return Left(InvalidCompleteInteractiveTx(fundingParams.channelId))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -41,7 +41,7 @@ import fr.acinq.eclair.{Alias, BlockHeight, CltvExpiry, CltvExpiryDelta, Feature
 import org.json4s
 import org.json4s.JsonAST._
 import org.json4s.jackson.Serialization
-import org.json4s.{DefaultFormats, Extraction, Formats, JDecimal, JValue, KeySerializer, Serializer, ShortTypeHints, TypeHints, jackson}
+import org.json4s.{CustomSerializer, DefaultFormats, Extraction, Formats, JDecimal, JValue, KeySerializer, Serializer, ShortTypeHints, TypeHints, jackson}
 import scodec.bits.ByteVector
 
 import java.net.InetSocketAddress
@@ -488,8 +488,8 @@ object OriginSerializer extends MinimalSerializer({
 })
 
 // @formatter:off
-case class CommitmentJson(fundingTx: InputInfo, localFunding: LocalFundingStatus, remoteFunding: RemoteFundingStatus, localCommit: LocalCommit, remoteCommit: RemoteCommit, nextRemoteCommit: Option[RemoteCommit])
-object CommitmentSerializer extends ConvertClassSerializer[Commitment](c => CommitmentJson(c.commitInput, c.localFundingStatus, c.remoteFundingStatus, c.localCommit, c.remoteCommit, c.nextRemoteCommit_opt.map(_.commit)))
+case class CommitmentJson(fundingTxIndex: Long, fundingTx: InputInfo, localFunding: LocalFundingStatus, remoteFunding: RemoteFundingStatus, localCommit: LocalCommit, remoteCommit: RemoteCommit, nextRemoteCommit: Option[RemoteCommit])
+object CommitmentSerializer extends ConvertClassSerializer[Commitment](c => CommitmentJson(c.fundingTxIndex, c.commitInput, c.localFundingStatus, c.remoteFundingStatus, c.localCommit, c.remoteCommit, c.nextRemoteCommit_opt.map(_.commit)))
 // @formatter:on
 
 // @formatter:off
@@ -656,6 +656,11 @@ object JsonSerializers {
     OnionMessageReceivedSerializer +
     ShortIdsSerializer +
     FundingTxStatusSerializer +
-    CommitmentSerializer
+    CommitmentSerializer +
+    new CustomSerializer[SpliceStatus](_ => (
+      PartialFunction.empty, {
+      case _: SpliceStatus => JNothing
+    }
+    ))
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelCodecs0.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelCodecs0.scala
@@ -403,7 +403,7 @@ private[channel] object ChannelCodecs0 {
         ("remoteShutdown" | optional(bool, shutdownCodec)) ::
         ("closingFeerates" | provide(Option.empty[ClosingFeerates]))).map {
       case commitments :: shortChannelId :: buried :: channelAnnouncement :: channelUpdate :: localShutdown :: remoteShutdown :: closingFeerates :: HNil =>
-        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates)
+        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates, SpliceStatus.NoSplice)
     }.decodeOnly
 
     val DATA_NORMAL_10_Codec: Codec[DATA_NORMAL] = (
@@ -416,7 +416,7 @@ private[channel] object ChannelCodecs0 {
         ("remoteShutdown" | optional(bool, shutdownCodec)) ::
         ("closingFeerates" | provide(Option.empty[ClosingFeerates]))).map {
       case commitments :: shortChannelId :: buried :: channelAnnouncement :: channelUpdate :: localShutdown :: remoteShutdown :: closingFeerates :: HNil =>
-        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates)
+        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates, SpliceStatus.NoSplice)
     }.decodeOnly
 
     val DATA_SHUTDOWN_04_Codec: Codec[DATA_SHUTDOWN] = (

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelTypes0.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version0/ChannelTypes0.scala
@@ -206,6 +206,7 @@ private[channel] object ChannelTypes0 {
         ChannelFeatures()
       }
       val commitment = Commitment(
+        fundingTxIndex = 0,
         // We set an empty funding tx, even if it may be confirmed already (and the channel fully operational). We could
         // have set a specific Unknown status, but it would have forced us to keep it forever. We will retrieve the
         // funding tx when the channel is instantiated, and update the status (possibly immediately if it was confirmed).
@@ -216,6 +217,7 @@ private[channel] object ChannelTypes0 {
         ChannelParams(channelId, channelConfig, channelFeatures, localParams, remoteParams, channelFlags),
         CommitmentChanges(localChanges, remoteChanges, localNextHtlcId, remoteNextHtlcId),
         Seq(commitment),
+        inactive = Nil,
         remoteNextCommitInfo.fold(w => Left(WaitForRev(w.sentAfterLocalCommitIndex)), remotePerCommitmentPoint => Right(remotePerCommitmentPoint)),
         remotePerCommitmentSecrets,
         originChannels

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version1/ChannelCodecs1.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version1/ChannelCodecs1.scala
@@ -263,7 +263,7 @@ private[channel] object ChannelCodecs1 {
         ("remoteShutdown" | optional(bool8, lengthDelimited(shutdownCodec))) ::
         ("closingFeerates" | provide(Option.empty[ClosingFeerates]))).map {
       case commitments :: shortChannelId :: buried :: channelAnnouncement :: channelUpdate :: localShutdown :: remoteShutdown :: closingFeerates :: HNil =>
-        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates)
+        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates, SpliceStatus.NoSplice)
     }.decodeOnly
 
     val DATA_SHUTDOWN_23_Codec: Codec[DATA_SHUTDOWN] = (

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version2/ChannelCodecs2.scala
@@ -298,7 +298,7 @@ private[channel] object ChannelCodecs2 {
         ("remoteShutdown" | optional(bool8, lengthDelimited(shutdownCodec))) ::
         ("closingFeerates" | provide(Option.empty[ClosingFeerates]))).map {
       case commitments :: shortChannelId :: buried :: channelAnnouncement :: channelUpdate :: localShutdown :: remoteShutdown :: closingFeerates :: HNil =>
-        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates)
+        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates, SpliceStatus.NoSplice)
     }.decodeOnly
 
     val DATA_SHUTDOWN_03_Codec: Codec[DATA_SHUTDOWN] = (

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelCodecs3.scala
@@ -355,7 +355,7 @@ private[channel] object ChannelCodecs3 {
         ("remoteShutdown" | optional(bool8, lengthDelimited(shutdownCodec))) ::
         ("closingFeerates" | provide(Option.empty[ClosingFeerates]))).map {
       case commitments :: shortChannelId :: buried :: channelAnnouncement :: channelUpdate :: localShutdown :: remoteShutdown :: closingFeerates :: HNil =>
-        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates)
+        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates, SpliceStatus.NoSplice)
     }.decodeOnly
 
     val DATA_NORMAL_07_Codec: Codec[DATA_NORMAL] = (
@@ -368,7 +368,7 @@ private[channel] object ChannelCodecs3 {
         ("remoteShutdown" | optional(bool8, lengthDelimited(shutdownCodec))) ::
         ("closingFeerates" | optional(bool8, closingFeeratesCodec))).map {
       case commitments :: shortChannelId :: buried :: channelAnnouncement :: channelUpdate :: localShutdown :: remoteShutdown :: closingFeerates :: HNil =>
-        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates)
+        DATA_NORMAL(commitments, shortIds = ShortIds(real = if (buried) RealScidStatus.Final(shortChannelId) else RealScidStatus.Temporary(shortChannelId), localAlias = Alias(shortChannelId.toLong), remoteAlias_opt = None), channelAnnouncement, channelUpdate, localShutdown, remoteShutdown, closingFeerates, SpliceStatus.NoSplice)
     }.decodeOnly
 
     val DATA_NORMAL_09_Codec: Codec[DATA_NORMAL] = (
@@ -378,7 +378,8 @@ private[channel] object ChannelCodecs3 {
         ("channelUpdate" | lengthDelimited(channelUpdateCodec)) ::
         ("localShutdown" | optional(bool8, lengthDelimited(shutdownCodec))) ::
         ("remoteShutdown" | optional(bool8, lengthDelimited(shutdownCodec))) ::
-        ("closingFeerates" | optional(bool8, closingFeeratesCodec))).as[DATA_NORMAL]
+        ("closingFeerates" | optional(bool8, closingFeeratesCodec)) ::
+        ("spliceStatus" | provide[SpliceStatus](SpliceStatus.NoSplice))).as[DATA_NORMAL]
 
     val DATA_SHUTDOWN_03_Codec: Codec[DATA_SHUTDOWN] = (
       ("commitments" | commitmentsCodec) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelTypes3.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version3/ChannelTypes3.scala
@@ -44,7 +44,8 @@ private[channel] object ChannelTypes3 {
     def migrate(): channel.Commitments = channel.Commitments(
       ChannelParams(channelId, channelConfig, channelFeatures, localParams, remoteParams, channelFlags),
       CommitmentChanges(localChanges, remoteChanges, localNextHtlcId, remoteNextHtlcId),
-      Seq(Commitment(localFundingStatus, remoteFundingStatus, localCommit, remoteCommit, remoteNextCommitInfo.left.toOption.map(w => NextRemoteCommit(w.sent, w.nextRemoteCommit)))),
+      Seq(Commitment(fundingTxIndex = 0, localFundingStatus, remoteFundingStatus, localCommit, remoteCommit, remoteNextCommitInfo.left.toOption.map(w => NextRemoteCommit(w.sent, w.nextRemoteCommit)))),
+      inactive = Nil,
       remoteNextCommitInfo.fold(w => Left(WaitForRev(w.sentAfterLocalCommitIndex)), remotePerCommitmentPoint => Right(remotePerCommitmentPoint)),
       remotePerCommitmentSecrets,
       originChannels

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/HtlcTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/HtlcTlv.scala
@@ -16,7 +16,6 @@
 
 package fr.acinq.eclair.wire.protocol
 
-import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.UInt64
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
@@ -62,19 +61,14 @@ sealed trait CommitSigTlv extends Tlv
 
 object CommitSigTlv {
 
-  case class FundingTxIdTlv(txId: ByteVector32) extends CommitSigTlv
-  object FundingTxIdTlv {
-    val codec: Codec[FundingTxIdTlv] = tlvField(bytes32)
-  }
-
   /** @param size the number of [[CommitSig]] messages in the batch */
   case class BatchTlv(size: Int) extends CommitSigTlv
+
   object BatchTlv {
     val codec: Codec[BatchTlv] = tlvField(tu16)
   }
 
   val commitSigTlvCodec: Codec[TlvStream[CommitSigTlv]] = tlvStream(discriminated[CommitSigTlv].by(varint)
-    .typecase(UInt64(0x47010003), FundingTxIdTlv.codec)
     .typecase(UInt64(0x47010005), BatchTlv.codec)
   )
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/InteractiveTxTlv.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/InteractiveTxTlv.scala
@@ -92,7 +92,6 @@ object TxInitRbfTlv {
   val txInitRbfTlvCodec: Codec[TlvStream[TxInitRbfTlv]] = tlvStream(discriminated[TxInitRbfTlv].by(varint)
     .typecase(UInt64(0), tlvField(satoshiSigned.as[SharedOutputContributionTlv]))
   )
-
 }
 
 object TxAckRbfTlv {
@@ -102,7 +101,6 @@ object TxAckRbfTlv {
   val txAckRbfTlvCodec: Codec[TlvStream[TxAckRbfTlv]] = tlvStream(discriminated[TxAckRbfTlv].by(varint)
     .typecase(UInt64(0), tlvField(satoshiSigned.as[SharedOutputContributionTlv]))
   )
-
 }
 
 sealed trait TxAbortTlv extends Tlv

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecs.scala
@@ -403,7 +403,22 @@ object LightningMessageCodecs {
   //
 
   //
+  val spliceInitCodec: Codec[SpliceInit] = (
+    ("channelId" | bytes32) ::
+      ("fundingContribution" | satoshiSigned) ::
+      ("lockTime" | uint32) ::
+      ("feerate" | feeratePerKw) ::
+      ("tlvStream" | SpliceInitTlv.spliceInitTlvCodec)).as[SpliceInit]
 
+  val spliceAckCodec: Codec[SpliceAck] = (
+    ("channelId" | bytes32) ::
+      ("fundingContribution" | satoshiSigned) ::
+      ("tlvStream" | SpliceAckTlv.spliceAckTlvCodec)).as[SpliceAck]
+
+  val spliceLockedCodec: Codec[SpliceLocked] = (
+    ("channelId" | bytes32) ::
+      ("fundingTxid" | bytes32) ::
+      ("tlvStream" | SpliceLockedTlv.spliceLockedTlvCodec)).as[SpliceLocked]
   //
 
   //
@@ -455,10 +470,12 @@ object LightningMessageCodecs {
     .typecase(264, replyChannelRangeCodec)
     .typecase(265, gossipTimestampFilterCodec)
     .typecase(513, onionMessageCodec)
-  // NB: blank lines to minimize merge conflicts
+    // NB: blank lines to minimize merge conflicts
 
-  //
-
+    //
+    .typecase(37000, spliceInitCodec)
+    .typecase(37002, spliceAckCodec)
+    .typecase(37004, spliceLockedCodec)
   //
 
   //

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
@@ -49,7 +49,8 @@ sealed trait HasTemporaryChannelId extends LightningMessage { def temporaryChann
 sealed trait HasChannelId extends LightningMessage { def channelId: ByteVector32 } // <- not in the spec
 sealed trait HasChainHash extends LightningMessage { def chainHash: ByteVector32 } // <- not in the spec
 sealed trait HasSerialId extends LightningMessage { def serialId: UInt64 } // <- not in the spec
-sealed trait UpdateMessage extends HtlcMessage // <- not in the spec
+sealed trait ForbiddenMessageDuringSplice extends LightningMessage // <- not in the spec
+sealed trait UpdateMessage extends HtlcMessage with ForbiddenMessageDuringSplice // <- not in the spec
 sealed trait HtlcSettlementMessage extends UpdateMessage { def id: Long } // <- not in the spec
 sealed trait HtlcFailureMessage extends HtlcSettlementMessage // <- not in the spec
 // @formatter:on
@@ -277,9 +278,51 @@ case class ChannelReady(channelId: ByteVector32,
   val alias_opt: Option[Alias] = tlvStream.get[ShortChannelIdTlv].map(_.alias)
 }
 
+case class SpliceInit(channelId: ByteVector32,
+                      fundingContribution: Satoshi,
+                      lockTime: Long,
+                      feerate: FeeratePerKw,
+                      tlvStream: TlvStream[SpliceInitTlv] = TlvStream.empty) extends ChannelMessage with HasChannelId {
+  val requireConfirmedInputs: Boolean = tlvStream.get[ChannelTlv.RequireConfirmedInputsTlv].nonEmpty
+  val pushAmount: MilliSatoshi = tlvStream.get[ChannelTlv.PushAmountTlv].map(_.amount).getOrElse(0 msat)
+}
+
+object SpliceInit {
+  def apply(channelId: ByteVector32, fundingContribution: Satoshi, lockTime: Long, feerate: FeeratePerKw, pushAmount: MilliSatoshi, requireConfirmedInputs: Boolean): SpliceInit = {
+    val tlvs: Set[SpliceInitTlv] = Set(
+      Some(ChannelTlv.PushAmountTlv(pushAmount)),
+      if (requireConfirmedInputs) Some(ChannelTlv.RequireConfirmedInputsTlv()) else None,
+    ).flatten
+    SpliceInit(channelId, fundingContribution, lockTime, feerate, TlvStream(tlvs))
+  }
+}
+
+case class SpliceAck(channelId: ByteVector32,
+                     fundingContribution: Satoshi,
+                     tlvStream: TlvStream[SpliceAckTlv] = TlvStream.empty) extends ChannelMessage with HasChannelId {
+  val requireConfirmedInputs: Boolean = tlvStream.get[ChannelTlv.RequireConfirmedInputsTlv].nonEmpty
+  val pushAmount: MilliSatoshi = tlvStream.get[ChannelTlv.PushAmountTlv].map(_.amount).getOrElse(0 msat)
+}
+
+object SpliceAck {
+  def apply(channelId: ByteVector32, fundingContribution: Satoshi, pushAmount: MilliSatoshi, requireConfirmedInputs: Boolean): SpliceAck = {
+    val tlvs: Set[SpliceAckTlv] = Set(
+      Some(ChannelTlv.PushAmountTlv(pushAmount)),
+      if (requireConfirmedInputs) Some(ChannelTlv.RequireConfirmedInputsTlv()) else None,
+    ).flatten
+    SpliceAck(channelId, fundingContribution, TlvStream(tlvs))
+  }
+}
+
+case class SpliceLocked(channelId: ByteVector32,
+                        fundingTxHash: ByteVector32,
+                        tlvStream: TlvStream[SpliceLockedTlv] = TlvStream.empty) extends ChannelMessage with HasChannelId {
+  val fundingTxid: ByteVector32 = fundingTxHash.reverse
+}
+
 case class Shutdown(channelId: ByteVector32,
                     scriptPubKey: ByteVector,
-                    tlvStream: TlvStream[ShutdownTlv] = TlvStream.empty) extends ChannelMessage with HasChannelId
+                    tlvStream: TlvStream[ShutdownTlv] = TlvStream.empty) extends ChannelMessage with HasChannelId with ForbiddenMessageDuringSplice
 
 case class ClosingSigned(channelId: ByteVector32,
                          feeSatoshis: Satoshi,
@@ -332,6 +375,7 @@ case class CommitSig(channelId: ByteVector32,
                      htlcSignatures: List[ByteVector64],
                      tlvStream: TlvStream[CommitSigTlv] = TlvStream.empty) extends HtlcMessage with HasChannelId {
   val fundingTxId_opt: Option[ByteVector32] = tlvStream.get[CommitSigTlv.FundingTxIdTlv].map(_.txId)
+  val batchSize: Int = tlvStream.get[CommitSigTlv.BatchTlv].map(_.size).getOrElse(1)
 }
 
 case class RevokeAndAck(channelId: ByteVector32,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageTypes.scala
@@ -374,7 +374,6 @@ case class CommitSig(channelId: ByteVector32,
                      signature: ByteVector64,
                      htlcSignatures: List[ByteVector64],
                      tlvStream: TlvStream[CommitSigTlv] = TlvStream.empty) extends HtlcMessage with HasChannelId {
-  val fundingTxId_opt: Option[ByteVector32] = tlvStream.get[CommitSigTlv.FundingTxIdTlv].map(_.txId)
   val batchSize: Int = tlvStream.get[CommitSigTlv.BatchTlv].map(_.size).getOrElse(1)
 }
 

--- a/eclair-core/src/test/resources/nonreg/codecs/000003-DATA_NORMAL/fundee-announced/data.json
+++ b/eclair-core/src/test/resources/nonreg/codecs/000003-DATA_NORMAL/fundee-announced/data.json
@@ -67,6 +67,7 @@
       "remoteNextHtlcId" : 4147
     },
     "active" : [ {
+      "fundingTxIndex" : 0,
       "fundingTx" : {
         "outPoint" : "3dd6450c0bb55d6e4ef6ba6bd62d9061af1690e0c6ebca5b79246ac1228f7307:1",
         "amountSatoshis" : 16777215
@@ -106,6 +107,7 @@
         "remotePerCommitmentPoint" : "03daadaed37bcfed40d15e34979fbf2a0643e748e8960363bb8e930cefe2255c35"
       }
     } ],
+    "inactive" : [ ],
     "remoteNextCommitInfo" : "034dcc0704325064a1fa68edc13adb5fd173051775df73a298ec291f22ad9d19f6",
     "remotePerCommitmentSecrets" : null,
     "originChannels" : { }

--- a/eclair-core/src/test/resources/nonreg/codecs/000003-DATA_NORMAL/funder/data.json
+++ b/eclair-core/src/test/resources/nonreg/codecs/000003-DATA_NORMAL/funder/data.json
@@ -67,6 +67,7 @@
       "remoteNextHtlcId" : 151
     },
     "active" : [ {
+      "fundingTxIndex" : 0,
       "fundingTx" : {
         "outPoint" : "115641011cceeb4a1709a6cbd8f5f1b387460ee5fd2e48be3fbd1ae0e9e1cf6e:0",
         "amountSatoshis" : 15000000
@@ -106,6 +107,7 @@
         "remotePerCommitmentPoint" : "02b82bbd59e0d22665671d9e47d8733058b92f18e906e9403753661aa03dc9e4dd"
       }
     } ],
+    "inactive" : [ ],
     "remoteNextCommitInfo" : "02a4471183c519e54b8ee66fb41cbe06fed1153fce258db72ce67f9a9e044f0a16",
     "remotePerCommitmentSecrets" : null,
     "originChannels" : { }

--- a/eclair-core/src/test/resources/nonreg/codecs/020002-DATA_NORMAL/funder-announced/data.json
+++ b/eclair-core/src/test/resources/nonreg/codecs/020002-DATA_NORMAL/funder-announced/data.json
@@ -81,6 +81,7 @@
       "remoteNextHtlcId" : 0
     },
     "active" : [ {
+      "fundingTxIndex" : 0,
       "fundingTx" : {
         "outPoint" : "1bade1718aaf98ab1f91a97ed5b34ab47bfb78085e384f67c156793544f68659:0",
         "amountSatoshis" : 15000000
@@ -120,6 +121,7 @@
         "remotePerCommitmentPoint" : "02e7e1abac1feb54ee3ac2172c9e2231f77765df57664fb44a6dc2e4aa9e6a9a6a"
       }
     } ],
+    "inactive" : [ ],
     "remoteNextCommitInfo" : "03fd10fe44564e2d7e1550099785c2c1bad32a5ae0feeef6e27f0c108d18b4931d",
     "remotePerCommitmentSecrets" : null,
     "originChannels" : { }

--- a/eclair-core/src/test/resources/nonreg/codecs/030000-DATA_WAIT_FOR_FUNDING_CONFIRMED/funder/data.json
+++ b/eclair-core/src/test/resources/nonreg/codecs/030000-DATA_WAIT_FOR_FUNDING_CONFIRMED/funder/data.json
@@ -74,6 +74,7 @@
       "remoteNextHtlcId" : 0
     },
     "active" : [ {
+      "fundingTxIndex" : 0,
       "fundingTx" : {
         "outPoint" : "f4e3ba374da1a85abcd12a86c9a25b1391bda144619c770fe03f3881c6ad17e9:0",
         "amountSatoshis" : 1000000
@@ -114,6 +115,7 @@
         "remotePerCommitmentPoint" : "032a992c123095216f7937a8b0baf442211eeb57942d586854a61a0dc6b01ca6ee"
       }
     } ],
+    "inactive" : [ ],
     "remoteNextCommitInfo" : "030af74aa1e98668a504d50fe6f664aff3fbdb5c8681f0667c34cdb80024fb950f",
     "remotePerCommitmentSecrets" : null,
     "originChannels" : { }

--- a/eclair-core/src/test/resources/nonreg/codecs/03000a-DATA_WAIT_FOR_CHANNEL_READY/funder/data.json
+++ b/eclair-core/src/test/resources/nonreg/codecs/03000a-DATA_WAIT_FOR_CHANNEL_READY/funder/data.json
@@ -76,6 +76,7 @@
       "remoteNextHtlcId" : 0
     },
     "active" : [ {
+      "fundingTxIndex" : 0,
       "fundingTx" : {
         "outPoint" : "7d314422179e4e93e201da84b7b86cf9a23470933877f10db675f9ada8dea683:0",
         "amountSatoshis" : 1000000
@@ -115,6 +116,7 @@
         "remotePerCommitmentPoint" : "0324b50221ad635b97f597802fbe5b2d6414fdf41f224ac1869d3772314e9fbfa5"
       }
     } ],
+    "inactive" : [ ],
     "remoteNextCommitInfo" : "0209317c45de4cff05adbf9d69edbc334a1c89325bade86f4194c6665336b7e9f8",
     "remotePerCommitmentSecrets" : null,
     "originChannels" : { }

--- a/eclair-core/src/test/resources/nonreg/codecs/03000c-DATA_WAIT_FOR_DUAL_FUNDING_READY/funder/data.json
+++ b/eclair-core/src/test/resources/nonreg/codecs/03000c-DATA_WAIT_FOR_DUAL_FUNDING_READY/funder/data.json
@@ -82,6 +82,7 @@
       "remoteNextHtlcId" : 0
     },
     "active" : [ {
+      "fundingTxIndex" : 0,
       "fundingTx" : {
         "outPoint" : "7443277377ab5ca44330a332d79e6ff33d21a3b8889559f54894982af47e1cdb:0",
         "amountSatoshis" : 1500000
@@ -121,6 +122,7 @@
         "remotePerCommitmentPoint" : "037d0b91e7bf58eec2eddf033d457b17140a341533808a346c869ada9ecea0cec0"
       }
     } ],
+    "inactive" : [ ],
     "remoteNextCommitInfo" : "02a7d9d163632731c7211ced4ee21ae181bb0dfa73f5538607c081dd63d89f9820",
     "remotePerCommitmentSecrets" : null,
     "originChannels" : { }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
@@ -79,6 +79,10 @@ object TestDatabases {
         case d: DATA_WAIT_FOR_DUAL_FUNDING_READY => d.copy(commitments = freeze2(d.commitments))
         case d: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT => d.copy(commitments = freeze2(d.commitments))
         case d: DATA_NORMAL => d.copy(commitments = freeze2(d.commitments))
+          .modify(_.spliceStatus).using {
+          case s: SpliceStatus.SpliceWaitingForSigs => s
+          case _ => SpliceStatus.NoSplice
+        }
         case d: DATA_CLOSING => d.copy(commitments = freeze2(d.commitments))
         case d: DATA_NEGOTIATING => d.copy(commitments = freeze2(d.commitments))
         case d: DATA_SHUTDOWN => d.copy(commitments = freeze2(d.commitments))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -492,7 +492,8 @@ object CommitmentsSpec {
     Commitments(
       ChannelParams(randomBytes32(), ChannelConfig.standard, ChannelFeatures(), localParams, remoteParams, ChannelFlags(announceChannel = announceChannel)),
       CommitmentChanges(LocalChanges(Nil, Nil, Nil), RemoteChanges(Nil, Nil, Nil), localNextHtlcId = 1, remoteNextHtlcId = 1),
-      List(Commitment(LocalFundingStatus.SingleFundedUnconfirmedFundingTx(None), RemoteFundingStatus.Locked, localCommit, remoteCommit, None)),
+      List(Commitment(0, LocalFundingStatus.SingleFundedUnconfirmedFundingTx(None), RemoteFundingStatus.Locked, localCommit, remoteCommit, None)),
+      inactive = Nil,
       Right(randomKey().publicKey),
       ShaChain.init,
       Map.empty,
@@ -509,7 +510,8 @@ object CommitmentsSpec {
     Commitments(
       ChannelParams(randomBytes32(), ChannelConfig.standard, ChannelFeatures(), localParams, remoteParams, ChannelFlags(announceChannel = announceChannel)),
       CommitmentChanges(LocalChanges(Nil, Nil, Nil), RemoteChanges(Nil, Nil, Nil), localNextHtlcId = 1, remoteNextHtlcId = 1),
-      List(Commitment(LocalFundingStatus.SingleFundedUnconfirmedFundingTx(None), RemoteFundingStatus.Locked, localCommit, remoteCommit, None)),
+      List(Commitment(0, LocalFundingStatus.SingleFundedUnconfirmedFundingTx(None), RemoteFundingStatus.Locked, localCommit, remoteCommit, None)),
+      inactive = Nil,
       Right(randomKey().publicKey),
       ShaChain.init,
       Map.empty,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
@@ -2080,7 +2080,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     val testCases = Seq(
       TxAddOutput(params.channelId, UInt64(1), 25_000 sat, Script.write(Script.pay2pkh(randomKey().publicKey))),
       TxAddOutput(params.channelId, UInt64(1), 25_000 sat, Script.write(Script.pay2sh(OP_1 :: Nil))),
-      TxAddOutput(params.channelId, UInt64(1), 25_000 sat, Script.write(OP_1 :: Nil)),
+      //TxAddOutput(params.channelId, UInt64(1), 25_000 sat, Script.write(OP_1 :: Nil)),
     )
     testCases.foreach { output =>
       val alice = params.spawnTxBuilderAlice(wallet)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
@@ -2073,14 +2073,16 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     }
   }
 
-  test("allow all output types") {
+  test("allow standard output types") {
     val probe = TestProbe()
     val wallet = new SingleKeyOnChainWallet()
     val params = createFixtureParams(100_000 sat, 0 sat, FeeratePerKw(5000 sat), 330 sat, 0)
     val testCases = Seq(
       TxAddOutput(params.channelId, UInt64(1), 25_000 sat, Script.write(Script.pay2pkh(randomKey().publicKey))),
       TxAddOutput(params.channelId, UInt64(1), 25_000 sat, Script.write(Script.pay2sh(OP_1 :: Nil))),
-      //TxAddOutput(params.channelId, UInt64(1), 25_000 sat, Script.write(OP_1 :: Nil)),
+      TxAddOutput(params.channelId, UInt64(1), 25_000 sat, Script.write(Script.pay2wpkh(randomKey().publicKey))),
+      TxAddOutput(params.channelId, UInt64(1), 25_000 sat, Script.write(Script.pay2wsh(OP_1 :: Nil))),
+      TxAddOutput(params.channelId, UInt64(1), 25_000 sat, Script.write(Script.pay2tr(randomKey().xOnlyPublicKey()))),
     )
     testCases.foreach { output =>
       val alice = params.spawnTxBuilderAlice(wallet)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
@@ -52,6 +52,8 @@ object ChannelStateTestsTags {
   val DisableWumbo = "disable_wumbo"
   /** If set, channels will use option_dual_fund. */
   val DualFunding = "dual_funding"
+  /** If set, peers will support splicing. */
+  val Splicing = "splicing"
   /** If set, channels will use option_static_remotekey. */
   val StaticRemoteKey = "static_remotekey"
   /** If set, channels will use option_anchor_outputs. */
@@ -184,6 +186,7 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.ZeroConf))(_.updated(Features.ZeroConf, FeatureSupport.Optional))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.ScidAlias))(_.updated(Features.ScidAlias, FeatureSupport.Optional))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.DualFunding))(_.updated(Features.DualFunding, FeatureSupport.Optional))
+      .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.Splicing))(_.updated(Features.SplicePrototype, FeatureSupport.Optional))
       .initFeatures()
     val bobInitFeatures = Bob.nodeParams.features
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.DisableWumbo))(_.removed(Features.Wumbo))
@@ -196,6 +199,7 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.ZeroConf))(_.updated(Features.ZeroConf, FeatureSupport.Optional))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.ScidAlias))(_.updated(Features.ScidAlias, FeatureSupport.Optional))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.DualFunding))(_.updated(Features.DualFunding, FeatureSupport.Optional))
+      .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.Splicing))(_.updated(Features.SplicePrototype, FeatureSupport.Optional))
       .initFeatures()
 
     val channelType = ChannelTypes.defaultFromFeatures(aliceInitFeatures, bobInitFeatures, announceChannel = channelFlags.announceChannel)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptDualFundedChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptDualFundedChannelStateSpec.scala
@@ -81,7 +81,7 @@ class WaitForAcceptDualFundedChannelStateSpec extends TestKitBaseClass with Fixt
     val listener = TestProbe()
     alice.underlyingActor.context.system.eventStream.subscribe(listener.ref, classOf[ChannelIdAssigned])
     bob2alice.forward(alice, accept)
-    assert(listener.expectMsgType[ChannelIdAssigned].channelId == Helpers.computeChannelId(open, accept))
+    assert(listener.expectMsgType[ChannelIdAssigned].channelId == Helpers.computeChannelId(open.revocationBasepoint, accept.revocationBasepoint))
 
     awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_CREATED)
     aliceOpenReplyTo.expectNoMessage()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenDualFundedChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForOpenDualFundedChannelStateSpec.scala
@@ -89,7 +89,7 @@ class WaitForOpenDualFundedChannelStateSpec extends TestKitBaseClass with Fixtur
     val accept = bob2alice.expectMsgType[AcceptDualFundedChannel]
     val channelIdAssigned = bobListener.expectMsgType[ChannelIdAssigned]
     assert(channelIdAssigned.temporaryChannelId == ByteVector32.Zeroes)
-    assert(channelIdAssigned.channelId == Helpers.computeChannelId(open, accept))
+    assert(channelIdAssigned.channelId == Helpers.computeChannelId(open.revocationBasepoint, accept.revocationBasepoint))
     assert(!accept.requireConfirmedInputs)
 
     awaitCond(bob.stateName == WAIT_FOR_DUAL_FUNDING_CREATED)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForChannelReadyStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForChannelReadyStateSpec.scala
@@ -260,7 +260,7 @@ class WaitForChannelReadyStateSpec extends TestKitBaseClass with FixtureAnyFunSu
     awaitCond(alice.stateName == CLOSING)
   }
 
-  test("recv WatchFundingSpentTriggered (other commit)") { f =>
+  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
     awaitCond(alice.stateName == ERR_INFORMATION_LEAK)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForChannelReadyStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForChannelReadyStateSpec.scala
@@ -260,10 +260,11 @@ class WaitForChannelReadyStateSpec extends TestKitBaseClass with FixtureAnyFunSu
     awaitCond(alice.stateName == CLOSING)
   }
 
-  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
+  test("recv WatchFundingSpentTriggered (unrecognized commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
-    awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
+    alice2blockchain.expectNoMessage(100 millis)
+    assert(alice.stateName == WAIT_FOR_CHANNEL_READY)
   }
 
   test("recv Error") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingConfirmedStateSpec.scala
@@ -270,12 +270,18 @@ class WaitForDualFundingConfirmedStateSpec extends TestKitBaseClass with Fixture
     assert(alice2blockchain.expectMsgType[WatchFundingSpent].txId == fundingTx1.txid)
     alice2bob.expectMsgType[ChannelReady]
     awaitCond(alice2.stateName == WAIT_FOR_DUAL_FUNDING_READY)
+    assert(alice2.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_READY].commitments.active.size == 1)
+    assert(alice2.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_READY].commitments.inactive.isEmpty)
+    assert(alice2.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_READY].commitments.latest.fundingTxId == fundingTx1.txid)
 
     bob2 ! WatchFundingConfirmedTriggered(BlockHeight(42000), 42, fundingTx1)
     assert(bobListener.expectMsgType[TransactionConfirmed].tx == fundingTx1)
     assert(bob2blockchain.expectMsgType[WatchFundingSpent].txId == fundingTx1.txid)
     bob2alice.expectMsgType[ChannelReady]
     awaitCond(bob2.stateName == WAIT_FOR_DUAL_FUNDING_READY)
+    assert(bob2.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_READY].commitments.active.size == 1)
+    assert(bob2.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_READY].commitments.inactive.isEmpty)
+    assert(bob2.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_READY].commitments.latest.fundingTxId == fundingTx1.txid)
   }
 
   def testBumpFundingFees(f: FixtureParam): FullySignedSharedTransaction = {
@@ -611,21 +617,12 @@ class WaitForDualFundingConfirmedStateSpec extends TestKitBaseClass with Fixture
 
     // Bob broadcasts his commit tx.
     alice ! WatchFundingSpentTriggered(bobCommitTx1)
-    aliceListener.expectMsgType[ChannelAborted]
-    assert(alice2blockchain.expectMsgType[WatchAlternativeCommitTxConfirmed].txId == bobCommitTx1.txid)
-    // alice publishes her local commitment for the current commit
-    val aliceCommitTx2 = alice2blockchain.expectMsgType[TxPublisher.PublishFinalTx]
-    assert(aliceCommitTx2.input.txid == fundingTx2.txid)
-    val claimMainDelayed2 = alice2blockchain.expectMsgType[TxPublisher.PublishFinalTx] // claim-main-delayed
-    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceCommitTx2.tx.txid)
-    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == claimMainDelayed2.tx.txid)
-
-    alice ! WatchAlternativeCommitTxConfirmedTriggered(BlockHeight(42001), 42, bobCommitTx1)
-    assert(aliceListener.expectMsgType[TransactionPublished].tx == bobCommitTx1)
+    assert(aliceListener.expectMsgType[TransactionPublished].tx.txid == bobCommitTx1.txid)
     val claimMain = alice2blockchain.expectMsgType[TxPublisher.PublishFinalTx]
     assert(claimMain.input.txid == bobCommitTx1.txid)
     assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == bobCommitTx1.txid)
     assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == claimMain.tx.txid)
+    aliceListener.expectMsgType[ChannelAborted]
     awaitCond(alice.stateName == CLOSING)
   }
 
@@ -677,43 +674,28 @@ class WaitForDualFundingConfirmedStateSpec extends TestKitBaseClass with Fixture
     assert(aliceListener.expectMsgType[TransactionConfirmed].tx == fundingTx1)
     assert(alice2blockchain.expectMsgType[WatchFundingSpent].txId == fundingTx1.txid)
     alice2 ! WatchFundingSpentTriggered(bobCommitTx1)
-
-    // alice publishes her local commitment for the current commit
-    assert(alice2blockchain.expectMsgType[WatchAlternativeCommitTxConfirmed].txId == bobCommitTx1.txid)
-    val aliceCommitTx2 = alice2blockchain.expectMsgType[TxPublisher.PublishFinalTx]
-    assert(aliceCommitTx2.input.txid == fundingTx2.txid)
-    val aliceClaimMainDelayed2 = alice2blockchain.expectMsgType[TxPublisher.PublishFinalTx] // claim-main-delayed
-    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceCommitTx2.tx.txid)
-    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceClaimMainDelayed2.tx.txid)
-    awaitCond(alice2.stateName == CLOSING)
-    alice2 ! WatchAlternativeCommitTxConfirmedTriggered(BlockHeight(42001), 42, bobCommitTx1)
-    val aliceClaimMain1 = alice2blockchain.expectMsgType[TxPublisher.PublishFinalTx]
-    assert(aliceClaimMain1.input.txid == bobCommitTx1.txid)
+    val claimMainAlice = alice2blockchain.expectMsgType[TxPublisher.PublishFinalTx]
+    assert(claimMainAlice.input.txid == bobCommitTx1.txid)
     assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == bobCommitTx1.txid)
-    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceClaimMain1.tx.txid)
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == claimMainAlice.tx.txid)
+    awaitCond(alice2.stateName == CLOSING)
 
     bob2 ! WatchFundingConfirmedTriggered(BlockHeight(42000), 42, fundingTx1)
     assert(bobListener.expectMsgType[TransactionConfirmed].tx == fundingTx1)
     assert(bob2blockchain.expectMsgType[WatchFundingSpent].txId == fundingTx1.txid)
     bob2 ! WatchFundingSpentTriggered(aliceCommitTx1)
-    // bob publishes his local commitment for the current commit
-    assert(bob2blockchain.expectMsgType[WatchAlternativeCommitTxConfirmed].txId == aliceCommitTx1.txid)
-    assert(bob2blockchain.expectMsgType[TxPublisher.PublishFinalTx].tx.txid == bobCommitTx2.txid)
-    val bobClaimMainDelayed2 = bob2blockchain.expectMsgType[TxPublisher.PublishFinalTx] // claim-main-delayed
-    assert(bob2blockchain.expectMsgType[WatchTxConfirmed].txId == bobCommitTx2.txid)
-    assert(bob2blockchain.expectMsgType[WatchTxConfirmed].txId == bobClaimMainDelayed2.tx.txid)
-    awaitCond(bob2.stateName == CLOSING)
-    bob2 ! WatchAlternativeCommitTxConfirmedTriggered(BlockHeight(42001), 42, aliceCommitTx1)
-    val bobClaimMain1 = bob2blockchain.expectMsgType[TxPublisher.PublishFinalTx]
-    assert(bobClaimMain1.input.txid == aliceCommitTx1.txid)
+    val claimMainBob = bob2blockchain.expectMsgType[TxPublisher.PublishFinalTx]
+    assert(claimMainBob.input.txid == aliceCommitTx1.txid)
     assert(bob2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceCommitTx1.txid)
-    assert(bob2blockchain.expectMsgType[WatchTxConfirmed].txId == bobClaimMain1.tx.txid)
+    assert(bob2blockchain.expectMsgType[WatchTxConfirmed].txId == claimMainBob.tx.txid)
+    awaitCond(bob2.stateName == CLOSING)
   }
 
-  ignore("recv WatchFundingSpentTriggered (other commit)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
+  test("recv WatchFundingSpentTriggered (unrecognized commit)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
-    awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
+    alice2blockchain.expectNoMessage(100 millis)
+    assert(alice.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
   }
 
   test("recv INPUT_DISCONNECTED (unsigned rbf attempt)", Tag(ChannelStateTestsTags.DualFunding)) { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
@@ -204,11 +204,12 @@ class WaitForDualFundingReadyStateSpec extends TestKitBaseClass with FixtureAnyF
     awaitCond(alice.stateName == CLOSING)
   }
 
-  ignore("recv WatchFundingSpentTriggered (other commit)", Tag(ChannelStateTestsTags.DualFunding), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
+  test("recv WatchFundingSpentTriggered (unrecognized commit)", Tag(ChannelStateTestsTags.DualFunding), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
     import f._
     alice2bob.expectMsgType[ChannelReady]
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
-    awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
+    alice2blockchain.expectNoMessage(100 millis)
+    assert(alice.stateName == WAIT_FOR_DUAL_FUNDING_READY)
   }
 
   test("recv Error", Tag(ChannelStateTestsTags.DualFunding), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
@@ -204,7 +204,7 @@ class WaitForDualFundingReadyStateSpec extends TestKitBaseClass with FixtureAnyF
     awaitCond(alice.stateName == CLOSING)
   }
 
-  test("recv WatchFundingSpentTriggered (other commit)", Tag(ChannelStateTestsTags.DualFunding), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
+  ignore("recv WatchFundingSpentTriggered (other commit)", Tag(ChannelStateTestsTags.DualFunding), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
     import f._
     alice2bob.expectMsgType[ChannelReady]
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -242,7 +242,7 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     awaitCond(alice.stateName == CLOSING)
   }
 
-  test("recv WatchFundingSpentTriggered (other commit)") { f =>
+  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
     awaitCond(alice.stateName == ERR_INFORMATION_LEAK)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForFundingConfirmedStateSpec.scala
@@ -242,10 +242,11 @@ class WaitForFundingConfirmedStateSpec extends TestKitBaseClass with FixtureAnyF
     awaitCond(alice.stateName == CLOSING)
   }
 
-  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
+  test("recv WatchFundingSpentTriggered (unrecognized commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
-    awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
+    alice2blockchain.expectNoMessage(100 millis)
+    assert(alice.stateName == WAIT_FOR_FUNDING_CONFIRMED)
   }
 
   test("recv Error") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -50,7 +50,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
   implicit val log: akka.event.LoggingAdapter = akka.event.NoLogging
 
   override def withFixture(test: OneArgTest): Outcome = {
-    val tags = test.tags + ChannelStateTestsTags.DualFunding
+    val tags = test.tags + ChannelStateTestsTags.DualFunding + ChannelStateTestsTags.Splicing
     val setup = init(tags = tags)
     import setup._
     reachNormal(setup, tags)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -166,26 +166,6 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     val sender = TestProbe()
     val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = None, Some(SpliceOut(790_000 sat, defaultSpliceOutScriptPubKey)))
     alice ! cmd
-    alice2bob.expectMsgType[SpliceInit]
-    alice2bob.forward(bob)
-    bob2alice.expectMsgType[SpliceAck]
-    bob2alice.forward(alice)
-    alice2bob.expectMsgType[TxAddInput]
-    alice2bob.forward(bob)
-    bob2alice.expectMsgType[TxComplete]
-    bob2alice.forward(alice)
-    alice2bob.expectMsgType[TxAddOutput]
-    alice2bob.forward(bob)
-    bob2alice.expectMsgType[TxComplete]
-    bob2alice.forward(alice)
-    alice2bob.expectMsgType[TxAddOutput]
-    alice2bob.forward(bob)
-    bob2alice.expectMsgType[TxComplete]
-    bob2alice.forward(alice)
-    alice2bob.expectMsgType[TxComplete]
-    alice2bob.forward(bob)
-    bob2alice.expectMsgType[TxAbort]
-    bob2alice.forward(alice)
     sender.expectMsgType[RES_FAILURE[_, _]]
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -1,0 +1,1095 @@
+/*
+ * Copyright 2019 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.channel.states.e
+
+import akka.actor.ActorRef
+import akka.actor.typed.scaladsl.adapter.actorRefAdapter
+import akka.testkit.{TestFSMRef, TestProbe}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, SatoshiLong, Transaction}
+import fr.acinq.eclair._
+import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
+import fr.acinq.eclair.channel.Helpers.Closing.{LocalClose, RemoteClose, RevokedClose}
+import fr.acinq.eclair.channel.LocalFundingStatus.DualFundedUnconfirmedFundingTx
+import fr.acinq.eclair.channel._
+import fr.acinq.eclair.channel.fsm.Channel
+import fr.acinq.eclair.channel.fund.InteractiveTxBuilder.FullySignedSharedTransaction
+import fr.acinq.eclair.channel.publish.TxPublisher.{PublishFinalTx, PublishReplaceableTx, PublishTx, SetChannelId}
+import fr.acinq.eclair.channel.states.ChannelStateTestsBase.FakeTxPublisherFactory
+import fr.acinq.eclair.channel.states.ChannelStateTestsTags.NoMaxHtlcValueInFlight
+import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
+import fr.acinq.eclair.testutils.PimpTestProbe.convert
+import fr.acinq.eclair.transactions.Transactions
+import fr.acinq.eclair.wire.protocol._
+import org.scalatest.funsuite.FixtureAnyFunSuiteLike
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+import org.scalatest.{Outcome, Tag}
+import scodec.bits.{ByteVector, HexStringSyntax}
+
+/**
+ * Created by PM on 23/12/2022.
+ */
+
+class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ChannelStateTestsBase {
+
+  type FixtureParam = SetupFixture
+
+  implicit val log: akka.event.LoggingAdapter = akka.event.NoLogging
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val tags = test.tags + ChannelStateTestsTags.DualFunding
+    val setup = init(tags = tags)
+    import setup._
+    reachNormal(setup, tags)
+    awaitCond(alice.stateName == NORMAL)
+    awaitCond(bob.stateName == NORMAL)
+    withFixture(test.toNoArgTest(setup))
+  }
+
+  private val defaultSpliceOutScriptPubKey = hex"0020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+  private def initiateSplice(f: FixtureParam, spliceIn_opt: Option[SpliceIn] = None, spliceOut_opt: Option[SpliceOut] = None): Transaction = {
+    import f._
+
+    val sender = TestProbe()
+    val cmd = CMD_SPLICE(sender.ref, spliceIn_opt, spliceOut_opt)
+    alice ! cmd
+    alice2bob.expectMsgType[SpliceInit]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceAck]
+    bob2alice.forward(alice)
+
+    alice2bob.expectMsgType[TxAddInput]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[TxComplete]
+    bob2alice.forward(alice)
+    if (spliceIn_opt.isDefined) {
+      alice2bob.expectMsgType[TxAddInput]
+      alice2bob.forward(bob)
+      bob2alice.expectMsgType[TxComplete]
+      bob2alice.forward(alice)
+      alice2bob.expectMsgType[TxAddOutput]
+      alice2bob.forward(bob)
+      bob2alice.expectMsgType[TxComplete]
+      bob2alice.forward(alice)
+    }
+    if (spliceOut_opt.isDefined) {
+      alice2bob.expectMsgType[TxAddOutput]
+      alice2bob.forward(bob)
+      bob2alice.expectMsgType[TxComplete]
+      bob2alice.forward(alice)
+    }
+    alice2bob.expectMsgType[TxAddOutput]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[TxComplete]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxComplete]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+
+    bob2alice.expectMsgType[TxSignatures]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxSignatures]
+    alice2bob.forward(bob)
+
+    sender.expectMsgType[RES_SPLICE]
+
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].spliceStatus == SpliceStatus.NoSplice)
+    awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].spliceStatus == SpliceStatus.NoSplice)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.asInstanceOf[DualFundedUnconfirmedFundingTx].sharedTx.isInstanceOf[FullySignedSharedTransaction])
+    awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.asInstanceOf[DualFundedUnconfirmedFundingTx].sharedTx.isInstanceOf[FullySignedSharedTransaction])
+
+    val fundingTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    fundingTx
+  }
+
+  test("recv CMD_SPLICE (splice-in)") { f =>
+    import f._
+
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    assert(initialState.commitments.latest.capacity == 1_500_000.sat)
+    assert(initialState.commitments.latest.localCommit.spec.toLocal == 800_000_000.msat)
+    assert(initialState.commitments.latest.localCommit.spec.toRemote == 700_000_000.msat)
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat)))
+
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.capacity == 2_000_000.sat)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toLocal == 1_300_000_000.msat)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toRemote == 700_000_000.msat)
+  }
+
+  test("recv CMD_SPLICE (splice-out)") { f =>
+    import f._
+
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    assert(initialState.commitments.latest.capacity == 1_500_000.sat)
+    assert(initialState.commitments.latest.localCommit.spec.toLocal == 800_000_000.msat)
+    assert(initialState.commitments.latest.localCommit.spec.toRemote == 700_000_000.msat)
+
+    initiateSplice(f, spliceOut_opt = Some(SpliceOut(100_000 sat, defaultSpliceOutScriptPubKey)))
+
+    val fundingTx1 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    val feerate = TestConstants.Alice.nodeParams.onChainFeeConf.feeEstimator.getFeeratePerKw(TestConstants.Alice.nodeParams.onChainFeeConf.feeTargets.fundingBlockTarget)
+    val expectedMiningFee = Transactions.weight2fee(feerate, fundingTx1.weight())
+    val actualMiningFee = 1_400_000.sat - alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.capacity
+    // fee computation is approximate
+    assert(actualMiningFee - expectedMiningFee < 100.sat || expectedMiningFee - actualMiningFee < 100.sat)
+    // initiator pays the fee
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toLocal == 700_000_000.msat - actualMiningFee)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toRemote == 700_000_000.msat)
+  }
+
+  test("recv CMD_SPLICE (splice-out, would go below reserve)") { f =>
+    import f._
+
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    assert(initialState.commitments.latest.capacity == 1_500_000.sat)
+    assert(initialState.commitments.latest.localCommit.spec.toLocal == 800_000_000.msat)
+    assert(initialState.commitments.latest.localCommit.spec.toRemote == 700_000_000.msat)
+
+    val sender = TestProbe()
+    val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = None, Some(SpliceOut(790_000 sat, defaultSpliceOutScriptPubKey)))
+    alice ! cmd
+    alice2bob.expectMsgType[SpliceInit]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceAck]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAddInput]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[TxComplete]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAddOutput]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[TxComplete]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAddOutput]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[TxComplete]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxComplete]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[TxAbort]
+    bob2alice.forward(alice)
+    sender.expectMsgType[RES_FAILURE[_, _]]
+  }
+
+  test("recv CMD_SPLICE (splice-in + splice-out)") { f =>
+    import f._
+
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    assert(initialState.commitments.latest.capacity == 1_500_000.sat)
+    assert(initialState.commitments.latest.localCommit.spec.toLocal == 800_000_000.msat)
+    assert(initialState.commitments.latest.localCommit.spec.toRemote == 700_000_000.msat)
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat)), spliceOut_opt = Some(SpliceOut(100_000 sat, defaultSpliceOutScriptPubKey)))
+
+    // NB: since there is a splice-in, swap-out fees will be paid from bitcoind so final capacity is predictable
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.capacity == 1_900_000.sat)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toLocal == 1_200_000_000.msat)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toRemote == 700_000_000.msat)
+  }
+
+  test("recv WatchFundingConfirmedTriggered on splice tx", Tag(NoMaxHtlcValueInFlight)) { f =>
+    import f._
+
+    val sender = TestProbe()
+    // command for a large payment (larger than local balance pre-slice)
+    val cmd = CMD_ADD_HTLC(sender.ref, 1_000_000_000 msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, None, localOrigin(sender.ref))
+    // first attempt at payment fails (not enough balance)
+    alice ! cmd
+    sender.expectMsgType[RES_ADD_FAILED[_]]
+    alice2bob.expectNoMessage(100 millis)
+
+    val fundingTx = initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat)))
+    alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // the splice tx isn't yet confirmed, payment still fails
+    alice ! cmd
+    sender.expectMsgType[RES_ADD_FAILED[_]]
+
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx)
+    bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx)
+    alice2bob.expectMsgType[SpliceLocked]
+    alice2bob.forward(bob)
+
+    // the splice tx is only considered locked by alice, payment still fails
+    alice ! cmd
+    sender.expectMsgType[RES_ADD_FAILED[_]]
+
+    bob2alice.expectMsgType[SpliceLocked]
+    bob2alice.forward(alice)
+
+    // now the payment works!
+    alice ! cmd
+    sender.expectMsgType[RES_SUCCESS[CMD_ADD_HTLC]]
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    alice2bob.forward(bob)
+
+    alice ! CMD_SIGN()
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+  }
+
+  private def setup2Splices(f: FixtureParam): (Transaction, Transaction) = {
+    import f._
+
+    val fundingTx1 = initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat)))
+    alice2blockchain.expectWatchFundingConfirmed(fundingTx1.txid)
+    alice2blockchain.expectNoMessage(100 millis)
+    bob2blockchain.expectWatchFundingConfirmed(fundingTx1.txid)
+    bob2blockchain.expectNoMessage(100 millis)
+
+    val fundingTx2 = initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat)))
+    alice2blockchain.expectWatchFundingConfirmed(fundingTx2.txid)
+    alice2blockchain.expectNoMessage(100 millis)
+    bob2blockchain.expectWatchFundingConfirmed(fundingTx2.txid)
+    bob2blockchain.expectNoMessage(100 millis)
+
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.map(_.fundingTxIndex) == Seq(2, 1, 0))
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.map(_.fundingTxIndex) == Seq.empty)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.map(_.fundingTxIndex) == Seq(2, 1, 0))
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.map(_.fundingTxIndex) == Seq.empty)
+
+    (fundingTx1, fundingTx2)
+  }
+
+  test("splice local/remote locking", Tag(NoMaxHtlcValueInFlight)) { f =>
+    import f._
+
+    val (fundingTx1, fundingTx2) = setup2Splices(f)
+
+    // splice 1 confirms
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    alice2bob.expectMsgTypeHaving[SpliceLocked](_.fundingTxid == fundingTx1.txid)
+    alice2bob.forward(bob)
+    bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    bob2alice.expectMsgTypeHaving[SpliceLocked](_.fundingTxid == fundingTx1.txid)
+    bob2alice.forward(alice)
+    alice2blockchain.expectWatchFundingSpent(fundingTx1.txid)
+    bob2blockchain.expectWatchFundingSpent(fundingTx1.txid)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.map(_.fundingTxIndex) == Seq(2, 1))
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.map(_.fundingTxIndex) == Seq.empty)
+
+    // splice 2 confirms
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    alice2bob.expectMsgTypeHaving[SpliceLocked](_.fundingTxid == fundingTx2.txid)
+    alice2bob.forward(bob)
+    bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    bob2alice.expectMsgTypeHaving[SpliceLocked](_.fundingTxid == fundingTx2.txid)
+    bob2alice.forward(alice)
+    alice2blockchain.expectWatchFundingSpent(fundingTx2.txid)
+    bob2blockchain.expectWatchFundingSpent(fundingTx2.txid)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.map(_.fundingTxIndex) == Seq(2))
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.map(_.fundingTxIndex) == Seq.empty)
+  }
+
+  test("splice local/remote locking (reverse order)", Tag(NoMaxHtlcValueInFlight)) { f =>
+    import f._
+
+    val (fundingTx1, fundingTx2) = setup2Splices(f)
+
+    // splice 2 confirms
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    alice2bob.expectMsgTypeHaving[SpliceLocked](_.fundingTxid == fundingTx2.txid)
+    alice2bob.forward(bob)
+    bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    bob2alice.expectMsgTypeHaving[SpliceLocked](_.fundingTxid == fundingTx2.txid)
+    bob2alice.forward(alice)
+    alice2blockchain.expectWatchFundingSpent(fundingTx2.txid)
+    bob2blockchain.expectWatchFundingSpent(fundingTx2.txid)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.map(_.fundingTxIndex) == Seq(2))
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.map(_.fundingTxIndex) == Seq.empty)
+
+    // splice 1 confirms
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    // we don't send a splice_locked for the older tx
+    alice2bob.expectNoMessage(100 millis)
+    bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    // we don't send a splice_locked for the older tx
+    bob2alice.expectNoMessage(100 millis)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.map(_.fundingTxIndex) == Seq(2))
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.map(_.fundingTxIndex) == Seq.empty)
+  }
+
+  test("splice local/remote locking (intermingled)", Tag(NoMaxHtlcValueInFlight)) { f =>
+    import f._
+
+    val (fundingTx1, fundingTx2) = setup2Splices(f)
+
+    // splice 1 confirms on alice, splice 2 confirms on bob
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    alice2bob.expectMsgTypeHaving[SpliceLocked](_.fundingTxid == fundingTx1.txid)
+    alice2bob.forward(bob)
+    bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    bob2alice.expectMsgTypeHaving[SpliceLocked](_.fundingTxid == fundingTx2.txid)
+    bob2alice.forward(alice)
+    alice2blockchain.expectWatchFundingSpent(fundingTx1.txid)
+    bob2blockchain.expectWatchFundingSpent(fundingTx2.txid)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.map(_.fundingTxIndex) == Seq(2, 1))
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.map(_.fundingTxIndex) == Seq.empty)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.map(_.fundingTxIndex) == Seq(2, 1))
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.map(_.fundingTxIndex) == Seq.empty)
+
+    // splice 2 confirms on bob, splice 1 confirms on alice
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    alice2bob.expectMsgTypeHaving[SpliceLocked](_.fundingTxid == fundingTx2.txid)
+    alice2bob.forward(bob)
+    bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    bob2alice.expectNoMessage(100 millis)
+    bob2alice.forward(alice)
+    alice2blockchain.expectWatchFundingSpent(fundingTx2.txid)
+    bob2blockchain.expectNoMessage(100 millis)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.map(_.fundingTxIndex) == Seq(2))
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.map(_.fundingTxIndex) == Seq.empty)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.map(_.fundingTxIndex) == Seq(2))
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.map(_.fundingTxIndex) == Seq.empty)
+  }
+
+  test("emit post-splice events", Tag(NoMaxHtlcValueInFlight)) { f =>
+    import f._
+
+    val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
+    assert(initialState.commitments.latest.capacity == 1_500_000.sat)
+    assert(initialState.commitments.latest.localCommit.spec.toLocal == 800_000_000.msat)
+    assert(initialState.commitments.latest.localCommit.spec.toRemote == 700_000_000.msat)
+
+    val aliceEvents = TestProbe()
+    val bobEvents = TestProbe()
+    systemA.eventStream.subscribe(aliceEvents.ref, classOf[AvailableBalanceChanged])
+    systemA.eventStream.subscribe(aliceEvents.ref, classOf[LocalChannelUpdate])
+    systemA.eventStream.subscribe(aliceEvents.ref, classOf[LocalChannelDown])
+    systemB.eventStream.subscribe(bobEvents.ref, classOf[AvailableBalanceChanged])
+    systemB.eventStream.subscribe(bobEvents.ref, classOf[LocalChannelUpdate])
+    systemB.eventStream.subscribe(bobEvents.ref, classOf[LocalChannelDown])
+
+    val (fundingTx1, fundingTx2) = setup2Splices(f)
+
+    // splices haven't been locked, so no event is emitted
+    aliceEvents.expectNoMessage(100 millis)
+    bobEvents.expectNoMessage(100 millis)
+
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    alice2bob.expectMsgType[SpliceLocked]
+    alice2bob.forward(bob)
+    aliceEvents.expectNoMessage(100 millis)
+    bobEvents.expectNoMessage(100 millis)
+
+    bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    bob2alice.expectMsgType[SpliceLocked]
+    bob2alice.forward(alice)
+    aliceEvents.expectAvailableBalanceChanged(balance = 1_300_000_000.msat, capacity = 2_000_000.sat)
+    bobEvents.expectAvailableBalanceChanged(balance = 700_000_000.msat, capacity = 2_000_000.sat)
+    aliceEvents.expectNoMessage(100 millis)
+    bobEvents.expectNoMessage(100 millis)
+
+    bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    bob2alice.expectMsgType[SpliceLocked]
+    bob2alice.forward(alice)
+    aliceEvents.expectNoMessage(100 millis)
+    bobEvents.expectNoMessage(100 millis)
+
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    alice2bob.expectMsgType[SpliceLocked]
+    alice2bob.forward(bob)
+    aliceEvents.expectAvailableBalanceChanged(balance = 1_800_000_000.msat, capacity = 2_500_000.sat)
+    bobEvents.expectAvailableBalanceChanged(balance = 700_000_000.msat, capacity = 2_500_000.sat)
+    aliceEvents.expectNoMessage(100 millis)
+    bobEvents.expectNoMessage(100 millis)
+  }
+
+  test("recv CMD_ADD_HTLC with multiple commitments") { f =>
+    import f._
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat)))
+    val sender = TestProbe()
+    alice ! CMD_ADD_HTLC(sender.ref, 500000 msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, None, localOrigin(sender.ref))
+    sender.expectMsgType[RES_SUCCESS[CMD_ADD_HTLC]]
+    alice2bob.expectMsgType[UpdateAddHtlc]
+    alice2bob.forward(bob)
+    alice ! CMD_SIGN()
+    val sig1 = alice2bob.expectMsgType[CommitSig]
+    assert(sig1.batchSize == 2)
+    alice2bob.forward(bob)
+    val sig2 = alice2bob.expectMsgType[CommitSig]
+    assert(sig2.batchSize == 2)
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[RevokeAndAck]
+    bob2alice.forward(alice)
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[RevokeAndAck]
+    alice2bob.forward(bob)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.forall(_.localCommit.spec.htlcs.size == 1))
+    awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.forall(_.localCommit.spec.htlcs.size == 1))
+  }
+
+  test("recv CMD_ADD_HTLC while a splice is requested") { f =>
+    import f._
+    val sender = TestProbe()
+    val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)), spliceOut_opt = None)
+    alice ! cmd
+    alice2bob.expectMsgType[SpliceInit]
+    alice ! CMD_ADD_HTLC(sender.ref, 500000 msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, None, localOrigin(sender.ref))
+    sender.expectMsgType[RES_ADD_FAILED[_]]
+    alice2bob.expectNoMessage(100 millis)
+  }
+
+  test("recv CMD_ADD_HTLC while a splice is in progress") { f =>
+    import f._
+    val sender = TestProbe()
+    val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)), spliceOut_opt = None)
+    alice ! cmd
+    alice2bob.expectMsgType[SpliceInit]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceAck]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAddInput]
+    alice ! CMD_ADD_HTLC(sender.ref, 500000 msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, None, localOrigin(sender.ref))
+    sender.expectMsgType[RES_ADD_FAILED[_]]
+    alice2bob.expectNoMessage(100 millis)
+  }
+
+  test("recv UpdateAddHtlc while a splice is requested") { f =>
+    import f._
+    val sender = TestProbe()
+    val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)), spliceOut_opt = None)
+    alice ! cmd
+    alice2bob.expectMsgType[SpliceInit]
+    // we're holding the splice_init to create a race
+
+    val (preimage, cmdAdd: CMD_ADD_HTLC) = makeCmdAdd(5_000_000 msat, bob.underlyingActor.remoteNodeId, bob.underlyingActor.nodeParams.currentBlockHeight)
+    bob ! cmdAdd
+    val add = bob2alice.expectMsgType[UpdateAddHtlc]
+    bob2alice.forward(alice)
+    // now we forward the splice_init
+    alice2bob.forward(bob)
+    // this cancels the splice
+    bob2alice.expectMsgType[TxAbort]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAbort]
+    alice2bob.forward(bob)
+    // but the htlc goes through normally
+    crossSign(bob, alice, bob2alice, alice2bob)
+    fulfillHtlc(add.id, preimage, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+  }
+
+  test("recv UpdateAddHtlc while a splice is in progress") { f =>
+    import f._
+    val sender = TestProbe()
+    val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)), spliceOut_opt = None)
+    alice ! cmd
+    alice2bob.expectMsgType[SpliceInit]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceAck]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAddInput]
+
+    // have to build a htlc manually because eclair would refuse to accept this command as it's forbidden
+    val fakeHtlc = UpdateAddHtlc(channelId = randomBytes32(), id = 5656, amountMsat = 50000000 msat, cltvExpiry = CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), paymentHash = randomBytes32(), onionRoutingPacket = TestConstants.emptyOnionPacket, blinding_opt = None)
+    bob2alice.forward(alice, fakeHtlc)
+    alice2bob.expectMsgType[Error]
+    assertPublished(alice2blockchain, "commit-tx")
+    assertPublished(alice2blockchain, "local-main-delayed")
+    alice2blockchain.expectMsgType[WatchTxConfirmed]
+    alice2blockchain.expectMsgType[WatchTxConfirmed]
+    alice2blockchain.expectNoMessage(100 millis)
+  }
+
+  test("cancels splice on disconnection") { f =>
+    import f._
+
+    val sender = TestProbe()
+    val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)), spliceOut_opt = None)
+    alice ! cmd
+    alice2bob.expectMsgType[SpliceInit]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceAck]
+    bob2alice.forward(alice)
+
+    alice ! INPUT_DISCONNECTED
+    sender.expectMsgType[RES_FAILURE[_, _]]
+    awaitCond(alice.stateName == OFFLINE)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].spliceStatus == SpliceStatus.NoSplice)
+  }
+
+  test("don't resend splice_locked when zero-conf channel confirms", Tag(ChannelStateTestsTags.ZeroConf), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
+    import f._
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    alice2blockchain.expectMsgType[WatchPublished]
+    // splice tx gets published, alice sends splice_locked
+    alice ! WatchPublishedTriggered(fundingTx)
+    alice2bob.expectMsgType[SpliceLocked]
+    alice2blockchain.expectWatchFundingConfirmed(fundingTx.txid)
+    // splice tx confirms
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx)
+    alice2bob.expectNoMessage(100 millis)
+    alice2blockchain.expectWatchFundingSpent(fundingTx.txid)
+  }
+
+  test("re-send splice_locked on reconnection") { f =>
+    import f._
+
+    def disconnect(): Unit = {
+      alice ! INPUT_DISCONNECTED
+      bob ! INPUT_DISCONNECTED
+      awaitCond(alice.stateName == OFFLINE)
+      awaitCond(bob.stateName == OFFLINE)
+    }
+
+    def reconnect() = {
+      val aliceInit = Init(alice.stateData.asInstanceOf[ChannelDataWithCommitments].commitments.params.localParams.initFeatures)
+      val bobInit = Init(bob.stateData.asInstanceOf[ChannelDataWithCommitments].commitments.params.localParams.initFeatures)
+      alice ! INPUT_RECONNECTED(alice2bob.ref, aliceInit, bobInit)
+      bob ! INPUT_RECONNECTED(bob2alice.ref, bobInit, aliceInit)
+      alice2bob.expectMsgType[ChannelReestablish]
+      alice2bob.forward(bob)
+      bob2alice.expectMsgType[ChannelReestablish]
+      bob2alice.forward(alice)
+
+      alice2blockchain.expectMsgType[WatchFundingDeeplyBuried]
+      bob2blockchain.expectMsgType[WatchFundingDeeplyBuried]
+    }
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx1 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    val watchConfirmed1a = alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    val watchConfirmed1b = bob2blockchain.expectMsgType[WatchFundingConfirmed]
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx2 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    val watchConfirmed2a = alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    val watchConfirmed2b = bob2blockchain.expectMsgType[WatchFundingConfirmed]
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+    // we now have two unconfirmed splices
+
+    alice2bob.ignoreMsg { case _: ChannelUpdate => true }
+    bob2alice.ignoreMsg { case _: ChannelUpdate => true }
+
+    disconnect()
+    reconnect()
+
+    // channel_ready are not re-sent because the channel has already been used (for building splices)
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+
+    // splice 1 confirms on alice's side
+    watchConfirmed1a.replyTo ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    assert(alice2bob.expectMsgType[SpliceLocked].fundingTxid == fundingTx1.txid)
+    alice2bob.forward(bob)
+    alice2blockchain.expectMsgType[WatchFundingSpent]
+
+    disconnect()
+    reconnect()
+
+    assert(alice2bob.expectMsgType[SpliceLocked].fundingTxid == fundingTx1.txid)
+    alice2bob.forward(bob)
+
+    // splice 2 confirms on alice's side
+    watchConfirmed2a.replyTo ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    assert(alice2bob.expectMsgType[SpliceLocked].fundingTxid == fundingTx2.txid)
+    alice2bob.forward(bob)
+    alice2blockchain.expectMsgType[WatchFundingSpent]
+
+    disconnect()
+    reconnect()
+
+    assert(alice2bob.expectMsgType[SpliceLocked].fundingTxid == fundingTx2.txid)
+    alice2bob.forward(bob)
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+
+    // splice 1 confirms on bob's side
+    watchConfirmed1b.replyTo ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    assert(bob2alice.expectMsgType[SpliceLocked].fundingTxid == fundingTx1.txid)
+    bob2alice.forward(alice)
+    bob2blockchain.expectMsgType[WatchFundingSpent]
+
+    disconnect()
+    reconnect()
+
+    assert(alice2bob.expectMsgType[SpliceLocked].fundingTxid == fundingTx2.txid)
+    alice2bob.forward(bob)
+    assert(bob2alice.expectMsgType[SpliceLocked].fundingTxid == fundingTx1.txid)
+    bob2alice.forward(alice)
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+
+    // splice 2 confirms on bob's side
+    watchConfirmed2b.replyTo ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    assert(bob2alice.expectMsgType[SpliceLocked].fundingTxid == fundingTx2.txid)
+    bob2blockchain.expectMsgType[WatchFundingSpent]
+
+    // NB: we disconnect *before* transmitting the splice_confirmed to alice
+
+    disconnect()
+    reconnect()
+
+    assert(alice2bob.expectMsgType[SpliceLocked].fundingTxid == fundingTx2.txid)
+    alice2bob.forward(bob)
+    assert(bob2alice.expectMsgType[SpliceLocked].fundingTxid == fundingTx2.txid)
+    // this time alice received the splice_confirmed for funding tx 2
+    bob2alice.forward(alice)
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+
+    disconnect()
+    reconnect()
+
+    assert(alice2bob.expectMsgType[SpliceLocked].fundingTxid == fundingTx2.txid)
+    alice2bob.forward(bob)
+    assert(bob2alice.expectMsgType[SpliceLocked].fundingTxid == fundingTx2.txid)
+    bob2alice.forward(alice)
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+
+  }
+
+  /** Check type of published transactions */
+  def assertPublished(probe: TestProbe, desc: String): Transaction = {
+    val p = probe.expectMsgType[PublishTx]
+    assert(desc == p.desc)
+    p match {
+      case p: PublishFinalTx => p.tx
+      case p: PublishReplaceableTx => p.txInfo.tx
+    }
+  }
+
+  test("force-close with multiple splices (simple)") { f =>
+    import f._
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx1 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    val watchConfirmed1 = alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx2 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    val watchConfirmed2 = alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+    alice2blockchain.expectNoMessage(100 millis)
+    // we now have two unconfirmed splices
+
+    alice ! CMD_FORCECLOSE(ActorRef.noSender)
+    alice2bob.expectMsgType[Error]
+    val commitTx2 = assertPublished(alice2blockchain, "commit-tx")
+    val claimMainDelayed2 = assertPublished(alice2blockchain, "local-main-delayed")
+    val watchConfirmedCommit2 = alice2blockchain.expectMsgType[WatchTxConfirmed]
+    val watchConfirmedClaimMainDelayed2 = alice2blockchain.expectMsgType[WatchTxConfirmed]
+    alice ! WatchFundingSpentTriggered(commitTx2)
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // splice 1 confirms
+    watchConfirmed1.replyTo ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    alice2bob.forward(bob)
+    alice2blockchain.expectMsgType[WatchFundingSpent]
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // splice 2 confirms
+    watchConfirmed2.replyTo ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx2)
+    alice2bob.forward(bob)
+    alice2blockchain.expectMsgType[WatchFundingSpent]
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // commit tx confirms
+    watchConfirmedCommit2.replyTo ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, commitTx2)
+
+    // claim-main-delayed tx confirms
+    watchConfirmedClaimMainDelayed2.replyTo ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, claimMainDelayed2)
+
+    // done
+    awaitCond(alice.stateName == CLOSED)
+    assert(Helpers.Closing.isClosed(alice.stateData.asInstanceOf[DATA_CLOSING], None).exists(_.isInstanceOf[LocalClose]))
+  }
+
+  test("force-close with multiple splices (previous active remote)") { f =>
+    import f._
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx1 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    val watchConfirmed1 = alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+    alice2blockchain.expectNoMessage(100 millis)
+    // we now have two unconfirmed splices
+
+    alice ! CMD_FORCECLOSE(ActorRef.noSender)
+    alice2bob.expectMsgType[Error]
+    val aliceCommitTx2 = assertPublished(alice2blockchain, "commit-tx")
+    assertPublished(alice2blockchain, "local-main-delayed")
+    alice2blockchain.expectMsgType[WatchTxConfirmed]
+    alice2blockchain.expectMsgType[WatchTxConfirmed]
+    alice ! WatchFundingSpentTriggered(aliceCommitTx2)
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // splice 1 confirms
+    watchConfirmed1.replyTo ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    alice2bob.forward(bob)
+    alice2blockchain.expectMsgType[WatchFundingSpent]
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // oops! remote commit for splice 1 is published
+    val bobCommitTx1 = bob.stateData.asInstanceOf[ChannelDataWithCommitments].commitments.active.find(_.fundingTxIndex == 1).get.localCommit.commitTxAndRemoteSig.commitTx.tx
+    alice ! WatchFundingSpentTriggered(bobCommitTx1)
+    val watchAlternativeConfirmed = alice2blockchain.expectMsgType[WatchAlternativeCommitTxConfirmed]
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // remote commit tx confirms
+    watchAlternativeConfirmed.replyTo ! WatchAlternativeCommitTxConfirmedTriggered(BlockHeight(400000), 42, bobCommitTx1)
+
+    // we're back to the normal handling of remote commit
+    val claimMain = alice2blockchain.expectMsgType[PublishFinalTx].tx
+    val watchConfirmedRemoteCommit = alice2blockchain.expectMsgType[WatchTxConfirmed]
+    assert(watchConfirmedRemoteCommit.txId == bobCommitTx1.txid)
+    // this one fires immediately, tx is already confirmed
+    watchConfirmedRemoteCommit.replyTo ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, bobCommitTx1)
+    val watchConfirmedClaimMain = alice2blockchain.expectMsgType[WatchTxConfirmed]
+
+    // claim-main tx confirms
+    watchConfirmedClaimMain.replyTo ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, claimMain)
+
+    // done
+    awaitCond(alice.stateName == CLOSED)
+    assert(Helpers.Closing.isClosed(alice.stateData.asInstanceOf[DATA_CLOSING], None).exists(_.isInstanceOf[RemoteClose]))
+  }
+
+  test("force-close with multiple splices (previous active revoked)") { f =>
+    import f._
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx1 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    // remember bob's commitment for later
+    val bobCommit1 = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.head
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+    alice2blockchain.expectNoMessage(100 millis)
+    // we now have two unconfirmed splices, both active
+
+    // bob makes a payment
+    val (preimage, add) = addHtlc(10_000_000 msat, bob, alice, bob2alice, alice2bob)
+    crossSign(bob, alice, bob2alice, alice2bob)
+    fulfillHtlc(add.id, preimage, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // funding tx1 confirms
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    // alice puts a watch-spent
+    alice2blockchain.expectMsgType[WatchFundingSpent]
+    // bob publishes a revoked commitment for fundingTx1!
+    val bobRevokedCommitTx = bobCommit1.localCommit.commitTxAndRemoteSig.commitTx.tx
+    alice ! WatchFundingSpentTriggered(bobRevokedCommitTx)
+    // alice watches bob's revoked commit tx, and force-closes with latest commitment
+    assert(alice2blockchain.expectMsgType[WatchAlternativeCommitTxConfirmed].txId == bobRevokedCommitTx.txid)
+    val aliceCommitTx2 = assertPublished(alice2blockchain, "commit-tx")
+    val claimMainDelayed2 = assertPublished(alice2blockchain, "local-main-delayed")
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceCommitTx2.txid)
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == claimMainDelayed2.txid)
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // bob's revoked tx wins
+    alice ! WatchAlternativeCommitTxConfirmedTriggered(BlockHeight(400000), 42, bobRevokedCommitTx)
+    // alice reacts by punishing bob
+    val aliceClaimMain1 = assertPublished(alice2blockchain, "remote-main")
+    val aliceMainPenalty1 = assertPublished(alice2blockchain, "main-penalty")
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == bobRevokedCommitTx.txid)
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceClaimMain1.txid)
+    assert(alice2blockchain.expectMsgType[WatchOutputSpent].txId == bobRevokedCommitTx.txid)
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // both tx confirm
+    alice ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, bobRevokedCommitTx)
+    alice ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, aliceClaimMain1)
+    alice ! WatchOutputSpentTriggered(aliceMainPenalty1)
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceMainPenalty1.txid)
+    alice ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, aliceMainPenalty1)
+
+    // done
+    awaitCond(alice.stateName == CLOSED)
+    assert(Helpers.Closing.isClosed(alice.stateData.asInstanceOf[DATA_CLOSING], None).exists(_.isInstanceOf[RevokedClose]))
+  }
+
+  test("force-close with multiple splices (inactive remote)", Tag(ChannelStateTestsTags.ZeroConf), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
+    import f._
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx1 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    alice2blockchain.expectMsgType[WatchPublished]
+    bob2blockchain.expectMsgType[WatchPublished]
+
+    // splice 1 gets published
+    alice ! WatchPublishedTriggered(fundingTx1)
+    bob ! WatchPublishedTriggered(fundingTx1)
+    alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    bob2blockchain.expectMsgType[WatchFundingConfirmed]
+    alice2bob.expectMsgType[SpliceLocked]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceLocked]
+    bob2alice.forward(alice)
+
+    // bob makes a payment
+    val (preimage, add) = addHtlc(10_000_000 msat, bob, alice, bob2alice, alice2bob)
+    crossSign(bob, alice, bob2alice, alice2bob)
+    fulfillHtlc(add.id, preimage, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // remember bob's commitment for later
+    val bobCommit1 = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.head
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx2 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    alice2blockchain.expectMsgType[WatchPublished]
+    bob2blockchain.expectMsgType[WatchPublished]
+    // splice 2 gets published
+    alice ! WatchPublishedTriggered(fundingTx2)
+    bob ! WatchPublishedTriggered(fundingTx2)
+    alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    bob2blockchain.expectMsgType[WatchFundingConfirmed]
+    alice2bob.expectMsgType[SpliceLocked]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceLocked]
+    bob2alice.forward(alice)
+    // splice 1 is now inactive
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.exists(_.fundingTxId == fundingTx1.txid))
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.exists(_.fundingTxId == fundingTx1.txid))
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+    alice2blockchain.expectNoMessage(100 millis)
+    // we now have two unconfirmed splices, one active and one inactive, and the inactive initial funding
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.size == 1)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.size == 2)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.size == 1)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.size == 2)
+
+    // funding tx1 confirms
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    // alice puts a watch-spent and prunes the initial funding
+    alice2blockchain.expectMsgType[WatchFundingSpent]
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.size == 1)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.size == 1)
+    // bob publishes his latest commitment for fundingTx1
+    val bobCommitTx1 = bobCommit1.localCommit.commitTxAndRemoteSig.commitTx.tx
+    alice ! WatchFundingSpentTriggered(bobCommitTx1)
+    // alice watches bob's revoked commit tx, and force-closes with latest commitment
+    assert(alice2blockchain.expectMsgType[WatchAlternativeCommitTxConfirmed].txId == bobCommitTx1.txid)
+    val aliceCommitTx2 = assertPublished(alice2blockchain, "commit-tx")
+    assertPublished(alice2blockchain, "local-anchor")
+    val claimMainDelayed2 = assertPublished(alice2blockchain, "local-main-delayed")
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceCommitTx2.txid)
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == claimMainDelayed2.txid)
+    alice2blockchain.expectMsgType[WatchOutputSpent]
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // bob's remote tx wins
+    alice ! WatchAlternativeCommitTxConfirmedTriggered(BlockHeight(400000), 42, bobCommitTx1)
+    // we're back to the normal handling of remote commit
+    val claimMain = alice2blockchain.expectMsgType[PublishFinalTx].tx
+    val watchConfirmedRemoteCommit = alice2blockchain.expectMsgType[WatchTxConfirmed]
+    assert(watchConfirmedRemoteCommit.txId == bobCommitTx1.txid)
+    // this one fires immediately, tx is already confirmed
+    watchConfirmedRemoteCommit.replyTo ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, bobCommitTx1)
+    val watchConfirmedClaimMain = alice2blockchain.expectMsgType[WatchTxConfirmed]
+
+    // claim-main tx confirms
+    watchConfirmedClaimMain.replyTo ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, claimMain)
+
+    // done
+    awaitCond(alice.stateName == CLOSED)
+    assert(Helpers.Closing.isClosed(alice.stateData.asInstanceOf[DATA_CLOSING], None).exists(_.isInstanceOf[RemoteClose]))
+  }
+
+  test("force-close with multiple splices (inactive revoked)", Tag(ChannelStateTestsTags.ZeroConf), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
+    import f._
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx1 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    alice2blockchain.expectMsgType[WatchPublished]
+    bob2blockchain.expectMsgType[WatchPublished]
+    // remember bob's commitment for later
+    val bobCommit1 = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.head
+    // splice 1 gets published
+    alice ! WatchPublishedTriggered(fundingTx1)
+    bob ! WatchPublishedTriggered(fundingTx1)
+    alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    bob2blockchain.expectMsgType[WatchFundingConfirmed]
+    alice2bob.expectMsgType[SpliceLocked]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceLocked]
+    bob2alice.forward(alice)
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx2 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    alice2blockchain.expectMsgType[WatchPublished]
+    bob2blockchain.expectMsgType[WatchPublished]
+    // splice 2 gets published
+    alice ! WatchPublishedTriggered(fundingTx2)
+    bob ! WatchPublishedTriggered(fundingTx2)
+    alice2blockchain.expectMsgType[WatchFundingConfirmed]
+    bob2blockchain.expectMsgType[WatchFundingConfirmed]
+    alice2bob.expectMsgType[SpliceLocked]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceLocked]
+    bob2alice.forward(alice)
+    // splice 1 is now inactive
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.exists(_.fundingTxId == fundingTx1.txid))
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.exists(_.fundingTxId == fundingTx1.txid))
+    alice2bob.expectNoMessage(100 millis)
+    bob2alice.expectNoMessage(100 millis)
+    alice2blockchain.expectNoMessage(100 millis)
+    // we now have two unconfirmed splices, one active and one inactive, and the inactive initial funding
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.size == 1)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.size == 2)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.size == 1)
+    assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.size == 2)
+
+    // bob makes a payment
+    val (preimage, add) = addHtlc(10_000_000 msat, bob, alice, bob2alice, alice2bob)
+    crossSign(bob, alice, bob2alice, alice2bob)
+    fulfillHtlc(add.id, preimage, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+
+    // funding tx1 confirms
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
+    // alice puts a watch-spent and prunes the initial funding
+    alice2blockchain.expectMsgType[WatchFundingSpent]
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.size == 1)
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.inactive.size == 1)
+    // bob publishes a revoked commitment for fundingTx1!
+    val bobRevokedCommitTx = bobCommit1.localCommit.commitTxAndRemoteSig.commitTx.tx
+    alice ! WatchFundingSpentTriggered(bobRevokedCommitTx)
+    // alice watches bob's revoked commit tx, and force-closes with latest commitment
+    assert(alice2blockchain.expectMsgType[WatchAlternativeCommitTxConfirmed].txId == bobRevokedCommitTx.txid)
+    val aliceCommitTx2 = assertPublished(alice2blockchain, "commit-tx")
+    assertPublished(alice2blockchain, "local-anchor")
+    val claimMainDelayed2 = assertPublished(alice2blockchain, "local-main-delayed")
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceCommitTx2.txid)
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == claimMainDelayed2.txid)
+    alice2blockchain.expectMsgType[WatchOutputSpent]
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // bob's revoked tx wins
+    alice ! WatchAlternativeCommitTxConfirmedTriggered(BlockHeight(400000), 42, bobRevokedCommitTx)
+    // alice reacts by punishing bob
+    val aliceClaimMain1 = assertPublished(alice2blockchain, "remote-main-delayed")
+    val aliceMainPenalty1 = assertPublished(alice2blockchain, "main-penalty")
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == bobRevokedCommitTx.txid)
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceClaimMain1.txid)
+    assert(alice2blockchain.expectMsgType[WatchOutputSpent].txId == bobRevokedCommitTx.txid)
+    alice2blockchain.expectNoMessage(100 millis)
+
+    // both tx confirm
+    alice ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, bobRevokedCommitTx)
+    alice ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, aliceClaimMain1)
+    alice ! WatchOutputSpentTriggered(aliceMainPenalty1)
+    assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == aliceMainPenalty1.txid)
+    alice ! WatchTxConfirmedTriggered(BlockHeight(400000), 42, aliceMainPenalty1)
+
+    // done
+    awaitCond(alice.stateName == CLOSED)
+    assert(Helpers.Closing.isClosed(alice.stateData.asInstanceOf[DATA_CLOSING], None).exists(_.isInstanceOf[RevokedClose]))
+  }
+
+  test("put back watches after restart") { f =>
+    import f._
+
+    val fundingTx0 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    val (fundingTx1, fundingTx2) = setup2Splices(f)
+
+    val (aliceNodeParams, bobNodeParams) = (alice.underlyingActor.nodeParams, bob.underlyingActor.nodeParams)
+    val (alicePeer, bobPeer) = (alice.getParent, bob.getParent)
+
+    val aliceData = alice.stateData.asInstanceOf[PersistentChannelData]
+    val bobData = bob.stateData.asInstanceOf[PersistentChannelData]
+
+    alice.stop()
+    bob.stop()
+
+    alice2blockchain.expectNoMessage(100 millis)
+
+    val alice2 = TestFSMRef(new Channel(aliceNodeParams, wallet, bobNodeParams.nodeId, alice2blockchain.ref, TestProbe().ref, FakeTxPublisherFactory(alice2blockchain)), alicePeer)
+    alice2 ! INPUT_RESTORED(aliceData)
+
+    alice2blockchain.expectMsgType[SetChannelId]
+    alice2blockchain.expectWatchFundingConfirmed(fundingTx2.txid)
+    alice2blockchain.expectWatchFundingConfirmed(fundingTx1.txid)
+    alice2blockchain.expectWatchFundingSpent(fundingTx0.txid)
+    alice2blockchain.expectNoMessage(100 millis)
+  }
+
+  test("put back watches after restart (inactive)", Tag(ChannelStateTestsTags.ZeroConf), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
+    import f._
+
+    val fundingTx0 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+
+    alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx0)
+    bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx0)
+    alice2blockchain.expectWatchFundingSpent(fundingTx0.txid)
+    bob2blockchain.expectWatchFundingSpent(fundingTx0.txid)
+
+    // create splice 1
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx1 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    alice2blockchain.expectMsgType[WatchPublished]
+    bob2blockchain.expectMsgType[WatchPublished]
+    alice ! WatchPublishedTriggered(fundingTx1)
+    bob ! WatchPublishedTriggered(fundingTx1)
+    alice2blockchain.expectWatchFundingConfirmed(fundingTx1.txid)
+    bob2blockchain.expectWatchFundingConfirmed(fundingTx1.txid)
+    alice2bob.expectMsgType[SpliceLocked]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceLocked]
+    bob2alice.forward(alice)
+    // splice 1 has been locked, fundingTx0 is inactive
+
+    initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)))
+    val fundingTx2 = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.signedTx_opt.get
+    alice2blockchain.expectMsgType[WatchPublished]
+    bob2blockchain.expectMsgType[WatchPublished]
+
+    val (aliceNodeParams, bobNodeParams) = (alice.underlyingActor.nodeParams, bob.underlyingActor.nodeParams)
+    val (alicePeer, bobPeer) = (alice.getParent, bob.getParent)
+
+    val aliceData = alice.stateData.asInstanceOf[PersistentChannelData]
+    val bobData = bob.stateData.asInstanceOf[PersistentChannelData]
+
+    alice.stop()
+    bob.stop()
+
+    alice2blockchain.expectNoMessage(100 millis)
+
+    val alice2 = TestFSMRef(new Channel(aliceNodeParams, wallet, bobNodeParams.nodeId, alice2blockchain.ref, TestProbe().ref, FakeTxPublisherFactory(alice2blockchain)), alicePeer)
+    alice2 ! INPUT_RESTORED(aliceData)
+
+    alice2blockchain.expectMsgType[SetChannelId]
+    alice2blockchain.expectWatchPublished(fundingTx2.txid)
+    alice2blockchain.expectWatchFundingConfirmed(fundingTx1.txid)
+    alice2blockchain.expectWatchFundingSpent(fundingTx0.txid)
+    alice2blockchain.expectNoMessage(100 millis)
+  }
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -3266,7 +3266,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     assert(addSettled.htlc == htlc3)
   }
 
-  test("recv WatchFundingSpentTriggered (other commit)") { f =>
+  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
     awaitCond(alice.stateName == ERR_INFORMATION_LEAK)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -3266,10 +3266,11 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     assert(addSettled.htlc == htlc3)
   }
 
-  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
+  test("recv WatchFundingSpentTriggered (unrecognized commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
-    awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
+    alice2blockchain.expectNoMessage(100 millis)
+    assert(alice.stateName == NORMAL)
   }
 
   test("recv Error") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -797,10 +797,11 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     channelUpdateListener.expectMsgType[LocalChannelUpdate]
   }
 
-  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
+  test("recv WatchFundingSpentTriggered (unrecognized commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
-    awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
+    alice2blockchain.expectNoMessage(100 millis)
+    assert(alice.stateName == NORMAL)
   }
 
   def disconnect(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel]): Unit = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -409,10 +409,8 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     // alice then finds out bob is lying
     bob2alice.send(alice, invalidReestablish)
     val error = alice2bob.expectMsgType[Error]
-    assert(alice2blockchain.expectMsgType[PublishFinalTx].tx.txid == aliceCommitTx.txid)
-    val claimMainOutput = alice2blockchain.expectMsgType[PublishFinalTx].tx
-    Transaction.correctlySpends(claimMainOutput, aliceCommitTx :: Nil, ScriptFlags.STANDARD_SCRIPT_VERIFY_FLAGS)
-    assert(error == Error(channelId(alice), InvalidRevokedCommitProof(channelId(alice), 0, 42, invalidReestablish.yourLastPerCommitmentSecret).getMessage))
+    assert(error == Error(channelId(alice), PleasePublishYourCommitment(channelId(alice)).getMessage))
+    awaitCond(alice.stateName == WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT)
   }
 
   test("change relay fee while offline", Tag(IgnoreChannelUpdates)) { f =>
@@ -799,7 +797,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     channelUpdateListener.expectMsgType[LocalChannelUpdate]
   }
 
-  test("recv WatchFundingSpentTriggered (other commit)") { f =>
+  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
     awaitCond(alice.stateName == ERR_INFORMATION_LEAK)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -903,7 +903,7 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     alice2blockchain.expectNoMessage(1 second)
   }
 
-  test("recv WatchFundingSpentTriggered (other commit)") { f =>
+  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
     awaitCond(alice.stateName == ERR_INFORMATION_LEAK)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -903,10 +903,11 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
     alice2blockchain.expectNoMessage(1 second)
   }
 
-  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
+  test("recv WatchFundingSpentTriggered (unrecognized commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
-    awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
+    alice2blockchain.expectNoMessage(100 millis)
+    assert(alice.stateName == SHUTDOWN)
   }
 
   test("recv Error") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
@@ -541,7 +541,7 @@ class NegotiatingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     awaitCond(bob.stateName == CLOSING)
   }
 
-  test("recv WatchFundingSpentTriggered (other commit)") { f =>
+  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
     awaitCond(alice.stateName == ERR_INFORMATION_LEAK)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -1638,7 +1638,7 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     assert(new String(error.data.toArray) == FundingTxSpent(channelId(alice), initialState.spendingTxs.head.txid).getMessage)
   }
 
-  test("recv WatchFundingSpentTriggered (other commit)") { f =>
+  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
     import f._
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
     awaitCond(alice.stateName == ERR_INFORMATION_LEAK)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/h/ClosingStateSpec.scala
@@ -1638,10 +1638,12 @@ class ClosingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     assert(new String(error.data.toArray) == FundingTxSpent(channelId(alice), initialState.spendingTxs.head.txid).getMessage)
   }
 
-  ignore("recv WatchFundingSpentTriggered (other commit)") { f =>
+  test("recv WatchFundingSpentTriggered (unrecognized commit)") { f =>
     import f._
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
     alice ! WatchFundingSpentTriggered(Transaction(0, Nil, Nil, 0))
-    awaitCond(alice.stateName == ERR_INFORMATION_LEAK)
+    alice2blockchain.expectNoMessage(100 millis)
+    assert(alice.stateName == CLOSING)
   }
 
   test("recv CMD_CLOSE") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2019 ACINQ SAS
  *

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2019 ACINQ SAS
  *

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PendingChannelsRateLimiterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PendingChannelsRateLimiterSpec.scala
@@ -75,7 +75,7 @@ class PendingChannelsRateLimiterSpec extends ScalaTestWithActorTestKit(ConfigFac
     val peerBelowLimit2 = randomKey().publicKey
     val channelsBelowLimit2 = Seq(
       DATA_WAIT_FOR_DUAL_FUNDING_READY(commitments(peerBelowLimit2, channelIdBelowLimit2), ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), None)),
-      DATA_NORMAL(commitments(peerBelowLimit2, randomBytes32()), ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), None), None, null, None, None, None),
+      DATA_NORMAL(commitments(peerBelowLimit2, randomBytes32()), ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), None), None, null, None, None, None, SpliceStatus.NoSplice),
       DATA_SHUTDOWN(commitments(peerBelowLimit2, randomBytes32()), Shutdown(randomBytes32(), ByteVector.empty), Shutdown(randomBytes32(), ByteVector.empty), None),
       DATA_CLOSING(commitments(peerBelowLimit2, randomBytes32()), BlockHeight(0), ByteVector.empty, List(), List(closingTx))
     )
@@ -83,7 +83,7 @@ class PendingChannelsRateLimiterSpec extends ScalaTestWithActorTestKit(ConfigFac
     val privatePeer2 = randomKey().publicKey
     val privateChannels = Seq(
       DATA_WAIT_FOR_DUAL_FUNDING_READY(commitments(privatePeer1, channelIdPrivate1), ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), None)),
-      DATA_NORMAL(commitments(privatePeer2, randomBytes32()), ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), None), None, null, None, None, None),
+      DATA_NORMAL(commitments(privatePeer2, randomBytes32()), ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), None), None, null, None, None, None, SpliceStatus.NoSplice),
     )
     val publicChannels = channelsOnWhitelistAtLimit ++ channelsAtLimit1 ++ channelsAtLimit2 ++ channelsBelowLimit1 ++ channelsBelowLimit2
     val publicPeers = publicChannels.map(_.commitments.remoteNodeId).toSet
@@ -291,7 +291,7 @@ class PendingChannelsRateLimiterSpec extends ScalaTestWithActorTestKit(ConfigFac
     val channels = Seq(
       DATA_WAIT_FOR_CHANNEL_READY(commitments(randomKey().publicKey, randomBytes32()), ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), None)),
       DATA_WAIT_FOR_DUAL_FUNDING_READY(commitments(randomKey().publicKey, randomBytes32()), ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), None)),
-      DATA_NORMAL(commitments(randomKey().publicKey, randomBytes32()), ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), None), None, null, None, None, None),
+      DATA_NORMAL(commitments(randomKey().publicKey, randomBytes32()), ShortIds(RealScidStatus.Unknown, ShortChannelId.generateLocalAlias(), None), None, null, None, None, None, SpliceStatus.NoSplice),
       DATA_SHUTDOWN(commitments(randomKey().publicKey, randomBytes32()), Shutdown(randomBytes32(), ByteVector.empty), Shutdown(randomBytes32(), ByteVector.empty), None),
       DATA_WAIT_FOR_FUNDING_CONFIRMED(commitments(randomKey().publicKey, randomBytes32()), BlockHeight(0), None, Left(FundingCreated(randomBytes32(), ByteVector32.Zeroes, 3, randomBytes64()))),
     )

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
@@ -711,7 +711,8 @@ object PaymentPacketSpec {
     new Commitments(
       ChannelParams(channelId, ChannelConfig.standard, channelFeatures, localParams, remoteParams, channelFlags),
       CommitmentChanges(localChanges, remoteChanges, 0, 0),
-      List(Commitment(LocalFundingStatus.SingleFundedUnconfirmedFundingTx(None), RemoteFundingStatus.Locked, localCommit, remoteCommit, None)),
+      List(Commitment(0, LocalFundingStatus.SingleFundedUnconfirmedFundingTx(None), RemoteFundingStatus.Locked, localCommit, remoteCommit, None)),
+      inactive = Nil,
       Right(randomKey().publicKey),
       ShaChain.init,
       Map.empty,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/testutils/PimpTestProbe.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/testutils/PimpTestProbe.scala
@@ -1,0 +1,46 @@
+package fr.acinq.eclair.testutils
+
+import akka.testkit.TestProbe
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi}
+import fr.acinq.eclair.MilliSatoshi
+import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{WatchFundingConfirmed, WatchFundingSpent, WatchPublished}
+import fr.acinq.eclair.channel.AvailableBalanceChanged
+import org.scalatest.Assertions
+
+import scala.reflect.ClassTag
+
+case class PimpTestProbe(probe: TestProbe) extends Assertions {
+
+  /**
+   * Generic method to perform validation on an expected message.
+   *
+   * @param asserts should contains asserts on the message
+   */
+  def expectMsgTypeHaving[T](asserts: T => Unit)(implicit t: ClassTag[T]): T = {
+    val msg = probe.expectMsgType[T]
+    asserts(msg)
+    msg
+  }
+
+  def expectWatchFundingSpent(txid: ByteVector32): WatchFundingSpent =
+    expectMsgTypeHaving[WatchFundingSpent](w => assert(w.txId == txid, "txid"))
+
+  def expectWatchFundingConfirmed(txid: ByteVector32): WatchFundingConfirmed =
+    expectMsgTypeHaving[WatchFundingConfirmed](w => assert(w.txId == txid, "txid"))
+
+  def expectWatchPublished(txid: ByteVector32): WatchPublished =
+    expectMsgTypeHaving[WatchPublished](w => assert(w.txId == txid, "txid"))
+
+  def expectAvailableBalanceChanged(balance: MilliSatoshi, capacity: Satoshi): AvailableBalanceChanged =
+    expectMsgTypeHaving[AvailableBalanceChanged] { e =>
+      // NB: we check raw local balance, not availableBalanceForSend, because the latter is more difficult to compute
+      assert(e.commitments.active.map(_.localCommit.spec.toLocal).min == balance, "balance")
+      assert(e.commitments.active.map(_.capacity).min == capacity, "capacity")
+    }
+}
+
+object PimpTestProbe {
+
+  implicit def convert(probe: TestProbe): PimpTestProbe = PimpTestProbe(probe)
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/ChannelCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/ChannelCodecsSpec.scala
@@ -323,11 +323,11 @@ object ChannelCodecsSpec {
     val commitments = Commitments(
       ChannelParams(channelId, ChannelConfig.standard, ChannelFeatures(), localParams, remoteParams, channelFlags),
       CommitmentChanges(LocalChanges(Nil, Nil, Nil), RemoteChanges(Nil, Nil, Nil), localNextHtlcId = 32, remoteNextHtlcId = 4),
-      Seq(Commitment(LocalFundingStatus.SingleFundedUnconfirmedFundingTx(None), RemoteFundingStatus.NotLocked, localCommit, remoteCommit, None)),
+      Seq(Commitment(fundingTxIndex = 0, LocalFundingStatus.SingleFundedUnconfirmedFundingTx(None), RemoteFundingStatus.NotLocked, localCommit, remoteCommit, None)),
       remoteNextCommitInfo = Right(randomKey().publicKey),
       remotePerCommitmentSecrets = ShaChain.init,
       originChannels = origins)
-    DATA_NORMAL(commitments, ShortIds(RealScidStatus.Final(RealShortChannelId(42)), ShortChannelId.generateLocalAlias(), None), None, channelUpdate, None, None, None)
+    DATA_NORMAL(commitments, ShortIds(RealScidStatus.Final(RealShortChannelId(42)), ShortChannelId.generateLocalAlias(), None), None, channelUpdate, None, None, None, SpliceStatus.NoSplice)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version4/ChannelCodecs4Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version4/ChannelCodecs4Spec.scala
@@ -136,6 +136,7 @@ class ChannelCodecs4Spec extends AnyFunSuite {
     )
     val waitingForSigs = InteractiveTxSigningSession.WaitingForSigs(
       InteractiveTxParams(channelId, isInitiator = true, 100_000 sat, 75_000 sat, None, ByteVector.empty, Nil, 0, 330 sat, FeeratePerKw(500 sat), None, RequireConfirmedInputs(forLocal = false, forRemote = false)),
+      fundingTxIndex = 0,
       PartiallySignedSharedTransaction(fundingTx, TxSignatures(channelId, randomBytes32(), Nil)),
       Left(UnsignedLocalCommit(0, CommitmentSpec(Set.empty, FeeratePerKw(1000 sat), 100_000_000 msat, 75_000_000 msat), commitTx, Nil)),
       RemoteCommit(0, CommitmentSpec(Set.empty, FeeratePerKw(1000 sat), 75_000_000 msat, 100_000_000 msat), randomBytes32(), randomKey().publicKey)


### PR DESCRIPTION
This PR adds support for both splice-in and splice-out in Eclair.

It differs from the current wip BOLT proposal on at least the following points:
- we use a poor man's _quiescence_ protocol which just rejects the splice if the channel is not idle
- splice txs always _spend_ the previous funding/splice tx, even if it isn't confirmed yet and could theoretically be RBFed. This is done to be compatible with zero-conf splices, as we intend to use this for Phoenix

We closely mimick RBFing the initial funding tx (`RbfStatus` vs `SpliceStatus`, reuse of `TxInitRbf`/`TxAckRbf` messages).

Mixing concurrent local/remote splice-in/splice-out is wired, although not supported in the API.