### PR TITLE
Use apache archives for mvn in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache curl tar bash
 ARG MAVEN_VERSION=3.9.2
 ARG USER_HOME_DIR="/root"
 ARG SHA=900bdeeeae550d2d2b3920fe0e00e41b0069f32c019d566465015bdd1b3866395cbe016e22d95d25d51d3a5e614af2c83ec9b282d73309f644859bbad08b63db
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \

--- a/contrib/arm64v8.Dockerfile
+++ b/contrib/arm64v8.Dockerfile
@@ -8,7 +8,7 @@ RUN apt update && apt install -y curl tar bash
 ARG MAVEN_VERSION=3.9.2
 ARG USER_HOME_DIR="/root"
 ARG SHA=900bdeeeae550d2d2b3920fe0e00e41b0069f32c019d566465015bdd1b3866395cbe016e22d95d25d51d3a5e614af2c83ec9b282d73309f644859bbad08b63db
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \


### PR DESCRIPTION
The previous repository we used removed the binaries for mvn 3.9.2, which broke our docker build. It looks like `archive.apache.org` keeps artifacts longer and hopefully won't break our docker build again soon.