### PR TITLE
Import descriptors during setup

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -180,7 +180,7 @@ trait Eclair {
 
   def getOnchainMasterPubKey(account: Long): String
 
-  def getDescriptors(account: Long): Descriptors
+  def getDescriptors(account: Long, hSuffix: Boolean = true): Descriptors
 
   def stop(): Future[Unit]
 }
@@ -701,8 +701,8 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
     payOfferInternal(offer, amount, quantity, externalId_opt, maxAttempts_opt, maxFeeFlat_opt, maxFeePct_opt, pathFindingExperimentName_opt, blocking = true).mapTo[PaymentEvent]
   }
 
-  override def getDescriptors(account: Long): Descriptors = appKit.wallet match {
-    case bitcoinCoreClient: BitcoinCoreClient if bitcoinCoreClient.onchainKeyManager_opt.isDefined => bitcoinCoreClient.onchainKeyManager_opt.get.getDescriptors(account)
+  override def getDescriptors(account: Long, hSuffix: Boolean = true): Descriptors = appKit.wallet match {
+    case bitcoinCoreClient: BitcoinCoreClient if bitcoinCoreClient.onchainKeyManager_opt.isDefined => bitcoinCoreClient.onchainKeyManager_opt.get.getDescriptors(account, hSuffix)
     case _ => throw new RuntimeException("onchain seed is not configured")
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -65,10 +65,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val onchainKeyManag
       "desc" -> JString(f.desc),
       "internal" -> JBool(f.internal),
       "active" -> JBool(f.active),
-      f.timestamp match {
-        case Right(t) => "timestamp" -> JInt(t)
-        case Left(t) => "timestamp" -> JString(t)
-      }
+      "timestamp" -> JInt(f.timestamp)
     ))
     rpcClient.invoke("importdescriptors", json).collect {
       case JArray(results) => results.forall(item => {
@@ -87,7 +84,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val onchainKeyManag
         val JBool(internal) = d \ "internal"
         val JBool(active) = d \ "active"
         val JInt(timestamp) = d \ "timestamp"
-        Descriptor(desc, internal, Right(timestamp.toLong), active)
+        Descriptor(desc, internal, timestamp.toLong, active)
       })
     }
 
@@ -816,7 +813,7 @@ object BitcoinCoreClient {
 
   def toSatoshi(btcAmount: BigDecimal): Satoshi = Satoshi(btcAmount.bigDecimal.scaleByPowerOfTen(8).longValue)
 
-  case class Descriptor(desc: String, internal: Boolean = false, timestamp: Either[String, Long] = Left("now"), active: Boolean = true)
+  case class Descriptor(desc: String, internal: Boolean = false, timestamp: Long, active: Boolean = true)
 
   case class Descriptors(wallet_name: String, descriptors: Seq[Descriptor])
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/keymanager/LocalOnchainKeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/keymanager/LocalOnchainKeyManager.scala
@@ -83,8 +83,8 @@ class LocalOnchainKeyManager(override val wallet: String, seed: ByteVector, time
     val changeDesc = s"wpkh([${this.fingerPrintHex}/$keyPath1]${encode(accountPub, prefix)}/1/*)"
 
     Descriptors(wallet_name = wallet, descriptors = List(
-      Descriptor(desc = s"$receiveDesc#${descriptorChecksum(receiveDesc)}", internal = false, active = true, timestamp = Right(timestamp.toLong)),
-      Descriptor(desc = s"$changeDesc#${descriptorChecksum(changeDesc)}", internal = true, active = true, timestamp = Right(timestamp.toLong)),
+      Descriptor(desc = s"$receiveDesc#${descriptorChecksum(receiveDesc)}", internal = false, active = true, timestamp = timestamp.toLong),
+      Descriptor(desc = s"$changeDesc#${descriptorChecksum(changeDesc)}", internal = true, active = true, timestamp = timestamp.toLong),
     ))
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/keymanager/LocalOnchainKeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/keymanager/LocalOnchainKeyManager.scala
@@ -68,8 +68,9 @@ class LocalOnchainKeyManager(override val wallet: String, seed: ByteVector, time
     DeterministicWallet.encode(accountPub, prefix)
   }
 
-  override def getDescriptors(account: Long): Descriptors = {
-    val keyPath = s"$rootPath/$account'".replace('\'', 'h') // Bitcoin Core understands both ' and h suffix for hardened derivation, and h is much easier to parse for external tools
+  override def getDescriptors(account: Long, hSuffix: Boolean = true): Descriptors = {
+    val keyPath = s"$rootPath/$account'"
+    val keyPath1 = if (hSuffix) keyPath.replace('\'', 'h') else keyPath // Bitcoin Core understands both ' and h suffix for hardened derivation, and h is much easier to parse for external tools
     val prefix: Int = chainHash match {
       case Block.LivenetGenesisBlock.hash => xpub
       case _ => tpub
@@ -78,8 +79,8 @@ class LocalOnchainKeyManager(override val wallet: String, seed: ByteVector, time
     // descriptors for account 0 are:
     // 84'/{0'/1'}/0'/0/* for main addresses
     // 84'/{0'/1'}/0'/1/* for change addresses
-    val receiveDesc = s"wpkh([${this.fingerPrintHex}/$keyPath]${encode(accountPub, prefix)}/0/*)"
-    val changeDesc = s"wpkh([${this.fingerPrintHex}/$keyPath]${encode(accountPub, prefix)}/1/*)"
+    val receiveDesc = s"wpkh([${this.fingerPrintHex}/$keyPath1]${encode(accountPub, prefix)}/0/*)"
+    val changeDesc = s"wpkh([${this.fingerPrintHex}/$keyPath1]${encode(accountPub, prefix)}/1/*)"
 
     Descriptors(wallet_name = wallet, descriptors = List(
       Descriptor(desc = s"$receiveDesc#${descriptorChecksum(receiveDesc)}", internal = false, active = true, timestamp = Right(timestamp.toLong)),

--- a/eclair-core/src/main/scala/fr/acinq/eclair/crypto/keymanager/OnchainKeyManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/crypto/keymanager/OnchainKeyManager.scala
@@ -25,9 +25,10 @@ trait OnchainKeyManager {
   /**
    *
    * @param account account number
+   * @param hSuffix use h instead of ' to indicate hardened path
    * @return a pair of (main, change) wallet descriptors that can be imported into an onchain wallet
    */
-  def getDescriptors(account: Long): Descriptors
+  def getDescriptors(account: Long, hSuffix: Boolean = true): Descriptors
 
   /**
    *

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
@@ -1481,8 +1481,10 @@ class BitcoinCoreClientWithEclairSignerSpec extends BitcoinCoreClientSpec {
       sender.expectMsgType[JValue]
 
       val jsonRpcClient = new BasicBitcoinJsonRPCClient(rpcAuthMethod = bitcoinrpcauthmethod, host = "localhost", port = bitcoindRpcPort, wallet = Some(s"eclair_$hex"))
-      importEclairDescriptors(jsonRpcClient, onchainKeyManager)
+      val descriptors = onchainKeyManager.getDescriptors(0).descriptors
       val wallet1 = new BitcoinCoreClient(jsonRpcClient, Some(onchainKeyManager))
+      wallet1.importDescriptors(descriptors).pipeTo(sender.ref)
+      sender.expectMsgType[true]
       wallet1.getReceiveAddress().pipeTo(sender.ref)
       val address = sender.expectMsgType[String]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -175,7 +175,12 @@ trait BitcoindService extends Logging {
 
   def importEclairDescriptors(jsonRpcClient: BitcoinJsonRPCClient, keyManager: OnchainKeyManager, probe: TestProbe = TestProbe()): Unit = {
     val descriptors = keyManager.getDescriptors(0).descriptors
-    jsonRpcClient.invoke("importdescriptors", descriptors).pipeTo(probe.ref)
+    jsonRpcClient.invoke("importdescriptors", descriptors.collect(f => JObject(
+      "desc" -> JString(f.desc),
+      "internal" -> JBool(f.internal),
+      "active" -> JBool(f.active),
+      "timestamp" -> JString("now")
+    ))).pipeTo(probe.ref)
     probe.expectMsgType[JValue]
   }
 


### PR DESCRIPTION
This PR just adds a step in Setup to automatically import the mnemonic wallet if it does not already exist. This should help simplify initial on-chain wallet creation and recovery using the eclair signer.

We should also be able to add the wallet to bitcoind if it's missing using the wallet name in the eclair-signer.conf file in a similar way.