### PR TITLE
Update maven version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM adoptopenjdk/openjdk11:jdk-11.0.3_7-alpine as BUILD
 # this was meant to make the image smaller, but we use multi-stage build so we don't care
 RUN apk add --no-cache curl tar bash
 
-ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_VERSION=3.9.2
 ARG USER_HOME_DIR="/root"
 ARG SHA=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries

--- a/contrib/arm64v8.Dockerfile
+++ b/contrib/arm64v8.Dockerfile
@@ -5,7 +5,7 @@ FROM eclipse-temurin:11-jdk-jammy as BUILD
 # this was meant to make the image smaller, but we use multi-stage build so we don't care
 RUN apt update && apt install -y curl tar bash
 
-ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_VERSION=3.9.2
 ARG USER_HOME_DIR="/root"
 ARG SHA=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries


### PR DESCRIPTION
We were previously relying on mvn 3.6.3 which has reached EOL. Building with mvn 3.9.2 creates some warnings that some of our existing build plugins won't be compatible with mvn 4.x, but we can ignore that.

I ran two eclair nodes built with mvn 3.9.2 on regtest, opened channels and made payments, and everything is looking good.