### PR TITLE
Ignore non-relayed incoming HTLCs when closing

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -793,7 +793,7 @@ object Helpers {
           case u: UpdateFailMalformedHtlc => u.id
         }.toSet
         // these htlcs have been signed by our peer, but we haven't received their revocation and relayed them yet
-        val nonRelayedIncomingHtlcs: Set[Long] = commitment.changes.remoteChanges.signed.collect { case add: UpdateAddHtlc => add.id }.toSet
+        val nonRelayedIncomingHtlcs: Set[Long] = commitment.changes.remoteChanges.all.collect { case add: UpdateAddHtlc => add.id }.toSet
 
         commitment.localCommit.htlcTxsAndRemoteSigs.collect {
           case HtlcTxAndRemoteSig(txInfo@HtlcSuccessTx(_, _, paymentHash, _, _), remoteSig) =>


### PR DESCRIPTION
If we force-close with HTLCs that have just been signed by our peer but for which we haven't received their revocation, we should ignore them. We have not relayed those HTLCs so they can't be fulfilled. It is our peer's responsibility to claim them on-chain (using their HTLC-timeout), but if for some reason they don't claim it, we don't want the channel to be stuck in the closing state.

This is a subtle and dangerous change, please review carefully!

Note that we don't fix existing channels that are already in that state (they will have an entry `Outpoint -> None` in `localCommitPublished.htlcTxs`). It is a bit dangerous to fix them automatically, I'd rather either wait for the peer to claim the HTLC on-chain or let impacted node operators (only @DerEwige as far as I know) manually fix it by running the following DB commands (while their eclair node is stopped, before restarting it).

For sqlite:

```
DELETE FROM pending_settlement_commands WHERE channel_id=X'<channel_id_hex_string>'
DELETE FROM htlc_infos WHERE channel_id=X'<channel_id_hex_string>'
UPDATE local_channels SET is_closed=1 WHERE channel_id=X'<channel_id_hex_string>'

Example for the channel in issue 2669:
DELETE FROM pending_settlement_commands WHERE channel_id=X'aac6edaa182ed25592e7c491f87b2f8c97e3e777bd825847cd0292ff2656e09c'
DELETE FROM htlc_infos WHERE channel_id=X'aac6edaa182ed25592e7c491f87b2f8c97e3e777bd825847cd0292ff2656e09c'
UPDATE local_channels SET is_closed=1 WHERE channel_id=X'aac6edaa182ed25592e7c491f87b2f8c97e3e777bd825847cd0292ff2656e09c'
```

For postgres:

```
DELETE FROM local.pending_settlement_commands WHERE channel_id='<channel_id_hex_string>'
DELETE FROM local.htlc_infos WHERE channel_id='<channel_id_hex_string>'
UPDATE local.channels SET is_closed=TRUE WHERE channel_id='<channel_id_hex_string>'

Example for the channel in issue 2669:
DELETE FROM local.pending_settlement_commands WHERE channel_id='aac6edaa182ed25592e7c491f87b2f8c97e3e777bd825847cd0292ff2656e09c'
DELETE FROM local.htlc_infos WHERE channel_id='aac6edaa182ed25592e7c491f87b2f8c97e3e777bd825847cd0292ff2656e09c'
UPDATE local.channels SET is_closed=TRUE WHERE channel_id='aac6edaa182ed25592e7c491f87b2f8c97e3e777bd825847cd0292ff2656e09c'
```

Fixes #2669