### PR TITLE
Update Bitcoin Core to v27.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This means that instead of re-implementing them, Eclair benefits from the verifi
 
 * Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
 * You must configure your Bitcoin node to use `bech32` or `bech32m` (segwit) addresses. If your wallet has "non-segwit UTXOs" (outputs that are neither `p2sh-segwit`, `bech32` or `bech32m`), you must send them to a `bech32` or `bech32m` address before running Eclair.
-* Eclair requires Bitcoin Core 26.1 or higher. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
+* Eclair requires Bitcoin Core 27.1 or higher. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
 
 Run bitcoind with the following minimal `bitcoin.conf`:
 

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -6,8 +6,16 @@
 
 ### Update minimal version of Bitcoin Core
 
-With this release, eclair requires using Bitcoin Core 26.1.
-Newer versions of Bitcoin Core may be used, but haven't been extensively tested.
+With this release, eclair requires using Bitcoin Core 27.1.
+Newer versions of Bitcoin Core may be used, but have not been extensively tested.
+
+This version introduces a new coin selection algorithm called  [CoinGrinder](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-27.0.md#wallet) that will reduce on-chain transaction costs when feerates are high.
+
+To enable CoinGrinder at all fee rates and prevent the automatic consolidation of UTXOs, add the following line to your `bitcoin.conf` file:
+
+```conf
+consolidatefeerate=0
+```
 
 ### API changes
 

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -88,9 +88,9 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-26.1/bitcoin-26.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
-                <bitcoind.md5>260a8942ca91b3b2da5a3a68e23d9f55</bitcoind.md5>
-                <bitcoind.sha1>4862009248449fdf41a9a6dcc8b4833c43527c10</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-27.1/bitcoin-27.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
+                <bitcoind.md5>3253eaa3b0b9b612d39db667699712ac</bitcoind.md5>
+                <bitcoind.sha1>8e37ee39b60d02cdb2934913e5bed756eb0b7107</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -101,9 +101,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-26.1/bitcoin-26.1-x86_64-apple-darwin.tar.gz</bitcoind.url>
-                <bitcoind.md5>61e272c43dcc8dcb0296d9bfec16acb6</bitcoind.md5>
-                <bitcoind.sha1>4aa320f6128e378c88462d7bfecb5fe412208b2e</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-27.1/bitcoin-27.1-x86_64-apple-darwin.tar.gz</bitcoind.url>
+                <bitcoind.md5>a741eb0bb55877b8bc05bf1928ed1f10</bitcoind.md5>
+                <bitcoind.sha1>4d67a36c11d0ff3e6b5148d808c439f99a53c7c5</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -114,9 +114,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-26.1/bitcoin-26.1-win64.zip</bitcoind.url>
-                <bitcoind.md5>5bdbc41e2ce04b30739e480e17c6e022</bitcoind.md5>
-                <bitcoind.sha1>5f797638eca9af85edb135723f6a10941c171478</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-27.1/bitcoin-27.1-win64.zip</bitcoind.url>
+                <bitcoind.md5>8102305fed89d99291a65b3ee2e649f2</bitcoind.md5>
+                <bitcoind.sha1>0ead7bd39f7ba72717ad3721f617beb84c8d5382</bitcoind.sha1>
             </properties>
         </profile>
     </profiles>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -187,7 +187,7 @@ class Setup(val datadir: File,
       await(getBitcoinStatus(bitcoinClient), 30 seconds, "bitcoind did not respond after 30 seconds")
     }
     logger.info(s"bitcoind version=${bitcoinStatus.version}")
-    assert(bitcoinStatus.version >= 260100, "Eclair requires Bitcoin Core 26.1 or higher")
+    assert(bitcoinStatus.version >= 270100, "Eclair requires Bitcoin Core 27.1 or higher")
     bitcoinStatus.unspentAddresses.foreach { address =>
       val isSegwit = addressToPublicKeyScript(bitcoinStatus.chainHash, address).map(script => Script.isNativeWitnessScript(script)).getOrElse(false)
       assert(isSegwit, s"Your wallet contains non-segwit UTXOs (e.g. address=$address). You must send those UTXOs to a segwit address to use Eclair (check out our README for more details).")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -62,7 +62,7 @@ trait BitcoindService extends Logging {
 
   val PATH_BITCOIND = sys.env.get("BITCOIND_DIR") match {
     case Some(customBitcoinDir) => new File(customBitcoinDir, "bitcoind")
-    case None => new File(TestUtils.BUILD_DIRECTORY, "bitcoin-26.1/bin/bitcoind")
+    case None => new File(TestUtils.BUILD_DIRECTORY, "bitcoin-27.1/bin/bitcoind")
   }
   logger.info(s"using bitcoind: $PATH_BITCOIND")
   val PATH_BITCOIND_DATADIR = new File(INTEGRATION_TMP_DIR, "datadir-bitcoin")


### PR DESCRIPTION
Bitcoin Core 27.1 adds the coingrinder coin selection algorithm which will help lower on-chain fees during feerate spikes.

  
