### PR TITLE
Activate route blinding and quiescence features

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -68,10 +68,10 @@ eclair {
     // Do not enable option_anchor_outputs unless you really know what you're doing.
     option_anchor_outputs = disabled
     option_anchors_zero_fee_htlc_tx = optional
-    option_route_blinding = disabled
+    option_route_blinding = optional
     option_shutdown_anysegwit = optional
     option_dual_fund = optional
-    option_quiesce = disabled
+    option_quiesce = optional
     option_onion_messages = optional
     option_channel_type = optional
     option_scid_alias = optional


### PR DESCRIPTION
We support those two features and they have been added to the BOLTs. We start advertising that we support them by default. Having `route_blinding` disabled by default means we won't relay blinded payments unless they're using trampoline, which is an issue.