### PR TITLE
Remove unnecessary dust limit hack in interactive-tx

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -223,7 +223,7 @@ object Helpers {
     }
 
     // BOLT #2: Channel funding limits
-    if (accept.fundingAmount > nodeParams.channelConf.maxFundingSatoshis) return Left(InvalidFundingAmount(accept.temporaryChannelId, accept.fundingAmount, 0 sat, nodeParams.channelConf.maxFundingSatoshis))
+    if (accept.fundingAmount > nodeParams.channelConf.maxFundingSatoshis || accept.fundingAmount < 0.sat) return Left(InvalidFundingAmount(accept.temporaryChannelId, accept.fundingAmount, 0 sat, nodeParams.channelConf.maxFundingSatoshis))
 
     // BOLT #2: The receiving node MUST fail the channel if: push_msat is greater than funding_satoshis * 1000.
     if (accept.pushAmount > accept.fundingAmount) return Left(InvalidPushAmount(accept.temporaryChannelId, accept.pushAmount, accept.fundingAmount.toMilliSatoshi))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -116,6 +116,8 @@ object InteractiveTxBuilder {
     val fundingAmount: Satoshi = localAmount + remoteAmount
     // BOLT 2: MUST set `feerate` greater than or equal to 25/24 times the `feerate` of the previously constructed transaction, rounded down.
     val minNextFeerate: FeeratePerKw = targetFeerate * 25 / 24
+    // BOLT 2: the initiator's serial IDs MUST use even values and the non-initiator odd values.
+    val serialIdParity = if (isInitiator) 0 else 1
   }
 
   // @formatter:off

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -113,6 +113,7 @@ object InteractiveTxBuilder {
                                  dustLimit: Satoshi,
                                  targetFeerate: FeeratePerKw,
                                  requireConfirmedInputs: RequireConfirmedInputs) {
+    require(localAmount >= 0.sat && remoteAmount >= 0.sat, "funding amount cannot be negative")
     val fundingAmount: Satoshi = localAmount + remoteAmount
     // BOLT 2: MUST set `feerate` greater than or equal to 25/24 times the `feerate` of the previously constructed transaction, rounded down.
     val minNextFeerate: FeeratePerKw = targetFeerate * 25 / 24

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxFunder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxFunder.scala
@@ -95,7 +95,6 @@ private class InteractiveTxFunder(replyTo: ActorRef[InteractiveTxFunder.Response
   }
 
   def start(): Behavior[Command] = {
-    require(fundingParams.localAmount >= 0.sat, "funding amount cannot be negative")
     log.debug("contributing {} to interactive-tx construction", fundingParams.localAmount)
     if (fundingParams.localAmount == 0.sat && !fundingParams.isInitiator) {
       // We're not the initiator and we don't want to contribute to the funding transaction.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxFunder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxFunder.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.{Logs, UInt64}
 import scodec.bits.ByteVector
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Random, Success}
 
 /**
  * Created by t-bast on 05/01/2023.
@@ -95,17 +95,9 @@ private class InteractiveTxFunder(replyTo: ActorRef[InteractiveTxFunder.Response
   }
 
   def start(): Behavior[Command] = {
-    val toFund = if (fundingParams.isInitiator) {
-      // If we're the initiator, we need to pay the fees of the common fields of the transaction, even if we don't want
-      // to contribute to the shared output. We create a non-zero amount here to ensure that bitcoind will fund the
-      // fees for the shared output (because it would otherwise reject a txOut with an amount of zero).
-      fundingParams.localAmount.max(fundingParams.dustLimit)
-    } else {
-      fundingParams.localAmount
-    }
-    require(toFund >= 0.sat, "funding amount cannot be negative")
-    log.debug("contributing {} to interactive-tx construction", toFund)
-    if (toFund == 0.sat) {
+    require(fundingParams.localAmount >= 0.sat, "funding amount cannot be negative")
+    log.debug("contributing {} to interactive-tx construction", fundingParams.localAmount)
+    if (fundingParams.localAmount == 0.sat && !fundingParams.isInitiator) {
       // We're not the initiator and we don't want to contribute to the funding transaction.
       replyTo ! FundingContributions(Nil, Nil)
       Behaviors.stopped
@@ -114,7 +106,8 @@ private class InteractiveTxFunder(replyTo: ActorRef[InteractiveTxFunder.Response
       // spend one input of each previous tx, but it's simpler and less error-prone this way. It also ensures that in
       // most cases, we won't need to add new inputs and will simply lower the change amount.
       val previousInputs = previousTransactions.flatMap(_.tx.localInputs).distinctBy(_.serialId)
-      val dummyTx = Transaction(2, previousInputs.map(i => TxIn(toOutPoint(i), ByteVector.empty, i.sequence)), Seq(TxOut(toFund, fundingParams.fundingPubkeyScript)), fundingParams.lockTime)
+      // Note that if the funding amount is smaller than the dust limit, bitcoind will reject the funding attempt.
+      val dummyTx = Transaction(2, previousInputs.map(i => TxIn(toOutPoint(i), ByteVector.empty, i.sequence)), Seq(TxOut(fundingParams.localAmount, fundingParams.fundingPubkeyScript)), fundingParams.lockTime)
       fund(dummyTx, previousInputs, Set.empty)
     }
   }
@@ -167,17 +160,9 @@ private class InteractiveTxFunder(replyTo: ActorRef[InteractiveTxFunder.Response
         } else {
           val changeOutput_opt = otherOutputs.headOption.map(txOut => TxAddOutput(fundingParams.channelId, UInt64(0), txOut.amount, txOut.publicKeyScript))
           val outputs = if (fundingParams.isInitiator) {
-            val initiatorChangeOutput = changeOutput_opt match {
-              case Some(changeOutput) if fundingParams.localAmount == 0.sat =>
-                // If the initiator doesn't want to contribute, we should cancel the dummy amount artificially added previously.
-                val dummyFundingAmount = fundingOutputs.head.amount
-                Seq(changeOutput.copy(amount = changeOutput.amount + dummyFundingAmount))
-              case Some(changeOutput) => Seq(changeOutput)
-              case None => Nil
-            }
             // The initiator is responsible for adding the shared output.
             val fundingOutput = TxAddOutput(fundingParams.channelId, UInt64(0), fundingParams.fundingAmount, fundingParams.fundingPubkeyScript)
-            fundingOutput +: initiatorChangeOutput
+            fundingOutput +: changeOutput_opt.toSeq
           } else {
             // The protocol only requires the non-initiator to pay the fees for its inputs and outputs, discounting the
             // common fields (shared output, version, nLockTime, etc). By using bitcoind's fundrawtransaction we are
@@ -193,10 +178,9 @@ private class InteractiveTxFunder(replyTo: ActorRef[InteractiveTxFunder.Response
             }
           }
           log.debug("added {} inputs and {} outputs to interactive tx", inputDetails.usableInputs.length, outputs.length)
-          // The initiator's serial IDs must use even values and the non-initiator odd values.
-          val serialIdParity = if (fundingParams.isInitiator) 0 else 1
-          val txAddInputs = inputDetails.usableInputs.zipWithIndex.map { case (input, i) => input.copy(serialId = UInt64(2 * i + serialIdParity)) }
-          val txAddOutputs = outputs.zipWithIndex.map { case (output, i) => output.copy(serialId = UInt64(2 * (i + txAddInputs.length) + serialIdParity)) }
+          // We randomize the order of inputs and outputs.
+          val txAddInputs = Random.shuffle(inputDetails.usableInputs).zipWithIndex.map { case (input, i) => input.copy(serialId = UInt64(2 * i + fundingParams.serialIdParity)) }
+          val txAddOutputs = Random.shuffle(outputs).zipWithIndex.map { case (output, i) => output.copy(serialId = UInt64(2 * (i + txAddInputs.length) + fundingParams.serialIdParity)) }
           val result = FundingContributions(txAddInputs, txAddOutputs)
           // We unlock the unusable inputs (if any) as they can be used outside of interactive-tx sessions.
           sendResultAndStop(result, unusableInputs.map(_.outpoint))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptDualFundedChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForAcceptDualFundedChannelStateSpec.scala
@@ -119,6 +119,17 @@ class WaitForAcceptDualFundedChannelStateSpec extends TestKitBaseClass with Fixt
     awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_CREATED)
   }
 
+  test("recv AcceptDualFundedChannel (negative funding amount)", Tag(ChannelStateTestsTags.DualFunding), Tag(dualFundingContribution), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
+    import f._
+
+    val accept = bob2alice.expectMsgType[AcceptDualFundedChannel]
+    alice ! accept.copy(fundingAmount = -1 sat)
+    val error = alice2bob.expectMsgType[Error]
+    assert(error == Error(accept.temporaryChannelId, InvalidFundingAmount(accept.temporaryChannelId, -1 sat, 0 sat, Alice.nodeParams.channelConf.maxFundingSatoshis).getMessage))
+    awaitCond(alice.stateName == CLOSED)
+    aliceOrigin.expectMsgType[Status.Failure]
+  }
+
   test("recv AcceptDualFundedChannel (invalid push amount)", Tag(ChannelStateTestsTags.DualFunding), Tag(dualFundingContribution), Tag(ChannelStateTestsTags.NonInitiatorPushAmount), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
     import f._
 


### PR DESCRIPTION
We previously inflated the funding amount to always exceed the dust limit, otherwise bitcoind would reject the funding attempt. It complicated the code for a scenario that doesn't make sense in practice, so it's better to just let the funding attempt fail in that case.

We also randomize the order of inputs and outputs, which is a common privacy best practice.