### PR TITLE
Trampoline to blinded (types only)

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentPacket.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentPacket.scala
@@ -23,6 +23,7 @@ import fr.acinq.eclair.channel.{CMD_ADD_HTLC, CMD_FAIL_HTLC, CannotExtractShared
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.send.Recipient
 import fr.acinq.eclair.router.Router.{BlindedHop, Route}
+import fr.acinq.eclair.wire.protocol.OnionPaymentPayloadTlv.OutgoingBlindedPaths
 import fr.acinq.eclair.wire.protocol.PaymentOnion.{FinalPayload, IntermediatePayload, PerHopPayload}
 import fr.acinq.eclair.wire.protocol._
 import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Feature, Features, MilliSatoshi, ShortChannelId, TimestampMilli, UInt64, randomKey}
@@ -147,7 +148,12 @@ object IncomingPaymentPacket {
                 // blinding point and use it to derive the decryption key for the blinded trampoline onion.
                 decryptOnion(add.paymentHash, privateKey, trampolinePacket).flatMap {
                   case DecodedOnionPacket(innerPayload, Some(next)) => validateNodeRelay(add, payload, innerPayload, next)
-                  case DecodedOnionPacket(innerPayload, None) => validateTrampolineFinalPayload(add, payload, innerPayload)
+                  case DecodedOnionPacket(innerPayload, None) =>
+                    if (innerPayload.get[OutgoingBlindedPaths].isDefined) {
+                      Left(InvalidOnionPayload(UInt64(66102), 0)) // Trampoline to blinded paths is not yet supported.
+                    } else {
+                      validateTrampolineFinalPayload(add, payload, innerPayload)
+                    }
                 }
               case None => validateFinalPayload(add, payload)
             }
@@ -206,11 +212,10 @@ object IncomingPaymentPacket {
   private def validateNodeRelay(add: UpdateAddHtlc, outerPayload: TlvStream[OnionPaymentPayloadTlv], innerPayload: TlvStream[OnionPaymentPayloadTlv], next: OnionRoutingPacket): Either[FailureMessage, NodeRelayPacket] = {
     // The outer payload cannot use route blinding, but the inner payload may (but it's not supported yet).
     FinalPayload.Standard.validate(outerPayload).left.map(_.failureMessage).flatMap { outerPayload =>
-      IntermediatePayload.NodeRelay.validate(innerPayload).left.map(_.failureMessage).flatMap {
+      IntermediatePayload.NodeRelay.Standard.validate(innerPayload).left.map(_.failureMessage).flatMap {
         case _ if add.amountMsat < outerPayload.amount => Left(FinalIncorrectHtlcAmount(add.amountMsat))
         case _ if add.cltvExpiry != outerPayload.expiry => Left(FinalIncorrectCltvExpiry(add.cltvExpiry))
-        case innerPayload: IntermediatePayload.NodeRelay.Standard => Right(NodeRelayPacket(add, outerPayload, innerPayload, next))
-        case _: IntermediatePayload.NodeRelay.ToBlindedPaths => Left(InvalidOnionPayload(UInt64(66102), 0)) // Relay to blinded paths is not yet supported.
+        case innerPayload => Right(NodeRelayPacket(add, outerPayload, innerPayload, next))
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -198,7 +198,7 @@ class PaymentInitiator(nodeParams: NodeParams, outgoingPaymentFactory: PaymentIn
 
   }
 
-  private def buildTrampolineRecipient(r: SendRequestedPayment, trampolineHop: NodeHop): Try[ClearTrampolineRecipient] = {
+  private def buildTrampolineRecipient(r: SendRequestedPayment, trampolineHop: NodeHop): Try[TrampolineRecipient] = {
     // We generate a random secret for the payment to the trampoline node.
     val trampolineSecret = r match {
       case r: SendPaymentToRoute => r.trampoline_opt.map(_.paymentSecret).getOrElse(randomBytes32())
@@ -206,7 +206,7 @@ class PaymentInitiator(nodeParams: NodeParams, outgoingPaymentFactory: PaymentIn
     }
     val finalExpiry = r.finalExpiry(nodeParams)
     r.invoice match {
-      case invoice: Bolt11Invoice => Success(ClearTrampolineRecipient(invoice, r.recipientAmount, finalExpiry, trampolineHop, trampolineSecret))
+      case invoice: Bolt11Invoice => Success(TrampolineRecipient(invoice, r.recipientAmount, finalExpiry, trampolineHop, trampolineSecret))
       case _: Bolt12Invoice => Failure(new IllegalArgumentException("trampoline blinded payments are not supported yet"))
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Recipient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Recipient.scala
@@ -235,7 +235,7 @@ case class ClearTrampolineRecipient(invoice: Bolt11Invoice,
       // The recipient doesn't support trampoline: the trampoline node will convert the payment to a non-trampoline payment.
       // The final payload will thus never reach the recipient, so we create the smallest payload possible to avoid overflowing the trampoline onion size.
       val dummyFinalPayload = NodePayload(nodeId, IntermediatePayload.ChannelRelay.Standard(ShortChannelId(0), 0 msat, CltvExpiry(0)))
-      val trampolinePayload = NodePayload(trampolineHop.nodeId, IntermediatePayload.NodeRelay.Standard.createNodeRelayToNonTrampolinePayload(totalAmount, totalAmount, expiry, nodeId, invoice))
+      val trampolinePayload = NodePayload(trampolineHop.nodeId, IntermediatePayload.NodeRelay.createNodeRelayToNonTrampolinePayload(totalAmount, totalAmount, expiry, invoice))
       val payloads = Seq(trampolinePayload, dummyFinalPayload)
       OutgoingPaymentPacket.buildOnion(payloads, paymentHash, packetPayloadLength_opt = None)
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Recipient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Recipient.scala
@@ -190,12 +190,12 @@ object BlindedRecipient {
  * Note that we don't need to support the case where we'd use multiple trampoline hops in the same route: since we have
  * access to the network graph, it's always more efficient to find a channel route to the last trampoline node.
  */
-case class ClearTrampolineRecipient(invoice: Invoice,
-                                    totalAmount: MilliSatoshi,
-                                    expiry: CltvExpiry,
-                                    trampolineHop: NodeHop,
-                                    trampolinePaymentSecret: ByteVector32,
-                                    customTlvs: Set[GenericTlv] = Set.empty) extends Recipient {
+case class TrampolineRecipient(invoice: Invoice,
+                               totalAmount: MilliSatoshi,
+                               expiry: CltvExpiry,
+                               trampolineHop: NodeHop,
+                               trampolinePaymentSecret: ByteVector32,
+                               customTlvs: Set[GenericTlv] = Set.empty) extends Recipient {
   require(trampolineHop.nextNodeId == invoice.nodeId, "trampoline hop must end at the recipient")
 
   val trampolineNodeId = trampolineHop.nodeId

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Recipient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/Recipient.scala
@@ -21,7 +21,7 @@ import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.payment.Invoice.ExtraEdge
 import fr.acinq.eclair.payment.OutgoingPaymentPacket._
-import fr.acinq.eclair.payment.{Bolt11Invoice, Bolt12Invoice, OutgoingPaymentPacket, PaymentBlindedRoute}
+import fr.acinq.eclair.payment.{Bolt11Invoice, Bolt12Invoice, Invoice, OutgoingPaymentPacket, PaymentBlindedRoute}
 import fr.acinq.eclair.router.Router._
 import fr.acinq.eclair.wire.protocol.PaymentOnion.{FinalPayload, IntermediatePayload, OutgoingBlindedPerHopPayload}
 import fr.acinq.eclair.wire.protocol.{GenericTlv, OnionRoutingPacket}
@@ -190,7 +190,7 @@ object BlindedRecipient {
  * Note that we don't need to support the case where we'd use multiple trampoline hops in the same route: since we have
  * access to the network graph, it's always more efficient to find a channel route to the last trampoline node.
  */
-case class ClearTrampolineRecipient(invoice: Bolt11Invoice,
+case class ClearTrampolineRecipient(invoice: Invoice,
                                     totalAmount: MilliSatoshi,
                                     expiry: CltvExpiry,
                                     trampolineHop: NodeHop,
@@ -225,19 +225,25 @@ case class ClearTrampolineRecipient(invoice: Bolt11Invoice,
   }
 
   private def createTrampolinePacket(paymentHash: ByteVector32, trampolineHop: NodeHop): Either[OutgoingPaymentError, Sphinx.PacketAndSecrets] = {
-    if (invoice.features.hasFeature(Features.TrampolinePaymentPrototype)) {
-      // This is the payload the final recipient will receive, so we use the invoice's payment secret.
-      val finalPayload = NodePayload(nodeId, FinalPayload.Standard.createPayload(totalAmount, totalAmount, expiry, invoice.paymentSecret, invoice.paymentMetadata, customTlvs))
-      val trampolinePayload = NodePayload(trampolineHop.nodeId, IntermediatePayload.NodeRelay.Standard(totalAmount, expiry, nodeId))
-      val payloads = Seq(trampolinePayload, finalPayload)
-      OutgoingPaymentPacket.buildOnion(payloads, paymentHash, packetPayloadLength_opt = None)
-    } else {
-      // The recipient doesn't support trampoline: the trampoline node will convert the payment to a non-trampoline payment.
-      // The final payload will thus never reach the recipient, so we create the smallest payload possible to avoid overflowing the trampoline onion size.
-      val dummyFinalPayload = NodePayload(nodeId, IntermediatePayload.ChannelRelay.Standard(ShortChannelId(0), 0 msat, CltvExpiry(0)))
-      val trampolinePayload = NodePayload(trampolineHop.nodeId, IntermediatePayload.NodeRelay.createNodeRelayToNonTrampolinePayload(totalAmount, totalAmount, expiry, invoice))
-      val payloads = Seq(trampolinePayload, dummyFinalPayload)
-      OutgoingPaymentPacket.buildOnion(payloads, paymentHash, packetPayloadLength_opt = None)
+    invoice match {
+      case invoice: Bolt11Invoice =>
+        if (invoice.features.hasFeature(Features.TrampolinePaymentPrototype)) {
+          // This is the payload the final recipient will receive, so we use the invoice's payment secret.
+          val finalPayload = NodePayload(nodeId, FinalPayload.Standard.createPayload(totalAmount, totalAmount, expiry, invoice.paymentSecret, invoice.paymentMetadata, customTlvs))
+          val trampolinePayload = NodePayload(trampolineHop.nodeId, IntermediatePayload.NodeRelay.Standard(totalAmount, expiry, nodeId))
+          val payloads = Seq(trampolinePayload, finalPayload)
+          OutgoingPaymentPacket.buildOnion(payloads, paymentHash, packetPayloadLength_opt = None)
+        } else {
+          // The recipient doesn't support trampoline: the trampoline node will convert the payment to a non-trampoline payment.
+          // The final payload will thus never reach the recipient, so we create the smallest payload possible to avoid overflowing the trampoline onion size.
+          val dummyFinalPayload = NodePayload(nodeId, IntermediatePayload.ChannelRelay.Standard(ShortChannelId(0), 0 msat, CltvExpiry(0)))
+          val trampolinePayload = NodePayload(trampolineHop.nodeId, IntermediatePayload.NodeRelay.Standard.createNodeRelayToNonTrampolinePayload(totalAmount, totalAmount, expiry, nodeId, invoice))
+          val payloads = Seq(trampolinePayload, dummyFinalPayload)
+          OutgoingPaymentPacket.buildOnion(payloads, paymentHash, packetPayloadLength_opt = None)
+        }
+      case invoice: Bolt12Invoice =>
+        val trampolinePayload = NodePayload(trampolineHop.nodeId, IntermediatePayload.NodeRelay.ToBlindedPaths(totalAmount, expiry, invoice))
+        OutgoingPaymentPacket.buildOnion(Seq(trampolinePayload), paymentHash, packetPayloadLength_opt = None)
     }
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/RouteCalculation.scala
@@ -164,7 +164,7 @@ object RouteCalculation {
         // In that case, we will slightly over-estimate the fee we're paying, but at least we won't exceed our fee budget.
         val maxFee = totalMaxFee - pendingChannelFee - r.pendingPayments.map(_.blindedFee).sum
         (targetNodeId, amountToSend, maxFee, extraEdges)
-      case recipient: ClearTrampolineRecipient =>
+      case recipient: TrampolineRecipient =>
         // Trampoline payments require finding routes to the trampoline node, not the final recipient.
         // This also ensures that we correctly take the trampoline fee into account only once, even when using MPP to
         // reach the trampoline node (which will aggregate the incoming MPP payment and re-split as necessary).
@@ -180,7 +180,7 @@ object RouteCalculation {
       recipient match {
         case _: ClearRecipient => Some(route)
         case _: SpontaneousRecipient => Some(route)
-        case recipient: ClearTrampolineRecipient => Some(route.copy(finalHop_opt = Some(recipient.trampolineHop)))
+        case recipient: TrampolineRecipient => Some(route.copy(finalHop_opt = Some(recipient.trampolineHop)))
         case recipient: BlindedRecipient =>
           route.hops.lastOption.flatMap {
             hop => recipient.blindedHops.find(_.dummyId == hop.shortChannelId)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/OfferCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/OfferCodecs.scala
@@ -131,7 +131,7 @@ object OfferCodecs {
 
   private val invoicePaths: Codec[InvoicePaths] = tlvField(list(pathCodec).xmap[Seq[BlindedContactInfo]](_.toSeq, _.toList))
 
-  private val paymentInfo: Codec[PaymentInfo] =
+  val paymentInfo: Codec[PaymentInfo] =
     (("fee_base_msat" | millisatoshi32) ::
       ("fee_proportional_millionths" | uint32) ::
       ("cltv_expiry_delta" | cltvExpiryDelta) ::

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartPaymentLifecycleSpec.scala
@@ -147,7 +147,7 @@ class MultiPartPaymentLifecycleSpec extends TestKitBaseClass with FixtureAnyFunS
     assert(payFsm.stateName == WAIT_FOR_PAYMENT_REQUEST)
     val invoice = Bolt11Invoice(Block.RegtestGenesisBlock.hash, Some(finalAmount), randomBytes32(), randomKey(), Left("invoice"), CltvExpiryDelta(12))
     val trampolineHop = NodeHop(e, invoice.nodeId, CltvExpiryDelta(50), 1000 msat)
-    val recipient = ClearTrampolineRecipient(invoice, finalAmount, expiry, trampolineHop, randomBytes32())
+    val recipient = TrampolineRecipient(invoice, finalAmount, expiry, trampolineHop, randomBytes32())
     val payment = SendMultiPartPayment(sender.ref, recipient, 1, routeParams)
     sender.send(payFsm, payment)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -721,9 +721,9 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     val hints = List(ExtraHop(randomKey().publicKey, ShortChannelId(42), feeBase = 10 msat, feeProportionalMillionths = 1, cltvExpiryDelta = CltvExpiryDelta(12)))
     val features = Features[Bolt11Feature](VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory, BasicMultiPartPayment -> Optional)
     val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(outgoingAmount * 3), paymentHash, outgoingNodeKey, Left("Some invoice"), CltvExpiryDelta(18), extraHops = List(hints), paymentMetadata = Some(hex"123456"), features = features)
-    val incomingPayments = incomingMultiPart.map(incoming => incoming.copy(innerPayload = IntermediatePayload.NodeRelay.createNodeRelayToNonTrampolinePayload(
-      incoming.innerPayload.amountToForward, outgoingAmount * 3, outgoingExpiry, invoice
-    ).asInstanceOf[IntermediatePayload.NodeRelay.Standard]))
+    val incomingPayments = incomingMultiPart.map(incoming => incoming.copy(innerPayload = IntermediatePayload.NodeRelay.Standard.createNodeRelayToNonTrampolinePayload(
+      incoming.innerPayload.amountToForward, outgoingAmount * 3, outgoingExpiry, outgoingNodeId, invoice
+    )))
     val (nodeRelayer, parent) = f.createNodeRelay(incomingPayments.head)
     incomingPayments.foreach(incoming => nodeRelayer ! NodeRelay.Relay(incoming))
 
@@ -765,9 +765,9 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     val hints = List(ExtraHop(randomKey().publicKey, ShortChannelId(42), feeBase = 10 msat, feeProportionalMillionths = 1, cltvExpiryDelta = CltvExpiryDelta(12)))
     val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(outgoingAmount), paymentHash, outgoingNodeKey, Left("Some invoice"), CltvExpiryDelta(18), extraHops = List(hints), paymentMetadata = Some(hex"123456"))
     assert(!invoice.features.hasFeature(BasicMultiPartPayment))
-    val incomingPayments = incomingMultiPart.map(incoming => incoming.copy(innerPayload = IntermediatePayload.NodeRelay.createNodeRelayToNonTrampolinePayload(
-      incoming.innerPayload.amountToForward, incoming.innerPayload.amountToForward, outgoingExpiry, invoice
-    ).asInstanceOf[IntermediatePayload.NodeRelay.Standard]))
+    val incomingPayments = incomingMultiPart.map(incoming => incoming.copy(innerPayload = IntermediatePayload.NodeRelay.Standard.createNodeRelayToNonTrampolinePayload(
+      incoming.innerPayload.amountToForward, incoming.innerPayload.amountToForward, outgoingExpiry, outgoingNodeId, invoice
+    )))
     val (nodeRelayer, parent) = f.createNodeRelay(incomingPayments.head)
     incomingPayments.foreach(incoming => nodeRelayer ! NodeRelay.Relay(incoming))
 
@@ -806,10 +806,10 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     import f._
 
     // Receive an upstream multi-part payment.
-    val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(outgoingAmount), paymentHash, outgoingNodeKey, Left("Some invoice"), CltvExpiryDelta(18))
+    val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(outgoingAmount), paymentHash, randomKey(), Left("Some invoice"), CltvExpiryDelta(18))
     val incomingPayments = incomingMultiPart.map(incoming => {
-      val innerPayload = IntermediatePayload.NodeRelay.createNodeRelayToNonTrampolinePayload(incoming.innerPayload.amountToForward, incoming.innerPayload.amountToForward, outgoingExpiry, invoice)
-      val invalidPayload = IntermediatePayload.NodeRelay.Standard(records = TlvStream(innerPayload.records.records.collect { case r if !r.isInstanceOf[OnionPaymentPayloadTlv.PaymentData] => r })) // we remove the payment secret
+      val innerPayload = IntermediatePayload.NodeRelay.Standard.createNodeRelayToNonTrampolinePayload(incoming.innerPayload.amountToForward, incoming.innerPayload.amountToForward, outgoingExpiry, outgoingNodeId, invoice)
+      val invalidPayload = innerPayload.copy(records = TlvStream(innerPayload.records.records.collect { case r if !r.isInstanceOf[OnionPaymentPayloadTlv.PaymentData] => r })) // we remove the payment secret
       incoming.copy(innerPayload = invalidPayload)
     })
     val (nodeRelayer, _) = f.createNodeRelay(incomingPayments.head)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -721,9 +721,9 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     val hints = List(ExtraHop(randomKey().publicKey, ShortChannelId(42), feeBase = 10 msat, feeProportionalMillionths = 1, cltvExpiryDelta = CltvExpiryDelta(12)))
     val features = Features[Bolt11Feature](VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory, BasicMultiPartPayment -> Optional)
     val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(outgoingAmount * 3), paymentHash, outgoingNodeKey, Left("Some invoice"), CltvExpiryDelta(18), extraHops = List(hints), paymentMetadata = Some(hex"123456"), features = features)
-    val incomingPayments = incomingMultiPart.map(incoming => incoming.copy(innerPayload = IntermediatePayload.NodeRelay.Standard.createNodeRelayToNonTrampolinePayload(
-      incoming.innerPayload.amountToForward, outgoingAmount * 3, outgoingExpiry, outgoingNodeId, invoice
-    )))
+    val incomingPayments = incomingMultiPart.map(incoming => incoming.copy(innerPayload = IntermediatePayload.NodeRelay.createNodeRelayToNonTrampolinePayload(
+      incoming.innerPayload.amountToForward, outgoingAmount * 3, outgoingExpiry, invoice
+    ).asInstanceOf[IntermediatePayload.NodeRelay.Standard]))
     val (nodeRelayer, parent) = f.createNodeRelay(incomingPayments.head)
     incomingPayments.foreach(incoming => nodeRelayer ! NodeRelay.Relay(incoming))
 
@@ -765,9 +765,9 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     val hints = List(ExtraHop(randomKey().publicKey, ShortChannelId(42), feeBase = 10 msat, feeProportionalMillionths = 1, cltvExpiryDelta = CltvExpiryDelta(12)))
     val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(outgoingAmount), paymentHash, outgoingNodeKey, Left("Some invoice"), CltvExpiryDelta(18), extraHops = List(hints), paymentMetadata = Some(hex"123456"))
     assert(!invoice.features.hasFeature(BasicMultiPartPayment))
-    val incomingPayments = incomingMultiPart.map(incoming => incoming.copy(innerPayload = IntermediatePayload.NodeRelay.Standard.createNodeRelayToNonTrampolinePayload(
-      incoming.innerPayload.amountToForward, incoming.innerPayload.amountToForward, outgoingExpiry, outgoingNodeId, invoice
-    )))
+    val incomingPayments = incomingMultiPart.map(incoming => incoming.copy(innerPayload = IntermediatePayload.NodeRelay.createNodeRelayToNonTrampolinePayload(
+      incoming.innerPayload.amountToForward, incoming.innerPayload.amountToForward, outgoingExpiry, invoice
+    ).asInstanceOf[IntermediatePayload.NodeRelay.Standard]))
     val (nodeRelayer, parent) = f.createNodeRelay(incomingPayments.head)
     incomingPayments.foreach(incoming => nodeRelayer ! NodeRelay.Relay(incoming))
 
@@ -806,10 +806,10 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     import f._
 
     // Receive an upstream multi-part payment.
-    val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(outgoingAmount), paymentHash, randomKey(), Left("Some invoice"), CltvExpiryDelta(18))
+    val invoice = Bolt11Invoice(Block.LivenetGenesisBlock.hash, Some(outgoingAmount), paymentHash, outgoingNodeKey, Left("Some invoice"), CltvExpiryDelta(18))
     val incomingPayments = incomingMultiPart.map(incoming => {
-      val innerPayload = IntermediatePayload.NodeRelay.Standard.createNodeRelayToNonTrampolinePayload(incoming.innerPayload.amountToForward, incoming.innerPayload.amountToForward, outgoingExpiry, outgoingNodeId, invoice)
-      val invalidPayload = innerPayload.copy(records = TlvStream(innerPayload.records.records.collect { case r if !r.isInstanceOf[OnionPaymentPayloadTlv.PaymentData] => r })) // we remove the payment secret
+      val innerPayload = IntermediatePayload.NodeRelay.createNodeRelayToNonTrampolinePayload(incoming.innerPayload.amountToForward, incoming.innerPayload.amountToForward, outgoingExpiry, invoice)
+      val invalidPayload = IntermediatePayload.NodeRelay.Standard(records = TlvStream(innerPayload.records.records.collect { case r if !r.isInstanceOf[OnionPaymentPayloadTlv.PaymentData] => r })) // we remove the payment secret
       incoming.copy(innerPayload = invalidPayload)
     })
     val (nodeRelayer, _) = f.createNodeRelay(incomingPayments.head)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/RelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/RelayerSpec.scala
@@ -33,7 +33,7 @@ import fr.acinq.eclair.payment.IncomingPaymentPacket.FinalPacket
 import fr.acinq.eclair.payment.OutgoingPaymentPacket.{NodePayload, Upstream, buildOnion, buildOutgoingPayment}
 import fr.acinq.eclair.payment.PaymentPacketSpec._
 import fr.acinq.eclair.payment.relay.Relayer._
-import fr.acinq.eclair.payment.send.{ClearRecipient, ClearTrampolineRecipient}
+import fr.acinq.eclair.payment.send.{ClearRecipient, TrampolineRecipient}
 import fr.acinq.eclair.router.BaseRouterSpec.{blindedRouteFromHops, channelHopFromUpdate}
 import fr.acinq.eclair.router.Router.{NodeHop, Route}
 import fr.acinq.eclair.wire.protocol.PaymentOnion.FinalPayload
@@ -198,7 +198,7 @@ class RelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("applicat
     val invoiceFeatures = Features[Bolt11Feature](VariableLengthOnion -> Mandatory, PaymentSecret -> Mandatory, BasicMultiPartPayment -> Optional, PaymentMetadata -> Optional, TrampolinePaymentPrototype -> Optional)
     val invoice = Bolt11Invoice(Block.RegtestGenesisBlock.hash, None, paymentHash, priv_c.privateKey, Left("invoice"), CltvExpiryDelta(6), paymentSecret = paymentSecret, features = invoiceFeatures)
     val trampolineHop = NodeHop(b, c, channelUpdate_bc.cltvExpiryDelta, fee_b)
-    val recipient = ClearTrampolineRecipient(invoice, finalAmount, finalExpiry, trampolineHop, randomBytes32())
+    val recipient = TrampolineRecipient(invoice, finalAmount, finalExpiry, trampolineHop, randomBytes32())
     val Right(payment) = buildOutgoingPayment(ActorRef.noSender, priv_a.privateKey, Upstream.Local(UUID.randomUUID()), paymentHash, Route(recipient.trampolineAmount, Seq(channelHopFromUpdate(priv_a.publicKey, b, channelUpdate_ab)), Some(trampolineHop)), recipient)
 
     // and then manually build an htlc

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -29,7 +29,7 @@ import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
 import fr.acinq.eclair.payment.Bolt11Invoice.ExtraHop
 import fr.acinq.eclair.payment.Invoice.ExtraEdge
-import fr.acinq.eclair.payment.send.{ClearRecipient, ClearTrampolineRecipient, SpontaneousRecipient}
+import fr.acinq.eclair.payment.send.{ClearRecipient, TrampolineRecipient, SpontaneousRecipient}
 import fr.acinq.eclair.payment.{Bolt11Invoice, Invoice}
 import fr.acinq.eclair.router.Announcements.{makeChannelUpdate, makeNodeAnnouncement}
 import fr.acinq.eclair.router.BaseRouterSpec.{blindedRoutesFromPaths, channelAnnouncement}
@@ -515,7 +515,7 @@ class RouterSpec extends BaseRouterSpec {
     val recipientKey = randomKey()
     val invoice = Bolt11Invoice(Block.RegtestGenesisBlock.hash, None, randomBytes32(), recipientKey, Left("invoice"), CltvExpiryDelta(6))
     val trampolineHop = NodeHop(c, recipientKey.publicKey, CltvExpiryDelta(100), 25_000 msat)
-    val recipient = ClearTrampolineRecipient(invoice, 725_000 msat, DEFAULT_EXPIRY, trampolineHop, randomBytes32())
+    val recipient = TrampolineRecipient(invoice, 725_000 msat, DEFAULT_EXPIRY, trampolineHop, randomBytes32())
     sender.send(router, RouteRequest(a, recipient, routeParams))
     val route1 = sender.expectMsgType[RouteResponse].routes.head
     assert(route1.amount == 750_000.msat)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/PaymentOnionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/PaymentOnionSpec.scala
@@ -125,7 +125,7 @@ class PaymentOnionSpec extends AnyFunSuite {
 
     val decoded = perHopPayloadCodec.decode(bin.bits).require.value
     assert(decoded == expected)
-    val Right(payload: IntermediatePayload.NodeRelay.Standard) = IntermediatePayload.NodeRelay.validate(decoded)
+    val Right(payload) = IntermediatePayload.NodeRelay.Standard.validate(decoded)
     assert(payload.amountToForward == 561.msat)
     assert(payload.totalAmount == 561.msat)
     assert(payload.outgoingCltv == CltvExpiry(42))
@@ -151,7 +151,7 @@ class PaymentOnionSpec extends AnyFunSuite {
 
     val decoded = perHopPayloadCodec.decode(bin.bits).require.value
     assert(decoded == expected)
-    val Right(payload: IntermediatePayload.NodeRelay.Standard) = IntermediatePayload.NodeRelay.validate(decoded)
+    val Right(payload) = IntermediatePayload.NodeRelay.Standard.validate(decoded)
     assert(payload.amountToForward == 561.msat)
     assert(payload.totalAmount == 1105.msat)
     assert(payload.paymentSecret.contains(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619")))
@@ -172,14 +172,13 @@ class PaymentOnionSpec extends AnyFunSuite {
       Seq(RouteBlinding.BlindedNode(PublicKey(hex"03823aa560d631e9d7b686be4a9227e577009afb5173023b458a6a6aff056ac980"), hex""))
     )
     val path = PaymentBlindedContactInfo(blindedRoute, OfferTypes.PaymentInfo(1000 msat, 678, CltvExpiryDelta(82), 300 msat, 4000000 msat, Features.empty))
-    val expected = TlvStream[OnionPaymentPayloadTlv](AmountToForward(341 msat), OutgoingCltv(CltvExpiry(826483)), TotalAmount(1678 msat), OutgoingBlindedPaths(Seq(path)), InvoiceFeatures(features))
-    val bin = hex"86 02020155 04030c9c73 1202068efe000 1023103020000fe000 102366a0100000000000001d40232882c4982576e00f0d6bd4998f5b3e92d47ecc8fbad5b6a5e7521819d891d9e0103823aa560d631e9d7b686be4a9227e577009afb5173023b458a6a6aff056ac9800000000003e8000002a60052000000000000012c00000000003d09000000"
+    val expected = TlvStream[OnionPaymentPayloadTlv](AmountToForward(341 msat), OutgoingCltv(CltvExpiry(826483)), OutgoingBlindedPaths(Seq(path)), InvoiceFeatures(features))
+    val bin = hex"82 02020155 04030c9c73 fe0001023103020000 fe000102366a0100000000000001d40232882c4982576e00f0d6bd4998f5b3e92d47ecc8fbad5b6a5e7521819d891d9e0103823aa560d631e9d7b686be4a9227e577009afb5173023b458a6a6aff056ac9800000000003e8000002a60052000000000000012c00000000003d09000000"
 
     val decoded = perHopPayloadCodec.decode(bin.bits).require.value
     assert(decoded == expected)
-    val Right(payload: IntermediatePayload.NodeRelay.ToBlindedPaths) = IntermediatePayload.NodeRelay.validate(decoded)
+    val Right(payload) = IntermediatePayload.NodeRelay.ToBlindedPaths.validate(decoded)
     assert(payload.amountToForward == 341.msat)
-    assert(payload.totalAmount == 1678.msat)
     assert(payload.outgoingCltv == CltvExpiry(826483))
     assert(payload.outgoingBlindedPaths == Seq(path))
     assert(payload.invoiceFeatures == features)
@@ -316,7 +315,7 @@ class PaymentOnionSpec extends AnyFunSuite {
     )
 
     for ((expectedErr, bin) <- testCases) {
-      assert(IntermediatePayload.NodeRelay.validate(perHopPayloadCodec.decode(bin.bits).require.value) == Left(expectedErr))
+      assert(IntermediatePayload.NodeRelay.Standard.validate(perHopPayloadCodec.decode(bin.bits).require.value) == Left(expectedErr))
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/PaymentOnionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/PaymentOnionSpec.scala
@@ -19,12 +19,14 @@ package fr.acinq.eclair.wire.protocol
 import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.UInt64.Conversions._
+import fr.acinq.eclair.crypto.Sphinx.RouteBlinding
 import fr.acinq.eclair.payment.Bolt11Invoice.ExtraHop
+import fr.acinq.eclair.payment.PaymentBlindedContactInfo
 import fr.acinq.eclair.wire.protocol.OnionPaymentPayloadTlv._
 import fr.acinq.eclair.wire.protocol.OnionRoutingCodecs.{ForbiddenTlv, InvalidTlvPayload, MissingRequiredTlv}
 import fr.acinq.eclair.wire.protocol.PaymentOnion._
 import fr.acinq.eclair.wire.protocol.PaymentOnionCodecs._
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, MilliSatoshiLong, ShortChannelId, UInt64, randomKey}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, FeatureSupport, Features, MilliSatoshiLong, RealShortChannelId, ShortChannelId, UInt64, randomKey}
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits.{ByteVector, HexStringSyntax}
 
@@ -123,7 +125,7 @@ class PaymentOnionSpec extends AnyFunSuite {
 
     val decoded = perHopPayloadCodec.decode(bin.bits).require.value
     assert(decoded == expected)
-    val Right(payload) = IntermediatePayload.NodeRelay.Standard.validate(decoded)
+    val Right(payload: IntermediatePayload.NodeRelay.Standard) = IntermediatePayload.NodeRelay.validate(decoded)
     assert(payload.amountToForward == 561.msat)
     assert(payload.totalAmount == 561.msat)
     assert(payload.outgoingCltv == CltvExpiry(42))
@@ -149,7 +151,7 @@ class PaymentOnionSpec extends AnyFunSuite {
 
     val decoded = perHopPayloadCodec.decode(bin.bits).require.value
     assert(decoded == expected)
-    val Right(payload) = IntermediatePayload.NodeRelay.Standard.validate(decoded)
+    val Right(payload: IntermediatePayload.NodeRelay.Standard) = IntermediatePayload.NodeRelay.validate(decoded)
     assert(payload.amountToForward == 561.msat)
     assert(payload.totalAmount == 1105.msat)
     assert(payload.paymentSecret.contains(ByteVector32(hex"eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619")))
@@ -157,6 +159,30 @@ class PaymentOnionSpec extends AnyFunSuite {
     assert(payload.outgoingNodeId == nodeId)
     assert(payload.invoiceFeatures.contains(features))
     assert(payload.invoiceRoutingInfo.contains(routingHints))
+
+    val encoded = perHopPayloadCodec.encode(expected).require.bytes
+    assert(encoded == bin)
+  }
+
+  test("encode/decode node relay to blinded paths per-hop payload") {
+    val features = Features(Features.BasicMultiPartPayment -> FeatureSupport.Optional).toByteVector
+    val blindedRoute = OfferTypes.CompactBlindedPath(
+      OfferTypes.ShortChannelIdDir(isNode1 = false, RealShortChannelId(468)),
+      PublicKey(hex"0232882c4982576e00f0d6bd4998f5b3e92d47ecc8fbad5b6a5e7521819d891d9e"),
+      Seq(RouteBlinding.BlindedNode(PublicKey(hex"03823aa560d631e9d7b686be4a9227e577009afb5173023b458a6a6aff056ac980"), hex""))
+    )
+    val path = PaymentBlindedContactInfo(blindedRoute, OfferTypes.PaymentInfo(1000 msat, 678, CltvExpiryDelta(82), 300 msat, 4000000 msat, Features.empty))
+    val expected = TlvStream[OnionPaymentPayloadTlv](AmountToForward(341 msat), OutgoingCltv(CltvExpiry(826483)), TotalAmount(1678 msat), OutgoingBlindedPaths(Seq(path)), InvoiceFeatures(features))
+    val bin = hex"86 02020155 04030c9c73 1202068efe000 1023103020000fe000 102366a0100000000000001d40232882c4982576e00f0d6bd4998f5b3e92d47ecc8fbad5b6a5e7521819d891d9e0103823aa560d631e9d7b686be4a9227e577009afb5173023b458a6a6aff056ac9800000000003e8000002a60052000000000000012c00000000003d09000000"
+
+    val decoded = perHopPayloadCodec.decode(bin.bits).require.value
+    assert(decoded == expected)
+    val Right(payload: IntermediatePayload.NodeRelay.ToBlindedPaths) = IntermediatePayload.NodeRelay.validate(decoded)
+    assert(payload.amountToForward == 341.msat)
+    assert(payload.totalAmount == 1678.msat)
+    assert(payload.outgoingCltv == CltvExpiry(826483))
+    assert(payload.outgoingBlindedPaths == Seq(path))
+    assert(payload.invoiceFeatures == features)
 
     val encoded = perHopPayloadCodec.encode(expected).require.bytes
     assert(encoded == bin)
@@ -290,7 +316,7 @@ class PaymentOnionSpec extends AnyFunSuite {
     )
 
     for ((expectedErr, bin) <- testCases) {
-      assert(IntermediatePayload.NodeRelay.Standard.validate(perHopPayloadCodec.decode(bin.bits).require.value) == Left(expectedErr))
+      assert(IntermediatePayload.NodeRelay.validate(perHopPayloadCodec.decode(bin.bits).require.value) == Left(expectedErr))
     }
   }
 


### PR DESCRIPTION
Allow trampoline to pay a list of blinded paths instead of a node id. Only the last trampoline hop can target blinded paths, trampoline nodes are still reached with their node id, not with blinded paths.
Followed by #2811