### PR TITLE
Fix opportunistic zero-conf

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -379,7 +379,7 @@ object Helpers {
 
     /**
      * When using dual funding, we wait for multiple confirmations even if we're the initiator because:
-     *  - our peer may also contribute to the funding transaction
+     *  - our peer may also contribute to the funding transaction, even if they don't contribute to the channel funding amount
      *  - even if they don't, we may RBF the transaction and don't want to handle reorgs
      */
     def minDepthDualFunding(channelConf: ChannelConf, localFeatures: Features[InitFeature], isInitiator: Boolean, localAmount: Satoshi, remoteAmount: Satoshi): Option[Long] = {


### PR DESCRIPTION
If we didn't plan on using zero-conf, but our peer sends us an early `channel_ready`, we can opportunistically switch to zero-conf. But we can only do that if we're sure that our peer cannot double-spend the funding transaction. We previously checked their contribution to the funding output, but that's not enough: they may add inputs to the funding transaction even if they don't contribute to the funding output.

We were also setting duplicate `WatchPublished` in case we were already using zero-conf, which is now fixed.

The second commit fixes an issue where we think we're doing opportunistic zero-conf, but the transaction is actually confirmed. Please have a look at the commit message for more details. I don't know if we should move that change to `updateLocalFundingStatus` (instead of doing it in a `WatchPublishedTriggered` handler) and make sure we always progress, and never go from a confirmed status to an unconfirmed one?

This PR replaces #2615 (it contains its fix and additional fixes).