### PR TITLE
Ignore outgoing connection requests if front not ready

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -585,6 +585,7 @@ object PeerConnection {
     }
 
     case object NoAddressFound extends ConnectionResult.Failure { override def toString: String = "no address found" }
+    case object FrontendUnavailable extends ConnectionResult.Failure { override def toString: String = "frontend unavailable" }
     case class ConnectionFailed(address: NodeAddress) extends ConnectionResult.Failure { override def toString: String = s"connection failed to $address" }
     case class AuthenticationFailed(reason: String) extends ConnectionResult.Failure { override def toString: String = reason }
     case class InitializationFailed(reason: String) extends ConnectionResult.Failure { override def toString: String = reason }


### PR DESCRIPTION
In cluster mode, outgoing connections are initiated by frontend nodes. If there are no frontend node available, we fail the connection attempt with a dedicated error.

The `initial-random-reconnect-delay` should be configured to allow enough time for the front nodes to bootstrap at reconnection.