### PR TITLE
Unlock utxos on reconnect when signatures haven't been sent

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -436,7 +436,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
       handleFastClose(c, d.channelId) sending Error(d.channelId, DualFundingAborted(d.channelId).getMessage)
 
     case Event(e: Error, d: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED) =>
-      rollbackFundingAttempt(d.signingSession.fundingTx.tx, Nil)
+      // handleRemoteError takes care of rolling back the funding tx
       handleRemoteError(e, d)
 
     case Event(INPUT_DISCONNECTED, d: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ErrorHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ErrorHandlers.scala
@@ -145,7 +145,9 @@ trait ErrorHandlers extends CommonHandlers {
           spendLocalCurrent(hasCommitments)
         }
       // When there is no commitment yet, we just go to CLOSED state in case an error occurs.
-      case _: ChannelDataWithoutCommitments => goto(CLOSED)
+      case waitForDualFundingSigned: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED =>
+        rollbackFundingAttempt(waitForDualFundingSigned.signingSession.fundingTx.tx, Nil)
+        goto(CLOSED)
       case _: TransientChannelData => goto(CLOSED)
     }
   }


### PR DESCRIPTION
In the case where we have not sent our `TxSignatures`, and our peer replies with an error at reconnection, we can safely unlock our local inputs.