### PR TITLE
Accept closing fee above commit fee

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/g/NegotiatingStateSpec.scala
@@ -26,6 +26,7 @@ import fr.acinq.eclair.channel.fsm.Channel
 import fr.acinq.eclair.channel.publish.TxPublisher.{PublishFinalTx, PublishTx}
 import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
 import fr.acinq.eclair.transactions.Transactions
+import fr.acinq.eclair.transactions.Transactions.ZeroFeeHtlcTxAnchorOutputsCommitmentFormat
 import fr.acinq.eclair.wire.protocol.ClosingSignedTlv.FeeRange
 import fr.acinq.eclair.wire.protocol.{ClosingSigned, Error, Shutdown, TlvStream, Warning}
 import fr.acinq.eclair.{CltvExpiry, Features, MilliSatoshiLong, TestConstants, TestFeeEstimator, TestKitBaseClass, randomBytes32}
@@ -415,17 +416,21 @@ class NegotiatingStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     bob2alice.expectNoMessage(100 millis)
   }
 
-  test("recv ClosingSigned (fee too high)") { f =>
+  test("recv ClosingSigned (fee higher than commit tx fee)", Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
     import f._
-    bobClose(f)
+    val commitment = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest
+    val commitFee = Transactions.commitTxFeeMsat(commitment.localParams.dustLimit, commitment.localCommit.spec, ZeroFeeHtlcTxAnchorOutputsCommitmentFormat)
+    aliceClose(f)
     val aliceCloseSig = alice2bob.expectMsgType[ClosingSigned]
-    val tx = bob.stateData.asInstanceOf[DATA_NEGOTIATING].commitments.latest.localCommit.commitTxAndRemoteSig.commitTx.tx
-    alice2bob.forward(bob, aliceCloseSig.copy(feeSatoshis = 99000 sat)) // sig doesn't matter, it is checked later
-    val error = bob2alice.expectMsgType[Error]
-    assert(new String(error.data.toArray).startsWith("invalid close fee: fee_satoshis=99000 sat"))
-    assert(bob2blockchain.expectMsgType[PublishFinalTx].tx.txid == tx.txid)
-    bob2blockchain.expectMsgType[PublishTx]
-    bob2blockchain.expectMsgType[WatchTxConfirmed]
+    assert(aliceCloseSig.feeSatoshis > commitFee.truncateToSatoshi)
+    alice2bob.forward(bob, aliceCloseSig)
+    val bobCloseSig = bob2alice.expectMsgType[ClosingSigned]
+    assert(bobCloseSig.feeSatoshis == aliceCloseSig.feeSatoshis)
+    awaitCond(bob.stateName == CLOSING)
+    val closingTx = bob.stateData.asInstanceOf[DATA_CLOSING].mutualClosePublished.head.tx
+    assert(bob2blockchain.expectMsgType[PublishFinalTx].tx.txid == closingTx.txid)
+    bob2alice.forward(alice, bobCloseSig)
+    assert(alice2blockchain.expectMsgType[PublishFinalTx].tx.txid == closingTx.txid)
   }
 
   test("recv ClosingSigned (invalid sig)") { f =>


### PR DESCRIPTION
When performing a mutual close, we initially rejected fees that were higher to the commit tx fees. This was removed from the specification for anchor output channels, and doesn't make a lot of sense for standard channels either: even at a higher fee, it makes sense to do a mutual close to avoid waiting for relative delays on our outputs.

Fixes https://github.com/ACINQ/eclair/issues/2646