### PR TITLE
Set child splices as hints in watch-funding-spent

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -1153,7 +1153,7 @@ case class Commitments(params: ChannelParams,
   def updateLocalFundingStatus(fundingTxId: ByteVector32, status: LocalFundingStatus)(implicit log: LoggingAdapter): Either[Commitments, (Commitments, Commitment)] =
     updateFundingStatus(fundingTxId, _ => {
       case c if c.fundingTxId == fundingTxId =>
-        log.info(s"setting localFundingStatus=${status.getClass.getSimpleName} for fundingTxId=$fundingTxId fundingTxIndex=${c.fundingTxIndex}")
+        log.info(s"setting localFundingStatus=${status.getClass.getSimpleName} for fundingTxId=${c.fundingTxId} fundingTxIndex=${c.fundingTxIndex}")
         c.copy(localFundingStatus = status)
       case c => c
     })
@@ -1162,7 +1162,7 @@ case class Commitments(params: ChannelParams,
     updateFundingStatus(fundingTxId, fundingTxIndex => {
       // all funding older than this one are considered locked
       case c if c.fundingTxId == fundingTxId || c.fundingTxIndex < fundingTxIndex =>
-        log.info(s"setting remoteFundingStatus=${RemoteFundingStatus.Locked.getClass.getSimpleName} for fundingTxId=$fundingTxId fundingTxIndex=${c.fundingTxIndex}")
+        log.info(s"setting remoteFundingStatus=${RemoteFundingStatus.Locked.getClass.getSimpleName} for fundingTxId=${c.fundingTxId} fundingTxIndex=${c.fundingTxIndex}")
         c.copy(remoteFundingStatus = RemoteFundingStatus.Locked)
       case c => c
     })

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -288,7 +288,9 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
                   // in all other cases we need to be ready for any type of closing
                   watchFundingSpent(commitment, closing.spendingTxs.map(_.txid).toSet)
                 case _ =>
-                  watchFundingSpent(commitment)
+                  // Children splice transactions may already spend that confirmed funding transaction.
+                  val spliceSpendingTxs = data.commitments.all.collect { case c if c.fundingTxIndex == commitment.fundingTxIndex + 1 => c.fundingTxId }
+                  watchFundingSpent(commitment, additionalKnownSpendingTxs = spliceSpendingTxs.toSet)
               }
           }
         }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/testutils/PimpTestProbe.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/testutils/PimpTestProbe.scala
@@ -22,8 +22,11 @@ case class PimpTestProbe(probe: TestProbe) extends Assertions {
     msg
   }
 
-  def expectWatchFundingSpent(txid: ByteVector32): WatchFundingSpent =
-    expectMsgTypeHaving[WatchFundingSpent](w => assert(w.txId == txid, "txid"))
+  def expectWatchFundingSpent(txid: ByteVector32, hints_opt: Option[Set[ByteVector32]] = None): WatchFundingSpent =
+    expectMsgTypeHaving[WatchFundingSpent](w => {
+      assert(w.txId == txid, "txid")
+      hints_opt.foreach(hints => assert(hints == w.hints))
+    })
 
   def expectWatchFundingConfirmed(txid: ByteVector32): WatchFundingConfirmed =
     expectMsgTypeHaving[WatchFundingConfirmed](w => assert(w.txId == txid, "txid"))


### PR DESCRIPTION
We start watching funding outputs once the corresponding funding transaction has been confirmed with 3 confirmations. We may have already spent that transaction with a child splice transaction by that time: providing hints with the corresponding txids to the `ZmqWatcher` improves the performance when that happens.