### PR TITLE
Update logback-classic to 1.2.13

### DIFF
--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -296,7 +296,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.13</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/eclair-front/pom.xml
+++ b/eclair-front/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.13</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.janino</groupId>

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.3</version>
+            <version>1.2.13</version>
         </dependency>
         <dependency>
             <!--conditional logging -->


### PR DESCRIPTION
This version of logback fixes the following CVE:

"a potential denial of service attack on a centralized logback receiver when a third party controlling a remote appender connects to said receiver and could shut down or slow down logging of events."

Eclair isn't affected since we don't use logback receivers, but if there are applications or plugins that depend on eclair and use logback receivers, it's better to use the logback version containing the fix.