### PR TITLE
Use shared input's `txOut` in `shouldSignFirst`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -1008,7 +1008,7 @@ object InteractiveTxSigningSession {
   case class UnsignedLocalCommit(index: Long, spec: CommitmentSpec, commitTx: CommitTx, htlcTxs: List[HtlcTx])
 
   private def shouldSignFirst(isInitiator: Boolean, channelParams: ChannelParams, tx: SharedTransaction): Boolean = {
-    val sharedAmountIn = tx.sharedInput_opt.map(i => i.localAmount + i.remoteAmount + i.htlcAmount).getOrElse(0 msat).truncateToSatoshi
+    val sharedAmountIn = tx.sharedInput_opt.map(_.txOut.amount).getOrElse(0 sat)
     val (localAmountIn, remoteAmountIn) = if (isInitiator) {
       (sharedAmountIn + tx.localInputs.map(i => i.txOut.amount).sum, tx.remoteInputs.map(i => i.txOut.amount).sum)
     } else {


### PR DESCRIPTION
This is clearer that way and yields the same result: we only look at `txOut` amounts when computing each node's contributions.

See a related lightning-kmp PR: https://github.com/ACINQ/lightning-kmp/pull/724 