### PR TITLE
Disable channel when closing

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/f/ShutdownStateSpec.scala
@@ -32,7 +32,7 @@ import fr.acinq.eclair.payment.OutgoingPaymentPacket.Upstream
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.relay.Relayer._
 import fr.acinq.eclair.payment.send.SpontaneousRecipient
-import fr.acinq.eclair.wire.protocol.{ClosingSigned, CommitSig, Error, FailureMessageCodecs, PermanentChannelFailure, RevokeAndAck, Shutdown, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFee, UpdateFulfillHtlc}
+import fr.acinq.eclair.wire.protocol.{AnnouncementSignatures, ClosingSigned, CommitSig, Error, FailureMessageCodecs, PermanentChannelFailure, RevokeAndAck, Shutdown, UpdateAddHtlc, UpdateFailHtlc, UpdateFailMalformedHtlc, UpdateFee, UpdateFulfillHtlc}
 import fr.acinq.eclair.{BlockHeight, CltvExpiry, CltvExpiryDelta, MilliSatoshiLong, TestConstants, TestKitBaseClass, randomBytes32}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.{Outcome, Tag}
@@ -100,6 +100,42 @@ class ShutdownStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wit
       channelUpdateListener.expectMsgType[LocalChannelDown]
       channelUpdateListener.expectMsgType[LocalChannelDown]
       withFixture(test.toNoArgTest(setup))
+    }
+  }
+
+  test("emit disabled channel update", Tag(ChannelStateTestsTags.ChannelsPublic)) { () =>
+    val setup = init()
+    import setup._
+    within(30 seconds) {
+      reachNormal(setup, Set(ChannelStateTestsTags.ChannelsPublic))
+
+      val aliceListener = TestProbe()
+      systemA.eventStream.subscribe(aliceListener.ref, classOf[LocalChannelUpdate])
+      val bobListener = TestProbe()
+      systemB.eventStream.subscribe(bobListener.ref, classOf[LocalChannelUpdate])
+
+      alice ! WatchFundingDeeplyBuriedTriggered(BlockHeight(400_000), 42, null)
+      alice2bob.expectMsgType[AnnouncementSignatures]
+      alice2bob.forward(bob)
+      bob ! WatchFundingDeeplyBuriedTriggered(BlockHeight(400_000), 42, null)
+      bob2alice.expectMsgType[AnnouncementSignatures]
+      bob2alice.forward(alice)
+      assert(aliceListener.expectMsgType[LocalChannelUpdate].channelUpdate.channelFlags.isEnabled)
+      assert(bobListener.expectMsgType[LocalChannelUpdate].channelUpdate.channelFlags.isEnabled)
+
+      addHtlc(50_000_000 msat, alice, bob, alice2bob, bob2alice)
+      crossSign(alice, bob, alice2bob, bob2alice)
+
+      alice ! CMD_CLOSE(TestProbe().ref, None, None)
+      alice2bob.expectMsgType[Shutdown]
+      alice2bob.forward(bob)
+      bob2alice.expectMsgType[Shutdown]
+      bob2alice.forward(alice)
+      awaitCond(alice.stateName == SHUTDOWN)
+      awaitCond(bob.stateName == SHUTDOWN)
+
+      assert(!aliceListener.expectMsgType[LocalChannelUpdate].channelUpdate.channelFlags.isEnabled)
+      assert(!bobListener.expectMsgType[LocalChannelUpdate].channelUpdate.channelFlags.isEnabled)
     }
   }
 


### PR DESCRIPTION
As soon as a channel is transitioning to a closing state (mutual or unilateral close), it cannot be used to relay HTLCs anymore. We should notify the network by sending a disabled `channel_update`.

Fixes #2766