### PR TITLE
Use `bumpforceclose` RPC to also bump remote commit fees

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/OnChainFeeConf.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/OnChainFeeConf.scala
@@ -24,26 +24,29 @@ import fr.acinq.eclair.transactions.Transactions
 
 // @formatter:off
 sealed trait ConfirmationPriority extends Ordered[ConfirmationPriority] {
+  def underlying: Int
+
   def getFeerate(feerates: FeeratesPerKw): FeeratePerKw = this match {
     case ConfirmationPriority.Slow => feerates.slow
     case ConfirmationPriority.Medium => feerates.medium
     case ConfirmationPriority.Fast => feerates.fast
   }
 
-  override def compare(that:  ConfirmationPriority): Int = (this, that) match {
-    case (ConfirmationPriority.Slow, ConfirmationPriority.Slow) => 0
-    case (ConfirmationPriority.Slow, _) => -1
-    case (ConfirmationPriority.Medium, ConfirmationPriority.Slow) => 1
-    case (ConfirmationPriority.Medium, ConfirmationPriority.Medium) => 0
-    case (ConfirmationPriority.Medium, ConfirmationPriority.Fast) => -1
-    case (ConfirmationPriority.Fast, ConfirmationPriority.Fast) => 0
-    case (ConfirmationPriority.Fast, _) => 1
-  }
+  override def compare(that: ConfirmationPriority): Int = this.underlying.compare(that.underlying)
 }
 object ConfirmationPriority {
-  case object Slow extends ConfirmationPriority { override def toString = "slow" }
-  case object Medium extends ConfirmationPriority { override def toString = "medium" }
-  case object Fast extends ConfirmationPriority { override def toString = "fast" }
+  case object Slow extends ConfirmationPriority {
+    override val underlying = 1
+    override def toString = "slow"
+  }
+  case object Medium extends ConfirmationPriority {
+    override val underlying = 2
+    override def toString = "medium"
+  }
+  case object Fast extends ConfirmationPriority {
+    override val underlying = 3
+    override def toString = "fast"
+  }
 }
 sealed trait ConfirmationTarget
 object ConfirmationTarget {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/OnChainFeeConf.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/OnChainFeeConf.scala
@@ -23,11 +23,21 @@ import fr.acinq.eclair.channel.{ChannelTypes, SupportedChannelType}
 import fr.acinq.eclair.transactions.Transactions
 
 // @formatter:off
-sealed trait ConfirmationPriority {
+sealed trait ConfirmationPriority extends Ordered[ConfirmationPriority] {
   def getFeerate(feerates: FeeratesPerKw): FeeratePerKw = this match {
     case ConfirmationPriority.Slow => feerates.slow
     case ConfirmationPriority.Medium => feerates.medium
     case ConfirmationPriority.Fast => feerates.fast
+  }
+
+  override def compare(that:  ConfirmationPriority): Int = (this, that) match {
+    case (ConfirmationPriority.Slow, ConfirmationPriority.Slow) => 0
+    case (ConfirmationPriority.Slow, _) => -1
+    case (ConfirmationPriority.Medium, ConfirmationPriority.Slow) => 1
+    case (ConfirmationPriority.Medium, ConfirmationPriority.Medium) => 0
+    case (ConfirmationPriority.Medium, ConfirmationPriority.Fast) => -1
+    case (ConfirmationPriority.Fast, ConfirmationPriority.Fast) => 0
+    case (ConfirmationPriority.Fast, _) => 1
   }
 }
 object ConfirmationPriority {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -720,7 +720,7 @@ object Helpers {
 
     /**
      * This function checks if the proposed confirmation target is more aggressive than whatever confirmation target
-     * we previously had. Not that absolute targets are always considered more aggressive than relative targets.
+     * we previously had. Note that absolute targets are always considered more aggressive than relative targets.
      */
     private def shouldUpdateAnchorTxs(anchorTxs: List[ClaimAnchorOutputTx], confirmationTarget: ConfirmationTarget): Boolean = {
       anchorTxs

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -1706,20 +1706,23 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
     case Event(c: CMD_CLOSE, d: DATA_CLOSING) => handleCommandError(ClosingAlreadyInProgress(d.channelId), c)
 
     case Event(c: CMD_BUMP_FORCE_CLOSE_FEE, d: DATA_CLOSING) =>
-      d.localCommitPublished match {
-        case Some(lcp) => d.commitments.params.commitmentFormat match {
-          case _: Transactions.AnchorOutputsCommitmentFormat =>
-            val lcp1 = Closing.LocalClose.claimAnchors(keyManager, d.commitments.latest, lcp, c.confirmationTarget)
-            lcp1.claimAnchorTxs.collect { case tx: Transactions.ClaimLocalAnchorOutputTx => txPublisher ! PublishReplaceableTx(tx, d.commitments.latest) }
+      d.commitments.params.commitmentFormat match {
+        case _: Transactions.AnchorOutputsCommitmentFormat =>
+          val lcp1 = d.localCommitPublished.map(lcp => Closing.LocalClose.claimAnchors(keyManager, d.commitments.latest, lcp, c.confirmationTarget))
+          val rcp1 = d.remoteCommitPublished.map(rcp => Closing.RemoteClose.claimAnchors(keyManager, d.commitments.latest, rcp, c.confirmationTarget))
+          val nrcp1 = d.nextRemoteCommitPublished.map(nrcp => Closing.RemoteClose.claimAnchors(keyManager, d.commitments.latest, nrcp, c.confirmationTarget))
+          val claimAnchorTxs = lcp1.toSeq.flatMap(_.claimAnchorTxs) ++ rcp1.toSeq.flatMap(_.claimAnchorTxs) ++ nrcp1.toSeq.flatMap(_.claimAnchorTxs)
+          claimAnchorTxs.collect { case tx: Transactions.ClaimLocalAnchorOutputTx => txPublisher ! PublishReplaceableTx(tx, d.commitments.latest) }
+          if (claimAnchorTxs.nonEmpty) {
             c.replyTo ! RES_SUCCESS(c, d.channelId)
-            stay() using d.copy(localCommitPublished = Some(lcp1))
-          case Transactions.DefaultCommitmentFormat =>
-            log.warning("cannot bump force-close fees, channel is not using anchor outputs")
+            stay() using d.copy(localCommitPublished = lcp1, remoteCommitPublished = rcp1, nextRemoteCommitPublished = nrcp1) storing()
+          } else {
+            log.warning("cannot bump force-close fees, local or remote commit not published")
             c.replyTo ! RES_FAILURE(c, CommandUnavailableInThisState(d.channelId, "rbf-force-close", stateName))
             stay()
-        }
-        case None =>
-          log.warning("cannot bump force-close fees, local commit hasn't been published")
+          }
+        case _ =>
+          log.warning("cannot bump force-close fees, channel is not using anchor outputs")
           c.replyTo ! RES_FAILURE(c, CommandUnavailableInThisState(d.channelId, "rbf-force-close", stateName))
           stay()
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ErrorHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ErrorHandlers.scala
@@ -272,8 +272,9 @@ trait ErrorHandlers extends CommonHandlers {
   def doPublish(remoteCommitPublished: RemoteCommitPublished, commitment: FullCommitment): Unit = {
     import remoteCommitPublished._
 
+    val claimLocalAnchor = claimAnchorTxs.collect { case tx: Transactions.ClaimLocalAnchorOutputTx => PublishReplaceableTx(tx, commitment) }
     val redeemableHtlcTxs = claimHtlcTxs.values.flatten.map(tx => PublishReplaceableTx(tx, commitment))
-    val publishQueue = claimMainOutputTx.map(tx => PublishFinalTx(tx, tx.fee, None)).toSeq ++ redeemableHtlcTxs
+    val publishQueue = claimLocalAnchor ++ claimMainOutputTx.map(tx => PublishFinalTx(tx, tx.fee, None)).toSeq ++ redeemableHtlcTxs
     publishIfNeeded(publishQueue, irrevocablySpent)
 
     // we watch:

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/TxPublisher.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/publish/TxPublisher.scala
@@ -244,6 +244,9 @@ private class TxPublisher(nodeParams: NodeParams, factory: TxPublisher.ChildFact
               case (_: ConfirmationTarget.Priority, ConfirmationTarget.Absolute(_)) =>
                 // Switch from relative priority mode to absolute blockheight mode
                 updateConfirmationTarget()
+              case (ConfirmationTarget.Priority(current), ConfirmationTarget.Priority(proposed)) if current < proposed =>
+                // Switch to a higher relative priority.
+                updateConfirmationTarget()
               case _ =>
                 log.debug("not publishing replaceable {} spending {}:{} with confirmation target={}, publishing is already in progress with confirmation target={}", cmd.desc, cmd.input.txid, cmd.input.index, proposedConfirmationTarget, currentConfirmationTarget)
                 Behaviors.same

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
@@ -27,6 +27,7 @@ import fr.acinq.eclair.channel.publish.TxPublisher
 import fr.acinq.eclair.channel.publish.TxPublisher.SetChannelId
 import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
 import fr.acinq.eclair.payment.relay.Relayer.RelayFees
+import fr.acinq.eclair.transactions.Transactions.ClaimLocalAnchorOutputTx
 import fr.acinq.eclair.wire.protocol._
 import fr.acinq.eclair.{BlockHeight, MilliSatoshiLong, TestConstants, TestKitBaseClass}
 import org.scalatest.OptionValues.convertOptionToValuable
@@ -198,6 +199,7 @@ class WaitForDualFundingReadyStateSpec extends TestKitBaseClass with FixtureAnyF
     // bob publishes his commitment tx
     val bobCommitTx = bob.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_READY].commitments.latest.localCommit.commitTxAndRemoteSig.commitTx.tx
     alice ! WatchFundingSpentTriggered(bobCommitTx)
+    assert(alice2blockchain.expectMsgType[TxPublisher.PublishReplaceableTx].txInfo.isInstanceOf[ClaimLocalAnchorOutputTx])
     alice2blockchain.expectMsgType[TxPublisher.PublishTx]
     assert(alice2blockchain.expectMsgType[WatchTxConfirmed].txId == bobCommitTx.txid)
     listener.expectMsgType[ChannelAborted]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -34,6 +34,7 @@ import fr.acinq.eclair.channel.states.ChannelStateTestsTags.{AnchorOutputsZeroFe
 import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
 import fr.acinq.eclair.testutils.PimpTestProbe.convert
 import fr.acinq.eclair.transactions.Transactions
+import fr.acinq.eclair.transactions.Transactions.ClaimLocalAnchorOutputTx
 import fr.acinq.eclair.wire.protocol._
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
@@ -1339,6 +1340,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     // bob's remote tx wins
     alice ! WatchAlternativeCommitTxConfirmedTriggered(BlockHeight(400000), 42, bobCommitTx1)
     // we're back to the normal handling of remote commit
+    assert(alice2blockchain.expectMsgType[PublishReplaceableTx].txInfo.isInstanceOf[ClaimLocalAnchorOutputTx])
     val claimMain = alice2blockchain.expectMsgType[PublishFinalTx].tx
     val watchConfirmedRemoteCommit = alice2blockchain.expectMsgType[WatchTxConfirmed]
     assert(watchConfirmedRemoteCommit.txId == bobCommitTx1.txid)


### PR DESCRIPTION
This is a follow-up for #2743

When manually bumping the fees of a force-close (to help wallet users recover their funds more quickly), we also want to handle the case where they were the one publishing the commit tx and bump their remote commit. It can also be helpful for node operators who set `eclair.on-chain-fees.spend-anchor-without-htlcs = false` and want to recover their liquidity on a case-by-case basis.

We also fix two issues in #2743:

- we weren't persisting the manual fee-bump to the DB: if the node was restarted, we wouldn't keep on bumping the fees
- we didn't have an ordering on `ConfirmationPriority`, which means `fast` wasn't replacing a previous `medium` or `slow`
