### PR TITLE
Ignore lnd's internal errors

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -3342,6 +3342,14 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     alice2blockchain.expectNoMessage(1 second)
   }
 
+  test("recv Error (ignored internal error from lnd)") { f =>
+    import f._
+
+    alice ! Error(channelId(alice), "internal error")
+    alice2bob.expectMsgType[Warning]
+    alice2blockchain.expectNoMessage(100 millis)
+  }
+
   def testErrorAnchorOutputsWithHtlcs(f: FixtureParam): Unit = {
     import f._
 


### PR DESCRIPTION
It seems like lnd sends this error whenever something wrong happens on their side, regardless of whether the channel actually needs to be closed. We ignore it to avoid paying the cost of a channel force-close, it's up to them to broadcast their commitment if they wish.

See https://github.com/lightningnetwork/lnd/issues/7657 for example.