### PR TITLE
Trampoline to blinded

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -23,7 +23,9 @@ import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.actor.{ActorRef, typed}
 import com.softwaremill.quicklens.ModifyPimp
 import fr.acinq.bitcoin.scalacompat.ByteVector32
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.channel.{CMD_FAIL_HTLC, CMD_FULFILL_HTLC}
+import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.BlindedRoute
 import fr.acinq.eclair.db.PendingCommandsDb
 import fr.acinq.eclair.payment.IncomingPaymentPacket.NodeRelayPacket
 import fr.acinq.eclair.payment.Monitoring.{Metrics, Tags}
@@ -34,15 +36,17 @@ import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM.HtlcPart
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.{PreimageReceived, SendMultiPartPayment}
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentConfig
 import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPaymentToNode
-import fr.acinq.eclair.payment.send.{ClearRecipient, MultiPartPaymentLifecycle, PaymentInitiator, PaymentLifecycle}
+import fr.acinq.eclair.payment.send.{BlindedRecipient, ClearRecipient, MultiPartPaymentLifecycle, PaymentInitiator, PaymentLifecycle, Recipient}
 import fr.acinq.eclair.router.Router.RouteParams
-import fr.acinq.eclair.router.{BalanceTooLow, RouteNotFound}
+import fr.acinq.eclair.router.{BalanceTooLow, RouteNotFound, Router}
+import fr.acinq.eclair.wire.protocol.OfferTypes.{BlindedPath, CompactBlindedPath, PaymentInfo}
 import fr.acinq.eclair.wire.protocol.PaymentOnion.IntermediatePayload
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{CltvExpiry, Features, Logs, MilliSatoshi, NodeParams, TimestampMilli, UInt64, nodeFee, randomBytes32}
+import fr.acinq.eclair.{CltvExpiry, Features, Logs, MilliSatoshi, NodeParams, TimestampMilli, UInt64, nodeFee, randomBytes32, randomKey}
 
 import java.util.UUID
 import java.util.concurrent.TimeUnit
+import scala.annotation.tailrec
 import scala.collection.immutable.Queue
 
 /**
@@ -62,6 +66,7 @@ object NodeRelay {
   private case class WrappedPaymentSent(paymentSent: PaymentSent) extends Command
   private case class WrappedPaymentFailed(paymentFailed: PaymentFailed) extends Command
   private[relay] case class WrappedPeerReadyResult(result: AsyncPaymentTriggerer.Result) extends Command
+  private case class WrappedNodeId(nodeId_opt: Option[PublicKey]) extends Command
   // @formatter:on
 
   trait OutgoingPaymentFactory {
@@ -81,12 +86,13 @@ object NodeRelay {
   }
 
   def apply(nodeParams: NodeParams,
-            parent: akka.actor.typed.ActorRef[NodeRelayer.Command],
+            parent: typed.ActorRef[NodeRelayer.Command],
             register: ActorRef,
             relayId: UUID,
             nodeRelayPacket: NodeRelayPacket,
             outgoingPaymentFactory: OutgoingPaymentFactory,
-            triggerer: typed.ActorRef[AsyncPaymentTriggerer.Command]): Behavior[Command] =
+            triggerer: typed.ActorRef[AsyncPaymentTriggerer.Command],
+            router: ActorRef): Behavior[Command] =
     Behaviors.setup { context =>
       val paymentHash = nodeRelayPacket.add.paymentHash
       val totalAmountIn = nodeRelayPacket.outerPayload.totalAmount
@@ -101,12 +107,16 @@ object NodeRelay {
           context.messageAdapter[MultiPartPaymentFSM.MultiPartPaymentSucceeded](WrappedMultiPartPaymentSucceeded)
         }.toClassic
         val incomingPaymentHandler = context.actorOf(MultiPartPaymentFSM.props(nodeParams, paymentHash, totalAmountIn, mppFsmAdapters))
-        new NodeRelay(nodeParams, parent, register, relayId, paymentHash, nodeRelayPacket.outerPayload.paymentSecret, context, outgoingPaymentFactory, triggerer)
-          .receiving(Queue.empty, nodeRelayPacket.innerPayload, nodeRelayPacket.nextPacket, incomingPaymentHandler)
+        val nextPacket_opt = nodeRelayPacket match {
+          case IncomingPaymentPacket.RelayToTrampolinePacket(_, _, _, nextPacket) => Some(nextPacket)
+          case _: IncomingPaymentPacket.RelayToBlindedPathsPacket => None
+        }
+        new NodeRelay(nodeParams, parent, register, relayId, paymentHash, nodeRelayPacket.outerPayload.paymentSecret, context, outgoingPaymentFactory, triggerer, router)
+          .receiving(Queue.empty, nodeRelayPacket.innerPayload, nextPacket_opt, incomingPaymentHandler)
       }
     }
 
-  private def validateRelay(nodeParams: NodeParams, upstream: Upstream.Trampoline, payloadOut: IntermediatePayload.NodeRelay.Standard): Option[FailureMessage] = {
+  private def validateRelay(nodeParams: NodeParams, upstream: Upstream.Trampoline, payloadOut: IntermediatePayload.NodeRelay): Option[FailureMessage] = {
     val fee = nodeFee(nodeParams.relayParams.minTrampolineFees, payloadOut.amountToForward)
     if (upstream.amountIn - payloadOut.amountToForward < fee) {
       Some(TrampolineFeeInsufficient())
@@ -114,12 +124,19 @@ object NodeRelay {
       Some(TrampolineExpiryTooSoon())
     } else if (payloadOut.outgoingCltv <= CltvExpiry(nodeParams.currentBlockHeight)) {
       Some(TrampolineExpiryTooSoon())
-    } else if (payloadOut.invoiceFeatures.isDefined && payloadOut.paymentSecret.isEmpty) {
-      Some(InvalidOnionPayload(UInt64(8), 0)) // payment secret field is missing
     } else if (payloadOut.amountToForward <= MilliSatoshi(0)) {
       Some(InvalidOnionPayload(UInt64(2), 0))
     } else {
-      None
+      payloadOut match {
+        case payloadOut: IntermediatePayload.NodeRelay.Standard =>
+          if (payloadOut.invoiceFeatures.isDefined && payloadOut.paymentSecret.isEmpty) {
+            Some(InvalidOnionPayload(UInt64(8), 0)) // payment secret field is missing
+          } else {
+            None
+          }
+        case payloadOut: IntermediatePayload.NodeRelay.ToBlindedPaths =>
+          None
+      }
     }
   }
 
@@ -136,7 +153,7 @@ object NodeRelay {
    * This helper method translates relaying errors (returned by the downstream nodes) to a BOLT 4 standard error that we
    * should return upstream.
    */
-  private def translateError(nodeParams: NodeParams, failures: Seq[PaymentFailure], upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay.Standard): Option[FailureMessage] = {
+  private def translateError(nodeParams: NodeParams, failures: Seq[PaymentFailure], upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay): Option[FailureMessage] = {
     val routeNotFound = failures.collectFirst { case f@LocalFailure(_, _, RouteNotFound) => f }.nonEmpty
     val routingFeeHigh = upstream.amountIn - nextPayload.amountToForward >= nodeFee(nodeParams.relayParams.minTrampolineFees, nextPayload.amountToForward) * 5
     failures match {
@@ -150,7 +167,7 @@ object NodeRelay {
       case _ if routeNotFound => Some(TrampolineFeeInsufficient()) // if we couldn't find routes, it's likely that the fee/cltv was insufficient
       case _ =>
         // Otherwise, we try to find a downstream error that we could decrypt.
-        val outgoingNodeFailure = failures.collectFirst { case RemoteFailure(_, _, e) if e.originNode == nextPayload.outgoingNodeId => e.failureMessage }
+        val outgoingNodeFailure = failures.collectFirst { case RemoteFailure(_, _, e) if nextPayload.isInstanceOf[IntermediatePayload.NodeRelay.Standard] && e.originNode == nextPayload.asInstanceOf[IntermediatePayload.NodeRelay.Standard].outgoingNodeId => e.failureMessage }
         val otherNodeFailure = failures.collectFirst { case RemoteFailure(_, _, e) => e.failureMessage }
         val failure = outgoingNodeFailure.getOrElse(otherNodeFailure.getOrElse(TemporaryNodeFailure()))
         Some(failure)
@@ -170,7 +187,8 @@ class NodeRelay private(nodeParams: NodeParams,
                         paymentSecret: ByteVector32,
                         context: ActorContext[NodeRelay.Command],
                         outgoingPaymentFactory: NodeRelay.OutgoingPaymentFactory,
-                        triggerer: typed.ActorRef[AsyncPaymentTriggerer.Command]) {
+                        triggerer: typed.ActorRef[AsyncPaymentTriggerer.Command],
+                        router: ActorRef) {
 
   import NodeRelay._
 
@@ -178,18 +196,18 @@ class NodeRelay private(nodeParams: NodeParams,
    * We start by aggregating an incoming HTLC set. Once we received the whole set, we will compute a route to the next
    * trampoline node and forward the payment.
    *
-   * @param htlcs       received incoming HTLCs for this set.
-   * @param nextPayload relay instructions (should be identical across HTLCs in this set).
-   * @param nextPacket  trampoline onion to relay to the next trampoline node.
-   * @param handler     actor handling the aggregation of the incoming HTLC set.
+   * @param htlcs           received incoming HTLCs for this set.
+   * @param nextPayload     relay instructions (should be identical across HTLCs in this set).
+   * @param nextPacket_opt  trampoline onion to relay to the next trampoline node.
+   * @param handler         actor handling the aggregation of the incoming HTLC set.
    */
-  private def receiving(htlcs: Queue[Upstream.ReceivedHtlc], nextPayload: IntermediatePayload.NodeRelay.Standard, nextPacket: OnionRoutingPacket, handler: ActorRef): Behavior[Command] =
+  private def receiving(htlcs: Queue[Upstream.ReceivedHtlc], nextPayload: IntermediatePayload.NodeRelay, nextPacket_opt: Option[OnionRoutingPacket], handler: ActorRef): Behavior[Command] =
     Behaviors.receiveMessagePartial {
-      case Relay(IncomingPaymentPacket.NodeRelayPacket(add, outer, _, _)) =>
-        require(outer.paymentSecret == paymentSecret, "payment secret mismatch")
-        context.log.debug("forwarding incoming htlc #{} from channel {} to the payment FSM", add.id, add.channelId)
-        handler ! MultiPartPaymentFSM.HtlcPart(outer.totalAmount, add)
-        receiving(htlcs :+ Upstream.ReceivedHtlc(add, TimestampMilli.now()), nextPayload, nextPacket, handler)
+      case Relay(packet: IncomingPaymentPacket.NodeRelayPacket) =>
+        require(packet.outerPayload.paymentSecret == paymentSecret, "payment secret mismatch")
+        context.log.debug("forwarding incoming htlc #{} from channel {} to the payment FSM", packet.add.id, packet.add.channelId)
+        handler ! MultiPartPaymentFSM.HtlcPart(packet.outerPayload.totalAmount, packet.add)
+        receiving(htlcs :+ Upstream.ReceivedHtlc(packet.add, TimestampMilli.now()), nextPayload, nextPacket_opt, handler)
       case WrappedMultiPartPaymentFailed(MultiPartPaymentFSM.MultiPartPaymentFailed(_, failure, parts)) =>
         context.log.warn("could not complete incoming multi-part payment (parts={} paidAmount={} failure={})", parts.size, parts.map(_.amount).sum, failure)
         Metrics.recordPaymentRelayFailed(failure.getClass.getSimpleName, Tags.RelayType.Trampoline)
@@ -204,15 +222,16 @@ class NodeRelay private(nodeParams: NodeParams,
             rejectPayment(upstream, Some(failure))
             stopping()
           case None =>
-            if (nextPayload.isAsyncPayment && nodeParams.features.hasFeature(Features.AsyncPaymentPrototype)) {
-              waitForTrigger(upstream, nextPayload, nextPacket)
-            } else {
-              doSend(upstream, nextPayload, nextPacket)
+            nextPayload match {
+              case nextPayload: IntermediatePayload.NodeRelay.Standard if nextPayload.isAsyncPayment && nodeParams.features.hasFeature(Features.AsyncPaymentPrototype) =>
+                waitForTrigger(upstream, nextPayload, nextPacket_opt)
+              case _ =>
+                doSend(upstream, nextPayload, nextPacket_opt)
             }
         }
     }
 
-  private def waitForTrigger(upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay.Standard, nextPacket: OnionRoutingPacket): Behavior[Command] = {
+  private def waitForTrigger(upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay.Standard, nextPacket_opt: Option[OnionRoutingPacket]): Behavior[Command] = {
     context.log.info(s"waiting for async payment to trigger before relaying trampoline payment (amountIn=${upstream.amountIn} expiryIn=${upstream.expiryIn} amountOut=${nextPayload.amountToForward} expiryOut=${nextPayload.outgoingCltv}, asyncPaymentsParams=${nodeParams.relayParams.asyncPaymentsParams})")
     val timeoutBlock = nodeParams.currentBlockHeight + nodeParams.relayParams.asyncPaymentsParams.holdTimeoutBlocks
     val safetyBlock = (upstream.expiryIn - nodeParams.relayParams.asyncPaymentsParams.cancelSafetyBeforeTimeout).blockHeight
@@ -232,14 +251,13 @@ class NodeRelay private(nodeParams: NodeParams,
         rejectPayment(upstream, Some(TemporaryNodeFailure())) // TODO: replace failure type when async payment spec is finalized
         stopping()
       case WrappedPeerReadyResult(AsyncPaymentTriggerer.AsyncPaymentTriggered) =>
-        doSend(upstream, nextPayload, nextPacket)
+        doSend(upstream, nextPayload, nextPacket_opt)
     }
   }
 
-  private def doSend(upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay.Standard, nextPacket: OnionRoutingPacket): Behavior[Command] = {
+  private def doSend(upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay, nextPacket_opt: Option[OnionRoutingPacket]): Behavior[Command] = {
     context.log.debug(s"relaying trampoline payment (amountIn=${upstream.amountIn} expiryIn=${upstream.expiryIn} amountOut=${nextPayload.amountToForward} expiryOut=${nextPayload.outgoingCltv})")
-    relay(upstream, nextPayload, nextPacket)
-    sending(upstream, nextPayload, TimestampMilli.now(), fulfilledUpstream = false)
+    relay(upstream, nextPayload, nextPacket_opt)
   }
 
   /**
@@ -249,7 +267,7 @@ class NodeRelay private(nodeParams: NodeParams,
    * @param nextPayload       relay instructions.
    * @param fulfilledUpstream true if we already fulfilled the payment upstream.
    */
-  private def sending(upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay.Standard, startedAt: TimestampMilli, fulfilledUpstream: Boolean): Behavior[Command] =
+  private def sending(upstream: Upstream.Trampoline, nextPayload: IntermediatePayload.NodeRelay, startedAt: TimestampMilli, fulfilledUpstream: Boolean): Behavior[Command] =
     Behaviors.receiveMessagePartial {
       rejectExtraHtlcPartialFunction orElse {
         // this is the fulfill that arrives from downstream channels
@@ -296,39 +314,104 @@ class NodeRelay private(nodeParams: NodeParams,
     context.messageAdapter[PaymentFailed](WrappedPaymentFailed)
   }.toClassic
 
-  private def relay(upstream: Upstream.Trampoline, payloadOut: IntermediatePayload.NodeRelay.Standard, packetOut: OnionRoutingPacket): ActorRef = {
-    val paymentCfg = SendPaymentConfig(relayId, relayId, None, paymentHash, payloadOut.outgoingNodeId, upstream, None, None, storeInDb = false, publishEvent = false, recordPathFindingMetrics = true)
-    val routeParams = computeRouteParams(nodeParams, upstream.amountIn, upstream.expiryIn, payloadOut.amountToForward, payloadOut.outgoingCltv)
-    // If invoice features are provided in the onion, the sender is asking us to relay to a non-trampoline recipient.
-    val payFSM = payloadOut.invoiceFeatures match {
-      case Some(features) =>
-        val extraEdges = payloadOut.invoiceRoutingInfo.getOrElse(Nil).flatMap(Bolt11Invoice.toExtraEdges(_, payloadOut.outgoingNodeId))
-        val paymentSecret = payloadOut.paymentSecret.get // NB: we've verified that there was a payment secret in validateRelay
-        val recipient = ClearRecipient(payloadOut.outgoingNodeId, Features(features).invoiceFeatures(), payloadOut.amountToForward, payloadOut.outgoingCltv, paymentSecret, extraEdges, payloadOut.paymentMetadata)
-        if (recipient.features.hasFeature(Features.BasicMultiPartPayment)) {
-          context.log.debug("sending the payment to non-trampoline recipient using MPP")
-          val payment = SendMultiPartPayment(payFsmAdapters, recipient, nodeParams.maxPaymentAttempts, routeParams)
-          val payFSM = outgoingPaymentFactory.spawnOutgoingPayFSM(context, paymentCfg, multiPart = true)
-          payFSM ! payment
-          payFSM
-        } else {
-          context.log.debug("sending the payment to non-trampoline recipient without MPP")
-          val payment = SendPaymentToNode(payFsmAdapters, recipient, nodeParams.maxPaymentAttempts, routeParams)
-          val payFSM = outgoingPaymentFactory.spawnOutgoingPayFSM(context, paymentCfg, multiPart = false)
-          payFSM ! payment
-          payFSM
-        }
-      case None =>
-        context.log.debug("sending the payment to the next trampoline node")
-        val paymentSecret = randomBytes32() // we generate a new secret to protect against probing attacks
-        val recipient = ClearRecipient(payloadOut.outgoingNodeId, Features.empty, payloadOut.amountToForward, payloadOut.outgoingCltv, paymentSecret, nextTrampolineOnion_opt = Some(packetOut))
-        val payment = SendMultiPartPayment(payFsmAdapters, recipient, nodeParams.maxPaymentAttempts, routeParams)
-        val payFSM = outgoingPaymentFactory.spawnOutgoingPayFSM(context, paymentCfg, multiPart = true)
-        payFSM ! payment
-        payFSM
+  private def relay(upstream: Upstream.Trampoline, payloadOut: IntermediatePayload.NodeRelay, packetOut_opt: Option[OnionRoutingPacket]): Behavior[Command] = {
+    val displayNodeId = payloadOut match {
+      case payloadOut: IntermediatePayload.NodeRelay.Standard => payloadOut.outgoingNodeId
+      case _: IntermediatePayload.NodeRelay.ToBlindedPaths => randomKey().publicKey
     }
-    payFSM
+    val paymentCfg = SendPaymentConfig(relayId, relayId, None, paymentHash, displayNodeId, upstream, None, None, storeInDb = false, publishEvent = false, recordPathFindingMetrics = true)
+    val routeParams = computeRouteParams(nodeParams, upstream.amountIn, upstream.expiryIn, payloadOut.amountToForward, payloadOut.outgoingCltv)
+    payloadOut match {
+      case payloadOut: IntermediatePayload.NodeRelay.Standard =>
+        // If invoice features are provided in the onion, the sender is asking us to relay to a non-trampoline recipient.
+        payloadOut.invoiceFeatures match {
+          case Some(features) =>
+            val extraEdges = payloadOut.invoiceRoutingInfo.getOrElse(Nil).flatMap(Bolt11Invoice.toExtraEdges(_, payloadOut.outgoingNodeId))
+            val paymentSecret = payloadOut.paymentSecret.get // NB: we've verified that there was a payment secret in validateRelay
+            val recipient = ClearRecipient(payloadOut.outgoingNodeId, Features(features).invoiceFeatures(), payloadOut.amountToForward, payloadOut.outgoingCltv, paymentSecret, extraEdges, payloadOut.paymentMetadata)
+            if (recipient.features.hasFeature(Features.BasicMultiPartPayment)) {
+              context.log.debug("sending the payment to non-trampoline recipient using MPP")
+              relayToRecipient(upstream, payloadOut, recipient, paymentCfg, routeParams, useMultiPart = true)
+            } else {
+              context.log.debug("sending the payment to non-trampoline recipient without MPP")
+              relayToRecipient(upstream, payloadOut, recipient, paymentCfg, routeParams, useMultiPart = false)
+            }
+          case None =>
+            context.log.debug("sending the payment to the next trampoline node")
+            val paymentSecret = randomBytes32() // we generate a new secret to protect against probing attacks
+            val recipient = ClearRecipient(payloadOut.outgoingNodeId, Features.empty, payloadOut.amountToForward, payloadOut.outgoingCltv, paymentSecret, nextTrampolineOnion_opt = packetOut_opt)
+            relayToRecipient(upstream, payloadOut, recipient, paymentCfg, routeParams, useMultiPart = true)
+        }
+      case payloadOut: IntermediatePayload.NodeRelay.ToBlindedPaths =>
+        resolveCompactBlindedPaths(payloadOut.outgoingBlindedPaths, Nil, upstream, payloadOut, paymentCfg, routeParams)
+    }
   }
+
+  private def relayToRecipient(upstream: Upstream.Trampoline,
+                               payloadOut: IntermediatePayload.NodeRelay,
+                               recipient: Recipient,
+                               paymentCfg: SendPaymentConfig,
+                               routeParams: RouteParams,
+                               useMultiPart: Boolean): Behavior[Command] = {
+    val payment =
+      if (useMultiPart) {
+        SendMultiPartPayment(payFsmAdapters, recipient, nodeParams.maxPaymentAttempts, routeParams)
+      } else {
+        SendPaymentToNode(payFsmAdapters, recipient, nodeParams.maxPaymentAttempts, routeParams)
+      }
+    val payFSM = outgoingPaymentFactory.spawnOutgoingPayFSM(context, paymentCfg, useMultiPart)
+    payFSM ! payment
+    sending(upstream, payloadOut, TimestampMilli.now(), fulfilledUpstream = false)
+  }
+
+  /**
+   * Blinded paths in Bolt 12 invoices may encode the introduction node with an scid and a direction: we need to resolve
+   * that to a nodeId in order to reach that introduction node and use the blinded path.
+   */
+  @tailrec
+  private def resolveCompactBlindedPaths(toResolve: Seq[PaymentBlindedContactInfo],
+                                         resolved: Seq[PaymentBlindedRoute],
+                                         upstream: Upstream.Trampoline,
+                                         payloadOut: IntermediatePayload.NodeRelay.ToBlindedPaths,
+                                         paymentCfg: SendPaymentConfig,
+                                         routeParams: RouteParams): Behavior[Command] = {
+    if (toResolve.isEmpty) {
+      if (resolved.isEmpty) {
+        context.log.warn(s"rejecting trampoline payment to blinded paths: no usable blinded path")
+        rejectPayment(upstream, Some(TemporaryNodeFailure()))
+        stopping()
+      } else {
+        val features = Features(payloadOut.invoiceFeatures).invoiceFeatures()
+        val recipient = BlindedRecipient.fromPaths(randomKey().publicKey, features, payloadOut.amountToForward, payloadOut.outgoingCltv, resolved, Set.empty)
+        context.log.debug("sending the payment to blinded recipient, useMultiPart={}", features.hasFeature(Features.BasicMultiPartPayment))
+        relayToRecipient(upstream, payloadOut, recipient, paymentCfg, routeParams, features.hasFeature(Features.BasicMultiPartPayment))
+      }
+    } else {
+      toResolve.head match {
+        case PaymentBlindedContactInfo(BlindedPath(route), paymentInfo) =>
+          resolveCompactBlindedPaths(toResolve.tail, resolved :+ PaymentBlindedRoute(route, paymentInfo), upstream, payloadOut, paymentCfg, routeParams)
+        case PaymentBlindedContactInfo(route: CompactBlindedPath, paymentInfo) =>
+          router ! Router.GetNodeId(context.messageAdapter(WrappedNodeId), route.introductionNode.scid, route.introductionNode.isNode1)
+          waitForNodeId(route, paymentInfo, toResolve.tail, resolved, upstream, payloadOut, paymentCfg, routeParams)
+      }
+    }
+  }
+
+  private def waitForNodeId(compactRoute: CompactBlindedPath,
+                            paymentInfo: PaymentInfo,
+                            toResolve: Seq[PaymentBlindedContactInfo],
+                            resolved: Seq[PaymentBlindedRoute],
+                            upstream: Upstream.Trampoline,
+                            payloadOut: IntermediatePayload.NodeRelay.ToBlindedPaths,
+                            paymentCfg: SendPaymentConfig,
+                            routeParams: RouteParams): Behavior[Command] =
+    Behaviors.receiveMessagePartial {
+      case WrappedNodeId(None) =>
+        resolveCompactBlindedPaths(toResolve, resolved, upstream, payloadOut, paymentCfg, routeParams)
+      case WrappedNodeId(Some(nodeId)) =>
+        val resolvedPaymentBlindedRoute = PaymentBlindedRoute(BlindedRoute(nodeId, compactRoute.blindingKey, compactRoute.blindedNodes), paymentInfo)
+        resolveCompactBlindedPaths(toResolve, resolved :+ resolvedPaymentBlindedRoute, upstream, payloadOut, paymentCfg, routeParams)
+    }
 
   private def rejectExtraHtlcPartialFunction: PartialFunction[Command, Behavior[Command]] = {
     case Relay(nodeRelayPacket) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelayer.scala
@@ -57,7 +57,7 @@ object NodeRelayer {
    *                 NB: the payment secret used here is different from the invoice's payment secret and ensures we can
    *                 group together HTLCs that the previous trampoline node sent in the same MPP.
    */
-  def apply(nodeParams: NodeParams, register: akka.actor.ActorRef, outgoingPaymentFactory: NodeRelay.OutgoingPaymentFactory, triggerer: typed.ActorRef[AsyncPaymentTriggerer.Command], children: Map[PaymentKey, ActorRef[NodeRelay.Command]] = Map.empty): Behavior[Command] =
+  def apply(nodeParams: NodeParams, register: akka.actor.ActorRef, outgoingPaymentFactory: NodeRelay.OutgoingPaymentFactory, triggerer: typed.ActorRef[AsyncPaymentTriggerer.Command], router: akka.actor.ActorRef, children: Map[PaymentKey, ActorRef[NodeRelay.Command]] = Map.empty): Behavior[Command] =
     Behaviors.setup { context =>
       Behaviors.withMdc(Logs.mdc(category_opt = Some(Logs.LogCategory.PAYMENT)), mdc) {
         Behaviors.receiveMessage {
@@ -72,15 +72,15 @@ object NodeRelayer {
               case None =>
                 val relayId = UUID.randomUUID()
                 context.log.debug(s"spawning a new handler with relayId=$relayId")
-                val handler = context.spawn(NodeRelay.apply(nodeParams, context.self, register, relayId, nodeRelayPacket, outgoingPaymentFactory, triggerer), relayId.toString)
+                val handler = context.spawn(NodeRelay.apply(nodeParams, context.self, register, relayId, nodeRelayPacket, outgoingPaymentFactory, triggerer, router), relayId.toString)
                 context.log.debug("forwarding incoming htlc #{} from channel {} to new handler", htlcIn.id, htlcIn.channelId)
                 handler ! NodeRelay.Relay(nodeRelayPacket)
-                apply(nodeParams, register, outgoingPaymentFactory, triggerer, children + (childKey -> handler))
+                apply(nodeParams, register, outgoingPaymentFactory, triggerer, router, children + (childKey -> handler))
             }
           case RelayComplete(childHandler, paymentHash, paymentSecret) =>
             // we do a back-and-forth between parent and child before stopping the child to prevent a race condition
             childHandler ! NodeRelay.Stop
-            apply(nodeParams, register, outgoingPaymentFactory, triggerer, children - PaymentKey(paymentHash, paymentSecret))
+            apply(nodeParams, register, outgoingPaymentFactory, triggerer, router, children - PaymentKey(paymentHash, paymentSecret))
           case GetPendingPayments(replyTo) =>
             replyTo ! children
             Behaviors.same

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -58,7 +58,7 @@ class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paym
 
   private val postRestartCleaner = context.actorOf(PostRestartHtlcCleaner.props(nodeParams, register, initialized), "post-restart-htlc-cleaner")
   private val channelRelayer = context.spawn(Behaviors.supervise(ChannelRelayer(nodeParams, register)).onFailure(SupervisorStrategy.resume), "channel-relayer")
-  private val nodeRelayer = context.spawn(Behaviors.supervise(NodeRelayer(nodeParams, register, NodeRelay.SimpleOutgoingPaymentFactory(nodeParams, router, register), triggerer)).onFailure(SupervisorStrategy.resume), name = "node-relayer")
+  private val nodeRelayer = context.spawn(Behaviors.supervise(NodeRelayer(nodeParams, register, NodeRelay.SimpleOutgoingPaymentFactory(nodeParams, router, register), triggerer, router)).onFailure(SupervisorStrategy.resume), name = "node-relayer")
 
   def receive: Receive = {
     case init: PostRestartHtlcCleaner.Init => postRestartCleaner forward init
@@ -70,9 +70,16 @@ class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paym
           paymentHandler forward p
         case Right(r: IncomingPaymentPacket.ChannelRelayPacket) =>
           channelRelayer ! ChannelRelayer.Relay(r)
-        case Right(r: IncomingPaymentPacket.NodeRelayPacket) =>
+        case Right(r: IncomingPaymentPacket.RelayToTrampolinePacket) =>
           if (!nodeParams.enableTrampolinePayment) {
             log.warning(s"rejecting htlc #${add.id} from channelId=${add.channelId} to nodeId=${r.innerPayload.outgoingNodeId} reason=trampoline disabled")
+            PendingCommandsDb.safeSend(register, nodeParams.db.pendingCommands, add.channelId, CMD_FAIL_HTLC(add.id, Right(RequiredNodeFeatureMissing()), commit = true))
+          } else {
+            nodeRelayer ! NodeRelayer.Relay(r)
+          }
+        case Right(r: IncomingPaymentPacket.RelayToBlindedPathsPacket) =>
+          if (!nodeParams.enableTrampolinePayment) {
+            log.warning(s"rejecting htlc #${add.id} from channelId=${add.channelId} to blinded paths reason=trampoline disabled")
             PendingCommandsDb.safeSend(register, nodeParams.db.pendingCommands, add.channelId, CMD_FAIL_HTLC(add.id, Right(RequiredNodeFeatureMissing()), commit = true))
           } else {
             nodeRelayer ! NodeRelayer.Relay(r)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/Relayer.scala
@@ -70,16 +70,9 @@ class Relayer(nodeParams: NodeParams, router: ActorRef, register: ActorRef, paym
           paymentHandler forward p
         case Right(r: IncomingPaymentPacket.ChannelRelayPacket) =>
           channelRelayer ! ChannelRelayer.Relay(r)
-        case Right(r: IncomingPaymentPacket.RelayToTrampolinePacket) =>
+        case Right(r: IncomingPaymentPacket.NodeRelayPacket) =>
           if (!nodeParams.enableTrampolinePayment) {
-            log.warning(s"rejecting htlc #${add.id} from channelId=${add.channelId} to nodeId=${r.innerPayload.outgoingNodeId} reason=trampoline disabled")
-            PendingCommandsDb.safeSend(register, nodeParams.db.pendingCommands, add.channelId, CMD_FAIL_HTLC(add.id, Right(RequiredNodeFeatureMissing()), commit = true))
-          } else {
-            nodeRelayer ! NodeRelayer.Relay(r)
-          }
-        case Right(r: IncomingPaymentPacket.RelayToBlindedPathsPacket) =>
-          if (!nodeParams.enableTrampolinePayment) {
-            log.warning(s"rejecting htlc #${add.id} from channelId=${add.channelId} to blinded paths reason=trampoline disabled")
+            log.warning(s"rejecting htlc #${add.id} from channelId=${add.channelId} reason=trampoline disabled")
             PendingCommandsDb.safeSend(register, nodeParams.db.pendingCommands, add.channelId, CMD_FAIL_HTLC(add.id, Right(RequiredNodeFeatureMissing()), commit = true))
           } else {
             nodeRelayer ! NodeRelayer.Relay(r)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/CompactBlindedPathsResolver.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/CompactBlindedPathsResolver.scala
@@ -1,0 +1,62 @@
+package fr.acinq.eclair.payment.send
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import akka.actor.{ActorRef, typed}
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.BlindedRoute
+import fr.acinq.eclair.payment.send.CompactBlindedPathsResolver._
+import fr.acinq.eclair.payment.{PaymentBlindedContactInfo, PaymentBlindedRoute}
+import fr.acinq.eclair.router.Router
+import fr.acinq.eclair.wire.protocol.OfferTypes.{BlindedPath, CompactBlindedPath, PaymentInfo}
+
+import scala.annotation.tailrec
+
+object CompactBlindedPathsResolver {
+  sealed trait Command
+
+  case class Resolve(replyTo: typed.ActorRef[Seq[PaymentBlindedRoute]], blindedPaths: Seq[PaymentBlindedContactInfo]) extends Command
+
+  private case class WrappedNodeId(nodeId_opt: Option[PublicKey]) extends Command
+
+  def apply(router: ActorRef): Behavior[Command] = {
+    Behaviors.receivePartial {
+      case (context, Resolve(replyTo, blindedPaths)) =>
+        val resolver = new CompactBlindedPathsResolver(replyTo, router, context)
+        resolver.resolveCompactBlindedPaths(blindedPaths, Nil)
+    }
+  }
+}
+
+private class CompactBlindedPathsResolver(replyTo: typed.ActorRef[Seq[PaymentBlindedRoute]],
+                                          router: ActorRef,
+                                          context: ActorContext[Command]) {
+  @tailrec
+  private def resolveCompactBlindedPaths(toResolve: Seq[PaymentBlindedContactInfo],
+                                         resolved: Seq[PaymentBlindedRoute]): Behavior[Command] = {
+    if (toResolve.isEmpty) {
+      replyTo ! resolved
+      Behaviors.stopped
+    } else {
+      toResolve.head match {
+        case PaymentBlindedContactInfo(BlindedPath(route), paymentInfo) =>
+          resolveCompactBlindedPaths(toResolve.tail, resolved :+ PaymentBlindedRoute(route, paymentInfo))
+        case PaymentBlindedContactInfo(route: CompactBlindedPath, paymentInfo) =>
+          router ! Router.GetNodeId(context.messageAdapter(WrappedNodeId), route.introductionNode.scid, route.introductionNode.isNode1)
+          waitForNodeId(route, paymentInfo, toResolve.tail, resolved)
+      }
+    }
+  }
+
+  private def waitForNodeId(compactRoute: CompactBlindedPath,
+                            paymentInfo: PaymentInfo,
+                            toResolve: Seq[PaymentBlindedContactInfo],
+                            resolved: Seq[PaymentBlindedRoute]): Behavior[Command] =
+    Behaviors.receiveMessagePartial {
+      case WrappedNodeId(None) =>
+        resolveCompactBlindedPaths(toResolve, resolved)
+      case WrappedNodeId(Some(nodeId)) =>
+        val resolvedPaymentBlindedRoute = PaymentBlindedRoute(BlindedRoute(nodeId, compactRoute.blindingKey, compactRoute.blindedNodes), paymentInfo)
+        resolveCompactBlindedPaths(toResolve, resolved :+ resolvedPaymentBlindedRoute)
+    }
+}

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Recipient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Recipient.scala
@@ -170,7 +170,10 @@ object BlindedRecipient {
    * @param invoice Bolt invoice. Paths from the invoice must be passed as `paths` with compact paths expanded to include the node id.
    * @param paths   Payment paths to use to reach the recipient.
    */
-  def apply(invoice: Bolt12Invoice, paths: Seq[PaymentBlindedRoute], totalAmount: MilliSatoshi, expiry: CltvExpiry, customTlvs: Set[GenericTlv]): BlindedRecipient = {
+  def apply(invoice: Bolt12Invoice, paths: Seq[PaymentBlindedRoute], totalAmount: MilliSatoshi, expiry: CltvExpiry, customTlvs: Set[GenericTlv]): BlindedRecipient =
+    BlindedRecipient.fromPaths(invoice.nodeId, invoice.features, totalAmount, expiry, paths, customTlvs)
+
+  def fromPaths(nodeId: PublicKey, features: Features[InvoiceFeature], totalAmount: MilliSatoshi, expiry: CltvExpiry, paths: Seq[PaymentBlindedRoute], customTlvs: Set[GenericTlv]): BlindedRecipient = {
     val blindedHops = paths.map(
       path => {
         // We don't know the scids of channels inside the blinded route, but it's useful to have an ID to refer to a
@@ -178,7 +181,7 @@ object BlindedRecipient {
         val dummyId = ShortChannelId.generateLocalAlias()
         BlindedHop(dummyId, path.route, path.paymentInfo)
       })
-    BlindedRecipient(invoice.nodeId, invoice.features, totalAmount, expiry, blindedHops, customTlvs)
+    BlindedRecipient(nodeId, features, totalAmount, expiry, blindedHops, customTlvs)
   }
 }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -22,7 +22,7 @@ import fr.acinq.eclair.payment.{Bolt11Invoice, Bolt12Invoice, PaymentBlindedCont
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
 import fr.acinq.eclair.wire.protocol.OnionRoutingCodecs.{ForbiddenTlv, InvalidTlvPayload, MissingRequiredTlv}
 import fr.acinq.eclair.wire.protocol.TlvCodecs._
-import fr.acinq.eclair.{CltvExpiry, Features, MilliSatoshi, MilliSatoshiLong, ShortChannelId, UInt64}
+import fr.acinq.eclair.{CltvExpiry, Features, MilliSatoshi, MilliSatoshiLong, ShortChannelId, UInt64, randomKey}
 import scodec.bits.{BitVector, ByteVector}
 
 /**

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -379,7 +379,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val ignoredRoutingHints = List(List(ExtraHop(b, channelUpdate_bc.shortChannelId, feeBase = 10 msat, feeProportionalMillionths = 1, cltvExpiryDelta = CltvExpiryDelta(12))))
     val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(9), features = featuresWithTrampoline, extraHops = ignoredRoutingHints)
     val trampolineFees = 21_000 msat
-    val req = SendTrampolinePayment(finalAmount, invoice, b, Seq((trampolineFees, CltvExpiryDelta(12))), nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
+    val req = SendTrampolinePayment(sender.ref, finalAmount, invoice, b, Seq((trampolineFees, CltvExpiryDelta(12))), nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -406,7 +406,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some wallet invoice"), CltvExpiryDelta(9))
     val trampolineFees = 21_000 msat
-    val req = SendTrampolinePayment(finalAmount, invoice, b, Seq((trampolineFees, CltvExpiryDelta(12))), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
+    val req = SendTrampolinePayment(sender.ref, finalAmount, invoice, b, Seq((trampolineFees, CltvExpiryDelta(12))), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -430,7 +430,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val routingHints = List(List(Bolt11Invoice.ExtraHop(b, channelUpdate_bc.shortChannelId, 10 msat, 100, CltvExpiryDelta(144))))
     val invoice = Bolt11Invoice(Block.RegtestGenesisBlock.hash, None, paymentHash, priv_a.privateKey, Left("#abittooreckless"), CltvExpiryDelta(18), None, None, routingHints, features = featuresWithoutRouteBlinding)
     val trampolineFees = 21_000 msat
-    val req = SendTrampolinePayment(finalAmount, invoice, b, Seq((trampolineFees, CltvExpiryDelta(12))), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
+    val req = SendTrampolinePayment(sender.ref, finalAmount, invoice, b, Seq((trampolineFees, CltvExpiryDelta(12))), routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     val fail = sender.expectMsgType[PaymentFailed]
@@ -445,7 +445,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(18), features = featuresWithTrampoline)
     val trampolineAttempts = (21_000 msat, CltvExpiryDelta(12)) :: (25_000 msat, CltvExpiryDelta(24)) :: Nil
-    val req = SendTrampolinePayment(finalAmount, invoice, b, trampolineAttempts, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
+    val req = SendTrampolinePayment(sender.ref, finalAmount, invoice, b, trampolineAttempts, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
     val cfg = multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -482,7 +482,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(18), features = featuresWithTrampoline)
     val trampolineAttempts = (21_000 msat, CltvExpiryDelta(12)) :: (25_000 msat, CltvExpiryDelta(24)) :: Nil
-    val req = SendTrampolinePayment(finalAmount, invoice, b, trampolineAttempts, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
+    val req = SendTrampolinePayment(sender.ref, finalAmount, invoice, b, trampolineAttempts, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
     val cfg = multiPartPayFsm.expectMsgType[SendPaymentConfig]
@@ -513,7 +513,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(finalAmount), paymentHash, priv_c.privateKey, Left("Some phoenix invoice"), CltvExpiryDelta(18), features = featuresWithTrampoline)
     val trampolineAttempts = (21_000 msat, CltvExpiryDelta(12)) :: (25_000 msat, CltvExpiryDelta(24)) :: Nil
-    val req = SendTrampolinePayment(finalAmount, invoice, b, trampolineAttempts, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
+    val req = SendTrampolinePayment(sender.ref, finalAmount, invoice, b, trampolineAttempts, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams)
     sender.send(initiator, req)
     sender.expectMsgType[UUID]
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
@@ -25,7 +25,7 @@ import fr.acinq.eclair.TestUtils.randomTxId
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.fsm.Channel
 import fr.acinq.eclair.crypto.{ShaChain, Sphinx}
-import fr.acinq.eclair.payment.IncomingPaymentPacket.{ChannelRelayPacket, FinalPacket, NodeRelayPacket, RelayToTrampolinePacket, decrypt}
+import fr.acinq.eclair.payment.IncomingPaymentPacket.{ChannelRelayPacket, FinalPacket, RelayToTrampolinePacket, decrypt}
 import fr.acinq.eclair.payment.OutgoingPaymentPacket._
 import fr.acinq.eclair.payment.send.{BlindedRecipient, ClearRecipient, TrampolineRecipient}
 import fr.acinq.eclair.router.BaseRouterSpec.{blindedRouteFromHops, channelHopFromUpdate}


### PR DESCRIPTION
Allow trampoline to pay a list of blinded paths instead of a node id. Only the last trampoline hop can target blinded paths, trampoline nodes are still reached with their node id, not with blinded paths.