### PR TITLE
Included doc folder in the assembly zip

### DIFF
--- a/eclair-front/modules/assembly.xml
+++ b/eclair-front/modules/assembly.xml
@@ -13,10 +13,11 @@
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>
-  <fileSets> <!-- Include readme and license -->
+  <fileSets> <!-- Include docs, readme and license -->
     <fileSet>
       <directory>../</directory>
       <includes>
+        <include>docs/**</include>
         <include>README.md</include>
         <include>LICENSE*</include>
       </includes>

--- a/eclair-node/modules/assembly.xml
+++ b/eclair-node/modules/assembly.xml
@@ -13,10 +13,11 @@
       <scope>runtime</scope>
     </dependencySet>
   </dependencySets>
-  <fileSets> <!-- Include readme and license -->
+  <fileSets> <!-- Include docs, readme and license -->
     <fileSet>
       <directory>../</directory>
       <includes>
+        <include>docs/**</include>
         <include>README.md</include>
         <include>LICENSE*</include>
       </includes>


### PR DESCRIPTION
## Description

Included doc folder in the assembly zip.  `**` wildcard indicates all the files in the current folder and all the files in the subfolders of the current folder.

Fixes  #1645 
