### PR TITLE
Update dependencies

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.7.0</version>
+                <version>1.6.8</version>
                 <executions>
                     <execution>
                         <id>download-bitcoind</id>

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -174,7 +174,7 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-jackson_${scala.version.short}</artifactId>
-            <version>4.0.3</version>
+            <version>4.0.6</version>
         </dependency>
         <dependency>
             <groupId>com.softwaremill.sttp.client3</groupId>
@@ -185,7 +185,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
-            <version>4.1.42.Final</version>
+            <version>4.1.94.Final</version>
         </dependency>
         <!-- BITCOIN -->
         <dependency>
@@ -208,18 +208,18 @@
         <dependency>
             <groupId>org.scodec</groupId>
             <artifactId>scodec-core_${scala.version.short}</artifactId>
-            <version>1.11.9</version>
+            <version>1.11.10</version>
         </dependency>
         <dependency>
             <!-- needed to fix "No implicit Ordering defined for scodec.bits.ByteVector" -->
             <groupId>org.scodec</groupId>
             <artifactId>scodec-bits_${scala.version.short}</artifactId>
-            <version>1.1.30</version>
+            <version>1.1.37</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.9</version>
+            <version>1.15</version>
         </dependency>
         <!-- LOGGING -->
         <dependency>
@@ -231,27 +231,27 @@
         <dependency>
             <groupId>org.jheaps</groupId>
             <artifactId>jheaps</artifactId>
-            <version>0.9</version>
+            <version>0.14</version>
         </dependency>
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.39.2.0</version>
+            <version>3.42.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.3</version>
+            <version>42.6.0</version>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>3.4.2</version>
+            <version>4.0.3</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.68</version>
+            <version>1.70</version>
         </dependency>
         <dependency>
             <!-- This is to get rid of '[WARNING] warning: Class javax.annotation.Nonnull not found - continuing with a stub.' compile errors -->
@@ -267,7 +267,7 @@
         <dependency>
             <groupId>com.softwaremill.quicklens</groupId>
             <artifactId>quicklens_${scala.version.short}</artifactId>
-            <version>1.5.0</version>
+            <version>1.9.4</version>
         </dependency>
         <!-- MONITORING -->
         <dependency>

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -34,7 +34,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.3.0</version>
+                <version>1.7.0</version>
                 <executions>
                     <execution>
                         <id>download-bitcoind</id>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -77,10 +77,10 @@ class Setup(val datadir: File,
             seeds_opt: Option[Seeds] = None,
             db: Option[Databases] = None)(implicit system: ActorSystem) extends Logging {
 
-  implicit val timeout = Timeout(30 seconds)
-  implicit val formats = org.json4s.DefaultFormats
-  implicit val ec = ExecutionContext.Implicits.global
-  implicit val sttpBackend = OkHttpFutureBackend()
+  implicit val timeout: Timeout = Timeout(30 seconds)
+  implicit val formats: org.json4s.Formats = org.json4s.DefaultFormats
+  implicit val ec: ExecutionContext = ExecutionContext.Implicits.global
+  implicit val sttpBackend: sttp.client3.SttpBackend[Future, sttp.capabilities.WebSockets] = OkHttpFutureBackend()
 
   logger.info(s"hello!")
   logger.info(s"version=${Kit.getVersion} commit=${Kit.getCommit}")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/UInt64.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/UInt64.scala
@@ -48,8 +48,8 @@ object UInt64 {
 
   object Conversions {
 
-    implicit def intToUint64(l: Int) = UInt64(l)
+    implicit def intToUint64(l: Int): UInt64 = UInt64(l)
 
-    implicit def longToUint64(l: Long) = UInt64(l)
+    implicit def longToUint64(l: Long): UInt64 = UInt64(l)
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BasicBitcoinJsonRPCClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BasicBitcoinJsonRPCClient.scala
@@ -19,9 +19,9 @@ package fr.acinq.eclair.blockchain.bitcoind.rpc
 import fr.acinq.eclair.KamonExt
 import fr.acinq.eclair.blockchain.Monitoring.{Metrics, Tags}
 import fr.acinq.eclair.json.{ByteVector32KmpSerializer, ByteVector32Serializer}
-import org.json4s.DefaultFormats
 import org.json4s.JsonAST.JValue
-import org.json4s.jackson.Serialization
+import org.json4s.jackson.{JacksonSerialization, Serialization}
+import org.json4s.{DefaultFormats, Formats}
 import sttp.client3._
 import sttp.client3.json4s._
 import sttp.model.StatusCode
@@ -34,7 +34,7 @@ import scala.util.{Failure, Success, Try}
 
 class BasicBitcoinJsonRPCClient(rpcAuthMethod: BitcoinJsonRPCAuthMethod, host: String = "127.0.0.1", port: Int = 8332, ssl: Boolean = false, wallet: Option[String] = None)(implicit sb: SttpBackend[Future, _]) extends BitcoinJsonRPCClient {
 
-  implicit val formats = DefaultFormats.withBigDecimal + ByteVector32Serializer + ByteVector32KmpSerializer
+  implicit val formats: Formats = DefaultFormats.withBigDecimal + ByteVector32Serializer + ByteVector32KmpSerializer
 
   private val scheme = if (ssl) "https" else "http"
   private val serviceUri = wallet match {
@@ -42,7 +42,7 @@ class BasicBitcoinJsonRPCClient(rpcAuthMethod: BitcoinJsonRPCAuthMethod, host: S
     case None => uri"$scheme://$host:$port"
   }
   private val credentials = new AtomicReference[BitcoinJsonRPCCredentials](rpcAuthMethod.credentials)
-  implicit val serialization = Serialization
+  implicit val serialization: JacksonSerialization = Serialization
 
   override def invoke(method: String, params: Any*)(implicit ec: ExecutionContext): Future[JValue] =
     invoke(Seq(JsonRPCRequest(method = method, params = params))).map(l => jsonResponse2Exception(l.head).result)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/BitcoinCoreFeeProvider.scala
@@ -18,8 +18,8 @@ package fr.acinq.eclair.blockchain.fee
 
 import fr.acinq.bitcoin.scalacompat._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinJsonRPCClient
-import org.json4s.DefaultFormats
 import org.json4s.JsonAST._
+import org.json4s.{DefaultFormats, Formats}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
  */
 case class BitcoinCoreFeeProvider(rpcClient: BitcoinJsonRPCClient, defaultFeerates: FeeratesPerKB)(implicit ec: ExecutionContext) extends FeeProvider {
 
-  implicit val formats = DefaultFormats.withBigDecimal
+  implicit val formats: Formats = DefaultFormats.withBigDecimal
 
   /**
    * We need this to keep commitment tx fees in sync with the state of the network

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -33,6 +33,7 @@ import sttp.client3.okhttp.OkHttpFutureBackend
 import java.io.File
 import java.nio.file.Files
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.io.Source
 
@@ -44,7 +45,7 @@ trait BitcoindService extends Logging {
   import scala.sys.process._
 
   implicit val system: ActorSystem
-  implicit val sttpBackend = OkHttpFutureBackend()
+  implicit val sttpBackend: sttp.client3.SttpBackend[Future, sttp.capabilities.WebSockets] = OkHttpFutureBackend()
 
   val defaultWallet: String = "miner"
   val bitcoindPort: Int = TestUtils.availablePort

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/watchdogs/ExplorerApiSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/watchdogs/ExplorerApiSpec.scala
@@ -23,10 +23,13 @@ import fr.acinq.eclair.blockchain.watchdogs.BlockchainWatchdog.LatestHeaders
 import fr.acinq.eclair.blockchain.watchdogs.ExplorerApi.{BlockcypherExplorer, BlockstreamExplorer, CheckLatestHeaders, MempoolSpaceExplorer}
 import fr.acinq.eclair.{BlockHeight, TestTags}
 import org.scalatest.funsuite.AnyFunSuiteLike
+import sttp.client3.SttpBackend
+
+import scala.concurrent.Future
 
 class ExplorerApiSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with AnyFunSuiteLike {
 
-  implicit val sttpBackend = ExplorerApi.createSttpBackend(None)
+  implicit val sttpBackend: SttpBackend[Future, _] = ExplorerApi.createSttpBackend(None)
 
   val explorers = Seq(BlockcypherExplorer(), BlockstreamExplorer(useTorEndpoints = false), MempoolSpaceExplorer(useTorEndpoints = false))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/NoiseDemo.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/NoiseDemo.scala
@@ -25,7 +25,7 @@ import scodec.bits.{ByteVector, _}
   * Created by fabrice on 12/12/16.
   */
 object NoiseDemo extends App {
-  implicit val system = ActorSystem("test")
+  implicit val system: ActorSystem = ActorSystem("test")
 
   class NoiseHandler(keyPair: KeyPair, rs: Option[ByteVector], them: ActorRef, isWriter: Boolean, listenerFactory: => ActorRef) extends Actor with Stash {
     // initiator must know pubkey (i.e long-term ID) of responder

--- a/eclair-front/pom.xml
+++ b/eclair-front/pom.xml
@@ -50,7 +50,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.6.0</version>
                 <configuration>
                     <finalName>${project.name}-${project.version}-${git.commit.id.abbrev}</finalName>
                     <descriptors>

--- a/eclair-front/pom.xml
+++ b/eclair-front/pom.xml
@@ -85,13 +85,13 @@
         <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.10</version>
         </dependency>
         <!-- key management -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-secretsmanager</artifactId>
-            <version>1.11.776</version>
+            <version>1.12.504</version>
         </dependency>
         <!-- metrics -->
         <dependency>
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>io.kamon</groupId>
             <artifactId>kanela-agent</artifactId>
-            <version>1.0.5</version>
+            <version>1.0.17</version>
         </dependency>
         <!-- tests -->
         <dependency>
@@ -134,12 +134,6 @@
             <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-actor-testkit-typed_${scala.version.short}</artifactId>
             <version>${akka.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.opentable.components</groupId>
-            <artifactId>otj-pg-embedded</artifactId>
-            <version>0.13.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/eclair-front/src/main/scala/fr/acinq/eclair/FrontSetup.scala
+++ b/eclair-front/src/main/scala/fr/acinq/eclair/FrontSetup.scala
@@ -39,7 +39,7 @@ import scala.concurrent.{ExecutionContext, Future, Promise}
 
 class FrontSetup(datadir: File)(implicit system: ActorSystem) extends Logging {
 
-  implicit val timeout = Timeout(30 seconds)
+  implicit val timeout: Timeout = Timeout(30 seconds)
   implicit val ec: ExecutionContext = system.dispatcher
 
   logger.info(s"hello!")

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -85,7 +85,7 @@
             <!--conditional logging -->
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
-            <version>3.0.7</version>
+            <version>3.1.10</version>
         </dependency>
         <!-- http server -->
         <dependency>
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>io.kamon</groupId>
             <artifactId>kanela-agent</artifactId>
-            <version>1.0.5</version>
+            <version>1.0.17</version>
         </dependency>
     </dependencies>
 </project>

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -50,7 +50,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.6.0</version>
                 <configuration>
                     <finalName>${project.name}-${project.version}-${git.commit.id.abbrev}</finalName>
                     <descriptors>

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/WebSocket.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/WebSocket.scala
@@ -49,7 +49,7 @@ trait WebSocket {
     // register an actor that feeds the queue on payment related events
     actorSystem.actorOf(Props(new Actor {
 
-      override def preStart: Unit = {
+      override def preStart(): Unit = {
         context.system.eventStream.subscribe(self, classOf[PaymentEvent])
         context.system.eventStream.subscribe(self, classOf[ChannelCreated])
         context.system.eventStream.subscribe(self, classOf[ChannelOpened])

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
             <plugin>
                 <groupId>org.scoverage</groupId>
                 <artifactId>scoverage-maven-plugin</artifactId>
-                <version>1.4.2</version>
+                <version>1.4.1</version>
                 <configuration>
                     <skip>${maven.test.skip}</skip>
                     <scalaVersion>${scala.version}</scalaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.0.2</version>
+                    <version>3.6.0</version>
                     <executions>
                         <execution>
                             <phase>package</phase>
@@ -99,25 +99,25 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.0</version>
                 </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.6.0</version>
                 <inherited>true</inherited>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.3</version>
+                <version>2.7</version>
             </plugin>
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>2.2.3</version>
+                <version>4.9.10</version>
                 <executions>
                     <execution>
                         <goals>
@@ -132,7 +132,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>4.7.2</version>
+                <version>4.8.1</version>
                 <configuration>
                     <args combine.children="append">
                         <arg>-feature</arg>
@@ -174,7 +174,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -187,7 +187,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -219,7 +219,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>
@@ -228,7 +228,7 @@
             <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
-                <version>2.0.2</version>
+                <version>2.2.0</version>
                 <configuration>
                     <parallel>true</parallel>
                     <stdout>I</stdout>
@@ -249,7 +249,7 @@
             <plugin>
                 <groupId>org.scoverage</groupId>
                 <artifactId>scoverage-maven-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>1.4.11</version>
                 <configuration>
                     <skip>${maven.test.skip}</skip>
                     <scalaVersion>${scala.version}</scalaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
             <plugin>
                 <groupId>org.scoverage</groupId>
                 <artifactId>scoverage-maven-plugin</artifactId>
-                <version>1.4.11</version>
+                <version>1.4.2</version>
                 <configuration>
                     <skip>${maven.test.skip}</skip>
                     <scalaVersion>${scala.version}</scalaVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -67,14 +67,14 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <scala.version>2.13.10</scala.version>
+        <scala.version>2.13.11</scala.version>
         <scala.version.short>2.13</scala.version.short>
         <akka.version>2.6.20</akka.version>
         <akka.http.version>10.2.7</akka.http.version>
-        <sttp.version>3.8.5</sttp.version>
+        <sttp.version>3.8.16</sttp.version>
         <bitcoinlib.version>0.28</bitcoinlib.version>
-        <guava.version>31.1-jre</guava.version>
-        <kamon.version>2.6.1</kamon.version>
+        <guava.version>32.1.1-jre</guava.version>
+        <kamon.version>2.6.3</kamon.version>
     </properties>
 
     <build>
@@ -274,7 +274,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.version.short}</artifactId>
-            <version>3.2.12</version>
+            <version>3.2.16</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This is a chore that was on my post-release todo list. Some of our dependencies have newer versions, and updating to mvn 3.9.2 yielded some build warnings that are mostly fixed by updating the build dependencies.

I was tempted to update `logback` (we're on an older version that contains a CVE - which doesn't affect us), but couldn't get it to work, I was hitting issues because of our custom logger in `FixtureSpec` (`LoggingEventAware` not found). I'm not sure how hard I should try to update `logback`?