### PR TITLE
Update to bitcoind 24.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This means that instead of re-implementing them, Eclair benefits from the verifi
 
 * Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
 * You must configure your Bitcoin node to use `bech32` or `bech32m` (segwit) addresses. If your wallet has "non-segwit UTXOs" (outputs that are neither `p2sh-segwit`, `bech32` or `bech32m`), you must send them to a `bech32` or `bech32m` address before running Eclair.
-* Eclair requires Bitcoin Core 23.2 or higher. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
+* Eclair requires Bitcoin Core 24.1 or higher. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
 
 Run bitcoind with the following minimal `bitcoin.conf`:
 

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -88,9 +88,9 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-23.2/bitcoin-23.2-x86_64-linux-gnu.tar.gz</bitcoind.url>
-                <bitcoind.md5>1ec6ca817c679f3b4b6daa8021e401c7</bitcoind.md5>
-                <bitcoind.sha1>089476b853d8e33a52f67ffc46197dc49aa8a656</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-24.1/bitcoin-24.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
+                <bitcoind.md5>35a2faf826a9d866aa6821832e39231e</bitcoind.md5>
+                <bitcoind.sha1>a006ef05514b95cf4d78b5ec844e6cf78fabc196</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -101,9 +101,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-23.2/bitcoin-23.2-x86_64-apple-darwin.tar.gz</bitcoind.url>
-                <bitcoind.md5>406feabaad970a70ba10991577536970</bitcoind.md5>
-                <bitcoind.sha1>37165f9ccc23a8bea6a1029cd1186090c01b737c</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-24.1/bitcoin-24.1-x86_64-apple-darwin.tar.gz</bitcoind.url>
+                <bitcoind.md5>eba2d59fc9b81c0f6a9ccf77639b8b57</bitcoind.md5>
+                <bitcoind.sha1>b75f30dfa9095c733a9402e243e18174de4522d6</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -114,9 +114,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-23.2/bitcoin-23.2-win64.zip</bitcoind.url>
-                <bitcoind.md5>ba46d7646039bfcaa13137d953ff58bf</bitcoind.md5>
-                <bitcoind.sha1>684c669b1c929485422c48f3db6e8bc8304e55f7</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-24.1/bitcoin-24.1-win64.zip</bitcoind.url>
+                <bitcoind.md5>3a6cff40522e392f4ab1d8aef1274a9d</bitcoind.md5>
+                <bitcoind.sha1>588a60fe5d0b4d8fd09fae6bf366c3f0fc9336b8</bitcoind.sha1>
             </properties>
         </profile>
     </profiles>

--- a/eclair-core/src/test/resources/integration/bitcoin.conf
+++ b/eclair-core/src/test/resources/integration/bitcoin.conf
@@ -7,7 +7,8 @@ txindex=1
 zmqpubhashblock=tcp://127.0.0.1:28334
 zmqpubrawtx=tcp://127.0.0.1:28335
 rpcworkqueue=64
-fallbackfee=0.0002
+fallbackfee=0.0001 # 10 sat/byte
+consolidatefeerate=0 # we don't want bitcoind to consolidate utxos during tests
 [regtest]
 bind=127.0.0.1
 port=28333

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
@@ -1205,6 +1205,9 @@ class BitcoinCoreClientSpec extends TestKitBaseClass with BitcoindService with A
     // If we include the mempool, we see that tx1 produces an output that is still unspent.
     bitcoinClient.isTransactionOutputSpendable(tx1.txid, 0, includeMempool = true).pipeTo(sender.ref)
     sender.expectMsg(true)
+    // We're able to find the spending transaction in the mempool.
+    bitcoinClient.lookForMempoolSpendingTx(tx1.txIn.head.outPoint.txid, tx1.txIn.head.outPoint.index.toInt).pipeTo(sender.ref)
+    sender.expectMsg(tx1)
 
     // Let's confirm our transaction.
     generateBlocks(1)
@@ -1219,6 +1222,8 @@ class BitcoinCoreClientSpec extends TestKitBaseClass with BitcoindService with A
     sender.expectMsg(true)
 
     generateBlocks(1)
+    bitcoinClient.lookForMempoolSpendingTx(tx1.txIn.head.outPoint.txid, tx1.txIn.head.outPoint.index.toInt).pipeTo(sender.ref)
+    sender.expectMsgType[Failure]
     bitcoinClient.lookForSpendingTx(None, tx1.txIn.head.outPoint.txid, tx1.txIn.head.outPoint.index.toInt).pipeTo(sender.ref)
     sender.expectMsg(tx1)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -58,7 +58,7 @@ trait BitcoindService extends Logging {
 
   val PATH_BITCOIND = sys.env.get("BITCOIND_DIR") match {
     case Some(customBitcoinDir) => new File(customBitcoinDir, "bitcoind")
-    case None => new File(TestUtils.BUILD_DIRECTORY, "bitcoin-23.2/bin/bitcoind")
+    case None => new File(TestUtils.BUILD_DIRECTORY, "bitcoin-24.1/bin/bitcoind")
   }
   logger.info(s"using bitcoind: $PATH_BITCOIND")
   val PATH_BITCOIND_DATADIR = new File(INTEGRATION_TMP_DIR, "datadir-bitcoin")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
@@ -539,9 +539,9 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
   test("initiator and non-initiator splice-in") {
     val targetFeerate = FeeratePerKw(1000 sat)
     val fundingA1 = 100_000 sat
-    val utxosA = Seq(150_000 sat, 85_000 sat)
+    val utxosA = Seq(350_000 sat, 150_000 sat)
     val fundingB1 = 50_000 sat
-    val utxosB = Seq(90_000 sat, 80_000 sat)
+    val utxosB = Seq(175_000 sat, 90_000 sat)
     withFixture(fundingA1, utxosA, fundingB1, utxosB, targetFeerate, 660 sat, 0, RequireConfirmedInputs(forLocal = true, forRemote = true)) { f =>
       import f._
 
@@ -813,9 +813,9 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
   test("initiator and non-initiator combine splice-in and splice-out") {
     val targetFeerate = FeeratePerKw(1000 sat)
     val fundingA1 = 150_000 sat
-    val utxosA = Seq(200_000 sat, 100_000 sat)
+    val utxosA = Seq(480_000 sat, 130_000 sat)
     val fundingB1 = 100_000 sat
-    val utxosB = Seq(150_000 sat, 50_000 sat)
+    val utxosB = Seq(340_000 sat, 70_000 sat)
     withFixture(fundingA1, utxosA, fundingB1, utxosB, targetFeerate, 660 sat, 0, RequireConfirmedInputs(forLocal = true, forRemote = true)) { f =>
       import f._
 
@@ -1321,9 +1321,9 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
   test("fund splice transaction with previous inputs (no new inputs)") {
     val targetFeerate = FeeratePerKw(2_000 sat)
     val fundingA1 = 150_000 sat
-    val utxosA = Seq(200_000 sat, 75_000 sat)
+    val utxosA = Seq(480_000 sat, 75_000 sat)
     val fundingB1 = 100_000 sat
-    val utxosB = Seq(150_000 sat, 50_000 sat)
+    val utxosB = Seq(325_000 sat, 60_000 sat)
     withFixture(fundingA1, utxosA, fundingB1, utxosB, targetFeerate, 660 sat, 0, RequireConfirmedInputs(forLocal = false, forRemote = false)) { f =>
       import f._
 
@@ -1446,9 +1446,9 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
   test("fund splice transaction with previous inputs (with new inputs)") {
     val targetFeerate = FeeratePerKw(2_500 sat)
     val fundingA1 = 100_000 sat
-    val utxosA = Seq(140_000 sat, 40_000 sat, 35_000 sat)
+    val utxosA = Seq(340_000 sat, 40_000 sat, 35_000 sat)
     val fundingB1 = 80_000 sat
-    val utxosB = Seq(110_000 sat, 20_000 sat, 15_000 sat)
+    val utxosB = Seq(280_000 sat, 20_000 sat, 15_000 sat)
     withFixture(fundingA1, utxosA, fundingB1, utxosB, targetFeerate, 660 sat, 0, RequireConfirmedInputs(forLocal = false, forRemote = false)) { f =>
       import f._
 
@@ -1579,9 +1579,9 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
   test("funding splice transaction with previous inputs (different balance)") {
     val targetFeerate = FeeratePerKw(2_500 sat)
     val fundingA1 = 100_000 sat
-    val utxosA = Seq(140_000 sat, 40_000 sat, 35_000 sat)
+    val utxosA = Seq(340_000 sat, 40_000 sat, 35_000 sat)
     val fundingB1 = 80_000 sat
-    val utxosB = Seq(110_000 sat, 20_000 sat, 15_000 sat)
+    val utxosB = Seq(290_000 sat, 20_000 sat, 15_000 sat)
     withFixture(fundingA1, utxosA, fundingB1, utxosB, targetFeerate, 660 sat, 0, RequireConfirmedInputs(forLocal = false, forRemote = false)) { f =>
       import f._
 


### PR DESCRIPTION
This lets us use the new `gettxspendingprevout` instead of fetching the whole mempool when looking for txs spending one of our channels.

I had to change many of the test values in `InteractiveTxBuilderSpec` because `bitcoind` updated the way it generates the change output in https://github.com/bitcoin/bitcoin/pull/24494 which had mostly an impact on outputs around the 50k sat threshold. Bitcoin Core tries to create a change output with an amount similar to the main output for privacy reason (and has done so for a few versions already). While this makes sense for most users, it creates more liquidity churn for LSPs: ideally that's something we'd like to turn off (we probably don't want to pay for privacy). We may want to start using our own fork of `bitcoind` with small `coinselection` tweaks if we want to preserve our utxo set.