### PR TITLE
Update to select funding inputs before sending open_channel2 and splice_init and add excess to requests  

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -525,6 +525,8 @@ object SpliceStatus {
   case class SpliceRequested(cmd: CMD_SPLICE, init: SpliceInit, fundingContributions_opt: Option[InteractiveTxFunder.FundingContributions]) extends SpliceStatus
   /** We told our peer we want to RBF the latest splice transaction. */
   case class RbfRequested(cmd: CMD_BUMP_FUNDING_FEE, rbf: TxInitRbf) extends SpliceStatus
+  /** Our peer initiated a spice */
+  case class SpliceInitiated(init: SpliceInit, willFund_opt: Option[LiquidityAds.WillFundPurchase]) extends SpliceStatus
   /** We both agreed to splice/rbf and are building the corresponding transaction. */
   case class SpliceInProgress(cmd_opt: Option[ChannelFundingCommand], sessionId: ByteVector32, splice: typed.ActorRef[InteractiveTxBuilder.Command], remoteCommitSig: Option[CommitSig]) extends SpliceStatus
   /** The splice transaction has been negotiated, we're exchanging signatures. */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -22,7 +22,7 @@ import fr.acinq.bitcoin.scalacompat.{ByteVector32, DeterministicWallet, OutPoint
 import fr.acinq.eclair.blockchain.fee.{ConfirmationTarget, FeeratePerKw}
 import fr.acinq.eclair.channel.LocalFundingStatus.DualFundedUnconfirmedFundingTx
 import fr.acinq.eclair.channel.fund.InteractiveTxBuilder._
-import fr.acinq.eclair.channel.fund.{InteractiveTxBuilder, InteractiveTxSigningSession}
+import fr.acinq.eclair.channel.fund.{InteractiveTxBuilder, InteractiveTxFunder, InteractiveTxSigningSession}
 import fr.acinq.eclair.io.Peer
 import fr.acinq.eclair.transactions.CommitmentSpec
 import fr.acinq.eclair.transactions.Transactions._
@@ -62,6 +62,7 @@ case object WAIT_FOR_FUNDING_CONFIRMED extends ChannelState
 case object WAIT_FOR_CHANNEL_READY extends ChannelState
 // Dual-funded channel opening:
 case object WAIT_FOR_INIT_DUAL_FUNDED_CHANNEL extends ChannelState
+case object WAIT_FOR_DUAL_FUNDING_INTERNAL extends ChannelState
 case object WAIT_FOR_OPEN_DUAL_FUNDED_CHANNEL extends ChannelState
 case object WAIT_FOR_ACCEPT_DUAL_FUNDED_CHANNEL extends ChannelState
 case object WAIT_FOR_DUAL_FUNDING_CREATED extends ChannelState
@@ -521,7 +522,7 @@ object SpliceStatus {
   /** The channel is quiescent, we wait for our peer to send splice_init or tx_init_rbf. */
   case object NonInitiatorQuiescent extends SpliceStatus
   /** We told our peer we want to splice funds in the channel. */
-  case class SpliceRequested(cmd: CMD_SPLICE, init: SpliceInit) extends SpliceStatus
+  case class SpliceRequested(cmd: CMD_SPLICE, init: SpliceInit, fundingContributions_opt: Option[InteractiveTxFunder.FundingContributions]) extends SpliceStatus
   /** We told our peer we want to RBF the latest splice transaction. */
   case class RbfRequested(cmd: CMD_BUMP_FUNDING_FEE, rbf: TxInitRbf) extends SpliceStatus
   /** We both agreed to splice/rbf and are building the corresponding transaction. */
@@ -598,10 +599,14 @@ final case class DATA_WAIT_FOR_FUNDING_CONFIRMED(commitments: Commitments,
 }
 final case class DATA_WAIT_FOR_CHANNEL_READY(commitments: Commitments, aliases: ShortIdAliases) extends ChannelDataWithCommitments
 
+final case class DATA_WAIT_FOR_DUAL_FUNDING_INTERNAL(input: INPUT_INIT_CHANNEL_INITIATOR) extends TransientChannelData {
+  val channelId: ByteVector32 = input.temporaryChannelId
+}
+
 final case class DATA_WAIT_FOR_OPEN_DUAL_FUNDED_CHANNEL(init: INPUT_INIT_CHANNEL_NON_INITIATOR) extends TransientChannelData {
   val channelId: ByteVector32 = init.temporaryChannelId
 }
-final case class DATA_WAIT_FOR_ACCEPT_DUAL_FUNDED_CHANNEL(init: INPUT_INIT_CHANNEL_INITIATOR, lastSent: OpenDualFundedChannel) extends TransientChannelData {
+final case class DATA_WAIT_FOR_ACCEPT_DUAL_FUNDED_CHANNEL(init: INPUT_INIT_CHANNEL_INITIATOR, lastSent: OpenDualFundedChannel, fundingContributions: InteractiveTxFunder.FundingContributions) extends TransientChannelData {
   val channelId: ByteVector32 = lastSent.temporaryChannelId
 }
 final case class DATA_WAIT_FOR_DUAL_FUNDING_CREATED(channelId: ByteVector32,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -21,7 +21,7 @@ import akka.actor.typed.scaladsl.adapter.{ClassicActorContextOps, actorRefAdapte
 import akka.actor.{Actor, ActorContext, ActorRef, FSM, OneForOneStrategy, PossiblyHarmful, Props, SupervisorStrategy, typed}
 import akka.event.Logging.MDC
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, SatoshiLong, Transaction, TxId}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, SatoshiLong, Script, Transaction, TxId}
 import fr.acinq.eclair.Logs.LogCategory
 import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.OnChainWallet.MakeFundingTxResponse
@@ -979,7 +979,25 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
                     context.system.scheduler.scheduleOnce(2 second, peer, Peer.Disconnect(remoteNodeId))
                     stay() using d.copy(spliceStatus = SpliceStatus.NoSplice) sending Warning(d.channelId, f.getMessage)
                   case Right(spliceInit) =>
-                    stay() using d.copy(spliceStatus = SpliceStatus.SpliceRequested(cmd, spliceInit)) sending spliceInit
+                    val parentCommitment = d.commitments.latest.commitment
+                    val fundingParams = InteractiveTxParams(
+                      channelId = spliceInit.channelId,
+                      isInitiator = true,
+                      localContribution = spliceInit.fundingContribution,
+                      remoteContribution = 0 sat,
+                      sharedInput_opt = Some(Multisig2of2Input(parentCommitment)),
+                      remoteFundingPubKey = Transactions.PlaceHolderPubKey,
+                      localOutputs = cmd.spliceOutputs,
+                      lockTime = nodeParams.currentBlockHeight.toLong,
+                      dustLimit = d.commitments.params.localParams.dustLimit,
+                      targetFeerate = spliceInit.feerate,
+                      // Assume our peer requires confirmed inputs when we initiate a splice.
+                      requireConfirmedInputs = RequireConfirmedInputs(forLocal = true, forRemote = nodeParams.channelConf.requireConfirmedInputsForDualFunding)
+                    )
+                    val dummyFundingPubkeyScript = Script.write(Script.pay2wsh(Scripts.multiSig2of2(Transactions.PlaceHolderPubKey, Transactions.PlaceHolderPubKey)))
+                    val txFunder = context.spawnAnonymous(InteractiveTxFunder(remoteNodeId, fundingParams, dummyFundingPubkeyScript, purpose = InteractiveTxBuilder.SpliceTx(parentCommitment, d.commitments.changes), wallet))
+                    txFunder ! InteractiveTxFunder.FundTransaction(self)
+                    stay() using d.copy(spliceStatus = SpliceStatus.SpliceRequested(cmd, spliceInit, None))
                 }
                 case cmd: CMD_BUMP_FUNDING_FEE => initiateSpliceRbf(cmd, d) match {
                   case Left(f) =>
@@ -1004,6 +1022,28 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
         // NB: we use a small delay to ensure we've sent our warning before disconnecting.
         context.system.scheduler.scheduleOnce(2 second, peer, Peer.Disconnect(remoteNodeId))
         stay() using d.copy(spliceStatus = SpliceStatus.NoSplice) sending Warning(d.channelId, InvalidSpliceNotQuiescent(d.channelId).getMessage)
+      }
+
+    case Event(msg: InteractiveTxFunder.Response, d: DATA_NORMAL) =>
+      d.spliceStatus match {
+        case SpliceStatus.SpliceRequested(cmd, spliceInit, _) =>
+          msg match {
+            case InteractiveTxFunder.FundingFailed =>
+              cmd.replyTo ! RES_FAILURE(cmd, ChannelFundingError(d.channelId))
+              stay() using d.copy(spliceStatus = SpliceStatus.NoSplice) calling endQuiescence(d)
+            case fundingContributions: InteractiveTxFunder.FundingContributions =>
+              val spliceInit1 = spliceInit.copy(fundingContribution = spliceInit.fundingContribution + fundingContributions.excess_opt.getOrElse(0 sat))
+              stay() using d.copy(spliceStatus = SpliceStatus.SpliceRequested(cmd, spliceInit1, Some(fundingContributions))) sending spliceInit1
+          }
+        case _ =>
+          msg match {
+            case InteractiveTxFunder.FundingFailed =>
+              log.warning("received unexpected response from txFunder: {}, current splice status is {}.", msg, d.spliceStatus)
+            case fundingContributions: InteractiveTxFunder.FundingContributions =>
+              log.warning("received unexpected response from txFunder: {}, current splice status is {}. Rolling back funding contributions.", msg, d.spliceStatus)
+              rollbackOpenAttempt(fundingContributions)
+          }
+          stay()
       }
 
     case Event(_: QuiescenceTimeout, d: DATA_NORMAL) => handleQuiescenceTimeout(d)
@@ -1063,6 +1103,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
                   purpose = InteractiveTxBuilder.SpliceTx(parentCommitment, d.commitments.changes),
                   localPushAmount = spliceAck.pushAmount, remotePushAmount = msg.pushAmount,
                   liquidityPurchase_opt = willFund_opt.map(_.purchase),
+                  None,
                   wallet
                 ))
                 txBuilder ! InteractiveTxBuilder.Start(self)
@@ -1082,7 +1123,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
 
     case Event(msg: SpliceAck, d: DATA_NORMAL) =>
       d.spliceStatus match {
-        case SpliceStatus.SpliceRequested(cmd, spliceInit) =>
+        case SpliceStatus.SpliceRequested(cmd, spliceInit, fundingContributions_opt) =>
           log.info("our peer accepted our splice request and will contribute {} to the funding transaction", msg.fundingContribution)
           val parentCommitment = d.commitments.latest.commitment
           val fundingParams = InteractiveTxParams(
@@ -1113,6 +1154,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
                 purpose = InteractiveTxBuilder.SpliceTx(parentCommitment, d.commitments.changes),
                 localPushAmount = cmd.pushAmount, remotePushAmount = msg.pushAmount,
                 liquidityPurchase_opt = liquidityPurchase_opt,
+                fundingContributions_opt = fundingContributions_opt,
                 wallet
               ))
               txBuilder ! InteractiveTxBuilder.Start(self)
@@ -1181,6 +1223,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
                     purpose = rbf,
                     localPushAmount = 0 msat, remotePushAmount = 0 msat,
                     willFund_opt.map(_.purchase),
+                    None,
                     wallet
                   ))
                   txBuilder ! InteractiveTxBuilder.Start(self)
@@ -1234,6 +1277,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
                     purpose = rbf,
                     localPushAmount = 0 msat, remotePushAmount = 0 msat,
                     liquidityPurchase_opt = liquidityPurchase_opt,
+                    None,
                     wallet
                   ))
                   txBuilder ! InteractiveTxBuilder.Start(self)
@@ -1259,9 +1303,14 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
           log.info("our peer aborted the splice attempt: ascii='{}' bin={}", msg.toAscii, msg.data)
           rollbackFundingAttempt(signingSession.fundingTx.tx, previousTxs = Seq.empty) // no splice rbf yet
           stay() using d.copy(spliceStatus = SpliceStatus.NoSplice) sending TxAbort(d.channelId, SpliceAttemptAborted(d.channelId).getMessage) calling endQuiescence(d)
-        case SpliceStatus.SpliceRequested(cmd, _) =>
+        case SpliceStatus.SpliceRequested(_, _, None) =>
+          log.info("our peer aborted the splice attempt: ascii='{}' bin={}", msg.toAscii, msg.data)
+          // Our pending funding attempt will be rolled back if it succeeds.
+          stay() using d.copy(spliceStatus = SpliceStatus.NoSplice) sending TxAbort(d.channelId, SpliceAttemptAborted(d.channelId).getMessage) calling endQuiescence(d)
+        case SpliceStatus.SpliceRequested(cmd, _, fundingContributions_opt) =>
           log.info("our peer rejected our splice attempt: ascii='{}' bin={}", msg.toAscii, msg.data)
           cmd.replyTo ! RES_FAILURE(cmd, new RuntimeException(s"splice attempt rejected by our peer: ${msg.toAscii}"))
+          fundingContributions_opt.foreach(rollbackOpenAttempt)
           stay() using d.copy(spliceStatus = SpliceStatus.NoSplice) sending TxAbort(d.channelId, SpliceAttemptAborted(d.channelId).getMessage) calling endQuiescence(d)
         case SpliceStatus.RbfRequested(cmd, _) =>
           log.info("our peer rejected our rbf attempt: ascii='{}' bin={}", msg.toAscii, msg.data)
@@ -3345,13 +3394,19 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
   }
 
   private def handleQuiescenceTimeout(d: DATA_NORMAL): State = {
-    if (d.spliceStatus == SpliceStatus.NoSplice) {
-      log.warning("quiescence timed out with no ongoing splice, did we forget to cancel the timer?")
-      stay()
-    } else {
-      log.warning("quiescence timed out in state {}, closing connection", d.spliceStatus.getClass.getSimpleName)
-      context.system.scheduler.scheduleOnce(2 second, peer, Peer.Disconnect(remoteNodeId))
-      stay() sending Warning(d.channelId, SpliceAttemptTimedOut(d.channelId).getMessage)
+    d.spliceStatus match {
+      case SpliceStatus.NoSplice =>
+        log.warning("quiescence timed out with no ongoing splice, did we forget to cancel the timer?")
+        stay()
+      case SpliceStatus.SpliceRequested(_, _, Some(fundingContributions)) =>
+        log.warning("quiescence timed out after sending splice request, rolling back funding contributions and closing connection")
+        rollbackOpenAttempt(fundingContributions)
+        context.system.scheduler.scheduleOnce(2 second, peer, Peer.Disconnect(remoteNodeId))
+        stay() sending Warning(d.channelId, SpliceAttemptTimedOut(d.channelId).getMessage)
+      case _ =>
+        log.warning("quiescence timed out in state {}, closing connection", d.spliceStatus.getClass.getSimpleName)
+        context.system.scheduler.scheduleOnce(2 second, peer, Peer.Disconnect(remoteNodeId))
+        stay() sending Warning(d.channelId, SpliceAttemptTimedOut(d.channelId).getMessage)
     }
   }
 
@@ -3367,7 +3422,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
   private def reportSpliceFailure(spliceStatus: SpliceStatus, f: Throwable): Unit = {
     val cmd_opt = spliceStatus match {
       case SpliceStatus.NegotiatingQuiescence(cmd_opt, _) => cmd_opt
-      case SpliceStatus.SpliceRequested(cmd, _) => Some(cmd)
+      case SpliceStatus.SpliceRequested(cmd, _, _) => Some(cmd)
       case SpliceStatus.RbfRequested(cmd, _) => Some(cmd)
       case SpliceStatus.SpliceInProgress(cmd_opt, _, txBuilder, _) =>
         txBuilder ! InteractiveTxBuilder.Abort

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerReadyNotifier.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerReadyNotifier.scala
@@ -180,6 +180,7 @@ object PeerReadyNotifier {
     case channel.WAIT_FOR_INIT_INTERNAL => false
     case channel.WAIT_FOR_INIT_SINGLE_FUNDED_CHANNEL => false
     case channel.WAIT_FOR_INIT_DUAL_FUNDED_CHANNEL => false
+    case channel.WAIT_FOR_DUAL_FUNDING_INTERNAL => false
     case channel.OFFLINE => false
     case channel.SYNCING => false
     case channel.WAIT_FOR_OPEN_CHANNEL => true

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -18,6 +18,7 @@ package fr.acinq.eclair
 
 import akka.actor.ActorRef
 import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, Satoshi, SatoshiLong}
+import fr.acinq.eclair.blockchain.DummyOnChainWallet
 import fr.acinq.eclair.blockchain.fee._
 import fr.acinq.eclair.channel.fsm.Channel.{ChannelConf, RemoteRbfLimits, UnhandledExceptionStrategy}
 import fr.acinq.eclair.channel.{ChannelFlags, LocalParams, Origin, Upstream}
@@ -53,7 +54,8 @@ object TestConstants {
   val feeratePerKw: FeeratePerKw = FeeratePerKw(10_000 sat)
   val anchorOutputsFeeratePerKw: FeeratePerKw = FeeratePerKw(2_500 sat)
   val defaultLiquidityRates: LiquidityAds.WillFundRates = LiquidityAds.WillFundRates(
-    fundingRates = LiquidityAds.FundingRate(100_000 sat, 10_000_000 sat, 500, 100, 100 sat, 1000 sat) :: Nil,
+    fundingRates = LiquidityAds.FundingRate(100_000 sat, 10_000_000 sat, 500, 100, 100 sat, 1000 sat) ::
+      LiquidityAds.FundingRate(DummyOnChainWallet.invalidFundingAmount, DummyOnChainWallet.invalidFundingAmount+1.sat, 500, 100, 100 sat, 1000 sat) :: Nil,
     paymentTypes = Set(LiquidityAds.PaymentType.FromChannelBalance)
   )
   val emptyOnionPacket: OnionRoutingPacket = OnionRoutingPacket(0, ByteVector.fill(33)(0), ByteVector.fill(1300)(0), ByteVector32.Zeroes)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
@@ -198,7 +198,7 @@ class SingleKeyOnChainWallet extends OnChainWallet with OnChainPubkeyCache {
     val excess = if (amountOut - currentAmountIn == 100_000.sat) 1_000.sat else 0.sat
     val fee = Transactions.weight2fee(feeRate, dummySignedTx.weight() + externalInputsWeight.values.sum.toInt)
     // We add a single input to reach the desired feerate.
-    val inputAmount1 = if (changeless) amountOut + fee + excess else inputAmount
+    val inputAmount1 = if (changeless) amountOut + fee + excess - currentAmountIn else inputAmount
     val inputTx1 = Transaction(2, Seq(TxIn(OutPoint(randomTxId(), 1), Nil, 0)), Seq(TxOut(inputAmount1, script)), 0)
     inputs = inputs :+ inputTx1
     feeBudget_opt match {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
@@ -176,9 +176,10 @@ class SingleKeyOnChainWallet extends OnChainWallet with OnChainPubkeyCache {
 
   override def getP2wpkhPubkey()(implicit ec: ExecutionContext): Future[Crypto.PublicKey] = Future.successful(p2wpkhPublicKey)
 
-  override def fundTransaction(tx: Transaction, feeRate: FeeratePerKw, replaceable: Boolean, changePosition: Option[Int], externalInputsWeight: Map[OutPoint, Long], minInputConfirmations_opt: Option[Int], feeBudget_opt: Option[Satoshi])(implicit ec: ExecutionContext): Future[FundTransactionResponse] = synchronized {
+  def createFundedTx(tx: Transaction, feeRate: FeeratePerKw, replaceable: Boolean, changePosition: Option[Int], externalInputsWeight: Map[OutPoint, Long], minInputConfirmations_opt: Option[Int], feeBudget_opt: Option[Satoshi], changeless: Boolean): Either[Exception, FundTransactionResponse] = {
     val currentAmountIn = tx.txIn.flatMap(txIn => inputs.find(_.txid == txIn.outPoint.txid).flatMap(_.txOut.lift(txIn.outPoint.index.toInt))).map(_.amount).sum
     val amountOut = tx.txOut.map(_.amount).sum
+    if (amountOut >= DummyOnChainWallet.invalidFundingAmount) return Left(new RuntimeException(s"invalid funding amount"))
     // We add a single input to reach the desired feerate.
     val inputAmount = amountOut + 100_000.sat
     // We randomly use either p2wpkh or p2tr.
@@ -186,24 +187,39 @@ class SingleKeyOnChainWallet extends OnChainWallet with OnChainPubkeyCache {
     val dummyP2wpkhWitness = Script.witnessPay2wpkh(p2wpkhPublicKey, ByteVector.fill(73)(0))
     val dummyP2trWitness = Script.witnessKeyPathPay2tr(ByteVector64.Zeroes)
     val inputTx = Transaction(2, Seq(TxIn(OutPoint(randomTxId(), 1), Nil, 0)), Seq(TxOut(inputAmount, script)), 0)
-    inputs = inputs :+ inputTx
     val dummySignedTx = tx.copy(
       txIn = tx.txIn.filterNot(i => externalInputsWeight.contains(i.outPoint)).appended(TxIn(OutPoint(inputTx, 0), ByteVector.empty, 0, ScriptWitness.empty)).map(txIn => {
         val isP2tr = inputs.find(_.txid == txIn.outPoint.txid).map(_.txOut(txIn.outPoint.index.toInt).publicKeyScript).map(Script.parse).exists(Script.isPay2tr)
         txIn.copy(witness = if (isP2tr) dummyP2trWitness else dummyP2wpkhWitness)
       }),
-      txOut = tx.txOut :+ TxOut(inputAmount, script),
+      txOut = if (changeless) tx.txOut else tx.txOut :+ TxOut(inputAmount, script)
     )
+    // When funding an output of exactly 100_000 sats, we add excess of exactly 1_000 sats to a changeless funding request.
+    val excess = if (amountOut - currentAmountIn == 100_000.sat) 1_000.sat else 0.sat
     val fee = Transactions.weight2fee(feeRate, dummySignedTx.weight() + externalInputsWeight.values.sum.toInt)
+    // We add a single input to reach the desired feerate.
+    val inputAmount1 = if (changeless) amountOut + fee + excess else inputAmount
+    val inputTx1 = Transaction(2, Seq(TxIn(OutPoint(randomTxId(), 1), Nil, 0)), Seq(TxOut(inputAmount1, script)), 0)
+    inputs = inputs :+ inputTx1
     feeBudget_opt match {
-      case Some(feeBudget) if fee > feeBudget =>
-        Future.failed(new RuntimeException(s"mining fee is higher than budget ($fee > $feeBudget)"))
+      case Some(feeBudget) if fee > feeBudget => Left(new RuntimeException(s"mining fee is higher than budget ($fee > $feeBudget)"))
       case _ =>
         val fundedTx = tx.copy(
-          txIn = tx.txIn :+ TxIn(OutPoint(inputTx, 0), Nil, 0),
-          txOut = tx.txOut :+ TxOut(inputAmount + currentAmountIn - amountOut - fee, script),
+          txIn = tx.txIn :+ TxIn(OutPoint(inputTx1, 0), Nil, 0),
+          txOut = if (changeless) tx.txOut else tx.txOut :+ TxOut(inputAmount + currentAmountIn - amountOut - fee, script),
         )
-        Future.successful(FundTransactionResponse(fundedTx, fee, Some(tx.txOut.length)))
+        if (changeless) {
+          Right(FundTransactionResponse(fundedTx, fee + excess, None))
+        } else {
+          Right(FundTransactionResponse(fundedTx, fee, Some(tx.txOut.length)))
+        }
+    }
+  }
+
+  override def fundTransaction(tx: Transaction, feeRate: FeeratePerKw, replaceable: Boolean, changePosition: Option[Int], externalInputsWeight: Map[OutPoint, Long], minInputConfirmations_opt: Option[Int], feeBudget_opt: Option[Satoshi])(implicit ec: ExecutionContext): Future[FundTransactionResponse] = synchronized {
+    createFundedTx(tx, feeRate, replaceable, changePosition, externalInputsWeight, minInputConfirmations_opt, feeBudget_opt, changeless = false) match {
+      case Right(response) => Future.successful(response)
+      case Left(error) => Future.failed(error)
     }
   }
 
@@ -286,8 +302,22 @@ class SingleKeyOnChainWallet extends OnChainWallet with OnChainPubkeyCache {
   override def getReceivePublicKeyScript(renew: Boolean): Seq[ScriptElt] = p2trScript
 }
 
+class SingleKeyOnChainWalletWithConfirmedInputs extends SingleKeyOnChainWallet {
+  override def getTxConfirmations(txid: TxId)(implicit ec: ExecutionContext): Future[Option[Int]] = Future.successful(Some(6))
+}
+
+class ChangelessFundingWallet extends SingleKeyOnChainWallet {
+  override def fundTransaction(tx: Transaction, feeRate: FeeratePerKw, replaceable: Boolean, changePosition: Option[Int], externalInputsWeight: Map[OutPoint, Long], minInputConfirmations_opt: Option[Int], feeBudget_opt: Option[Satoshi])(implicit ec: ExecutionContext): Future[FundTransactionResponse] = synchronized {
+    createFundedTx(tx, feeRate, replaceable, changePosition, externalInputsWeight, minInputConfirmations_opt, feeBudget_opt, changeless = true) match {
+      case Right(response) => Future.successful(response)
+      case Left(error) => Future.failed(error)
+    }
+  }
+}
+
 object DummyOnChainWallet {
   val dummyReceivePubkey: PublicKey = PublicKey(hex"028feba10d0eafd0fad8fe20e6d9206e6bd30242826de05c63f459a00aced24b12")
+  val invalidFundingAmount: Satoshi = 2_100_000_000.sat
 
   def makeDummyFundingTx(pubkeyScript: ByteVector, amount: Satoshi): MakeFundingTxResponse = {
     val fundingTx = Transaction(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
@@ -127,6 +127,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       nodeParamsA, fundingParams, channelParamsA,
       FundingTx(commitFeerate, firstPerCommitmentPointB, feeBudget_opt = None),
       0 msat, 0 msat, liquidityPurchase_opt,
+      fundingContributions_opt = None,
       wallet))
 
     def spawnTxBuilderRbfAlice(fundingParams: InteractiveTxParams, commitment: Commitment, previousTransactions: Seq[InteractiveTxBuilder.SignedSharedTransaction], wallet: OnChainWallet): ActorRef[InteractiveTxBuilder.Command] = system.spawnAnonymous(InteractiveTxBuilder(
@@ -134,6 +135,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       nodeParamsA, fundingParams, channelParamsA,
       FundingTxRbf(commitment, previousTransactions, feeBudget_opt = None),
       0 msat, 0 msat, None,
+      fundingContributions_opt = None,
       wallet))
 
     def spawnTxBuilderSpliceAlice(fundingParams: InteractiveTxParams, commitment: Commitment, wallet: OnChainWallet, liquidityPurchase_opt: Option[LiquidityAds.Purchase] = None): ActorRef[InteractiveTxBuilder.Command] = system.spawnAnonymous(InteractiveTxBuilder(
@@ -141,6 +143,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       nodeParamsA, fundingParams, channelParamsA,
       SpliceTx(commitment, CommitmentChanges.init()),
       0 msat, 0 msat, liquidityPurchase_opt,
+      fundingContributions_opt = None,
       wallet))
 
     def spawnTxBuilderSpliceRbfAlice(fundingParams: InteractiveTxParams, parentCommitment: Commitment, latestFundingTx: LocalFundingStatus.DualFundedUnconfirmedFundingTx, previousTransactions: Seq[InteractiveTxBuilder.SignedSharedTransaction], wallet: OnChainWallet): ActorRef[InteractiveTxBuilder.Command] = system.spawnAnonymous(InteractiveTxBuilder(
@@ -148,6 +151,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       nodeParamsA, fundingParams, channelParamsA,
       SpliceTxRbf(parentCommitment, CommitmentChanges.init(), latestFundingTx, previousTransactions, feeBudget_opt = None),
       0 msat, 0 msat, None,
+      fundingContributions_opt = None,
       wallet))
 
     def spawnTxBuilderBob(wallet: OnChainWallet, fundingParams: InteractiveTxParams = fundingParamsB, liquidityPurchase_opt: Option[LiquidityAds.Purchase] = None): ActorRef[InteractiveTxBuilder.Command] = system.spawnAnonymous(InteractiveTxBuilder(
@@ -155,6 +159,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       nodeParamsB, fundingParams, channelParamsB,
       FundingTx(commitFeerate, firstPerCommitmentPointA, feeBudget_opt = None),
       0 msat, 0 msat, liquidityPurchase_opt,
+      fundingContributions_opt = None,
       wallet))
 
     def spawnTxBuilderRbfBob(fundingParams: InteractiveTxParams, commitment: Commitment, previousTransactions: Seq[InteractiveTxBuilder.SignedSharedTransaction], wallet: OnChainWallet): ActorRef[InteractiveTxBuilder.Command] = system.spawnAnonymous(InteractiveTxBuilder(
@@ -162,6 +167,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       nodeParamsB, fundingParams, channelParamsB,
       FundingTxRbf(commitment, previousTransactions, feeBudget_opt = None),
       0 msat, 0 msat, None,
+      fundingContributions_opt = None,
       wallet))
 
     def spawnTxBuilderSpliceBob(fundingParams: InteractiveTxParams, commitment: Commitment, wallet: OnChainWallet, liquidityPurchase_opt: Option[LiquidityAds.Purchase] = None): ActorRef[InteractiveTxBuilder.Command] = system.spawnAnonymous(InteractiveTxBuilder(
@@ -169,6 +175,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       nodeParamsB, fundingParams, channelParamsB,
       SpliceTx(commitment, CommitmentChanges.init()),
       0 msat, 0 msat, liquidityPurchase_opt,
+      fundingContributions_opt = None,
       wallet))
 
     def spawnTxBuilderSpliceRbfBob(fundingParams: InteractiveTxParams, parentCommitment: Commitment, latestFundingTx: LocalFundingStatus.DualFundedUnconfirmedFundingTx, previousTransactions: Seq[InteractiveTxBuilder.SignedSharedTransaction], wallet: OnChainWallet): ActorRef[InteractiveTxBuilder.Command] = system.spawnAnonymous(InteractiveTxBuilder(
@@ -176,6 +183,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       nodeParamsB, fundingParams, channelParamsB,
       SpliceTxRbf(parentCommitment, CommitmentChanges.init(), latestFundingTx, previousTransactions, feeBudget_opt = None),
       0 msat, 0 msat, None,
+      fundingContributions_opt = None,
       wallet))
 
     def exchangeSigsAliceFirst(fundingParams: InteractiveTxParams, successA: InteractiveTxBuilder.Succeeded, successB: InteractiveTxBuilder.Succeeded): (FullySignedSharedTransaction, Commitment, FullySignedSharedTransaction, Commitment) = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForFundingInternalDualFundedChannelStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/a/WaitForFundingInternalDualFundedChannelStateSpec.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.channel.states.a
+
+import akka.actor.Status
+import akka.actor.typed.scaladsl.adapter.ClassicActorRefOps
+import akka.testkit.{TestFSMRef, TestProbe}
+import fr.acinq.bitcoin.scalacompat.ByteVector32
+import fr.acinq.eclair.blockchain.NoOpOnChainWallet
+import fr.acinq.eclair.channel._
+import fr.acinq.eclair.channel.fsm.Channel
+import fr.acinq.eclair.channel.fsm.Channel.TickChannelOpenTimeout
+import fr.acinq.eclair.channel.fund.InteractiveTxFunder
+import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
+import fr.acinq.eclair.io.Peer.OpenChannelResponse
+import fr.acinq.eclair.wire.protocol._
+import fr.acinq.eclair.{TestConstants, TestKitBaseClass}
+import org.scalatest.Outcome
+import org.scalatest.funsuite.FixtureAnyFunSuiteLike
+
+import scala.concurrent.duration._
+
+class WaitForFundingInternalDualFundedChannelStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ChannelStateTestsBase {
+
+  case class FixtureParam(alice: TestFSMRef[ChannelState, ChannelData, Channel], aliceOpenReplyTo: TestProbe, alice2bob: TestProbe, listener: TestProbe)
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val setup = init(wallet_opt = Some(new NoOpOnChainWallet()), tags = test.tags + ChannelStateTestsTags.DualFunding)
+    import setup._
+    val channelConfig = ChannelConfig.standard
+    val channelFlags = ChannelFlags(announceChannel = false)
+    val (aliceParams, bobParams, channelType) = computeFeatures(setup, test.tags, channelFlags)
+    val bobInit = Init(bobParams.initFeatures)
+    val listener = TestProbe()
+    within(30 seconds) {
+      alice.underlying.system.eventStream.subscribe(listener.ref, classOf[ChannelAborted])
+      alice ! INPUT_INIT_CHANNEL_INITIATOR(ByteVector32.Zeroes, TestConstants.fundingSatoshis, dualFunded = true, TestConstants.feeratePerKw, TestConstants.feeratePerKw, fundingTxFeeBudget_opt = None, Some(TestConstants.initiatorPushAmount), requireConfirmedInputs = true, requestFunding_opt = None, aliceParams, alice2bob.ref, bobInit, channelFlags, channelConfig, channelType, replyTo = aliceOpenReplyTo.ref.toTyped)
+      withFixture(test.toNoArgTest(FixtureParam(alice, aliceOpenReplyTo, alice2bob, listener)))
+    }
+  }
+
+  test("recv Status.Failure (wallet error)") { f =>
+    import f._
+    awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_INTERNAL)
+    alice ! Status.Failure(new RuntimeException("insufficient funds"))
+    listener.expectMsgType[ChannelAborted]
+    awaitCond(alice.stateName == CLOSED)
+    aliceOpenReplyTo.expectMsgType[OpenChannelResponse.Rejected]
+  }
+
+  test("recv Error") { f =>
+    import f._
+    alice ! Error(ByteVector32.Zeroes, "oops")
+    listener.expectMsgType[ChannelAborted]
+    awaitCond(alice.stateName == CLOSED)
+    aliceOpenReplyTo.expectMsgType[OpenChannelResponse.RemoteError]
+  }
+
+  test("recv CMD_CLOSE") { f =>
+    import f._
+    val sender = TestProbe()
+    val c = CMD_CLOSE(sender.ref, None, None)
+    alice ! c
+    sender.expectMsg(RES_SUCCESS(c, ByteVector32.Zeroes))
+    listener.expectMsgType[ChannelAborted]
+    awaitCond(alice.stateName == CLOSED)
+    aliceOpenReplyTo.expectMsg(OpenChannelResponse.Cancelled)
+  }
+
+  test("recv INPUT_DISCONNECTED") { f =>
+    import f._
+    alice ! INPUT_DISCONNECTED
+    listener.expectMsgType[ChannelAborted]
+    awaitCond(alice.stateName == CLOSED)
+    aliceOpenReplyTo.expectMsg(OpenChannelResponse.Disconnected)
+  }
+
+  test("recv TickChannelOpenTimeout") { f =>
+    import f._
+    alice ! TickChannelOpenTimeout
+    listener.expectMsgType[ChannelAborted]
+    awaitCond(alice.stateName == CLOSED)
+    aliceOpenReplyTo.expectMsg(OpenChannelResponse.TimedOut)
+  }
+
+  test("recv funding success") { f =>
+    import f._
+    alice ! InteractiveTxFunder.FundingContributions(Seq(), Seq(), None)
+    alice2bob.expectMsgType[OpenDualFundedChannel]
+    awaitCond(alice.stateName == WAIT_FOR_ACCEPT_DUAL_FUNDED_CHANNEL)
+  }
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForDualFundingCreatedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForDualFundingCreatedStateSpec.scala
@@ -19,7 +19,7 @@ package fr.acinq.eclair.channel.states.b
 import akka.actor.typed.scaladsl.adapter.ClassicActorRefOps
 import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, SatoshiLong, Script}
-import fr.acinq.eclair.blockchain.SingleKeyOnChainWallet
+import fr.acinq.eclair.blockchain.SingleKeyOnChainWalletWithConfirmedInputs
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.fsm.Channel
@@ -37,10 +37,10 @@ import scala.concurrent.duration.DurationInt
 
 class WaitForDualFundingCreatedStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ChannelStateTestsBase {
 
-  case class FixtureParam(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], aliceOpenReplyTo: TestProbe, alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, wallet: SingleKeyOnChainWallet, aliceListener: TestProbe, bobListener: TestProbe)
+  case class FixtureParam(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], aliceOpenReplyTo: TestProbe, alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, wallet: SingleKeyOnChainWalletWithConfirmedInputs, aliceListener: TestProbe, bobListener: TestProbe)
 
   override def withFixture(test: OneArgTest): Outcome = {
-    val wallet = new SingleKeyOnChainWallet()
+    val wallet = new SingleKeyOnChainWalletWithConfirmedInputs()
     val setup = init(wallet_opt = Some(wallet), tags = test.tags)
     import setup._
     val channelConfig = ChannelConfig.standard

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForDualFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForDualFundingSignedStateSpec.scala
@@ -22,6 +22,7 @@ import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, SatoshiLong, Tx
 import fr.acinq.eclair.TestUtils.randomTxId
 import fr.acinq.eclair.blockchain.SingleKeyOnChainWallet
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{WatchFundingConfirmed, WatchPublished, WatchPublishedTriggered}
+import fr.acinq.eclair.blockchain.SingleKeyOnChainWalletWithConfirmedInputs
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.fsm.Channel
@@ -39,10 +40,10 @@ import scala.concurrent.duration.DurationInt
 
 class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ChannelStateTestsBase {
 
-  case class FixtureParam(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], alicePeer: TestProbe, bobPeer: TestProbe, alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, wallet: SingleKeyOnChainWallet, aliceListener: TestProbe, bobListener: TestProbe)
+  case class FixtureParam(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], alicePeer: TestProbe, bobPeer: TestProbe, alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, wallet: SingleKeyOnChainWalletWithConfirmedInputs, aliceListener: TestProbe, bobListener: TestProbe)
 
   override def withFixture(test: OneArgTest): Outcome = {
-    val wallet = new SingleKeyOnChainWallet()
+    val wallet = new SingleKeyOnChainWalletWithConfirmedInputs()
     val setup = init(wallet_opt = Some(wallet), tags = test.tags)
     import setup._
     val channelConfig = ChannelConfig.standard

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingConfirmedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingConfirmedStateSpec.scala
@@ -22,7 +22,7 @@ import com.softwaremill.quicklens.{ModifyPimp, QuicklensAt}
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, SatoshiLong, Transaction}
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
-import fr.acinq.eclair.blockchain.{CurrentBlockHeight, SingleKeyOnChainWallet}
+import fr.acinq.eclair.blockchain.{CurrentBlockHeight, SingleKeyOnChainWallet, SingleKeyOnChainWalletWithConfirmedInputs}
 import fr.acinq.eclair.channel.LocalFundingStatus.DualFundedUnconfirmedFundingTx
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.fsm.Channel
@@ -47,10 +47,10 @@ class WaitForDualFundingConfirmedStateSpec extends TestKitBaseClass with Fixture
   val noFundingContribution = "no_funding_contribution"
   val liquidityPurchase = "liquidity_purchase"
 
-  case class FixtureParam(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, aliceListener: TestProbe, bobListener: TestProbe, wallet: SingleKeyOnChainWallet)
+  case class FixtureParam(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, bob2blockchain: TestProbe, aliceListener: TestProbe, bobListener: TestProbe, wallet: SingleKeyOnChainWalletWithConfirmedInputs)
 
   override def withFixture(test: OneArgTest): Outcome = {
-    val wallet = new SingleKeyOnChainWallet()
+    val wallet = new SingleKeyOnChainWalletWithConfirmedInputs()
     val setup = init(wallet_opt = Some(wallet), tags = test.tags)
     import setup._
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -24,7 +24,7 @@ import fr.acinq.bitcoin.ScriptFlags
 import fr.acinq.bitcoin.scalacompat.NumericSatoshi.abs
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, SatoshiLong, Transaction}
 import fr.acinq.eclair._
-import fr.acinq.eclair.blockchain.{DummyOnChainWallet, SingleKeyOnChainWallet}
+import fr.acinq.eclair.blockchain.{DummyOnChainWallet, SingleKeyOnChainWallet, SingleKeyOnChainWalletWithConfirmedInputs}
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.Helpers.Closing.{LocalClose, RemoteClose, RevokedClose}
@@ -113,16 +113,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
 
   private def initiateSpliceWithoutSigs(f: FixtureParam, spliceIn_opt: Option[SpliceIn] = None, spliceOut_opt: Option[SpliceOut] = None): TestProbe = initiateSpliceWithoutSigs(f.alice, f.bob, f.alice2bob, f.bob2alice, spliceIn_opt, spliceOut_opt)
 
-  private def initiateRbfWithoutSigs(s: TestFSMRef[ChannelState, ChannelData, Channel], r: TestFSMRef[ChannelState, ChannelData, Channel], s2r: TestProbe, r2s: TestProbe, feerate: FeeratePerKw, sInputsCount: Int, sOutputsCount: Int, rInputsCount: Int, rOutputsCount: Int): TestProbe = {
-    val sender = TestProbe()
-    val cmd = CMD_BUMP_FUNDING_FEE(sender.ref, feerate, 100_000 sat, 0, None)
-    s ! cmd
-    exchangeStfu(s, r, s2r, r2s)
-    s2r.expectMsgType[TxInitRbf]
-    s2r.forward(r)
-    r2s.expectMsgType[TxAckRbf]
-    r2s.forward(s)
-
+  private def constructTx(s: TestFSMRef[ChannelState, ChannelData, Channel], r: TestFSMRef[ChannelState, ChannelData, Channel], s2r: TestProbe, r2s: TestProbe, sInputsCount: Int, sOutputsCount: Int, rInputsCount: Int, rOutputsCount: Int): Unit = {
     // The initiator also adds the shared input and shared output.
     var sRemainingInputs = sInputsCount + 1
     var sRemainingOutputs = sOutputsCount + 1
@@ -169,12 +160,25 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
         r2s.forward(s)
       }
     }
+  }
+
+  private def initiateRbfWithoutSigs(s: TestFSMRef[ChannelState, ChannelData, Channel], r: TestFSMRef[ChannelState, ChannelData, Channel], s2r: TestProbe, r2s: TestProbe, feerate: FeeratePerKw, sInputsCount: Int, sOutputsCount: Int, rInputsCount: Int, rOutputsCount: Int, requestFunding_opt: Option[LiquidityAds.RequestFunding]): TestProbe = {
+    val sender = TestProbe()
+    val cmd = CMD_BUMP_FUNDING_FEE(sender.ref, feerate, 100_000 sat, 0, requestFunding_opt)
+    s ! cmd
+    exchangeStfu(s, r, s2r, r2s)
+    s2r.expectMsgType[TxInitRbf]
+    s2r.forward(r)
+    r2s.expectMsgType[TxAckRbf]
+    r2s.forward(s)
+
+    constructTx(s, r, s2r, r2s, sInputsCount, sOutputsCount, rInputsCount, rOutputsCount)
 
     sender
   }
 
-  private def initiateRbfWithoutSigs(f: FixtureParam, feerate: FeeratePerKw, sInputsCount: Int, sOutputsCount: Int): TestProbe = {
-    initiateRbfWithoutSigs(f.alice, f.bob, f.alice2bob, f.bob2alice, feerate, sInputsCount, sOutputsCount, rInputsCount = 0, rOutputsCount = 0)
+  private def initiateRbfWithoutSigs(f: FixtureParam, feerate: FeeratePerKw, sInputsCount: Int, sOutputsCount: Int, requestFunding_opt: Option[LiquidityAds.RequestFunding] = None): TestProbe = {
+    initiateRbfWithoutSigs(f.alice, f.bob, f.alice2bob, f.bob2alice, feerate, sInputsCount, sOutputsCount, rInputsCount = 0, rOutputsCount = 0, requestFunding_opt)
   }
 
   private def exchangeSpliceSigs(s: TestFSMRef[ChannelState, ChannelData, Channel], r: TestFSMRef[ChannelState, ChannelData, Channel], s2r: TestProbe, r2s: TestProbe, sender: TestProbe): Transaction = {
@@ -218,8 +222,8 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
 
   private def initiateSplice(f: FixtureParam, spliceIn_opt: Option[SpliceIn] = None, spliceOut_opt: Option[SpliceOut] = None): Transaction = initiateSplice(f.alice, f.bob, f.alice2bob, f.bob2alice, spliceIn_opt, spliceOut_opt)
 
-  private def initiateRbf(f: FixtureParam, feerate: FeeratePerKw, sInputsCount: Int, sOutputsCount: Int): Transaction = {
-    val sender = initiateRbfWithoutSigs(f, feerate, sInputsCount, sOutputsCount)
+  private def initiateRbf(f: FixtureParam, feerate: FeeratePerKw, sInputsCount: Int, sOutputsCount: Int, requestFunding_opt: Option[LiquidityAds.RequestFunding] = None): Transaction = {
+    val sender = initiateRbfWithoutSigs(f, feerate, sInputsCount, sOutputsCount, requestFunding_opt)
     exchangeSpliceSigs(f, sender)
   }
 
@@ -297,7 +301,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     TestHtlcs(Seq(adda1, adda2), Seq(addb1, addb2))
   }
 
-  def spliceOutFee(f: FixtureParam, capacity: Satoshi): Satoshi = {
+  private def spliceOutFee(f: FixtureParam, capacity: Satoshi): Satoshi = {
     import f._
 
     // When we only splice-out, the fees are paid by deducing them from the next funding amount.
@@ -310,7 +314,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     actualMiningFee
   }
 
-  def checkPostSpliceState(f: FixtureParam, spliceOutFee: Satoshi): Unit = {
+  private def checkPostSpliceState(f: FixtureParam, spliceOutFee: Satoshi): Unit = {
     import f._
 
     // if the swap includes a splice-in, swap-out fees will be paid from bitcoind so final capacity is predictable
@@ -324,7 +328,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     assert(postSpliceState.commitments.latest.localCommit.spec.htlcs.collect(outgoing).toSeq.map(_.amountMsat).sum == outgoingHtlcs)
   }
 
-  def resolveHtlcs(f: FixtureParam, htlcs: TestHtlcs, spliceOutFee: Satoshi = 0.sat): Unit = {
+  private def resolveHtlcs(f: FixtureParam, htlcs: TestHtlcs, spliceOutFee: Satoshi = 0.sat): Unit = {
     import f._
 
     checkPostSpliceState(f, spliceOutFee)
@@ -349,6 +353,10 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     assert(finalState.commitments.latest.localCommit.spec.toLocal == 1_200_000_000.msat - spliceOutFee + settledHtlcs)
     assert(finalState.commitments.latest.localCommit.spec.toRemote == 700_000_000.msat - settledHtlcs)
   }
+
+  private def computeFees(tx: Transaction, wallet: SingleKeyOnChainWallet): Satoshi =
+    tx.txIn.flatMap(txIn => wallet.inputs.find(_.txid == txIn.outPoint.txid).flatMap(_.txOut.lift(txIn.outPoint.index.toInt))).map(_.amount).sum - tx.txOut.map(_.amount).sum
+
 
   test("recv CMD_SPLICE (splice-in)") { f =>
     import f._
@@ -407,24 +415,10 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     alice2bob.forward(bob)
     assert(bob2alice.expectMsgType[SpliceAck].willFund_opt.nonEmpty)
     bob2alice.forward(alice)
-    alice2bob.expectMsgType[TxAddInput]
-    alice2bob.forward(bob)
-    bob2alice.expectMsgType[TxAddInput]
-    bob2alice.forward(alice)
-    alice2bob.expectMsgType[TxAddInput]
-    alice2bob.forward(bob)
-    bob2alice.expectMsgType[TxAddOutput]
-    bob2alice.forward(alice)
-    alice2bob.expectMsgType[TxAddOutput]
-    alice2bob.forward(bob)
-    bob2alice.expectMsgType[TxComplete]
-    bob2alice.forward(alice)
-    alice2bob.expectMsgType[TxAddOutput]
-    alice2bob.forward(bob)
-    bob2alice.expectMsgType[TxComplete]
-    bob2alice.forward(alice)
-    alice2bob.expectMsgType[TxComplete]
-    alice2bob.forward(bob)
+
+    // Alice adds splice-in input and change output, Bob adds liquidity splice-in input and change output.
+    constructTx(alice, bob, alice2bob, bob2alice, sInputsCount = 1, sOutputsCount = 1, rInputsCount = 1, rOutputsCount = 1)
+
     exchangeSpliceSigs(alice, bob, alice2bob, bob2alice, sender)
 
     // Alice paid fees to Bob for the additional liquidity.
@@ -521,6 +515,23 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     bob2alice.forward(alice)
     assert(alice2bob.expectMsgType[TxAbort].toAscii.contains("invalid balances"))
     assert(bob2alice.expectMsgType[TxAbort].toAscii.contains("invalid balances"))
+  }
+
+  test("recv CMD_SPLICE (splice-in, liquidity ads, cannot fund request)") { f =>
+    import f._
+
+    val sender = TestProbe()
+    val fundingRequest = LiquidityAds.RequestFunding(DummyOnChainWallet.invalidFundingAmount, TestConstants.defaultLiquidityRates.fundingRates.last, LiquidityAds.PaymentDetails.FromChannelBalance)
+    val cmd = CMD_SPLICE(sender.ref, Some(SpliceIn(500_000 sat)), None, Some(fundingRequest))
+    alice ! cmd
+
+    exchangeStfu(alice, bob, alice2bob, bob2alice)
+    assert(alice2bob.expectMsgType[SpliceInit].requestFunding_opt.nonEmpty)
+    alice2bob.forward(bob)
+    assert(bob2alice.expectMsgType[TxAbort].toAscii.contains("channel funding error"))
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAbort]
+    alice2bob.forward(bob)
   }
 
   test("recv CMD_SPLICE (splice-in, local and remote commit index mismatch)") { f =>
@@ -756,7 +767,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
 
     // Bob RBFs the splice transaction: he needs to add an input to pay the fees.
     // Our dummy bitcoin wallet adds an additional input for Alice: a real bitcoin wallet would simply lower the previous change output.
-    val sender2 = initiateRbfWithoutSigs(bob, alice, bob2alice, alice2bob, FeeratePerKw(20_000 sat), sInputsCount = 1, sOutputsCount = 1, rInputsCount = 3, rOutputsCount = 2)
+    val sender2 = initiateRbfWithoutSigs(bob, alice, bob2alice, alice2bob, FeeratePerKw(20_000 sat), sInputsCount = 1, sOutputsCount = 1, rInputsCount = 3, rOutputsCount = 2, None)
     val rbfTx2 = exchangeSpliceSigs(alice, bob, alice2bob, bob2alice, sender2)
     assert(rbfTx2.txIn.size > rbfTx1.txIn.size)
     rbfTx1.txIn.foreach(txIn => assert(rbfTx2.txIn.map(_.outPoint).contains(txIn.outPoint)))
@@ -802,7 +813,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     assert(spliceTx2.txIn.exists(_.outPoint.txid == spliceTx1.txid))
 
     // Alice cannot RBF her first splice, so she RBFs Bob's splice instead.
-    val sender = initiateRbfWithoutSigs(alice, bob, alice2bob, bob2alice, FeeratePerKw(15_000 sat), sInputsCount = 1, sOutputsCount = 1, rInputsCount = 2, rOutputsCount = 2)
+    val sender = initiateRbfWithoutSigs(alice, bob, alice2bob, bob2alice, FeeratePerKw(15_000 sat), sInputsCount = 1, sOutputsCount = 1, rInputsCount = 2, rOutputsCount = 2, None)
     val rbfTx = exchangeSpliceSigs(bob, alice, bob2alice, alice2bob, sender)
     assert(rbfTx.txIn.size > spliceTx2.txIn.size)
     spliceTx2.txIn.foreach(txIn => assert(rbfTx.txIn.map(_.outPoint).contains(txIn.outPoint)))
@@ -979,6 +990,21 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     alice2bob.expectMsgType[Stfu]
     bob2alice.forward(alice, TxInitRbf(alice.stateData.channelId, 0, FeeratePerKw(15_000 sat), 250_000 sat, requireConfirmedInputs = false, None))
     assert(alice2bob.expectMsgType[TxAbort].toAscii.contains("we're using zero-conf"))
+  }
+
+  test("recv TxAbort (before sending SpliceAck)") { f =>
+    import f._
+
+    val sender = TestProbe()
+    val requestFunding = Some(LiquidityAds.RequestFunding(TestConstants.nonInitiatorFundingSatoshis, TestConstants.defaultLiquidityRates.fundingRates.head, LiquidityAds.PaymentDetails.FromChannelBalance))
+    alice ! CMD_SPLICE(sender.ref, spliceIn_opt = None, spliceOut_opt = Some(SpliceOut(50_000 sat, defaultSpliceOutScriptPubKey)), requestFunding_opt = requestFunding)
+    exchangeStfu(f)
+    alice2bob.expectMsgType[SpliceInit]
+    alice2bob.forward(bob)
+    alice2bob.forward(bob, TxAbort(channelId(alice), "changed my mind!"))
+    bob2alice.expectMsgType[TxAbort]
+    awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].spliceStatus == SpliceStatus.NoSplice)
+    awaitCond(wallet.asInstanceOf[SingleKeyOnChainWalletWithConfirmedInputs].rolledback.size == 1)
   }
 
   test("recv TxAbort (before TxComplete)") { f =>
@@ -1580,7 +1606,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     alice2bob.expectNoMessage(100 millis)
   }
 
-  test("Excess added to additional local funding", Tag(ChannelStateTestsTags.ChangelessFunding)) { f =>
+  test("Added excess to funding (splice-in, changeless)", Tag(ChannelStateTestsTags.ChangelessFunding)) { f =>
     import f._
     val sender = TestProbe()
     val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(100_000 sat, pushAmount = 0 msat)), spliceOut_opt = None, requestFunding_opt = None)
@@ -1589,6 +1615,76 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     val spliceInit = alice2bob.expectMsgType[SpliceInit]
     // When we request an input of 100_000 sat, we should get an input of 101_000 sat + fees from our dummy wallet.
     assert(spliceInit.fundingContribution == 101_000.sat)
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[SpliceAck]
+    bob2alice.forward(alice)
+
+    // Alice adds splice-in input (no change output), Bob does not add inputs or outputs.
+    constructTx(alice, bob, alice2bob, bob2alice, sInputsCount = 1, sOutputsCount = 0, rInputsCount = 0, rOutputsCount = 0)
+    val spliceTx = exchangeSpliceSigs(f, sender)
+    assert(spliceTx.txIn.size == 2)
+    assert(computeFees(spliceTx, wallet.asInstanceOf[SingleKeyOnChainWallet]) < 10_000.sat)
+
+    val rbfTx1 = initiateRbf(f, FeeratePerKw(15_000 sat), sInputsCount = 2, sOutputsCount = 0)
+    assert(computeFees(rbfTx1, wallet.asInstanceOf[SingleKeyOnChainWallet]) < 18_000.sat)
+    rbfTx1.txIn.foreach(txIn => assert(rbfTx1.txIn.map(_.outPoint).contains(txIn.outPoint)))
+
+    // Alice keeps excess from initial funding.
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toLocal == 901_000_000.msat)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toRemote == 700_000_000.msat)
+  }
+
+  test("Added excess to funding (splice-in, liquidity ads, changeless)", Tag(ChannelStateTestsTags.ChangelessFunding)) { f =>
+    import f._
+
+    val sender = TestProbe()
+    val fundingRequest = LiquidityAds.RequestFunding(100_000 sat, TestConstants.defaultLiquidityRates.fundingRates.head, LiquidityAds.PaymentDetails.FromChannelBalance)
+    val cmd = CMD_SPLICE(sender.ref, Some(SpliceIn(500_000 sat)), None, Some(fundingRequest))
+    alice ! cmd
+
+    exchangeStfu(alice, bob, alice2bob, bob2alice)
+    assert(alice2bob.expectMsgType[SpliceInit].requestFunding_opt.nonEmpty)
+    alice2bob.forward(bob)
+    val spliceAck = bob2alice.expectMsgType[SpliceAck]
+    bob2alice.forward(alice)
+    assert(spliceAck.willFund_opt.nonEmpty)
+    // When we request an input of 100_000 sat, we should get an input of 101_000 sat + fees from our dummy wallet.
+    assert(spliceAck.fundingContribution == 101_000.sat)
+
+    // Alice adds splice-in input (no change output), Bob adds liquidity splice-in input (no change output).
+    constructTx(alice, bob, alice2bob, bob2alice, sInputsCount = 1, sOutputsCount = 0, rInputsCount = 1, rOutputsCount = 0)
+
+    val spliceTx = exchangeSpliceSigs(alice, bob, alice2bob, bob2alice, sender)
+    assert(computeFees(spliceTx, wallet.asInstanceOf[SingleKeyOnChainWallet]) < 15_000.sat)
+
+    // Alice paid fees to Bob for the additional liquidity.
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.capacity == 2_101_000.sat)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toLocal < 1_300_000_000.msat)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toRemote > 801_000_000.msat)
+
+    // Bob signed a liquidity purchase.
+    bobPeer.fishForMessage() {
+      case l: LiquidityPurchaseSigned =>
+        assert(l.purchase.paymentDetails == LiquidityAds.PaymentDetails.FromChannelBalance)
+        assert(l.fundingTxIndex == 1)
+        assert(l.txId == alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.fundingTxId)
+        true
+      case _ => false
+    }
+
+    // Alice adds two inputs: splice-in and fee bump (no excess, no change output), Bob adds two inputs: liquidity splice-in
+    // and fee bump (no change output); our dummy wallet always adds an input during funding but a real bitcoin wallet would
+    // use the previous input with less change.
+    val rbfSender = initiateRbfWithoutSigs(f.alice, f.bob, f.alice2bob, f.bob2alice, FeeratePerKw(15_000 sat), sInputsCount = 2, sOutputsCount = 0, rInputsCount = 2, rOutputsCount = 0, Some(fundingRequest))
+    val rbfTx1 = exchangeSpliceSigs(f, rbfSender)
+
+    assert(computeFees(rbfTx1, wallet.asInstanceOf[SingleKeyOnChainWallet]) < 30_000.sat)
+    rbfTx1.txIn.foreach(txIn => assert(rbfTx1.txIn.map(_.outPoint).contains(txIn.outPoint)))
+
+    // Bob does not add the initial excess funding to their added inbound liquidity; only what was initially requested.
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.capacity == 2_100_000.sat)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toLocal < 1_300_000_000.msat)
+    assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.spec.toRemote > 800_000_000.msat)
   }
 
   test("recv CMD_ADD_HTLC while a splice is requested") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -24,7 +24,7 @@ import fr.acinq.bitcoin.ScriptFlags
 import fr.acinq.bitcoin.scalacompat.NumericSatoshi.abs
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, SatoshiLong, Transaction}
 import fr.acinq.eclair._
-import fr.acinq.eclair.blockchain.SingleKeyOnChainWallet
+import fr.acinq.eclair.blockchain.{DummyOnChainWallet, SingleKeyOnChainWallet}
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher._
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.Helpers.Closing.{LocalClose, RemoteClose, RevokedClose}
@@ -1569,13 +1569,36 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     awaitCond(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.forall(_.localCommit.spec.htlcs.size == 1))
   }
 
+  test("Funding failed before a splice is requested from our peer") { f =>
+    import f._
+    val sender = TestProbe()
+    val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(DummyOnChainWallet.invalidFundingAmount, pushAmount = 0 msat)), spliceOut_opt = None, requestFunding_opt = None)
+    alice ! cmd
+    exchangeStfu(f)
+    sender.expectMsg(RES_FAILURE(cmd, ChannelFundingError(channelId(alice))))
+    awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].spliceStatus == SpliceStatus.NoSplice)
+    alice2bob.expectNoMessage(100 millis)
+  }
+
+  test("Excess added to additional local funding", Tag(ChannelStateTestsTags.ChangelessFunding)) { f =>
+    import f._
+    val sender = TestProbe()
+    val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(100_000 sat, pushAmount = 0 msat)), spliceOut_opt = None, requestFunding_opt = None)
+    alice ! cmd
+    exchangeStfu(f)
+    val spliceInit = alice2bob.expectMsgType[SpliceInit]
+    // When we request an input of 100_000 sat, we should get an input of 101_000 sat + fees from our dummy wallet.
+    assert(spliceInit.fundingContribution == 101_000.sat)
+  }
+
   test("recv CMD_ADD_HTLC while a splice is requested") { f =>
     import f._
     val sender = TestProbe()
     val cmd = CMD_SPLICE(sender.ref, spliceIn_opt = Some(SpliceIn(500_000 sat, pushAmount = 0 msat)), spliceOut_opt = None, requestFunding_opt = None)
     alice ! cmd
     exchangeStfu(f)
-    alice2bob.expectMsgType[SpliceInit]
+    val spliceInit = alice2bob.expectMsgType[SpliceInit]
+    assert(spliceInit.fundingContribution == 500_000.sat)
     alice ! CMD_ADD_HTLC(sender.ref, 500000 msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, None, 1.0, None, localOrigin(sender.ref))
     sender.expectMsgType[RES_ADD_FAILED[_]]
     alice2bob.expectNoMessage(100 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, OutPoint, Satoshi, SatoshiLong, Transaction, TxId}
 import fr.acinq.eclair.ShortChannelId.txIndex
-import fr.acinq.eclair.blockchain.SingleKeyOnChainWallet
+import fr.acinq.eclair.blockchain.SingleKeyOnChainWalletWithConfirmedInputs
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{WatchFundingConfirmed, WatchFundingConfirmedTriggered}
 import fr.acinq.eclair.blockchain.fee.{FeeratePerKw, FeeratesPerKw}
@@ -57,7 +57,7 @@ case class MinimalNodeFixture private(nodeParams: NodeParams,
                                       defaultOfferHandler: typed.ActorRef[OfferManager.HandlerCommand],
                                       postman: typed.ActorRef[Postman.Command],
                                       watcher: TestProbe,
-                                      wallet: SingleKeyOnChainWallet,
+                                      wallet: SingleKeyOnChainWalletWithConfirmedInputs,
                                       bitcoinClient: TestBitcoinCoreClient) {
   val nodeId = nodeParams.nodeId
   val routeParams = nodeParams.routerConf.pathFindingExperimentConf.experiments.values.head.getDefaultRouteParams
@@ -89,7 +89,7 @@ object MinimalNodeFixture extends Assertions with Eventually with IntegrationPat
     val readyListener = TestProbe("ready-listener")
     system.eventStream.subscribe(readyListener.ref, classOf[SubscriptionsComplete])
     val bitcoinClient = new TestBitcoinCoreClient()
-    val wallet = new SingleKeyOnChainWallet()
+    val wallet = new SingleKeyOnChainWalletWithConfirmedInputs()
     val watcher = TestProbe("watcher")
     val watcherTyped = watcher.ref.toTyped[ZmqWatcher.Command]
     val register = system.actorOf(Register.props(), "register")


### PR DESCRIPTION
This is an alternative to PR #2903 which does not assume modifying bitcoind to add excess to a selected output during coin selection (see [PR 30080](https://github.com/bitcoin/bitcoin/pull/30080)).

When funds are added to a dual funded channel, or spliced into an existing channel, our channel should be credited in their channel balance any excess that is added to the channel over what the user requests. Currently if a changeless solution is found for funding, excess value over what was requested will be treated as waste and used as extra fees. 

We introduce a new optional funding contributions parameter to `InteractiveTxBuilder`. When set, we will start by processing the passed in funding inputs/outputs instead of using `InteractiveTxFunder` to fund the transaction. The call to `InteractiveTxFunder` is now made before sending `open_channel2` or `splice_init` and the results are then passed to `InteractiveTxBuilder`. 

This PR builds on [PR #2887 - Use final spec values for splicing](https://github.com/ACINQ/eclair/pull/2887) and should be rebased once the final official splicing code is merged.