### PR TITLE
FIX eclair-cli error code in case of HTTP problem

### DIFF
--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -166,4 +166,5 @@ else
 fi
 
 # we're now ready to execute the API call
+set -o pipefail # ensures we preserve curl error code in case of HTTP issue
 eval curl "--user $auth --silent --show-error -X POST -H \"Content-Type: application/x-www-form-urlencoded\" $api_payload $api_url/$api_endpoint" | jq -r "$jq_filter"


### PR DESCRIPTION
Last command of eclair-cli is a curl piped to jq. In case of an error with the curl command (for instance, eclair service is not running) the error code is swallowed by the pipe which will return the exit code of the last command of the pipe (here, jq).

Setting `pipefail` ensures that the error code of curl is preserved in case of HTTP issue.

This can come handy, for instance, to check that eclair is not ok:

```
if eclair-cli getinfo
then
  echo eclair is answering
else
  echo problem communicating with eclair
fi
```