### PR TITLE
Add limit for incoming connections from peers without channels

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -61,15 +61,15 @@ eclair.channel.channel-open-limits.max-pending-channels-per-peer = 3
 eclair.channel.channel-open-limits.max-total-pending-channels-private-nodes = 99 
 ```
 
-#### Configurable incoming connections rate limits (#2601)
+#### Configurable limit on incoming connections (#2601)
 
 We have added a parameter to `eclair.conf` to allow nodes to track the number of incoming connections they maintain from peers they do not have existing channels with. Once the limit is reached, Eclair will disconnect from the oldest tracked peers first.
 
-Outgoing connections are except from and do not count towards the limit. 
+Outgoing connections and peers on the `sync-whitelist` are exempt from and do not count towards the limit. 
 
 The new configuration option and default is as follows:
 ```conf
-// maximum number of incoming connections from peers that do not have any channel with us
+// maximum number of incoming connections from peers that do not have any channels with us
 eclair.peer-connection.max-no-channels = 250 
 ```
 

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -70,7 +70,7 @@ Outgoing connections are except from and do not count towards the limit.
 The new configuration option and default is as follows:
 ```conf
 // maximum number of incoming connections from peers that do not have any channel with us
-eclair.peer-connection.max-without-channels = 250 
+eclair.peer-connection.max-no-channels = 250 
 ```
 
 ## Verifying signatures

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -61,6 +61,18 @@ eclair.channel.channel-open-limits.max-pending-channels-per-peer = 3
 eclair.channel.channel-open-limits.max-total-pending-channels-private-nodes = 99 
 ```
 
+#### Configurable inbound connections rate limits (#????)
+
+We have added a parameter to `eclair.conf` to allow nodes to manage the number of inbound connections they accept from peers they do not have any existing channels with.
+
+Outgoing connections are except from this limit, as are incoming connections from peers on the `sync-whitelist`. 
+
+The new configuration option and default is as follows:
+```conf
+// number of peers without established channels with us that may initiate a connection 
+eclair.peer-connection.max-without-channels = 250 
+```
+
 ## Verifying signatures
 
 You will need `gpg` and our release signing key 7A73FE77DE2C4027. Note that you can get it:

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -65,11 +65,11 @@ eclair.channel.channel-open-limits.max-total-pending-channels-private-nodes = 99
 
 We have added a parameter to `eclair.conf` to allow nodes to manage the number of inbound connections they accept from peers they do not have any existing channels with.
 
-Outgoing connections are except from this limit, as are incoming connections from peers on the `sync-whitelist`. 
+Outgoing connections are except from this limit. 
 
 The new configuration option and default is as follows:
 ```conf
-// number of peers without established channels with us that may initiate a connection 
+// maximum number of inbound connections from peers that do not have any channel with us
 eclair.peer-connection.max-without-channels = 250 
 ```
 

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -61,11 +61,11 @@ eclair.channel.channel-open-limits.max-pending-channels-per-peer = 3
 eclair.channel.channel-open-limits.max-total-pending-channels-private-nodes = 99 
 ```
 
-#### Configurable inbound connections rate limits (#????)
+#### Configurable inbound connections rate limits (#2601)
 
-We have added a parameter to `eclair.conf` to allow nodes to manage the number of inbound connections they accept from peers they do not have any existing channels with.
+We have added a parameter to `eclair.conf` to allow nodes to track the number of inbound connections they maintain from peers they do not have existing channels with. Once the limit is reached, Eclair will disconnect from the oldest tracked peers first.
 
-Outgoing connections are except from this limit. 
+Outgoing connections are except from and do not count towards the limit. 
 
 The new configuration option and default is as follows:
 ```conf

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -61,15 +61,15 @@ eclair.channel.channel-open-limits.max-pending-channels-per-peer = 3
 eclair.channel.channel-open-limits.max-total-pending-channels-private-nodes = 99 
 ```
 
-#### Configurable inbound connections rate limits (#2601)
+#### Configurable incoming connections rate limits (#2601)
 
-We have added a parameter to `eclair.conf` to allow nodes to track the number of inbound connections they maintain from peers they do not have existing channels with. Once the limit is reached, Eclair will disconnect from the oldest tracked peers first.
+We have added a parameter to `eclair.conf` to allow nodes to track the number of incoming connections they maintain from peers they do not have existing channels with. Once the limit is reached, Eclair will disconnect from the oldest tracked peers first.
 
 Outgoing connections are except from and do not count towards the limit. 
 
 The new configuration option and default is as follows:
 ```conf
-// maximum number of inbound connections from peers that do not have any channel with us
+// maximum number of incoming connections from peers that do not have any channel with us
 eclair.peer-connection.max-without-channels = 250 
 ```
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -278,7 +278,7 @@ eclair {
     // When enabled, if we receive an incoming connection, we will echo the source IP address in our init message.
     // This should be disabled if your node is behind a load balancer that doesn't preserve source IP addresses.
     send-remote-address-init = true
-    max-without-channels = 250 // number of peers without established channels with us that may initiate a connection
+    max-without-channels = 250 // maximum number of inbound connections from peers that do not have any channel with us
   }
 
   auto-reconnect = true

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -278,7 +278,7 @@ eclair {
     // When enabled, if we receive an incoming connection, we will echo the source IP address in our init message.
     // This should be disabled if your node is behind a load balancer that doesn't preserve source IP addresses.
     send-remote-address-init = true
-    max-without-channels = 250 // maximum number of incoming connections from peers that do not have any channel with us
+    max-no-channels = 250 // maximum number of incoming connections from peers that do not have any channel with us
   }
 
   auto-reconnect = true

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -278,6 +278,7 @@ eclair {
     // When enabled, if we receive an incoming connection, we will echo the source IP address in our init message.
     // This should be disabled if your node is behind a load balancer that doesn't preserve source IP addresses.
     send-remote-address-init = true
+    max-without-channels = 250 // number of peers without established channels with us that may initiate a connection
   }
 
   auto-reconnect = true

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -278,7 +278,7 @@ eclair {
     // When enabled, if we receive an incoming connection, we will echo the source IP address in our init message.
     // This should be disabled if your node is behind a load balancer that doesn't preserve source IP addresses.
     send-remote-address-init = true
-    max-without-channels = 250 // maximum number of inbound connections from peers that do not have any channel with us
+    max-without-channels = 250 // maximum number of incoming connections from peers that do not have any channel with us
   }
 
   auto-reconnect = true

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -278,7 +278,7 @@ eclair {
     // When enabled, if we receive an incoming connection, we will echo the source IP address in our init message.
     // This should be disabled if your node is behind a load balancer that doesn't preserve source IP addresses.
     send-remote-address-init = true
-    max-no-channels = 250 // maximum number of incoming connections from peers that do not have any channel with us
+    max-no-channels = 250 // maximum number of incoming connections from peers that do not have any channels with us
   }
 
   auto-reconnect = true

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -186,7 +186,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
   }
 
   override def disconnect(nodeId: PublicKey)(implicit timeout: Timeout): Future[String] = {
-    (appKit.switchboard ? Peer.Disconnect(nodeId)).mapTo[String]
+    (appKit.switchboard ? Peer.Disconnect(nodeId)).mapTo[Peer.DisconnectResponse].map(_.toString)
   }
 
   override def open(nodeId: PublicKey, fundingAmount: Satoshi, pushAmount_opt: Option[MilliSatoshi], channelType_opt: Option[SupportedChannelType], fundingFeeratePerByte_opt: Option[FeeratePerByte], announceChannel_opt: Option[Boolean], openTimeout_opt: Option[Timeout])(implicit timeout: Timeout): Future[ChannelOpenResponse] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -449,6 +449,9 @@ object NodeParams extends Logging {
     val maxPendingChannelsPerPeer = config.getInt("channel.channel-open-limits.max-pending-channels-per-peer")
     val maxTotalPendingChannelsPrivateNodes = config.getInt("channel.channel-open-limits.max-total-pending-channels-private-nodes")
 
+    val maxWithoutChannels = config.getInt("peer-connection.max-without-channels")
+    require(maxWithoutChannels > 0, "peer-connection.max-without-channels must be > 0")
+
     NodeParams(
       nodeKeyManager = nodeKeyManager,
       channelKeyManager = channelKeyManager,
@@ -544,7 +547,7 @@ object NodeParams extends Logging {
         killIdleDelay = FiniteDuration(config.getDuration("onion-messages.kill-transient-connection-after").getSeconds, TimeUnit.SECONDS),
         maxOnionMessagesPerSecond = config.getInt("onion-messages.max-per-peer-per-second"),
         sendRemoteAddressInit = config.getBoolean("peer-connection.send-remote-address-init"),
-        maxWithoutChannels = config.getInt("peer-connection.max-without-channels"),
+        maxWithoutChannels = maxWithoutChannels,
       ),
       routerConf = RouterConf(
         watchSpentWindow = watchSpentWindow,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -449,8 +449,8 @@ object NodeParams extends Logging {
     val maxPendingChannelsPerPeer = config.getInt("channel.channel-open-limits.max-pending-channels-per-peer")
     val maxTotalPendingChannelsPrivateNodes = config.getInt("channel.channel-open-limits.max-total-pending-channels-private-nodes")
 
-    val maxWithoutChannels = config.getInt("peer-connection.max-without-channels")
-    require(maxWithoutChannels > 0, "peer-connection.max-without-channels must be > 0")
+    val maxNoChannels = config.getInt("peer-connection.max-no-channels")
+    require(maxNoChannels > 0, "peer-connection.max-no-channels must be > 0")
 
     NodeParams(
       nodeKeyManager = nodeKeyManager,
@@ -547,7 +547,7 @@ object NodeParams extends Logging {
         killIdleDelay = FiniteDuration(config.getDuration("onion-messages.kill-transient-connection-after").getSeconds, TimeUnit.SECONDS),
         maxOnionMessagesPerSecond = config.getInt("onion-messages.max-per-peer-per-second"),
         sendRemoteAddressInit = config.getBoolean("peer-connection.send-remote-address-init"),
-        maxWithoutChannels = maxWithoutChannels,
+        maxNoChannels = maxNoChannels,
       ),
       routerConf = RouterConf(
         watchSpentWindow = watchSpentWindow,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -544,6 +544,7 @@ object NodeParams extends Logging {
         killIdleDelay = FiniteDuration(config.getDuration("onion-messages.kill-transient-connection-after").getSeconds, TimeUnit.SECONDS),
         maxOnionMessagesPerSecond = config.getInt("onion-messages.max-per-peer-per-second"),
         sendRemoteAddressInit = config.getBoolean("peer-connection.send-remote-address-init"),
+        maxWithoutChannels = config.getInt("peer-connection.max-without-channels"),
       ),
       routerConf = RouterConf(
         watchSpentWindow = watchSpentWindow,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -1,0 +1,61 @@
+package fr.acinq.eclair.io
+
+import akka.actor.typed.delivery.DurableProducerQueue.TimestampMillis
+import akka.actor.typed.eventstream.EventStream
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, Behavior}
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.eclair.NodeParams
+import fr.acinq.eclair.channel.ChannelOpened
+import fr.acinq.eclair.io.Peer.Disconnect
+
+/**
+ * A singleton actor that limits the total number of inbound connections from peers that do not have channels with us.
+ *
+ * When a new incoming connection request is received, the Switchboard should send an
+ * [[IncomingConnectionsTracker.TrackIncomingConnection]] message.
+ *
+ * When the number of tracked peers exceeds `eclair.peer-connection.max-without-channels`, send [[Peer.Disconnect]] to
+ * the tracked peer with the oldest incoming connection.
+ *
+ * When a tracked peer disconnects or adds a channel, we will stop tracking that peer.
+ *
+ * We do not need to track peers that disconnect because they will terminate if they have no channels.
+ * Likewise, peers with channels will terminate when their last channel closes.
+ *
+ * Note: Peers on the sync whitelist are not tracked.
+*/
+object IncomingConnectionsTracker {
+  // @formatter:off
+  sealed trait Command
+
+  case class TrackIncomingConnection(remoteNodeId: PublicKey) extends Command
+  private case class ForgetIncomingConnection(remoteNodeId: PublicKey) extends Command
+  // @formatter:on
+
+  def apply(nodeParams: NodeParams, switchboard: ActorRef[Disconnect]): Behavior[Command] = {
+    Behaviors.setup { context =>
+      context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[PeerDisconnected](c => ForgetIncomingConnection(c.nodeId)))
+      context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelOpened](c => ForgetIncomingConnection(c.remoteNodeId)))
+      new IncomingConnectionsTracker(nodeParams, switchboard).tracking(Map())
+    }
+  }
+}
+
+private class IncomingConnectionsTracker(nodeParams: NodeParams, switchboard: ActorRef[Disconnect]) {
+  import IncomingConnectionsTracker._
+
+  private def tracking(inboundConnections: Map[PublicKey, TimestampMillis]): Behavior[Command] =
+    Behaviors.receiveMessage {
+      case TrackIncomingConnection(remoteNodeId) =>
+        if (nodeParams.syncWhitelist.contains(remoteNodeId)) {
+          Behaviors.same
+        } else {
+          if (inboundConnections.size >= nodeParams.peerConnectionConf.maxWithoutChannels) {
+            switchboard ! Disconnect(inboundConnections.minBy(_._2)._1)
+          }
+          tracking(inboundConnections + (remoteNodeId -> System.currentTimeMillis()))
+        }
+      case ForgetIncomingConnection(remoteNodeId) => tracking(inboundConnections - remoteNodeId)
+    }
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -32,7 +32,7 @@ object IncomingConnectionsTracker {
 
   case class TrackIncomingConnection(remoteNodeId: PublicKey) extends Command
   private case class ForgetIncomingConnection(remoteNodeId: PublicKey) extends Command
-  private[io] case class IncomingConnectionsCount(replyTo: ActorRef[Int]) extends Command
+  private[io] case class CountIncomingConnections(replyTo: ActorRef[Int]) extends Command
   // @formatter:on
 
   def apply(nodeParams: NodeParams, switchboard: ActorRef[Disconnect]): Behavior[Command] = {
@@ -65,7 +65,7 @@ private class IncomingConnectionsTracker(nodeParams: NodeParams, switchboard: Ac
           }
         }
       case ForgetIncomingConnection(remoteNodeId) => tracking(incomingConnections - remoteNodeId)
-      case IncomingConnectionsCount(replyTo) =>
+      case CountIncomingConnections(replyTo) =>
         replyTo ! incomingConnections.size
         Behaviors.same
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -36,7 +36,7 @@ object IncomingConnectionsTracker {
   sealed trait Command
 
   case class TrackIncomingConnection(remoteNodeId: PublicKey) extends Command
-  private case class ForgetIncomingConnection(remoteNodeId: PublicKey) extends Command
+  private[io] case class ForgetIncomingConnection(remoteNodeId: PublicKey) extends Command
   private[io] case class CountIncomingConnections(replyTo: ActorRef[Int]) extends Command
   // @formatter:on
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -16,7 +16,7 @@ import fr.acinq.eclair.io.Peer.Disconnect
  * When a new incoming connection request is received, the Switchboard should send an
  * [[IncomingConnectionsTracker.TrackIncomingConnection]] message.
  *
- * When the number of tracked peers exceeds `eclair.peer-connection.max-without-channels`, send [[Peer.Disconnect]] to
+ * When the number of tracked peers exceeds `eclair.peer-connection.max-no-channels`, send [[Peer.Disconnect]] to
  * the tracked peer with the oldest incoming connection.
  *
  * When a tracked peer disconnects or adds a channel, we will stop tracking that peer.
@@ -54,7 +54,7 @@ private class IncomingConnectionsTracker(nodeParams: NodeParams, switchboard: Ac
         if (nodeParams.syncWhitelist.contains(remoteNodeId)) {
           Behaviors.same
         } else {
-          if (incomingConnections.size >= nodeParams.peerConnectionConf.maxWithoutChannels) {
+          if (incomingConnections.size >= nodeParams.peerConnectionConf.maxNoChannels) {
             Metrics.IncomingConnectionsDisconnected.withoutTags().increment()
             val oldest = incomingConnections.minBy(_._2)._1
             switchboard ! Disconnect(oldest)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -48,7 +48,7 @@ private class IncomingConnectionsTracker(nodeParams: NodeParams, switchboard: Ac
   import IncomingConnectionsTracker._
 
   private def tracking(incomingConnections: Map[PublicKey, TimestampMillis]): Behavior[Command] = {
-    Metrics.IncomingConnectionsWithoutChannels.withoutTags().update(incomingConnections.size)
+    Metrics.IncomingConnectionsNoChannels.withoutTags().update(incomingConnections.size)
     Behaviors.receiveMessage {
       case TrackIncomingConnection(remoteNodeId) =>
         if (nodeParams.syncWhitelist.contains(remoteNodeId)) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -6,7 +6,7 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorRef, Behavior}
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.NodeParams
-import fr.acinq.eclair.channel.ChannelOpened
+import fr.acinq.eclair.channel.ChannelCreated
 import fr.acinq.eclair.io.Peer.Disconnect
 
 /**
@@ -36,7 +36,7 @@ object IncomingConnectionsTracker {
   def apply(nodeParams: NodeParams, switchboard: ActorRef[Disconnect]): Behavior[Command] = {
     Behaviors.setup { context =>
       context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[PeerDisconnected](c => ForgetIncomingConnection(c.nodeId)))
-      context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelOpened](c => ForgetIncomingConnection(c.remoteNodeId)))
+      context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelCreated](c => ForgetIncomingConnection(c.remoteNodeId)))
       new IncomingConnectionsTracker(nodeParams, switchboard).tracking(Map())
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -30,7 +30,8 @@ object IncomingConnectionsTracker {
   sealed trait Command
 
   case class TrackIncomingConnection(remoteNodeId: PublicKey) extends Command
-  private[io] case class ForgetIncomingConnection(remoteNodeId: PublicKey) extends Command
+  private case class ForgetIncomingConnection(remoteNodeId: PublicKey) extends Command
+  private[io] case class InboundConnectionsCount(replyTo: ActorRef[Int]) extends Command
   // @formatter:on
 
   def apply(nodeParams: NodeParams, switchboard: ActorRef[Disconnect]): Behavior[Command] = {
@@ -61,5 +62,8 @@ private class IncomingConnectionsTracker(nodeParams: NodeParams, switchboard: Ac
           }
         }
       case ForgetIncomingConnection(remoteNodeId) => tracking(inboundConnections - remoteNodeId)
+      case InboundConnectionsCount(replyTo) =>
+        replyTo ! inboundConnections.size
+        Behaviors.same
     }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -30,7 +30,7 @@ object IncomingConnectionsTracker {
   sealed trait Command
 
   case class TrackIncomingConnection(remoteNodeId: PublicKey) extends Command
-  private case class ForgetIncomingConnection(remoteNodeId: PublicKey) extends Command
+  private[io] case class ForgetIncomingConnection(remoteNodeId: PublicKey) extends Command
   // @formatter:on
 
   def apply(nodeParams: NodeParams, switchboard: ActorRef[Disconnect]): Behavior[Command] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -25,6 +25,10 @@ import fr.acinq.eclair.io.Peer.Disconnect
  * Likewise, peers with channels will disconnect and terminate when their last channel closes.
  *
  * Note: Peers on the sync whitelist are not tracked.
+
+ * This actor enables a DoS attack that can block new incoming liquidity from non-whitelisted nodes.
+ * An attacker can trivially disconnect other incoming connections before they can open channels by repeatedly opening
+ * new connections using random node IDs.
 */
 object IncomingConnectionsTracker {
   // @formatter:off

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -9,7 +9,7 @@ import fr.acinq.eclair.NodeParams
 import fr.acinq.eclair.channel.ChannelOpened
 import fr.acinq.eclair.io.IncomingConnectionsTracker.Command
 import fr.acinq.eclair.io.Monitoring.Metrics
-import fr.acinq.eclair.io.Peer.Disconnect
+import fr.acinq.eclair.io.Peer.{Disconnect, DisconnectResponse}
 
 /**
  * A singleton actor that limits the total number of incoming connections from peers that do not have channels with us.
@@ -63,7 +63,7 @@ private class IncomingConnectionsTracker(nodeParams: NodeParams, switchboard: Ac
             Metrics.IncomingConnectionsDisconnected.withoutTags().increment()
             val oldest = incomingConnections.minBy(_._2)._1
             context.log.warn(s"disconnecting peer=$oldest, too many incoming connections from peers without channels.")
-            switchboard ! Disconnect(oldest)
+            switchboard ! Disconnect(oldest, Some(context.system.ignoreRef[DisconnectResponse]))
             tracking(incomingConnections + (remoteNodeId -> System.currentTimeMillis()) - oldest)
           }
           else {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
@@ -33,6 +33,9 @@ object Monitoring {
     val OnionMessagesThrottled = Kamon.counter("onionmessages.throttled")
 
     val OpenChannelRequestsPending = Kamon.gauge("openchannelrequests.pending")
+
+    val IncomingConnectionsWithoutChannels = Kamon.gauge("incomingconnections.withoutchannels")
+    val IncomingConnectionsDisconnected = Kamon.counter("incomingconnections.disconnected")
   }
 
   object Tags {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
@@ -34,7 +34,7 @@ object Monitoring {
 
     val OpenChannelRequestsPending = Kamon.gauge("openchannelrequests.pending")
 
-    val IncomingConnectionsWithoutChannels = Kamon.gauge("incomingconnections.withoutchannels")
+    val IncomingConnectionsNoChannels = Kamon.gauge("incomingconnections.nochannels")
     val IncomingConnectionsDisconnected = Kamon.counter("incomingconnections.disconnected")
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -90,6 +90,17 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnchainP
         stay() using d.copy(channels = channels1)
       }
 
+    case Event(ConnectionDown(_), d: DisconnectedData) =>
+      Logs.withMdc(diagLog)(Logs.mdc(category_opt = Some(Logs.LogCategory.CONNECTION))) {
+        log.debug("connection lost while negotiating connection")
+      }
+      if (d.channels.isEmpty) {
+        // we have no existing channels, we can forget about this peer
+        stopPeer()
+      } else {
+        stay()
+      }
+
     // This event is usually handled while we're connected, but if our peer disconnects right when we're emitting this,
     // we still want to record the channelId mapping.
     case Event(ChannelIdAssigned(channel, _, temporaryChannelId, channelId), d: DisconnectedData) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -226,9 +226,10 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnchainP
         // we won't clean it up, but we won't remember the temporary id on channel termination
         stay() using d.copy(channels = d.channels + (FinalChannelId(channelId) -> channel))
 
-      case Event(Disconnect(nodeId), d: ConnectedData) if nodeId == remoteNodeId =>
+      case Event(Disconnect(nodeId, replyTo_opt), d: ConnectedData) if nodeId == remoteNodeId =>
         log.debug("disconnecting")
-        sender() ! "disconnecting"
+        val replyTo = replyTo_opt.getOrElse(sender().toTyped)
+        replyTo ! Disconnecting(nodeId)
         d.peerConnection ! PeerConnection.Kill(KillReason.UserRequest)
         stay()
 
@@ -301,8 +302,9 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnchainP
       sender() ! Status.Failure(new RuntimeException("not connected"))
       stay()
 
-    case Event(_: Peer.Disconnect, _) =>
-      sender() ! Status.Failure(new RuntimeException("not connected"))
+    case Event(Disconnect(nodeId, replyTo_opt), _) =>
+      val replyTo = replyTo_opt.getOrElse(sender().toTyped)
+      replyTo ! NotConnected(nodeId)
       stay()
 
     case Event(r: GetPeerInfo, d) =>
@@ -470,7 +472,12 @@ object Peer {
     def apply(uri: NodeURI, replyTo: ActorRef, isPersistent: Boolean): Connect = new Connect(uri.nodeId, Some(uri.address), replyTo, isPersistent)
   }
 
-  case class Disconnect(nodeId: PublicKey) extends PossiblyHarmful
+  case class Disconnect(nodeId: PublicKey, replyTo_opt: Option[typed.ActorRef[DisconnectResponse]] = None) extends PossiblyHarmful
+  sealed trait DisconnectResponse {
+    def nodeId: PublicKey
+  }
+  case class Disconnecting(nodeId: PublicKey) extends DisconnectResponse { override def toString: String = s"peer $nodeId disconnecting" }
+  case class NotConnected(nodeId: PublicKey) extends DisconnectResponse { override def toString: String = s"peer $nodeId not connected" }
 
   case class OpenChannel(remoteNodeId: PublicKey,
                          fundingAmount: Satoshi,
@@ -499,7 +506,7 @@ object Peer {
     def nodeId: PublicKey
   }
   case class PeerInfo(peer: ActorRef, nodeId: PublicKey, state: State, address: Option[NodeAddress], channels: Set[ActorRef]) extends PeerInfoResponse
-  case class PeerNotFound(nodeId: PublicKey) extends PeerInfoResponse { override def toString: String = s"peer $nodeId not found" }
+  case class PeerNotFound(nodeId: PublicKey) extends PeerInfoResponse with DisconnectResponse { override def toString: String = s"peer $nodeId not found" }
 
   case class PeerRoutingMessage(peerConnection: ActorRef, remoteNodeId: PublicKey, message: RoutingMessage) extends RemoteTypes
 
@@ -523,5 +530,4 @@ object Peer {
   case class RelayOnionMessage(messageId: ByteVector32, msg: OnionMessage, replyTo_opt: Option[typed.ActorRef[Status]])
 
   case class RelayUnknownMessage(unknownMessage: UnknownMessage)
-  // @formatter:on
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -541,4 +541,5 @@ object Peer {
   case class RelayOnionMessage(messageId: ByteVector32, msg: OnionMessage, replyTo_opt: Option[typed.ActorRef[Status]])
 
   case class RelayUnknownMessage(unknownMessage: UnknownMessage)
+  // @formatter:on
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -464,6 +464,9 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
     case StopEvent(_, CONNECTED, d: ConnectedData) =>
       Metrics.PeerConnectionsConnected.withoutTags().decrement()
       d.peer ! Peer.ConnectionDown(self)
+    case StopEvent(_, INITIALIZING, d: InitializingData) =>
+      log.debug(s"terminated while initializing.")
+      d.peer ! Peer.ConnectionDown(self)
   }
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -543,7 +543,7 @@ object PeerConnection {
                   killIdleDelay: FiniteDuration,
                   maxOnionMessagesPerSecond: Int,
                   sendRemoteAddressInit: Boolean,
-                  maxWithoutChannels: Int)
+                  maxNoChannels: Int)
 
   // @formatter:off
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -88,7 +88,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
       cancelTimer(AUTH_TIMER)
       log.info(s"connection authenticated (direction=${if (d.pendingAuth.outgoing) "outgoing" else "incoming"})")
       Metrics.PeerConnectionsConnecting.withTag(Tags.ConnectionState, Tags.ConnectionStates.Authenticated).increment()
-      switchboard ! Authenticated(self, remoteNodeId)
+      switchboard ! Authenticated(self, remoteNodeId, d.pendingAuth.outgoing)
       goto(BEFORE_INIT) using BeforeInitData(remoteNodeId, d.pendingAuth, d.transport, d.isPersistent)
 
     case Event(AuthTimeout, d: AuthenticatingData) =>
@@ -568,7 +568,7 @@ object PeerConnection {
   case class PendingAuth(connection: ActorRef, remoteNodeId_opt: Option[PublicKey], address: NodeAddress, origin_opt: Option[ActorRef], transport_opt: Option[ActorRef] = None, isPersistent: Boolean) {
     def outgoing: Boolean = remoteNodeId_opt.isDefined // if this is an outgoing connection, we know the node id in advance
   }
-  case class Authenticated(peerConnection: ActorRef, remoteNodeId: PublicKey) extends RemoteTypes
+  case class Authenticated(peerConnection: ActorRef, remoteNodeId: PublicKey, outgoing: Boolean) extends RemoteTypes
   case class InitializeConnection(peer: ActorRef, chainHash: ByteVector32, features: Features[InitFeature], doSync: Boolean) extends RemoteTypes
   case class ConnectionReady(peerConnection: ActorRef, remoteNodeId: PublicKey, address: NodeAddress, outgoing: Boolean, localInit: protocol.Init, remoteInit: protocol.Init) extends RemoteTypes
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -465,7 +465,7 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
       Metrics.PeerConnectionsConnected.withoutTags().decrement()
       d.peer ! Peer.ConnectionDown(self)
     case StopEvent(_, INITIALIZING, d: InitializingData) =>
-      log.debug(s"terminated while initializing.")
+      log.debug("terminated while initializing.")
       d.peer ! Peer.ConnectionDown(self)
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -605,7 +605,6 @@ object PeerConnection {
     case object NoRemainingChannel extends KillReason
     case object AllChannelsFail extends KillReason
     case object ConnectionReplaced extends KillReason
-    case object TooManyIncoming extends KillReason
   }
   // @formatter:on
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -542,7 +542,8 @@ object PeerConnection {
                   maxRebroadcastDelay: FiniteDuration,
                   killIdleDelay: FiniteDuration,
                   maxOnionMessagesPerSecond: Int,
-                  sendRemoteAddressInit: Boolean)
+                  sendRemoteAddressInit: Boolean,
+                  maxWithoutChannels: Int)
 
   // @formatter:off
 
@@ -604,6 +605,7 @@ object PeerConnection {
     case object NoRemainingChannel extends KillReason
     case object AllChannelsFail extends KillReason
     case object ConnectionReplaced extends KillReason
+    case object TooManyIncoming extends KillReason
   }
   // @formatter:on
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -100,7 +100,7 @@ class Switchboard(nodeParams: NodeParams, peerFactory: Switchboard.PeerFactory) 
       val features = nodeParams.initFeaturesFor(authenticated.remoteNodeId)
       val hasChannels = peersWithChannels.contains(authenticated.remoteNodeId)
       // if the peer is whitelisted, we sync with them, otherwise we only sync with peers with whom we have at least one channel
-      val doSync = nodeParams.syncWhitelist.contains(authenticated.remoteNodeId) || (nodeParams.syncWhitelist.isEmpty && peersWithChannels.contains(authenticated.remoteNodeId))
+      val doSync = nodeParams.syncWhitelist.contains(authenticated.remoteNodeId) || (nodeParams.syncWhitelist.isEmpty && hasChannels)
       authenticated.peerConnection ! PeerConnection.InitializeConnection(peer, nodeParams.chainHash, features, doSync)
       if (!hasChannels) {
         incomingConnectionsTracker ! TrackIncomingConnection(authenticated.remoteNodeId)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.io
 
 import akka.actor.typed.scaladsl.Behaviors
-import akka.actor.typed.scaladsl.adapter.{ClassicActorContextOps, ClassicActorRefOps}
+import akka.actor.typed.scaladsl.adapter.{ClassicActorContextOps, ClassicActorRefOps, TypedActorRefOps}
 import akka.actor.{Actor, ActorContext, ActorLogging, ActorRef, OneForOneStrategy, Props, Stash, Status, SupervisorStrategy, typed}
 import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
@@ -111,7 +111,7 @@ class Switchboard(nodeParams: NodeParams, peerFactory: Switchboard.PeerFactory) 
 
     case LastChannelClosed(_, remoteNodeId) => context.become(normal(peersWithChannels - remoteNodeId))
 
-    case GetPeers => sender() ! context.children.filterNot(_.path.name.startsWith("incoming-connections-tracker"))
+    case GetPeers => sender() ! context.children.filterNot(_ == incomingConnectionsTracker.toClassic)
 
     case GetPeerInfo(replyTo, remoteNodeId) =>
       getPeer(remoteNodeId) match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -102,7 +102,7 @@ class Switchboard(nodeParams: NodeParams, peerFactory: Switchboard.PeerFactory) 
       // if the peer is whitelisted, we sync with them, otherwise we only sync with peers with whom we have at least one channel
       val doSync = nodeParams.syncWhitelist.contains(authenticated.remoteNodeId) || (nodeParams.syncWhitelist.isEmpty && hasChannels)
       authenticated.peerConnection ! PeerConnection.InitializeConnection(peer, nodeParams.chainHash, features, doSync)
-      if (!hasChannels) {
+      if (!hasChannels && !authenticated.outgoing) {
         incomingConnectionsTracker ! TrackIncomingConnection(authenticated.remoteNodeId)
       }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Switchboard.scala
@@ -141,6 +141,7 @@ class Switchboard(nodeParams: NodeParams, peerFactory: Switchboard.PeerFactory) 
     getPeer(remoteNodeId) match {
       case Some(peer) => peer
       case None =>
+        // do not count the incoming-connections-tracker child actor that is not a peer
         log.debug(s"creating new peer (current={})", context.children.size - 1)
         val peer = createPeer(remoteNodeId)
         peer ! Peer.Init(offlineChannels)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -111,7 +111,7 @@ object EclairInternalsSerializer {
       ("killIdleDelay" | finiteDurationCodec) ::
       ("maxOnionMessagesPerSecond" | int32) ::
       ("sendRemoteAddressInit" | bool(8)) ::
-      ("maxWithoutChannels" | int32)).as[PeerConnection.Conf]
+      ("maxNoChannels" | int32)).as[PeerConnection.Conf]
 
   val peerConnectionDoSyncCodec: Codec[PeerConnection.DoSync] = bool(8).as[PeerConnection.DoSync]
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -177,7 +177,7 @@ object EclairInternalsSerializer {
     .typecase(1, (routerConfCodec :: peerConnectionConfCodec).as[RouterPeerConf])
     .typecase(5, readAckCodec)
     .typecase(7, connectionRequestCodec(system))
-    .typecase(10, (actorRefCodec(system) :: publicKey).as[PeerConnection.Authenticated])
+    .typecase(10, (actorRefCodec(system) :: publicKey :: bool).as[PeerConnection.Authenticated])
     .typecase(11, initializeConnectionCodec(system))
     .typecase(12, connectionReadyCodec(system))
     .typecase(13, provide(PeerConnection.ConnectionResult.NoAddressFound))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -110,7 +110,8 @@ object EclairInternalsSerializer {
       ("maxRebroadcastDelay" | finiteDurationCodec) ::
       ("killIdleDelay" | finiteDurationCodec) ::
       ("maxOnionMessagesPerSecond" | int32) ::
-      ("sendRemoteAddressInit" | bool(8))).as[PeerConnection.Conf]
+      ("sendRemoteAddressInit" | bool(8)) ::
+      ("maxWithoutChannels" | int32)).as[PeerConnection.Conf]
 
   val peerConnectionDoSyncCodec: Codec[PeerConnection.DoSync] = bool(8).as[PeerConnection.DoSync]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -30,7 +30,7 @@ import fr.acinq.eclair.blockchain.fee.{FeeratePerByte, FeeratePerKw}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.io.Peer
-import fr.acinq.eclair.io.Peer.OpenChannel
+import fr.acinq.eclair.io.Peer.{Disconnect, Disconnecting, OpenChannel}
 import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceiveStandardPayment
 import fr.acinq.eclair.payment.receive.PaymentHandler
 import fr.acinq.eclair.payment.relay.Relayer.{GetOutgoingChannels, RelayFees}
@@ -697,4 +697,15 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     relayer.expectMsg(GetOutgoingChannels())
   }
 
+  test("disconnect") { f =>
+    import f._
+
+    val eclair = new EclairImpl(kit)
+
+    eclair.disconnect(randomKey().publicKey).pipeTo(sender.ref)
+    val disconnect = switchboard.expectMsgType[Disconnect]
+    val replyTo = disconnect.replyTo_opt.getOrElse(sender.ref.toTyped)
+    replyTo ! Disconnecting(disconnect.nodeId)
+    sender.expectMsg(Disconnecting(disconnect.nodeId))
+  }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -30,7 +30,7 @@ import fr.acinq.eclair.blockchain.fee.{FeeratePerByte, FeeratePerKw}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db._
 import fr.acinq.eclair.io.Peer
-import fr.acinq.eclair.io.Peer.{Disconnect, Disconnecting, OpenChannel}
+import fr.acinq.eclair.io.Peer.OpenChannel
 import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceiveStandardPayment
 import fr.acinq.eclair.payment.receive.PaymentHandler
 import fr.acinq.eclair.payment.relay.Relayer.{GetOutgoingChannels, RelayFees}
@@ -695,17 +695,5 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     relayer.expectMsg(GetOutgoingChannels(enabledOnly = false))
     eclair.usableBalances().pipeTo(sender.ref)
     relayer.expectMsg(GetOutgoingChannels())
-  }
-
-  test("disconnect") { f =>
-    import f._
-
-    val eclair = new EclairImpl(kit)
-
-    eclair.disconnect(randomKey().publicKey).pipeTo(sender.ref)
-    val disconnect = switchboard.expectMsgType[Disconnect]
-    val replyTo = disconnect.replyTo_opt.getOrElse(sender.ref.toTyped)
-    replyTo ! Disconnecting(disconnect.nodeId)
-    sender.expectMsg(Disconnecting(disconnect.nodeId))
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -169,7 +169,7 @@ object TestConstants {
         killIdleDelay = 1 seconds,
         maxOnionMessagesPerSecond = 10,
         sendRemoteAddressInit = true,
-        maxWithoutChannels = 250,
+        maxNoChannels = 250,
       ),
       routerConf = RouterConf(
         watchSpentWindow = 1 second,
@@ -324,7 +324,7 @@ object TestConstants {
         killIdleDelay = 10 seconds,
         maxOnionMessagesPerSecond = 10,
         sendRemoteAddressInit = true,
-        maxWithoutChannels = 250,
+        maxNoChannels = 250,
       ),
       routerConf = RouterConf(
         watchSpentWindow = 1 second,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -169,6 +169,7 @@ object TestConstants {
         killIdleDelay = 1 seconds,
         maxOnionMessagesPerSecond = 10,
         sendRemoteAddressInit = true,
+        maxWithoutChannels = 250,
       ),
       routerConf = RouterConf(
         watchSpentWindow = 1 second,
@@ -323,6 +324,7 @@ object TestConstants {
         killIdleDelay = 10 seconds,
         maxOnionMessagesPerSecond = 10,
         sendRemoteAddressInit = true,
+        maxWithoutChannels = 250,
       ),
       routerConf = RouterConf(
         watchSpentWindow = 1 second,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -2605,7 +2605,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     bob2alice.expectMsgType[Warning]
     // we should fail the connection as per the BOLTs
     bobPeer.fishForMessage(3 seconds) {
-      case Peer.Disconnect(nodeId) if nodeId == bob.stateData.asInstanceOf[DATA_NORMAL].commitments.params.remoteParams.nodeId => true
+      case Peer.Disconnect(nodeId, _) if nodeId == bob.stateData.asInstanceOf[DATA_NORMAL].commitments.params.remoteParams.nodeId => true
       case _ => false
     }
   }
@@ -2616,7 +2616,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     bob2alice.expectMsgType[Warning]
     // we should fail the connection as per the BOLTs
     bobPeer.fishForMessage(3 seconds) {
-      case Peer.Disconnect(nodeId) if nodeId == bob.stateData.asInstanceOf[DATA_NORMAL].commitments.params.remoteParams.nodeId => true
+      case Peer.Disconnect(nodeId, _) if nodeId == bob.stateData.asInstanceOf[DATA_NORMAL].commitments.params.remoteParams.nodeId => true
       case _ => false
     }
   }
@@ -2636,7 +2636,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     bob ! Shutdown(ByteVector32.Zeroes, hex"00112233445566778899")
     // we should fail the connection as per the BOLTs
     bobPeer.fishForMessage(3 seconds) {
-      case Peer.Disconnect(nodeId) if nodeId == bob.stateData.asInstanceOf[DATA_NORMAL].commitments.params.remoteParams.nodeId => true
+      case Peer.Disconnect(nodeId, _) if nodeId == bob.stateData.asInstanceOf[DATA_NORMAL].commitments.params.remoteParams.nodeId => true
       case _ => false
     }
   }
@@ -2647,7 +2647,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
 
     // we should fail the connection as per the BOLTs
     bobPeer.fishForMessage(3 seconds) {
-      case Peer.Disconnect(nodeId) if nodeId == bob.stateData.asInstanceOf[DATA_NORMAL].commitments.params.remoteParams.nodeId => true
+      case Peer.Disconnect(nodeId, _) if nodeId == bob.stateData.asInstanceOf[DATA_NORMAL].commitments.params.remoteParams.nodeId => true
       case _ => false
     }
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
@@ -513,7 +513,7 @@ class StandardChannelIntegrationSpec extends ChannelIntegrationSpec {
 
     // simulate a disconnection
     sender.send(funder.switchboard, Peer.Disconnect(fundee.nodeParams.nodeId))
-    assert(sender.expectMsgType[String] == "disconnecting")
+    sender.expectMsgType[Peer.Disconnecting]
 
     awaitCond({
       fundee.register ! Register.Forward(sender.ref.toTyped[Any], channelId, CMD_GET_CHANNEL_STATE(ActorRef.noSender))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
@@ -16,7 +16,6 @@
 
 package fr.acinq.eclair.io
 
-import akka.actor.Status
 import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
 import akka.actor.typed.ActorRef
 import akka.actor.typed.eventstream.EventStream
@@ -111,14 +110,6 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
     // Track a new node connection and disconnect the oldest node connection.
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
     assert(switchboard.expectMessageType[Disconnect].nodeId === connection2)
-  }
-
-  test("terminate if an unhandled message received from classic actor") { f =>
-    import f._
-    // confirm behavior after receiving an untyped reply from switchboard when Disconnect message cannot be sent to a
-    // non-existent peer.
-    tracker.toClassic ! Status.Failure(new RuntimeException(s"peer $connection2 not found"))
-    monitorProbe.expectTerminated(tracker, 100 millis)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
@@ -68,7 +68,7 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
     val probe = TestProbe[Int]()
     system.eventStream ! EventStream.Publish(PeerDisconnected(system.deadLetters.toClassic, connection1))
     eventually {
-      tracker ! IncomingConnectionsTracker.InboundConnectionsCount(probe.ref)
+      tracker ! IncomingConnectionsTracker.IncomingConnectionsCount(probe.ref)
       probe.expectMessage(1)
     }
 
@@ -92,7 +92,7 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
     val probe = TestProbe[Int]()
     system.eventStream ! EventStream.Publish(ChannelCreated(system.deadLetters.toClassic, system.deadLetters.toClassic, connection1, isInitiator = true, randomBytes32(), FeeratePerKw(0 sat), None))
     eventually {
-      tracker ! IncomingConnectionsTracker.InboundConnectionsCount(probe.ref)
+      tracker ! IncomingConnectionsTracker.IncomingConnectionsCount(probe.ref)
       probe.expectMessage(1)
     }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
@@ -16,14 +16,17 @@
 
 package fr.acinq.eclair.io
 
+import akka.actor.Status
 import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
 import akka.actor.typed.ActorRef
 import akka.actor.typed.eventstream.EventStream
+import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
 import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.scalacompat.Crypto
 import fr.acinq.eclair.TestConstants.Alice.nodeParams
 import fr.acinq.eclair.channel.ChannelOpened
+import fr.acinq.eclair.io.IncomingConnectionsTracker.{ForgetIncomingConnection, TrackIncomingConnection}
 import fr.acinq.eclair.io.Peer.Disconnect
 import fr.acinq.eclair.{randomBytes32, randomKey}
 import org.scalatest.Outcome
@@ -38,11 +41,12 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
   override def withFixture(test: OneArgTest): Outcome = {
     val nodeParams1 = nodeParams.copy(peerConnectionConf = nodeParams.peerConnectionConf.copy(maxNoChannels = 2))
     val switchboard = TestProbe[Disconnect]()
-    val tracker = testKit.spawn(IncomingConnectionsTracker(nodeParams1, switchboard.ref))
-    withFixture(test.toNoArgTest(FixtureParam(tracker, switchboard)))
+    val monitorProbe = testKit.createTestProbe[IncomingConnectionsTracker.Command]()
+    val tracker = testKit.spawn(Behaviors.monitor(monitorProbe.ref, IncomingConnectionsTracker(nodeParams1, switchboard.ref)))
+    withFixture(test.toNoArgTest(FixtureParam(tracker, switchboard, monitorProbe)))
   }
 
-  case class FixtureParam(tracker: ActorRef[IncomingConnectionsTracker.Command], switchboard: TestProbe[Disconnect])
+  case class FixtureParam(tracker: ActorRef[IncomingConnectionsTracker.Command], switchboard: TestProbe[Disconnect], monitorProbe: TestProbe[IncomingConnectionsTracker.Command])
 
   test("accept new node connections, after limit is reached kill oldest node connection first") { f =>
     import f._
@@ -50,9 +54,9 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection1)
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection2)
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
-    switchboard.expectMessage(Disconnect(connection1))
+    assert(switchboard.expectMessageType[Disconnect].nodeId === connection1)
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
-    switchboard.expectMessage(Disconnect(connection2))
+    assert(switchboard.expectMessageType[Disconnect].nodeId === connection2)
   }
 
   test("stop tracking a node that disconnects and free space for a new node connection") { f =>
@@ -61,10 +65,13 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
     // Track nodes without channels.
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection1)
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection2)
+    monitorProbe.expectMessageType[TrackIncomingConnection]
+    monitorProbe.expectMessageType[TrackIncomingConnection]
 
     // Untrack a node when it disconnects.
     val probe = TestProbe[Int]()
     system.eventStream ! EventStream.Publish(PeerDisconnected(system.deadLetters.toClassic, connection1))
+    monitorProbe.expectMessageType[ForgetIncomingConnection]
     eventually {
       tracker ! IncomingConnectionsTracker.CountIncomingConnections(probe.ref)
       probe.expectMessage(1)
@@ -76,7 +83,7 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
 
     // Track a new node connection and disconnect the oldest node connection.
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
-    switchboard.expectMessage(Disconnect(connection2))
+    assert(switchboard.expectMessageType[Disconnect].nodeId === connection2)
   }
 
   test("stop tracking a node that creates a channel and free space for a new node connection") { f =>
@@ -85,10 +92,13 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
     // Track nodes without channels.
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection1)
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection2)
+    monitorProbe.expectMessageType[TrackIncomingConnection]
+    monitorProbe.expectMessageType[TrackIncomingConnection]
 
     // Untrack a node when a channel with it is confirmed on-chain.
     val probe = TestProbe[Int]()
     system.eventStream ! EventStream.Publish(ChannelOpened(system.deadLetters.toClassic, connection1, randomBytes32()))
+    monitorProbe.expectMessageType[ForgetIncomingConnection]
     eventually {
       tracker ! IncomingConnectionsTracker.CountIncomingConnections(probe.ref)
       probe.expectMessage(1)
@@ -100,7 +110,15 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
 
     // Track a new node connection and disconnect the oldest node connection.
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
-    switchboard.expectMessage(Disconnect(connection2))
+    assert(switchboard.expectMessageType[Disconnect].nodeId === connection2)
+  }
+
+  test("terminate if an unhandled message received from classic actor") { f =>
+    import f._
+    // confirm behavior after receiving an untyped reply from switchboard when Disconnect message cannot be sent to a
+    // non-existent peer.
+    tracker.toClassic ! Status.Failure(new RuntimeException(s"peer $connection2 not found"))
+    monitorProbe.expectTerminated(tracker, 100 millis)
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
@@ -38,7 +38,7 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
   val connection2: Crypto.PublicKey = randomKey().publicKey
 
   override def withFixture(test: OneArgTest): Outcome = {
-    val nodeParams1 = nodeParams.copy(peerConnectionConf = nodeParams.peerConnectionConf.copy(maxWithoutChannels = 2))
+    val nodeParams1 = nodeParams.copy(peerConnectionConf = nodeParams.peerConnectionConf.copy(maxNoChannels = 2))
     val switchboard = TestProbe[Disconnect]()
     val tracker = testKit.spawn(IncomingConnectionsTracker(nodeParams1, switchboard.ref))
     withFixture(test.toNoArgTest(FixtureParam(tracker, switchboard)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
@@ -21,10 +21,9 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
 import com.typesafe.config.ConfigFactory
-import fr.acinq.bitcoin.scalacompat.{Crypto, SatoshiLong}
+import fr.acinq.bitcoin.scalacompat.Crypto
 import fr.acinq.eclair.TestConstants.Alice.nodeParams
-import fr.acinq.eclair.blockchain.fee.FeeratePerKw
-import fr.acinq.eclair.channel.ChannelCreated
+import fr.acinq.eclair.channel.ChannelOpened
 import fr.acinq.eclair.io.Peer.Disconnect
 import fr.acinq.eclair.{randomBytes32, randomKey}
 import org.scalatest.Outcome
@@ -87,9 +86,9 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection1)
     tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection2)
 
-    // Untrack a node when it creates a channel.
+    // Untrack a node when a channel with it is confirmed on-chain.
     val probe = TestProbe[Int]()
-    system.eventStream ! EventStream.Publish(ChannelCreated(system.deadLetters.toClassic, system.deadLetters.toClassic, connection1, isInitiator = true, randomBytes32(), FeeratePerKw(0 sat), None))
+    system.eventStream ! EventStream.Publish(ChannelOpened(system.deadLetters.toClassic, connection1, randomBytes32()))
     eventually {
       tracker ! IncomingConnectionsTracker.CountIncomingConnections(probe.ref)
       probe.expectMessage(1)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.io
+
+import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
+import akka.actor.typed.ActorRef
+import akka.actor.typed.eventstream.EventStream
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
+import com.typesafe.config.ConfigFactory
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, Crypto}
+import fr.acinq.eclair.TestConstants.Alice.nodeParams
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
+import fr.acinq.eclair.channel.ChannelCreated
+import fr.acinq.eclair.io.IncomingConnectionsTracker.{ForgetIncomingConnection, TrackIncomingConnection}
+import fr.acinq.eclair.io.Peer.Disconnect
+import fr.acinq.eclair.{randomBytes32, randomKey}
+import org.scalatest.Outcome
+import org.scalatest.funsuite.FixtureAnyFunSuiteLike
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
+import fr.acinq.bitcoin.scalacompat.SatoshiLong
+
+import scala.concurrent.duration.DurationInt
+
+class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with FixtureAnyFunSuiteLike {
+  val connection1: Crypto.PublicKey = randomKey().publicKey
+  val connection2: Crypto.PublicKey = randomKey().publicKey
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val nodeParams1 = nodeParams.copy(peerConnectionConf = nodeParams.peerConnectionConf.copy(maxWithoutChannels = 2))
+    val switchboard = TestProbe[Disconnect]()
+
+    val commandProbe = testKit.createTestProbe[IncomingConnectionsTracker.Command]()
+    val tracker = testKit.spawn(Behaviors.monitor(commandProbe.ref, IncomingConnectionsTracker(nodeParams1, switchboard.ref)))
+    withFixture(test.toNoArgTest(FixtureParam(tracker, switchboard, commandProbe)))
+  }
+
+  case class FixtureParam(tracker: ActorRef[IncomingConnectionsTracker.Command], switchboard: TestProbe[Disconnect], commandProbe: TestProbe[IncomingConnectionsTracker.Command])
+
+  test("accept new node connections, after limit is reached kill oldest node connection first") { f =>
+    import f._
+
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection1)
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection2)
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
+    switchboard.expectMessage(Disconnect(connection1))
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
+    switchboard.expectMessage(Disconnect(connection2))
+  }
+
+  test("stop tracking a node that disconnects and free space for a new node connection") { f =>
+    import f._
+
+    // Track nodes without channels.
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection1)
+    commandProbe.expectMessage(TrackIncomingConnection(connection1))
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection2)
+    commandProbe.expectMessage(TrackIncomingConnection(connection2))
+
+    // Untrack a node when it disconnects.
+    system.eventStream ! EventStream.Publish(PeerDisconnected(system.deadLetters.toClassic, connection1))
+    commandProbe.expectMessage(ForgetIncomingConnection(connection1))
+
+    // Track a new node connection without disconnecting the oldest node connection.
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
+    switchboard.expectNoMessage(100 millis)
+
+    // Track a new node connection and disconnect the oldest node connection.
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
+    switchboard.expectMessage(Disconnect(connection2))
+  }
+
+  test("stop tracking a node that creates a channel and free space for a new node connection") { f =>
+    import f._
+
+    // Track nodes without channels.
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection1)
+    commandProbe.expectMessage(TrackIncomingConnection(connection1))
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(connection2)
+    commandProbe.expectMessage(TrackIncomingConnection(connection2))
+
+    // Untrack a node when it creates a channel.
+    system.eventStream ! EventStream.Publish(ChannelCreated(system.deadLetters.toClassic, system.deadLetters.toClassic, connection1, isInitiator = true, randomBytes32(), FeeratePerKw(0 sat), None))
+    commandProbe.expectMessage(ForgetIncomingConnection(connection1))
+
+    // Track a new node connection without disconnecting the oldest node connection.
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
+    switchboard.expectNoMessage(100 millis)
+
+    // Track a new node connection and disconnect the oldest node connection.
+    tracker ! IncomingConnectionsTracker.TrackIncomingConnection(randomKey().publicKey)
+    switchboard.expectMessage(Disconnect(connection2))
+  }
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
@@ -28,7 +28,6 @@ import fr.acinq.eclair.channel.ChannelCreated
 import fr.acinq.eclair.io.Peer.Disconnect
 import fr.acinq.eclair.{randomBytes32, randomKey}
 import org.scalatest.Outcome
-import org.scalatest.concurrent.PatienceConfiguration
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 
 import scala.concurrent.duration.DurationInt

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
@@ -68,7 +68,7 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
     val probe = TestProbe[Int]()
     system.eventStream ! EventStream.Publish(PeerDisconnected(system.deadLetters.toClassic, connection1))
     eventually {
-      tracker ! IncomingConnectionsTracker.IncomingConnectionsCount(probe.ref)
+      tracker ! IncomingConnectionsTracker.CountIncomingConnections(probe.ref)
       probe.expectMessage(1)
     }
 
@@ -92,7 +92,7 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
     val probe = TestProbe[Int]()
     system.eventStream ! EventStream.Publish(ChannelCreated(system.deadLetters.toClassic, system.deadLetters.toClassic, connection1, isInitiator = true, randomBytes32(), FeeratePerKw(0 sat), None))
     eventually {
-      tracker ! IncomingConnectionsTracker.IncomingConnectionsCount(probe.ref)
+      tracker ! IncomingConnectionsTracker.CountIncomingConnections(probe.ref)
       probe.expectMessage(1)
     }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -73,7 +73,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     val probe = TestProbe()
     probe.send(peerConnection, PeerConnection.PendingAuth(connection.ref, Some(remoteNodeId), address, origin_opt = None, transport_opt = Some(transport.ref), isPersistent = isPersistent))
     transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
-    switchboard.expectMsg(PeerConnection.Authenticated(peerConnection, remoteNodeId))
+    switchboard.expectMsg(PeerConnection.Authenticated(peerConnection, remoteNodeId, outgoing = true))
     probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref, aliceParams.chainHash, aliceParams.features.initFeatures(), doSync))
     transport.expectMsgType[TransportHandler.Listener]
     val localInit = transport.expectMsgType[protocol.Init]
@@ -101,7 +101,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     assert(!incomingConnection.outgoing)
     probe.send(peerConnection, incomingConnection)
     transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
-    switchboard.expectMsg(PeerConnection.Authenticated(peerConnection, remoteNodeId))
+    switchboard.expectMsg(PeerConnection.Authenticated(peerConnection, remoteNodeId, outgoing = true))
     probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref, nodeParams.chainHash, nodeParams.features.initFeatures(), doSync = false))
     transport.expectMsgType[TransportHandler.Listener]
     val localInit = transport.expectMsgType[protocol.Init]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -101,7 +101,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     assert(!incomingConnection.outgoing)
     probe.send(peerConnection, incomingConnection)
     transport.send(peerConnection, TransportHandler.HandshakeCompleted(remoteNodeId))
-    switchboard.expectMsg(PeerConnection.Authenticated(peerConnection, remoteNodeId, outgoing = true))
+    switchboard.expectMsg(PeerConnection.Authenticated(peerConnection, remoteNodeId, outgoing = false))
     probe.send(peerConnection, PeerConnection.InitializeConnection(peer.ref, nodeParams.chainHash, nodeParams.features.initFeatures(), doSync = false))
     transport.expectMsgType[TransportHandler.Listener]
     val localInit = transport.expectMsgType[protocol.Init]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -245,7 +245,7 @@ class PeerSpec extends FixtureSpec {
     assert(probe.expectMsgType[Peer.PeerInfo].state == Peer.CONNECTED)
 
     probe.send(peer, Peer.Disconnect(f.remoteNodeId))
-    probe.expectMsg("disconnecting")
+    probe.expectMsgType[Peer.Disconnecting]
   }
 
   test("handle disconnect in state DISCONNECTED") { f =>
@@ -260,7 +260,7 @@ class PeerSpec extends FixtureSpec {
     }
 
     probe.send(peer, Peer.Disconnect(f.remoteNodeId))
-    assert(probe.expectMsgType[Status.Failure].cause.getMessage == "not connected")
+    probe.expectMsgType[Peer.NotConnected]
   }
 
   test("handle new connection in state CONNECTED") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
@@ -144,7 +144,7 @@ class SwitchboardSpec extends TestKitBaseClass with AnyFunSuiteLike {
   }
 
   test("track incoming nodes that do not have a channel") {
-    val nodeParams = Alice.nodeParams.copy(peerConnectionConf = Alice.nodeParams.peerConnectionConf.copy(maxWithoutChannels = 2))
+    val nodeParams = Alice.nodeParams.copy(peerConnectionConf = Alice.nodeParams.peerConnectionConf.copy(maxNoChannels = 2))
     val (probe, peer, peerConnection, channel) = (TestProbe(), TestProbe(), TestProbe(), TestProbe())
     val hasChannelsNodeId1 = randomKey().publicKey
     val hasChannelsNodeId2 = randomKey().publicKey

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
@@ -184,7 +184,7 @@ class SwitchboardSpec extends TestKitBaseClass with AnyFunSuiteLike {
 
     // Disconnect the next oldest tracked peer when an incoming connection from a peer without channels connects.
     switchboard ! PeerConnection.Authenticated(peerConnection.ref, randomKey().publicKey, outgoing = false)
-    peer.fishForMessage()  {
+    peer.fishForMessage() {
       case d: Peer.Disconnect => d.nodeId == unknownNodeId2
       case _: Peer.Init => false
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
@@ -171,8 +171,10 @@ class SwitchboardSpec extends TestKitBaseClass with AnyFunSuiteLike {
 
     // Disconnect the oldest tracked peer when an incoming connection from a peer without channels connects.
     switchboard ! PeerConnection.Authenticated(peerConnection.ref, randomKey().publicKey, outgoing = false)
-    peer.expectMsgType[Peer.Init]
-    assert(peer.expectMsgType[Peer.Disconnect].nodeId == unknownNodeId1)
+    peer.fishForMessage() {
+      case d: Peer.Disconnect => d.nodeId == unknownNodeId1
+      case _: Peer.Init => false
+    }
 
     // Do not disconnect an old peer when a peer with channels connects.
     switchboard ! ChannelIdAssigned(channel.ref, hasChannelsNodeId2, randomBytes32(), randomBytes32())
@@ -182,8 +184,10 @@ class SwitchboardSpec extends TestKitBaseClass with AnyFunSuiteLike {
 
     // Disconnect the next oldest tracked peer when an incoming connection from a peer without channels connects.
     switchboard ! PeerConnection.Authenticated(peerConnection.ref, randomKey().publicKey, outgoing = false)
-    peer.expectMsgType[Peer.Init]
-    assert(peer.expectMsgType[Peer.Disconnect].nodeId == unknownNodeId2)
+    peer.fishForMessage()  {
+      case d: Peer.Disconnect => d.nodeId == unknownNodeId2
+      case _: Peer.Init => false
+    }
   }
 
 }


### PR DESCRIPTION
Limit the number of incoming connections from nodes we don't have channels with.

- when an incoming connection comes in, the `switchboard` checks if we have channels with that peer
- if we have channels with an incoming peer, do not  track it
- if an incoming peer is on the `sync-whitelist`, do not track it
- otherwise, track the connection 
- when we reach our configured limit of tracked peers without channels, disconnect the oldest tracked peer
- when a tracked peer disconnects or creates a channel, we will stop tracking that peer

We do not track peers we initiate outgoing channel connections to