### PR TITLE
Find route for messages

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -310,10 +310,12 @@ eclair {
     message-path-finding {
       max-route-length = 6
       ratios {
-        base = 0.6
-        channel-age = 0.1
-        channel-capacity = 0.3
-        disabled-multiplier = 2.5
+        // The next three weights must sum to one.
+        base = 0.6             // when computing the weight for a channel, proportion that stays the same for all channels
+        channel-age = 0.1      // when computing the weight for a channel, consider its AGE in this proportion
+        channel-capacity = 0.3 // when computing the weight for a channel, consider its CAPACITY in this proportion
+
+        disabled-multiplier = 2.5 // How much we prefer relaying a message along an active channel instead of a disabled one.
       }
     }
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -478,6 +478,9 @@ eclair {
 
     max-per-peer-per-second = 10
 
+    # Minimum number of hops before our node to hide it in the reply paths that we build
+    min-intermediate-hops = 8
+
     # Consider a message to be lost if we haven't received a reply after that amount of time
     reply-timeout = 5 seconds
 

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -479,10 +479,10 @@ eclair {
     max-per-peer-per-second = 10
 
     # Minimum number of hops before our node to hide it in the reply paths that we build
-    min-intermediate-hops = 8
+    min-intermediate-hops = 6
 
     # Consider a message to be lost if we haven't received a reply after that amount of time
-    reply-timeout = 5 seconds
+    reply-timeout = 15 seconds
 
     # If we expect a reply but do not get one, retry until we reach this number of attempts
     max-attempts = 3

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -307,6 +307,16 @@ eclair {
       channel-query-chunk-size = 100 // max number of short_channel_ids in query_short_channel_ids *do not change this unless you know what you are doing*
     }
 
+    message-path-finding {
+      max-route-length = 6
+      ratios {
+        base = 0.6
+        channel-age = 0.1
+        channel-capacity = 0.3
+        disabled-multiplier = 2.5
+      }
+    }
+
     path-finding {
       default {
         randomize-route-selection = true // when computing a route for a payment we randomize the final selection

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -174,9 +174,9 @@ trait Eclair {
 
   def sendOnionMessage(messageRoute_opt: Option[Seq[PublicKey]], destination: Either[PublicKey, Sphinx.RouteBlinding.BlindedRoute], expectsReply: Boolean, userCustomContent: ByteVector)(implicit timeout: Timeout): Future[SendOnionMessageResponse]
 
-  def payOffer(offer: Offer, amount: MilliSatoshi, quantity: Long, externalId_opt: Option[String] = None, maxAttempts_opt: Option[Int] = None, maxFeeFlat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None, pathFindingExperimentName_opt: Option[String] = None)(implicit timeout: Timeout): Future[UUID]
+  def payOffer(offer: Offer, amount: MilliSatoshi, quantity: Long, externalId_opt: Option[String] = None, maxAttempts_opt: Option[Int] = None, maxFeeFlat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None, pathFindingExperimentName_opt: Option[String] = None, connectDirectly: Boolean = false)(implicit timeout: Timeout): Future[UUID]
 
-  def payOfferBlocking(offer: Offer, amount: MilliSatoshi, quantity: Long, externalId_opt: Option[String] = None, maxAttempts_opt: Option[Int] = None, maxFeeFlat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None, pathFindingExperimentName_opt: Option[String] = None)(implicit timeout: Timeout): Future[PaymentEvent]
+  def payOfferBlocking(offer: Offer, amount: MilliSatoshi, quantity: Long, externalId_opt: Option[String] = None, maxAttempts_opt: Option[Int] = None, maxFeeFlat_opt: Option[Satoshi] = None, maxFeePct_opt: Option[Double] = None, pathFindingExperimentName_opt: Option[String] = None, connectDirectly: Boolean = false)(implicit timeout: Timeout): Future[PaymentEvent]
 
   def stop(): Future[Unit]
 }
@@ -652,6 +652,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
                        maxFeeFlat_opt: Option[Satoshi],
                        maxFeePct_opt: Option[Double],
                        pathFindingExperimentName_opt: Option[String],
+                       connectDirectly: Boolean,
                        blocking: Boolean)(implicit timeout: Timeout): Future[Any] = {
     if (externalId_opt.exists(_.length > externalIdMaxLength)) {
       return Future.failed(new IllegalArgumentException(s"externalId is too long: cannot exceed $externalIdMaxLength characters"))
@@ -663,7 +664,7 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
           .modify(_.boundaries.maxFeeFlat).setToIfDefined(maxFeeFlat_opt.map(_.toMilliSatoshi))
       case Left(t) => return Future.failed(t)
     }
-    val sendPaymentConfig = OfferPayment.SendPaymentConfig(externalId_opt, maxAttempts_opt.getOrElse(appKit.nodeParams.maxPaymentAttempts), routeParams, blocking)
+    val sendPaymentConfig = OfferPayment.SendPaymentConfig(externalId_opt, connectDirectly, maxAttempts_opt.getOrElse(appKit.nodeParams.maxPaymentAttempts), routeParams, blocking)
     val offerPayment = appKit.system.spawnAnonymous(OfferPayment(appKit.nodeParams, appKit.postman, appKit.paymentInitiator))
     offerPayment.ask((ref: typed.ActorRef[Any]) => OfferPayment.PayOffer(ref.toClassic, offer, amount, quantity, sendPaymentConfig)).flatMap {
       case f: OfferPayment.Failure => Future.failed(new Exception(f.toString))
@@ -678,8 +679,9 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
                         maxAttempts_opt: Option[Int],
                         maxFeeFlat_opt: Option[Satoshi],
                         maxFeePct_opt: Option[Double],
-                        pathFindingExperimentName_opt: Option[String])(implicit timeout: Timeout): Future[UUID] = {
-    payOfferInternal(offer, amount, quantity, externalId_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, pathFindingExperimentName_opt, blocking = false).mapTo[UUID]
+                        pathFindingExperimentName_opt: Option[String],
+                        connectDirectly: Boolean)(implicit timeout: Timeout): Future[UUID] = {
+    payOfferInternal(offer, amount, quantity, externalId_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, pathFindingExperimentName_opt, connectDirectly, blocking = false).mapTo[UUID]
   }
 
   override def payOfferBlocking(offer: Offer,
@@ -689,8 +691,9 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
                                 maxAttempts_opt: Option[Int],
                                 maxFeeFlat_opt: Option[Satoshi],
                                 maxFeePct_opt: Option[Double],
-                                pathFindingExperimentName_opt: Option[String])(implicit timeout: Timeout): Future[PaymentEvent] = {
-    payOfferInternal(offer, amount, quantity, externalId_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, pathFindingExperimentName_opt, blocking = true).mapTo[PaymentEvent]
+                                pathFindingExperimentName_opt: Option[String],
+                                connectDirectly: Boolean)(implicit timeout: Timeout): Future[PaymentEvent] = {
+    payOfferInternal(offer, amount, quantity, externalId_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, pathFindingExperimentName_opt, connectDirectly, blocking = true).mapTo[PaymentEvent]
   }
 
   override def stop(): Future[Unit] = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -568,6 +568,7 @@ object NodeParams extends Logging {
       blockchainWatchdogSources = config.getStringList("blockchain-watchdog.sources").asScala.toSeq,
       onionMessageConfig = OnionMessageConfig(
         relayPolicy = onionMessageRelayPolicy,
+        minIntermediateHops = config.getInt("onion-messages.min-intermediate-hops"),
         timeout = FiniteDuration(config.getDuration("onion-messages.reply-timeout").getSeconds, TimeUnit.SECONDS),
         maxAttempts = config.getInt("onion-messages.max-attempts"),
       ),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -369,7 +369,7 @@ class Setup(val datadir: File,
       _ = triggerer ! AsyncPaymentTriggerer.Start(switchboard.toTyped)
       balanceActor = system.spawn(BalanceActor(nodeParams.db, bitcoinClient, channelsListener, nodeParams.balanceCheckInterval), name = "balance-actor")
 
-      postman = system.spawn(Behaviors.supervise(Postman(nodeParams, switchboard.toTyped, offerManager)).onFailure(typed.SupervisorStrategy.restart), name = "postman")
+      postman = system.spawn(Behaviors.supervise(Postman(nodeParams, switchboard.toTyped, router.toTyped, offerManager)).onFailure(typed.SupervisorStrategy.restart), name = "postman")
 
       kit = Kit(
         nodeParams = nodeParams,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/message/OnionMessages.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/message/OnionMessages.scala
@@ -31,7 +31,16 @@ import scala.concurrent.duration.FiniteDuration
 
 object OnionMessages {
 
+  /**
+   *
+   * @param relayPolicy          When to relay onion messages (always, never, only along existing channels).
+   * @param minIntermediateHops  For routes we build to us, minimum number of hops before our node. Dummy hops are added
+   *                             if needed to hide our position in the network.
+   * @param timeout              Time after which we consider that the message has been lost and stop waiting for a reply.
+   * @param maxAttempts          Maximum number of attempts for sending a message.
+   */
   case class OnionMessageConfig(relayPolicy: RelayPolicy,
+                                minIntermediateHops: Int,
                                 timeout: FiniteDuration,
                                 maxAttempts: Int)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/message/Postman.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/message/Postman.scala
@@ -18,14 +18,14 @@ package fr.acinq.eclair.message
 
 import akka.actor.typed
 import akka.actor.typed.eventstream.EventStream
-import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.actor.typed.{ActorRef, Behavior}
 import fr.acinq.bitcoin.scalacompat.ByteVector32
-import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.io.{MessageRelay, Switchboard}
-import fr.acinq.eclair.message.OnionMessages.Destination
+import fr.acinq.eclair.message.OnionMessages.{Destination, RoutingStrategy}
 import fr.acinq.eclair.payment.offer.OfferManager
 import fr.acinq.eclair.router.Router
+import fr.acinq.eclair.router.Router.{MessageRoute, MessageRouteNotFound, MessageRouteResponse}
 import fr.acinq.eclair.wire.protocol.MessageOnion.{FinalPayload, InvoiceRequestPayload}
 import fr.acinq.eclair.wire.protocol.{OnionMessagePayloadTlv, TlvStream}
 import fr.acinq.eclair.{NodeParams, randomBytes32, randomKey}
@@ -35,17 +35,17 @@ import scala.collection.mutable
 object Postman {
   // @formatter:off
   sealed trait Command
-
-  /** Builds a message packet and send it to the destination using the provided path.
+  /**
+   * Builds a message packet and send it to the destination using the provided path.
    *
-   * @param destination      Recipient of the message
-   * @param messageRoute_opt Route to use. If None, asks the router to find a route.
-   * @param message          Content of the message to send
-   * @param expectsReply     Whether the message expects a reply
-   * @param replyTo          Actor to send the status and reply to
+   * @param destination     Recipient of the message
+   * @param routingStrategy How to reach the destination (recipient or blinded path introduction node).
+   * @param message         Content of the message to send
+   * @param expectsReply    Whether the message expects a reply
+   * @param replyTo         Actor to send the status and reply to
    */
   case class SendMessage(destination: Destination,
-                         messageRoute_opt: Option[Seq[PublicKey]],
+                         routingStrategy: RoutingStrategy,
                          message: TlvStream[OnionMessagePayloadTlv],
                          expectsReply: Boolean,
                          replyTo: ActorRef[OnionMessageResponse]) extends Command
@@ -83,13 +83,9 @@ object Postman {
             case _ => // ignoring message with invalid or missing pathId
           }
           Behaviors.same
-        case SendMessage(destination, None, messageContent, expectsReply, replyTo) =>
-          val child = context.spawnAnonymous(SendingMessage(nodeParams, switchboard, router, context.self, destination, messageContent, expectsReply, replyTo))
+        case SendMessage(destination, routingStrategy, messageContent, expectsReply, replyTo) =>
+          val child = context.spawnAnonymous(SendingMessage(nodeParams, switchboard, router, context.self, destination, messageContent, routingStrategy, expectsReply, replyTo))
           child ! SendingMessage.SendMessage
-          Behaviors.same
-        case SendMessage(destination, Some(messageRoute), messageContent, expectsReply, replyTo) =>
-          val child = context.spawnAnonymous(SendingMessage.waitingForRoute(nodeParams, switchboard, context.self, destination, messageContent, expectsReply, replyTo))
-          child ! SendingMessage.MessageRouteFound(messageRoute)
           Behaviors.same
         case Subscribe(pathId, replyTo) =>
           subscribed += (pathId -> replyTo)
@@ -109,12 +105,9 @@ object Postman {
 object SendingMessage {
   // @formatter:off
   sealed trait Command
-
   case object SendMessage extends Command
-  case class SendingStatus(status: MessageRelay.Status) extends Command
-  sealed trait RouteResult extends Command
-  case class MessageRouteFound(messageRoute: Seq[PublicKey]) extends RouteResult
-  case object MessageRouteNotFound extends RouteResult
+  private case class SendingStatus(status: MessageRelay.Status) extends Command
+  private case class WrappedMessageRouteResponse(response: MessageRouteResponse) extends Command
   // @formatter:on
 
   def apply(nodeParams: NodeParams,
@@ -123,65 +116,80 @@ object SendingMessage {
             postman: ActorRef[Postman.Command],
             destination: Destination,
             message: TlvStream[OnionMessagePayloadTlv],
+            routingStrategy: RoutingStrategy,
             expectsReply: Boolean,
             replyTo: ActorRef[Postman.OnionMessageResponse]): Behavior[Command] = {
     Behaviors.setup(context => {
-      Behaviors.receiveMessagePartial {
-        case SendMessage =>
-          val targetNodeId = destination match {
-            case OnionMessages.BlindedPath(route) => route.introductionNodeId
-            case OnionMessages.Recipient(nodeId, _, _, _) => nodeId
-          }
-          router ! Router.MessageRouteRequest(context.self, nodeParams.nodeId, targetNodeId, Set.empty)
-          waitingForRoute(nodeParams, switchboard, postman, destination, message, expectsReply, replyTo)
-      }
+      val actor = new SendingMessage(nodeParams, switchboard, router, postman, destination, message, routingStrategy, expectsReply, replyTo, context)
+      actor.start()
     })
   }
+}
 
-  def waitingForRoute(nodeParams: NodeParams,
-                      switchboard: ActorRef[Switchboard.RelayMessage],
-                      postman: ActorRef[Postman.Command],
-                      destination: Destination,
-                      message: TlvStream[OnionMessagePayloadTlv],
-                      expectsReply: Boolean,
-                      replyTo: ActorRef[Postman.OnionMessageResponse]): Behavior[Command] = {
-    Behaviors.setup(context => {
-      Behaviors.receiveMessagePartial {
-        case MessageRouteFound(messageRoute) =>
-          val messageId = randomBytes32()
-          val replyRoute =
-            if (expectsReply) {
-              val numHopsToAdd = 0.max(nodeParams.onionMessageConfig.minIntermediateHops - messageRoute.length)
-              val intermediateHops = (messageRoute.reverse ++ Seq.fill(numHopsToAdd)(nodeParams.nodeId)).map(OnionMessages.IntermediateNode(_))
-              val lastHop = OnionMessages.Recipient(nodeParams.nodeId, Some(messageId))
-              Some(OnionMessages.buildRoute(randomKey(), intermediateHops, lastHop))
-            } else {
-              None
-            }
-          OnionMessages.buildMessage(
-            nodeParams.privateKey,
-            randomKey(),
-            randomKey(),
-            messageRoute.dropRight(1).map(OnionMessages.IntermediateNode(_)),
-            destination,
-            TlvStream(replyRoute.map(OnionMessagePayloadTlv.ReplyPath).toSet ++ message.records, message.unknown)) match {
-            case Left(failure) =>
-              replyTo ! Postman.MessageFailed(failure.toString)
-              Behaviors.stopped
-            case Right((nextNodeId, message)) =>
-              switchboard ! Switchboard.RelayMessage(messageId, None, nextNodeId, message, MessageRelay.RelayAll, Some(context.messageAdapter[MessageRelay.Status](SendingStatus)))
-              waitForSent(expectsReply, replyTo, postman)
-          }
-        case MessageRouteNotFound =>
-          replyTo ! Postman.MessageFailed("No route found")
-          Behaviors.stopped
-      }
-    })
+private class SendingMessage(nodeParams: NodeParams,
+                             switchboard: ActorRef[Switchboard.RelayMessage],
+                             router: ActorRef[Router.MessageRouteRequest],
+                             postman: ActorRef[Postman.Command],
+                             destination: Destination,
+                             message: TlvStream[OnionMessagePayloadTlv],
+                             routingStrategy: RoutingStrategy,
+                             expectsReply: Boolean,
+                             replyTo: ActorRef[Postman.OnionMessageResponse],
+                             context: ActorContext[SendingMessage.Command]) {
+
+  import SendingMessage._
+
+  def start(): Behavior[Command] = {
+    Behaviors.receiveMessagePartial {
+      case SendMessage =>
+        val targetNodeId = destination match {
+          case OnionMessages.BlindedPath(route) => route.introductionNodeId
+          case OnionMessages.Recipient(nodeId, _, _, _) => nodeId
+        }
+        routingStrategy match {
+          case RoutingStrategy.UseRoute(intermediateNodes) => context.self ! WrappedMessageRouteResponse(MessageRoute(intermediateNodes, targetNodeId))
+          case RoutingStrategy.FindRoute if targetNodeId == nodeParams.nodeId => context.self ! WrappedMessageRouteResponse(MessageRoute(Nil, targetNodeId))
+          case RoutingStrategy.FindRoute => router ! Router.MessageRouteRequest(context.messageAdapter(WrappedMessageRouteResponse), nodeParams.nodeId, targetNodeId, Set.empty)
+        }
+        waitForRoute()
+    }
   }
 
-  def waitForSent(expectsReply: Boolean,
-                  replyTo: ActorRef[Postman.OnionMessageResponse],
-                  postman: ActorRef[Postman.Command]): Behavior[Command] = {
+  private def waitForRoute(): Behavior[Command] = {
+    Behaviors.receiveMessagePartial {
+      case WrappedMessageRouteResponse(MessageRoute(intermediateNodes, targetNodeId)) =>
+        val messageId = randomBytes32()
+        val replyRoute =
+          if (expectsReply) {
+            val numHopsToAdd = 0.max(nodeParams.onionMessageConfig.minIntermediateHops - intermediateNodes.length - 1)
+            val intermediateHops = (Seq(targetNodeId) ++ intermediateNodes.reverse ++ Seq.fill(numHopsToAdd)(nodeParams.nodeId)).map(OnionMessages.IntermediateNode(_))
+            val lastHop = OnionMessages.Recipient(nodeParams.nodeId, Some(messageId))
+            Some(OnionMessages.buildRoute(randomKey(), intermediateHops, lastHop))
+          } else {
+            None
+          }
+        OnionMessages.buildMessage(
+          nodeParams.privateKey,
+          randomKey(),
+          randomKey(),
+          intermediateNodes.map(OnionMessages.IntermediateNode(_)),
+          destination,
+          TlvStream(replyRoute.map(OnionMessagePayloadTlv.ReplyPath).toSet ++ message.records, message.unknown)) match {
+          case Left(failure) =>
+            replyTo ! Postman.MessageFailed(failure.toString)
+            Behaviors.stopped
+          case Right((nextNodeId, message)) =>
+            switchboard ! Switchboard.RelayMessage(messageId, None, nextNodeId, message, MessageRelay.RelayAll, Some(context.messageAdapter[MessageRelay.Status](SendingStatus)))
+            waitForSent()
+        }
+      case WrappedMessageRouteResponse(MessageRouteNotFound(targetNodeId)) =>
+        context.log.debug("no route found to {}", targetNodeId)
+        replyTo ! Postman.MessageFailed("No route found")
+        Behaviors.stopped
+    }
+  }
+
+  private def waitForSent(): Behavior[Command] = {
     Behaviors.receiveMessagePartial {
       case SendingStatus(MessageRelay.Sent(messageId)) =>
         if (expectsReply) {
@@ -195,4 +203,5 @@ object SendingMessage {
         Behaviors.stopped
     }
   }
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/offer/OfferManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/offer/OfferManager.scala
@@ -192,7 +192,7 @@ object OfferManager {
       def waitForHandler(): Behavior[Command] = {
         Behaviors.receiveMessagePartial {
           case RejectRequest(error) =>
-            postman ! Postman.SendMessage(Nil, pathToSender, None, TlvStream(OnionMessagePayloadTlv.InvoiceError(TlvStream(OfferTypes.Error(error)))), context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse), 0 seconds)
+            postman ! Postman.SendMessage(pathToSender, None, TlvStream(OnionMessagePayloadTlv.InvoiceError(TlvStream(OfferTypes.Error(error)))), expectsReply = false, context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse))
             waitForSent()
           case ApproveRequest(amount, routes, pluginData_opt, additionalTlvs, customTlvs) =>
             val preimage = randomBytes32()
@@ -210,7 +210,7 @@ object OfferManager {
           case WrappedInvoiceResponse(invoiceResponse) =>
             invoiceResponse match {
               case CreateInvoiceActor.InvoiceCreated(invoice) =>
-                postman ! Postman.SendMessage(Nil, pathToSender, None, TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)), context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse), 0 seconds)
+                postman ! Postman.SendMessage(pathToSender, None, TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)), expectsReply = false, context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse))
                 waitForSent()
               case f: CreateInvoiceActor.InvoiceCreationFailed =>
                 context.log.debug("invoice creation failed: {}", f.message)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/offer/OfferManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/offer/OfferManager.scala
@@ -38,8 +38,6 @@ import scala.concurrent.duration.FiniteDuration
  * Created by thomash-acinq on 13/01/2023.
  */
 
-import scala.concurrent.duration.DurationInt
-
 object OfferManager {
   sealed trait Command
 
@@ -192,7 +190,7 @@ object OfferManager {
       def waitForHandler(): Behavior[Command] = {
         Behaviors.receiveMessagePartial {
           case RejectRequest(error) =>
-            postman ! Postman.SendMessage(pathToSender, None, TlvStream(OnionMessagePayloadTlv.InvoiceError(TlvStream(OfferTypes.Error(error)))), expectsReply = false, context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse))
+            postman ! Postman.SendMessage(pathToSender, OnionMessages.RoutingStrategy.FindRoute, TlvStream(OnionMessagePayloadTlv.InvoiceError(TlvStream(OfferTypes.Error(error)))), expectsReply = false, context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse))
             waitForSent()
           case ApproveRequest(amount, routes, pluginData_opt, additionalTlvs, customTlvs) =>
             val preimage = randomBytes32()
@@ -210,7 +208,7 @@ object OfferManager {
           case WrappedInvoiceResponse(invoiceResponse) =>
             invoiceResponse match {
               case CreateInvoiceActor.InvoiceCreated(invoice) =>
-                postman ! Postman.SendMessage(pathToSender, None, TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)), expectsReply = false, context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse))
+                postman ! Postman.SendMessage(pathToSender, OnionMessages.RoutingStrategy.FindRoute, TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)), expectsReply = false, context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse))
                 waitForSent()
               case f: CreateInvoiceActor.InvoiceCreationFailed =>
                 context.log.debug("invoice creation failed: {}", f.message)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/OfferPayment.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/OfferPayment.scala
@@ -111,15 +111,8 @@ object OfferPayment {
         OnionMessages.Recipient(nodeId, None, None)
     }
     val messageContent = TlvStream[OnionMessagePayloadTlv](OnionMessagePayloadTlv.InvoiceRequest(request.records))
-    val messageRoute_opt = if (sendPaymentConfig.connectDirectly) {
-      destination match {
-        case OnionMessages.BlindedPath(route) => Some(route.introductionNodeId :: Nil)
-        case OnionMessages.Recipient(nodeId, _, _, _) => Some(nodeId :: Nil)
-      }
-    } else {
-      None
-    }
-    postman ! SendMessage(destination, messageRoute_opt, messageContent, expectsReply = true, context.messageAdapter(WrappedMessageResponse))
+    val routingStrategy = if (sendPaymentConfig.connectDirectly) OnionMessages.RoutingStrategy.connectDirectly else OnionMessages.RoutingStrategy.FindRoute
+    postman ! SendMessage(destination, routingStrategy, messageContent, expectsReply = true, context.messageAdapter(WrappedMessageResponse))
     waitForInvoice(nodeParams, postman, paymentInitiator, context, request, payerKey, replyTo, attemptNumber + 1, sendPaymentConfig)
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/OfferPayment.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/OfferPayment.scala
@@ -109,10 +109,8 @@ object OfferPayment {
       case Right(nodeId) =>
         OnionMessages.Recipient(nodeId, None, None)
     }
-    // TODO: Find a path made of channels as some nodes may refuse to relay messages to nodes with which they don't have a channel.
-    val intermediateNodesToRecipient = Nil
     val messageContent = TlvStream[OnionMessagePayloadTlv](OnionMessagePayloadTlv.InvoiceRequest(request.records))
-    postman ! SendMessage(intermediateNodesToRecipient, destination, Some((nodeParams.nodeId +: intermediateNodesToRecipient).reverse), messageContent, context.messageAdapter(WrappedMessageResponse), nodeParams.onionMessageConfig.timeout)
+    postman ! SendMessage(destination, None, messageContent, expectsReply = true, context.messageAdapter(WrappedMessageResponse))
     waitForInvoice(nodeParams, postman, paymentInitiator, context, request, payerKey, replyTo, attemptNumber + 1, sendPaymentConfig)
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/EclairInternalsSerializer.scala
@@ -86,6 +86,13 @@ object EclairInternalsSerializer {
     "experiments" | listOfN(int32, pathFindingConfCodec).xmap[Map[String, PathFindingConf]](_.map(e => e.experimentName -> e).toMap, _.values.toList)
     ).as[PathFindingExperimentConf]
 
+  val messageRouteParamsCodec: Codec[MessageRouteParams] = (
+    ("maxRouteLength" | int32) ::
+      (("baseFactor" | double) ::
+      ("ageFactor" | double) ::
+      ("capacityFactor" | double) ::
+      ("disabledMultiplier" | double)).as[Graph.MessagePath.WeightRatios]).as[MessageRouteParams]
+
   val routerConfCodec: Codec[RouterConf] = (
     ("watchSpentWindow" | finiteDurationCodec) ::
       ("channelExcludeDuration" | finiteDurationCodec) ::
@@ -97,6 +104,7 @@ object EclairInternalsSerializer {
       ("channelRangeChunkSize" | int32) ::
       ("channelQueryChunkSize" | int32) ::
       ("pathFindingExperimentConf" | pathFindingExperimentConfCodec) ::
+      ("messageRouteParams" | messageRouteParamsCodec) ::
       ("balanceEstimateHalfLife" | finiteDurationCodec)).as[RouterConf]
 
   val overrideFeaturesListCodec: Codec[List[(PublicKey, Features[Feature])]] = listOfN(uint16, publicKey ~ lengthPrefixedFeaturesCodec)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/BalanceEstimate.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/BalanceEstimate.scala
@@ -285,7 +285,7 @@ case class BalancesEstimates(balances: Map[(PublicKey, PublicKey), BalanceEstima
 }
 
 case class GraphWithBalanceEstimates(graph: DirectedGraph, private val balances: BalancesEstimates) {
-  def addVertex(ann: NodeAnnouncement): GraphWithBalanceEstimates = GraphWithBalanceEstimates(graph.addVertex(ann), balances)
+  def addOrUpdateVertex(ann: NodeAnnouncement): GraphWithBalanceEstimates = GraphWithBalanceEstimates(graph.addOrUpdateVertex(ann), balances)
 
   def addEdge(edge: GraphEdge): GraphWithBalanceEstimates = GraphWithBalanceEstimates(graph.addEdge(edge), balances.addEdge(edge))
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/BalanceEstimate.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/BalanceEstimate.scala
@@ -286,11 +286,13 @@ case class BalancesEstimates(balances: Map[(PublicKey, PublicKey), BalanceEstima
 case class GraphWithBalanceEstimates(graph: DirectedGraph, private val balances: BalancesEstimates) {
   def addEdge(edge: GraphEdge): GraphWithBalanceEstimates = GraphWithBalanceEstimates(graph.addEdge(edge), balances.addEdge(edge))
 
-  def removeEdge(desc: ChannelDesc): GraphWithBalanceEstimates = GraphWithBalanceEstimates(graph.removeEdge(desc), balances.removeEdge(desc))
+  def disableEdge(desc: ChannelDesc): GraphWithBalanceEstimates = GraphWithBalanceEstimates(graph.disableEdge(desc), balances.removeEdge(desc))
 
-  def removeEdges(descList: Iterable[ChannelDesc]): GraphWithBalanceEstimates = GraphWithBalanceEstimates(
-    graph.removeEdges(descList),
-    descList.foldLeft(balances)((acc, edge) => acc.removeEdge(edge)),
+  def removeChannel(desc: ChannelDesc): GraphWithBalanceEstimates = GraphWithBalanceEstimates(graph.removeChannel(desc), balances.removeEdge(desc).removeEdge(desc.reversed))
+
+  def removeChannels(descList: Iterable[ChannelDesc]): GraphWithBalanceEstimates = GraphWithBalanceEstimates(
+    graph.removeChannels(descList),
+    descList.foldLeft(balances)((acc, edge) => acc.removeEdge(edge).removeEdge(edge.reversed)),
   )
 
   def routeCouldRelay(route: Route): GraphWithBalanceEstimates = {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/BalanceEstimate.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/BalanceEstimate.scala
@@ -20,6 +20,7 @@ import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{Satoshi, SatoshiLong}
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
 import fr.acinq.eclair.router.Router.{ChannelDesc, ChannelHop, Route}
+import fr.acinq.eclair.wire.protocol.NodeAnnouncement
 import fr.acinq.eclair.{MilliSatoshi, MilliSatoshiLong, ShortChannelId, TimestampSecond, TimestampSecondLong, ToMilliSatoshiConversion}
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
@@ -284,6 +285,8 @@ case class BalancesEstimates(balances: Map[(PublicKey, PublicKey), BalanceEstima
 }
 
 case class GraphWithBalanceEstimates(graph: DirectedGraph, private val balances: BalancesEstimates) {
+  def addVertex(ann: NodeAnnouncement): GraphWithBalanceEstimates = GraphWithBalanceEstimates(graph.addVertex(ann), balances)
+
   def addEdge(edge: GraphEdge): GraphWithBalanceEstimates = GraphWithBalanceEstimates(graph.addEdge(edge), balances.addEdge(edge))
 
   def disableEdge(desc: ChannelDesc): GraphWithBalanceEstimates = GraphWithBalanceEstimates(graph.disableEdge(desc), balances.removeEdge(desc))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -191,7 +191,7 @@ object Graph {
                          ignoredVertices: Set[PublicKey],
                          nodeFeatures: Features[NodeFeature]): Option[Seq[PublicKey]] = {
     if (sourceNode == targetNode) {
-      return Some(Nil)
+      return Some(targetNode:: Nil)
     }
     val toExplore = mutable.Queue.empty[List[PublicKey]]
     toExplore.enqueue(targetNode :: Nil)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -25,7 +25,7 @@ import fr.acinq.eclair._
 import fr.acinq.eclair.message.SendingMessage
 import fr.acinq.eclair.payment.send._
 import fr.acinq.eclair.router.Graph.GraphStructure.DirectedGraph.graphEdgeToHop
-import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
+import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, ActiveEdge}
 import fr.acinq.eclair.router.Graph.{InfiniteLoop, MessagePath, NegativeProbability, RichWeight}
 import fr.acinq.eclair.router.Monitoring.{Metrics, Tags}
 import fr.acinq.eclair.router.Router._
@@ -37,7 +37,7 @@ import scala.util.{Failure, Random, Success, Try}
 
 object RouteCalculation {
 
-  private def getEdgeRelayScid(d: Data, localNodeId: PublicKey, e: GraphEdge): ShortChannelId = {
+  private def getEdgeRelayScid(d: Data, localNodeId: PublicKey, e: ActiveEdge): ShortChannelId = {
     if (e.desc.b == localNodeId) {
       // We are the destination of that edge: local graph edges always use either the local alias or the real scid.
       // We want to use the remote alias when available, because our peer won't understand our local alias.
@@ -66,8 +66,8 @@ object RouteCalculation {
       paymentHash_opt = fr.paymentContext.map(_.paymentHash))) {
       implicit val sender: ActorRef = ctx.self // necessary to preserve origin when sending messages to other actors
 
-      val extraEdges = fr.extraEdges.map(GraphEdge(_))
-      val g = extraEdges.foldLeft(d.graphWithBalances.graph) { case (g: DirectedGraph, e: GraphEdge) => g.addEdge(e) }
+      val extraEdges = fr.extraEdges.map(ActiveEdge(_))
+      val g = extraEdges.foldLeft(d.graphWithBalances.graph) { case (g: DirectedGraph, e: ActiveEdge) => g.addEdge(e) }
 
       fr.route match {
         case PredefinedNodeRoute(amount, hops, maxFee_opt) =>
@@ -129,7 +129,7 @@ object RouteCalculation {
    *
    * The routes found must then be post-processed by calling [[addFinalHop]].
    */
-  private def computeTarget(r: RouteRequest, ignoredEdges: Set[ChannelDesc]): (PublicKey, MilliSatoshi, MilliSatoshi, Set[GraphEdge]) = {
+  private def computeTarget(r: RouteRequest, ignoredEdges: Set[ChannelDesc]): (PublicKey, MilliSatoshi, MilliSatoshi, Set[ActiveEdge]) = {
     val pendingAmount = r.pendingPayments.map(_.amount).sum
     val totalMaxFee = r.routeParams.getMaxFee(r.target.totalAmount)
     val pendingChannelFee = r.pendingPayments.map(_.channelFee(r.routeParams.includeLocalChannelCost)).sum
@@ -140,7 +140,7 @@ object RouteCalculation {
         val maxFee = totalMaxFee - pendingChannelFee
         val extraEdges = recipient.extraEdges
           .filter(_.sourceNodeId != r.source) // we ignore routing hints for our own channels, we have more accurate information
-          .map(GraphEdge(_))
+          .map(ActiveEdge(_))
           .filterNot(e => ignoredEdges.contains(e.desc))
           .toSet
         (targetNodeId, amountToSend, maxFee, extraEdges)
@@ -156,7 +156,7 @@ object RouteCalculation {
           .map(_.copy(targetNodeId = targetNodeId))
           .filterNot(e => ignoredEdges.exists(_.shortChannelId == e.shortChannelId))
           // For blinded routes, the maximum htlc field is used to indicate the maximum amount that can be sent through the route.
-          .map(e => GraphEdge(e).copy(balance_opt = e.htlcMaximum_opt))
+          .map(e => ActiveEdge(e).copy(balance_opt = e.htlcMaximum_opt))
           .toSet
         val amountToSend = recipient.totalAmount - pendingAmount
         // When we are the introduction node and includeLocalChannelCost is false, we cannot easily remove the fee for
@@ -300,7 +300,7 @@ object RouteCalculation {
                 amount: MilliSatoshi,
                 maxFee: MilliSatoshi,
                 numRoutes: Int,
-                extraEdges: Set[GraphEdge] = Set.empty,
+                extraEdges: Set[ActiveEdge] = Set.empty,
                 ignoredEdges: Set[ChannelDesc] = Set.empty,
                 ignoredVertices: Set[PublicKey] = Set.empty,
                 routeParams: RouteParams,
@@ -318,7 +318,7 @@ object RouteCalculation {
                                 amount: MilliSatoshi,
                                 maxFee: MilliSatoshi,
                                 numRoutes: Int,
-                                extraEdges: Set[GraphEdge] = Set.empty,
+                                extraEdges: Set[ActiveEdge] = Set.empty,
                                 ignoredEdges: Set[ChannelDesc] = Set.empty,
                                 ignoredVertices: Set[PublicKey] = Set.empty,
                                 routeParams: RouteParams,
@@ -375,7 +375,7 @@ object RouteCalculation {
                          targetNodeId: PublicKey,
                          amount: MilliSatoshi,
                          maxFee: MilliSatoshi,
-                         extraEdges: Set[GraphEdge] = Set.empty,
+                         extraEdges: Set[ActiveEdge] = Set.empty,
                          ignoredEdges: Set[ChannelDesc] = Set.empty,
                          ignoredVertices: Set[PublicKey] = Set.empty,
                          pendingHtlcs: Seq[Route] = Nil,
@@ -399,7 +399,7 @@ object RouteCalculation {
                                          targetNodeId: PublicKey,
                                          amount: MilliSatoshi,
                                          maxFee: MilliSatoshi,
-                                         extraEdges: Set[GraphEdge] = Set.empty,
+                                         extraEdges: Set[ActiveEdge] = Set.empty,
                                          ignoredEdges: Set[ChannelDesc] = Set.empty,
                                          ignoredVertices: Set[PublicKey] = Set.empty,
                                          pendingHtlcs: Seq[Route] = Nil,
@@ -412,7 +412,7 @@ object RouteCalculation {
       val directChannels = g.getEdgesBetween(localNodeId, targetNodeId).collect {
         // We should always have balance information available for local channels.
         // NB: htlcMinimumMsat is set by our peer and may be 0 msat (even though it's not recommended).
-        case GraphEdge(_, params, _, Some(balance)) => DirectChannel(balance, balance <= 0.msat || balance < params.htlcMinimum)
+        case ActiveEdge(_, params, _, Some(balance)) => DirectChannel(balance, balance <= 0.msat || balance < params.htlcMinimum)
       }.toSeq
       // If we have direct channels to the target, we can use them all.
       // We also count empty channels, which allows replacing them with a non-direct route (multiple hops).
@@ -465,7 +465,7 @@ object RouteCalculation {
   }
 
   /** Compute the maximum amount that we can send through the given route. */
-  private def computeRouteMaxAmount(route: Seq[GraphEdge], usedCapacity: mutable.Map[ShortChannelId, MilliSatoshi]): Route = {
+  private def computeRouteMaxAmount(route: Seq[ActiveEdge], usedCapacity: mutable.Map[ShortChannelId, MilliSatoshi]): Route = {
     val firstHopMaxAmount = route.head.maxHtlcAmount(usedCapacity.getOrElse(route.head.desc.shortChannelId, 0 msat))
     val amount = route.drop(1).foldLeft(firstHopMaxAmount) { case (amount, edge) =>
       // We compute fees going forward instead of backwards. That means we will slightly overestimate the fees of some

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -240,7 +240,7 @@ object RouteCalculation {
   }
 
   def handleMessageRouteRequest(d: Data, r: MessageRouteRequest)(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Data = {
-    r.replyTo ! Graph.breadthFirstSearch(d.graphWithBalances.graph, d.nodes, r.source, r.target, r.ignoredNodes, Features(Features.OnionMessages -> FeatureSupport.Mandatory))
+    // TODO
     d
   }
 
@@ -401,7 +401,7 @@ object RouteCalculation {
         // We should always have balance information available for local channels.
         // NB: htlcMinimumMsat is set by our peer and may be 0 msat (even though it's not recommended).
         case GraphEdge(_, params, _, Some(balance)) => DirectChannel(balance, balance <= 0.msat || balance < params.htlcMinimum)
-      }
+      }.toSeq
       // If we have direct channels to the target, we can use them all.
       // We also count empty channels, which allows replacing them with a non-direct route (multiple hops).
       val numRoutes = routeParams.mpp.maxParts.max(directChannels.length)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -240,10 +240,7 @@ object RouteCalculation {
   }
 
   def handleMessageRouteRequest(d: Data, r: MessageRouteRequest)(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Data = {
-    Graph.breadthFirstSearch(d.graphWithBalances.graph, d.nodes, r.source, r.target, r.ignoredNodes, Features(Features.OnionMessages -> FeatureSupport.Mandatory)) match {
-      case None => r.replyTo ! SendingMessage.MessageRouteNotFound
-      case Some(path) => r.replyTo ! SendingMessage.MessageRouteFound(path.drop(1))
-    }
+    r.replyTo ! Graph.breadthFirstSearch(d.graphWithBalances.graph, d.nodes, r.source, r.target, r.ignoredNodes, Features(Features.OnionMessages -> FeatureSupport.Mandatory))
     d
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -22,6 +22,7 @@ import com.softwaremill.quicklens.ModifyPimp
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair._
+import fr.acinq.eclair.message.SendingMessage
 import fr.acinq.eclair.payment.send._
 import fr.acinq.eclair.router.Graph.GraphStructure.DirectedGraph.graphEdgeToHop
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
@@ -236,6 +237,14 @@ object RouteCalculation {
       }
       d
     }
+  }
+
+  def handleMessageRouteRequest(d: Data, r: MessageRouteRequest)(implicit ctx: ActorContext, log: DiagnosticLoggingAdapter): Data = {
+    Graph.breadthFirstSearch(d.graphWithBalances.graph, d.nodes, r.source, r.target, r.ignoredNodes, Features(Features.OnionMessages -> FeatureSupport.Mandatory)) match {
+      case None => r.replyTo ! SendingMessage.MessageRouteNotFound
+      case Some(path) => r.replyTo ! SendingMessage.MessageRouteFound(path.drop(1))
+    }
+    d
   }
 
   /** This method is used after a payment failed, and we want to exclude some nodes that we know are failing */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -37,7 +37,7 @@ import fr.acinq.eclair.payment.relay.Relayer
 import fr.acinq.eclair.payment.send.Recipient
 import fr.acinq.eclair.payment.{Bolt11Invoice, Invoice}
 import fr.acinq.eclair.remote.EclairInternalsSerializer.RemoteTypes
-import fr.acinq.eclair.router.Graph.GraphStructure.DirectedGraph
+import fr.acinq.eclair.router.Graph.GraphStructure.{ActiveEdge, DirectedGraph}
 import fr.acinq.eclair.router.Graph.{HeuristicsConstants, MessagePath, WeightRatios}
 import fr.acinq.eclair.router.Monitoring.Metrics
 import fr.acinq.eclair.wire.protocol._
@@ -205,7 +205,7 @@ class Router(val nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Comm
       d.nodes.get(nodeId) match {
         case Some(announcement) =>
           // This only provides a lower bound on the number of channels this peer has: disabled channels will be filtered out.
-          val activeChannels = d.graphWithBalances.graph.getIncomingEdgesOf(nodeId)
+          val activeChannels = d.graphWithBalances.graph.getIncomingEdgesOf(nodeId).collect{case e: ActiveEdge => e}
           val totalCapacity = activeChannels.map(_.capacity).sum
           replyTo ! PublicNode(announcement, activeChannels.size, totalCapacity)
         case None =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -32,7 +32,6 @@ import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.BlindedRoute
 import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.db.NetworkDb
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
-import fr.acinq.eclair.message.SendingMessage
 import fr.acinq.eclair.payment.Invoice.ExtraEdge
 import fr.acinq.eclair.payment.relay.Relayer
 import fr.acinq.eclair.payment.send.Recipient
@@ -585,10 +584,16 @@ object Router {
                            extraEdges: Seq[ExtraEdge] = Nil,
                            paymentContext: Option[PaymentContext] = None)
 
-  case class MessageRouteRequest(replyTo: typed.ActorRef[SendingMessage.RouteResult],
+  case class MessageRouteRequest(replyTo: typed.ActorRef[MessageRouteResponse],
                                  source: PublicKey,
                                  target: PublicKey,
                                  ignoredNodes: Set[PublicKey])
+
+  // @formatter:off
+  sealed trait MessageRouteResponse { def target: PublicKey }
+  case class MessageRoute(intermediateNodes: Seq[PublicKey], target: PublicKey) extends MessageRouteResponse
+  case class MessageRouteNotFound(target: PublicKey) extends MessageRouteResponse
+  // @formatter:on
 
   /**
    * Useful for having appropriate logging context at hand when finding routes

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -80,7 +80,7 @@ class Router(val nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Comm
     log.info("loaded from db: channels={} nodes={}", channels.size, nodes.size)
     log.info("{} pruned channels at blockHeight={}", pruned.size, nodeParams.currentBlockHeight)
     // this will be used to calculate routes
-    val graph = DirectedGraph.makeGraph(channels)
+    val graph = DirectedGraph.makeGraph(channels, nodes)
     // send events for remaining channels/nodes
     context.system.eventStream.publish(ChannelsDiscovered(channels.values.map(pc => SingleChannelDiscovered(pc.ann, pc.capacity, pc.update_1_opt, pc.update_2_opt))))
     context.system.eventStream.publish(ChannelUpdatesReceived(channels.values.flatMap(pc => pc.update_1_opt ++ pc.update_2_opt ++ Nil)))
@@ -365,7 +365,9 @@ object Router {
   }
 
   // @formatter:off
-  case class ChannelDesc private(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey)
+  case class ChannelDesc private(shortChannelId: ShortChannelId, a: PublicKey, b: PublicKey){
+    def reversed: ChannelDesc = ChannelDesc(shortChannelId, b, a)
+  }
   object ChannelDesc {
     def apply(u: ChannelUpdate, ann: ChannelAnnouncement): ChannelDesc = {
       // the least significant bit tells us if it is node1 or node2

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/StaleChannels.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/StaleChannels.scala
@@ -44,8 +44,8 @@ object StaleChannels {
       ctx.system.eventStream.publish(ChannelLost(shortChannelId))
     }
 
-    val staleChannelsToRemove = staleChannels.flatMap(pc => Seq(ChannelDesc(pc.ann.shortChannelId, pc.ann.nodeId1, pc.ann.nodeId2), ChannelDesc(pc.ann.shortChannelId, pc.ann.nodeId2, pc.ann.nodeId1)))
-    val graphWithBalances1 = d.graphWithBalances.removeEdges(staleChannelsToRemove)
+    val staleChannelsToRemove = staleChannels.map(pc => ChannelDesc(pc.ann.shortChannelId, pc.ann.nodeId1, pc.ann.nodeId2))
+    val graphWithBalances1 = d.graphWithBalances.removeChannels(staleChannelsToRemove)
     staleNodes.foreach { nodeId =>
       log.info("pruning nodeId={} (stale)", nodeId)
       db.removeNode(nodeId)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -28,7 +28,7 @@ import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{UtxoStatus, ValidateReque
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.db.NetworkDb
-import fr.acinq.eclair.router.Graph.GraphStructure.GraphEdge
+import fr.acinq.eclair.router.Graph.GraphStructure.ActiveEdge
 import fr.acinq.eclair.router.Monitoring.Metrics
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.transactions.Scripts
@@ -181,8 +181,8 @@ object Validation {
         // remove previous private edges
         graph = graph.removeChannel(ChannelDesc(privateChannel.shortIds.localAlias, privateChannel.nodeId1, privateChannel.nodeId2))
         // add new public edges
-        pubChan.update_1_opt.foreach(u => graph = graph.addEdge(GraphEdge(u, pubChan)))
-        pubChan.update_2_opt.foreach(u => graph = graph.addEdge(GraphEdge(u, pubChan)))
+        pubChan.update_1_opt.foreach(u => graph = graph.addEdge(ActiveEdge(u, pubChan)))
+        pubChan.update_2_opt.foreach(u => graph = graph.addEdge(ActiveEdge(u, pubChan)))
         graph
       case None => d.graphWithBalances
     }
@@ -323,7 +323,7 @@ object Validation {
             case Left(_) =>
               // NB: we update the channels because the balances may have changed even if the channel_update is the same.
               val pc1 = pc.applyChannelUpdate(update)
-              val graphWithBalances1 = d.graphWithBalances.addEdge(GraphEdge(u, pc1))
+              val graphWithBalances1 = d.graphWithBalances.addEdge(ActiveEdge(u, pc1))
               d.copy(rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins1)), channels = d.channels + (pc.shortChannelId -> pc1), graphWithBalances = graphWithBalances1)
             case Right(_) =>
               d.copy(rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins1)))
@@ -339,7 +339,7 @@ object Validation {
             case Left(_) =>
               // NB: we update the graph because the balances may have changed even if the channel_update is the same.
               val pc1 = pc.applyChannelUpdate(update)
-              val graphWithBalances1 = d.graphWithBalances.addEdge(GraphEdge(u, pc1))
+              val graphWithBalances1 = d.graphWithBalances.addEdge(ActiveEdge(u, pc1))
               d.copy(channels = d.channels + (pc.shortChannelId -> pc1), graphWithBalances = graphWithBalances1)
             case Right(_) => d
           }
@@ -357,7 +357,7 @@ object Validation {
           val pc1 = pc.applyChannelUpdate(update)
           val graphWithBalances1 = if (u.channelFlags.isEnabled) {
             update.left.foreach(_ => log.info("added local shortChannelId={} public={} to the network graph", u.shortChannelId, publicChannel))
-            d.graphWithBalances.addEdge(GraphEdge(u, pc1))
+            d.graphWithBalances.addEdge(ActiveEdge(u, pc1))
           } else {
             update.left.foreach(_ => log.info("disabled local shortChannelId={} public={} in the network graph", u.shortChannelId, publicChannel))
             d.graphWithBalances.disableEdge(ChannelDesc(u, pc1.ann))
@@ -370,7 +370,7 @@ object Validation {
           db.updateChannel(u)
           // we also need to update the graph
           val pc1 = pc.applyChannelUpdate(update)
-          val graphWithBalances1 = d.graphWithBalances.addEdge(GraphEdge(u, pc1))
+          val graphWithBalances1 = d.graphWithBalances.addEdge(ActiveEdge(u, pc1))
           update.left.foreach(_ => log.info("added local shortChannelId={} public={} to the network graph", u.shortChannelId, publicChannel))
           d.copy(channels = d.channels + (pc.shortChannelId -> pc1), rebroadcast = d.rebroadcast.copy(updates = d.rebroadcast.updates + (u -> origins)), graphWithBalances = graphWithBalances1)
         }
@@ -397,7 +397,7 @@ object Validation {
           val pc1 = pc.applyChannelUpdate(update)
           val graphWithBalances1 = if (u.channelFlags.isEnabled) {
             update.left.foreach(_ => log.info("added local channelId={} public={} to the network graph", pc.channelId, publicChannel))
-            d.graphWithBalances.addEdge(GraphEdge(u, pc1))
+            d.graphWithBalances.addEdge(ActiveEdge(u, pc1))
           } else {
             update.left.foreach(_ => log.info("disabled local channelId={} public={} in the network graph", pc.channelId, publicChannel))
             d.graphWithBalances.disableEdge(ChannelDesc(u, pc1))
@@ -409,7 +409,7 @@ object Validation {
           ctx.system.eventStream.publish(ChannelUpdatesReceived(u :: Nil))
           // we also need to update the graph
           val pc1 = pc.applyChannelUpdate(update)
-          val graphWithBalances1 = d.graphWithBalances.addEdge(GraphEdge(u, pc1))
+          val graphWithBalances1 = d.graphWithBalances.addEdge(ActiveEdge(u, pc1))
           update.left.foreach(_ => log.info("added local channelId={} public={} to the network graph", pc.channelId, publicChannel))
           d.copy(privateChannels = d.privateChannels + (pc.channelId -> pc1), graphWithBalances = graphWithBalances1)
         }
@@ -459,7 +459,7 @@ object Validation {
                 ctx.system.eventStream.publish(ChannelUpdatesReceived(channelUpdates.keys))
                 // We update the graph.
                 val graphWithBalances1 = channelUpdates.keys.foldLeft(d.graphWithBalances) {
-                  case (currentGraph, currentUpdate) if currentUpdate.channelFlags.isEnabled => currentGraph.addEdge(GraphEdge(currentUpdate, pc1))
+                  case (currentGraph, currentUpdate) if currentUpdate.channelFlags.isEnabled => currentGraph.addEdge(ActiveEdge(currentUpdate, pc1))
                   case (currentGraph, _) => currentGraph
                 }
                 d.copy(channels = d.channels + (pc1.shortChannelId -> pc1), prunedChannels = d.prunedChannels - pc1.shortChannelId, rebroadcast = rebroadcast1, graphWithBalances = graphWithBalances1)
@@ -568,7 +568,7 @@ object Validation {
         val pc1 = pc.updateBalances(e.commitments)
         log.debug("public channel balance updated: {}", pc1)
         val update_opt = if (e.commitments.localNodeId == pc1.ann.nodeId1) pc1.update_1_opt else pc1.update_2_opt
-        val graphWithBalances1 = update_opt.map(u => d.graphWithBalances.addEdge(GraphEdge(u, pc1))).getOrElse(d.graphWithBalances)
+        val graphWithBalances1 = update_opt.map(u => d.graphWithBalances.addEdge(ActiveEdge(u, pc1))).getOrElse(d.graphWithBalances)
         (d.channels + (pc.ann.shortChannelId -> pc1), graphWithBalances1)
       case None =>
         (d.channels, d.graphWithBalances)
@@ -578,7 +578,7 @@ object Validation {
         val pc1 = pc.updateBalances(e.commitments)
         log.debug("private channel balance updated: {}", pc1)
         val update_opt = if (e.commitments.localNodeId == pc1.nodeId1) pc1.update_1_opt else pc1.update_2_opt
-        val graphWithBalances2 = update_opt.map(u => graphWithBalances1.addEdge(GraphEdge(u, pc1))).getOrElse(graphWithBalances1)
+        val graphWithBalances2 = update_opt.map(u => graphWithBalances1.addEdge(ActiveEdge(u, pc1))).getOrElse(graphWithBalances1)
         (d.privateChannels + (e.channelId -> pc1), graphWithBalances2)
       case None =>
         (d.privateChannels, graphWithBalances1)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -179,7 +179,7 @@ object Validation {
         // mutable variable is simpler here
         var graph = d.graphWithBalances
         // remove previous private edges
-        graph.removeChannel(ChannelDesc(privateChannel.shortIds.localAlias, privateChannel.nodeId1, privateChannel.nodeId2))
+        graph = graph.removeChannel(ChannelDesc(privateChannel.shortIds.localAlias, privateChannel.nodeId1, privateChannel.nodeId2))
         // add new public edges
         pubChan.update_1_opt.foreach(u => graph = graph.addEdge(GraphEdge(u, pubChan)))
         pubChan.update_2_opt.foreach(u => graph = graph.addEdge(GraphEdge(u, pubChan)))
@@ -280,13 +280,13 @@ object Validation {
       remoteOrigins.foreach(sendDecision(_, GossipDecision.Accepted(n)))
       ctx.system.eventStream.publish(NodeUpdated(n))
       db.updateNode(n)
-      d.copy(nodes = d.nodes + (n.nodeId -> n), rebroadcast = d.rebroadcast.copy(nodes = d.rebroadcast.nodes ++ rebroadcastNode))
+      d.copy(nodes = d.nodes + (n.nodeId -> n), rebroadcast = d.rebroadcast.copy(nodes = d.rebroadcast.nodes ++ rebroadcastNode), graphWithBalances = d.graphWithBalances.addVertex(n))
     } else if (d.channels.values.exists(c => isRelatedTo(c.ann, n.nodeId))) {
       log.debug("added node nodeId={}", n.nodeId)
       remoteOrigins.foreach(sendDecision(_, GossipDecision.Accepted(n)))
       ctx.system.eventStream.publish(NodesDiscovered(n :: Nil))
       db.addNode(n)
-      d.copy(nodes = d.nodes + (n.nodeId -> n), rebroadcast = d.rebroadcast.copy(nodes = d.rebroadcast.nodes ++ rebroadcastNode))
+      d.copy(nodes = d.nodes + (n.nodeId -> n), rebroadcast = d.rebroadcast.copy(nodes = d.rebroadcast.nodes ++ rebroadcastNode), graphWithBalances = d.graphWithBalances.addVertex(n))
     } else if (d.awaiting.keys.exists(c => isRelatedTo(c, n.nodeId))) {
       log.debug("stashing {}", n)
       d.copy(stash = d.stash.copy(nodes = d.stash.nodes + (n -> origins)))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -280,13 +280,13 @@ object Validation {
       remoteOrigins.foreach(sendDecision(_, GossipDecision.Accepted(n)))
       ctx.system.eventStream.publish(NodeUpdated(n))
       db.updateNode(n)
-      d.copy(nodes = d.nodes + (n.nodeId -> n), rebroadcast = d.rebroadcast.copy(nodes = d.rebroadcast.nodes ++ rebroadcastNode), graphWithBalances = d.graphWithBalances.addVertex(n))
+      d.copy(nodes = d.nodes + (n.nodeId -> n), rebroadcast = d.rebroadcast.copy(nodes = d.rebroadcast.nodes ++ rebroadcastNode), graphWithBalances = d.graphWithBalances.addOrUpdateVertex(n))
     } else if (d.channels.values.exists(c => isRelatedTo(c.ann, n.nodeId))) {
       log.debug("added node nodeId={}", n.nodeId)
       remoteOrigins.foreach(sendDecision(_, GossipDecision.Accepted(n)))
       ctx.system.eventStream.publish(NodesDiscovered(n :: Nil))
       db.addNode(n)
-      d.copy(nodes = d.nodes + (n.nodeId -> n), rebroadcast = d.rebroadcast.copy(nodes = d.rebroadcast.nodes ++ rebroadcastNode), graphWithBalances = d.graphWithBalances.addVertex(n))
+      d.copy(nodes = d.nodes + (n.nodeId -> n), rebroadcast = d.rebroadcast.copy(nodes = d.rebroadcast.nodes ++ rebroadcastNode), graphWithBalances = d.graphWithBalances.addOrUpdateVertex(n))
     } else if (d.awaiting.keys.exists(c => isRelatedTo(c, n.nodeId))) {
       log.debug("stashing {}", n)
       d.copy(stash = d.stash.copy(nodes = d.stash.nodes + (n -> origins)))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -27,9 +27,9 @@ import fr.acinq.eclair.io.MessageRelay.RelayAll
 import fr.acinq.eclair.io.{OpenChannelInterceptor, PeerConnection}
 import fr.acinq.eclair.message.OnionMessages.OnionMessageConfig
 import fr.acinq.eclair.payment.relay.Relayer.{AsyncPaymentsParams, RelayFees, RelayParams}
-import fr.acinq.eclair.router.Graph.WeightRatios
+import fr.acinq.eclair.router.Graph.{MessagePath, WeightRatios}
 import fr.acinq.eclair.router.PathFindingExperimentConf
-import fr.acinq.eclair.router.Router.{MultiPartParams, PathFindingConf, RouterConf, SearchBoundaries}
+import fr.acinq.eclair.router.Router.{MessageRouteParams, MultiPartParams, PathFindingConf, RouterConf, SearchBoundaries}
 import fr.acinq.eclair.wire.protocol.{Color, EncodingType, NodeAddress, OnionRoutingPacket}
 import org.scalatest.Tag
 import scodec.bits.{ByteVector, HexStringSyntax}
@@ -200,6 +200,7 @@ object TestConstants {
           ),
           experimentName = "alice-test-experiment",
           experimentPercentage = 100))),
+        messageRouteParams = MessageRouteParams(8, MessagePath.WeightRatios(0.7, 0.1, 0.2, 1.5)),
         balanceEstimateHalfLife = 1 day,
       ),
       socksProxy_opt = None,
@@ -357,6 +358,7 @@ object TestConstants {
           ),
           experimentName = "bob-test-experiment",
           experimentPercentage = 100))),
+        messageRouteParams = MessageRouteParams(9, MessagePath.WeightRatios(0.5, 0.2, 0.3, 3.14)),
         balanceEstimateHalfLife = 1 day,
       ),
       socksProxy_opt = None,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -212,7 +212,8 @@ object TestConstants {
       blockchainWatchdogSources = blockchainWatchdogSources,
       onionMessageConfig = OnionMessageConfig(
         relayPolicy = RelayAll,
-        timeout = 1 minute,
+        minIntermediateHops = 9,
+        timeout = 200 millis,
         maxAttempts = 2,
       ),
       purgeInvoicesInterval = None
@@ -368,7 +369,8 @@ object TestConstants {
       blockchainWatchdogSources = blockchainWatchdogSources,
       onionMessageConfig = OnionMessageConfig(
         relayPolicy = RelayAll,
-        timeout = 1 minute,
+        minIntermediateHops = 8,
+        timeout = 100 millis,
         maxAttempts = 2,
       ),
       purgeInvoicesInterval = None

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
@@ -58,7 +58,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
   test("try to reach unknown node") {
     val alice = new EclairImpl(nodes("A"))
     val probe = TestProbe()
-    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Left(nodes("B").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(Nil), Left(nodes("B").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     val result = probe.expectMsgType[SendOnionMessageResponse]
     assert(!result.sent)
   }
@@ -70,7 +70,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("B").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Left(nodes("B").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(Nil), Left(nodes("B").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
     eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }
@@ -96,13 +96,13 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("B").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Left(nodes("B").nodeParams.nodeId), expectsReply = true, hex"3f00").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(Nil), Left(nodes("B").nodeParams.nodeId), expectsReply = true, hex"3f00").pipeTo(probe.ref)
 
     val recv = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
     assert(recv.finalPayload.records.get[ReplyPath].nonEmpty)
     val replyPath = recv.finalPayload.records.get[ReplyPath].get.blindedRoute
     assert(replyPath.introductionNodeId == nodes("B").nodeParams.nodeId)
-    bob.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Right(replyPath), expectsReply = false, hex"1d01ab")
+    bob.sendOnionMessage(Some(Nil), Right(replyPath), expectsReply = false, hex"1d01ab")
 
     val res = probe.expectMsgType[SendOnionMessageResponse]
     assert(res.failureMessage.isEmpty)
@@ -115,7 +115,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("A").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    bob.sendOnionMessage(Some(nodes("A").nodeParams.nodeId :: Nil), Left(nodes("A").nodeParams.nodeId), expectsReply = true, hex"3f00").pipeTo(probe.ref)
+    bob.sendOnionMessage(Some(Nil), Left(nodes("A").nodeParams.nodeId), expectsReply = true, hex"3f00").pipeTo(probe.ref)
 
     val recv = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
     assert(recv.finalPayload.records.get[ReplyPath].nonEmpty)
@@ -131,7 +131,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("A").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    eve.sendOnionMessage(Some(nodes("A").nodeParams.nodeId :: Nil), Left(nodes("A").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
+    eve.sendOnionMessage(Some(Nil), Left(nodes("A").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
     eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }
@@ -143,7 +143,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("A").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    fabrice.sendOnionMessage(Some(nodes("A").nodeParams.nodeId :: Nil), Left(nodes("A").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
+    fabrice.sendOnionMessage(Some(Nil), Left(nodes("A").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
     eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }
@@ -166,7 +166,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
@@ -183,7 +183,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, encodedBytes).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, encodedBytes).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
@@ -200,7 +200,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, encodedBytes).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, encodedBytes).pipeTo(probe.ref)
     assert(!probe.expectMsgType[SendOnionMessageResponse].sent)
 
     eventListener.expectNoMessage()
@@ -213,7 +213,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Some(nodes("E").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("E").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     eventListener.expectNoMessage()
@@ -226,7 +226,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Some(nodes("F").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("F").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     eventListener.expectNoMessage()
@@ -292,7 +292,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Some(nodes("E").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("E").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
@@ -305,7 +305,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Some(nodes("F").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("F").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     eventListener.expectNoMessage()
@@ -317,7 +317,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val eventListener = TestProbe()
 
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Some(nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
     eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
 
@@ -369,7 +369,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
     waitEventStreamSynced(nodes("C").system.eventStream)
-    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"7300").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"7300").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
@@ -58,7 +58,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
   test("try to reach unknown node") {
     val alice = new EclairImpl(nodes("A"))
     val probe = TestProbe()
-    alice.sendOnionMessage(Nil, Left(nodes("B").nodeParams.nodeId), None, ByteVector.empty).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Left(nodes("B").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     val result = probe.expectMsgType[SendOnionMessageResponse]
     assert(!result.sent)
   }
@@ -70,7 +70,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("B").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Nil, Left(nodes("B").nodeParams.nodeId), None, ByteVector.empty).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Left(nodes("B").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
     eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }
@@ -85,7 +85,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val blindedRoute = buildRoute(randomKey(), Seq(IntermediateNode(nodes("A").nodeParams.nodeId), IntermediateNode(nodes("B").nodeParams.nodeId), IntermediateNode(nodes("B").nodeParams.nodeId)), Recipient(nodes("B").nodeParams.nodeId, None))
     assert(blindedRoute.introductionNodeId == nodes("A").nodeParams.nodeId)
 
-    alice.sendOnionMessage(Nil, Right(blindedRoute), None, ByteVector.empty).pipeTo(probe.ref)
+    alice.sendOnionMessage(None, Right(blindedRoute), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
     eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }
@@ -96,11 +96,13 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("B").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Nil, Left(nodes("B").nodeParams.nodeId), Some(Seq(nodes("A").nodeParams.nodeId)), hex"3f00").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Left(nodes("B").nodeParams.nodeId), expectsReply = true, hex"3f00").pipeTo(probe.ref)
 
     val recv = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
     assert(recv.finalPayload.records.get[ReplyPath].nonEmpty)
-    bob.sendOnionMessage(Nil, Right(recv.finalPayload.records.get[ReplyPath].get.blindedRoute), None, hex"1d01ab")
+    val replyPath = recv.finalPayload.records.get[ReplyPath].get.blindedRoute
+    assert(replyPath.introductionNodeId == nodes("B").nodeParams.nodeId)
+    bob.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: Nil), Right(replyPath), expectsReply = false, hex"1d01ab")
 
     val res = probe.expectMsgType[SendOnionMessageResponse]
     assert(res.failureMessage.isEmpty)
@@ -113,7 +115,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("A").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    bob.sendOnionMessage(Nil, Left(nodes("A").nodeParams.nodeId), Some(Seq(nodes("B").nodeParams.nodeId)), hex"3f00").pipeTo(probe.ref)
+    bob.sendOnionMessage(Some(nodes("A").nodeParams.nodeId :: Nil), Left(nodes("A").nodeParams.nodeId), expectsReply = true, hex"3f00").pipeTo(probe.ref)
 
     val recv = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
     assert(recv.finalPayload.records.get[ReplyPath].nonEmpty)
@@ -129,7 +131,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("A").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    eve.sendOnionMessage(Nil, Left(nodes("A").nodeParams.nodeId), None, ByteVector.empty).pipeTo(probe.ref)
+    eve.sendOnionMessage(Some(nodes("A").nodeParams.nodeId :: Nil), Left(nodes("A").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
     eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }
@@ -141,7 +143,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("A").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    fabrice.sendOnionMessage(Nil, Left(nodes("A").nodeParams.nodeId), None, ByteVector.empty).pipeTo(probe.ref)
+    fabrice.sendOnionMessage(Some(nodes("A").nodeParams.nodeId :: Nil), Left(nodes("A").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
     eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }
@@ -164,7 +166,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(nodes("B").nodeParams.nodeId :: Nil, Left(nodes("C").nodeParams.nodeId), None, hex"710301020375020102").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
@@ -181,7 +183,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(nodes("B").nodeParams.nodeId :: Nil, Left(nodes("C").nodeParams.nodeId), None, encodedBytes).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, encodedBytes).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
@@ -198,7 +200,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(nodes("B").nodeParams.nodeId :: Nil, Left(nodes("C").nodeParams.nodeId), None, encodedBytes).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, encodedBytes).pipeTo(probe.ref)
     assert(!probe.expectMsgType[SendOnionMessageResponse].sent)
 
     eventListener.expectNoMessage()
@@ -211,7 +213,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(nodes("E").nodeParams.nodeId :: Nil, Left(nodes("C").nodeParams.nodeId), None, hex"710301020375020102").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("E").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     eventListener.expectNoMessage()
@@ -224,7 +226,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(nodes("F").nodeParams.nodeId :: Nil, Left(nodes("C").nodeParams.nodeId), None, hex"710301020375020102").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("F").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     eventListener.expectNoMessage()
@@ -290,7 +292,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(nodes("E").nodeParams.nodeId :: Nil, Left(nodes("C").nodeParams.nodeId), None, hex"710301020375020102").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("E").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
@@ -303,7 +305,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(nodes("F").nodeParams.nodeId :: Nil, Left(nodes("C").nodeParams.nodeId), None, hex"710301020375020102").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("F").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"710301020375020102").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     eventListener.expectNoMessage()
@@ -315,7 +317,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val eventListener = TestProbe()
 
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Nil, Left(nodes("C").nodeParams.nodeId), None, ByteVector.empty).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
     eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
 
@@ -367,7 +369,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val eventListener = TestProbe()
     nodes("C").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
     waitEventStreamSynced(nodes("C").system.eventStream)
-    alice.sendOnionMessage(nodes("B").nodeParams.nodeId :: Nil, Left(nodes("C").nodeParams.nodeId), None, hex"7300").pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(nodes("B").nodeParams.nodeId :: nodes("C").nodeParams.nodeId :: Nil), Left(nodes("C").nodeParams.nodeId), expectsReply = false, hex"7300").pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
 
     val r = eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/MessageIntegrationSpec.scala
@@ -154,7 +154,7 @@ class MessageIntegrationSpec extends IntegrationSpec {
     val probe = TestProbe()
     val eventListener = TestProbe()
     nodes("F").system.eventStream.subscribe(eventListener.ref, classOf[OnionMessages.ReceiveMessage])
-    alice.sendOnionMessage(Nil, Left(nodes("F").nodeParams.nodeId), None, ByteVector.empty).pipeTo(probe.ref)
+    alice.sendOnionMessage(Some(Nil), Left(nodes("F").nodeParams.nodeId), expectsReply = false, ByteVector.empty).pipeTo(probe.ref)
     assert(probe.expectMsgType[SendOnionMessageResponse].sent)
     eventListener.expectMsgType[OnionMessages.ReceiveMessage](max = 60 seconds)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
@@ -102,7 +102,7 @@ object MinimalNodeFixture extends Assertions with Eventually with IntegrationPat
     val paymentFactory = PaymentInitiator.SimplePaymentFactory(nodeParams, router, register)
     val paymentInitiator = system.actorOf(PaymentInitiator.props(nodeParams, paymentFactory), "payment-initiator")
     val channels = nodeParams.db.channels.listLocalChannels()
-    val postman = system.spawn(Behaviors.supervise(Postman(nodeParams, switchboard.toTyped, offerManager)).onFailure(typed.SupervisorStrategy.restart), name = "postman")
+    val postman = system.spawn(Behaviors.supervise(Postman(nodeParams, switchboard.toTyped, router.toTyped, offerManager)).onFailure(typed.SupervisorStrategy.restart), name = "postman")
     switchboard ! Switchboard.Init(channels)
     relayer ! PostRestartHtlcCleaner.Init(channels)
     readyListener.expectMsgAllOf(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/payment/OfferPaymentSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/payment/OfferPaymentSpec.scala
@@ -122,7 +122,7 @@ class OfferPaymentSpec extends FixtureSpec with IntegrationPatience {
     val handler = recipient.system.spawnAnonymous(offerHandler(amount, routes))
     recipient.offerManager ! OfferManager.RegisterOffer(offer, recipient.nodeParams.privateKey, None, handler)
     val offerPayment = payer.system.spawnAnonymous(OfferPayment(payer.nodeParams, payer.postman, payer.paymentInitiator))
-    val sendPaymentConfig = OfferPayment.SendPaymentConfig(None, maxAttempts = 1, payer.routeParams, blocking = true)
+    val sendPaymentConfig = OfferPayment.SendPaymentConfig(None, connectDirectly = false, maxAttempts = 1, payer.routeParams, blocking = true)
     offerPayment ! OfferPayment.PayOffer(sender.ref, offer, amount, 1, sendPaymentConfig)
     (offer, sender.expectMsgType[PaymentEvent])
   }
@@ -141,7 +141,7 @@ class OfferPaymentSpec extends FixtureSpec with IntegrationPatience {
     val handler = recipient.system.spawnAnonymous(offerHandler(amount, routes))
     recipient.offerManager ! OfferManager.RegisterOffer(offer, recipientKey, Some(pathId), handler)
     val offerPayment = payer.system.spawnAnonymous(OfferPayment(payer.nodeParams, payer.postman, payer.paymentInitiator))
-    val sendPaymentConfig = OfferPayment.SendPaymentConfig(None, maxAttempts = 1, payer.routeParams, blocking = true)
+    val sendPaymentConfig = OfferPayment.SendPaymentConfig(None, connectDirectly = false, maxAttempts = 1, payer.routeParams, blocking = true)
     offerPayment ! OfferPayment.PayOffer(sender.ref, offer, amount, 1, sendPaymentConfig)
     (offer, sender.expectMsgType[PaymentEvent])
   }
@@ -155,7 +155,7 @@ class OfferPaymentSpec extends FixtureSpec with IntegrationPatience {
     val handler = recipient.system.spawnAnonymous(offerHandler(recipientAmount, routes))
     recipient.offerManager ! OfferManager.RegisterOffer(offer, recipient.nodeParams.privateKey, None, handler)
     val offerPayment = payer.system.spawnAnonymous(OfferPayment(payer.nodeParams, payer.postman, paymentInterceptor.ref))
-    val sendPaymentConfig = OfferPayment.SendPaymentConfig(None, maxAttempts = 1, payer.routeParams, blocking = true)
+    val sendPaymentConfig = OfferPayment.SendPaymentConfig(None, connectDirectly = false, maxAttempts = 1, payer.routeParams, blocking = true)
     offerPayment ! OfferPayment.PayOffer(sender.ref, offer, recipientAmount, 1, sendPaymentConfig)
     // We intercept the payment and modify it to use a different amount.
     val payment = paymentInterceptor.expectMsgType[SendPaymentToNode]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/send/OfferPaymentSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/send/OfferPaymentSpec.scala
@@ -24,6 +24,7 @@ import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 import fr.acinq.eclair.crypto.Sphinx.RouteBlinding
 import fr.acinq.eclair.message.OnionMessages.Recipient
+import fr.acinq.eclair.message.OnionMessages.RoutingStrategy.FindRoute
 import fr.acinq.eclair.message.Postman
 import fr.acinq.eclair.payment.send.OfferPayment._
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentToNode
@@ -66,7 +67,7 @@ class OfferPaymentSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     val offer = Offer(None, "amountless offer", merchantKey.publicKey, Features.empty, nodeParams.chainHash)
     offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, connectDirectly = false, 1, routeParams, blocking = false))
-    val Postman.SendMessage(Recipient(recipientId, _, _, _), None, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
+    val Postman.SendMessage(Recipient(recipientId, _, _, _), FindRoute, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
     assert(recipientId == merchantKey.publicKey)
     assert(message.get[OnionMessagePayloadTlv.InvoiceRequest].nonEmpty)
     assert(expectsReply)
@@ -91,7 +92,7 @@ class OfferPaymentSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     val offer = Offer(None, "amountless offer", merchantKey.publicKey, Features.empty, nodeParams.chainHash)
     offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, connectDirectly = false, 1, routeParams, blocking = false))
     for (_ <- 1 to nodeParams.onionMessageConfig.maxAttempts) {
-      val Postman.SendMessage(Recipient(recipientId, _, _, _), None, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
+      val Postman.SendMessage(Recipient(recipientId, _, _, _), FindRoute, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
       assert(recipientId == merchantKey.publicKey)
       assert(message.get[OnionMessagePayloadTlv.InvoiceRequest].nonEmpty)
       assert(expectsReply)
@@ -113,7 +114,7 @@ class OfferPaymentSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     val offer = Offer(None, "amountless offer", merchantKey.publicKey, Features.empty, nodeParams.chainHash)
     offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, connectDirectly = false, 1, routeParams, blocking = false))
-    val Postman.SendMessage(Recipient(recipientId, _, _, _), None, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
+    val Postman.SendMessage(Recipient(recipientId, _, _, _), FindRoute, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
     assert(recipientId == merchantKey.publicKey)
     assert(message.get[OnionMessagePayloadTlv.InvoiceRequest].nonEmpty)
     assert(expectsReply)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/send/OfferPaymentSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/send/OfferPaymentSpec.scala
@@ -65,7 +65,7 @@ class OfferPaymentSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     val merchantKey = randomKey()
 
     val offer = Offer(None, "amountless offer", merchantKey.publicKey, Features.empty, nodeParams.chainHash)
-    offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, 1, routeParams, blocking = false))
+    offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, connectDirectly = false, 1, routeParams, blocking = false))
     val Postman.SendMessage(Recipient(recipientId, _, _, _), None, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
     assert(recipientId == merchantKey.publicKey)
     assert(message.get[OnionMessagePayloadTlv.InvoiceRequest].nonEmpty)
@@ -89,7 +89,7 @@ class OfferPaymentSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     val merchantKey = randomKey()
 
     val offer = Offer(None, "amountless offer", merchantKey.publicKey, Features.empty, nodeParams.chainHash)
-    offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, 1, routeParams, blocking = false))
+    offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, connectDirectly = false, 1, routeParams, blocking = false))
     for (_ <- 1 to nodeParams.onionMessageConfig.maxAttempts) {
       val Postman.SendMessage(Recipient(recipientId, _, _, _), None, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
       assert(recipientId == merchantKey.publicKey)
@@ -112,7 +112,7 @@ class OfferPaymentSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     val merchantKey = randomKey()
 
     val offer = Offer(None, "amountless offer", merchantKey.publicKey, Features.empty, nodeParams.chainHash)
-    offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, 1, routeParams, blocking = false))
+    offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, connectDirectly = false, 1, routeParams, blocking = false))
     val Postman.SendMessage(Recipient(recipientId, _, _, _), None, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
     assert(recipientId == merchantKey.publicKey)
     assert(message.get[OnionMessagePayloadTlv.InvoiceRequest].nonEmpty)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/send/OfferPaymentSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/send/OfferPaymentSpec.scala
@@ -66,9 +66,10 @@ class OfferPaymentSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     val offer = Offer(None, "amountless offer", merchantKey.publicKey, Features.empty, nodeParams.chainHash)
     offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, 1, routeParams, blocking = false))
-    val Postman.SendMessage(_, Recipient(recipientId, _, _, _), _, message, replyTo, _) = postman.expectMessageType[Postman.SendMessage]
+    val Postman.SendMessage(Recipient(recipientId, _, _, _), None, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
     assert(recipientId == merchantKey.publicKey)
     assert(message.get[OnionMessagePayloadTlv.InvoiceRequest].nonEmpty)
+    assert(expectsReply)
     val Right(invoiceRequest) = InvoiceRequest.validate(message.get[OnionMessagePayloadTlv.InvoiceRequest].get.tlvs)
 
     val preimage = randomBytes32()
@@ -90,9 +91,10 @@ class OfferPaymentSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     val offer = Offer(None, "amountless offer", merchantKey.publicKey, Features.empty, nodeParams.chainHash)
     offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, 1, routeParams, blocking = false))
     for (_ <- 1 to nodeParams.onionMessageConfig.maxAttempts) {
-      val Postman.SendMessage(_, Recipient(recipientId, _, _, _), _, message, replyTo, _) = postman.expectMessageType[Postman.SendMessage]
+      val Postman.SendMessage(Recipient(recipientId, _, _, _), None, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
       assert(recipientId == merchantKey.publicKey)
       assert(message.get[OnionMessagePayloadTlv.InvoiceRequest].nonEmpty)
+      assert(expectsReply)
       val Right(invoiceRequest) = InvoiceRequest.validate(message.get[OnionMessagePayloadTlv.InvoiceRequest].get.tlvs)
       assert(invoiceRequest.isValid)
       assert(invoiceRequest.offer == offer)
@@ -111,9 +113,10 @@ class OfferPaymentSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     val offer = Offer(None, "amountless offer", merchantKey.publicKey, Features.empty, nodeParams.chainHash)
     offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, 1, routeParams, blocking = false))
-    val Postman.SendMessage(_, Recipient(recipientId, _, _, _), _, message, replyTo, _) = postman.expectMessageType[Postman.SendMessage]
+    val Postman.SendMessage(Recipient(recipientId, _, _, _), None, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
     assert(recipientId == merchantKey.publicKey)
     assert(message.get[OnionMessagePayloadTlv.InvoiceRequest].nonEmpty)
+    assert(expectsReply)
     val Right(invoiceRequest) = InvoiceRequest.validate(message.get[OnionMessagePayloadTlv.InvoiceRequest].get.tlvs)
 
     val preimage = randomBytes32()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
@@ -19,7 +19,7 @@ package fr.acinq.eclair.router
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{Satoshi, SatoshiLong}
 import fr.acinq.eclair.payment.Invoice
-import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
+import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, ActiveEdge}
 import fr.acinq.eclair.router.Router.{ChannelDesc, HopRelayParams}
 import fr.acinq.eclair.{CltvExpiryDelta, MilliSatoshiLong, ShortChannelId, TimestampSecond, randomKey}
 import org.scalactic.Tolerance.convertNumericToPlusOrMinusWrapper
@@ -35,13 +35,13 @@ class BalanceEstimateSpec extends AnyFunSuite {
       balance.high <= balance.maxCapacity
   }
 
-  def makeEdge(nodeId1: PublicKey, nodeId2: PublicKey, channelId: Long, capacity: Satoshi): GraphEdge =
-    GraphEdge(
+  def makeEdge(nodeId1: PublicKey, nodeId2: PublicKey, channelId: Long, capacity: Satoshi): ActiveEdge =
+    ActiveEdge(
       ChannelDesc(ShortChannelId(channelId), nodeId1, nodeId2),
       HopRelayParams.FromHint(Invoice.ExtraEdge(nodeId1, nodeId2, ShortChannelId(channelId), 0 msat, 0, CltvExpiryDelta(0), 0 msat, None)),
       capacity, None)
 
-  def makeEdge(channelId: Long, capacity: Satoshi): GraphEdge =
+  def makeEdge(channelId: Long, capacity: Satoshi): ActiveEdge =
     makeEdge(randomKey().publicKey, randomKey().publicKey, channelId, capacity)
 
   test("no balance information") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRouterIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/ChannelRouterIntegrationSpec.scala
@@ -6,7 +6,7 @@ import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{WatchExternalChannelSpent
 import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
 import fr.acinq.eclair.channel.{CMD_CLOSE, DATA_NORMAL}
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
-import fr.acinq.eclair.router.Graph.GraphStructure.GraphEdge
+import fr.acinq.eclair.router.Graph.GraphStructure.ActiveEdge
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.wire.protocol.{AnnouncementSignatures, ChannelUpdate, Shutdown}
 import fr.acinq.eclair.{BlockHeight, TestKitBaseClass}
@@ -82,7 +82,7 @@ class ChannelRouterIntegrationSpec extends TestKitBaseClass with FixtureAnyFunSu
 
     // router graph contains a single channel
     assert(router.stateData.graphWithBalances.graph.vertexSet() == Set(aliceNodeId, bobNodeId))
-    assert(router.stateData.graphWithBalances.graph.edgeSet().toSet == Set(GraphEdge(aliceInitialChannelUpdate, privateChannel), GraphEdge(bobChannelUpdate1, privateChannel)))
+    assert(router.stateData.graphWithBalances.graph.edgeSet().toSet == Set(ActiveEdge(aliceInitialChannelUpdate, privateChannel), ActiveEdge(bobChannelUpdate1, privateChannel)))
 
     if (testTags.contains(ChannelStateTestsTags.ChannelsPublic)) {
       // this is a public channel
@@ -151,7 +151,7 @@ class ChannelRouterIntegrationSpec extends TestKitBaseClass with FixtureAnyFunSu
       // router graph contains a single channel
       assert(router.stateData.graphWithBalances.graph.vertexSet() == Set(aliceNodeId, bobNodeId))
       assert(router.stateData.graphWithBalances.graph.edgeSet().size == 2)
-      assert(router.stateData.graphWithBalances.graph.edgeSet().toSet == Set(GraphEdge(aliceChannelUpdate2, publicChannel), GraphEdge(bobChannelUpdate2, publicChannel)))
+      assert(router.stateData.graphWithBalances.graph.edgeSet().toSet == Set(ActiveEdge(aliceChannelUpdate2, publicChannel), ActiveEdge(bobChannelUpdate2, publicChannel)))
     } else {
       // this is a private channel
       // funding tx reaches 6 blocks, no announcements are exchanged because the channel is private
@@ -166,7 +166,7 @@ class ChannelRouterIntegrationSpec extends TestKitBaseClass with FixtureAnyFunSu
 
       // router graph contains a single channel
       assert(router.stateData.graphWithBalances.graph.vertexSet() == Set(aliceNodeId, bobNodeId))
-      assert(router.stateData.graphWithBalances.graph.edgeSet().toSet == Set(GraphEdge(aliceInitialChannelUpdate, privateChannel), GraphEdge(bobChannelUpdate1, privateChannel)))
+      assert(router.stateData.graphWithBalances.graph.edgeSet().toSet == Set(ActiveEdge(aliceInitialChannelUpdate, privateChannel), ActiveEdge(bobChannelUpdate1, privateChannel)))
     }
     // channel closes
     channels.alice ! CMD_CLOSE(TestProbe().ref, scriptPubKey = None, feerates = None)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
@@ -23,7 +23,7 @@ import fr.acinq.eclair.router.Announcements.makeNodeAnnouncement
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
 import fr.acinq.eclair.router.Graph.{HeuristicsConstants, WeightRatios, breadthFirstSearch, yenKshortestPaths}
 import fr.acinq.eclair.router.RouteCalculationSpec._
-import fr.acinq.eclair.router.Router.ChannelDesc
+import fr.acinq.eclair.router.Router.{ChannelDesc, MessageRoute, MessageRouteNotFound}
 import fr.acinq.eclair.wire.protocol.Color
 import fr.acinq.eclair.{BlockHeight, FeatureSupport, Features, MilliSatoshiLong, ShortChannelId, randomKey}
 import org.scalactic.Tolerance.convertNumericToPlusOrMinusWrapper
@@ -400,10 +400,10 @@ class GraphSpec extends AnyFunSuite {
     val annE = makeNodeAnnouncement(priv_e, "E", Color(0, 0, 0), Nil, Features.empty)
     val annERelay = makeNodeAnnouncement(priv_e, "E", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional))
 
-    assert(breadthFirstSearch(graph, Map(b -> annBRelay, c -> annCRelay, d -> annD, e -> annE), a, d, Set.empty, Features(Features.OnionMessages -> FeatureSupport.Mandatory)).contains(Seq(a, b, c, d)))
-    assert(breadthFirstSearch(graph, Map(b -> annBRelay, c -> annCRelay, d -> annD, e -> annERelay), a, d, Set.empty, Features(Features.OnionMessages -> FeatureSupport.Mandatory)).contains(Seq(a, e, d)))
-    assert(breadthFirstSearch(graph, Map(b -> annBRelay, c -> annCRelay, d -> annD, e -> annERelay), a, d, Set(e), Features(Features.OnionMessages -> FeatureSupport.Mandatory)).contains(Seq(a, b, c, d)))
-    assert(breadthFirstSearch(graph, Map(b -> annBRelay, c -> annCRelay, d -> annD, e -> annE), a, a, Set.empty, Features(Features.OnionMessages -> FeatureSupport.Mandatory)).contains(Seq(a)))
-    assert(breadthFirstSearch(graph, Map(b -> annBRelay, c -> annCRelay, d -> annD, e -> annE), a, f, Set.empty, Features(Features.OnionMessages -> FeatureSupport.Mandatory)).isEmpty)
+    assert(breadthFirstSearch(graph, Map(b -> annBRelay, c -> annCRelay, d -> annD, e -> annE), a, d, Set.empty, Features(Features.OnionMessages -> FeatureSupport.Mandatory)) == MessageRoute(Seq(b, c), d))
+    assert(breadthFirstSearch(graph, Map(b -> annBRelay, c -> annCRelay, d -> annD, e -> annERelay), a, d, Set.empty, Features(Features.OnionMessages -> FeatureSupport.Mandatory)) == MessageRoute(Seq(e), d))
+    assert(breadthFirstSearch(graph, Map(b -> annBRelay, c -> annCRelay, d -> annD, e -> annERelay), a, d, Set(e), Features(Features.OnionMessages -> FeatureSupport.Mandatory)) == MessageRoute(Seq(b, c), d))
+    assert(breadthFirstSearch(graph, Map(b -> annBRelay, c -> annCRelay, d -> annD, e -> annE), a, a, Set.empty, Features(Features.OnionMessages -> FeatureSupport.Mandatory)) == MessageRoute(Nil, a))
+    assert(breadthFirstSearch(graph, Map(b -> annBRelay, c -> annCRelay, d -> annD, e -> annE), a, f, Set.empty, Features(Features.OnionMessages -> FeatureSupport.Mandatory)) == MessageRouteNotFound(f))
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
@@ -61,15 +61,15 @@ class GraphSpec extends AnyFunSuite {
 
   test("instantiate a graph, with vertices and then add edges") {
     val graph = DirectedGraph(a)
-      .addVertex(annB)
-      .addVertex(annC)
-      .addVertex(annD)
-      .addVertex(annE)
+      .addOrUpdateVertex(annB)
+      .addOrUpdateVertex(annC)
+      .addOrUpdateVertex(annD)
+      .addOrUpdateVertex(annE)
 
     assert(graph.containsVertex(a) && graph.containsVertex(e))
     assert(graph.vertexSet().size == 5)
 
-    val otherGraph = graph.addVertex(annA) // adding the same vertex twice!
+    val otherGraph = graph.addOrUpdateVertex(annA) // adding the same vertex twice!
     assert(otherGraph.vertexSet().size == 5)
 
     // add some edges to the graph
@@ -407,11 +407,11 @@ class GraphSpec extends AnyFunSuite {
       makeEdge(4L, e, a, 7 msat, 7, capacity = 1000 sat, minHtlc = 700 msat, maxHtlc = Some(800 msat)),
       makeEdge(5L, d, e, 8 msat, 8, capacity = 1000 sat, minHtlc = 800 msat, maxHtlc = Some(900 msat)),
       makeEdge(5L, e, d, 9 msat, 9, capacity = 1000 sat, minHtlc = 900 msat, maxHtlc = Some(1000 msat)),
-    )).addVertex(makeNodeAnnouncement(priv_a, "A", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional)))
-      .addVertex(makeNodeAnnouncement(priv_b, "B", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional)))
-      .addVertex(makeNodeAnnouncement(priv_c, "C", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional)))
-      .addVertex(makeNodeAnnouncement(priv_d, "D", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional)))
-      .addVertex(makeNodeAnnouncement(priv_e, "E", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional)))
+    )).addOrUpdateVertex(makeNodeAnnouncement(priv_a, "A", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional)))
+      .addOrUpdateVertex(makeNodeAnnouncement(priv_b, "B", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional)))
+      .addOrUpdateVertex(makeNodeAnnouncement(priv_c, "C", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional)))
+      .addOrUpdateVertex(makeNodeAnnouncement(priv_d, "D", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional)))
+      .addOrUpdateVertex(makeNodeAnnouncement(priv_e, "E", Color(0, 0, 0), Nil, Features(Features.OnionMessages -> FeatureSupport.Optional)))
 
     {
       // All nodes can relay messages, same weight for each channel.
@@ -424,8 +424,8 @@ class GraphSpec extends AnyFunSuite {
       // Source and target don't relay messages but they can still emit and receive.
       val boundaries = (w: MessagePath.RichWeight) => w.length <= 8
       val wr = MessagePath.WeightRatios(1.0, 0.0, 0.0, 1.0)
-      val g = graph.addVertex(makeNodeAnnouncement(priv_a, "A", Color(0, 0, 0), Nil, Features.empty))
-        .addVertex(makeNodeAnnouncement(priv_d, "D", Color(0, 0, 0), Nil, Features.empty))
+      val g = graph.addOrUpdateVertex(makeNodeAnnouncement(priv_a, "A", Color(0, 0, 0), Nil, Features.empty))
+        .addOrUpdateVertex(makeNodeAnnouncement(priv_d, "D", Color(0, 0, 0), Nil, Features.empty))
       val Some(path) = MessagePath.dijkstraMessagePath(g, a, d, Set.empty, boundaries, BlockHeight(793397), wr)
       assert(path.map(_.shortChannelId.toLong) == Seq(4, 5))
     }
@@ -433,7 +433,7 @@ class GraphSpec extends AnyFunSuite {
       // E doesn't relay messages.
       val boundaries = (w: MessagePath.RichWeight) => w.length <= 8
       val wr = MessagePath.WeightRatios(1.0, 0.0, 0.0, 1.0)
-      val g = graph.addVertex(makeNodeAnnouncement(priv_e, "E", Color(0, 0, 0), Nil, Features.empty))
+      val g = graph.addOrUpdateVertex(makeNodeAnnouncement(priv_e, "E", Color(0, 0, 0), Nil, Features.empty))
       val Some(path) = MessagePath.dijkstraMessagePath(g, a, d, Set.empty, boundaries, BlockHeight(793397), wr)
       assert(path.map(_.shortChannelId.toLong) == Seq(1, 2, 3))
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -326,7 +326,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
     val g = DirectedGraph(List(
       makeEdge(2L, b, c, 0 msat, 0),
       makeEdge(4L, c, d, 0 msat, 0)
-    )).addVertex(annA).addVertex(annE)
+    )).addOrUpdateVertex(annA).addOrUpdateVertex(annE)
 
     assert(findRoute(g, a, d, DEFAULT_AMOUNT_MSAT, DEFAULT_MAX_FEE, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = BlockHeight(400000)) == Failure(RouteNotFound))
     assert(findRoute(g, b, e, DEFAULT_AMOUNT_MSAT, DEFAULT_MAX_FEE, numRoutes = 1, routeParams = DEFAULT_ROUTE_PARAMS, currentBlockHeight = BlockHeight(400000)) == Failure(RouteNotFound))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouteCalculationSpec.scala
@@ -927,7 +927,7 @@ class RouteCalculationSpec extends AnyFunSuite with ParallelTestExecution {
       )
     )
 
-    val g = DirectedGraph.makeGraph(updates, Map.empty)
+    val g = DirectedGraph.makeGraph(updates, Seq.empty)
     val params = DEFAULT_ROUTE_PARAMS
       .modify(_.boundaries.maxCltv).setTo(CltvExpiryDelta(1008))
       .modify(_.heuristics).setTo(Left(WeightRatios(baseFactor = 0, cltvDeltaFactor = 0.15, ageFactor = 0.35, capacityFactor = 0.5, hopCost = RelayFees(0 msat, 0))))

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Message.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Message.scala
@@ -46,19 +46,21 @@ trait Message {
       "recipientNode".as[PublicKey](publicKeyUnmarshaller).?,
       "recipientBlindedRoute".as[Sphinx.RouteBlinding.BlindedRoute](blindedRouteUnmarshaller).?,
       "intermediateNodes".as[List[PublicKey]](pubkeyListUnmarshaller).?,
-      "replyPath".as[List[PublicKey]](pubkeyListUnmarshaller).?,
+      "expectsReply".as[Boolean],
       "content".as[ByteVector](bytesUnmarshaller)) {
-      case (Some(recipientNode), None, intermediateNodes, replyPath, userCustomContent) =>
+      case (Some(recipientNode), None, intermediateNodes_opt, expectsReply, userCustomContent) =>
         complete(
-          eclairApi.sendOnionMessage(intermediateNodes.getOrElse(Nil),
+          eclairApi.sendOnionMessage(
+            intermediateNodes_opt,
             Left(recipientNode),
-            replyPath,
+            expectsReply,
             userCustomContent))
-      case (None, Some(recipientBlindedRoute), intermediateNodes, replyPath, userCustomContent) =>
+      case (None, Some(recipientBlindedRoute), intermediateNodes_opt, expectsReply, userCustomContent) =>
         complete(
-          eclairApi.sendOnionMessage(intermediateNodes.getOrElse(Nil),
+          eclairApi.sendOnionMessage(
+            intermediateNodes_opt,
             Right(recipientBlindedRoute),
-            replyPath,
+            expectsReply,
             userCustomContent))
       case (None, None, _, _, _) =>
         reject(MalformedFormFieldRejection("recipientNode", "You must provide recipientNode or recipientBlindedRoute"))

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Payment.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Payment.scala
@@ -104,11 +104,11 @@ trait Payment {
   }
 
   val payOffer: Route = postRequest("payoffer") { implicit t =>
-    formFields(offerFormParam, amountMsatFormParam, "quantity".as[Long].?, "maxAttempts".as[Int].?, "maxFeeFlatSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?, "pathFindingExperimentName".?, "blocking".as[Boolean].?) {
-      case (offer, amountMsat, quantity_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, externalId_opt, pathFindingExperimentName_opt, blocking_opt) =>
+    formFields(offerFormParam, amountMsatFormParam, "quantity".as[Long].?, "maxAttempts".as[Int].?, "maxFeeFlatSat".as[Satoshi].?, "maxFeePct".as[Double].?, "externalId".?, "pathFindingExperimentName".?, "connectDirectly".as[Boolean].?, "blocking".as[Boolean].?) {
+      case (offer, amountMsat, quantity_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, externalId_opt, pathFindingExperimentName_opt, connectDirectly, blocking_opt) =>
         blocking_opt match {
-          case Some(true) => complete(eclairApi.payOfferBlocking(offer, amountMsat, quantity_opt.getOrElse(1), externalId_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, pathFindingExperimentName_opt))
-          case _ => complete(eclairApi.payOffer(offer, amountMsat, quantity_opt.getOrElse(1), externalId_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, pathFindingExperimentName_opt))
+          case Some(true) => complete(eclairApi.payOfferBlocking(offer, amountMsat, quantity_opt.getOrElse(1), externalId_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, pathFindingExperimentName_opt, connectDirectly.getOrElse(false)))
+          case _ => complete(eclairApi.payOffer(offer, amountMsat, quantity_opt.getOrElse(1), externalId_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, pathFindingExperimentName_opt, connectDirectly.getOrElse(false)))
         }
     }
   }


### PR DESCRIPTION
When sending a message, the postman can now ask the router to find a route using channels only. The same route is also used as a reply path when applicable.