### PR TITLE
Abandon transactions whose ancestors have been double spent

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -483,12 +483,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val onChainKeyManag
         getRawTransaction(tx.txid).map(_ => tx.txid).recoverWith { case _ => Future.failed(e) }
     }
 
-  /**
-   * Mark a transaction as abandoned, which will allow for its wallet inputs to be re-spent.
-   * This method can be used to replace "stuck" or evicted transactions.
-   * It only works on transactions which are not included in a block and are not currently in the mempool.
-   */
-  def abandonTransaction(txId: TxId)(implicit ec: ExecutionContext): Future[Boolean] = {
+  override def abandon(txId: TxId)(implicit ec: ExecutionContext): Future[Boolean] = {
     rpcClient.invoke("abandontransaction", txId).map(_ => true).recover(_ => false)
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -1738,7 +1738,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
       if (d1.remoteCommitPublished.exists(_.commitTx.txid == tx.txid) || d1.nextRemoteCommitPublished.exists(_.commitTx.txid == tx.txid)) {
         nodeParams.db.audit.listPublished(d.channelId).collect {
           case tx if tx.desc == "local-anchor" =>
-            log.warning("abandoning local-anchor txId={} (local commit was confirmed)", tx.txId)
+            log.warning("abandoning local-anchor txId={} (remote commit was confirmed)", tx.txId)
             wallet.abandon(tx.txId)
         }
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/AuditDb.scala
@@ -17,12 +17,12 @@
 package fr.acinq.eclair.db
 
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi}
-import fr.acinq.eclair.{Paginated, TimestampMilli}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, TxId}
 import fr.acinq.eclair.channel._
-import fr.acinq.eclair.db.AuditDb.{NetworkFee, Stats}
+import fr.acinq.eclair.db.AuditDb.{NetworkFee, PublishedTransaction, Stats}
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.payment.{PathFindingExperimentMetrics, PaymentReceived, PaymentRelayed, PaymentSent}
+import fr.acinq.eclair.{Paginated, TimestampMilli}
 
 trait AuditDb {
 
@@ -44,6 +44,8 @@ trait AuditDb {
 
   def addPathFindingExperimentMetrics(metrics: PathFindingExperimentMetrics): Unit
 
+  def listPublished(channelId: ByteVector32): Seq[PublishedTransaction]
+
   def listSent(from: TimestampMilli, to: TimestampMilli, paginated_opt: Option[Paginated] = None): Seq[PaymentSent]
 
   def listReceived(from: TimestampMilli, to: TimestampMilli, paginated_opt: Option[Paginated] = None): Seq[PaymentReceived]
@@ -57,6 +59,8 @@ trait AuditDb {
 }
 
 object AuditDb {
+
+  case class PublishedTransaction(txId: TxId, desc: String, miningFee: Satoshi)
 
   case class NetworkFee(remoteNodeId: PublicKey, channelId: ByteVector32, txId: ByteVector32, fee: Satoshi, txType: String, timestamp: TimestampMilli)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/DualDatabases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/DualDatabases.scala
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, Crypto, Satoshi, TxId}
 import fr.acinq.eclair.channel._
+import fr.acinq.eclair.db.AuditDb.PublishedTransaction
 import fr.acinq.eclair.db.Databases.{FileBackup, PostgresDatabases, SqliteDatabases}
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.db.DualDatabases.runAsync
@@ -173,6 +174,11 @@ case class DualAuditDb(primary: AuditDb, secondary: AuditDb) extends AuditDb {
   override def addPathFindingExperimentMetrics(metrics: PathFindingExperimentMetrics): Unit = {
     runAsync(secondary.addPathFindingExperimentMetrics(metrics))
     primary.addPathFindingExperimentMetrics(metrics)
+  }
+
+  override def listPublished(channelId: ByteVector32): Seq[PublishedTransaction] = {
+    runAsync(secondary.listPublished(channelId))
+    primary.listPublished(channelId)
   }
 
   override def listSent(from: TimestampMilli, to: TimestampMilli, paginated_opt: Option[Paginated]): Seq[PaymentSent] = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
@@ -42,6 +42,7 @@ class DummyOnChainWallet extends OnChainWallet with OnchainPubkeyCache {
   val funded = collection.concurrent.TrieMap.empty[TxId, Transaction]
   val published = collection.concurrent.TrieMap.empty[TxId, Transaction]
   var rolledback = Set.empty[Transaction]
+  var abandoned = Set.empty[TxId]
 
   override def onChainBalance()(implicit ec: ExecutionContext): Future[OnChainBalance] = Future.successful(OnChainBalance(1105 sat, 561 sat))
 
@@ -78,6 +79,11 @@ class DummyOnChainWallet extends OnChainWallet with OnchainPubkeyCache {
     Future.successful(true)
   }
 
+  override def abandon(txId: TxId)(implicit ec: ExecutionContext): Future[Boolean] = {
+    abandoned = abandoned + txId
+    Future.successful(true)
+  }
+
   override def doubleSpent(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean] = Future.successful(false)
 
   override def getP2wpkhPubkey(renew: Boolean): PublicKey = dummyReceivePubkey
@@ -89,6 +95,7 @@ class NoOpOnChainWallet extends OnChainWallet with OnchainPubkeyCache {
 
   var rolledback = Seq.empty[Transaction]
   var doubleSpent = Set.empty[TxId]
+  var abandoned = Set.empty[TxId]
 
   override def onChainBalance()(implicit ec: ExecutionContext): Future[OnChainBalance] = Future.successful(OnChainBalance(1105 sat, 561 sat))
 
@@ -115,6 +122,11 @@ class NoOpOnChainWallet extends OnChainWallet with OnchainPubkeyCache {
     Future.successful(true)
   }
 
+  override def abandon(txId: TxId)(implicit ec: ExecutionContext): Future[Boolean] = {
+    abandoned = abandoned + txId
+    Future.successful(true)
+  }
+
   override def doubleSpent(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean] = Future.successful(doubleSpent.contains(tx.txid))
 
   override def getP2wpkhPubkey(renew: Boolean): PublicKey = dummyReceivePubkey
@@ -127,6 +139,7 @@ class SingleKeyOnChainWallet extends OnChainWallet with OnchainPubkeyCache {
   var inputs = Seq.empty[Transaction]
   var rolledback = Seq.empty[Transaction]
   var doubleSpent = Set.empty[TxId]
+  var abandoned = Set.empty[TxId]
 
   override def onChainBalance()(implicit ec: ExecutionContext): Future[OnChainBalance] = Future.successful(OnChainBalance(1105 sat, 561 sat))
 
@@ -215,6 +228,11 @@ class SingleKeyOnChainWallet extends OnChainWallet with OnchainPubkeyCache {
 
   override def rollback(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean] = {
     rolledback = rolledback :+ tx
+    Future.successful(true)
+  }
+
+  override def abandon(txId: TxId)(implicit ec: ExecutionContext): Future[Boolean] = {
+    abandoned = abandoned + txId
     Future.successful(true)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
@@ -900,19 +900,19 @@ class BitcoinCoreClientSpec extends TestKitBaseClass with BitcoindService with A
     sender.expectMsg(signedTx2.txid)
 
     // Abandon the first wallet transaction.
-    bitcoinClient.abandonTransaction(signedTx1.txid).pipeTo(sender.ref)
+    bitcoinClient.abandon(signedTx1.txid).pipeTo(sender.ref)
     sender.expectMsg(true)
 
     // Abandoning an already-abandoned transaction is a no-op.
-    bitcoinClient.abandonTransaction(signedTx1.txid).pipeTo(sender.ref)
+    bitcoinClient.abandon(signedTx1.txid).pipeTo(sender.ref)
     sender.expectMsg(true)
 
     // We can't abandon the second transaction (it's in the mempool).
-    bitcoinClient.abandonTransaction(signedTx2.txid).pipeTo(sender.ref)
+    bitcoinClient.abandon(signedTx2.txid).pipeTo(sender.ref)
     sender.expectMsg(false)
 
     // We can't abandon a confirmed transaction.
-    bitcoinClient.abandonTransaction(signedTx2.txIn.head.outPoint.txid).pipeTo(sender.ref)
+    bitcoinClient.abandon(signedTx2.txIn.head.outPoint.txid).pipeTo(sender.ref)
     sender.expectMsg(false)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -169,6 +169,10 @@ class AuditDbSpec extends AnyFunSuite {
       db.add(TransactionPublished(c4, n4, Transaction(0, Seq.empty, Seq(TxOut(4500 sat, hex"1111222233")), 0), 500 sat, "funding")) // unconfirmed
       db.add(TransactionConfirmed(c4, n4, Transaction(0, Seq.empty, Seq(TxOut(2500 sat, hex"ffffff")), 0))) // doesn't match a published tx
 
+      assert(db.listPublished(randomBytes32()).isEmpty)
+      assert(db.listPublished(c4).map(_.txId).toSet.size == 2)
+      assert(db.listPublished(c4).map(_.desc) == Seq("funding", "funding"))
+
       // NB: we only count a relay fee for the outgoing channel, no the incoming one.
       assert(db.stats(0 unixms, TimestampMilli.now() + 1.milli).toSet == Set(
         Stats(channelId = c1, direction = "IN", avgPaymentAmount = 0 sat, paymentCount = 0, relayFee = 0 sat, networkFee = 0 sat),


### PR DESCRIPTION
When a transaction is directly double-spent, bitcoind is able to automatically detect it and free up wallet inputs that are used in double-spent transactions. However, when a transaction becomes invalid because one of its ancestors is double-spent, bitcoind is not able to detect it and will keep wallet inputs locked forever.

The only cases where this can happen are:

- splice transactions when a commitment transaction that is not based on the latest splice is confirmed
- anchor transactions in the above case, or when a different version of the commitment confirms (e.g. remote commit while we're trying to CPFP ou local commit)

When we detect that this happened, we abandon the corresponding transactions, which ensures that we don't end up with unusable liquidity in our wallet.

We also remove cases where we eagerly abandoned transactions, which could lead us to double-spend ourselves inadvertently because the abandoned transaction could still confirm while we reused its inputs in another transaction (which is a real issue when using 0-conf).