### PR TITLE
Delay considering a channel closed when seeing an on-chain spend

### DIFF
--- a/commit.md
+++ b/commit.md
@@ -1,5 +1,0 @@
-Add more splice RBF reconnection tests
-
-We add more tests around disconnection in the middle of signing an RBF
-attempt, and verify more details of the `channel_reestablish` message
-sent on reconnection.

--- a/commit.md
+++ b/commit.md
@@ -1,0 +1,5 @@
+Add more splice RBF reconnection tests
+
+We add more tests around disconnection in the middle of signing an RBF
+attempt, and verify more details of the `channel_reestablish` message
+sent on reconnection.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -805,6 +805,8 @@ case class Commitments(params: ChannelParams,
   val remoteCommitIndex = active.head.remoteCommit.index
   val nextRemoteCommitIndex = remoteCommitIndex + 1
 
+  // While we have multiple active commitments, we use the most restrictive one.
+  val capacity = active.map(_.capacity).min
   lazy val availableBalanceForSend: MilliSatoshi = active.map(_.availableBalanceForSend(params, changes)).min
   lazy val availableBalanceForReceive: MilliSatoshi = active.map(_.availableBalanceForReceive(params, changes)).min
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Graph.scala
@@ -679,6 +679,26 @@ object Graph {
       }
 
       /**
+       * Update the shortChannelId and capacity of edges corresponding to the given channel-desc,
+       * both edges (corresponding to both directions) are updated.
+       *
+       * @param desc the channel description for the channel to update
+       * @param newShortChannelId the new shortChannelId for this channel
+       * @param newCapacity the new capacity of the channel
+       * @return a new graph with updated vertexes
+       */
+      def updateChannel(desc: ChannelDesc, newShortChannelId: RealShortChannelId, newCapacity: Satoshi): DirectedGraph = {
+        val newDesc = desc.copy(shortChannelId = newShortChannelId)
+        val updatedVertices =
+          vertices
+            .updatedWith(desc.b)(_.map(vertexB => vertexB.copy(incomingEdges = vertexB.incomingEdges - desc +
+              (newDesc -> vertexB.incomingEdges(desc).copy(desc = newDesc, capacity = newCapacity)))))
+            .updatedWith(desc.a)(_.map(vertexA => vertexA.copy(incomingEdges = vertexA.incomingEdges - desc.reversed +
+              (newDesc.reversed -> vertexA.incomingEdges(desc.reversed).copy(desc = newDesc.reversed, capacity = newCapacity)))))
+        DirectedGraph(updatedVertices)
+      }
+
+      /**
        * @return For edges to be considered equal they must have the same in/out vertices AND same shortChannelId
        */
       def getEdge(edge: GraphEdge): Option[GraphEdge] = getEdge(edge.desc)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -420,9 +420,9 @@ object Router {
     def getBalanceSameSideAs(u: ChannelUpdate): Option[MilliSatoshi] = if (u.channelFlags.isNode1) meta_opt.map(_.balance1) else meta_opt.map(_.balance2)
     def updateChannelUpdateSameSideAs(u: ChannelUpdate): PublicChannel = if (u.channelFlags.isNode1) copy(update_1_opt = Some(u)) else copy(update_2_opt = Some(u))
     def updateBalances(commitments: Commitments): PublicChannel = if (commitments.localNodeId == ann.nodeId1) {
-      copy(meta_opt = Some(ChannelMeta(commitments.availableBalanceForSend, commitments.availableBalanceForReceive)))
+      copy(capacity = commitments.capacity, meta_opt = Some(ChannelMeta(commitments.availableBalanceForSend, commitments.availableBalanceForReceive)))
     } else {
-      copy(meta_opt = Some(ChannelMeta(commitments.availableBalanceForReceive, commitments.availableBalanceForSend)))
+      copy(capacity = commitments.capacity, meta_opt = Some(ChannelMeta(commitments.availableBalanceForReceive, commitments.availableBalanceForSend)))
     }
     def applyChannelUpdate(update: Either[LocalChannelUpdate, RemoteChannelUpdate]): PublicChannel = update match {
       case Left(lcu) => updateChannelUpdateSameSideAs(lcu.channelUpdate).updateBalances(lcu.commitments)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Router.scala
@@ -269,7 +269,7 @@ class Router(val nodeParams: NodeParams, watcher: typed.ActorRef[ZmqWatcher.Comm
 
     case Event(WatchTxConfirmedTriggered(_, _, spendingTx), d) =>
       d.spentChannels.get(spendingTx.txid) match {
-        case Some(shortChannelId) => stay() using Validation.handleChannelSpent(d, watcher, nodeParams.db.network, shortChannelId)
+        case Some(shortChannelId) => stay() using Validation.handleChannelSpent(d, watcher, nodeParams.db.network, spendingTx.txid, shortChannelId)
         case None => stay()
       }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -626,7 +626,7 @@ object Validation {
   def handleAvailableBalanceChanged(d: Data, e: AvailableBalanceChanged)(implicit log: LoggingAdapter): Data = {
     val (publicChannels1, graphWithBalances1) = e.shortIds.real.toOption.flatMap(d.channels.get) match {
       case Some(pc) =>
-        val pc1 = pc.updateBalances(e.commitments)
+        val pc1 = pc.updateBalances(e.commitments).copy(capacity = e.commitments.latest.capacity)
         log.debug("public channel balance updated: {}", pc1)
         val update_opt = if (e.commitments.localNodeId == pc1.ann.nodeId1) pc1.update_1_opt else pc1.update_2_opt
         val graphWithBalances1 = update_opt.map(u => d.graphWithBalances.addEdge(GraphEdge(u, pc1))).getOrElse(d.graphWithBalances)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -294,7 +294,7 @@ object Validation {
     // we will re-add a spliced channel as a new channel later when we receive the announcement
     watcher ! UnwatchExternalChannelSpent(lostChannel.fundingTxId, outputIndex(lostChannel.ann.shortChannelId))
     val spendingTxs = d.spentChannels.filter(_._2 == shortChannelId).keySet
-    // stop watching the spending txs that will never confirm, but continue to watch the tx that spends the parent channel
+    // stop watching the spending txs that will never confirm, we already got confirmations for this spending tx
     (spendingTxs - spendingTxId).foreach(txId => watcher ! UnwatchTxConfirmed(txId))
     val spentChannels1 = d.spentChannels -- spendingTxs
     d.copy(nodes = d.nodes -- lostNodes, channels = channels1, prunedChannels = prunedChannels1, graphWithBalances = graphWithBalances1, spentChannels = spentChannels1)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -626,7 +626,7 @@ object Validation {
   def handleAvailableBalanceChanged(d: Data, e: AvailableBalanceChanged)(implicit log: LoggingAdapter): Data = {
     val (publicChannels1, graphWithBalances1) = e.shortIds.real.toOption.flatMap(d.channels.get) match {
       case Some(pc) =>
-        val pc1 = pc.updateBalances(e.commitments).copy(capacity = e.commitments.latest.capacity)
+        val pc1 = pc.updateBalances(e.commitments)
         log.debug("public channel balance updated: {}", pc1)
         val update_opt = if (e.commitments.localNodeId == pc1.ann.nodeId1) pc1.update_1_opt else pc1.update_2_opt
         val graphWithBalances1 = update_opt.map(u => d.graphWithBalances.addEdge(GraphEdge(u, pc1))).getOrElse(d.graphWithBalances)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/EclairImplSpec.scala
@@ -375,7 +375,7 @@ class EclairImplSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with I
       shortIds4.real.toOption.get.toLong -> channelId4,
     )
     val g = GraphWithBalanceEstimates(DirectedGraph(Nil), 1 hour)
-    val routerData = Router.Data(Map.empty, publicChannels, SortedMap.empty, Router.Stash(Map.empty, Map.empty), Router.Rebroadcast(Map.empty, Map.empty, Map.empty), Map.empty, privateChannels, scidMapping, Map.empty, g, Map.empty)
+    val routerData = Router.Data(Map.empty, publicChannels, SortedMap.empty, Router.Stash(Map.empty, Map.empty), Router.Rebroadcast(Map.empty, Map.empty, Map.empty), Map.empty, privateChannels, scidMapping, Map.empty, g, Map.empty, Map.empty)
 
     eclair.findRoute(c, 250_000 msat, None)
     val routeRequest1 = router.expectMsgType[RouteRequest]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
@@ -641,13 +641,10 @@ class StandardChannelIntegrationSpec extends ChannelIntegrationSpec {
       val receivedByC = listReceivedByAddress(finalAddressC, sender)
       (receivedByC diff previouslyReceivedByC).size == 5
     }, max = 30 seconds, interval = 1 second)
-    // we generate blocks to make txs confirm
-    generateBlocks(2)
+    // we generate enough blocks for the channel to be deeply confirmed
+    generateBlocks(12)
     // and we wait for C's channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
-
-    // generate enough blocks so the router will know the channel has been closed and not spliced
-    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -769,11 +766,8 @@ abstract class AnchorChannelIntegrationSpec extends ChannelIntegrationSpec {
     }, max = 20 seconds, interval = 1 second)
 
     // get the claim-remote-output confirmed, then the channel can go to the CLOSED state
-    generateBlocks(2)
-    awaitCond(stateListener.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
-
-    // generate enough blocks so the router will know the channel has been closed and not spliced
     generateBlocks(12)
+    awaitCond(stateListener.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
     awaitAnnouncements(1)
   }
 
@@ -799,13 +793,10 @@ abstract class AnchorChannelIntegrationSpec extends ChannelIntegrationSpec {
       val receivedByC = listReceivedByAddress(finalAddressC, sender)
       (receivedByC diff previouslyReceivedByC).size == 6
     }, max = 30 seconds, interval = 1 second)
-    // we generate blocks to make txs confirm
-    generateBlocks(2)
+    // we generate enough blocks for the channel to be deeply confirmed
+    generateBlocks(12)
     // and we wait for C's channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
-
-    // generate enough blocks so the router will know the channel has been closed and not spliced
-    generateBlocks(12)
     awaitAnnouncements(1)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
@@ -194,14 +194,11 @@ abstract class ChannelIntegrationSpec extends IntegrationSpec {
       val receivedByF = listReceivedByAddress(finalAddressF)
       (receivedByF diff previouslyReceivedByF).size == expectedTxCountF && (receivedByC diff previouslyReceivedByC).size == expectedTxCountC
     }, max = 30 seconds, interval = 1 second)
-    // we generate blocks to make txs confirm
-    generateBlocks(2, Some(minerAddress))
+    // we generate enough blocks for the channel to be deeply confirmed
+    generateBlocks(12, Some(minerAddress))
     // and we wait for the channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
     awaitCond(stateListenerF.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
-
-    // generate enough blocks so the router will know the channel has been closed and not spliced
-    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -238,14 +235,11 @@ abstract class ChannelIntegrationSpec extends IntegrationSpec {
       val receivedByF = listReceivedByAddress(finalAddressF, sender)
       (receivedByF diff previouslyReceivedByF).size == expectedTxCountF && (receivedByC diff previouslyReceivedByC).size == expectedTxCountC
     }, max = 30 seconds, interval = 1 second)
-    // we generate blocks to make txs confirm
-    generateBlocks(2, Some(minerAddress))
+    // we generate enough blocks for the channel to be deeply confirmed
+    generateBlocks(12, Some(minerAddress))
     // and we wait for the channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
     awaitCond(stateListenerF.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
-
-    // generate enough blocks so the router will know the channel has been closed and not spliced
-    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -294,14 +288,11 @@ abstract class ChannelIntegrationSpec extends IntegrationSpec {
       val receivedByF = listReceivedByAddress(finalAddressF, sender)
       (receivedByF diff previouslyReceivedByF).size == expectedTxCountF && (receivedByC diff previouslyReceivedByC).size == expectedTxCountC
     }, max = 30 seconds, interval = 1 second)
-    // we generate blocks to make txs confirm
-    generateBlocks(2, Some(minerAddress))
+    // we generate enough blocks for the channel to be deeply confirmed
+    generateBlocks(12, Some(minerAddress))
     // and we wait for the channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
     awaitCond(stateListenerF.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
-
-    // generate enough blocks so the router will know the channel has been closed and not spliced
-    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -353,14 +344,11 @@ abstract class ChannelIntegrationSpec extends IntegrationSpec {
       val receivedByF = listReceivedByAddress(finalAddressF, sender)
       (receivedByF diff previouslyReceivedByF).size == expectedTxCountF && (receivedByC diff previouslyReceivedByC).size == expectedTxCountC
     }, max = 30 seconds, interval = 1 second)
-    // we generate blocks to make tx confirm
-    generateBlocks(2, Some(minerAddress))
+    // we generate enough blocks for the channel to be deeply confirmed
+    generateBlocks(12, Some(minerAddress))
     // and we wait for the channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
     awaitCond(stateListenerF.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
-
-    // generate enough blocks so the router will know the channel has been closed and not spliced
-    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -599,15 +587,13 @@ class StandardChannelIntegrationSpec extends ChannelIntegrationSpec {
       bitcoinClient.getMempool().pipeTo(sender.ref)
       sender.expectMsgType[Seq[Transaction]].exists(_.txIn.head.outPoint.txid == fundingOutpoint.txid)
     }, max = 20 seconds, interval = 1 second)
-    generateBlocks(3)
+    // we generate enough blocks for the channel to be deeply confirmed
+    generateBlocks(12)
     awaitCond(stateListener.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
 
-    bitcoinClient.lookForSpendingTx(None, fundingOutpoint.txid, fundingOutpoint.index.toInt, limit = 10).pipeTo(sender.ref)
+    bitcoinClient.lookForSpendingTx(None, fundingOutpoint.txid, fundingOutpoint.index.toInt, limit = 12).pipeTo(sender.ref)
     val closingTx = sender.expectMsgType[Transaction]
     assert(closingTx.txOut.map(_.publicKeyScript).toSet == Set(finalPubKeyScriptC, finalPubKeyScriptF))
-
-    // generate enough blocks so the router will know the channel has been closed and not spliced
-    generateBlocks(12)
     awaitAnnouncements(1)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/ChannelIntegrationSpec.scala
@@ -199,6 +199,9 @@ abstract class ChannelIntegrationSpec extends IntegrationSpec {
     // and we wait for the channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
     awaitCond(stateListenerF.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
+
+    // generate enough blocks so the router will know the channel has been closed and not spliced
+    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -240,6 +243,9 @@ abstract class ChannelIntegrationSpec extends IntegrationSpec {
     // and we wait for the channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
     awaitCond(stateListenerF.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
+
+    // generate enough blocks so the router will know the channel has been closed and not spliced
+    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -293,6 +299,9 @@ abstract class ChannelIntegrationSpec extends IntegrationSpec {
     // and we wait for the channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
     awaitCond(stateListenerF.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
+
+    // generate enough blocks so the router will know the channel has been closed and not spliced
+    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -349,6 +358,9 @@ abstract class ChannelIntegrationSpec extends IntegrationSpec {
     // and we wait for the channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
     awaitCond(stateListenerF.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
+
+    // generate enough blocks so the router will know the channel has been closed and not spliced
+    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -594,6 +606,8 @@ class StandardChannelIntegrationSpec extends ChannelIntegrationSpec {
     val closingTx = sender.expectMsgType[Transaction]
     assert(closingTx.txOut.map(_.publicKeyScript).toSet == Set(finalPubKeyScriptC, finalPubKeyScriptF))
 
+    // generate enough blocks so the router will know the channel has been closed and not spliced
+    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -645,6 +659,9 @@ class StandardChannelIntegrationSpec extends ChannelIntegrationSpec {
     generateBlocks(2)
     // and we wait for C's channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
+
+    // generate enough blocks so the router will know the channel has been closed and not spliced
+    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -768,6 +785,9 @@ abstract class AnchorChannelIntegrationSpec extends ChannelIntegrationSpec {
     // get the claim-remote-output confirmed, then the channel can go to the CLOSED state
     generateBlocks(2)
     awaitCond(stateListener.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
+
+    // generate enough blocks so the router will know the channel has been closed and not spliced
+    generateBlocks(12)
     awaitAnnouncements(1)
   }
 
@@ -797,6 +817,9 @@ abstract class AnchorChannelIntegrationSpec extends ChannelIntegrationSpec {
     generateBlocks(2)
     // and we wait for C's channel to close
     awaitCond(stateListenerC.expectMsgType[ChannelStateChanged](max = 60 seconds).currentState == CLOSED, max = 60 seconds)
+
+    // generate enough blocks so the router will know the channel has been closed and not spliced
+    generateBlocks(12)
     awaitAnnouncements(1)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/channel/GossipIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/channel/GossipIntegrationSpec.scala
@@ -1,0 +1,79 @@
+package fr.acinq.eclair.integration.basic.channel
+
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, SatoshiLong}
+import fr.acinq.eclair.channel.states.ChannelStateTestsTags
+import fr.acinq.eclair.channel.{DATA_NORMAL, RES_SPLICE, RealScidStatus}
+import fr.acinq.eclair.integration.basic.ThreeNodesIntegrationSpec
+import fr.acinq.eclair.integration.basic.fixtures.MinimalNodeFixture.{getChannelData, getPeerChannels, spliceIn}
+import fr.acinq.eclair.integration.basic.fixtures.composite.ThreeNodesFixture
+import fr.acinq.eclair.{FeatureSupport, Features}
+import org.scalatest.{Tag, TestData}
+import scodec.bits.HexStringSyntax
+
+/**
+ * These test checks the gossip sent between nodes by the Router
+ */
+class GossipIntegrationSpec extends ThreeNodesIntegrationSpec {
+
+  import fr.acinq.eclair.integration.basic.fixtures.MinimalNodeFixture.{connect, getRouterData, knownFundingTxs, nodeParamsFor, openChannel, watcherAutopilot}
+
+  override def createFixture(testData: TestData): FixtureParam = {
+    // seeds have been chosen so that node ids start with 02aaaa for alice, 02bbbb for bob, etc.
+    val aliceParams = nodeParamsFor("alice", ByteVector32(hex"b4acd47335b25ab7b84b8c020997b12018592bb4631b868762154d77fa8b93a3"))
+    val aliceParams1 = aliceParams.copy(
+      features = aliceParams.features.add(Features.SplicePrototype, FeatureSupport.Optional)
+    )
+    val bobParams = nodeParamsFor("bob", ByteVector32(hex"7620226fec887b0b2ebe76492e5a3fd3eb0e47cd3773263f6a81b59a704dc492"))
+    val bobParams1 = bobParams.copy(
+      features = bobParams.features.add(Features.SplicePrototype, FeatureSupport.Optional)
+    )
+    val carolParams = nodeParamsFor("carol", ByteVector32(hex"ebd5a5d3abfb3ef73731eb3418d918f247445183180522674666db98a66411cc"))
+    ThreeNodesFixture(aliceParams1, bobParams1, carolParams, testData.name)
+  }
+
+  override def cleanupFixture(fixture: ThreeNodesFixture): Unit = {
+    fixture.cleanup()
+  }
+
+  test("send gossip when alice->bob channel is spliced", Tag(ChannelStateTestsTags.DualFunding)) { f =>
+    import f._
+    connect(alice, bob)
+    connect(bob, carol)
+
+    // we put watchers on auto pilot to confirm funding txs
+    alice.watcher.setAutoPilot(watcherAutopilot(knownFundingTxs(alice, bob, carol)))
+    bob.watcher.setAutoPilot(watcherAutopilot(knownFundingTxs(alice, bob, carol)))
+    carol.watcher.setAutoPilot(watcherAutopilot(knownFundingTxs(alice, bob, carol)))
+
+    val channelId_ab = openChannel(alice, bob, 100_000 sat).channelId
+    val channelId_bc = openChannel(bob, carol, 100_000 sat).channelId
+    val channels = getPeerChannels(alice, bob.nodeId) ++ getPeerChannels(bob, carol.nodeId)
+    assert(channels.map(_.data.channelId).toSet == Set(channelId_ab, channelId_bc))
+
+    // channels confirm deeply
+    eventually {
+      assert(getChannelData(alice, channelId_ab).asInstanceOf[DATA_NORMAL].shortIds.real.isInstanceOf[RealScidStatus.Final])
+      assert(getChannelData(bob, channelId_bc).asInstanceOf[DATA_NORMAL].shortIds.real.isInstanceOf[RealScidStatus.Final])
+    }
+    val scid_ab = getChannelData(alice, channelId_ab).asInstanceOf[DATA_NORMAL].shortIds.real.asInstanceOf[RealScidStatus.Final].realScid
+    val scid_bc = getChannelData(bob, channelId_bc).asInstanceOf[DATA_NORMAL].shortIds.real.asInstanceOf[RealScidStatus.Final].realScid
+
+    // splice in to increase capacity of alice->bob channel
+    spliceIn(alice, bob, channelId_ab, 100_000 sat, None).asInstanceOf[RES_SPLICE].fundingTxId
+
+    // verify that the new capacity and scid are correctly propagated
+    eventually {
+      val scid_ab1 = getChannelData(alice, channelId_ab).asInstanceOf[DATA_NORMAL].shortIds.real.asInstanceOf[RealScidStatus.Final].realScid
+      /// assert(scid_ab != scid_ab1)
+      val channelData_alice1 = getChannelData(alice, channelId_ab).asInstanceOf[DATA_NORMAL]
+      val channelData_bob1 = getChannelData(bob, channelId_ab).asInstanceOf[DATA_NORMAL]
+      assert(channelData_alice1.commitments.latest.capacity == 200_000.sat)
+      assert(channelData_bob1.commitments.latest.capacity == 200_000.sat)
+      assert(channelData_alice1.shortIds.real.toOption.get == channelData_bob1.shortIds.real.toOption.get)
+      //assert(getRouterData(alice).channels(scid_ab1).capacity == 200_000.sat)
+      //assert(getRouterData(bob).channels(scid_ab1).capacity == 200_000.sat)
+      //assert(getRouterData(carol).channels(scid_ab1).capacity == 200_000.sat)
+    }
+
+  }
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/fixtures/MinimalNodeFixture.scala
@@ -8,7 +8,7 @@ import akka.testkit.{TestActor, TestProbe}
 import com.softwaremill.quicklens.ModifyPimp
 import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, Satoshi, SatoshiLong, Transaction, TxId}
+import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, OutPoint, Satoshi, SatoshiLong, Transaction, TxId}
 import fr.acinq.eclair.ShortChannelId.txIndex
 import fr.acinq.eclair.blockchain.SingleKeyOnChainWallet
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher
@@ -325,7 +325,7 @@ object MinimalNodeFixture extends Assertions with Eventually with IntegrationPat
               }
               Behaviors.same
             case watch: ZmqWatcher.WatchExternalChannelSpent =>
-              knownFundingTxs().find(_.txIn.exists(_.outPoint.txid == watch.txId)) match {
+              knownFundingTxs().find(_.txIn.exists(_.outPoint == OutPoint(watch.txId, watch.outputIndex))) match {
                 case Some(nextFundingTx) =>
                   watch.replyTo ! ZmqWatcher.WatchExternalChannelSpentTriggered(watch.shortChannelId, nextFundingTx)
                 case None => timers.startSingleTimer(watch, 10 millis)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
@@ -98,8 +98,7 @@ class BalanceEstimateSpec extends AnyFunSuite {
       .couldSend(60_000 msat, TimestampSecond.now())
 
     // a splice-in that increases channel capacity increases high but not low bounds
-    val balance1 = balance
-      .updateEdge(a.desc, RealShortChannelId(5), 250 sat)
+    val balance1 = balance.updateEdge(a.desc, RealShortChannelId(5), 250 sat)
     assert(balance1.maxCapacity == 250.sat)
     assert(balance1.low == 60_000.msat)
     assert(balance1.high == 190_000.msat)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BalanceEstimateSpec.scala
@@ -21,7 +21,7 @@ import fr.acinq.bitcoin.scalacompat.{Satoshi, SatoshiLong}
 import fr.acinq.eclair.payment.Invoice
 import fr.acinq.eclair.router.Graph.GraphStructure.{DirectedGraph, GraphEdge}
 import fr.acinq.eclair.router.Router.{ChannelDesc, HopRelayParams}
-import fr.acinq.eclair.{CltvExpiryDelta, MilliSatoshiLong, ShortChannelId, TimestampSecond, randomKey}
+import fr.acinq.eclair.{CltvExpiryDelta, MilliSatoshiLong, RealShortChannelId, ShortChannelId, TimestampSecond, randomKey}
 import org.scalactic.Tolerance.convertNumericToPlusOrMinusWrapper
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -85,6 +85,68 @@ class BalanceEstimateSpec extends AnyFunSuite {
     assert(isValid(balance2))
     assert(balance2.maxCapacity == 0.sat)
     assert(balance2.capacities.isEmpty)
+  }
+
+  test("update channels after a splice") {
+    val a = makeEdge(0, 200 sat)
+    val b = makeEdge(1, 100 sat)
+    val unknownDesc = ChannelDesc(ShortChannelId(3), randomKey().publicKey, randomKey().publicKey)
+    val balance = BalanceEstimate.empty(1 day)
+      .addEdge(a)
+      .addEdge(b)
+      .couldNotSend(140_000 msat, TimestampSecond.now())
+      .couldSend(60_000 msat, TimestampSecond.now())
+
+    // a splice-in that increases channel capacity increases high but not low bounds
+    val balance1 = balance
+      .updateEdge(a.desc, RealShortChannelId(5), 250 sat)
+    assert(balance1.maxCapacity == 250.sat)
+    assert(balance1.low == 60_000.msat)
+    assert(balance1.high == 190_000.msat)
+
+    // a splice-in that increases channel capacity of smaller channel does not increase high more than max capacity
+    val balance2 = balance
+      .updateEdge(b.desc, RealShortChannelId(5), 300 sat)
+    assert(balance2.maxCapacity == 300.sat)
+    assert(balance2.low == 60_000.msat)
+    assert(balance2.high == 300_000.msat)
+
+    // a splice-out that decreases channel capacity decreases low bounds but not high bounds
+    val balance3 = balance
+      .updateEdge(a.desc, RealShortChannelId(5), 150 sat)
+    assert(balance3.maxCapacity == 150.sat)
+    assert(balance3.low == 10_000.msat)
+    assert(balance3.high == 140_000.msat)
+
+    // a splice-out that decreases channel capacity of largest channel does not decrease low bounds below zero
+    val balance4 = balance
+      .updateEdge(a.desc, RealShortChannelId(5), 50 sat)
+    assert(balance4.maxCapacity == 100.sat)
+    assert(balance4.low == 0.msat)
+    assert(balance4.high == 100_000.msat)
+
+    // a splice-out that does not decrease the largest channel only decreases low bounds
+    val balance5 = balance
+      .updateEdge(b.desc, RealShortChannelId(5), 50 sat)
+    assert(balance5.maxCapacity == 200.sat)
+    assert(balance5.low == 10_000.msat)
+    assert(balance5.high == 140_000.msat)
+
+    // a splice of an unknown channel that increases max capacity does not change the low/high bounds
+    val balance6 = balance
+      .updateEdge(unknownDesc, RealShortChannelId(5), 900 sat)
+    assert(isValid(balance6))
+    assert(balance6.maxCapacity == 900.sat)
+    assert(balance6.low == 60_000.msat)
+    assert(balance6.high == 140_000.msat)
+
+    // a splice of an unknown channel below max capacity does not change max capacity or low/high bounds
+    val balance7 = balance
+      .updateEdge(unknownDesc, RealShortChannelId(5), 150 sat)
+    assert(isValid(balance7))
+    assert(balance7.maxCapacity == 200.sat)
+    assert(balance7.low == 60_000.msat)
+    assert(balance7.high == 140_000.msat)
   }
 
   test("update bounds based on what could then could not be sent (increasing amounts)") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/GraphSpec.scala
@@ -461,4 +461,25 @@ class GraphSpec extends AnyFunSuite {
       assert(MessagePath.dijkstraMessagePath(graph, a, f, Set.empty, boundaries, BlockHeight(793397), wr).isEmpty)
     }
   }
+
+  test("a channel update only changes the scid and capacity of one edge") {
+    // A --> B has two edges with different short channel ids.
+    val edge = makeEdge(7, a, b, 1 msat, 1)
+    val g = makeTestGraph().addEdge(edge)
+
+    val g1 = g.updateChannel(ChannelDesc(ShortChannelId(7), a, b), RealShortChannelId(10), 99 sat)
+    val edge1 = g1.getEdge(ChannelDesc(ShortChannelId(10), a, b)).get
+    assert(edge1.capacity == 99.sat)
+    assert(g1.getEdge(ChannelDesc(ShortChannelId(7), a, b)).isEmpty)
+
+    // Only the scid and capacity of one edge changes.
+    assert(g1 == makeTestGraph().addEdge(edge1))
+
+    // Updates are symmetric.
+    assert(g1 == g.updateChannel(ChannelDesc(ShortChannelId(7), b, a), RealShortChannelId(10), 99 sat))
+
+    // Updates to an unknown channel do not change the graph.
+    assert(g == g.updateChannel(ChannelDesc(ShortChannelId(1), randomKey().publicKey, b), RealShortChannelId(10), 99 sat))
+  }
+
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -1146,6 +1146,7 @@ class RouterSpec extends BaseRouterSpec {
     // The channel update for the splice is confirmed and the channel is not removed.
     router ! WatchTxConfirmedTriggered(BlockHeight(0), 0, spendingTx(funding_a, funding_b))
     eventListener.expectMsg(ChannelsDiscovered(SingleChannelDiscovered(spliceAnn, newCapacity1, None, None) :: Nil))
+    eventListener.expectMsg(ChannelLost(scid_ab))
     peerConnection.expectNoMessage(100 millis)
     eventListener.expectNoMessage(100 millis)
 


### PR DESCRIPTION
See issue #2437

When an external channel is spent, the router will add it to a new `spentChannels` map instead of immediately removing it from the graph. 

If after 12 blocks an entry in the `spentChannels` map is not part of a splice, it will be removed as before.

When a newly added channel is validated, if it spends the shared output of a recently spent channel then it is a splice.

A splice will update the `shortChannelId` and `capacity` of graph edges of the parent channel instead of removing the parent's edges and adding edges for a new channel. A splice will also reuse and adjust the parent edge's low/high balance bounds information based on the splice.