### PR TITLE
Fix a flaky async payment triggerer test

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerReadyNotifier.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerReadyNotifier.scala
@@ -126,7 +126,7 @@ object PeerReadyNotifier {
         context.log.debug("waiting for peer to connect at block {}", currentBlockHeight)
         Behaviors.same
       case Timeout =>
-        context.log.info("timed out waiting for peer to be ready")
+        context.log.info("timed out waiting for peer to connect")
         replyTo ! PeerUnavailable(remoteNodeId)
         Behaviors.stopped
     }


### PR DESCRIPTION
Sometimes the `PeerReadyNotifier` for node A has not been killed before node A connects. This causes an extra `GetPeerInfo` message to be sent to the switchboard and the `assert(request3.remoteNodeId == remoteNodeId2)` check to fail when the `GetPeerInfo` for node A comes before the one for node B. Just waiting to receive the `AsyncPaymentTimeout` message does not guarantee the notifier has been stopped.

If node A connects after node B then this race does not occur.

In the logs the error looked like this:
```
watch two nodes, one connects and the other times out *** FAILED ***
 02aaaa00ce2f18a967dc4f25f414e671ba6585f8ef0b8c5fb812c21064f55a2eaa did not equal 02bbbb671d15145722fb8c28d732cddb249bcc6652ed2b297ff1f77a18371b1e63 (AsyncPaymentTriggererSpec.scala:185)
 Analysis:
 Crypto$PublicKey(pub: 02aaaa00ce2f18a967dc4f25f414e671ba6585f8ef0b8c5fb812c21064f55a2eaa -> 02bbbb671d15145722fb8c28d732cddb249bcc6652ed2b297ff1f77a18371b1e63, value: ByteVector$Chunk(bytes: ByteVector$View(at: scodec.bits.ByteVector$AtArray@414cba29 -> scodec.bits.ByteVector$AtArray@317a0b5e)))
```
