### PR TITLE
Make cluster serialization support unknown messages

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/remote/LightningMessageSerializer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/remote/LightningMessageSerializer.scala
@@ -16,6 +16,6 @@
 
 package fr.acinq.eclair.remote
 
-import fr.acinq.eclair.wire.protocol.LightningMessageCodecs.lightningMessageCodec
+import fr.acinq.eclair.wire.protocol.LightningMessageCodecs.lightningMessageCodecWithFallback
 
-class LightningMessageSerializer extends ScodecSerializer(42, lightningMessageCodec)
+class LightningMessageSerializer extends ScodecSerializer(42, lightningMessageCodecWithFallback)


### PR DESCRIPTION
The codec that we were using to serialize `LightningMessage`s in the eclair cluster didn't support `UnknownMessage`. This resulted in those messages being dropped by the front and never reaching the backend node.