### PR TITLE
Allow relaying messages to self

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -357,7 +357,7 @@ object RouteNodeIdsSerializer extends ConvertClassSerializer[Route](route => {
     case Some(hop: NodeHop) if channelNodeIds.nonEmpty => Seq(hop.nextNodeId)
     case Some(hop: NodeHop) => Seq(hop.nodeId, hop.nextNodeId)
     case Some(hop: BlindedHop) if channelNodeIds.nonEmpty => hop.route.blindedNodeIds.tail
-    case Some(hop: BlindedHop) => hop.route.introductionNodeId +: hop.route.blindedNodeIds.tail
+    case Some(hop: BlindedHop) => hop.nodeId +: hop.route.blindedNodeIds.tail
     case None => Nil
   }
   RouteNodeIdsJson(route.amount, channelNodeIds ++ finalNodeIds)
@@ -468,14 +468,8 @@ object InvoiceSerializer extends MinimalSerializer({
           UnknownFeatureSerializer
       )),
       JField("blindedPaths", JArray(p.blindedPaths.map(path => {
-        val introductionNode = path.route match {
-          case OfferTypes.BlindedPath(route) => route.introductionNodeId.toString
-          case OfferTypes.CompactBlindedPath(shortIdDir, _, _) => s"${if (shortIdDir.isNode1) '0' else '1'}x${shortIdDir.scid.toString}"
-        }
-        val blindedNodes = path.route match {
-          case OfferTypes.BlindedPath(route) => route.blindedNodes
-          case OfferTypes.CompactBlindedPath(_, _, nodes) => nodes
-        }
+        val introductionNode = path.route.introductionNodeId.toString
+        val blindedNodes = path.route.blindedNodes
         JObject(List(
           JField("introductionNodeId", JString(introductionNode)),
           JField("blindedNodeIds", JArray(blindedNodes.map(n => JString(n.blindedPublicKey.toString)).toList))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/message/OnionMessages.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/message/OnionMessages.scala
@@ -27,7 +27,6 @@ import fr.acinq.eclair.wire.protocol._
 import scodec.bits.ByteVector
 import scodec.{Attempt, DecodeResult}
 
-import scala.annotation.tailrec
 import scala.concurrent.duration.FiniteDuration
 
 object OnionMessages {
@@ -44,8 +43,8 @@ object OnionMessages {
                                 timeout: FiniteDuration,
                                 maxAttempts: Int)
 
-  case class IntermediateNode(nodeId: PublicKey, outgoingChannel_opt: Option[ShortChannelId] = None, padding: Option[ByteVector] = None, customTlvs: Set[GenericTlv] = Set.empty) {
-    def toTlvStream(nextNodeId: PublicKey, nextBlinding_opt: Option[PublicKey] = None): TlvStream[RouteBlindingEncryptedDataTlv] =
+  case class IntermediateNode(publicKey: PublicKey, encodedNodeId: EncodedNodeId, outgoingChannel_opt: Option[ShortChannelId] = None, padding: Option[ByteVector] = None, customTlvs: Set[GenericTlv] = Set.empty) {
+    def toTlvStream(nextNodeId: EncodedNodeId, nextBlinding_opt: Option[PublicKey] = None): TlvStream[RouteBlindingEncryptedDataTlv] =
       TlvStream(Set[Option[RouteBlindingEncryptedDataTlv]](
         padding.map(Padding),
         outgoingChannel_opt.map(OutgoingChannelId).orElse(Some(OutgoingNodeId(nextNodeId))),
@@ -53,14 +52,20 @@ object OnionMessages {
       ).flatten, customTlvs)
   }
 
+  object IntermediateNode {
+    def apply(publicKey: PublicKey): IntermediateNode = IntermediateNode(publicKey, EncodedNodeId(publicKey))
+  }
+
   // @formatter:off
   sealed trait Destination {
-    def nodeId: PublicKey
+    def introductionNodeId: EncodedNodeId
   }
   case class BlindedPath(route: Sphinx.RouteBlinding.BlindedRoute) extends Destination {
-    override def nodeId: PublicKey = route.introductionNodeId
+    override def introductionNodeId: EncodedNodeId = route.introductionNodeId
   }
-  case class Recipient(nodeId: PublicKey, pathId: Option[ByteVector], padding: Option[ByteVector] = None, customTlvs: Set[GenericTlv] = Set.empty) extends Destination
+  case class Recipient(nodeId: PublicKey, pathId: Option[ByteVector], padding: Option[ByteVector] = None, customTlvs: Set[GenericTlv] = Set.empty) extends Destination {
+    override def introductionNodeId: EncodedNodeId = EncodedNodeId(nodeId)
+  }
   // @formatter:on
 
   // @formatter:off
@@ -75,11 +80,11 @@ object OnionMessages {
   }
   // @formatter:on
 
-  private def buildIntermediatePayloads(intermediateNodes: Seq[IntermediateNode], lastNodeId: PublicKey, lastBlinding_opt: Option[PublicKey] = None): Seq[ByteVector] = {
+  private def buildIntermediatePayloads(intermediateNodes: Seq[IntermediateNode], lastNodeId: EncodedNodeId, lastBlinding_opt: Option[PublicKey] = None): Seq[ByteVector] = {
     if (intermediateNodes.isEmpty) {
       Nil
     } else {
-      val intermediatePayloads = intermediateNodes.dropRight(1).zip(intermediateNodes.tail).map { case (hop, nextNode) => hop.toTlvStream(nextNode.nodeId) }
+      val intermediatePayloads = intermediateNodes.dropRight(1).zip(intermediateNodes.tail).map { case (hop, nextNode) => hop.toTlvStream(nextNode.encodedNodeId) }
       val lastPayload = intermediateNodes.last.toTlvStream(lastNodeId, lastBlinding_opt)
       (intermediatePayloads :+ lastPayload).map(tlvs => RouteBlindingEncryptedDataCodecs.blindedRouteDataCodec.encode(tlvs).require.bytes)
     }
@@ -88,33 +93,22 @@ object OnionMessages {
   def buildRoute(blindingSecret: PrivateKey,
                  intermediateNodes: Seq[IntermediateNode],
                  recipient: Recipient): Sphinx.RouteBlinding.BlindedRoute = {
-    val intermediatePayloads = buildIntermediatePayloads(intermediateNodes, recipient.nodeId)
+    val intermediatePayloads = buildIntermediatePayloads(intermediateNodes, EncodedNodeId(recipient.nodeId))
     val tlvs: Set[RouteBlindingEncryptedDataTlv] = Set(recipient.padding.map(Padding), recipient.pathId.map(PathId)).flatten
     val lastPayload = RouteBlindingEncryptedDataCodecs.blindedRouteDataCodec.encode(TlvStream(tlvs, recipient.customTlvs)).require.bytes
-    Sphinx.RouteBlinding.create(blindingSecret, intermediateNodes.map(_.nodeId) :+ recipient.nodeId, intermediatePayloads :+ lastPayload).route
+    Sphinx.RouteBlinding.create(blindingSecret, intermediateNodes.map(_.publicKey) :+ recipient.nodeId, intermediatePayloads :+ lastPayload).route
   }
 
-  private[message] def buildRouteFrom(originKey: PrivateKey,
-                                      blindingSecret: PrivateKey,
+  private[message] def buildRouteFrom(blindingSecret: PrivateKey,
                                       intermediateNodes: Seq[IntermediateNode],
-                                      destination: Destination): Option[Sphinx.RouteBlinding.BlindedRoute] = {
+                                      destination: Destination): Sphinx.RouteBlinding.BlindedRoute = {
     destination match {
-      case recipient: Recipient => Some(buildRoute(blindingSecret, intermediateNodes, recipient))
-      case BlindedPath(route) if route.introductionNodeId == originKey.publicKey =>
-        RouteBlindingEncryptedDataCodecs.decode(originKey, route.blindingKey, route.blindedNodes.head.encryptedPayload) match {
-          case Left(_) => None
-          case Right(decoded) =>
-            decoded.tlvs.get[RouteBlindingEncryptedDataTlv.OutgoingNodeId] match {
-              case Some(RouteBlindingEncryptedDataTlv.OutgoingNodeId(EncodedNodeId.Plain(nextNodeId))) =>
-                Some(Sphinx.RouteBlinding.BlindedRoute(nextNodeId, decoded.nextBlinding, route.blindedNodes.tail))
-              case _ => None // TODO: allow compact node id and OutgoingChannelId
-            }
-        }
-      case BlindedPath(route) if intermediateNodes.isEmpty => Some(route)
+      case recipient: Recipient => buildRoute(blindingSecret, intermediateNodes, recipient)
+      case BlindedPath(route) if intermediateNodes.isEmpty => route
       case BlindedPath(route) =>
         val intermediatePayloads = buildIntermediatePayloads(intermediateNodes, route.introductionNodeId, Some(route.blindingKey))
-        val routePrefix = Sphinx.RouteBlinding.create(blindingSecret, intermediateNodes.map(_.nodeId), intermediatePayloads).route
-        Some(Sphinx.RouteBlinding.BlindedRoute(routePrefix.introductionNodeId, routePrefix.blindingKey, routePrefix.blindedNodes ++ route.blindedNodes))
+        val routePrefix = Sphinx.RouteBlinding.create(blindingSecret, intermediateNodes.map(_.publicKey), intermediatePayloads).route
+        Sphinx.RouteBlinding.BlindedRoute(routePrefix.introductionNodeId, routePrefix.blindingKey, routePrefix.blindedNodes ++ route.blindedNodes)
     }
   }
 
@@ -134,32 +128,28 @@ object OnionMessages {
    * @param content           List of TLVs to send to the recipient of the message
    * @return The node id to send the onion to and the onion containing the message
    */
-  def buildMessage(nodeKey: PrivateKey,
-                   sessionKey: PrivateKey,
+  def buildMessage(sessionKey: PrivateKey,
                    blindingSecret: PrivateKey,
                    intermediateNodes: Seq[IntermediateNode],
                    destination: Destination,
-                   content: TlvStream[OnionMessagePayloadTlv]): Either[BuildMessageError, (PublicKey, OnionMessage)] = {
-    buildRouteFrom(nodeKey, blindingSecret, intermediateNodes, destination) match {
-      case None => Left(InvalidDestination(destination))
-      case Some(route) =>
-        val lastPayload = MessageOnionCodecs.perHopPayloadCodec.encode(TlvStream(content.records + EncryptedData(route.encryptedPayloads.last), content.unknown)).require.bytes
-        val payloads = route.encryptedPayloads.dropRight(1).map(encTlv => MessageOnionCodecs.perHopPayloadCodec.encode(TlvStream(EncryptedData(encTlv))).require.bytes) :+ lastPayload
-        val payloadSize = payloads.map(_.length + Sphinx.MacLength).sum
-        val packetSize = if (payloadSize <= 1300) {
-          1300
-        } else if (payloadSize <= 32768) {
-          32768
-        } else if (payloadSize > 65432) {
-          // A payload of size 65432 corresponds to a total lightning message size of 65535.
-          return Left(MessageTooLarge(payloadSize))
-        } else {
-          payloadSize.toInt
-        }
-        // Since we are setting the packet size based on the payload, the onion creation should never fail (hence the `.get`).
-        val Sphinx.PacketAndSecrets(packet, _) = Sphinx.create(sessionKey, packetSize, route.blindedNodes.map(_.blindedPublicKey), payloads, None).get
-        Right((route.introductionNodeId, OnionMessage(route.blindingKey, packet)))
+                   content: TlvStream[OnionMessagePayloadTlv]): Either[BuildMessageError, OnionMessage] = {
+    val route = buildRouteFrom(blindingSecret, intermediateNodes, destination)
+    val lastPayload = MessageOnionCodecs.perHopPayloadCodec.encode(TlvStream(content.records + EncryptedData(route.encryptedPayloads.last), content.unknown)).require.bytes
+    val payloads = route.encryptedPayloads.dropRight(1).map(encTlv => MessageOnionCodecs.perHopPayloadCodec.encode(TlvStream(EncryptedData(encTlv))).require.bytes) :+ lastPayload
+    val payloadSize = payloads.map(_.length + Sphinx.MacLength).sum
+    val packetSize = if (payloadSize <= 1300) {
+      1300
+    } else if (payloadSize <= 32768) {
+      32768
+    } else if (payloadSize > 65432) {
+      // A payload of size 65432 corresponds to a total lightning message size of 65535.
+      return Left(MessageTooLarge(payloadSize))
+    } else {
+      payloadSize.toInt
     }
+    // Since we are setting the packet size based on the payload, the onion creation should never fail (hence the `.get`).
+    val Sphinx.PacketAndSecrets(packet, _) = Sphinx.create(sessionKey, packetSize, route.blindedNodes.map(_.blindedPublicKey), payloads, None).get
+    Right(OnionMessage(route.blindingKey, packet))
   }
 
   // @formatter:off
@@ -199,7 +189,6 @@ object OnionMessages {
     }
   }
 
-  @tailrec
   def process(privateKey: PrivateKey, msg: OnionMessage): Action = {
     val blindedPrivateKey = Sphinx.RouteBlinding.derivePrivateKey(privateKey, msg.blindingKey)
     decryptOnion(blindedPrivateKey, msg.onionRoutingPacket) match {
@@ -210,11 +199,7 @@ object OnionMessages {
             decryptEncryptedData(privateKey, msg.blindingKey, encryptedData) match {
               case Left(f) => DropMessage(f)
               case Right(DecodedEncryptedData(blindedPayload, nextBlinding)) => nextPacket_opt match {
-                case Some(nextPacket) => validateRelayPayload(payload, blindedPayload, nextBlinding, nextPacket) match {
-                  case SendMessage(Right(EncodedNodeId.Plain(publicKey)), nextMsg) if publicKey == privateKey.publicKey => process(privateKey, nextMsg) // TODO: remove and rely on MessageRelay
-                  case SendMessage(Left(outgoingChannelId), nextMsg) if outgoingChannelId == ShortChannelId.toSelf => process(privateKey, nextMsg) // TODO: remove and rely on MessageRelay
-                  case action => action
-                }
+                case Some(nextPacket) => validateRelayPayload(payload, blindedPayload, nextBlinding, nextPacket)
                 case None => validateFinalPayload(payload, blindedPayload)
               }
             }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/message/Postman.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/message/Postman.scala
@@ -161,7 +161,7 @@ private class SendingMessage(nodeParams: NodeParams,
   private def waitForNodeId(compactBlindedPath: BlindedRoute): Behavior[Command] = {
     Behaviors.receiveMessagePartial {
       case WrappedNodeIdResponse(None) =>
-        replyTo ! Postman.MessageFailed(s"Could not resolve introduction node for compact blinded path: ${compactBlindedPath.introductionNode}")
+        replyTo ! Postman.MessageFailed(s"Could not resolve introduction node for compact blinded path: ${compactBlindedPath.introductionNode.nodeId}")
         Behaviors.stopped
       case WrappedNodeIdResponse(Some(nodeId)) =>
         sendToDestination(OnionMessages.BlindedPath(compactBlindedPath), nodeId)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/message/Postman.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/message/Postman.scala
@@ -29,7 +29,7 @@ import fr.acinq.eclair.payment.offer.OfferManager
 import fr.acinq.eclair.router.Router
 import fr.acinq.eclair.router.Router.{MessageRoute, MessageRouteNotFound, MessageRouteResponse}
 import fr.acinq.eclair.wire.protocol.MessageOnion.{FinalPayload, InvoiceRequestPayload}
-import fr.acinq.eclair.wire.protocol.OfferTypes.{CompactBlindedPath, ContactInfo}
+import fr.acinq.eclair.wire.protocol.OfferTypes.ContactInfo
 import fr.acinq.eclair.wire.protocol.{OfferTypes, OnionMessagePayloadTlv, TlvStream}
 import fr.acinq.eclair.{EncodedNodeId, NodeParams, randomBytes32, randomKey}
 
@@ -149,42 +149,43 @@ private class SendingMessage(nodeParams: NodeParams,
     Behaviors.receiveMessagePartial {
       case SendMessage =>
         contactInfo match {
-          case compact: OfferTypes.CompactBlindedPath =>
-            router ! Router.GetNodeId(context.messageAdapter(WrappedNodeIdResponse), compact.introductionNode.scid, compact.introductionNode.isNode1)
-            waitForNodeId(compact)
-          case OfferTypes.BlindedPath(route) => sendToDestination(OnionMessages.BlindedPath(route))
-          case OfferTypes.RecipientNodeId(nodeId) => sendToDestination(OnionMessages.Recipient(nodeId, None))
+          case OfferTypes.BlindedPath(route@BlindedRoute(EncodedNodeId.ShortChannelIdDir(isNode1, scid), _, _)) =>
+            router ! Router.GetNodeId(context.messageAdapter(WrappedNodeIdResponse), scid, isNode1)
+            waitForNodeId(route)
+          case OfferTypes.BlindedPath(route@BlindedRoute(EncodedNodeId.Plain(publicKey), _, _)) => sendToDestination(OnionMessages.BlindedPath(route), publicKey)
+          case OfferTypes.RecipientNodeId(nodeId) => sendToDestination(OnionMessages.Recipient(nodeId, None), nodeId)
         }
     }
   }
 
-  private def waitForNodeId(compactBlindedPath: CompactBlindedPath): Behavior[Command] = {
+  private def waitForNodeId(compactBlindedPath: BlindedRoute): Behavior[Command] = {
     Behaviors.receiveMessagePartial {
       case WrappedNodeIdResponse(None) =>
-        replyTo ! Postman.MessageFailed(s"Could not resolve introduction node for compact blinded path (scid=${compactBlindedPath.introductionNode.scid.toCoordinatesString})")
+        replyTo ! Postman.MessageFailed(s"Could not resolve introduction node for compact blinded path: ${compactBlindedPath.introductionNode}")
         Behaviors.stopped
       case WrappedNodeIdResponse(Some(nodeId)) =>
-        sendToDestination(OnionMessages.BlindedPath(BlindedRoute(nodeId, compactBlindedPath.blindingKey, compactBlindedPath.blindedNodes)))
+        sendToDestination(OnionMessages.BlindedPath(compactBlindedPath), nodeId)
     }
   }
 
-  private def sendToDestination(destination: Destination): Behavior[Command] = {
+  private def sendToDestination(destination: Destination, plainNodeId: PublicKey): Behavior[Command] = {
     routingStrategy match {
-      case RoutingStrategy.UseRoute(intermediateNodes) => sendToRoute(intermediateNodes, destination)
-      case RoutingStrategy.FindRoute if destination.nodeId == nodeParams.nodeId =>
-        context.self ! WrappedMessageRouteResponse(MessageRoute(Nil, destination.nodeId))
-        waitForRouteFromRouter(destination)
+      case RoutingStrategy.UseRoute(intermediateNodes) =>
+        sendToRoute(intermediateNodes, destination, plainNodeId)
+      case RoutingStrategy.FindRoute if plainNodeId == nodeParams.nodeId =>
+        context.self ! WrappedMessageRouteResponse(MessageRoute(Nil, plainNodeId))
+        waitForRouteFromRouter(destination, plainNodeId)
       case RoutingStrategy.FindRoute =>
-        router ! Router.MessageRouteRequest(context.messageAdapter(WrappedMessageRouteResponse), nodeParams.nodeId, destination.nodeId, Set.empty)
-        waitForRouteFromRouter(destination)
+        router ! Router.MessageRouteRequest(context.messageAdapter(WrappedMessageRouteResponse), nodeParams.nodeId, plainNodeId, Set.empty)
+        waitForRouteFromRouter(destination, plainNodeId)
     }
   }
 
-  private def waitForRouteFromRouter(destination: Destination): Behavior[Command] = {
+  private def waitForRouteFromRouter(destination: Destination, plainNodeId: PublicKey): Behavior[Command] = {
     Behaviors.receiveMessagePartial {
       case WrappedMessageRouteResponse(MessageRoute(intermediateNodes, targetNodeId)) =>
         context.log.debug("Found route: {}", (intermediateNodes :+ targetNodeId).mkString(" -> "))
-        sendToRoute(intermediateNodes, destination)
+        sendToRoute(intermediateNodes, destination, plainNodeId)
       case WrappedMessageRouteResponse(MessageRouteNotFound(targetNodeId)) =>
         context.log.debug("No route found to {}", targetNodeId)
         replyTo ! Postman.MessageFailed("No route found")
@@ -192,19 +193,18 @@ private class SendingMessage(nodeParams: NodeParams,
     }
   }
 
-  private def sendToRoute(intermediateNodes: Seq[PublicKey], destination: Destination): Behavior[Command] = {
+  private def sendToRoute(intermediateNodes: Seq[PublicKey], destination: Destination, plainNodeId: PublicKey): Behavior[Command] = {
     val messageId = randomBytes32()
     val replyRoute =
       if (expectsReply) {
         val numHopsToAdd = 0.max(nodeParams.onionMessageConfig.minIntermediateHops - intermediateNodes.length - 1)
-        val intermediateHops = (Seq(destination.nodeId) ++ intermediateNodes.reverse ++ Seq.fill(numHopsToAdd)(nodeParams.nodeId)).map(OnionMessages.IntermediateNode(_))
+        val intermediateHops = OnionMessages.IntermediateNode(plainNodeId, destination.introductionNodeId) +: (intermediateNodes.reverse ++ Seq.fill(numHopsToAdd)(nodeParams.nodeId)).map(OnionMessages.IntermediateNode(_))
         val lastHop = OnionMessages.Recipient(nodeParams.nodeId, Some(messageId))
         Some(OnionMessages.buildRoute(randomKey(), intermediateHops, lastHop))
       } else {
         None
       }
     OnionMessages.buildMessage(
-      nodeParams.privateKey,
       randomKey(),
       randomKey(),
       intermediateNodes.map(OnionMessages.IntermediateNode(_)),
@@ -213,9 +213,10 @@ private class SendingMessage(nodeParams: NodeParams,
       case Left(failure) =>
         replyTo ! Postman.MessageFailed(failure.toString)
         Behaviors.stopped
-      case Right((nextNodeId, message)) =>
+      case Right(message) =>
+        val nextNodeId = EncodedNodeId(intermediateNodes.headOption.getOrElse(plainNodeId))
         val relay = context.spawn(Behaviors.supervise(MessageRelay(nodeParams, switchboard, register, router)).onFailure(typed.SupervisorStrategy.stop), s"relay-message-$messageId")
-        relay ! MessageRelay.RelayMessage(messageId, nodeParams.nodeId, Right(EncodedNodeId(nextNodeId)), message, MessageRelay.RelayAll, Some(context.messageAdapter[MessageRelay.Status](SendingStatus)))
+        relay ! MessageRelay.RelayMessage(messageId, nodeParams.nodeId, Right(nextNodeId), message, MessageRelay.RelayAll, Some(context.messageAdapter[MessageRelay.Status](SendingStatus)))
         waitForSent()
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -31,7 +31,7 @@ import fr.acinq.eclair.payment.OutgoingPaymentPacket.Upstream
 import fr.acinq.eclair.payment._
 import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM
 import fr.acinq.eclair.payment.receive.MultiPartPaymentFSM.HtlcPart
-import fr.acinq.eclair.payment.send.CompactBlindedPathsResolver.Resolve
+import fr.acinq.eclair.payment.send.CompactBlindedPathsResolver.{Resolve, ResolvedPath}
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.{PreimageReceived, SendMultiPartPayment}
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentConfig
 import fr.acinq.eclair.payment.send.PaymentLifecycle.SendPaymentToNode
@@ -63,7 +63,7 @@ object NodeRelay {
   private case class WrappedPaymentSent(paymentSent: PaymentSent) extends Command
   private case class WrappedPaymentFailed(paymentFailed: PaymentFailed) extends Command
   private[relay] case class WrappedPeerReadyResult(result: AsyncPaymentTriggerer.Result) extends Command
-  private case class WrappedResolvedPaths(resolved: Seq[PaymentBlindedRoute]) extends Command
+  private case class WrappedResolvedPaths(resolved: Seq[ResolvedPath]) extends Command
   // @formatter:on
 
   trait OutgoingPaymentFactory {
@@ -340,7 +340,7 @@ class NodeRelay private(nodeParams: NodeParams,
             relayToRecipient(upstream, payloadOut, recipient, paymentCfg, routeParams, useMultiPart = true)
         }
       case payloadOut: IntermediatePayload.NodeRelay.ToBlindedPaths =>
-        context.spawnAnonymous(CompactBlindedPathsResolver(router)) ! Resolve(context.messageAdapter[Seq[PaymentBlindedRoute]](WrappedResolvedPaths), payloadOut.outgoingBlindedPaths)
+        context.spawnAnonymous(CompactBlindedPathsResolver(router)) ! Resolve(context.messageAdapter[Seq[ResolvedPath]](WrappedResolvedPaths), payloadOut.outgoingBlindedPaths)
         waitForResolvedPaths(upstream, payloadOut, paymentCfg, routeParams)
     }
   }
@@ -378,7 +378,7 @@ class NodeRelay private(nodeParams: NodeParams,
       case WrappedResolvedPaths(resolved) =>
         val features = Features(payloadOut.invoiceFeatures).invoiceFeatures()
         // We don't have access to the invoice: we use the only node_id that somewhat makes sense for the recipient.
-        val blindedNodeId = resolved.head.route.blindedNodeIds.last
+        val blindedNodeId = resolved.head.blindedPath.route.blindedNodeIds.last
         val recipient = BlindedRecipient.fromPaths(blindedNodeId, features, payloadOut.amountToForward, payloadOut.outgoingCltv, resolved, Set.empty)
         context.log.debug("sending the payment to blinded recipient, useMultiPart={}", features.hasFeature(Features.BasicMultiPartPayment))
         relayToRecipient(upstream, payloadOut, recipient, paymentCfg, routeParams, features.hasFeature(Features.BasicMultiPartPayment))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/CompactBlindedPathsResolver.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/CompactBlindedPathsResolver.scala
@@ -4,19 +4,21 @@ import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.actor.{ActorRef, typed}
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.eclair.EncodedNodeId
 import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.BlindedRoute
+import fr.acinq.eclair.payment.PaymentBlindedRoute
 import fr.acinq.eclair.payment.send.CompactBlindedPathsResolver._
-import fr.acinq.eclair.payment.{PaymentBlindedContactInfo, PaymentBlindedRoute}
 import fr.acinq.eclair.router.Router
-import fr.acinq.eclair.wire.protocol.OfferTypes.{BlindedPath, CompactBlindedPath, PaymentInfo}
 
 import scala.annotation.tailrec
 
 object CompactBlindedPathsResolver {
   // @formatter:off
   sealed trait Command
-  case class Resolve(replyTo: typed.ActorRef[Seq[PaymentBlindedRoute]], blindedPaths: Seq[PaymentBlindedContactInfo]) extends Command
+  case class Resolve(replyTo: typed.ActorRef[Seq[ResolvedPath]], blindedPaths: Seq[PaymentBlindedRoute]) extends Command
   private case class WrappedNodeId(nodeId_opt: Option[PublicKey]) extends Command
+
+  case class ResolvedPath(blindedPath: PaymentBlindedRoute, introductionNodeId: PublicKey)
   // @formatter:on
 
   def apply(router: ActorRef): Behavior[Command] = {
@@ -28,33 +30,31 @@ object CompactBlindedPathsResolver {
   }
 }
 
-private class CompactBlindedPathsResolver(replyTo: typed.ActorRef[Seq[PaymentBlindedRoute]],
+private class CompactBlindedPathsResolver(replyTo: typed.ActorRef[Seq[ResolvedPath]],
                                           router: ActorRef,
                                           context: ActorContext[Command]) {
   @tailrec
-  private def resolveCompactBlindedPaths(toResolve: Seq[PaymentBlindedContactInfo],
-                                         resolved: Seq[PaymentBlindedRoute]): Behavior[Command] = {
+  private def resolveCompactBlindedPaths(toResolve: Seq[PaymentBlindedRoute],
+                                         resolved: Seq[ResolvedPath]): Behavior[Command] = {
     toResolve.headOption match {
-      case Some(PaymentBlindedContactInfo(BlindedPath(route), paymentInfo)) =>
-        resolveCompactBlindedPaths(toResolve.tail, resolved :+ PaymentBlindedRoute(route, paymentInfo))
-      case Some(PaymentBlindedContactInfo(route: CompactBlindedPath, paymentInfo)) =>
-        router ! Router.GetNodeId(context.messageAdapter(WrappedNodeId), route.introductionNode.scid, route.introductionNode.isNode1)
-        waitForNodeId(route, paymentInfo, toResolve.tail, resolved)
+      case Some(paymentRoute@PaymentBlindedRoute(BlindedRoute(EncodedNodeId.Plain(publicKey), _, _), _)) =>
+        resolveCompactBlindedPaths(toResolve.tail, resolved :+ ResolvedPath(paymentRoute, publicKey))
+      case Some(paymentRoute@PaymentBlindedRoute(BlindedRoute(EncodedNodeId.ShortChannelIdDir(isNode1, scid), _, _), _)) =>
+        router ! Router.GetNodeId(context.messageAdapter(WrappedNodeId), scid, isNode1)
+        waitForNodeId(paymentRoute, toResolve.tail, resolved)
       case None =>
         replyTo ! resolved
         Behaviors.stopped
     }
   }
 
-  private def waitForNodeId(compactRoute: CompactBlindedPath,
-                            paymentInfo: PaymentInfo,
-                            toResolve: Seq[PaymentBlindedContactInfo],
-                            resolved: Seq[PaymentBlindedRoute]): Behavior[Command] =
+  private def waitForNodeId(paymentRoute: PaymentBlindedRoute,
+                            toResolve: Seq[PaymentBlindedRoute],
+                            resolved: Seq[ResolvedPath]): Behavior[Command] =
     Behaviors.receiveMessagePartial {
       case WrappedNodeId(None) =>
         resolveCompactBlindedPaths(toResolve, resolved)
       case WrappedNodeId(Some(nodeId)) =>
-        val resolvedPaymentBlindedRoute = PaymentBlindedRoute(BlindedRoute(nodeId, compactRoute.blindingKey, compactRoute.blindedNodes), paymentInfo)
-        resolveCompactBlindedPaths(toResolve, resolved :+ resolvedPaymentBlindedRoute)
+        resolveCompactBlindedPaths(toResolve, resolved :+ ResolvedPath(paymentRoute, nodeId))
     }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentInitiator.scala
@@ -24,6 +24,7 @@ import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.db.PaymentType
 import fr.acinq.eclair.payment.OutgoingPaymentPacket.Upstream
 import fr.acinq.eclair.payment._
+import fr.acinq.eclair.payment.send.CompactBlindedPathsResolver.ResolvedPath
 import fr.acinq.eclair.payment.send.PaymentError._
 import fr.acinq.eclair.router.RouteNotFound
 import fr.acinq.eclair.router.Router._
@@ -31,7 +32,6 @@ import fr.acinq.eclair.wire.protocol._
 import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshi, NodeParams, randomBytes32}
 
 import java.util.UUID
-import scala.util.{Failure, Success, Try}
 
 /**
  * Created by PM on 29/08/2016.
@@ -299,7 +299,7 @@ object PaymentInitiator {
   case class SendPaymentToNode(replyTo: ActorRef,
                                recipientAmount: MilliSatoshi,
                                invoice: Invoice,
-                               resolvedPaths: Seq[PaymentBlindedRoute],
+                               resolvedPaths: Seq[ResolvedPath],
                                maxAttempts: Int,
                                externalId: Option[String] = None,
                                routeParams: RouteParams,
@@ -363,7 +363,7 @@ object PaymentInitiator {
    */
   case class SendPaymentToRoute(recipientAmount: MilliSatoshi,
                                 invoice: Invoice,
-                                resolvedPaths: Seq[PaymentBlindedRoute],
+                                resolvedPaths: Seq[ResolvedPath],
                                 route: PredefinedRoute,
                                 externalId: Option[String],
                                 parentId: Option[UUID],

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -523,14 +523,14 @@ object Router {
    * A directed hop over a blinded route composed of multiple (blinded) channels.
    * Since a blinded route has to be used from start to end, we model it as a single virtual hop.
    *
+   * @param nodeId      introduction node id
    * @param dummyId     dummy identifier to allow indexing in maps: unlike normal scid aliases, this one doesn't exist
    *                    in our routing tables and should be used carefully.
    * @param route       blinded route covered by that hop.
    * @param paymentInfo payment information about the blinded route.
    */
-  case class BlindedHop(dummyId: Alias, route: BlindedRoute, paymentInfo: OfferTypes.PaymentInfo) extends FinalHop {
+  case class BlindedHop(nodeId: PublicKey, dummyId: Alias, route: BlindedRoute, paymentInfo: OfferTypes.PaymentInfo) extends FinalHop {
     // @formatter:off
-    override val nodeId = route.introductionNodeId
     override val nextNodeId = route.blindedNodes.last.blindedPublicKey
     override val cltvExpiryDelta = paymentInfo.cltvExpiryDelta
     override def fee(amount: MilliSatoshi): MilliSatoshi = paymentInfo.fee(amount)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/MessageOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/MessageOnion.scala
@@ -17,11 +17,11 @@
 package fr.acinq.eclair.wire.protocol
 
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.eclair.{EncodedNodeId, ShortChannelId, UInt64}
-import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.{BlindedNode, BlindedRoute}
+import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.BlindedRoute
 import fr.acinq.eclair.payment.Bolt12Invoice
 import fr.acinq.eclair.wire.protocol.OnionRoutingCodecs.{ForbiddenTlv, InvalidTlvPayload, MissingRequiredTlv}
 import fr.acinq.eclair.wire.protocol.TlvCodecs.tlvField
+import fr.acinq.eclair.{EncodedNodeId, ShortChannelId, UInt64}
 import scodec.bits.ByteVector
 
 /** Tlv types used inside the onion of an [[OnionMessage]]. */
@@ -148,11 +148,7 @@ object MessageOnionCodecs {
   import scodec.Codec
   import scodec.codecs._
 
-  private val replyHopCodec: Codec[BlindedNode] = (("nodeId" | publicKey) :: ("encryptedData" | variableSizeBytes(uint16, bytes))).as[BlindedNode]
-
-  val blindedRouteCodec: Codec[BlindedRoute] = (("firstNodeId" | publicKey) :: ("blinding" | publicKey) :: ("path" | listOfN(uint8, replyHopCodec).xmap[Seq[BlindedNode]](_.toSeq, _.toList))).as[BlindedRoute]
-
-  private val replyPathCodec: Codec[ReplyPath] = tlvField(blindedRouteCodec)
+  private val replyPathCodec: Codec[ReplyPath] = tlvField(OfferCodecs.blindedRouteCodec)
 
   private val encryptedDataCodec: Codec[EncryptedData] = tlvField(bytes)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -18,11 +18,11 @@ package fr.acinq.eclair.wire.protocol
 
 import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.eclair.payment.{Bolt11Invoice, Bolt12Invoice, PaymentBlindedContactInfo}
+import fr.acinq.eclair.payment.{Bolt11Invoice, Bolt12Invoice, PaymentBlindedRoute}
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
 import fr.acinq.eclair.wire.protocol.OnionRoutingCodecs.{ForbiddenTlv, InvalidTlvPayload, MissingRequiredTlv}
 import fr.acinq.eclair.wire.protocol.TlvCodecs._
-import fr.acinq.eclair.{CltvExpiry, Features, MilliSatoshi, MilliSatoshiLong, ShortChannelId, UInt64, randomKey}
+import fr.acinq.eclair.{CltvExpiry, Features, MilliSatoshi, MilliSatoshiLong, ShortChannelId, UInt64}
 import scodec.bits.{BitVector, ByteVector}
 
 /**
@@ -186,7 +186,7 @@ object OnionPaymentPayloadTlv {
   case class AsyncPayment() extends OnionPaymentPayloadTlv
 
   /** Blinded paths to relay the payment to */
-  case class OutgoingBlindedPaths(paths: Seq[PaymentBlindedContactInfo]) extends OnionPaymentPayloadTlv
+  case class OutgoingBlindedPaths(paths: Seq[PaymentBlindedRoute]) extends OnionPaymentPayloadTlv
 }
 
 object PaymentOnion {
@@ -537,12 +537,12 @@ object PaymentOnionCodecs {
 
   private val trampolineOnion: Codec[TrampolineOnion] = tlvField(OnionRoutingCodecs.variableSizeOnionRoutingPacketCodec)
 
-  private val paymentBlindedContactInfo: Codec[PaymentBlindedContactInfo] =
-    (("route" | OfferCodecs.pathCodec) ::
-      ("paymentInfo" | OfferCodecs.paymentInfo)).as[PaymentBlindedContactInfo]
+  private val paymentBlindedRoute: Codec[PaymentBlindedRoute] =
+    (("route" | OfferCodecs.blindedRouteCodec) ::
+      ("paymentInfo" | OfferCodecs.paymentInfo)).as[PaymentBlindedRoute]
 
   private val outgoingBlindedPaths: Codec[OutgoingBlindedPaths] =
-    tlvField(list(paymentBlindedContactInfo).xmap[Seq[PaymentBlindedContactInfo]](_.toSeq, _.toList))
+    tlvField(list(paymentBlindedRoute).xmap[Seq[PaymentBlindedRoute]](_.toSeq, _.toList))
 
   private val keySend: Codec[KeySend] = tlvField(bytes32)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/crypto/SphinxSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/crypto/SphinxSpec.scala
@@ -21,7 +21,7 @@ import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.{BlindedRoute, BlindedRouteDetails}
 import fr.acinq.eclair.wire.protocol
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{BlockHeight, CltvExpiry, CltvExpiryDelta, MilliSatoshiLong, ShortChannelId, UInt64, randomKey}
+import fr.acinq.eclair.{BlockHeight, CltvExpiry, CltvExpiryDelta, EncodedNodeId, MilliSatoshiLong, ShortChannelId, UInt64, randomKey}
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits._
 
@@ -421,7 +421,7 @@ class SphinxSpec extends AnyFunSuite {
     }
 
     // We now have a blinded route Bob -> Carol -> Dave -> Eve
-    val blindedRoute = BlindedRoute(bob.publicKey, blinding, blindedRouteStart.blindedNodes ++ blindedRouteEnd.blindedNodes)
+    val blindedRoute = BlindedRoute(EncodedNodeId(bob.publicKey), blinding, blindedRouteStart.blindedNodes ++ blindedRouteEnd.blindedNodes)
     assert(blindedRoute.blindedNodeIds == Seq(
       PublicKey(hex"03da173ad2aee2f701f17e59fbd16cb708906d69838a5f088e8123fb36e89a2c25"),
       PublicKey(hex"02e466727716f044290abf91a14a6d90e87487da160c2a3cbd0d465d7a78eb83a7"),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/PaymentsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/PaymentsDbSpec.scala
@@ -801,7 +801,7 @@ object PaymentsDbSpec {
   def createBolt12Invoice(amount: MilliSatoshi, payerKey: PrivateKey, recipientKey: PrivateKey, preimage: ByteVector32): Bolt12Invoice = {
     val offer = Offer(Some(amount), "some offer", recipientKey.publicKey, Features.empty, Block.TestnetGenesisBlock.hash)
     val invoiceRequest = InvoiceRequest(offer, 789 msat, 1, Features.empty, payerKey, Block.TestnetGenesisBlock.hash)
-    val dummyRoute = PaymentBlindedContactInfo(BlindedPath(RouteBlinding.create(randomKey(), Seq(randomKey().publicKey), Seq(randomBytes(100))).route), PaymentInfo(0 msat, 0, CltvExpiryDelta(0), 0 msat, 0 msat, Features.empty))
+    val dummyRoute = PaymentBlindedRoute(RouteBlinding.create(randomKey(), Seq(randomKey().publicKey), Seq(randomBytes(100))).route, PaymentInfo(0 msat, 0, CltvExpiryDelta(0), 0 msat, 0 msat, Features.empty))
     Bolt12Invoice(invoiceRequest, preimage, recipientKey, 1 hour, Features.empty, Seq(dummyRoute))
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/MessageRelaySpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/MessageRelaySpec.scala
@@ -18,6 +18,7 @@ package fr.acinq.eclair.io
 
 import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe => TypedProbe}
 import akka.actor.typed.ActorRef
+import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
@@ -62,8 +63,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
   test("relay with new connection") { f =>
     import f._
 
-    val Right((nextNode, message)) = OnionMessages.buildMessage(randomKey(), randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
-    assert(nextNode == bobId)
+    val Right(message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
     val messageId = randomBytes32()
     relay ! RelayMessage(messageId, randomKey().publicKey, Right(EncodedNodeId(bobId)), message, RelayAll, None)
 
@@ -76,8 +76,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
   test("relay with existing peer") { f =>
     import f._
 
-    val Right((nextNode, message)) = OnionMessages.buildMessage(randomKey(), randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
-    assert(nextNode == bobId)
+    val Right(message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
     val messageId = randomBytes32()
     relay ! RelayMessage(messageId, randomKey().publicKey, Right(EncodedNodeId(bobId)), message, RelayAll, None)
 
@@ -90,8 +89,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
   test("can't open new connection") { f =>
     import f._
 
-    val Right((nextNode, message)) = OnionMessages.buildMessage(randomKey(), randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
-    assert(nextNode == bobId)
+    val Right(message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
     val messageId = randomBytes32()
     relay ! RelayMessage(messageId, randomKey().publicKey, Right(EncodedNodeId(bobId)), message, RelayAll, Some(probe.ref))
 
@@ -104,8 +102,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
   test("no channel with previous node") { f =>
     import f._
 
-    val Right((nextNode, message)) = OnionMessages.buildMessage(randomKey(), randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
-    assert(nextNode == bobId)
+    val Right(message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
     val messageId = randomBytes32()
     val previousNodeId = randomKey().publicKey
     relay ! RelayMessage(messageId, previousNodeId, Right(EncodedNodeId(bobId)), message, RelayChannelsOnly, Some(probe.ref))
@@ -121,8 +118,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
   test("no channel with next node") { f =>
     import f._
 
-    val Right((nextNode, message)) = OnionMessages.buildMessage(randomKey(), randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
-    assert(nextNode == bobId)
+    val Right(message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
     val messageId = randomBytes32()
     val previousNodeId = randomKey().publicKey
     relay ! RelayMessage(messageId, previousNodeId, Right(EncodedNodeId(bobId)), message, RelayChannelsOnly, Some(probe.ref))
@@ -142,8 +138,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
   test("channels on both ends") { f =>
     import f._
 
-    val Right((nextNode, message)) = OnionMessages.buildMessage(randomKey(), randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
-    assert(nextNode == bobId)
+    val Right(message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
     val messageId = randomBytes32()
     val previousNodeId = randomKey().publicKey
     relay ! RelayMessage(messageId, previousNodeId, Right(EncodedNodeId(bobId)), message, RelayChannelsOnly, None)
@@ -162,8 +157,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
   test("next node specified with channel id") { f =>
     import f._
 
-    val Right((nextNode, message)) = OnionMessages.buildMessage(randomKey(), randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
-    assert(nextNode == bobId)
+    val Right(message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
     val messageId = randomBytes32()
     val scid = ShortChannelId(123456L)
     relay ! RelayMessage(messageId, randomKey().publicKey, Left(scid), message, RelayAll, None)
@@ -181,8 +175,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
   test("next node is compact node id") { f =>
     import f._
 
-    val Right((nextNode, message)) = OnionMessages.buildMessage(randomKey(), randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
-    assert(nextNode == bobId)
+    val Right(message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(), Recipient(bobId, None), TlvStream.empty)
     val messageId = randomBytes32()
     val scid = RealShortChannelId(234567L)
     relay ! RelayMessage(messageId, randomKey().publicKey, Right(EncodedNodeId.ShortChannelIdDir(isNode1 = false, scid)), message, RelayAll, None)
@@ -201,8 +194,7 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
   test("next node is us as compact node id") { f =>
     import f._
 
-    val Right((nextNode, message)) = OnionMessages.buildMessage(randomKey(), randomKey(), randomKey(), Seq(IntermediateNode(aliceId)), Recipient(bobId, None), TlvStream(Set.empty[OnionMessagePayloadTlv], Set(GenericTlv(UInt64(31), hex"f3ed"))))
-    assert(nextNode == aliceId)
+    val Right(message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(IntermediateNode(aliceId)), Recipient(bobId, None), TlvStream(Set.empty[OnionMessagePayloadTlv], Set(GenericTlv(UInt64(31), hex"f3ed"))))
     val messageId = randomBytes32()
     val scid = RealShortChannelId(345678L)
     relay ! RelayMessage(messageId, randomKey().publicKey, Right(EncodedNodeId.ShortChannelIdDir(isNode1 = true, scid)), message, RelayAll, None)
@@ -218,5 +210,28 @@ class MessageRelaySpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     val messageToBob = peer.expectMessageType[Peer.RelayOnionMessage].msg
     val OnionMessages.ReceiveMessage(payload) = OnionMessages.process(Bob.nodeParams.privateKey, messageToBob)
     assert(payload.records.unknown == Set(GenericTlv(UInt64(31), hex"f3ed")))
+  }
+
+  test("relay to self and receive") { f =>
+    import f._
+
+    val probe = TypedProbe[OnionMessages.ReceiveMessage]()
+    system.eventStream ! EventStream.Subscribe(probe.ref)
+
+    val Right(message) = OnionMessages.buildMessage(randomKey(), randomKey(), Seq(
+      IntermediateNode(aliceId, EncodedNodeId(aliceId), outgoingChannel_opt = Some(ShortChannelId.toSelf)),
+      IntermediateNode(aliceId),
+      IntermediateNode(aliceId, EncodedNodeId.ShortChannelIdDir(isNode1 = false, scid = RealShortChannelId(123L)))
+    ), Recipient(aliceId, None), TlvStream(Set.empty[OnionMessagePayloadTlv], Set(GenericTlv(UInt64(33), hex"abcd"))))
+    val messageId = randomBytes32()
+    relay ! RelayMessage(messageId, randomKey().publicKey, Right(EncodedNodeId(aliceId)), message, RelayAll, None)
+
+    val getNodeId = router.expectMessageType[Router.GetNodeId]
+    assert(getNodeId.isNode1 == false)
+    assert(getNodeId.shortChannelId == RealShortChannelId(123L))
+    getNodeId.replyTo ! Some(aliceId)
+
+    val OnionMessages.ReceiveMessage(finalPayload) = probe.expectMessageType[OnionMessages.ReceiveMessage]
+    assert(finalPayload.records.unknown == Set(GenericTlv(UInt64(33), hex"abcd")))
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -402,7 +402,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     import f._
     connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer, isPersistent = false)
     val probe = TestProbe()
-    val Right((_, message)) = buildMessage(nodeParams.privateKey, randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
+    val Right(message) = buildMessage(randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
     probe.send(peerConnection, message)
     probe watch peerConnection
     probe.expectTerminated(peerConnection, max = 1500 millis)
@@ -418,7 +418,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     import f._
     connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer, isPersistent = false)
     val probe = TestProbe()
-    val Right((_, message)) = buildMessage(nodeParams.privateKey, randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
+    val Right(message) = buildMessage(randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
     probe watch peerConnection
     probe.send(peerConnection, message)
     // The connection is still open for a short while.
@@ -431,7 +431,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     import f._
     connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer, isPersistent = false)
     val probe = TestProbe()
-    val Right((_, message)) = buildMessage(nodeParams.privateKey, randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
+    val Right(message) = buildMessage(randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
     probe.send(peerConnection, message)
     assert(peerConnection.stateName == PeerConnection.CONNECTED)
     probe.send(peerConnection, ChannelReady(ByteVector32(hex"0000000000000000000000000000000000000000000000000000000000000000"), randomKey().publicKey))
@@ -444,7 +444,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
   test("incoming rate limiting") { f =>
     import f._
     connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer, isPersistent = true)
-    val Right((_, message)) = buildMessage(nodeParams.privateKey, randomKey(), randomKey(), Nil, Recipient(nodeParams.nodeId, None), TlvStream.empty)
+    val Right(message) = buildMessage(randomKey(), randomKey(), Nil, Recipient(nodeParams.nodeId, None), TlvStream.empty)
     for (_ <- 1 to 30) {
       transport.send(peerConnection, message)
     }
@@ -463,7 +463,7 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
   test("outgoing rate limiting") { f =>
     import f._
     connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer, isPersistent = true)
-    val Right((_, message)) = buildMessage(nodeParams.privateKey, randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
+    val Right(message) = buildMessage(randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
     for (_ <- 1 to 30) {
       peer.send(peerConnection, message)
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -598,7 +598,7 @@ class PeerSpec extends FixtureSpec {
   test("reply to relay request") { f =>
     import f._
     connect(remoteNodeId, peer, peerConnection, switchboard, channels = Set(ChannelCodecsSpec.normal))
-    val Right((_, msg)) = buildMessage(nodeParams.privateKey, randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
+    val Right(msg) = buildMessage(randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
     val messageId = randomBytes32()
     val probe = TestProbe()
     peer ! RelayOnionMessage(messageId, msg, Some(probe.ref.toTyped))
@@ -607,7 +607,7 @@ class PeerSpec extends FixtureSpec {
 
   test("reply to relay request disconnected") { f =>
     import f._
-    val Right((_, msg)) = buildMessage(nodeParams.privateKey, randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
+    val Right(msg) = buildMessage(randomKey(), randomKey(), Nil, Recipient(remoteNodeId, None), TlvStream.empty)
     val messageId = randomBytes32()
     val probe = TestProbe()
     peer ! RelayOnionMessage(messageId, msg, Some(probe.ref.toTyped))

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt12InvoiceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/Bolt12InvoiceSpec.scala
@@ -49,9 +49,9 @@ class Bolt12InvoiceSpec extends AnyFunSuite {
     signedInvoice
   }
 
-  def createPaymentBlindedRoute(nodeId: PublicKey, sessionKey: PrivateKey = randomKey(), pathId: ByteVector = randomBytes32()): PaymentBlindedContactInfo = {
+  def createPaymentBlindedRoute(nodeId: PublicKey, sessionKey: PrivateKey = randomKey(), pathId: ByteVector = randomBytes32()): PaymentBlindedRoute = {
     val selfPayload = blindedRouteDataCodec.encode(TlvStream(PathId(pathId), PaymentConstraints(CltvExpiry(1234567), 0 msat), AllowedFeatures(Features.empty))).require.bytes
-    PaymentBlindedContactInfo(OfferTypes.BlindedPath(Sphinx.RouteBlinding.create(sessionKey, Seq(nodeId), Seq(selfPayload)).route), PaymentInfo(1 msat, 2, CltvExpiryDelta(3), 4 msat, 5 msat, Features.empty))
+    PaymentBlindedRoute(Sphinx.RouteBlinding.create(sessionKey, Seq(nodeId), Seq(selfPayload)).route, PaymentInfo(1 msat, 2, CltvExpiryDelta(3), 4 msat, 5 msat, Features.empty))
   }
 
   test("check invoice signature") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
@@ -38,7 +38,7 @@ import fr.acinq.eclair.wire.protocol.OnionPaymentPayloadTlv._
 import fr.acinq.eclair.wire.protocol.PaymentOnion.FinalPayload
 import fr.acinq.eclair.wire.protocol.RouteBlindingEncryptedDataTlv.{PathId, PaymentConstraints}
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Feature, Features, MilliSatoshi, MilliSatoshiLong, NodeParams, ShortChannelId, TestConstants, TestKitBaseClass, TimestampMilli, TimestampMilliLong, randomBytes, randomBytes32, randomKey}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, EncodedNodeId, Feature, Features, MilliSatoshi, MilliSatoshiLong, NodeParams, ShortChannelId, TestConstants, TestKitBaseClass, TimestampMilli, TimestampMilliLong, randomBytes, randomBytes32, randomKey}
 import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import scodec.bits.{ByteVector, HexStringSyntax}
@@ -294,19 +294,19 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(invoice.description == Left("a blinded coffee please"))
     assert(invoice.invoiceRequest.offer == offer)
     assert(invoice.blindedPaths.length == 3)
-    assert(invoice.blindedPaths(0).route.asInstanceOf[OfferTypes.BlindedPath].route.blindedNodeIds.length == 4)
-    assert(invoice.blindedPaths(0).route.asInstanceOf[OfferTypes.BlindedPath].route.introductionNodeId == a)
+    assert(invoice.blindedPaths(0).route.blindedNodeIds.length == 4)
+    assert(invoice.blindedPaths(0).route.introductionNodeId == EncodedNodeId(a))
     assert(invoice.blindedPaths(0).paymentInfo == PaymentInfo(1950 msat, 0, CltvExpiryDelta(193), 1 msat, 25_000 msat, Features.empty))
-    assert(invoice.blindedPaths(1).route.asInstanceOf[OfferTypes.BlindedPath].route.blindedNodeIds.length == 4)
-    assert(invoice.blindedPaths(1).route.asInstanceOf[OfferTypes.BlindedPath].route.introductionNodeId == c)
+    assert(invoice.blindedPaths(1).route.blindedNodeIds.length == 4)
+    assert(invoice.blindedPaths(1).route.introductionNodeId == EncodedNodeId(c))
     assert(invoice.blindedPaths(1).paymentInfo == PaymentInfo(400 msat, 0, CltvExpiryDelta(183), 1 msat, 25_000 msat, Features.empty))
-    assert(invoice.blindedPaths(2).route.asInstanceOf[OfferTypes.BlindedPath].route.blindedNodeIds.length == 1)
-    assert(invoice.blindedPaths(2).route.asInstanceOf[OfferTypes.BlindedPath].route.introductionNodeId == d)
+    assert(invoice.blindedPaths(2).route.blindedNodeIds.length == 1)
+    assert(invoice.blindedPaths(2).route.introductionNodeId == EncodedNodeId(d))
     assert(invoice.blindedPaths(2).paymentInfo == PaymentInfo(0 msat, 0, CltvExpiryDelta(18), 0 msat, 25_000 msat, Features.empty))
     // Offer invoices shouldn't be stored in the DB until we receive a payment for it.
     assert(nodeParams.db.payments.getIncomingPayment(invoice.paymentHash).isEmpty)
     // Check that all non-final encrypted payloads for blinded routes have the same length.
-    assert(invoice.blindedPaths.flatMap(_.route.asInstanceOf[OfferTypes.BlindedPath].route.encryptedPayloads.dropRight(1)).map(_.length).toSet.size == 1)
+    assert(invoice.blindedPaths.flatMap(_.route.encryptedPayloads.dropRight(1)).map(_.length).toSet.size == 1)
   }
 
   test("Invoice generation with route blinding should fail when router returns an error") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/offer/OfferManagerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/offer/OfferManagerSpec.scala
@@ -88,7 +88,7 @@ class OfferManagerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     import f._
 
     assert(invoice.blindedPaths.length == 1)
-    val blindedPath = invoice.blindedPaths.head.route.asInstanceOf[OfferTypes.BlindedPath].route
+    val blindedPath = invoice.blindedPaths.head.route
     val Right(RouteBlindingDecryptedData(encryptedDataTlvs, _)) = RouteBlindingEncryptedDataCodecs.decode(nodeParams.privateKey, blindedPath.blindingKey, blindedPath.encryptedPayloads.head)
     val paymentTlvs = TlvStream[OnionPaymentPayloadTlv](
       OnionPaymentPayloadTlv.AmountToForward(invoice.amount),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BlindedRouteCreationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BlindedRouteCreationSpec.scala
@@ -19,7 +19,7 @@ package fr.acinq.eclair.router
 import fr.acinq.eclair.router.RouteCalculationSpec.makeUpdateShort
 import fr.acinq.eclair.router.Router.{ChannelHop, HopRelayParams}
 import fr.acinq.eclair.wire.protocol.{BlindedRouteData, RouteBlindingEncryptedDataCodecs, RouteBlindingEncryptedDataTlv}
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, MilliSatoshiLong, ShortChannelId, randomBytes32, randomKey}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, EncodedNodeId, MilliSatoshiLong, ShortChannelId, randomBytes32, randomKey}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.{ParallelTestExecution, Tag}
 
@@ -31,7 +31,7 @@ class BlindedRouteCreationSpec extends AnyFunSuite with ParallelTestExecution {
     val a = randomKey()
     val pathId = randomBytes32()
     val route = createBlindedRouteWithoutHops(a.publicKey, pathId, 1 msat, CltvExpiry(500))
-    assert(route.route.introductionNodeId == a.publicKey)
+    assert(route.route.introductionNodeId == EncodedNodeId(a.publicKey))
     assert(route.route.encryptedPayloads.length == 1)
     assert(route.route.blindingKey == route.lastBlinding)
     val Right(decoded) = RouteBlindingEncryptedDataCodecs.decode(a, route.route.blindingKey, route.route.encryptedPayloads.head)
@@ -48,7 +48,7 @@ class BlindedRouteCreationSpec extends AnyFunSuite with ParallelTestExecution {
       ChannelHop(scid2, b.publicKey, c.publicKey, HopRelayParams.FromAnnouncement(makeUpdateShort(scid2, b.publicKey, c.publicKey, 20 msat, 150, cltvDelta = CltvExpiryDelta(600)))),
     )
     val route = createBlindedRouteFromHops(hops, pathId, 1 msat, CltvExpiry(500))
-    assert(route.route.introductionNodeId == a.publicKey)
+    assert(route.route.introductionNodeId == EncodedNodeId(a.publicKey))
     assert(route.route.encryptedPayloads.length == 3)
     val Right(decoded1) = RouteBlindingEncryptedDataCodecs.decode(a, route.route.blindingKey, route.route.encryptedPayloads(0))
     assert(BlindedRouteData.validatePaymentRelayData(decoded1.tlvs).isRight)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/MessageOnionCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/MessageOnionCodecsSpec.scala
@@ -4,7 +4,7 @@ import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.crypto.Sphinx.RouteBlinding
-import fr.acinq.eclair.payment.{Bolt12Invoice, PaymentBlindedContactInfo}
+import fr.acinq.eclair.payment.{Bolt12Invoice, PaymentBlindedRoute}
 import fr.acinq.eclair.wire.protocol.MessageOnion.{FinalPayload, IntermediatePayload, InvalidResponsePayload, InvoiceErrorPayload, InvoicePayload, InvoiceRequestPayload}
 import fr.acinq.eclair.wire.protocol.MessageOnionCodecs._
 import fr.acinq.eclair.wire.protocol.OfferTypes.PaymentInfo
@@ -12,7 +12,7 @@ import fr.acinq.eclair.wire.protocol.OnionMessagePayloadTlv._
 import fr.acinq.eclair.wire.protocol.OnionRoutingCodecs.{ForbiddenTlv, InvalidTlvPayload, MissingRequiredTlv}
 import fr.acinq.eclair.wire.protocol.RouteBlindingEncryptedDataCodecs.blindedRouteDataCodec
 import fr.acinq.eclair.wire.protocol.RouteBlindingEncryptedDataTlv.{AllowedFeatures, OutgoingNodeId, PathId, PaymentConstraints, PaymentRelay}
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshiLong, EncodedNodeId, UInt64, randomBytes32, randomKey}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, EncodedNodeId, Features, MilliSatoshiLong, UInt64, randomBytes32, randomKey}
 import org.scalatest.funsuite.AnyFunSuiteLike
 import scodec.bits.{ByteVector, HexStringSyntax}
 
@@ -95,7 +95,7 @@ class MessageOnionCodecsSpec extends AnyFunSuiteLike {
     val payerKey = randomKey()
     val request = OfferTypes.InvoiceRequest(offer, 100_000 msat, 1, Features.empty, payerKey, Block.LivenetGenesisBlock.hash)
     val selfPayload = blindedRouteDataCodec.encode(TlvStream(PathId(randomBytes32()), PaymentConstraints(CltvExpiry(1234567), 0 msat), AllowedFeatures(Features.empty))).require.bytes
-    val route = PaymentBlindedContactInfo(OfferTypes.BlindedPath(Sphinx.RouteBlinding.create(randomKey(), Seq(nodeKey.publicKey), Seq(selfPayload)).route), PaymentInfo(1 msat, 2, CltvExpiryDelta(3), 4 msat, 5 msat, Features.empty))
+    val route = PaymentBlindedRoute(Sphinx.RouteBlinding.create(randomKey(), Seq(nodeKey.publicKey), Seq(selfPayload)).route, PaymentInfo(1 msat, 2, CltvExpiryDelta(3), 4 msat, 5 msat, Features.empty))
     val invoice = Bolt12Invoice(request, randomBytes32(), nodeKey, 300 seconds, Features.empty, Seq(route))
 
     val testCasesInvalid = Seq[TlvStream[OnionMessagePayloadTlv]](
@@ -106,7 +106,7 @@ class MessageOnionCodecsSpec extends AnyFunSuiteLike {
       // Invoice and unknown TLV.
       TlvStream(Set[OnionMessagePayloadTlv](EncryptedData(hex""), Invoice(invoice.records)), Set(GenericTlv(UInt64(1), hex""))),
       // Invoice and ReplyPath.
-      TlvStream(EncryptedData(hex""), Invoice(invoice.records), ReplyPath(route.route.asInstanceOf[OfferTypes.BlindedPath].route)),
+      TlvStream(EncryptedData(hex""), Invoice(invoice.records), ReplyPath(route.route)),
       // Invoice and InvoiceError.
       TlvStream(EncryptedData(hex""), Invoice(invoice.records), InvoiceError(TlvStream(OfferTypes.Error("")))),
       // InvoiceRequest without ReplyPath.
@@ -118,7 +118,7 @@ class MessageOnionCodecsSpec extends AnyFunSuiteLike {
       assert(finalPayload.isInstanceOf[InvalidResponsePayload])
     }
 
-    val Right(invoiceRequestPayload) = FinalPayload.validate(TlvStream(EncryptedData(hex""), InvoiceRequest(request.records), ReplyPath(route.route.asInstanceOf[OfferTypes.BlindedPath].route)), TlvStream.empty)
+    val Right(invoiceRequestPayload) = FinalPayload.validate(TlvStream(EncryptedData(hex""), InvoiceRequest(request.records), ReplyPath(route.route)), TlvStream.empty)
     assert(invoiceRequestPayload.isInstanceOf[InvoiceRequestPayload])
 
     val Right(invoicePayload) = FinalPayload.validate(TlvStream(EncryptedData(hex""), Invoice(invoice.records)), TlvStream.empty)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/OfferTypesSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/OfferTypesSpec.scala
@@ -19,7 +19,6 @@ package fr.acinq.eclair.wire.protocol
 import fr.acinq.bitcoin.Bech32
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.scalacompat.{Block, BlockHash, ByteVector32}
-import fr.acinq.eclair.EncodedNodeId.ShortChannelIdDir
 import fr.acinq.eclair.FeatureSupport.{Mandatory, Optional}
 import fr.acinq.eclair.Features.BasicMultiPartPayment
 import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.{BlindedNode, BlindedRoute}
@@ -264,23 +263,23 @@ class OfferTypesSpec extends AnyFunSuite {
   }
 
   test("compact blinded route") {
-    case class TestCase(encoded: ByteVector, decoded: BlindedContactInfo)
+    case class TestCase(encoded: ByteVector, decoded: BlindedRoute)
 
     val testCases = Seq(
       TestCase(hex"00 00000000000004d2 0379b470d00b78ded936f8972a0f3ecda2bb6e6df40dcd581dbaeb3742b30008ff 01 02fba71b72623187dd24670110eec870e28b848f255ba2edc0486d3a8e89ec44b7 0002 1dea",
-        CompactBlindedPath(ShortChannelIdDir(isNode1 = true, RealShortChannelId(1234)), PublicKey(hex"0379b470d00b78ded936f8972a0f3ecda2bb6e6df40dcd581dbaeb3742b30008ff"), Seq(BlindedNode(PublicKey(hex"02fba71b72623187dd24670110eec870e28b848f255ba2edc0486d3a8e89ec44b7"), hex"1dea")))),
+        BlindedRoute(EncodedNodeId.ShortChannelIdDir(isNode1 = true, RealShortChannelId(1234)), PublicKey(hex"0379b470d00b78ded936f8972a0f3ecda2bb6e6df40dcd581dbaeb3742b30008ff"), Seq(BlindedNode(PublicKey(hex"02fba71b72623187dd24670110eec870e28b848f255ba2edc0486d3a8e89ec44b7"), hex"1dea")))),
       TestCase(hex"01 000000000000ddd5 0353a081bb02d6e361be3df3e92b41b788ca65667f6ea0c01e2bfa03664460ef86 01 03bce3f0cdb4172caac82ec8a9251eb35df1201bdcb977c5a03f3624ec4156a65f 0003 c0ffee",
-        CompactBlindedPath(ShortChannelIdDir(isNode1 = false, RealShortChannelId(56789)), PublicKey(hex"0353a081bb02d6e361be3df3e92b41b788ca65667f6ea0c01e2bfa03664460ef86"), Seq(BlindedNode(PublicKey(hex"03bce3f0cdb4172caac82ec8a9251eb35df1201bdcb977c5a03f3624ec4156a65f"), hex"c0ffee")))),
+        BlindedRoute(EncodedNodeId.ShortChannelIdDir(isNode1 = false, RealShortChannelId(56789)), PublicKey(hex"0353a081bb02d6e361be3df3e92b41b788ca65667f6ea0c01e2bfa03664460ef86"), Seq(BlindedNode(PublicKey(hex"03bce3f0cdb4172caac82ec8a9251eb35df1201bdcb977c5a03f3624ec4156a65f"), hex"c0ffee")))),
       TestCase(hex"022d3b15cea00ee4a8e710b082bef18f0f3409cc4e7aff41c26eb0a4d3ab20dd73 0379a3b6e4bceb7519d09db776994b1f82cf6a9fa4d3ec2e52314c5938f2f9f966 01 02b446aaa523df82a992ab468e5298eabb6168e2c466455c210d8c97dbb8981328 0002 cafe",
-        BlindedPath(BlindedRoute(PublicKey(hex"022d3b15cea00ee4a8e710b082bef18f0f3409cc4e7aff41c26eb0a4d3ab20dd73"), PublicKey(hex"0379a3b6e4bceb7519d09db776994b1f82cf6a9fa4d3ec2e52314c5938f2f9f966"), Seq(BlindedNode(PublicKey(hex"02b446aaa523df82a992ab468e5298eabb6168e2c466455c210d8c97dbb8981328"), hex"cafe"))))),
+        BlindedRoute(EncodedNodeId.Plain(PublicKey(hex"022d3b15cea00ee4a8e710b082bef18f0f3409cc4e7aff41c26eb0a4d3ab20dd73")), PublicKey(hex"0379a3b6e4bceb7519d09db776994b1f82cf6a9fa4d3ec2e52314c5938f2f9f966"), Seq(BlindedNode(PublicKey(hex"02b446aaa523df82a992ab468e5298eabb6168e2c466455c210d8c97dbb8981328"), hex"cafe")))),
       TestCase(hex"03ba3c458e3299eb19d2e07ae86453f4290bcdf8689707f0862f35194397c45922 028aa5d1a10463d598a0a0ab7296af21619049f94fe03ef664a87561009e58c3dd 01 02988d7381d0434cfebbe521031505fb9987ae6cefd0bab0e5927852eb96bb6cc2 0003 ec1a13",
-        BlindedPath(BlindedRoute(PublicKey(hex"03ba3c458e3299eb19d2e07ae86453f4290bcdf8689707f0862f35194397c45922"), PublicKey(hex"028aa5d1a10463d598a0a0ab7296af21619049f94fe03ef664a87561009e58c3dd"), Seq(BlindedNode(PublicKey(hex"02988d7381d0434cfebbe521031505fb9987ae6cefd0bab0e5927852eb96bb6cc2"), hex"ec1a13"))))),
+        BlindedRoute(EncodedNodeId.Plain(PublicKey(hex"03ba3c458e3299eb19d2e07ae86453f4290bcdf8689707f0862f35194397c45922")), PublicKey(hex"028aa5d1a10463d598a0a0ab7296af21619049f94fe03ef664a87561009e58c3dd"), Seq(BlindedNode(PublicKey(hex"02988d7381d0434cfebbe521031505fb9987ae6cefd0bab0e5927852eb96bb6cc2"), hex"ec1a13")))),
     )
 
     testCases.foreach {
       case TestCase(encoded, decoded) =>
-        assert(OfferCodecs.pathCodec.encode(decoded).require.bytes == encoded)
-        assert(OfferCodecs.pathCodec.decode(encoded.bits).require.value == decoded)
+        assert(OfferCodecs.blindedRouteCodec.encode(decoded).require.bytes == encoded)
+        assert(OfferCodecs.blindedRouteCodec.decode(encoded.bits).require.value == decoded)
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/PaymentOnionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/PaymentOnionSpec.scala
@@ -20,13 +20,14 @@ import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.UInt64.Conversions._
 import fr.acinq.eclair.crypto.Sphinx.RouteBlinding
+import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.BlindedRoute
 import fr.acinq.eclair.payment.Bolt11Invoice.ExtraHop
-import fr.acinq.eclair.payment.PaymentBlindedContactInfo
+import fr.acinq.eclair.payment.PaymentBlindedRoute
 import fr.acinq.eclair.wire.protocol.OnionPaymentPayloadTlv._
 import fr.acinq.eclair.wire.protocol.OnionRoutingCodecs.{ForbiddenTlv, InvalidTlvPayload, MissingRequiredTlv}
 import fr.acinq.eclair.wire.protocol.PaymentOnion._
 import fr.acinq.eclair.wire.protocol.PaymentOnionCodecs._
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, FeatureSupport, Features, MilliSatoshiLong, EncodedNodeId, RealShortChannelId, ShortChannelId, UInt64, randomKey}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, EncodedNodeId, FeatureSupport, Features, MilliSatoshiLong, RealShortChannelId, ShortChannelId, UInt64, randomKey}
 import org.scalatest.funsuite.AnyFunSuite
 import scodec.bits.{ByteVector, HexStringSyntax}
 
@@ -166,12 +167,12 @@ class PaymentOnionSpec extends AnyFunSuite {
 
   test("encode/decode node relay to blinded paths per-hop payload") {
     val features = Features(Features.BasicMultiPartPayment -> FeatureSupport.Optional).toByteVector
-    val blindedRoute = OfferTypes.CompactBlindedPath(
+    val blindedRoute = BlindedRoute(
       EncodedNodeId.ShortChannelIdDir(isNode1 = false, RealShortChannelId(468)),
       PublicKey(hex"0232882c4982576e00f0d6bd4998f5b3e92d47ecc8fbad5b6a5e7521819d891d9e"),
       Seq(RouteBlinding.BlindedNode(PublicKey(hex"03823aa560d631e9d7b686be4a9227e577009afb5173023b458a6a6aff056ac980"), hex""))
     )
-    val path = PaymentBlindedContactInfo(blindedRoute, OfferTypes.PaymentInfo(1000 msat, 678, CltvExpiryDelta(82), 300 msat, 4000000 msat, Features.empty))
+    val path = PaymentBlindedRoute(blindedRoute, OfferTypes.PaymentInfo(1000 msat, 678, CltvExpiryDelta(82), 300 msat, 4000000 msat, Features.empty))
     val expected = TlvStream[OnionPaymentPayloadTlv](AmountToForward(341 msat), OutgoingCltv(CltvExpiry(826483)), OutgoingBlindedPaths(Seq(path)), InvoiceFeatures(features))
     val bin = hex"82 02020155 04030c9c73 fe0001023103020000 fe000102366a0100000000000001d40232882c4982576e00f0d6bd4998f5b3e92d47ecc8fbad5b6a5e7521819d891d9e0103823aa560d631e9d7b686be4a9227e577009afb5173023b458a6a6aff056ac9800000000003e8000002a60052000000000000012c00000000003d09000000"
 

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/serde/FormParamExtractors.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/serde/FormParamExtractors.scala
@@ -26,7 +26,7 @@ import fr.acinq.eclair.blockchain.fee.{ConfirmationPriority, FeeratePerByte}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.io.NodeURI
 import fr.acinq.eclair.payment.Bolt11Invoice
-import fr.acinq.eclair.wire.protocol.MessageOnionCodecs.blindedRouteCodec
+import fr.acinq.eclair.wire.protocol.OfferCodecs.blindedRouteCodec
 import fr.acinq.eclair.wire.protocol.OfferTypes.Offer
 import fr.acinq.eclair.{MilliSatoshi, ShortChannelId, TimestampSecond}
 import scodec.bits.ByteVector

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -1240,7 +1240,7 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
             GenericTlv(UInt64(5), hex"1111")
           )), TlvStream(RouteBlindingEncryptedDataTlv.PathId(hex"2222")))
         val msgrcv = OnionMessages.ReceiveMessage(payload)
-        val expectedSerializedMsgrcv = """{"type":"onion-message-received","pathId":"2222","tlvs":{"EncryptedData":{"data":""},"ReplyPath":{"blindedRoute":{"introductionNodeId":"039dc0e0b1d25905e44fdf6f8e89755a5e219685840d0bc1d28d3308f9628a3585","blindingKey":"02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619","blindedNodes":[{"blindedPublicKey":"020303f91e620504cde242df38d04599d8b4d4c555149cc742a5f12de452cbdd40","encryptedPayload":"126a26221759247584d704b382a5789f1d8c5a"}]}},"Unknown5":"1111"}}"""
+        val expectedSerializedMsgrcv = """{"type":"onion-message-received","pathId":"2222","tlvs":{"EncryptedData":{"data":""},"ReplyPath":{"blindedRoute":{"introductionNodeId":{"publicKey":"039dc0e0b1d25905e44fdf6f8e89755a5e219685840d0bc1d28d3308f9628a3585"},"blindingKey":"02eec7245d6b7d2ccb30380bfbe2a3648cd7a942653f5aa340edcea1f283686619","blindedNodes":[{"blindedPublicKey":"020303f91e620504cde242df38d04599d8b4d4c555149cc742a5f12de452cbdd40","encryptedPayload":"126a26221759247584d704b382a5789f1d8c5a"}]}},"Unknown5":"1111"}}"""
         assert(serialization.write(msgrcv) == expectedSerializedMsgrcv)
         system.eventStream.publish(msgrcv)
         wsClient.expectMessage(expectedSerializedMsgrcv)


### PR DESCRIPTION
In some cases, we may have to relay an onion message to ourselves. We previously tried to deal with such cases in the `OnionMessages` functions, however the addition of compact encoding for the next node made it impossible to do properly without calling the router.
All of the self-redirections are now taken care of in `MessageRelay` and `OnionMessages` has been simplified.
We've also simplified the type hierarchy for blinded paths: there is no more distinct `CompactBlindedPath`. Most of the time we do not care if the blinded route is in compact form or not, no need for multiple cases, it's only when we need to connect to the introduction node that it matters, for that we now use `case class ResolvedPath(blindedPath: PaymentBlindedRoute, introductionNodeId: PublicKey)`.