### PR TITLE
Add padding to blinded payment routes

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
@@ -305,6 +305,8 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(invoice.blindedPaths(2).paymentInfo == PaymentInfo(0 msat, 0, CltvExpiryDelta(18), 0 msat, 25_000 msat, Features.empty))
     // Offer invoices shouldn't be stored in the DB until we receive a payment for it.
     assert(nodeParams.db.payments.getIncomingPayment(invoice.paymentHash).isEmpty)
+    // Check that all non-final encrypted payloads for blinded routes have the same length.
+    assert(invoice.blindedPaths.flatMap(_.route.encryptedPayloads.dropRight(1)).map(_.length).toSet.size == 1)
   }
 
   test("Invoice generation with route blinding should fail when router returns an error") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BlindedRouteCreationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BlindedRouteCreationSpec.scala
@@ -93,4 +93,18 @@ class BlindedRouteCreationSpec extends AnyFunSuite with ParallelTestExecution {
     }
   }
 
+  test("non-final payloads must have the same size") {
+    val (a, b, c, d, e, f) = (randomKey(), randomKey(), randomKey(), randomKey(), randomKey(), randomKey())
+    val (scid1, scid2, scid3, scid4, scid5) = (ShortChannelId(1), ShortChannelId(100), ShortChannelId(1000000), ShortChannelId(100000000), ShortChannelId(100000000000L))
+    val hops = Seq(
+      ChannelHop(scid1, a.publicKey, b.publicKey, HopRelayParams.FromAnnouncement(makeUpdateShort(scid1, a.publicKey, b.publicKey, 0 msat, 0, cltvDelta = CltvExpiryDelta(0)))),
+      ChannelHop(scid2, b.publicKey, c.publicKey, HopRelayParams.FromAnnouncement(makeUpdateShort(scid2, b.publicKey, c.publicKey, 20 msat, 20, cltvDelta = CltvExpiryDelta(20)))),
+      ChannelHop(scid3, c.publicKey, d.publicKey, HopRelayParams.FromAnnouncement(makeUpdateShort(scid3, c.publicKey, d.publicKey, 5000 msat, 5000, cltvDelta = CltvExpiryDelta(5000)))),
+      ChannelHop(scid4, d.publicKey, e.publicKey, HopRelayParams.FromAnnouncement(makeUpdateShort(scid4, d.publicKey, e.publicKey, 100000 msat, 100000, cltvDelta = CltvExpiryDelta(60000)))),
+      ChannelHop(scid5, e.publicKey, f.publicKey, HopRelayParams.FromAnnouncement(makeUpdateShort(scid5, e.publicKey, f.publicKey, 999999999 msat, 999999999, cltvDelta = CltvExpiryDelta(65000)))),
+    )
+    val route = createBlindedRouteFromHops(hops, randomBytes32(), 0 msat, CltvExpiry(0))
+    assert(route.route.encryptedPayloads.dropRight(1).forall(_.length == 54))
+  }
+
 }


### PR DESCRIPTION
The lengths of the encrypted recipient data leak the base fees as they are encoded with a variable length, to compensate for that we always add padding.