### PR TITLE
Update Bitcoin Core to v26.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This means that instead of re-implementing them, Eclair benefits from the verifi
 
 * Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
 * You must configure your Bitcoin node to use `bech32` or `bech32m` (segwit) addresses. If your wallet has "non-segwit UTXOs" (outputs that are neither `p2sh-segwit`, `bech32` or `bech32m`), you must send them to a `bech32` or `bech32m` address before running Eclair.
-* Eclair requires Bitcoin Core 24.1 or higher. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
+* Eclair requires Bitcoin Core 26.1 or higher. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
 
 Run bitcoind with the following minimal `bitcoin.conf`:
 

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -4,7 +4,10 @@
 
 ## Major changes
 
-<insert changes>
+### Update minimal version of Bitcoin Core
+
+With this release, eclair requires using Bitcoin Core 26.1.
+Newer versions of Bitcoin Core may be used, but haven't been extensively tested.
 
 ### API changes
 

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -88,9 +88,9 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-24.1/bitcoin-24.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
-                <bitcoind.md5>35a2faf826a9d866aa6821832e39231e</bitcoind.md5>
-                <bitcoind.sha1>a006ef05514b95cf4d78b5ec844e6cf78fabc196</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-26.1/bitcoin-26.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
+                <bitcoind.md5>260a8942ca91b3b2da5a3a68e23d9f55</bitcoind.md5>
+                <bitcoind.sha1>4862009248449fdf41a9a6dcc8b4833c43527c10</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -101,9 +101,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-24.1/bitcoin-24.1-x86_64-apple-darwin.tar.gz</bitcoind.url>
-                <bitcoind.md5>eba2d59fc9b81c0f6a9ccf77639b8b57</bitcoind.md5>
-                <bitcoind.sha1>b75f30dfa9095c733a9402e243e18174de4522d6</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-26.1/bitcoin-26.1-x86_64-apple-darwin.tar.gz</bitcoind.url>
+                <bitcoind.md5>61e272c43dcc8dcb0296d9bfec16acb6</bitcoind.md5>
+                <bitcoind.sha1>4aa320f6128e378c88462d7bfecb5fe412208b2e</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -114,9 +114,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-24.1/bitcoin-24.1-win64.zip</bitcoind.url>
-                <bitcoind.md5>3a6cff40522e392f4ab1d8aef1274a9d</bitcoind.md5>
-                <bitcoind.sha1>588a60fe5d0b4d8fd09fae6bf366c3f0fc9336b8</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-26.1/bitcoin-26.1-win64.zip</bitcoind.url>
+                <bitcoind.md5>5bdbc41e2ce04b30739e480e17c6e022</bitcoind.md5>
+                <bitcoind.sha1>5f797638eca9af85edb135723f6a10941c171478</bitcoind.sha1>
             </properties>
         </profile>
     </profiles>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -235,7 +235,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val onChainKeyManag
   //------------------------- FUNDING  -------------------------//
 
   /**
-   * @param feeBudget max allowed fee, if the transaction returned by bitcoin core has a higher fee a funding error is returned.
+   * @param feeBudget_opt max allowed fee, if the transaction returned by bitcoin core has a higher fee a funding error is returned.
    */
   def fundTransaction(tx: Transaction, options: FundTransactionOptions, feeBudget_opt: Option[Satoshi])(implicit ec: ExecutionContext): Future[FundTransactionResponse] = {
     rpcClient.invoke("fundrawtransaction", tx.toString(), options).flatMap(json => {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/package.scala
@@ -50,11 +50,9 @@ package object eclair {
   }
 
   def serializationResult(attempt: Attempt[BitVector]): ByteVector = attempt match {
-    case Attempt.Successful(bin) => bin.toByteVector
+    case Attempt.Successful(bin) => bin.bytes
     case Attempt.Failure(cause) => throw new RuntimeException(s"serialization error: $cause")
   }
-
-  def isPay2PubkeyHash(address: String): Boolean = address.startsWith("1") || address.startsWith("m") || address.startsWith("n")
 
   /**
    * Tests whether the binary data is composed solely of printable ASCII characters (see BOLT 1)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -62,7 +62,7 @@ trait BitcoindService extends Logging {
 
   val PATH_BITCOIND = sys.env.get("BITCOIND_DIR") match {
     case Some(customBitcoinDir) => new File(customBitcoinDir, "bitcoind")
-    case None => new File(TestUtils.BUILD_DIRECTORY, "bitcoin-24.1/bin/bitcoind")
+    case None => new File(TestUtils.BUILD_DIRECTORY, "bitcoin-26.1/bin/bitcoind")
   }
   logger.info(s"using bitcoind: $PATH_BITCOIND")
   val PATH_BITCOIND_DATADIR = new File(INTEGRATION_TMP_DIR, "datadir-bitcoin")


### PR DESCRIPTION
Bitcoin Core 26.1 contains ancestor-aware funding: it will automatically fetch unconfirmed ancestors during funding and adapt the fee to apply the target feerate to the whole unconfirmed package.

We had custom code to implement this entirely in eclair, which we can now remove.