### PR TITLE
Fix channels DB migration

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
@@ -104,10 +104,11 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
         statement.executeUpdate("ALTER TABLE local.channels ADD COLUMN remote_node_id TEXT")
         migrateTable(pg, pg,
           "local.channels",
-          "UPDATE local.channels SET remote_node_id=?",
+          "UPDATE local.channels SET remote_node_id=? WHERE channel_id=?",
           (rs, statement) => {
             val state = channelDataCodec.decode(BitVector(rs.getBytes("data"))).require.value
             statement.setString(1, state.remoteNodeId.toHex)
+            statement.setString(2, state.channelId.toHex)
           })(logger)
         statement.executeUpdate("ALTER TABLE local.channels ALTER COLUMN remote_node_id SET NOT NULL")
         statement.executeUpdate("CREATE INDEX local_channels_remote_node_id_idx ON local.channels(remote_node_id)")


### PR DESCRIPTION
We were missing a match on `channel_id`, which means we were rewriting every row N times!