### PR TITLE
RPC: parse BOLT12 invoices and offers

### DIFF
--- a/contrib/eclair-cli.bash-completion
+++ b/contrib/eclair-cli.bash-completion
@@ -21,7 +21,7 @@ _eclair-cli()
         *)
             # works fine, but is too slow at the moment.
             # allopts=$($eclaircli help 2>&1 | awk '$1 ~ /^"/ { sub(/,/, ""); print $1}' | sed 's/[":]//g')
-            allopts="allchannels allupdates audit bumpforceclose channel channelbalances channels channelstats close closedchannels connect cpfpbumpfees createinvoice deleteinvoice disconnect findroute findroutebetweennodes findroutetonode forceclose getdescriptors getinfo getinvoice getmasterxpub getnewaddress getreceivedinfo getsentinfo globalbalance listinvoices listpendinginvoices listreceivedpayments networkfees node nodes onchainbalance onchaintransactions open parseinvoice payinvoice payoffer peers rbfopen sendonchain sendonionmessage sendtonode sendtoroute signmessage splicein spliceout stop updaterelayfee usablebalances verifymessage"
+            allopts="allchannels allupdates audit bumpforceclose channel channelbalances channels channelstats close closedchannels connect cpfpbumpfees createinvoice deleteinvoice disconnect findroute findroutebetweennodes findroutetonode forceclose getdescriptors getinfo getinvoice getmasterxpub getnewaddress getreceivedinfo getsentinfo globalbalance listinvoices listpendinginvoices listreceivedpayments networkfees node nodes onchainbalance onchaintransactions open parseinvoice parseoffer payinvoice payoffer peers rbfopen sendonchain sendonionmessage sendtonode sendtoroute signmessage splicein spliceout stop updaterelayfee usablebalances verifymessage"
 
             if ! [[ " $allopts " =~ " $prev " ]]; then          # prevent double arguments
                 if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then

--- a/eclair-core/eclair-cli
+++ b/eclair-core/eclair-cli
@@ -69,6 +69,7 @@ and COMMAND is one of the available commands:
     - listinvoices
     - listpendinginvoices
     - parseinvoice
+    - parseoffer
     - deleteinvoice
 
   === Payment ===

--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -441,9 +441,10 @@ object InvoiceSerializer extends MinimalSerializer({
         MilliSatoshiSerializer +
         CltvExpiryDeltaSerializer
     ))
+    import fr.acinq.eclair.json.JsonSerializers.formats
     val fieldList = List(
       JField("prefix", JString(p.prefix)),
-      JField("timestamp", JLong(p.createdAt.toLong)),
+      JField("timestamp", Extraction.decompose(p.createdAt)),
       JField("nodeId", JString(p.nodeId.toString())),
       JField("serialized", JString(p.toString)),
       p.description.fold(string => JField("description", JString(string)), hash => JField("descriptionHash", JString(hash.toHex))),
@@ -456,6 +457,7 @@ object InvoiceSerializer extends MinimalSerializer({
       routingInfo
     JObject(fieldList)
   case p: Bolt12Invoice =>
+    import fr.acinq.eclair.json.JsonSerializers.formats
     val fieldList = List(
       JField("amount", JLong(p.amount.toLong)),
       JField("nodeId", JString(p.nodeId.toString())),
@@ -475,8 +477,8 @@ object InvoiceSerializer extends MinimalSerializer({
           JField("blindedNodeIds", JArray(blindedNodes.map(n => JString(n.blindedPublicKey.toString)).toList))
         ))
       }).toList)),
-      JField("createdAt", JLong(p.createdAt.toLong)),
-      JField("expiresAt", JLong((p.createdAt + p.relativeExpiry).toLong)),
+      JField("createdAt", Extraction.decompose(p.createdAt)),
+      JField("expiresAt", Extraction.decompose((p.createdAt + p.relativeExpiry))),
       JField("serialized", JString(p.toString)))
     JObject(fieldList)
 })

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/OfferPayment.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/OfferPayment.scala
@@ -138,6 +138,7 @@ private class OfferPayment(replyTo: ActorRef,
             Behaviors.stopped
           case None =>
             context.spawnAnonymous(CompactBlindedPathsResolver(router)) ! Resolve(context.messageAdapter[Seq[ResolvedPath]](WrappedResolvedPaths), payload.invoice.blindedPaths)
+            context.log.info(s"BOLT12 invoice: ${payload.invoice}")
             waitForResolvedPaths(payload.invoice)
         }
       case WrappedMessageResponse(Postman.Response(payload)) =>

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/directives/ExtraDirectives.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair.ApiTypes.ChannelIdentifier
 import fr.acinq.eclair.api.serde.FormParamExtractors._
 import fr.acinq.eclair.api.serde.JsonSupport._
 import fr.acinq.eclair.blockchain.fee.ConfirmationPriority
-import fr.acinq.eclair.payment.Bolt11Invoice
+import fr.acinq.eclair.payment.{Bolt11Invoice, Invoice}
 import fr.acinq.eclair.wire.protocol.OfferTypes.Offer
 import fr.acinq.eclair.{MilliSatoshi, Paginated, ShortChannelId, TimestampSecond}
 
@@ -47,7 +47,7 @@ trait ExtraDirectives extends Directives {
   val outPointsFormParam: NameUnmarshallerReceptacle[List[OutPoint]] = "outpoints".as[List[OutPoint]](outPointListUnmarshaller)
   val paymentHashFormParam: NameUnmarshallerReceptacle[ByteVector32] = "paymentHash".as[ByteVector32](bytes32Unmarshaller)
   val amountMsatFormParam: NameReceptacle[MilliSatoshi] = "amountMsat".as[MilliSatoshi]
-  val invoiceFormParam: NameReceptacle[Bolt11Invoice] = "invoice".as[Bolt11Invoice]
+  val invoiceFormParam: NameUnmarshallerReceptacle[Invoice] = "invoice".as[Invoice](invoiceUnmarshaller)
   val routeFormatFormParam: NameUnmarshallerReceptacle[RouteFormat] = "format".as[RouteFormat](routeFormatUnmarshaller)
   val ignoreNodeIdsFormParam: NameUnmarshallerReceptacle[List[PublicKey]] = "ignoreNodeIds".as[List[PublicKey]](pubkeyListUnmarshaller)
   val ignoreShortChannelIdsFormParam: NameUnmarshallerReceptacle[List[ShortChannelId]] = "ignoreShortChannelIds".as[List[ShortChannelId]](shortChannelIdsUnmarshaller)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Invoice.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Invoice.scala
@@ -69,6 +69,12 @@ trait Invoice {
     }
   }
 
-  val invoiceRoutes: Route = createInvoice ~ getInvoice ~ listInvoices ~ listPendingInvoices ~ parseInvoice ~ deleteInvoice
+  val parseOffer: Route = postRequest("parseoffer") { implicit t =>
+    formFields(offerFormParam) { offer =>
+      complete(offer)
+    }
+  }
+
+  val invoiceRoutes: Route = createInvoice ~ getInvoice ~ listInvoices ~ listPendingInvoices ~ parseInvoice ~ deleteInvoice ~ parseOffer
 
 }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/serde/FormParamExtractors.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/serde/FormParamExtractors.scala
@@ -25,7 +25,7 @@ import fr.acinq.eclair.api.serde.JsonSupport._
 import fr.acinq.eclair.blockchain.fee.{ConfirmationPriority, FeeratePerByte}
 import fr.acinq.eclair.crypto.Sphinx
 import fr.acinq.eclair.io.NodeURI
-import fr.acinq.eclair.payment.Bolt11Invoice
+import fr.acinq.eclair.payment.{Bolt11Invoice, Bolt12Invoice, Invoice, MinimalBolt12Invoice}
 import fr.acinq.eclair.wire.protocol.OfferCodecs.blindedRouteCodec
 import fr.acinq.eclair.wire.protocol.OfferTypes.Offer
 import fr.acinq.eclair.{MilliSatoshi, ShortChannelId, TimestampSecond}
@@ -82,6 +82,10 @@ object FormParamExtractors {
 
   val offerUnmarshaller: Unmarshaller[String, Offer] = Unmarshaller.strict {
     Offer.decode(_).get
+  }
+
+  val invoiceUnmarshaller: Unmarshaller[String, Invoice] = Unmarshaller.strict { str =>
+    Bolt11Invoice.fromString(str).orElse(Bolt12Invoice.fromString(str)).get
   }
 
   val confirmationPriorityUnmarshaller: Unmarshaller[String, ConfirmationPriority] = Unmarshaller.strict {


### PR DESCRIPTION
This PR add the ability to parse BOLT12 invoices to `parseinvoice` RPC call, and introduces `parseoffer` RPC call, that parses BOLT12 offers.