### PR TITLE
Fixes for quiescence back ported from lightning-kmp

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -878,6 +878,11 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
         stay()
       }
 
+    case Event(_: Stfu, d: DATA_NORMAL) if d.localShutdown.isDefined =>
+      log.warning("our peer sent stfu but we sent shutdown first")
+      // We don't need to do anything, they should accept our shutdown.
+      stay()
+
     case Event(msg: Stfu, d: DATA_NORMAL) =>
       if (d.commitments.params.useQuiescence) {
         if (d.commitments.remoteIsQuiescent) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -928,6 +928,10 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
 
     case Event(_: QuiescenceTimeout, d: DATA_NORMAL) => handleQuiescenceTimeout(d)
 
+    case Event(_: SpliceInit, d: DATA_NORMAL) if d.spliceStatus == SpliceStatus.NoSplice && d.commitments.params.useQuiescence =>
+      log.info("rejecting splice attempt: quiescence not negotiated")
+      stay() using d.copy(spliceStatus = SpliceStatus.SpliceAborted) sending TxAbort(d.channelId, InvalidSpliceNotQuiescent(d.channelId).getMessage)
+
     case Event(msg: SpliceInit, d: DATA_NORMAL) =>
       d.spliceStatus match {
         case SpliceStatus.NoSplice | SpliceStatus.NonInitiatorQuiescent =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -2705,7 +2705,9 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
         spliceInAmount = cmd.additionalLocalFunding,
         spliceOut = cmd.spliceOutputs,
         targetFeerate = targetFeerate)
-      val commitTxFees = Transactions.commitTxTotalCost(d.commitments.params.remoteParams.dustLimit, parentCommitment.remoteCommit.spec, d.commitments.params.commitmentFormat)
+      val commitTxFees = if (d.commitments.params.localParams.isInitiator) {
+        Transactions.commitTxTotalCost(d.commitments.params.remoteParams.dustLimit, parentCommitment.remoteCommit.spec, d.commitments.params.commitmentFormat)
+      } else 0.sat
       if (fundingContribution < 0.sat && parentCommitment.localCommit.spec.toLocal + fundingContribution < parentCommitment.localChannelReserve(d.commitments.params).max(commitTxFees)) {
         log.warning(s"cannot do splice: insufficient funds (commitTxFees=$commitTxFees reserve=${parentCommitment.localChannelReserve(d.commitments.params)})")
         Left(InvalidSpliceRequest(d.channelId))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalQuiescentStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalQuiescentStateSpec.scala
@@ -115,7 +115,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
   test("send stfu after pending local changes have been added") { f =>
     import f._
     // we have an unsigned htlc in our local changes
-    addHtlc(10_000 msat, alice, bob, alice2bob, bob2alice)
+    addHtlc(50_000_000 msat, alice, bob, alice2bob, bob2alice)
     alice ! CMD_SPLICE(TestProbe().ref, spliceIn_opt = Some(SpliceIn(50_000 sat)), spliceOut_opt = None)
     alice2bob.expectNoMessage(100 millis)
     crossSign(alice, bob, alice2bob, bob2alice)
@@ -127,7 +127,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
     import f._
     initiateQuiescence(f, sendInitialStfu = false)
     // we're holding the stfu from alice so that bob can add a pending local change
-    addHtlc(10_000 msat, bob, alice, bob2alice, alice2bob)
+    addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
     // bob will not reply to alice's stfu until bob has no pending local commitment changes
     alice2bob.forward(bob)
     bob2alice.expectNoMessage(100 millis)
@@ -187,8 +187,8 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
   private def receiveSettlementCommand(f: FixtureParam, c: SettlementCommandEnum, sendInitialStfu: Boolean, resetConnection: Boolean = false): Unit = {
     import f._
 
-    val (preimage, add) = addHtlc(10_000 msat, bob, alice, bob2alice, alice2bob)
-    val cmd = c match {
+    val (preimage, add) = addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
+      val cmd = c match {
       case FulfillHtlc => CMD_FULFILL_HTLC(add.id, preimage)
       case FailHtlc => CMD_FAIL_HTLC(add.id, Left(randomBytes32()))
     }
@@ -269,7 +269,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
   test("recv second stfu while non-initiator waiting for local commitment to be signed") { f =>
     import f._
     initiateQuiescence(f, sendInitialStfu = false)
-    val (_, _) = addHtlc(10_000 msat, bob, alice, bob2alice, alice2bob)
+    val (_, _) = addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
     alice2bob.forward(bob)
     // second stfu to bob is ignored
     bob ! Stfu(channelId(bob), initiator = true)
@@ -300,7 +300,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
 
   test("recv (forbidden) UpdateFulfillHtlc message while quiescent") { f =>
     import f._
-    val (preimage, add) = addHtlc(10_000 msat, bob, alice, bob2alice, alice2bob)
+    val (preimage, add) = addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
     crossSign(bob, alice, bob2alice, alice2bob)
     alice2relayer.expectMsg(RelayForward(add))
     initiateQuiescence(f, sendInitialStfu = true)
@@ -315,7 +315,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
 
   test("recv (forbidden) UpdateFailHtlc message while quiescent") { f =>
     import f._
-    val (_, add) = addHtlc(10_000 msat, bob, alice, bob2alice, alice2bob)
+    val (_, add) = addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
     crossSign(bob, alice, bob2alice, alice2bob)
     initiateQuiescence(f, sendInitialStfu = true)
     val forbiddenMsg = UpdateFailHtlc(channelId(bob), add.id, randomBytes32())
@@ -328,7 +328,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
 
   test("recv (forbidden) UpdateFee message while quiescent") { f =>
     import f._
-    val (_, _) = addHtlc(10_000 msat, bob, alice, bob2alice, alice2bob)
+    val (_, _) = addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
     crossSign(bob, alice, bob2alice, alice2bob)
     initiateQuiescence(f, sendInitialStfu = true)
     val forbiddenMsg = UpdateFee(channelId(bob), FeeratePerKw(500 sat))
@@ -353,7 +353,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
 
   test("recv stfu from splice initiator that is not quiescent") { f =>
     import f._
-    addHtlc(10_000 msat, alice, bob, alice2bob, bob2alice)
+    addHtlc(50_000_000 msat, alice, bob, alice2bob, bob2alice)
     alice2bob.forward(bob, Stfu(channelId(alice), initiator = true))
     bob2alice.expectMsg(Warning(channelId(bob), InvalidSpliceNotQuiescent(channelId(bob)).getMessage))
     // we should disconnect after giving alice time to receive the warning
@@ -365,7 +365,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
 
   test("recv stfu from splice non-initiator that is not quiescent") { f =>
     import f._
-    addHtlc(10_000 msat, bob, alice, bob2alice, alice2bob)
+    addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
     initiateQuiescence(f, sendInitialStfu = false)
     alice2bob.forward(bob)
     bob2alice.forward(alice, Stfu(channelId(bob), initiator = false))
@@ -396,7 +396,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
   test("initiate quiescence concurrently (pending changes on initiator side)") { f =>
     import f._
 
-    addHtlc(10_000 msat, alice, bob, alice2bob, bob2alice)
+    addHtlc(50_000_000 msat, alice, bob, alice2bob, bob2alice)
     val sender = TestProbe()
     val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)), spliceOut_opt = None)
     alice ! cmd
@@ -415,7 +415,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
   test("initiate quiescence concurrently (pending changes on non-initiator side)") { f =>
     import f._
 
-    addHtlc(10_000 msat, bob, alice, bob2alice, alice2bob)
+    addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
     val sender = TestProbe()
     val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)), spliceOut_opt = None)
     alice ! cmd

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalQuiescentStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalQuiescentStateSpec.scala
@@ -526,4 +526,13 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
     bob2alice.expectMsg(Warning(channelId(bob), SpliceAttemptTimedOut(channelId(bob)).getMessage))
   }
 
+  test("receive SpliceInit when channel is not quiescent") { f =>
+    import f._
+    val spliceInit = SpliceInit(channelId(alice), 500_000.sat, FeeratePerKw(253.sat), 0, randomKey().publicKey)
+    alice ! spliceInit
+    // quiescence not negotiated
+    alice2bob.expectMsgType[TxAbort]
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].spliceStatus == SpliceStatus.SpliceAborted)
+  }
+
 }


### PR DESCRIPTION
This PR fixes some issues we found while [porting quiescence](https://github.com/ACINQ/lightning-kmp/pull/558) to lightning-kmp.

We might find more changes, so this should stay in draft until we also have splicing with htlcs ported.