### PR TITLE
Improve channels DB migration performance

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -38,6 +38,8 @@ Node operators that use Postgres as database backend and make SQL queries on cha
 1. Set `eclair.db.postgres.reset-json-columns = true` before restarting eclair
 2. Once restarted, set `eclair.db.postgres.reset-json-columns = false` (no need to restart again)
 
+Note that this requires re-writing every row of the database, which can be slow for nodes that have many channels.
+
 ### API changes
 
 - `audit` now accepts `--count` and `--skip` parameters to limit the number of retrieved items (#2474, #2487)


### PR DESCRIPTION
Migrating the channels table by decoding every channel and re-writing every row is extremely inefficient. On large databases, it will run into WAL checkpoint issues. See https://www.postgresql.org/docs/current/wal-intro.html and https://www.postgresql.org/docs/13/runtime-config-wal.html

It is much more efficient to update this table directly in SQL, even though it doesn't guarantee that all columns will correctly be filled if the JSON column wasn't up-to-date. We thus fill the new `remote_node_id` column whenever the channel is updated to ensure that it is eventually filled.