### PR TITLE
Fix `tx_signatures` ordering for splices

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -1232,7 +1232,6 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     testDisconnectTxSignaturesReceivedByAliceZeroConf(f)
   }
 
-
   test("disconnect (tx_signatures sent by alice, splice confirms while bob is offline)") { f =>
     import f._
 


### PR DESCRIPTION
We were incorrectly splitting the shared input amount based on each peer's balance, but for the signing order the peer that adds the shared input takes credit for the whole amount of that input.