### PR TITLE
Fix for Dockerfile smell DL3059

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ COPY eclair-node/pom.xml eclair-node/pom.xml
 COPY eclair-node/modules/assembly.xml eclair-node/modules/assembly.xml
 RUN mkdir -p eclair-core/src/main/scala && touch eclair-core/src/main/scala/empty.scala
 # Blank build. We only care about eclair-node, and we use install because eclair-node depends on eclair-core
-RUN mvn install -pl eclair-node -am
-RUN mvn clean
+RUN mvn install -pl eclair-node -am \
+    && mvn clean
 
 # Only then do we copy the sources
 COPY . .


### PR DESCRIPTION
Hi there!
The Dockerfile placed at "/Dockerfile" contains the best practice violation identified as [DL3059](https://github.com/hadolint/hadolint/wiki/DL3059) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3059 occurs when there are multiple consecutive RUN instructions
In this pull request, we propose a fix for that smell generated by our fixing tool. 
To fix this smell, specifically, the consecutive RUN instructions in which the smell is detected were merged.

This change is only aimed at fixing that specific smell. In the case the fix is not valid or useful, please briefly indicate the reason along with suggestions for possible improvements.

Thanks in advance.