### PR TITLE
Use bitcoin-lib 0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <akka.version>2.6.20</akka.version>
         <akka.http.version>10.2.7</akka.http.version>
         <sttp.version>3.8.5</sttp.version>
-        <bitcoinlib.version>0.27</bitcoinlib.version>
+        <bitcoinlib.version>0.28</bitcoinlib.version>
         <guava.version>31.1-jre</guava.version>
         <kamon.version>2.5.12</kamon.version>
     </properties>


### PR DESCRIPTION
`bitcoin-lib` 0.28 uses the same `secp256k1-kmp` and `bitcoin-kmp` libraries as `lightning-kmp` after https://github.com/ACINQ/lightning-kmp/pull/427 