### PR TITLE
Unlock non-wallet inputs

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/DualFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/DualFundingHandlers.scala
@@ -117,7 +117,7 @@ trait DualFundingHandlers extends CommonFundingHandlers {
    * never sent us their signatures, or the transaction wasn't accepted in our mempool), their inputs may still be locked.
    */
   def rollbackDualFundingTxs(txs: Seq[SignedSharedTransaction]): Unit = {
-    val inputs = txs.flatMap(_.tx.localInputs).distinctBy(_.serialId).map(i => TxIn(i.outPoint, Nil, 0))
+    val inputs = txs.flatMap(sharedTx => sharedTx.tx.localInputs ++ sharedTx.tx.sharedInput_opt.toSeq).distinctBy(_.serialId).map(i => TxIn(i.outPoint, Nil, 0))
     if (inputs.nonEmpty) {
       wallet.rollback(Transaction(2, inputs, Nil, 0))
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -832,12 +832,15 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
   }
 
   private def unlockAndStop(session: InteractiveTxSession): Behavior[Command] = {
-    val localInputs = session.localInputs ++ session.toSend.collect { case addInput: Input.Local => addInput }
+    val localInputs = session.localInputs ++ session.toSend.collect {
+      case addInput: Input.Local => addInput
+      case addInput: Input.Shared => addInput
+    }
     unlockAndStop(localInputs.map(_.outPoint).toSet)
   }
 
   private def unlockAndStop(tx: SharedTransaction): Behavior[Command] = {
-    val localInputs = tx.localInputs.map(_.outPoint).toSet
+    val localInputs = tx.localInputs.map(_.outPoint).toSet ++ tx.sharedInput_opt.map(_.outPoint).toSet
     unlockAndStop(localInputs)
   }
 


### PR DESCRIPTION
When funding a transaction that contains inputs that are external to our bitcoin wallet, bitcoin core will add a lock to those external inputs, thinking that they may be wallet inputs that it doesn't know about yet. In our case, those are never wallet inputs, they are instead:

- the current channel output, when creating a splice transaction
- an output of the commitment transaction, when force-closing

We previously explicitly filtered those inputs before calling `unlock`, which was wrong. We now also unlock those utxos.