### PR TITLE
Upgrade kamon to 2.7.3

### DIFF
--- a/eclair-front/pom.xml
+++ b/eclair-front/pom.xml
@@ -108,6 +108,13 @@
             <groupId>io.kamon</groupId>
             <artifactId>kamon-prometheus_${scala.version.short}</artifactId>
             <version>${kamon.version}</version>
+            <!-- depends on a old version of okhttp that depends on kotlin 1.6, which conflicts with kotlin 1.9 -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- agents -->
         <dependency>

--- a/eclair-node/pom.xml
+++ b/eclair-node/pom.xml
@@ -123,7 +123,7 @@
             <groupId>io.kamon</groupId>
             <artifactId>kamon-prometheus_${scala.version.short}</artifactId>
             <version>${kamon.version}</version>
-            <!-- depends on a old version of okhttp that depends on kotlin 1.5, which conflicts with kotlin 1.9 -->
+            <!-- depends on a old version of okhttp that depends on kotlin 1.6, which conflicts with kotlin 1.9 -->
             <exclusions>
                 <exclusion>
                     <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <sttp.version>3.8.16</sttp.version>
         <bitcoinlib.version>0.33</bitcoinlib.version>
         <guava.version>32.1.1-jre</guava.version>
-        <kamon.version>2.6.3</kamon.version>
+        <kamon.version>2.7.3</kamon.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Also add an exclusion on kamon-prometheus. The exclusion was previously only present in `eclair-node/pom.xml`.