### PR TITLE
Fix handling of early `channel_ready`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -378,9 +378,9 @@ object Helpers {
     }
 
     /**
-     * When using dual funding, we wait for multiple confirmations even if we're the initiator because:
-     *  - our peer may also contribute to the funding transaction
-     *  - even if they don't, we may RBF the transaction and don't want to handle reorgs
+     * When using dual funding, we wait for multiple confirmations even if we're the initiator when our peer also
+     * contributes to the funding transaction.
+     * Even if they don't, in the non-zero conf case, we may RBF the transaction and don't want to handle reorgs.
      */
     def minDepthDualFunding(channelConf: ChannelConf, localFeatures: Features[InitFeature], isInitiator: Boolean, localAmount: Satoshi, remoteAmount: Satoshi): Option[Long] = {
       if (isInitiator && remoteAmount == 0.sat) {


### PR DESCRIPTION
In #2558 we wait for the funding tx to be published in the zero-conf case. This creates a race between our watcher's ack and peer's `channel_ready`.

Luckily, since #2598 we store the `minDepth` in `InteractiveTxParams` and therefore do not need to recompute it.