### PR TITLE
Make shared transaction codecs more future-proof

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version4/ChannelCodecs4.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version4/ChannelCodecs4.scala
@@ -233,18 +233,20 @@ private[channel] object ChannelCodecs4 {
         ("targetFeerate" | feeratePerKw) ::
         ("requireConfirmedInputs" | requireConfirmedInputsCodec)).as[InteractiveTxBuilder.InteractiveTxParams]
 
-    private val sharedInteractiveTxInputCodec: Codec[InteractiveTxBuilder.Input.Shared] = (
-      ("serialId" | uint64) ::
-        ("outPoint" | outPointCodec) ::
-        ("sequence" | uint32) ::
-        ("localAmount" | millisatoshi) ::
-        ("remoteAmount" | millisatoshi)).as[InteractiveTxBuilder.Input.Shared]
+    private val sharedInteractiveTxInputCodec: Codec[InteractiveTxBuilder.Input.Shared] = discriminated[InteractiveTxBuilder.Input.Shared].by(byte)
+      .typecase(0x01, (
+        ("serialId" | uint64) ::
+          ("outPoint" | outPointCodec) ::
+          ("sequence" | uint32) ::
+          ("localAmount" | millisatoshi) ::
+          ("remoteAmount" | millisatoshi)).as[InteractiveTxBuilder.Input.Shared])
 
-    private val sharedInteractiveTxOutputCodec: Codec[InteractiveTxBuilder.Output.Shared] = (
-      ("serialId" | uint64) ::
-        ("scriptPubKey" | lengthDelimited(bytes)) ::
-        ("localAmount" | millisatoshi) ::
-        ("remoteAmount" | millisatoshi)).as[InteractiveTxBuilder.Output.Shared]
+    private val sharedInteractiveTxOutputCodec: Codec[InteractiveTxBuilder.Output.Shared] = discriminated[InteractiveTxBuilder.Output.Shared].by(byte)
+      .typecase(0x01, (
+        ("serialId" | uint64) ::
+          ("scriptPubKey" | lengthDelimited(bytes)) ::
+          ("localAmount" | millisatoshi) ::
+          ("remoteAmount" | millisatoshi)).as[InteractiveTxBuilder.Output.Shared])
 
     private val localOnlyInteractiveTxInputCodec: Codec[InteractiveTxBuilder.Input.Local] = (
       ("serialId" | uint64) ::

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version4/ChannelCodecs4.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/internal/channel/version4/ChannelCodecs4.scala
@@ -246,17 +246,23 @@ private[channel] object ChannelCodecs4 {
         ("localAmount" | millisatoshi) ::
         ("remoteAmount" | millisatoshi)).as[InteractiveTxBuilder.Output.Shared]
 
-    private val localInteractiveTxInputCodec: Codec[InteractiveTxBuilder.Input.Local] = (
+    private val localOnlyInteractiveTxInputCodec: Codec[InteractiveTxBuilder.Input.Local] = (
       ("serialId" | uint64) ::
         ("previousTx" | txCodec) ::
         ("previousTxOutput" | uint32) ::
         ("sequence" | uint32)).as[InteractiveTxBuilder.Input.Local]
 
-    private val remoteInteractiveTxInputCodec: Codec[InteractiveTxBuilder.Input.Remote] = (
+    private val localInteractiveTxInputCodec: Codec[InteractiveTxBuilder.Input.Local] = discriminated[InteractiveTxBuilder.Input.Local].by(byte)
+      .typecase(0x01, localOnlyInteractiveTxInputCodec)
+
+    private val remoteOnlyInteractiveTxInputCodec: Codec[InteractiveTxBuilder.Input.Remote] = (
       ("serialId" | uint64) ::
         ("outPoint" | outPointCodec) ::
         ("txOut" | txOutCodec) ::
         ("sequence" | uint32)).as[InteractiveTxBuilder.Input.Remote]
+
+    private val remoteInteractiveTxInputCodec: Codec[InteractiveTxBuilder.Input.Remote] = discriminated[InteractiveTxBuilder.Input.Remote].by(byte)
+      .typecase(0x01, remoteOnlyInteractiveTxInputCodec)
 
     private val localInteractiveTxChangeOutputCodec: Codec[InteractiveTxBuilder.Output.Local.Change] = (
       ("serialId" | uint64) ::
@@ -268,14 +274,17 @@ private[channel] object ChannelCodecs4 {
         ("amount" | satoshi) ::
         ("scriptPubKey" | lengthDelimited(bytes))).as[InteractiveTxBuilder.Output.Local.NonChange]
 
-    private val localInteractiveTxOutputCodec: Codec[InteractiveTxBuilder.Output.Local] = discriminated[InteractiveTxBuilder.Output.Local].by(uint16)
+    private val localInteractiveTxOutputCodec: Codec[InteractiveTxBuilder.Output.Local] = discriminated[InteractiveTxBuilder.Output.Local].by(byte)
       .typecase(0x01, localInteractiveTxChangeOutputCodec)
       .typecase(0x02, localInteractiveTxNonChangeOutputCodec)
 
-    private val remoteInteractiveTxOutputCodec: Codec[InteractiveTxBuilder.Output.Remote] = (
+    private val remoteStandardInteractiveTxOutputCodec: Codec[InteractiveTxBuilder.Output.Remote] = (
       ("serialId" | uint64) ::
         ("amount" | satoshi) ::
         ("scriptPubKey" | lengthDelimited(bytes))).as[InteractiveTxBuilder.Output.Remote]
+
+    private val remoteInteractiveTxOutputCodec: Codec[InteractiveTxBuilder.Output.Remote] = discriminated[InteractiveTxBuilder.Output.Remote].by(byte)
+      .typecase(0x01, remoteStandardInteractiveTxOutputCodec)
 
     private val sharedTransactionCodec: Codec[InteractiveTxBuilder.SharedTransaction] = (
       ("sharedInput" | optional(bool8, sharedInteractiveTxInputCodec)) ::


### PR DESCRIPTION
When we want to add new types of inputs/outputs that contain specific tlvs, we will need to store them alongside standard inputs/outputs.

We will use traits and case classes inside `InteractiveTxBuilder`, and need to thus add a discriminator when encoding them.

Note that this is a backwards-incompatible breaking change for dual-funded channels or splices that are still unconfirmed. We should make sure that we don't any such channels before deploying that change.

An open question is whether we should also version the shared input and output?