### PR TITLE
Define `channelReserve()` methods in `ChannelParams`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -101,6 +101,20 @@ case class ChannelParams(channelId: ByteVector32,
    */
   def minDepthDualFunding(defaultMinDepth: Int, sharedTx: SharedTransaction): Option[Long] = minDepthDualFunding(defaultMinDepth, sharedTx.sharedOutput.amount, Some(sharedTx.remoteInputs.nonEmpty))
 
+  /** Channel reserve that applies to our funds. */
+  def localChannelReserveForCapacity(capacity: Satoshi): Satoshi = if (channelFeatures.hasFeature(Features.DualFunding)) {
+    (capacity / 100).max(remoteParams.dustLimit)
+  } else {
+    remoteParams.requestedChannelReserve_opt.get // this is guarded by a require() in Params
+  }
+
+  /** Channel reserve that applies to our peer's funds. */
+  def remoteChannelReserveForCapacity(capacity: Satoshi): Satoshi = if (channelFeatures.hasFeature(Features.DualFunding)) {
+    (capacity / 100).max(localParams.dustLimit)
+  } else {
+    localParams.requestedChannelReserve_opt.get // this is guarded by a require() in Params
+  }
+
   /**
    *
    * @param localScriptPubKey local script pubkey (provided in CMD_CLOSE, as an upfront shutdown script, or set to the current final onchain script)
@@ -248,18 +262,10 @@ case class Commitment(fundingTxIndex: Long,
   val capacity: Satoshi = commitInput.txOut.amount
 
   /** Channel reserve that applies to our funds. */
-  def localChannelReserve(params: ChannelParams): Satoshi = if (params.channelFeatures.hasFeature(Features.DualFunding)) {
-    (capacity / 100).max(params.remoteParams.dustLimit)
-  } else {
-    params.remoteParams.requestedChannelReserve_opt.get // this is guarded by a require() in Params
-  }
+  def localChannelReserve(params: ChannelParams): Satoshi = params.localChannelReserveForCapacity(capacity)
 
   /** Channel reserve that applies to our peer's funds. */
-  def remoteChannelReserve(params: ChannelParams): Satoshi = if (params.channelFeatures.hasFeature(Features.DualFunding)) {
-    (capacity / 100).max(params.localParams.dustLimit)
-  } else {
-    params.localParams.requestedChannelReserve_opt.get // this is guarded by a require() in Params
-  }
+  def remoteChannelReserve(params: ChannelParams): Satoshi = params.remoteChannelReserveForCapacity(capacity)
 
   // NB: when computing availableBalanceForSend and availableBalanceForReceive, the initiator keeps an extra buffer on
   // top of its usual channel reserve to avoid getting channels stuck in case the on-chain feerate increases (see

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -649,7 +649,7 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
     }
 
     val sharedInput_opt = fundingParams.sharedInput_opt.map(_ => {
-      val remoteReserve = (fundingParams.fundingAmount / 100).max(channelParams.localParams.dustLimit)
+      val remoteReserve = channelParams.remoteChannelReserveForCapacity(fundingParams.fundingAmount)
       // We ignore the reserve requirement if we are splicing funds into the channel, which increases the size of the reserve.
       if (sharedOutput.remoteAmount < remoteReserve && remoteOutputs.nonEmpty && localInputs.isEmpty) {
         log.warn("invalid interactive tx: peer takes too much funds out and falls below the channel reserve ({} < {})", sharedOutput.remoteAmount, remoteReserve)


### PR DESCRIPTION
So it can be called from `InteractiveTx` for new commitments.