### PR TITLE
Make `updateLocalFundingStatus` method return `Either`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -1597,7 +1597,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
           val d1 = d match {
             // NB: we discard remote's stashed channel_ready, they will send it back at reconnection
             case d: DATA_WAIT_FOR_FUNDING_CONFIRMED =>
-              val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, d.commitments.latest.commitInput.outPoint.index.toInt))
+              val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, commitments1.latest.commitInput.outPoint.index.toInt))
               val shortIds = createShortIds(d.channelId, realScidStatus)
               DATA_WAIT_FOR_CHANNEL_READY(commitments1, shortIds)
             case d: DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -1073,7 +1073,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
 
     case Event(w: WatchFundingConfirmedTriggered, d: DATA_CLOSING) =>
       acceptFundingTxConfirmed(w, d) match {
-        case Right(commitments1) =>
+        case Right((commitments1, _)) =>
           if (d.commitments.latest.fundingTxId == w.tx.txid) {
             // The best funding tx candidate has been confirmed, alternative commitments have been pruned
             stay() using d.copy(commitments = commitments1) storing()
@@ -1592,16 +1592,16 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
 
     case Event(w: WatchFundingConfirmedTriggered, d: PersistentChannelData) =>
       acceptFundingTxConfirmed(w, d) match {
-        case Right(commitments1) =>
+        case Right((commitments1, commitment)) =>
           log.info(s"funding txid=${w.tx.txid} has been confirmed")
           val d1 = d match {
             // NB: we discard remote's stashed channel_ready, they will send it back at reconnection
             case d: DATA_WAIT_FOR_FUNDING_CONFIRMED =>
-              val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, commitments1.latest.commitInput.outPoint.index.toInt))
+              val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, commitment.commitInput.outPoint.index.toInt))
               val shortIds = createShortIds(d.channelId, realScidStatus)
               DATA_WAIT_FOR_CHANNEL_READY(commitments1, shortIds)
             case d: DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED =>
-              val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, commitments1.latest.commitInput.outPoint.index.toInt))
+              val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, commitment.commitInput.outPoint.index.toInt))
               val shortIds = createShortIds(d.channelId, realScidStatus)
               DATA_WAIT_FOR_DUAL_FUNDING_READY(commitments1, shortIds)
             case d: DATA_WAIT_FOR_CHANNEL_READY => d.copy(commitments = commitments1)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -594,8 +594,8 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
 
     case Event(w: WatchFundingConfirmedTriggered, d: DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED) =>
       acceptFundingTxConfirmed(w, d) match {
-        case Right(commitments1) =>
-          val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, d.commitments.latest.commitInput.outPoint.index.toInt))
+        case Right((commitments1, commitment)) =>
+          val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, commitment.commitInput.outPoint.index.toInt))
           val shortIds = createShortIds(d.channelId, realScidStatus)
           val channelReady = createChannelReady(shortIds, d.commitments.params)
           val toSend = d.rbfStatus match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
@@ -381,24 +381,30 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
       stay() using d.copy(deferred = Some(remoteChannelReady)) // no need to store, they will re-send if we get disconnected
 
     case Event(w: WatchPublishedTriggered, d: DATA_WAIT_FOR_FUNDING_CONFIRMED) =>
-      log.info("funding txid={} was successfully published for zero-conf channelId={}", w.tx.txid, d.channelId)
       val fundingStatus = LocalFundingStatus.ZeroconfPublishedFundingTx(w.tx)
-      val commitments1 = d.commitments.updateLocalFundingStatus(w.tx.txid, fundingStatus)
-      // we still watch the funding tx for confirmation even if we can use the zero-conf channel right away
-      watchFundingConfirmed(w.tx.txid, Some(nodeParams.channelConf.minDepthBlocks))
-      val realScidStatus = RealScidStatus.Unknown
-      val shortIds = createShortIds(d.channelId, realScidStatus)
-      val channelReady = createChannelReady(shortIds, d.commitments.params)
-      d.deferred.foreach(self ! _)
-      goto(WAIT_FOR_CHANNEL_READY) using DATA_WAIT_FOR_CHANNEL_READY(commitments1, shortIds) storing() sending channelReady
+      d.commitments.updateLocalFundingStatus(w.tx.txid, fundingStatus) match {
+        case Right((commitments1, _)) =>
+          log.info("funding txid={} was successfully published for zero-conf channelId={}", w.tx.txid, d.channelId)
+          // we still watch the funding tx for confirmation even if we can use the zero-conf channel right away
+          watchFundingConfirmed(w.tx.txid, Some(nodeParams.channelConf.minDepthBlocks))
+          val realScidStatus = RealScidStatus.Unknown
+          val shortIds = createShortIds(d.channelId, realScidStatus)
+          val channelReady = createChannelReady(shortIds, d.commitments.params)
+          d.deferred.foreach(self ! _)
+          goto(WAIT_FOR_CHANNEL_READY) using DATA_WAIT_FOR_CHANNEL_READY(commitments1, shortIds) storing() sending channelReady
+        case Left(_) => stay()
+      }
 
     case Event(w: WatchFundingConfirmedTriggered, d: DATA_WAIT_FOR_FUNDING_CONFIRMED) =>
-      val commitments1 = acceptFundingTxConfirmed(w, d)
-      val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, d.commitments.latest.commitInput.outPoint.index.toInt))
-      val shortIds = createShortIds(d.channelId, realScidStatus)
-      val channelReady = createChannelReady(shortIds, d.commitments.params)
-      d.deferred.foreach(self ! _)
-      goto(WAIT_FOR_CHANNEL_READY) using DATA_WAIT_FOR_CHANNEL_READY(commitments1, shortIds) storing() sending channelReady
+      acceptFundingTxConfirmed(w, d) match {
+        case Right(commitments1) =>
+          val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, d.commitments.latest.commitInput.outPoint.index.toInt))
+          val shortIds = createShortIds(d.channelId, realScidStatus)
+          val channelReady = createChannelReady(shortIds, d.commitments.params)
+          d.deferred.foreach(self ! _)
+          goto(WAIT_FOR_CHANNEL_READY) using DATA_WAIT_FOR_CHANNEL_READY(commitments1, shortIds) storing() sending channelReady
+        case Left(_) => stay()
+      }
 
     case Event(remoteAnnSigs: AnnouncementSignatures, d: DATA_WAIT_FOR_FUNDING_CONFIRMED) if d.commitments.announceChannel =>
       delayEarlyAnnouncementSigs(remoteAnnSigs)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
@@ -397,7 +397,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
 
     case Event(w: WatchFundingConfirmedTriggered, d: DATA_WAIT_FOR_FUNDING_CONFIRMED) =>
       acceptFundingTxConfirmed(w, d) match {
-        case Right(commitments1) =>
+        case Right((commitments1, _)) =>
           val realScidStatus = RealScidStatus.Temporary(RealShortChannelId(w.blockHeight, w.txIndex, d.commitments.latest.commitInput.outPoint.index.toInt))
           val shortIds = createShortIds(d.channelId, realScidStatus)
           val channelReady = createChannelReady(shortIds, d.commitments.params)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
@@ -54,7 +54,7 @@ trait CommonFundingHandlers extends CommonHandlers {
     }
   }
 
-  def acceptFundingTxConfirmed(w: WatchFundingConfirmedTriggered, d: PersistentChannelData): Either[Commitments, Commitments] = {
+  def acceptFundingTxConfirmed(w: WatchFundingConfirmedTriggered, d: PersistentChannelData): Either[Commitments, (Commitments, Commitment)] = {
     log.info("funding txid={} was confirmed at blockHeight={} txIndex={}", w.tx.txid, w.blockHeight, w.txIndex)
     d.commitments.latest.localFundingStatus match {
       case _: SingleFundedUnconfirmedFundingTx =>
@@ -80,7 +80,7 @@ trait CommonFundingHandlers extends CommonHandlers {
           .filter(c => c.fundingTxId != commitment.fundingTxId)
           .map(_.localFundingStatus).collect { case fundingTx: DualFundedUnconfirmedFundingTx => fundingTx.sharedTx }
         rollbackDualFundingTxs(otherFundingTxs)
-        commitments1
+        (commitments1, commitment)
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
@@ -54,7 +54,7 @@ trait CommonFundingHandlers extends CommonHandlers {
     }
   }
 
-  def acceptFundingTxConfirmed(w: WatchFundingConfirmedTriggered, d: PersistentChannelData): Commitments = {
+  def acceptFundingTxConfirmed(w: WatchFundingConfirmedTriggered, d: PersistentChannelData): Either[Commitments, Commitments] = {
     log.info("funding txid={} was confirmed at blockHeight={} txIndex={}", w.tx.txid, w.blockHeight, w.txIndex)
     d.commitments.latest.localFundingStatus match {
       case _: SingleFundedUnconfirmedFundingTx =>
@@ -70,18 +70,18 @@ trait CommonFundingHandlers extends CommonHandlers {
     }
     val fundingStatus = ConfirmedFundingTx(w.tx)
     context.system.eventStream.publish(TransactionConfirmed(d.channelId, remoteNodeId, w.tx))
-    val commitments1 = d.commitments.updateLocalFundingStatus(w.tx.txid, fundingStatus)
-    require(commitments1.active.size == 1, "there must be exactly one commitment after an initial funding tx is confirmed")
-    // first of all, we watch the funding tx that is now confirmed
-    val commitment = commitments1.active.head
-    require(commitment.fundingTxId == w.tx.txid)
-    watchFundingSpent(commitment)
-    // in the dual-funding case we can forget all other transactions, they have been double spent by the tx that just confirmed
-    val otherFundingTxs = d.commitments.active // note how we use the unpruned original commitments
-      .filter(c => c.fundingTxId != commitment.fundingTxId)
-      .map(_.localFundingStatus).collect { case fundingTx: DualFundedUnconfirmedFundingTx => fundingTx.sharedTx }
-    rollbackDualFundingTxs(otherFundingTxs)
-    commitments1
+    d.commitments.updateLocalFundingStatus(w.tx.txid, fundingStatus).map {
+      case (commitments1, commitment) =>
+        require(commitments1.active.size == 1 && commitment.fundingTxId == w.tx.txid, "there must be exactly one commitment after an initial funding tx is confirmed")
+        // first of all, we watch the funding tx that is now confirmed
+        watchFundingSpent(commitment)
+        // in the dual-funding case we can forget all other transactions, they have been double spent by the tx that just confirmed
+        val otherFundingTxs = d.commitments.active // note how we use the unpruned original commitments
+          .filter(c => c.fundingTxId != commitment.fundingTxId)
+          .map(_.localFundingStatus).collect { case fundingTx: DualFundedUnconfirmedFundingTx => fundingTx.sharedTx }
+        rollbackDualFundingTxs(otherFundingTxs)
+        commitments1
+    }
   }
 
   def createShortIds(channelId: ByteVector32, realScidStatus: RealScidStatus): ShortIds = {


### PR DESCRIPTION
After calling this method, we perform actions at several places that only make sense if the correct behavior happened. Instead of assuming things went ok, we use proper typing and make the result explicit.

This is a follow-up to #2598.