### PR TITLE
Add logs to onion message relay

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Logs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Logs.scala
@@ -50,6 +50,7 @@ object Logs {
           paymentId_opt: Option[UUID] = None,
           paymentHash_opt: Option[ByteVector32] = None,
           txPublishId_opt: Option[UUID] = None,
+          messageId_opt: Option[ByteVector32] = None,
           nodeAlias_opt: Option[String] = None): Map[String, String] =
     Seq(
       // nb: we preformat MDC values so that there is no white spaces in logs when they are not defined
@@ -60,6 +61,7 @@ object Logs {
       paymentId_opt.map(i => "paymentId" -> s" i:$i"),
       paymentHash_opt.map(h => "paymentHash" -> s" h:$h"),
       txPublishId_opt.map(t => "txPublishId" -> s" t:$t"),
+      messageId_opt.map(m => "messageId" -> s" m:$m"),
       nodeAlias_opt.map(a => "nodeAlias" -> s" a:$a"),
     ).flatten.toMap
 
@@ -105,6 +107,10 @@ object Logs {
       override def category: String = "SYN"
     }
 
+    case object MESSAGE extends LogCategory {
+      override def category: String = "MSG"
+    }
+
     case object PAYMENT extends LogCategory {
       override def category: String = "PAY"
     }
@@ -132,6 +138,8 @@ object Logs {
         case _: RoutingMessage => Some(LogCategory.ROUTING_SYNC)
         case TickBroadcast => Some(LogCategory.ROUTING_SYNC)
         case TickPruneStaleChannels => Some(LogCategory.ROUTING_SYNC)
+
+        case _: OnionMessage => Some(LogCategory.MESSAGE)
 
         case _: HandshakeCompleted => Some(LogCategory.CONNECTION)
         case _: Peer.Connect => Some(LogCategory.CONNECTION)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/MessageRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/MessageRelay.scala
@@ -126,6 +126,7 @@ private class MessageRelay(nodeParams: NodeParams,
         replyTo_opt.foreach(_ ! UnknownChannel(messageId, channelId))
         Behaviors.stopped
       case WrappedOptionalNodeId(Some(nextNodeId)) =>
+        log.info("found outgoing node {} for channel {}", nextNodeId, channelId)
         withNextNodeId(msg, nextNodeId)
     }
   }
@@ -151,7 +152,6 @@ private class MessageRelay(nodeParams: NodeParams,
           switchboard ! GetPeerInfo(context.messageAdapter(WrappedPeerInfo), prevNodeId)
           waitForPreviousPeerForPolicyCheck(msg, nextNodeId)
         case RelayAll =>
-          log.info("connecting to {} to relay onion message", nextNodeId)
           switchboard ! Peer.Connect(nextNodeId, None, context.messageAdapter(WrappedConnectionResult).toClassic, isPersistent = false)
           waitForConnection(msg, nextNodeId)
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -284,9 +284,10 @@ class Peer(val nodeParams: NodeParams,
       case Event(msg: OnionMessage, _: ConnectedData) =>
         OnionMessages.process(nodeParams.privateKey, msg) match {
           case OnionMessages.DropMessage(reason) =>
-            log.debug("dropping message from {}: {}", remoteNodeId.value.toHex, reason.toString)
+            log.info("dropping message from {}: {}", remoteNodeId.value.toHex, reason.toString)
           case OnionMessages.SendMessage(nextNode, message) if nodeParams.features.hasFeature(Features.OnionMessages) =>
             val messageId = randomBytes32()
+            log.info("relaying onion message with messageId={}", messageId)
             val relay = context.spawn(Behaviors.supervise(MessageRelay(nodeParams, switchboard, register, router)).onFailure(typed.SupervisorStrategy.stop), s"relay-message-$messageId")
             relay ! MessageRelay.RelayMessage(messageId, remoteNodeId, nextNode, message, nodeParams.onionMessageConfig.relayPolicy, None)
           case OnionMessages.SendMessage(_, _) =>


### PR DESCRIPTION
There weren't any logs when relaying onion messages, which makes it impossible to troubleshoot. While we're working on cross-compatibility, we keep those logs at the `INFO` level, and will change some of them to `DEBUG` once stabilized.