### PR TITLE
Remove reserve check if splice contribution is positive

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -2690,7 +2690,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
         spliceOut = cmd.spliceOutputs,
         targetFeerate = targetFeerate)
       val commitTxFees = Transactions.commitTxTotalCost(d.commitments.params.remoteParams.dustLimit, parentCommitment.remoteCommit.spec, d.commitments.params.commitmentFormat)
-      if (parentCommitment.localCommit.spec.toLocal + fundingContribution < parentCommitment.localChannelReserve(d.commitments.params).max(commitTxFees)) {
+      if (fundingContribution < 0.sat && parentCommitment.localCommit.spec.toLocal + fundingContribution < parentCommitment.localChannelReserve(d.commitments.params).max(commitTxFees)) {
         log.warning(s"cannot do splice: insufficient funds (commitTxFees=$commitTxFees reserve=${parentCommitment.localChannelReserve(d.commitments.params)})")
         Left(InvalidSpliceRequest(d.channelId))
       } else if (cmd.spliceOut_opt.map(_.scriptPubKey).exists(!MutualClose.isValidFinalScriptPubkey(_, allowAnySegwit = true))) {


### PR DESCRIPTION
If remote has a positive contribution, we do not check their post-splice reserve level, because they are improving their situation, even if they stay below the requirement. Note that if local splices-in some funds in the same operation, remote post-splice reserve may actually be worse than before, but that's not their fault.