### PR TITLE
Ignore `commit_sig` for aborted splice

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -515,6 +515,9 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
             case s: SpliceStatus.SpliceInProgress =>
               log.debug("received their commit_sig, deferring message")
               stay() using d.copy(spliceStatus = s.copy(remoteCommitSig = Some(commit)))
+            case SpliceStatus.SpliceAborted =>
+              log.warning("received commit_sig after sending tx_abort, they probably sent it before receiving our tx_abort, ignoring...")
+              stay()
             case SpliceStatus.SpliceWaitingForSigs(signingSession) =>
               signingSession.receiveCommitSig(nodeParams, d.commitments.params, commit) match {
                 case Left(f) =>


### PR DESCRIPTION
After exchanging `tx_complete`, we validate the splice transaction before sending our `commit_sig`. If we consider the transaction invalid, we send `tx_abort`. But if our peer thinks the transaction is valid, they will send their `commit_sig`, which we must ignore until they've acked our `tx_abort`.