### PR TITLE
Monitor onion messages

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
@@ -28,9 +28,9 @@ object Monitoring {
 
     val ReconnectionsAttempts = Kamon.counter("reconnections.attempts")
 
-    val OnionMessagesReceived = Kamon.counter("onionmessages.received")
     val OnionMessagesSent = Kamon.counter("onionmessages.sent")
     val OnionMessagesThrottled = Kamon.counter("onionmessages.throttled")
+    val OnionMessagesNotRelayed = Kamon.counter("onionmessages.not-relayed")
 
     val OpenChannelRequestsPending = Kamon.gauge("openchannelrequests.pending")
 
@@ -51,6 +51,19 @@ object Monitoring {
 
     val PublicPeers = "public"
 
+    val Direction = "direction"
+    object Directions {
+      val Incoming = "IN"
+      val Outgoing = "OUT"
+    }
+
+    val Reason = "reason"
+    object Reasons {
+      val UnknownNextNodeId = "UnknownNextNodeId"
+      val NoChannelWithPreviousPeer = "NoChannelWithPreviousPeer"
+      val NoChannelWithNextPeer = "NoChannelWithNextPeer"
+      val ConnectionFailure = "ConnectionFailure"
+    }
   }
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Monitoring.scala
@@ -28,7 +28,7 @@ object Monitoring {
 
     val ReconnectionsAttempts = Kamon.counter("reconnections.attempts")
 
-    val OnionMessagesSent = Kamon.counter("onionmessages.sent")
+    val OnionMessagesProcessed = Kamon.counter("onionmessages.processed")
     val OnionMessagesThrottled = Kamon.counter("onionmessages.throttled")
     val OnionMessagesNotRelayed = Kamon.counter("onionmessages.not-relayed")
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -182,14 +182,14 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
           d.transport ! TransportHandler.ReadAck(msg)
           if (incomingRateLimiter.tryAcquire()) {
             d.peer ! msg
-            Metrics.OnionMessagesSent.withTag(Tags.Direction, Tags.Directions.Incoming).increment()
+            Metrics.OnionMessagesProcessed.withTag(Tags.Direction, Tags.Directions.Incoming).increment()
           } else {
             Metrics.OnionMessagesThrottled.withTag(Tags.Direction, Tags.Directions.Incoming).increment()
           }
         } else {
           if (outgoingRateLimiter.tryAcquire()) {
             d.transport forward msg
-            Metrics.OnionMessagesSent.withTag(Tags.Direction, Tags.Directions.Outgoing).increment()
+            Metrics.OnionMessagesProcessed.withTag(Tags.Direction, Tags.Directions.Outgoing).increment()
             if (!d.isPersistent) {
               startSingleTimer(KILL_IDLE_TIMER, KillIdle, conf.killIdleDelay)
             }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -182,19 +182,19 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
           d.transport ! TransportHandler.ReadAck(msg)
           if (incomingRateLimiter.tryAcquire()) {
             d.peer ! msg
-            Metrics.OnionMessagesReceived.withoutTags().increment()
+            Metrics.OnionMessagesSent.withTag(Tags.Direction, Tags.Directions.Incoming).increment()
           } else {
-            Metrics.OnionMessagesThrottled.withoutTags().increment()
+            Metrics.OnionMessagesThrottled.withTag(Tags.Direction, Tags.Directions.Incoming).increment()
           }
         } else {
           if (outgoingRateLimiter.tryAcquire()) {
             d.transport forward msg
-            Metrics.OnionMessagesSent.withoutTags().increment()
+            Metrics.OnionMessagesSent.withTag(Tags.Direction, Tags.Directions.Outgoing).increment()
             if (!d.isPersistent) {
               startSingleTimer(KILL_IDLE_TIMER, KillIdle, conf.killIdleDelay)
             }
           } else {
-            Metrics.OnionMessagesThrottled.withoutTags().increment()
+            Metrics.OnionMessagesThrottled.withTag(Tags.Direction, Tags.Directions.Outgoing).increment()
           }
         }
         stay()


### PR DESCRIPTION
Improve metrics for for onion messages.
We count messages sent and received, throttled and that couldn't be relayed.