### PR TITLE
Fix flaky test

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
@@ -186,10 +186,6 @@ object MinimalNodeFixture extends Assertions with Eventually with IntegrationPat
     sender.expectMsgType[OpenChannelResponse.Created]
   }
 
-  def fundingTx(node: MinimalNodeFixture, channelId: ByteVector32)(implicit system: ActorSystem): Transaction = {
-    getChannelData(node, channelId).asInstanceOf[ChannelDataWithCommitments].commitments.latest.localFundingStatus.signedTx_opt.get
-  }
-
   def confirmChannel(node1: MinimalNodeFixture, node2: MinimalNodeFixture, channelId: ByteVector32, blockHeight: BlockHeight, txIndex: Int)(implicit system: ActorSystem): Option[RealScidStatus.Temporary] = {
     val fundingTx = getChannelData(node1, channelId) match {
       case d: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED => d.signingSession.fundingTx.tx.buildUnsignedTx()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/zeroconf/ZeroConfActivationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/zeroconf/ZeroConfActivationSpec.scala
@@ -5,7 +5,7 @@ import fr.acinq.bitcoin.scalacompat.{ByteVector32, SatoshiLong}
 import fr.acinq.eclair.FeatureSupport.Optional
 import fr.acinq.eclair.Features.ZeroConf
 import fr.acinq.eclair.channel.ChannelTypes.AnchorOutputsZeroFeeHtlcTx
-import fr.acinq.eclair.channel.{ChannelDataWithCommitments, DATA_NORMAL, NORMAL, SupportedChannelType}
+import fr.acinq.eclair.channel._
 import fr.acinq.eclair.integration.basic.fixtures.composite.TwoNodesFixture
 import fr.acinq.eclair.testutils.FixtureSpec
 import org.scalatest.concurrent.IntegrationPatience
@@ -60,8 +60,13 @@ class ZeroConfActivationSpec extends FixtureSpec with IntegrationPatience {
     assert(!bob.nodeParams.features.activated.contains(ZeroConf))
 
     val channelId = createChannel(f)
-    assert(!getChannelData(alice, channelId).asInstanceOf[ChannelDataWithCommitments].commitments.params.channelFeatures.hasFeature(ZeroConf))
-    assert(!getChannelData(bob, channelId).asInstanceOf[ChannelDataWithCommitments].commitments.params.channelFeatures.hasFeature(ZeroConf))
+    Seq(alice, bob).foreach { node =>
+      getChannelData(node, channelId) match {
+        case d: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED => assert(!d.channelParams.channelFeatures.hasFeature(ZeroConf))
+        case d: ChannelDataWithCommitments => assert(!d.commitments.params.channelFeatures.hasFeature(ZeroConf))
+        case d => fail(s"unexpected channel state: ${d.getClass.getSimpleName}")
+      }
+    }
   }
 
   test("open a channel alice-bob (zero-conf disabled on both sides, requested via channel type by alice)") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/zeroconf/ZeroConfActivationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/zeroconf/ZeroConfActivationSpec.scala
@@ -60,12 +60,9 @@ class ZeroConfActivationSpec extends FixtureSpec with IntegrationPatience {
     assert(!bob.nodeParams.features.activated.contains(ZeroConf))
 
     val channelId = createChannel(f)
-    Seq(alice, bob).foreach { node =>
-      getChannelData(node, channelId) match {
-        case d: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED => assert(!d.channelParams.channelFeatures.hasFeature(ZeroConf))
-        case d: ChannelDataWithCommitments => assert(!d.commitments.params.channelFeatures.hasFeature(ZeroConf))
-        case d => fail(s"unexpected channel state: ${d.getClass.getSimpleName}")
-      }
+    eventually {
+      assert(!getChannelData(alice, channelId).asInstanceOf[ChannelDataWithCommitments].commitments.params.channelFeatures.hasFeature(ZeroConf))
+      assert(!getChannelData(bob, channelId).asInstanceOf[ChannelDataWithCommitments].commitments.params.channelFeatures.hasFeature(ZeroConf))
     }
   }
 


### PR DESCRIPTION
We started using dual-funding by default in some integration tests. One of the changes is that we consider the channel created once we send our commitment signatures. At that point, we are not yet in a state where we have fully signed commitments: that will happen once we receive our peer's signatures.

Some tests assumed that when receiving the `ChannelCreated` event, we would have fully signed commitment. We update those tests to handle the case where we are actually still exchanging signatures.