### PR TITLE
Relax assumptions about `gossip_queries`

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -57,7 +57,7 @@ eclair {
     // Make sure you understand what it implies before you activate this feature.
     option_upfront_shutdown_script = disabled
     option_data_loss_protect = mandatory
-    gossip_queries = mandatory
+    gossip_queries = optional
     gossip_queries_ex = optional
     var_onion_optin = mandatory
     option_static_remotekey = mandatory

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -394,11 +394,13 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
         stay() using d.copy(behavior = behavior1)
 
       case Event(DoSync(replacePrevious), d: ConnectedData) =>
-        // We assume support for standard range queries since https://github.com/lightning/bolts/pull/1092
+        val canUseChannelRangeQueries = Features.canUseFeature(d.localInit.features, d.remoteInit.features, Features.ChannelRangeQueries)
         val canUseChannelRangeQueriesEx = Features.canUseFeature(d.localInit.features, d.remoteInit.features, Features.ChannelRangeQueriesExtended)
-        val flags_opt = if (canUseChannelRangeQueriesEx) Some(QueryChannelRangeTlv.QueryFlags(QueryChannelRangeTlv.QueryFlags.WANT_ALL)) else None
-        log.debug(s"sending sync channel range query with flags_opt=$flags_opt replacePrevious=$replacePrevious")
-        router ! SendChannelQuery(d.chainHash, d.remoteNodeId, self, replacePrevious, flags_opt)
+        if (canUseChannelRangeQueries || canUseChannelRangeQueriesEx) {
+          val flags_opt = if (canUseChannelRangeQueriesEx) Some(QueryChannelRangeTlv.QueryFlags(QueryChannelRangeTlv.QueryFlags.WANT_ALL)) else None
+          log.debug(s"sending sync channel range query with flags_opt=$flags_opt replacePrevious=$replacePrevious")
+          router ! SendChannelQuery(d.chainHash, d.remoteNodeId, self, replacePrevious, flags_opt)
+        }
         stay()
 
       case Event(ResumeAnnouncements, d: ConnectedData) =>


### PR DESCRIPTION
https://github.com/lightning/bolts/pull/1092 initially made the `gossip_queries` feature mandatory and assumed: however it generally doesn't make sense for mobile wallets. It was thus relaxed in the last commits of this BOLTs PR, so we revert our change to `mandatory` to make this optional and avoid sending gossip queries to nodes who don't activate the feature.

The code we're reverting was introduced in #2732