### PR TITLE
Use an available port in "bitcoind started with wallets disabled" test

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/StartupIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/StartupIntegrationSpec.scala
@@ -64,7 +64,7 @@ class StartupIntegrationSpec extends IntegrationSpec {
   test("bitcoind started with wallets disabled") {
     restartBitcoind(startupFlags = "-disablewallet", loadWallet = false)
     val thrown = intercept[BitcoinWalletDisabledException] {
-      instantiateEclairNode("F", ConfigFactory.load().getConfig("eclair").withFallback(withDefaultCommitment).withFallback(commonConfig))
+      instantiateEclairNode("F", ConfigFactory.parseMap(Map("eclair.server.port" -> TestUtils.availablePort).asJava).withFallback(withDefaultCommitment).withFallback(commonConfig))
     }
     assert(thrown == BitcoinWalletDisabledException(e = JsonRPCError(Error(-32601, "Method not found"))))
   }


### PR DESCRIPTION
Use an available port in "bitcoind started with wallets disabled" test instead of using 9735.