### PR TITLE
(Minor) Log local inputs in interactive-tx

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -451,7 +451,10 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
     session.toSend match {
       case (addInput: Input) +: tail =>
         val message = addInput match {
-          case i: Input.Local => TxAddInput(fundingParams.channelId, i.serialId, Some(i.previousTx), i.previousTxOutput, i.sequence)
+          case i: Input.Local =>
+            // for debugging wallet locking issues, it is useful to log local utxos
+            log.info(s"adding local input ${i.previousTx.txid}:${i.previousTxOutput}")
+            TxAddInput(fundingParams.channelId, i.serialId, Some(i.previousTx), i.previousTxOutput, i.sequence)
           case i: Input.Shared => TxAddInput(fundingParams.channelId, i.serialId, i.outPoint, i.sequence)
         }
         replyTo ! SendMessage(sessionId, message)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -453,7 +453,7 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
         val message = addInput match {
           case i: Input.Local =>
             // for debugging wallet locking issues, it is useful to log local utxos
-            log.info(s"adding local input ${i.previousTx.txid}:${i.previousTxOutput}")
+            log.info(s"adding local input ${i.previousTx.txid}:${i.previousTxOutput} to interactive-tx")
             TxAddInput(fundingParams.channelId, i.serialId, Some(i.previousTx), i.previousTxOutput, i.sequence)
           case i: Input.Shared => TxAddInput(fundingParams.channelId, i.serialId, i.outPoint, i.sequence)
         }


### PR DESCRIPTION
We do log all incoming/outgoing messages, including `TxAddInput`, but the `toString()` prints the whole serialized tx, not the txid, making grepping more difficult.