### PR TITLE
Move channel collector inside Peer actor

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -280,20 +280,20 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
 
     for {
       channelIds <- futureResponse
-      channels <- Future.sequence(channelIds.map(channelId => sendToChannel[CMD_GET_CHANNEL_INFO, CommandResponse[CMD_GET_CHANNEL_INFO]](Left(channelId), CMD_GET_CHANNEL_INFO(ActorRef.noSender, ByteVector32.Zeroes))))
+      channels <- Future.sequence(channelIds.map(channelId => sendToChannel[CMD_GET_CHANNEL_INFO, CommandResponse[CMD_GET_CHANNEL_INFO]](Left(channelId), CMD_GET_CHANNEL_INFO(ActorRef.noSender))))
     } yield channels.collect {
       case properResponse: RES_GET_CHANNEL_INFO => properResponse
     }
   }
 
   override def channelInfo(channel: ApiTypes.ChannelIdentifier)(implicit timeout: Timeout): Future[CommandResponse[CMD_GET_CHANNEL_INFO]] = {
-    sendToChannel[CMD_GET_CHANNEL_INFO, CommandResponse[CMD_GET_CHANNEL_INFO]](channel, CMD_GET_CHANNEL_INFO(ActorRef.noSender, ByteVector32.Zeroes))
+    sendToChannel[CMD_GET_CHANNEL_INFO, CommandResponse[CMD_GET_CHANNEL_INFO]](channel, CMD_GET_CHANNEL_INFO(ActorRef.noSender))
   }
 
   override def closedChannels(nodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated])(implicit timeout: Timeout): Future[Iterable[RES_GET_CHANNEL_INFO]] = {
     Future {
       appKit.nodeParams.db.channels.listClosedChannels(nodeId_opt, paginated_opt).map { data =>
-        RES_GET_CHANNEL_INFO(requestId = ByteVector32.Zeroes, nodeId = data.remoteNodeId, channelId = data.channelId, state = CLOSED, data = data)
+        RES_GET_CHANNEL_INFO(nodeId = data.remoteNodeId, channelId = data.channelId, channel = ActorRef.noSender, state = CLOSED, data = data)
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -280,20 +280,20 @@ class EclairImpl(appKit: Kit) extends Eclair with Logging {
 
     for {
       channelIds <- futureResponse
-      channels <- Future.sequence(channelIds.map(channelId => sendToChannel[CMD_GET_CHANNEL_INFO, CommandResponse[CMD_GET_CHANNEL_INFO]](Left(channelId), CMD_GET_CHANNEL_INFO(ActorRef.noSender))))
+      channels <- Future.sequence(channelIds.map(channelId => sendToChannel[CMD_GET_CHANNEL_INFO, CommandResponse[CMD_GET_CHANNEL_INFO]](Left(channelId), CMD_GET_CHANNEL_INFO(ActorRef.noSender, ByteVector32.Zeroes))))
     } yield channels.collect {
       case properResponse: RES_GET_CHANNEL_INFO => properResponse
     }
   }
 
   override def channelInfo(channel: ApiTypes.ChannelIdentifier)(implicit timeout: Timeout): Future[CommandResponse[CMD_GET_CHANNEL_INFO]] = {
-    sendToChannel[CMD_GET_CHANNEL_INFO, CommandResponse[CMD_GET_CHANNEL_INFO]](channel, CMD_GET_CHANNEL_INFO(ActorRef.noSender))
+    sendToChannel[CMD_GET_CHANNEL_INFO, CommandResponse[CMD_GET_CHANNEL_INFO]](channel, CMD_GET_CHANNEL_INFO(ActorRef.noSender, ByteVector32.Zeroes))
   }
 
   override def closedChannels(nodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated])(implicit timeout: Timeout): Future[Iterable[RES_GET_CHANNEL_INFO]] = {
     Future {
       appKit.nodeParams.db.channels.listClosedChannels(nodeId_opt, paginated_opt).map { data =>
-        RES_GET_CHANNEL_INFO(nodeId = data.remoteNodeId, channelId = data.channelId, state = CLOSED, data = data)
+        RES_GET_CHANNEL_INFO(requestId = ByteVector32.Zeroes, nodeId = data.remoteNodeId, channelId = data.channelId, state = CLOSED, data = data)
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -217,7 +217,7 @@ final case class CMD_SPLICE(replyTo: akka.actor.typed.ActorRef[CommandResponse[C
 final case class CMD_UPDATE_RELAY_FEE(replyTo: ActorRef, feeBase: MilliSatoshi, feeProportionalMillionths: Long, cltvExpiryDelta_opt: Option[CltvExpiryDelta]) extends HasReplyToCommand
 final case class CMD_GET_CHANNEL_STATE(replyTo: ActorRef) extends HasReplyToCommand
 final case class CMD_GET_CHANNEL_DATA(replyTo: ActorRef) extends HasReplyToCommand
-final case class CMD_GET_CHANNEL_INFO(replyTo: ActorRef)extends HasReplyToCommand
+final case class CMD_GET_CHANNEL_INFO(replyTo: ActorRef, requestId: ByteVector32) extends HasReplyToCommand
 
 /*
        88888888b.  8888888888  .d8888b.  88888888b.    ,ad8888ba,   888b      88  .d8888b.  8888888888  .d8888b.
@@ -265,7 +265,7 @@ final case class RES_BUMP_FUNDING_FEE(rbfIndex: Int, fundingTxId: ByteVector32, 
 final case class RES_SPLICE(fundingTxIndex: Long, fundingTxId: ByteVector32, capacity: Satoshi, balance: MilliSatoshi) extends CommandSuccess[CMD_SPLICE]
 final case class RES_GET_CHANNEL_STATE(state: ChannelState) extends CommandSuccess[CMD_GET_CHANNEL_STATE]
 final case class RES_GET_CHANNEL_DATA[+D <: ChannelData](data: D) extends CommandSuccess[CMD_GET_CHANNEL_DATA]
-final case class RES_GET_CHANNEL_INFO(nodeId: PublicKey, channelId: ByteVector32, state: ChannelState, data: ChannelData) extends CommandSuccess[CMD_GET_CHANNEL_INFO]
+final case class RES_GET_CHANNEL_INFO(requestId: ByteVector32, nodeId: PublicKey, channelId: ByteVector32, state: ChannelState, data: ChannelData) extends CommandSuccess[CMD_GET_CHANNEL_INFO]
 
 /*
       8888888b.        d8888 88888888888     d8888

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -217,7 +217,7 @@ final case class CMD_SPLICE(replyTo: akka.actor.typed.ActorRef[CommandResponse[C
 final case class CMD_UPDATE_RELAY_FEE(replyTo: ActorRef, feeBase: MilliSatoshi, feeProportionalMillionths: Long, cltvExpiryDelta_opt: Option[CltvExpiryDelta]) extends HasReplyToCommand
 final case class CMD_GET_CHANNEL_STATE(replyTo: ActorRef) extends HasReplyToCommand
 final case class CMD_GET_CHANNEL_DATA(replyTo: ActorRef) extends HasReplyToCommand
-final case class CMD_GET_CHANNEL_INFO(replyTo: ActorRef, requestId: ByteVector32) extends HasReplyToCommand
+final case class CMD_GET_CHANNEL_INFO(replyTo: ActorRef) extends HasReplyToCommand
 
 /*
        88888888b.  8888888888  .d8888b.  88888888b.    ,ad8888ba,   888b      88  .d8888b.  8888888888  .d8888b.
@@ -265,7 +265,7 @@ final case class RES_BUMP_FUNDING_FEE(rbfIndex: Int, fundingTxId: ByteVector32, 
 final case class RES_SPLICE(fundingTxIndex: Long, fundingTxId: ByteVector32, capacity: Satoshi, balance: MilliSatoshi) extends CommandSuccess[CMD_SPLICE]
 final case class RES_GET_CHANNEL_STATE(state: ChannelState) extends CommandSuccess[CMD_GET_CHANNEL_STATE]
 final case class RES_GET_CHANNEL_DATA[+D <: ChannelData](data: D) extends CommandSuccess[CMD_GET_CHANNEL_DATA]
-final case class RES_GET_CHANNEL_INFO(requestId: ByteVector32, nodeId: PublicKey, channelId: ByteVector32, state: ChannelState, data: ChannelData) extends CommandSuccess[CMD_GET_CHANNEL_INFO]
+final case class RES_GET_CHANNEL_INFO(nodeId: PublicKey, channelId: ByteVector32, channel: ActorRef, state: ChannelState, data: ChannelData) extends CommandSuccess[CMD_GET_CHANNEL_INFO]
 
 /*
       8888888b.        d8888 88888888888     d8888

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -1996,7 +1996,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
 
     case Event(c: CMD_GET_CHANNEL_INFO, _) =>
       val replyTo = if (c.replyTo == ActorRef.noSender) sender() else c.replyTo
-      replyTo ! RES_GET_CHANNEL_INFO(c.requestId, remoteNodeId, stateData.channelId, stateName, stateData)
+      replyTo ! RES_GET_CHANNEL_INFO(remoteNodeId, stateData.channelId, self, stateName, stateData)
       stay()
 
     case Event(c: CMD_ADD_HTLC, d: PersistentChannelData) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -1996,7 +1996,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
 
     case Event(c: CMD_GET_CHANNEL_INFO, _) =>
       val replyTo = if (c.replyTo == ActorRef.noSender) sender() else c.replyTo
-      replyTo ! RES_GET_CHANNEL_INFO(remoteNodeId, stateData.channelId, stateName, stateData)
+      replyTo ! RES_GET_CHANNEL_INFO(c.requestId, remoteNodeId, stateData.channelId, stateName, stateData)
       stay()
 
     case Event(c: CMD_ADD_HTLC, d: PersistentChannelData) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -332,7 +332,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnchainP
       if (d.channels.isEmpty) {
         r.replyTo ! PeerChannels(remoteNodeId, Nil)
       } else {
-        val actor = context.spawnAnonymous(PeerChannelsCollector(remoteNodeId, 15 seconds))
+        val actor = context.spawnAnonymous(PeerChannelsCollector(remoteNodeId))
         actor ! PeerChannelsCollector.GetChannels(r.replyTo, d.channels.values.map(_.toTyped).toSet)
       }
       stay()

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -42,6 +42,8 @@ import fr.acinq.eclair.remote.EclairInternalsSerializer.RemoteTypes
 import fr.acinq.eclair.wire.protocol
 import fr.acinq.eclair.wire.protocol.{Error, HasChannelId, HasTemporaryChannelId, LightningMessage, NodeAddress, OnionMessage, RoutingMessage, UnknownMessage, Warning}
 
+import scala.concurrent.duration.DurationInt
+
 /**
  * This actor represents a logical peer. There is one [[Peer]] per unique remote node id at all time.
  *
@@ -326,6 +328,15 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnchainP
       }, d.channels.values.toSet)
       stay()
 
+    case Event(r: GetPeerChannels, d) =>
+      if (d.channels.isEmpty) {
+        r.replyTo ! PeerChannels(remoteNodeId, Nil)
+      } else {
+        val actor = context.spawnAnonymous(PeerChannelsCollector(remoteNodeId, 15 seconds))
+        actor ! PeerChannelsCollector.GetChannels(r.replyTo, d.channels.values.toSet)
+      }
+      stay()
+
     case Event(_: Peer.OutgoingMessage, _) => stay() // we got disconnected or reconnected and this message was for the previous connection
 
     case Event(RelayOnionMessage(messageId, _, replyTo_opt), _) =>
@@ -528,13 +539,15 @@ object Peer {
   case class SpawnChannelNonInitiator(open: Either[protocol.OpenChannel, protocol.OpenDualFundedChannel], channelConfig: ChannelConfig, channelType: SupportedChannelType, localParams: LocalParams, peerConnection: ActorRef)
 
   case class GetPeerInfo(replyTo: Option[typed.ActorRef[PeerInfoResponse]])
-
-  sealed trait PeerInfoResponse {
-    def nodeId: PublicKey
-  }
-
+  sealed trait PeerInfoResponse { def nodeId: PublicKey }
   case class PeerInfo(peer: ActorRef, nodeId: PublicKey, state: State, address: Option[NodeAddress], channels: Set[ActorRef]) extends PeerInfoResponse
   case class PeerNotFound(nodeId: PublicKey) extends PeerInfoResponse with DisconnectResponse { override def toString: String = s"peer $nodeId not found" }
+
+  /** Return the peer's current channels: note that the data may change concurrently, never assume it is fully up-to-date. */
+  case class GetPeerChannels(replyTo: typed.ActorRef[PeerChannels])
+  case class ChannelInfo(state: ChannelState, data: ChannelData)
+  case class PeerChannels(nodeId: PublicKey, channels: Seq[ChannelInfo])
+
 
   case class PeerRoutingMessage(peerConnection: ActorRef, remoteNodeId: PublicKey, message: RoutingMessage) extends RemoteTypes
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -333,7 +333,7 @@ class Peer(val nodeParams: NodeParams, remoteNodeId: PublicKey, wallet: OnchainP
         r.replyTo ! PeerChannels(remoteNodeId, Nil)
       } else {
         val actor = context.spawnAnonymous(PeerChannelsCollector(remoteNodeId, 15 seconds))
-        actor ! PeerChannelsCollector.GetChannels(r.replyTo, d.channels.values.toSet)
+        actor ! PeerChannelsCollector.GetChannels(r.replyTo, d.channels.values.map(_.toTyped).toSet)
       }
       stay()
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerChannelsCollector.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerChannelsCollector.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.io
+
+import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import akka.actor.typed.{ActorRef, Behavior}
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.eclair.Logs
+import fr.acinq.eclair.channel.{CMD_GET_CHANNEL_INFO, ChannelData, ChannelState, RES_GET_CHANNEL_INFO}
+
+import scala.concurrent.duration.FiniteDuration
+
+object PeerChannelsCollector {
+
+  // @formatter:off
+  sealed trait Command
+  case class GetChannels(replyTo: ActorRef[Peer.PeerChannels], channels: Set[akka.actor.ActorRef]) extends Command
+  private case class WrappedChannelInfo(state: ChannelState, data: ChannelData) extends Command
+  private object Timeout extends Command
+  // @formatter:on
+
+  /**
+   * @param timeout channel actors should respond immediately, so this actor should be very short-lived. However, if one
+   *                of the channel actors dies (because the channel is closed), we won't get a response: we will wait
+   *                until the given timeout, and then return the subset of channels we were able to collect.
+   */
+  def apply(remoteNodeId: PublicKey, timeout: FiniteDuration): Behavior[Command] = {
+    Behaviors.setup { context =>
+      Behaviors.withTimers { timers =>
+        Behaviors.withMdc(Logs.mdc(remoteNodeId_opt = Some(remoteNodeId))) {
+          Behaviors.receiveMessagePartial {
+            case GetChannels(replyTo, channels) =>
+              timers.startSingleTimer(Timeout, timeout)
+              val adapter = context.messageAdapter[RES_GET_CHANNEL_INFO](r => WrappedChannelInfo(r.state, r.data))
+              channels.foreach(c => c ! CMD_GET_CHANNEL_INFO(adapter.toClassic))
+              new PeerChannelsCollector(replyTo, remoteNodeId, context).collect(Nil, channels.size)
+          }
+        }
+      }
+    }
+  }
+
+}
+
+private class PeerChannelsCollector(replyTo: ActorRef[Peer.PeerChannels], remoteNodeId: PublicKey, context: ActorContext[PeerChannelsCollector.Command]) {
+
+  import PeerChannelsCollector._
+
+  private val log = context.log
+
+  def collect(received: Seq[Peer.ChannelInfo], remaining: Int): Behavior[Command] = {
+    Behaviors.receiveMessagePartial {
+      case WrappedChannelInfo(state, data) if remaining == 1 =>
+        replyTo ! Peer.PeerChannels(remoteNodeId, received :+ Peer.ChannelInfo(state, data))
+        Behaviors.stopped
+      case WrappedChannelInfo(state, data) =>
+        collect(received :+ Peer.ChannelInfo(state, data), remaining - 1)
+      case Timeout =>
+        log.warn("timed out fetching peer channel information (remaining={})", remaining)
+        replyTo ! Peer.PeerChannels(remoteNodeId, received)
+        Behaviors.stopped
+    }
+  }
+
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerChannelsCollector.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerChannelsCollector.scala
@@ -29,7 +29,7 @@ object PeerChannelsCollector {
 
   // @formatter:off
   sealed trait Command
-  case class GetChannels(replyTo: ActorRef[Peer.PeerChannels], channels: Set[akka.actor.ActorRef]) extends Command
+  case class GetChannels(replyTo: ActorRef[Peer.PeerChannels], channels: Set[ActorRef[CMD_GET_CHANNEL_INFO]]) extends Command
   private case class WrappedChannelInfo(state: ChannelState, data: ChannelData) extends Command
   private object Timeout extends Command
   // @formatter:on

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -508,16 +508,16 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     register.reply(map)
 
     val c1 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_GET_CHANNEL_INFO(map(c1.channelId), c1.channelId, NORMAL, ChannelCodecsSpec.normal))
+    register.reply(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, map(c1.channelId), c1.channelId, NORMAL, ChannelCodecsSpec.normal))
     register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_FAILURE(CMD_GET_CHANNEL_INFO(ActorRef.noSender), new IllegalArgumentException("Non-standard channel")))
+    register.reply(RES_FAILURE(CMD_GET_CHANNEL_INFO(ActorRef.noSender, ByteVector32.Zeroes), new IllegalArgumentException("Non-standard channel")))
     val c3 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_GET_CHANNEL_INFO(map(c3.channelId), c3.channelId, NORMAL, ChannelCodecsSpec.normal))
+    register.reply(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, map(c3.channelId), c3.channelId, NORMAL, ChannelCodecsSpec.normal))
     register.expectNoMessage()
 
     assert(sender.expectMsgType[Iterable[RES_GET_CHANNEL_INFO]].toSet == Set(
-      RES_GET_CHANNEL_INFO(a, a1, NORMAL, ChannelCodecsSpec.normal),
-      RES_GET_CHANNEL_INFO(b, b1, NORMAL, ChannelCodecsSpec.normal),
+      RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, a, a1, NORMAL, ChannelCodecsSpec.normal),
+      RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, b, b1, NORMAL, ChannelCodecsSpec.normal),
     ))
   }
 
@@ -539,14 +539,14 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     register.reply(channels2Nodes)
 
     val c1 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_GET_CHANNEL_INFO(channels2Nodes(c1.channelId), c1.channelId, NORMAL, ChannelCodecsSpec.normal))
+    register.reply(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, channels2Nodes(c1.channelId), c1.channelId, NORMAL, ChannelCodecsSpec.normal))
     val c2 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_GET_CHANNEL_INFO(channels2Nodes(c2.channelId), c2.channelId, NORMAL, ChannelCodecsSpec.normal))
+    register.reply(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, channels2Nodes(c2.channelId), c2.channelId, NORMAL, ChannelCodecsSpec.normal))
     register.expectNoMessage()
 
     assert(sender.expectMsgType[Iterable[RES_GET_CHANNEL_INFO]].toSet == Set(
-      RES_GET_CHANNEL_INFO(a, a1, NORMAL, ChannelCodecsSpec.normal),
-      RES_GET_CHANNEL_INFO(a, a2, NORMAL, ChannelCodecsSpec.normal),
+      RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, a, a1, NORMAL, ChannelCodecsSpec.normal),
+      RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, a, a2, NORMAL, ChannelCodecsSpec.normal),
     ))
   }
 
@@ -565,10 +565,10 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     eclair.channelInfo(Left(a2)).pipeTo(sender.ref)
 
     val c1 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_GET_CHANNEL_INFO(channels2Nodes(c1.channelId), c1.channelId, NORMAL, ChannelCodecsSpec.normal))
+    register.reply(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, channels2Nodes(c1.channelId), c1.channelId, NORMAL, ChannelCodecsSpec.normal))
     register.expectNoMessage()
 
-    sender.expectMsg(RES_GET_CHANNEL_INFO(a, a2, NORMAL, ChannelCodecsSpec.normal))
+    sender.expectMsg(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, a, a2, NORMAL, ChannelCodecsSpec.normal))
   }
 
   test("get sent payment info") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -508,16 +508,16 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     register.reply(map)
 
     val c1 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, map(c1.channelId), c1.channelId, NORMAL, ChannelCodecsSpec.normal))
+    register.reply(RES_GET_CHANNEL_INFO(map(c1.channelId), c1.channelId, ActorRef.noSender, NORMAL, ChannelCodecsSpec.normal))
     register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_FAILURE(CMD_GET_CHANNEL_INFO(ActorRef.noSender, ByteVector32.Zeroes), new IllegalArgumentException("Non-standard channel")))
+    register.reply(RES_FAILURE(CMD_GET_CHANNEL_INFO(ActorRef.noSender), new IllegalArgumentException("Non-standard channel")))
     val c3 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, map(c3.channelId), c3.channelId, NORMAL, ChannelCodecsSpec.normal))
+    register.reply(RES_GET_CHANNEL_INFO(map(c3.channelId), c3.channelId, ActorRef.noSender, NORMAL, ChannelCodecsSpec.normal))
     register.expectNoMessage()
 
     assert(sender.expectMsgType[Iterable[RES_GET_CHANNEL_INFO]].toSet == Set(
-      RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, a, a1, NORMAL, ChannelCodecsSpec.normal),
-      RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, b, b1, NORMAL, ChannelCodecsSpec.normal),
+      RES_GET_CHANNEL_INFO(a, a1, ActorRef.noSender, NORMAL, ChannelCodecsSpec.normal),
+      RES_GET_CHANNEL_INFO(b, b1, ActorRef.noSender, NORMAL, ChannelCodecsSpec.normal),
     ))
   }
 
@@ -539,14 +539,14 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     register.reply(channels2Nodes)
 
     val c1 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, channels2Nodes(c1.channelId), c1.channelId, NORMAL, ChannelCodecsSpec.normal))
+    register.reply(RES_GET_CHANNEL_INFO(channels2Nodes(c1.channelId), c1.channelId, ActorRef.noSender, NORMAL, ChannelCodecsSpec.normal))
     val c2 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, channels2Nodes(c2.channelId), c2.channelId, NORMAL, ChannelCodecsSpec.normal))
+    register.reply(RES_GET_CHANNEL_INFO(channels2Nodes(c2.channelId), c2.channelId, ActorRef.noSender, NORMAL, ChannelCodecsSpec.normal))
     register.expectNoMessage()
 
     assert(sender.expectMsgType[Iterable[RES_GET_CHANNEL_INFO]].toSet == Set(
-      RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, a, a1, NORMAL, ChannelCodecsSpec.normal),
-      RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, a, a2, NORMAL, ChannelCodecsSpec.normal),
+      RES_GET_CHANNEL_INFO(a, a1, ActorRef.noSender, NORMAL, ChannelCodecsSpec.normal),
+      RES_GET_CHANNEL_INFO(a, a2, ActorRef.noSender, NORMAL, ChannelCodecsSpec.normal),
     ))
   }
 
@@ -565,10 +565,10 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
     eclair.channelInfo(Left(a2)).pipeTo(sender.ref)
 
     val c1 = register.expectMsgType[Register.Forward[CMD_GET_CHANNEL_INFO]]
-    register.reply(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, channels2Nodes(c1.channelId), c1.channelId, NORMAL, ChannelCodecsSpec.normal))
+    register.reply(RES_GET_CHANNEL_INFO(channels2Nodes(c1.channelId), c1.channelId, ActorRef.noSender, NORMAL, ChannelCodecsSpec.normal))
     register.expectNoMessage()
 
-    sender.expectMsg(RES_GET_CHANNEL_INFO(ByteVector32.Zeroes, a, a2, NORMAL, ChannelCodecsSpec.normal))
+    sender.expectMsg(RES_GET_CHANNEL_INFO(a, a2, ActorRef.noSender, NORMAL, ChannelCodecsSpec.normal))
   }
 
   test("get sent payment info") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
@@ -183,7 +183,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     sender.send(nodes("B").router, Router.GetChannels)
     val shortIdBC = sender.expectMsgType[Iterable[ChannelAnnouncement]].find(c => Set(c.nodeId1, c.nodeId2) == Set(nodes("B").nodeParams.nodeId, nodes("C").nodeParams.nodeId)).get.shortChannelId
     // we also need the full commitment
-    nodes("B").register ! Register.ForwardShortId(sender.ref.toTyped[Any], shortIdBC, CMD_GET_CHANNEL_INFO(ActorRef.noSender))
+    nodes("B").register ! Register.ForwardShortId(sender.ref.toTyped[Any], shortIdBC, CMD_GET_CHANNEL_INFO(ActorRef.noSender, ByteVector32.Zeroes))
     val normalBC = sender.expectMsgType[RES_GET_CHANNEL_INFO].data.asInstanceOf[DATA_NORMAL]
     // we then forge a new channel_update for B-C...
     val channelUpdateBC = Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, nodes("B").nodeParams.privateKey, nodes("C").nodeParams.nodeId, shortIdBC, nodes("B").nodeParams.channelConf.expiryDelta + 1, nodes("C").nodeParams.channelConf.htlcMinimum, nodes("B").nodeParams.relayParams.publicChannelFees.feeBase, nodes("B").nodeParams.relayParams.publicChannelFees.feeProportionalMillionths, 500000000 msat)
@@ -215,7 +215,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     // first let's wait 3 seconds to make sure the timestamp of the new channel_update will be strictly greater than the former
     sender.expectNoMessage(3 seconds)
     nodes("B").register ! Register.ForwardShortId(sender.ref.toTyped[Any], shortIdBC, BroadcastChannelUpdate(PeriodicRefresh))
-    nodes("B").register ! Register.ForwardShortId(sender.ref.toTyped[Any], shortIdBC, CMD_GET_CHANNEL_INFO(ActorRef.noSender))
+    nodes("B").register ! Register.ForwardShortId(sender.ref.toTyped[Any], shortIdBC, CMD_GET_CHANNEL_INFO(ActorRef.noSender, ByteVector32.Zeroes))
     val channelUpdateBC_new = sender.expectMsgType[RES_GET_CHANNEL_INFO].data.asInstanceOf[DATA_NORMAL].channelUpdate
     logger.info(s"channelUpdateBC=$channelUpdateBC")
     logger.info(s"channelUpdateBC_new=$channelUpdateBC_new")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/PaymentIntegrationSpec.scala
@@ -183,7 +183,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     sender.send(nodes("B").router, Router.GetChannels)
     val shortIdBC = sender.expectMsgType[Iterable[ChannelAnnouncement]].find(c => Set(c.nodeId1, c.nodeId2) == Set(nodes("B").nodeParams.nodeId, nodes("C").nodeParams.nodeId)).get.shortChannelId
     // we also need the full commitment
-    nodes("B").register ! Register.ForwardShortId(sender.ref.toTyped[Any], shortIdBC, CMD_GET_CHANNEL_INFO(ActorRef.noSender, ByteVector32.Zeroes))
+    nodes("B").register ! Register.ForwardShortId(sender.ref.toTyped[Any], shortIdBC, CMD_GET_CHANNEL_INFO(ActorRef.noSender))
     val normalBC = sender.expectMsgType[RES_GET_CHANNEL_INFO].data.asInstanceOf[DATA_NORMAL]
     // we then forge a new channel_update for B-C...
     val channelUpdateBC = Announcements.makeChannelUpdate(Block.RegtestGenesisBlock.hash, nodes("B").nodeParams.privateKey, nodes("C").nodeParams.nodeId, shortIdBC, nodes("B").nodeParams.channelConf.expiryDelta + 1, nodes("C").nodeParams.channelConf.htlcMinimum, nodes("B").nodeParams.relayParams.publicChannelFees.feeBase, nodes("B").nodeParams.relayParams.publicChannelFees.feeProportionalMillionths, 500000000 msat)
@@ -215,7 +215,7 @@ class PaymentIntegrationSpec extends IntegrationSpec {
     // first let's wait 3 seconds to make sure the timestamp of the new channel_update will be strictly greater than the former
     sender.expectNoMessage(3 seconds)
     nodes("B").register ! Register.ForwardShortId(sender.ref.toTyped[Any], shortIdBC, BroadcastChannelUpdate(PeriodicRefresh))
-    nodes("B").register ! Register.ForwardShortId(sender.ref.toTyped[Any], shortIdBC, CMD_GET_CHANNEL_INFO(ActorRef.noSender, ByteVector32.Zeroes))
+    nodes("B").register ! Register.ForwardShortId(sender.ref.toTyped[Any], shortIdBC, CMD_GET_CHANNEL_INFO(ActorRef.noSender))
     val channelUpdateBC_new = sender.expectMsgType[RES_GET_CHANNEL_INFO].data.asInstanceOf[DATA_NORMAL].channelUpdate
     logger.info(s"channelUpdateBC=$channelUpdateBC")
     logger.info(s"channelUpdateBC_new=$channelUpdateBC_new")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerChannelsCollectorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerChannelsCollectorSpec.scala
@@ -1,0 +1,74 @@
+package fr.acinq.eclair.io
+
+import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
+import akka.actor.typed.ActorRef
+import com.typesafe.config.ConfigFactory
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.eclair.channel._
+import fr.acinq.eclair.io.PeerChannelsCollector.GetChannels
+import fr.acinq.eclair.{randomBytes32, randomKey}
+import org.scalatest.Outcome
+import org.scalatest.funsuite.FixtureAnyFunSuiteLike
+
+import scala.concurrent.duration.DurationInt
+
+class PeerChannelsCollectorSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with FixtureAnyFunSuiteLike {
+
+  case class FixtureParam(remoteNodeId: PublicKey, collector: ActorRef[PeerChannelsCollector.Command], probe: TestProbe[Peer.PeerChannels]) {
+    def respond(request: CMD_GET_CHANNEL_INFO, channelState: ChannelState): Unit = {
+      request.replyTo ! RES_GET_CHANNEL_INFO(request.requestId, remoteNodeId, randomBytes32(), channelState, null)
+    }
+  }
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val remoteNodeId = randomKey().publicKey
+    val probe = TestProbe[Peer.PeerChannels]()
+    val collector = testKit.spawn(PeerChannelsCollector(remoteNodeId))
+    withFixture(test.toNoArgTest(FixtureParam(remoteNodeId, collector, probe)))
+  }
+
+  test("query multiple channels") { f =>
+    import f._
+
+    val (channel1, channel2, channel3) = (TestProbe[CMD_GET_CHANNEL_INFO](), TestProbe[CMD_GET_CHANNEL_INFO](), TestProbe[CMD_GET_CHANNEL_INFO]())
+    collector ! GetChannels(probe.ref, Set(channel1, channel2, channel3).map(_.ref))
+    val request1 = channel1.expectMessageType[CMD_GET_CHANNEL_INFO]
+    val request2 = channel2.expectMessageType[CMD_GET_CHANNEL_INFO]
+    val request3 = channel3.expectMessageType[CMD_GET_CHANNEL_INFO]
+    assert(Set(request1.requestId, request2.requestId, request3.requestId).size == 3)
+    respond(request1, NORMAL)
+    respond(request2, WAIT_FOR_FUNDING_CONFIRMED)
+    probe.expectNoMessage(100 millis) // we don't send a response back until we receive responses from all channels
+    respond(request3, CLOSING)
+    val peerChannels = probe.expectMessageType[Peer.PeerChannels]
+    assert(peerChannels.nodeId == remoteNodeId)
+    assert(peerChannels.channels.map(_.state).toSet == Set(NORMAL, WAIT_FOR_FUNDING_CONFIRMED, CLOSING))
+  }
+
+  test("channel dies before request") { f =>
+    import f._
+
+    val (channel1, channel2) = (TestProbe[CMD_GET_CHANNEL_INFO](), TestProbe[CMD_GET_CHANNEL_INFO]())
+    channel1.stop()
+    collector ! GetChannels(probe.ref, Set(channel1, channel2).map(_.ref))
+    val request2 = channel2.expectMessageType[CMD_GET_CHANNEL_INFO]
+    probe.expectNoMessage(100 millis)
+    respond(request2, NORMAL)
+    assert(probe.expectMessageType[Peer.PeerChannels].channels.size == 1)
+  }
+
+  test("channel dies after request") { f =>
+    import f._
+
+    val (channel1, channel2) = (TestProbe[CMD_GET_CHANNEL_INFO](), TestProbe[CMD_GET_CHANNEL_INFO]())
+    collector ! GetChannels(probe.ref, Set(channel1, channel2).map(_.ref))
+    channel1.expectMessageType[CMD_GET_CHANNEL_INFO]
+    channel1.stop()
+    val request2 = channel2.expectMessageType[CMD_GET_CHANNEL_INFO]
+    probe.expectNoMessage(100 millis)
+    respond(request2, NORMAL)
+    assert(probe.expectMessageType[Peer.PeerChannels].channels.size == 1)
+
+  }
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/AsyncPaymentTriggererSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/AsyncPaymentTriggererSpec.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.blockchain.CurrentBlockHeight
-import fr.acinq.eclair.channel.{CMD_GET_CHANNEL_STATE, NEGOTIATING, RES_GET_CHANNEL_STATE}
+import fr.acinq.eclair.channel.NEGOTIATING
 import fr.acinq.eclair.io.Switchboard.GetPeerInfo
 import fr.acinq.eclair.io.{Peer, PeerConnected, Switchboard}
 import fr.acinq.eclair.payment.relay.AsyncPaymentTriggerer._
@@ -20,18 +20,16 @@ import scala.concurrent.duration.DurationInt
 
 class AsyncPaymentTriggererSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with FixtureAnyFunSuiteLike {
 
-  case class FixtureParam(remoteNodeId: PublicKey, switchboard: TestProbe[Switchboard.GetPeerInfo], channel: TestProbe[CMD_GET_CHANNEL_STATE], probe: TestProbe[Result], triggerer: ActorRef[Command]) {
-    def channels: Set[akka.actor.ActorRef] = Set(channel.ref.toClassic)
-  }
+  case class FixtureParam(remoteNodeId: PublicKey, switchboard: TestProbe[Switchboard.GetPeerInfo], peer: TestProbe[Peer.GetPeerChannels], probe: TestProbe[Result], triggerer: ActorRef[Command])
 
   override def withFixture(test: OneArgTest): Outcome = {
     val remoteNodeId = TestConstants.Alice.nodeParams.nodeId
     val switchboard = TestProbe[Switchboard.GetPeerInfo]("switchboard")
-    val channel = TestProbe[CMD_GET_CHANNEL_STATE]("channel")
+    val peer = TestProbe[Peer.GetPeerChannels]("peer")
     val probe = TestProbe[Result]()
     val triggerer = testKit.spawn(AsyncPaymentTriggerer())
     triggerer ! Start(switchboard.ref)
-    withFixture(test.toNoArgTest(FixtureParam(remoteNodeId, switchboard, channel, probe, triggerer)))
+    withFixture(test.toNoArgTest(FixtureParam(remoteNodeId, switchboard, peer, probe, triggerer)))
   }
 
   test("remote node does not connect before timeout") { f =>
@@ -112,21 +110,21 @@ class AsyncPaymentTriggererSpec extends ScalaTestWithActorTestKit(ConfigFactory.
 
     triggerer ! Watch(probe.ref, remoteNodeId, paymentHash = ByteVector32.Zeroes, timeout = BlockHeight(100))
     val request1 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
-    request1.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.DISCONNECTED, None, channels)
+    request1.replyTo ! Peer.PeerInfo(peer.ref.toClassic, remoteNodeId, Peer.DISCONNECTED, None, Set(TestProbe().ref.toClassic))
 
     // An unrelated peer connects.
-    system.eventStream ! EventStream.Publish(PeerConnected(TestProbe().ref.toClassic, randomKey().publicKey, null))
+    system.eventStream ! EventStream.Publish(PeerConnected(peer.ref.toClassic, randomKey().publicKey, null))
     probe.expectNoMessage(100 millis)
 
     // The target peer connects.
-    system.eventStream ! EventStream.Publish(PeerConnected(TestProbe().ref.toClassic, remoteNodeId, null))
+    system.eventStream ! EventStream.Publish(PeerConnected(peer.ref.toClassic, remoteNodeId, null))
     val request2 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
-    request2.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.CONNECTED, None, channels)
-    channel.expectMessageType[CMD_GET_CHANNEL_STATE].replyTo ! RES_GET_CHANNEL_STATE(NEGOTIATING)
+    request2.replyTo ! Peer.PeerInfo(peer.ref.toClassic, remoteNodeId, Peer.CONNECTED, None, Set(TestProbe().ref.toClassic))
+    peer.expectMessageType[Peer.GetPeerChannels].replyTo ! Peer.PeerChannels(remoteNodeId, Seq(Peer.ChannelInfo(NEGOTIATING, null)))
     probe.expectMessage(AsyncPaymentTriggered)
 
     // Only get the trigger message once.
-    system.eventStream ! EventStream.Publish(PeerConnected(TestProbe().ref.toClassic, remoteNodeId, null))
+    system.eventStream ! EventStream.Publish(PeerConnected(peer.ref.toClassic, remoteNodeId, null))
     probe.expectNoMessage(100 millis)
   }
 
@@ -135,7 +133,7 @@ class AsyncPaymentTriggererSpec extends ScalaTestWithActorTestKit(ConfigFactory.
 
     triggerer ! Watch(probe.ref, remoteNodeId, paymentHash = ByteVector32.Zeroes, timeout = BlockHeight(100))
     val request1 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
-    request1.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.DISCONNECTED, None, channels)
+    request1.replyTo ! Peer.PeerInfo(peer.ref.toClassic, remoteNodeId, Peer.DISCONNECTED, None, Set(TestProbe().ref.toClassic))
 
     // Another async payment node relay watches the peer
     val probe2 = TestProbe[Result]()
@@ -146,10 +144,10 @@ class AsyncPaymentTriggererSpec extends ScalaTestWithActorTestKit(ConfigFactory.
     probe.expectMessage(AsyncPaymentTimeout)
 
     // Second watch succeeds
-    system.eventStream ! EventStream.Publish(PeerConnected(TestProbe().ref.toClassic, remoteNodeId, null))
+    system.eventStream ! EventStream.Publish(PeerConnected(peer.ref.toClassic, remoteNodeId, null))
     val request2 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
-    request2.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.CONNECTED, None, channels)
-    channel.expectMessageType[CMD_GET_CHANNEL_STATE].replyTo ! RES_GET_CHANNEL_STATE(NEGOTIATING)
+    request2.replyTo ! Peer.PeerInfo(peer.ref.toClassic, remoteNodeId, Peer.CONNECTED, None, Set(TestProbe().ref.toClassic))
+    peer.expectMessageType[Peer.GetPeerChannels].replyTo ! Peer.PeerChannels(remoteNodeId, Seq(Peer.ChannelInfo(NEGOTIATING, null)))
     probe.expectNoMessage(100 millis)
     probe2.expectMessage(AsyncPaymentTriggered)
   }
@@ -160,28 +158,28 @@ class AsyncPaymentTriggererSpec extends ScalaTestWithActorTestKit(ConfigFactory.
     // watch remote node
     triggerer ! Watch(probe.ref, remoteNodeId, paymentHash = ByteVector32.Zeroes, timeout = BlockHeight(100))
     val request1 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
-    request1.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.DISCONNECTED, None, channels)
+    request1.replyTo ! Peer.PeerInfo(peer.ref.toClassic, remoteNodeId, Peer.DISCONNECTED, None, Set(TestProbe().ref.toClassic))
 
     // watch another remote node
     val remoteNodeId2 = TestConstants.Bob.nodeParams.nodeId
     val probe2 = TestProbe[Result]()
     triggerer ! Watch(probe2.ref, remoteNodeId2, paymentHash = ByteVector32.Zeroes, timeout = BlockHeight(101))
     val request2 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
-    request2.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId, Peer.DISCONNECTED, None, channels)
+    request2.replyTo ! Peer.PeerInfo(peer.ref.toClassic, remoteNodeId, Peer.DISCONNECTED, None, Set(TestProbe().ref.toClassic))
 
     // First remote node times out
     system.eventStream ! EventStream.Publish(CurrentBlockHeight(BlockHeight(100)))
     probe.expectMessage(AsyncPaymentTimeout)
 
     // First remote node connects, but does not trigger expired watch
-    system.eventStream ! EventStream.Publish(PeerConnected(TestProbe().ref.toClassic, remoteNodeId, null))
+    system.eventStream ! EventStream.Publish(PeerConnected(peer.ref.toClassic, remoteNodeId, null))
 
     // Second remote node connects and triggers watch
-    system.eventStream ! EventStream.Publish(PeerConnected(TestProbe().ref.toClassic, remoteNodeId2, null))
+    system.eventStream ! EventStream.Publish(PeerConnected(peer.ref.toClassic, remoteNodeId2, null))
     val request3 = switchboard.expectMessageType[Switchboard.GetPeerInfo]
     assert(request3.remoteNodeId == remoteNodeId2)
-    request3.replyTo ! Peer.PeerInfo(TestProbe().ref.toClassic, remoteNodeId2, Peer.CONNECTED, None, channels)
-    channel.expectMessageType[CMD_GET_CHANNEL_STATE].replyTo ! RES_GET_CHANNEL_STATE(NEGOTIATING)
+    request3.replyTo ! Peer.PeerInfo(peer.ref.toClassic, remoteNodeId2, Peer.CONNECTED, None, Set(TestProbe().ref.toClassic))
+    peer.expectMessageType[Peer.GetPeerChannels].replyTo ! Peer.PeerChannels(remoteNodeId, Seq(Peer.ChannelInfo(NEGOTIATING, null)))
     probe.expectNoMessage(100 millis)
     probe2.expectMessage(AsyncPaymentTriggered)
   }


### PR DESCRIPTION
The `Peer` actor can now directly be queried for the list of its channels. This makes this feature more reusable than the previous actor that was customized for the peer-ready scenario.