### PR TITLE
Fix interpretation of option_onion_messages

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -466,10 +466,11 @@ eclair {
 
   onion-messages {
     # Valid values are
-    # - no-relay: Allow sending and receiving onion messages but never relay them
     # - channels-only: Only relay messages from peers with which we have a channel to peers with which we have a channel.
     # - relay-all: Relay everything and create new connections if necessary
     relay-policy = "channels-only"
+    # If you want to never relay onion messages (but still be able to send and receive them), you need to set
+    # features.option_onion_messages = disabled
 
     # Transient connections opened to relay messages will be closed after this delay of inactivity
     kill-transient-connection-after = 30 seconds

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.channel.fsm.Channel.{ChannelConf, UnhandledExceptionStrat
 import fr.acinq.eclair.crypto.Noise.KeyPair
 import fr.acinq.eclair.crypto.keymanager.{ChannelKeyManager, NodeKeyManager}
 import fr.acinq.eclair.db._
-import fr.acinq.eclair.io.MessageRelay.{NoRelay, RelayAll, RelayChannelsOnly, RelayPolicy}
+import fr.acinq.eclair.io.MessageRelay.{RelayAll, RelayChannelsOnly, RelayPolicy}
 import fr.acinq.eclair.io.PeerConnection
 import fr.acinq.eclair.message.OnionMessages.OnionMessageConfig
 import fr.acinq.eclair.payment.relay.Relayer.{AsyncPaymentsParams, RelayFees, RelayParams}
@@ -427,7 +427,6 @@ object NodeParams extends Logging {
     }
 
     val onionMessageRelayPolicy: RelayPolicy = config.getString("onion-messages.relay-policy") match {
-      case "no-relay" => NoRelay
       case "channels-only" => RelayChannelsOnly
       case "relay-all" => RelayAll
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/MessageRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/MessageRelay.scala
@@ -49,7 +49,6 @@ object MessageRelay {
   }
 
   sealed trait RelayPolicy
-  case object NoRelay extends RelayPolicy
   case object RelayChannelsOnly extends RelayPolicy
   case object RelayAll extends RelayPolicy
   // @formatter:on
@@ -58,9 +57,6 @@ object MessageRelay {
     Behaviors.receivePartial {
       case (context, RelayMessage(messageId, switchboard, prevNodeId, nextNodeId, msg, policy, replyTo_opt)) =>
         policy match {
-          case NoRelay =>
-            replyTo_opt.foreach(_ ! AgainstPolicy(messageId, policy))
-            Behaviors.stopped
           case RelayChannelsOnly =>
             switchboard ! GetPeerInfo(context.messageAdapter(WrappedPeerInfo), prevNodeId)
             waitForPreviousPeer(messageId, switchboard, nextNodeId, msg, replyTo_opt)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -277,13 +277,13 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnchainP
       case Event(msg: OnionMessage, _: ConnectedData) =>
         OnionMessages.process(nodeParams.privateKey, msg) match {
           case OnionMessages.DropMessage(reason) =>
-            log.debug(s"dropping message from ${remoteNodeId.value.toHex}: ${reason.toString}")
+            log.debug("dropping message from {}: {}", remoteNodeId.value.toHex, reason.toString)
           case OnionMessages.SendMessage(nextNodeId, message) if nodeParams.features.hasFeature(Features.OnionMessages) =>
             switchboard ! RelayMessage(randomBytes32(), Some(remoteNodeId), nextNodeId, message, nodeParams.onionMessageConfig.relayPolicy, None)
           case OnionMessages.SendMessage(_, _) =>
-            log.debug(s"dropping message from ${remoteNodeId.value.toHex}: relaying onion messages is disabled")
+            log.debug("dropping message from {}: relaying onion messages is disabled", remoteNodeId.value.toHex)
           case received: OnionMessages.ReceiveMessage =>
-            log.info(s"received message from ${remoteNodeId.value.toHex}: $received")
+            log.info("received message from {}: {}", remoteNodeId.value.toHex, received)
             context.system.eventStream.publish(received)
         }
         stay()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -275,16 +275,16 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnchainP
         gotoConnected(connectionReady, d.channels)
 
       case Event(msg: OnionMessage, _: ConnectedData) =>
-        if (nodeParams.features.hasFeature(Features.OnionMessages)) {
-          OnionMessages.process(nodeParams.privateKey, msg) match {
-            case OnionMessages.DropMessage(reason) =>
-              log.debug(s"dropping message from ${remoteNodeId.value.toHex}: ${reason.toString}")
-            case OnionMessages.SendMessage(nextNodeId, message) =>
-              switchboard ! RelayMessage(randomBytes32(), Some(remoteNodeId), nextNodeId, message, nodeParams.onionMessageConfig.relayPolicy, None)
-            case received: OnionMessages.ReceiveMessage =>
-              log.info(s"received message from ${remoteNodeId.value.toHex}: $received")
-              context.system.eventStream.publish(received)
-          }
+        OnionMessages.process(nodeParams.privateKey, msg) match {
+          case OnionMessages.DropMessage(reason) =>
+            log.debug(s"dropping message from ${remoteNodeId.value.toHex}: ${reason.toString}")
+          case OnionMessages.SendMessage(nextNodeId, message) if nodeParams.features.hasFeature(Features.OnionMessages) =>
+            switchboard ! RelayMessage(randomBytes32(), Some(remoteNodeId), nextNodeId, message, nodeParams.onionMessageConfig.relayPolicy, None)
+          case OnionMessages.SendMessage(_, _) =>
+            log.debug(s"dropping message from ${remoteNodeId.value.toHex}: relaying onion messages is disabled")
+          case received: OnionMessages.ReceiveMessage =>
+            log.info(s"received message from ${remoteNodeId.value.toHex}: $received")
+            context.system.eventStream.publish(received)
         }
         stay()
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/MessageRelaySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/MessageRelaySpec.scala
@@ -148,16 +148,4 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     assert(peer.expectMessageType[Peer.RelayOnionMessage].msg == message)
   }
-
-  test("no relay") { f =>
-    import f._
-
-    val Right((_, message)) = OnionMessages.buildMessage(randomKey(), randomKey(), randomKey(), Seq(IntermediateNode(aliceId)), Recipient(bobId, None), TlvStream.empty)
-    val messageId = randomBytes32()
-    val previousNodeId = randomKey().publicKey
-    relay ! RelayMessage(messageId, switchboard.ref, previousNodeId, bobId, message, NoRelay, Some(probe.ref))
-
-    switchboard.expectNoMessage(100 millis)
-    probe.expectMessage(AgainstPolicy(messageId, NoRelay))
-  }
 }


### PR DESCRIPTION
According to the spec, option_onion_messages signals that the node can forward onion messages which is different from being able to send or receive them (there is no feature bit for that). We now allow nodes with this feature disabled to still receive messages and remove the NoRelay relay policy as it is redundant.