### PR TITLE
Fix flaky test for punishing a published revoked commit

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
@@ -626,13 +626,13 @@ class StandardChannelIntegrationSpec extends ChannelIntegrationSpec {
     bitcoinClient.publishTransaction(htlcSuccess.head).pipeTo(sender.ref)
     sender.expectMsgType[Any] match {
       case txid: TxId => assert(txid == htlcSuccess.head.txid)
-      // 3rd stage txs (txs spending htlc txs) are not tested if C publishes htlc-success before F
+      // 3rd stage txs (txs spending htlc txs) are not tested if C publishes the htlc-penalty transaction before F publishes its htlc-success
       case Failure(e: JsonRPCError) => assert(e.error.message == "txn-mempool-conflict")
     }
     bitcoinClient.publishTransaction(htlcTimeout.head).pipeTo(sender.ref)
     sender.expectMsgType[Any] match {
       case txid: TxId => assert(txid == htlcTimeout.head.txid)
-      // 3rd stage txs (txs spending htlc txs) are not tested if C publishes htlc-fail before F
+      // 3rd stage txs (txs spending htlc txs) are not tested if C publishes the htlc-penalty transaction before F publishes its htlc-timeout
       case Failure(e: JsonRPCError) => assert(e.error.message == "txn-mempool-conflict")
     }
     // at this point C should have 5 recv transactions: F's main output and all htlc outputs (taken as punishment)


### PR DESCRIPTION
Fix flaky test for punishing a published revoked commit

A race exists because node C can publish the txs to spend the htlcs from the revoked commitment *before* F publishes their txs to spend two of the htlc outputs. 

 Instead we handle the rare case of a `txn-mempool-conflict` failure. 
 
 We will sometimes miss testing that C claims those two htlcs via 3rd stage txs.