### PR TITLE
Use resolved paths in `BlindedHop`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -356,8 +356,8 @@ object RouteNodeIdsSerializer extends ConvertClassSerializer[Route](route => {
   val finalNodeIds = route.finalHop_opt match {
     case Some(hop: NodeHop) if channelNodeIds.nonEmpty => Seq(hop.nextNodeId)
     case Some(hop: NodeHop) => Seq(hop.nodeId, hop.nextNodeId)
-    case Some(hop: BlindedHop) if channelNodeIds.nonEmpty => hop.route.blindedNodeIds.tail
-    case Some(hop: BlindedHop) => hop.nodeId +: hop.route.blindedNodeIds.tail
+    case Some(hop: BlindedHop) if channelNodeIds.nonEmpty => hop.resolved.route.blindedNodeIds.tail
+    case Some(hop: BlindedHop) => hop.nodeId +: hop.resolved.route.blindedNodeIds.tail
     case None => Nil
   }
   RouteNodeIdsJson(route.amount, channelNodeIds ++ finalNodeIds)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/PaymentEvents.scala
@@ -196,7 +196,7 @@ object PaymentFailure {
       case hop: BlindedHop if hop.nodeId == nodeId => ChannelDesc(hop.dummyId, hop.nodeId, hop.nextNodeId)
       // The error comes from inside the blinded route: this is a spec violation, errors should always come from the
       // introduction node, so we definitely want to ignore this blinded route when this happens.
-      case hop: BlindedHop if hop.route.blindedNodeIds.contains(nodeId) => ChannelDesc(hop.dummyId, hop.nodeId, hop.nextNodeId)
+      case hop: BlindedHop if hop.resolved.route.blindedNodeIds.contains(nodeId) => ChannelDesc(hop.dummyId, hop.nodeId, hop.nextNodeId)
     } match {
       case Some(faultyEdge) => ignore + faultyEdge
       case None => ignore

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -340,7 +340,7 @@ class NodeRelay private(nodeParams: NodeParams,
             relayToRecipient(upstream, payloadOut, recipient, paymentCfg, routeParams, useMultiPart = true)
         }
       case payloadOut: IntermediatePayload.NodeRelay.ToBlindedPaths =>
-        context.spawnAnonymous(BlindedPathsResolver(nodeParams, router, register)) ! Resolve(context.messageAdapter[Seq[ResolvedPath]](WrappedResolvedPaths), payloadOut.outgoingBlindedPaths)
+        context.spawnAnonymous(BlindedPathsResolver(nodeParams, paymentHash, router, register)) ! Resolve(context.messageAdapter[Seq[ResolvedPath]](WrappedResolvedPaths), payloadOut.outgoingBlindedPaths)
         waitForResolvedPaths(upstream, payloadOut, paymentCfg, routeParams)
     }
   }
@@ -378,7 +378,7 @@ class NodeRelay private(nodeParams: NodeParams,
       case WrappedResolvedPaths(resolved) =>
         val features = Features(payloadOut.invoiceFeatures).invoiceFeatures()
         // We don't have access to the invoice: we use the only node_id that somewhat makes sense for the recipient.
-        val blindedNodeId = resolved.head.blindedPath.route.blindedNodeIds.last
+        val blindedNodeId = resolved.head.route.blindedNodeIds.last
         val recipient = BlindedRecipient.fromPaths(blindedNodeId, features, payloadOut.amountToForward, payloadOut.outgoingCltv, resolved, Set.empty)
         context.log.debug("sending the payment to blinded recipient, useMultiPart={}", features.hasFeature(Features.BasicMultiPartPayment))
         relayToRecipient(upstream, payloadOut, recipient, paymentCfg, routeParams, features.hasFeature(Features.BasicMultiPartPayment))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/BlindedPathsResolver.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/BlindedPathsResolver.scala
@@ -3,80 +3,132 @@ package fr.acinq.eclair.payment.send
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.actor.{ActorRef, typed}
+import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.channel.Helpers.getRelayFees
 import fr.acinq.eclair.channel.Register
 import fr.acinq.eclair.crypto.Sphinx.RouteBlinding
-import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.BlindedRoute
+import fr.acinq.eclair.crypto.Sphinx.RouteBlinding.BlindedNode
 import fr.acinq.eclair.payment.PaymentBlindedRoute
-import fr.acinq.eclair.payment.send.BlindedPathsResolver._
 import fr.acinq.eclair.router.Router
+import fr.acinq.eclair.wire.protocol.OfferTypes.PaymentInfo
 import fr.acinq.eclair.wire.protocol.RouteBlindingEncryptedDataCodecs.RouteBlindingDecryptedData
 import fr.acinq.eclair.wire.protocol.{BlindedRouteData, OfferTypes, RouteBlindingEncryptedDataCodecs}
-import fr.acinq.eclair.{EncodedNodeId, NodeParams}
+import fr.acinq.eclair.{EncodedNodeId, Logs, NodeParams}
+import scodec.bits.ByteVector
 
 import scala.annotation.tailrec
 
+/**
+ * When paying a recipient that is using blinded paths, we pre-process the blinded paths provided to:
+ *  - resolve the introduction node_id if not provided
+ *  - if we are the introduction node, resolve the next node
+ */
 object BlindedPathsResolver {
+
+  /**
+   * Once resolved, a blinded path contains the ID of the next node we must reach.
+   * We can now use the graph to find a route to that node and send a payment.
+   */
+  case class ResolvedPath(route: ResolvedBlindedRoute, paymentInfo: PaymentInfo)
+
+  // @formatter:off
+  sealed trait ResolvedBlindedRoute {
+    /** The resolved (non-blinded) node_id of the first node in the route. */
+    def firstNodeId: PublicKey
+    def blindedNodes: Seq[BlindedNode]
+    def blindedNodeIds: Seq[PublicKey] = blindedNodes.map(_.blindedPublicKey)
+    def encryptedPayloads: Seq[ByteVector] = blindedNodes.map(_.encryptedPayload)
+  }
+  /** A blinded route that starts at a remote node that we were able to identify. */
+  case class FullBlindedRoute(introductionNodeId: PublicKey, firstBlinding: PublicKey, blindedNodes: Seq[BlindedNode]) extends ResolvedBlindedRoute {
+    override val firstNodeId: PublicKey = introductionNodeId
+  }
+  /** A partially unwrapped blinded route that started at our node: it only contains the part of the route after our node. */
+  case class PartialBlindedRoute(nextNodeId: PublicKey, nextBlinding: PublicKey, blindedNodes: Seq[BlindedNode]) extends ResolvedBlindedRoute {
+    override val firstNodeId: PublicKey = nextNodeId
+  }
+  // @formatter:on
+
   // @formatter:off
   sealed trait Command
   case class Resolve(replyTo: typed.ActorRef[Seq[ResolvedPath]], blindedPaths: Seq[PaymentBlindedRoute]) extends Command
   private case class WrappedNodeId(nodeId_opt: Option[PublicKey]) extends Command
-
-  case class ResolvedPath(blindedPath: PaymentBlindedRoute, nextNodeId: PublicKey, nextNodeIsIntroduction: Boolean)
   // @formatter:on
 
-  def apply(nodeParams: NodeParams, router: ActorRef, register: ActorRef): Behavior[Command] = {
-    Behaviors.receivePartial {
-      case (context, Resolve(replyTo, blindedPaths)) =>
-        val resolver = new BlindedPathsResolver(nodeParams, replyTo, router, register, context)
-        resolver.resolveBlindedPaths(blindedPaths, Nil)
+  def apply(nodeParams: NodeParams, paymentHash: ByteVector32, router: ActorRef, register: ActorRef): Behavior[Command] = {
+    Behaviors.setup { context =>
+      Behaviors.withMdc(Logs.mdc(category_opt = Some(Logs.LogCategory.PAYMENT), paymentHash_opt = Some(paymentHash))) {
+        Behaviors.receiveMessagePartial {
+          case Resolve(replyTo, blindedPaths) =>
+            val resolver = new BlindedPathsResolver(nodeParams, replyTo, router, register, context)
+            resolver.resolveBlindedPaths(blindedPaths, Nil)
+        }
+      }
     }
   }
 }
 
 private class BlindedPathsResolver(nodeParams: NodeParams,
-                                   replyTo: typed.ActorRef[Seq[ResolvedPath]],
+                                   replyTo: typed.ActorRef[Seq[BlindedPathsResolver.ResolvedPath]],
                                    router: ActorRef,
                                    register: ActorRef,
-                                   context: ActorContext[Command]) {
+                                   context: ActorContext[BlindedPathsResolver.Command]) {
+
+  import BlindedPathsResolver._
+
   @tailrec
-  private def resolveBlindedPaths(toResolve: Seq[PaymentBlindedRoute],
-                                  resolved: Seq[ResolvedPath]): Behavior[Command] = {
+  private def resolveBlindedPaths(toResolve: Seq[PaymentBlindedRoute], resolved: Seq[ResolvedPath]): Behavior[Command] = {
     toResolve.headOption match {
-      case Some(PaymentBlindedRoute(BlindedRoute(EncodedNodeId.Plain(publicKey), _, blindedNodes), _)) if publicKey == nodeParams.nodeId && blindedNodes.length == 1 =>
-        context.log.warn("trying to send a blinded payment to ourselves")
-        resolveBlindedPaths(toResolve.tail, resolved)
-      case Some(PaymentBlindedRoute(BlindedRoute(EncodedNodeId.Plain(publicKey), blindingKey, blindedNodes), paymentInfo)) if publicKey == nodeParams.nodeId =>
-        RouteBlindingEncryptedDataCodecs.decode(nodeParams.privateKey, blindingKey, blindedNodes.head.encryptedPayload) match {
-          case Left(_) => resolveBlindedPaths(toResolve.tail, resolved)
-          case Right(RouteBlindingDecryptedData(decrypted, nextBlinding)) =>
-            BlindedRouteData.validatePaymentRelayData(decrypted) match {
-              case Left(_) => resolveBlindedPaths(toResolve.tail, resolved)
-              case Right(paymentRelayData) =>
-                val nextFeeBase = paymentInfo.feeBase - paymentRelayData.paymentRelay.feeBase
-                val nextFeeProportionalMillionths = paymentInfo.feeProportionalMillionths - paymentRelayData.paymentRelay.feeProportionalMillionths
-                val nextCltvExpiryDelta = paymentInfo.cltvExpiryDelta - paymentRelayData.paymentRelay.cltvExpiryDelta
-                val nextPaymentInfo = paymentInfo.copy(
-                  feeBase = nextFeeBase,
-                  feeProportionalMillionths = nextFeeProportionalMillionths,
-                  cltvExpiryDelta = nextCltvExpiryDelta
-                )
-                register ! Register.GetNextNodeId(context.messageAdapter(WrappedNodeId), paymentRelayData.outgoingChannelId)
-                waitForNextNodeId(nextPaymentInfo, paymentRelayData, nextBlinding, blindedNodes.tail, toResolve.tail, resolved)
-            }
-        }
-      case Some(paymentRoute@PaymentBlindedRoute(BlindedRoute(EncodedNodeId.Plain(publicKey), _, _), _)) =>
-        resolveBlindedPaths(toResolve.tail, resolved :+ ResolvedPath(paymentRoute, publicKey, nextNodeIsIntroduction = true))
-      case Some(paymentRoute@PaymentBlindedRoute(BlindedRoute(EncodedNodeId.ShortChannelIdDir(isNode1, scid), _, _), _)) =>
-        router ! Router.GetNodeId(context.messageAdapter(WrappedNodeId), scid, isNode1)
-        waitForNodeId(paymentRoute, toResolve.tail, resolved)
+      case Some(paymentRoute) => paymentRoute.route.introductionNodeId match {
+        case EncodedNodeId.Plain(ourNodeId) if ourNodeId == nodeParams.nodeId && paymentRoute.route.length == 0 =>
+          context.log.warn("ignoring blinded path (empty route with ourselves as the introduction node)")
+          resolveBlindedPaths(toResolve.tail, resolved)
+        case EncodedNodeId.Plain(ourNodeId) if ourNodeId == nodeParams.nodeId =>
+          // We are the introduction node of the blinded route: we need to decrypt the first payload.
+          val firstBlinding = paymentRoute.route.introductionNode.blindingEphemeralKey
+          val firstEncryptedPayload = paymentRoute.route.introductionNode.encryptedPayload
+          RouteBlindingEncryptedDataCodecs.decode(nodeParams.privateKey, firstBlinding, firstEncryptedPayload) match {
+            case Left(f) =>
+              context.log.warn("ignoring blinded path starting at our node that we cannot decrypt: {}", f.message)
+              resolveBlindedPaths(toResolve.tail, resolved)
+            case Right(RouteBlindingDecryptedData(decrypted, nextBlinding)) =>
+              BlindedRouteData.validatePaymentRelayData(decrypted) match {
+                case Left(f) =>
+                  context.log.warn("ignoring blinded path starting at our node with invalid payment relay: {}", f.failureMessage.message)
+                  resolveBlindedPaths(toResolve.tail, resolved)
+                case Right(paymentRelayData) =>
+                  // Note that since fee aggregation iterates from the recipient to the blinded path's introduction node,
+                  // the fee_base and fee_proportional computed below are not exactly what should be used for the next node.
+                  // But we cannot compute those exact values, and this simple calculation always allocates slightly more
+                  // fees to the next nodes than what they expect, so they should relay the payment. We will collect slightly
+                  // less relay fees than expected, but it's ok.
+                  val nextFeeBase = paymentRoute.paymentInfo.feeBase - paymentRelayData.paymentRelay.feeBase
+                  val nextFeeProportionalMillionths = paymentRoute.paymentInfo.feeProportionalMillionths - paymentRelayData.paymentRelay.feeProportionalMillionths
+                  val nextCltvExpiryDelta = paymentRoute.paymentInfo.cltvExpiryDelta - paymentRelayData.paymentRelay.cltvExpiryDelta
+                  val nextPaymentInfo = paymentRoute.paymentInfo.copy(
+                    feeBase = nextFeeBase,
+                    feeProportionalMillionths = nextFeeProportionalMillionths,
+                    cltvExpiryDelta = nextCltvExpiryDelta
+                  )
+                  register ! Register.GetNextNodeId(context.messageAdapter(WrappedNodeId), paymentRelayData.outgoingChannelId)
+                  waitForNextNodeId(nextPaymentInfo, paymentRelayData, nextBlinding, paymentRoute.route.subsequentNodes, toResolve.tail, resolved)
+              }
+          }
+        case EncodedNodeId.Plain(remoteNodeId) =>
+          val path = ResolvedPath(FullBlindedRoute(remoteNodeId, paymentRoute.route.blindingKey, paymentRoute.route.blindedNodes), paymentRoute.paymentInfo)
+          resolveBlindedPaths(toResolve.tail, resolved :+ path)
+        case EncodedNodeId.ShortChannelIdDir(isNode1, scid) =>
+          router ! Router.GetNodeId(context.messageAdapter(WrappedNodeId), scid, isNode1)
+          waitForNodeId(paymentRoute, toResolve.tail, resolved)
+      }
       case None =>
         replyTo ! resolved
         Behaviors.stopped
     }
   }
 
+  /** Resolve the next node in the blinded path when we are the introduction node. */
   private def waitForNextNodeId(nextPaymentInfo: OfferTypes.PaymentInfo,
                                 paymentRelayData: BlindedRouteData.PaymentRelayData,
                                 nextBlinding: PublicKey,
@@ -85,32 +137,41 @@ private class BlindedPathsResolver(nodeParams: NodeParams,
                                 resolved: Seq[ResolvedPath]): Behavior[Command] =
     Behaviors.receiveMessagePartial {
       case WrappedNodeId(None) =>
+        context.log.warn("ignoring blinded path starting at our node: could not resolve outgoingChannelId={}", paymentRelayData.outgoingChannelId)
+        resolveBlindedPaths(toResolve, resolved)
+      case WrappedNodeId(Some(nodeId)) if nodeId == nodeParams.nodeId =>
+        // The next node in the route is also our node: this is fishy, there is not reason to include us in the route twice.
+        context.log.warn("ignoring blinded path starting at our node relaying to ourselves")
         resolveBlindedPaths(toResolve, resolved)
       case WrappedNodeId(Some(nodeId)) =>
-        val nextRoute = BlindedRoute(EncodedNodeId.Plain(nodeId), nextBlinding, nextBlindedNodes)
-        if (nodeId == nodeParams.nodeId) {
-          resolveBlindedPaths(PaymentBlindedRoute(nextRoute, nextPaymentInfo) +: toResolve, resolved)
+        // Note that we default to private fees if we don't have a channel yet with that node.
+        // The announceChannel parameter is ignored if we already have a channel.
+        val relayFees = getRelayFees(nodeParams, nodeId, announceChannel = false)
+        val shouldRelay = paymentRelayData.paymentRelay.feeBase >= relayFees.feeBase &&
+          paymentRelayData.paymentRelay.feeProportionalMillionths >= relayFees.feeProportionalMillionths &&
+          paymentRelayData.paymentRelay.cltvExpiryDelta >= nodeParams.channelConf.expiryDelta
+        if (shouldRelay) {
+          context.log.debug("unwrapped blinded path starting at our node: next_node={}", nodeId)
+          val path = ResolvedPath(PartialBlindedRoute(nodeId, nextBlinding, nextBlindedNodes), nextPaymentInfo)
+          resolveBlindedPaths(toResolve, resolved :+ path)
         } else {
-          val relayFees = getRelayFees(nodeParams, nodeId, announceChannel = false) // We use unannounced but we don't know if the channel is announced or not.
-          if (paymentRelayData.paymentRelay.feeBase >= relayFees.feeBase
-            && paymentRelayData.paymentRelay.feeProportionalMillionths >= relayFees.feeProportionalMillionths
-            && paymentRelayData.paymentRelay.cltvExpiryDelta >= nodeParams.channelConf.expiryDelta) {
-            resolveBlindedPaths(toResolve, resolved :+ ResolvedPath(PaymentBlindedRoute(nextRoute, nextPaymentInfo), nodeId, nextNodeIsIntroduction = false))
-          } else {
-            resolveBlindedPaths(toResolve, resolved)
-          }
+          context.log.warn("ignoring blinded path starting at our node: allocated fees are too low (base={}, proportional={}, expiryDelta={})", paymentRelayData.paymentRelay.feeBase, paymentRelayData.paymentRelay.feeProportionalMillionths, paymentRelayData.paymentRelay.cltvExpiryDelta)
+          resolveBlindedPaths(toResolve, resolved)
         }
     }
 
+  /** Resolve the introduction node's [[EncodedNodeId.ShortChannelIdDir]] to the corresponding [[EncodedNodeId.Plain]]. */
   private def waitForNodeId(paymentRoute: PaymentBlindedRoute,
                             toResolve: Seq[PaymentBlindedRoute],
                             resolved: Seq[ResolvedPath]): Behavior[Command] =
     Behaviors.receiveMessagePartial {
       case WrappedNodeId(None) =>
+        context.log.warn("ignoring blinded path with unknown scid_dir={}", paymentRoute.route.introductionNodeId)
         resolveBlindedPaths(toResolve, resolved)
-      case WrappedNodeId(Some(nodeId)) if nodeId == nodeParams.nodeId =>
-        resolveBlindedPaths(paymentRoute.copy(route = paymentRoute.route.copy(introductionNodeId = EncodedNodeId.Plain(nodeId))) +: toResolve, resolved)
       case WrappedNodeId(Some(nodeId)) =>
-        resolveBlindedPaths(toResolve, resolved :+ ResolvedPath(paymentRoute, nodeId, nextNodeIsIntroduction = true))
+        context.log.debug("successfully resolved scid_dir={} to node_id={}", paymentRoute.route.introductionNodeId, nodeId)
+        // We've identified the node matching this scid_dir, we retry resolving with that node_id.
+        val paymentRouteWithNodeId = paymentRoute.copy(route = paymentRoute.route.copy(introductionNodeId = EncodedNodeId.Plain(nodeId)))
+        resolveBlindedPaths(paymentRouteWithNodeId +: toResolve, resolved)
     }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentInitiatorSpec.scala
@@ -29,7 +29,7 @@ import fr.acinq.eclair.payment.Bolt11Invoice.ExtraHop
 import fr.acinq.eclair.payment.OutgoingPaymentPacket.Upstream
 import fr.acinq.eclair.payment.PaymentPacketSpec._
 import fr.acinq.eclair.payment.PaymentSent.PartialPayment
-import fr.acinq.eclair.payment.send.BlindedPathsResolver.ResolvedPath
+import fr.acinq.eclair.payment.send.BlindedPathsResolver.{FullBlindedRoute, ResolvedPath}
 import fr.acinq.eclair.payment.send.MultiPartPaymentLifecycle.SendMultiPartPayment
 import fr.acinq.eclair.payment.send.PaymentError.UnsupportedFeatures
 import fr.acinq.eclair.payment.send.PaymentInitiator._
@@ -285,7 +285,7 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
 
   def createBolt12Invoice(features: Features[Bolt12Feature], payerKey: PrivateKey): Bolt12Invoice = {
     val offer = Offer(None, Some("Bolt12 r0cks"), e, features, Block.RegtestGenesisBlock.hash)
-    val invoiceRequest = InvoiceRequest(offer, finalAmount, 1, features, randomKey(), Block.RegtestGenesisBlock.hash)
+    val invoiceRequest = InvoiceRequest(offer, finalAmount, 1, features, payerKey, Block.RegtestGenesisBlock.hash)
     val blindedRoute = BlindedRouteCreation.createBlindedRouteWithoutHops(e, hex"2a2a2a2a", 1 msat, CltvExpiry(500_000)).route
     val paymentInfo = OfferTypes.PaymentInfo(1_000 msat, 0, CltvExpiryDelta(24), 0 msat, finalAmount, Features.empty)
     Bolt12Invoice(invoiceRequest, paymentPreimage, priv_e.privateKey, 300 seconds, features, Seq(PaymentBlindedRoute(blindedRoute, paymentInfo)))
@@ -295,7 +295,10 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val payerKey = randomKey()
     val invoice = createBolt12Invoice(Features.empty, payerKey)
-    val resolvedPaths = invoice.blindedPaths.map(path => ResolvedPath(path, path.route.introductionNodeId.asInstanceOf[EncodedNodeId.Plain].publicKey, nextNodeIsIntroduction = true))
+    val resolvedPaths = invoice.blindedPaths.map(path => {
+      val introductionNodeId = path.route.introductionNodeId.asInstanceOf[EncodedNodeId.Plain].publicKey
+      ResolvedPath(FullBlindedRoute(introductionNodeId, path.route.blindingKey, path.route.blindedNodes), path.paymentInfo)
+    })
     val req = SendPaymentToNode(sender.ref, finalAmount, invoice, resolvedPaths, 1, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams, payerKey_opt = Some(payerKey))
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]
@@ -326,7 +329,10 @@ class PaymentInitiatorSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
     val payerKey = randomKey()
     val invoice = createBolt12Invoice(Features(BasicMultiPartPayment -> Optional), payerKey)
-    val resolvedPaths = invoice.blindedPaths.map(path => ResolvedPath(path, path.route.introductionNodeId.asInstanceOf[EncodedNodeId.Plain].publicKey, nextNodeIsIntroduction = true))
+    val resolvedPaths = invoice.blindedPaths.map(path => {
+      val introductionNodeId = path.route.introductionNodeId.asInstanceOf[EncodedNodeId.Plain].publicKey
+      ResolvedPath(FullBlindedRoute(introductionNodeId, path.route.blindingKey, path.route.blindedNodes), path.paymentInfo)
+    })
     val req = SendPaymentToNode(sender.ref, finalAmount, invoice, resolvedPaths, 1, routeParams = nodeParams.routerConf.pathFindingExperimentConf.getRandomConf().getDefaultRouteParams, payerKey_opt = Some(payerKey))
     sender.send(initiator, req)
     val id = sender.expectMsgType[UUID]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentLifecycleSpec.scala
@@ -880,7 +880,7 @@ class PaymentLifecycleSpec extends BaseRouterSpec {
       (RemoteFailure(defaultAmountMsat, route_abcd, Sphinx.DecryptedFailurePacket(c, UnknownNextPeer())), Set.empty, Set(ChannelDesc(scid_cd, c, d))),
       (RemoteFailure(defaultAmountMsat, route_abcd, Sphinx.DecryptedFailurePacket(b, FeeInsufficient(100 msat, update_bc))), Set.empty, Set.empty),
       (RemoteFailure(defaultAmountMsat, blindedRoute_abc, Sphinx.DecryptedFailurePacket(b, InvalidOnionBlinding(randomBytes32()))), Set.empty, Set(ChannelDesc(blindedHop_bc.dummyId, blindedHop_bc.nodeId, blindedHop_bc.nextNodeId))),
-      (RemoteFailure(defaultAmountMsat, blindedRoute_abc, Sphinx.DecryptedFailurePacket(blindedHop_bc.route.blindedNodeIds(1), InvalidOnionBlinding(randomBytes32()))), Set.empty, Set(ChannelDesc(blindedHop_bc.dummyId, blindedHop_bc.nodeId, blindedHop_bc.nextNodeId))),
+      (RemoteFailure(defaultAmountMsat, blindedRoute_abc, Sphinx.DecryptedFailurePacket(blindedHop_bc.resolved.route.blindedNodeIds(1), InvalidOnionBlinding(randomBytes32()))), Set.empty, Set(ChannelDesc(blindedHop_bc.dummyId, blindedHop_bc.nodeId, blindedHop_bc.nextNodeId))),
       // unreadable remote failures -> blacklist all nodes except our direct peer, the final recipient or the last hop
       (UnreadableRemoteFailure(defaultAmountMsat, channelHopFromUpdate(a, b, update_ab) :: Nil), Set.empty, Set.empty),
       (UnreadableRemoteFailure(defaultAmountMsat, channelHopFromUpdate(a, b, update_ab) :: channelHopFromUpdate(b, c, update_bc) :: channelHopFromUpdate(c, d, update_cd) :: Nil), Set(c), Set.empty),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/send/BlindedPathsResolverSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/send/BlindedPathsResolverSpec.scala
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.payment.send
+
+import akka.actor.ActorSystem
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorRef
+import akka.actor.typed.scaladsl.adapter._
+import akka.testkit.TestProbe
+import com.typesafe.config.ConfigFactory
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.eclair.channel.Register
+import fr.acinq.eclair.crypto.Sphinx.RouteBlinding
+import fr.acinq.eclair.payment.Invoice.ExtraEdge
+import fr.acinq.eclair.payment.PaymentBlindedRoute
+import fr.acinq.eclair.payment.send.BlindedPathsResolver.{FullBlindedRoute, PartialBlindedRoute, Resolve, ResolvedPath}
+import fr.acinq.eclair.router.Router.{ChannelHop, HopRelayParams}
+import fr.acinq.eclair.router.{BlindedRouteCreation, Router}
+import fr.acinq.eclair.wire.protocol.OfferTypes.PaymentInfo
+import fr.acinq.eclair.{BlockHeight, CltvExpiry, CltvExpiryDelta, EncodedNodeId, Features, MilliSatoshiLong, NodeParams, RealShortChannelId, TestConstants, randomBytes32, randomKey}
+import org.scalatest.Outcome
+import org.scalatest.funsuite.FixtureAnyFunSuiteLike
+import scodec.bits.HexStringSyntax
+
+import scala.concurrent.duration.DurationInt
+
+class BlindedPathsResolverSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with FixtureAnyFunSuiteLike {
+
+  case class FixtureParam(nodeParams: NodeParams, router: TestProbe, register: TestProbe, resolver: ActorRef[BlindedPathsResolver.Command])
+
+  implicit val classicSystem: ActorSystem = system.classicSystem
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val nodeParams = TestConstants.Alice.nodeParams
+    val router = TestProbe("router")
+    val register = TestProbe("register")
+    val resolver = testKit.spawn(BlindedPathsResolver(nodeParams, randomBytes32(), router.ref, register.ref))
+    try {
+      withFixture(test.toNoArgTest(FixtureParam(nodeParams, router, register, resolver)))
+    } finally {
+      testKit.stop(resolver)
+    }
+  }
+
+  test("resolve plain node_id") { f =>
+    import f._
+
+    val probe = TestProbe()
+    val Seq(a, b, c) = Seq(randomKey(), randomKey(), randomKey()).map(_.publicKey)
+    val paymentInfo = PaymentInfo(100 msat, 250, CltvExpiryDelta(36), 1 msat, 50_000_000 msat, Features.empty)
+    val blindedPaths = Seq(
+      RouteBlinding.create(randomKey(), Seq(a), Seq(hex"deadbeef")),
+      RouteBlinding.create(randomKey(), Seq(b, randomKey().publicKey), Seq(hex"deadbeef", hex"deadbeef")),
+      RouteBlinding.create(randomKey(), Seq(c, randomKey().publicKey, randomKey().publicKey), Seq(hex"deadbeef", hex"deadbeef", hex"deadbeef")),
+    ).map(r => PaymentBlindedRoute(r.route, paymentInfo))
+    resolver ! Resolve(probe.ref, blindedPaths)
+    val resolved = probe.expectMsgType[Seq[ResolvedPath]]
+    assert(resolved.size == 3)
+    assert(resolved.map(_.route.firstNodeId).toSet == Set(a, b, c))
+    resolved.foreach(r => {
+      assert(r.route.isInstanceOf[FullBlindedRoute])
+      assert(r.paymentInfo == paymentInfo)
+    })
+    // We directly have access to the introduction node_id, no need to call the router or register.
+    router.expectNoMessage(100 millis)
+    register.expectNoMessage(100 millis)
+  }
+
+  test("resolve scid_dir") { f =>
+    import f._
+
+    val probe = TestProbe()
+    val introductionNodeId = randomKey().publicKey
+    val scidDir = EncodedNodeId.ShortChannelIdDir(isNode1 = false, RealShortChannelId(BlockHeight(750_000), 3, 7))
+    val route = RouteBlinding.create(randomKey(), Seq(introductionNodeId), Seq(hex"deadbeef")).route.copy(introductionNodeId = scidDir)
+    val paymentInfo = PaymentInfo(100 msat, 250, CltvExpiryDelta(36), 1 msat, 50_000_000 msat, Features.empty)
+    resolver ! Resolve(probe.ref, Seq(PaymentBlindedRoute(route, paymentInfo)))
+    // We must resolve the scid_dir to a node_id.
+    val routerReq = router.expectMsgType[Router.GetNodeId]
+    assert(routerReq.shortChannelId == scidDir.scid)
+    assert(!routerReq.isNode1)
+    routerReq.replyTo ! Some(introductionNodeId)
+    val resolved = probe.expectMsgType[Seq[ResolvedPath]]
+    assert(resolved.size == 1)
+    assert(resolved.head.route.isInstanceOf[FullBlindedRoute])
+    val fullRoute = resolved.head.route.asInstanceOf[FullBlindedRoute]
+    assert(fullRoute.firstNodeId == introductionNodeId)
+    assert(fullRoute.firstBlinding == route.blindingKey)
+    assert(fullRoute.blindedNodes == route.blindedNodes)
+    assert(resolved.head.paymentInfo == paymentInfo)
+  }
+
+  test("resolve route starting at our node") { f =>
+    import f._
+
+    val probe = TestProbe()
+    val nextNodeId = randomKey().publicKey
+    val edges = Seq(
+      ExtraEdge(nodeParams.nodeId, nextNodeId, RealShortChannelId(BlockHeight(750_000), 3, 7), 600_000 msat, 100, CltvExpiryDelta(144), 1 msat, None),
+      ExtraEdge(nextNodeId, randomKey().publicKey, RealShortChannelId(BlockHeight(700_000), 1, 0), 750_000 msat, 150, CltvExpiryDelta(48), 1 msat, None),
+    )
+    val hops = edges.map(e => ChannelHop(e.shortChannelId, e.sourceNodeId, e.targetNodeId, HopRelayParams.FromHint(e)))
+    val route = BlindedRouteCreation.createBlindedRouteFromHops(hops, hex"deadbeef", 1 msat, CltvExpiry(800_000)).route
+    val paymentInfo = BlindedRouteCreation.aggregatePaymentInfo(100_000_000 msat, hops, CltvExpiryDelta(12))
+    Seq(true, false).foreach { useScidDir =>
+      val toResolve = if (useScidDir) {
+        val scidDir = EncodedNodeId.ShortChannelIdDir(isNode1 = true, edges.head.shortChannelId.asInstanceOf[RealShortChannelId])
+        route.copy(introductionNodeId = scidDir)
+      } else {
+        route
+      }
+      val resolver = testKit.spawn(BlindedPathsResolver(nodeParams, randomBytes32(), router.ref, register.ref))
+      resolver ! Resolve(probe.ref, Seq(PaymentBlindedRoute(toResolve, paymentInfo)))
+      if (useScidDir) {
+        // We first resolve the scid_dir to a node_id.
+        val routerReq = router.expectMsgType[Router.GetNodeId]
+        assert(routerReq.shortChannelId == edges.head.shortChannelId)
+        assert(routerReq.isNode1)
+        routerReq.replyTo ! Some(nodeParams.nodeId)
+      }
+      // We are the introduction node: we decrypt the payload and resolve the next node's ID.
+      val registerReq = register.expectMsgType[Register.GetNextNodeId]
+      assert(registerReq.shortChannelId == edges.head.shortChannelId)
+      registerReq.replyTo ! Some(nextNodeId)
+      // We return a partially unwrapped blinded path.
+      val resolved = probe.expectMsgType[Seq[ResolvedPath]]
+      assert(resolved.size == 1)
+      assert(resolved.head.route.isInstanceOf[PartialBlindedRoute])
+      val partialRoute = resolved.head.route.asInstanceOf[PartialBlindedRoute]
+      assert(partialRoute.firstNodeId == nextNodeId)
+      assert(partialRoute.blindedNodes == route.subsequentNodes)
+      assert(partialRoute.nextBlinding != route.blindingKey)
+      // The payment info for the partial route should be greater than the actual payment info.
+      assert(750_000.msat <= resolved.head.paymentInfo.feeBase && resolved.head.paymentInfo.feeBase <= 1_000_000.msat)
+      assert(150 <= resolved.head.paymentInfo.feeProportionalMillionths && resolved.head.paymentInfo.feeProportionalMillionths <= 200)
+      assert(resolved.head.paymentInfo.cltvExpiryDelta == CltvExpiryDelta(60)) // this includes the final expiry delta
+    }
+  }
+
+  test("ignore blinded paths that cannot be resolved") { f =>
+    import f._
+
+    val probe = TestProbe()
+    val scid = RealShortChannelId(BlockHeight(750_000), 3, 7)
+    val edge = ExtraEdge(nodeParams.nodeId, randomKey().publicKey, scid, 600_000 msat, 100, CltvExpiryDelta(144), 1 msat, None)
+    val hop = ChannelHop(edge.shortChannelId, edge.sourceNodeId, edge.targetNodeId, HopRelayParams.FromHint(edge))
+    val route = BlindedRouteCreation.createBlindedRouteFromHops(Seq(hop), hex"deadbeef", 1 msat, CltvExpiry(800_000)).route
+    val paymentInfo = BlindedRouteCreation.aggregatePaymentInfo(50_000_000 msat, Seq(hop), CltvExpiryDelta(12))
+    val toResolve = Seq(
+      PaymentBlindedRoute(route.copy(introductionNodeId = EncodedNodeId.ShortChannelIdDir(isNode1 = true, scid)), paymentInfo),
+      PaymentBlindedRoute(route, paymentInfo),
+      PaymentBlindedRoute(route, paymentInfo),
+    )
+    resolver ! Resolve(probe.ref, toResolve)
+    // The scid_dir of the first route cannot be found in the graph.
+    router.expectMsgType[Router.GetNodeId].replyTo ! Option.empty[PublicKey]
+    // The next node of the second route cannot be found based on the outgoing channel_id.
+    register.expectMsgType[Register.GetNextNodeId].replyTo ! Option.empty[PublicKey]
+    // The next node of the third route is actually ourselves, which shouldn't happen.
+    register.expectMsgType[Register.GetNextNodeId].replyTo ! Some(nodeParams.nodeId)
+    // All routes failed to resolve.
+    probe.expectMsg(Seq.empty[ResolvedPath])
+  }
+
+  test("ignore invalid blinded paths starting at our node") { f =>
+    import f._
+
+    val probe = TestProbe()
+    val scid = RealShortChannelId(BlockHeight(750_000), 3, 7)
+    val edgeLowFees = ExtraEdge(nodeParams.nodeId, randomKey().publicKey, scid, 100 msat, 5, CltvExpiryDelta(144), 1 msat, None)
+    val edgeLowExpiryDelta = ExtraEdge(nodeParams.nodeId, randomKey().publicKey, scid, 600_000 msat, 100, CltvExpiryDelta(36), 1 msat, None)
+    val toResolve = Seq(
+      // We don't allow paying blinded routes to ourselves.
+      BlindedRouteCreation.createBlindedRouteWithoutHops(nodeParams.nodeId, hex"deadbeef", 1 msat, CltvExpiry(800_000)).route,
+      // We reject blinded routes with low fees.
+      BlindedRouteCreation.createBlindedRouteFromHops(Seq(ChannelHop(scid, nodeParams.nodeId, edgeLowFees.targetNodeId, HopRelayParams.FromHint(edgeLowFees))), hex"deadbeef", 1 msat, CltvExpiry(800_000)).route,
+      // We reject blinded routes with low cltv_expiry_delta.
+      BlindedRouteCreation.createBlindedRouteFromHops(Seq(ChannelHop(scid, nodeParams.nodeId, edgeLowExpiryDelta.targetNodeId, HopRelayParams.FromHint(edgeLowExpiryDelta))), hex"deadbeef", 1 msat, CltvExpiry(800_000)).route,
+      // We reject blinded routes that cannot be decrypted.
+      BlindedRouteCreation.createBlindedRouteFromHops(Seq(ChannelHop(scid, nodeParams.nodeId, edgeLowFees.targetNodeId, HopRelayParams.FromHint(edgeLowFees))), hex"deadbeef", 1 msat, CltvExpiry(800_000)).route.copy(blindingKey = randomKey().publicKey)
+    ).map(r => PaymentBlindedRoute(r, PaymentInfo(1_000_000 msat, 2500, CltvExpiryDelta(300), 1 msat, 500_000_000 msat, Features.empty)))
+    resolver ! Resolve(probe.ref, toResolve)
+    // The routes with low fees or expiry require resolving the next node.
+    register.expectMsgType[Register.GetNextNodeId].replyTo ! Some(edgeLowFees.targetNodeId)
+    register.expectMsgType[Register.GetNextNodeId].replyTo ! Some(edgeLowExpiryDelta.targetNodeId)
+    // All routes are ignored.
+    probe.expectMsg(Seq.empty[ResolvedPath])
+  }
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/send/OfferPaymentSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/send/OfferPaymentSpec.scala
@@ -21,19 +21,17 @@ import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe =
 import akka.actor.typed.ActorRef
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
-import fr.acinq.eclair.EncodedNodeId.ShortChannelIdDir
 import fr.acinq.eclair.crypto.Sphinx.RouteBlinding
 import fr.acinq.eclair.message.OnionMessages.RoutingStrategy.FindRoute
 import fr.acinq.eclair.message.Postman
 import fr.acinq.eclair.payment.send.OfferPayment._
 import fr.acinq.eclair.payment.send.PaymentInitiator.SendPaymentToNode
 import fr.acinq.eclair.payment.{Bolt12Invoice, PaymentBlindedRoute}
-import fr.acinq.eclair.router.Router
 import fr.acinq.eclair.router.Router.RouteParams
 import fr.acinq.eclair.wire.protocol.MessageOnion.InvoicePayload
 import fr.acinq.eclair.wire.protocol.OfferTypes.{InvoiceRequest, Offer, PaymentInfo}
 import fr.acinq.eclair.wire.protocol.{OfferTypes, OnionMessagePayloadTlv, TlvStream}
-import fr.acinq.eclair.{CltvExpiryDelta, EncodedNodeId, Features, MilliSatoshiLong, NodeParams, RealShortChannelId, TestConstants, randomBytes, randomBytes32, randomKey}
+import fr.acinq.eclair.{CltvExpiryDelta, Features, MilliSatoshiLong, NodeParams, TestConstants, randomBytes, randomBytes32, randomKey}
 import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import scodec.bits.HexStringSyntax
@@ -129,56 +127,6 @@ class OfferPaymentSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
 
     probe.expectMsgType[InvalidInvoiceResponse]
     paymentInitiator.expectNoMessage(50 millis)
-
-    TypedProbe().expectTerminated(offerPayment)
-  }
-
-  test("resolve compact paths") { f =>
-    import f._
-
-    val probe = TestProbe()
-    val merchantKey = randomKey()
-
-    val offer = Offer(None, Some("offer"), merchantKey.publicKey, Features.empty, nodeParams.chainHash)
-    offerPayment ! PayOffer(probe.ref, offer, 40_000_000 msat, 1, SendPaymentConfig(None, connectDirectly = false, 1, routeParams, blocking = false))
-    val Postman.SendMessage(OfferTypes.RecipientNodeId(recipientId), FindRoute, message, expectsReply, replyTo) = postman.expectMessageType[Postman.SendMessage]
-    assert(recipientId == merchantKey.publicKey)
-    assert(message.get[OnionMessagePayloadTlv.InvoiceRequest].nonEmpty)
-    assert(expectsReply)
-    val Right(invoiceRequest) = InvoiceRequest.validate(message.get[OnionMessagePayloadTlv.InvoiceRequest].get.tlvs)
-
-    val preimage = randomBytes32()
-    val blindedRoutes = Seq.fill(6)(RouteBlinding.create(randomKey(), Seq.fill(3)(randomKey().publicKey), Seq.fill(3)(randomBytes(10))).route)
-    val paymentRoutes = Seq(
-      PaymentBlindedRoute(blindedRoutes(0), PaymentInfo(0 msat, 0, CltvExpiryDelta(0), 0 msat, 1_000_000_000 msat, Features.empty)),
-      PaymentBlindedRoute(blindedRoutes(1).copy(introductionNodeId = ShortChannelIdDir(isNode1 = true, RealShortChannelId(11111))), PaymentInfo(1 msat, 11, CltvExpiryDelta(111), 0 msat, 1_000_000_000 msat, Features.empty)),
-      PaymentBlindedRoute(blindedRoutes(2), PaymentInfo(2 msat, 22, CltvExpiryDelta(222), 0 msat, 1_000_000_000 msat, Features.empty)),
-      PaymentBlindedRoute(blindedRoutes(3).copy(introductionNodeId = ShortChannelIdDir(isNode1 = false, RealShortChannelId(33333))), PaymentInfo(3 msat, 33, CltvExpiryDelta(333), 0 msat, 1_000_000_000 msat, Features.empty)),
-      PaymentBlindedRoute(blindedRoutes(4).copy(introductionNodeId = ShortChannelIdDir(isNode1 = false, RealShortChannelId(44444))), PaymentInfo(4 msat, 44, CltvExpiryDelta(444), 0 msat, 1_000_000_000 msat, Features.empty)),
-      PaymentBlindedRoute(blindedRoutes(5), PaymentInfo(5 msat, 55, CltvExpiryDelta(555), 0 msat, 1_000_000_000 msat, Features.empty)),
-    )
-    val invoice = Bolt12Invoice(invoiceRequest, preimage, merchantKey, 1 minute, Features.empty, paymentRoutes)
-    replyTo ! Postman.Response(InvoicePayload(TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)), TlvStream.empty))
-
-    val getNode1 = router.expectMsgType[Router.GetNodeId]
-    assert(getNode1.isNode1)
-    assert(getNode1.shortChannelId == RealShortChannelId(11111))
-    getNode1.replyTo ! Some(blindedRoutes(1).introductionNodeId.asInstanceOf[EncodedNodeId.Plain].publicKey)
-
-    val getNode3 = router.expectMsgType[Router.GetNodeId]
-    assert(!getNode3.isNode1)
-    assert(getNode3.shortChannelId == RealShortChannelId(33333))
-    getNode3.replyTo ! None
-
-    val getNode4 = router.expectMsgType[Router.GetNodeId]
-    assert(!getNode4.isNode1)
-    assert(getNode4.shortChannelId == RealShortChannelId(44444))
-    getNode4.replyTo ! Some(blindedRoutes(4).introductionNodeId.asInstanceOf[EncodedNodeId.Plain].publicKey)
-
-    val send = paymentInitiator.expectMsgType[SendPaymentToNode]
-    assert(send.invoice == invoice)
-    assert(send.resolvedPaths.map(_.nextNodeId) == Seq(blindedRoutes(0), blindedRoutes(1), blindedRoutes(2), blindedRoutes(4), blindedRoutes(5)).map(_.introductionNodeId.asInstanceOf[EncodedNodeId.Plain].publicKey))
-    assert(send.resolvedPaths.map(_.blindedPath.paymentInfo.feeBase) == Seq(0 msat, 1 msat, 2 msat, 4 msat, 5 msat))
 
     TypedProbe().expectTerminated(offerPayment)
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -30,8 +30,8 @@ import fr.acinq.eclair.channel.fsm.Channel
 import fr.acinq.eclair.crypto.TransportHandler
 import fr.acinq.eclair.crypto.keymanager.{LocalChannelKeyManager, LocalNodeKeyManager}
 import fr.acinq.eclair.io.Peer.PeerRoutingMessage
+import fr.acinq.eclair.payment.send.BlindedPathsResolver.{FullBlindedRoute, ResolvedPath}
 import fr.acinq.eclair.payment.send.BlindedRecipient
-import fr.acinq.eclair.payment.send.BlindedPathsResolver.ResolvedPath
 import fr.acinq.eclair.payment.{Bolt12Invoice, PaymentBlindedRoute}
 import fr.acinq.eclair.router.Announcements._
 import fr.acinq.eclair.router.BaseRouterSpec.channelAnnouncement
@@ -276,7 +276,10 @@ object BaseRouterSpec {
       PaymentBlindedRoute(blindedRoute, paymentInfo)
     })
     val invoice = Bolt12Invoice(invoiceRequest, preimage, recipientKey, 300 seconds, features, blindedRoutes)
-    val resolvedPaths = invoice.blindedPaths.map(path => ResolvedPath(path, path.route.introductionNodeId.asInstanceOf[EncodedNodeId.Plain].publicKey, nextNodeIsIntroduction = true))
+    val resolvedPaths = invoice.blindedPaths.map(path => {
+      val introductionNodeId = path.route.introductionNodeId.asInstanceOf[EncodedNodeId.Plain].publicKey
+      ResolvedPath(FullBlindedRoute(introductionNodeId, path.route.blindingKey, path.route.blindedNodes), path.paymentInfo)
+    })
     val recipient = BlindedRecipient(invoice, resolvedPaths, amount, expiry, Set.empty)
     (invoice, recipient)
   }


### PR DESCRIPTION
We use resolved paths in `BlindedHop`s, since we need to potentially unwrap the first hop in the route if we're the introduction node. This lets us refactor resolved paths to clearly distinguish the case where we are the introduction node, for which we need to include a blinding in our `update_add_htlc` message.

We also include a small hack in the second commit to improve support for MPP with blinded paths (see commit message).

This is a PR on top of #2858