### PR TITLE
Fix tests that expect network minimum feerate to be less than other rates

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
@@ -136,8 +136,8 @@ object FeeratesPerKw {
     fastest = FeeratePerKw(feerates.fastest))
 
   /** Used in tests */
-  def single(feeratePerKw: FeeratePerKw): FeeratesPerKw = FeeratesPerKw(
-    minimum = feeratePerKw,
+  def single(feeratePerKw: FeeratePerKw, networkMinFee: FeeratePerKw = FeeratePerKw(1.sat)): FeeratesPerKw = FeeratesPerKw(
+    minimum = networkMinFee,
     slow = feeratePerKw,
     medium = feeratePerKw,
     fast = feeratePerKw,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/FeeProvider.scala
@@ -136,7 +136,7 @@ object FeeratesPerKw {
     fastest = FeeratePerKw(feerates.fastest))
 
   /** Used in tests */
-  def single(feeratePerKw: FeeratePerKw, networkMinFee: FeeratePerKw = FeeratePerKw(1.sat)): FeeratesPerKw = FeeratesPerKw(
+  def single(feeratePerKw: FeeratePerKw, networkMinFee: FeeratePerKw = FeeratePerKw(FeeratePerByte(1 sat))): FeeratesPerKw = FeeratesPerKw(
     minimum = networkMinFee,
     slow = feeratePerKw,
     medium = feeratePerKw,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -202,6 +202,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     alice ! cmd
     // we tweak the feerate
     val spliceInit = alice2bob.expectMsgType[SpliceInit].copy(feerate = FeeratePerKw(100.sat))
+    bob.setFeerates(alice.nodeParams.currentFeerates.copy(minimum = FeeratePerKw(101.sat)))
     alice2bob.forward(bob, spliceInit)
     val txAbortBob = bob2alice.expectMsgType[TxAbort]
     bob2alice.forward(alice, txAbortBob)


### PR DESCRIPTION
A minor fix needed after updating the test `"disconnect (tx_signatures received by alice, zero-conf)"` in #2720. It should not trigger a fee rate update after reconnecting when using anchors outputs, but does if the minimum feerate is the same as the other feerates.

