### PR TITLE
Fixup quiescence timeout when initiating splice

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -853,7 +853,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
       if (d.commitments.params.remoteParams.initFeatures.hasFeature(Features.SplicePrototype)) {
         d.spliceStatus match {
           case SpliceStatus.NoSplice if d.commitments.params.useQuiescence =>
-            startSingleTimer(QuiescenceTimeout.toString, QuiescenceTimeout(peer), nodeParams.channelConf.revocationTimeout)
+            startSingleTimer(QuiescenceTimeout.toString, QuiescenceTimeout(peer), nodeParams.channelConf.quiescenceTimeout)
             if (d.commitments.localIsQuiescent) {
               stay() using d.copy(spliceStatus = SpliceStatus.InitiatorQuiescent(cmd)) sending Stfu(d.channelId, initiator = true)
             } else {


### PR DESCRIPTION
We should use the quiescence timeout value instead of the revocation timeout value (copy-paste error) when initiating a splice.

Found this while doing integration testing with LND.