### PR TITLE
Update Bitcoin Core to 27.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ This means that instead of re-implementing them, Eclair benefits from the verifi
 
 * Eclair needs a _synchronized_, _segwit-ready_, **_zeromq-enabled_**, _wallet-enabled_, _non-pruning_, _tx-indexing_ [Bitcoin Core](https://github.com/bitcoin/bitcoin) node.
 * You must configure your Bitcoin node to use `bech32` or `bech32m` (segwit) addresses. If your wallet has "non-segwit UTXOs" (outputs that are neither `p2sh-segwit`, `bech32` or `bech32m`), you must send them to a `bech32` or `bech32m` address before running Eclair.
-* Eclair requires Bitcoin Core 27.1 or higher. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
+* Eclair requires Bitcoin Core 27.2 or higher. If you are upgrading an existing wallet, you may need to create a new address and send all your funds to that address.
 
 Run bitcoind with the following minimal `bitcoin.conf`:
 

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -15,7 +15,7 @@ This feature isn't meant to be used on mainnet yet and is thus disabled by defau
 
 ### Update minimal version of Bitcoin Core
 
-With this release, eclair requires using Bitcoin Core 27.1.
+With this release, eclair requires using Bitcoin Core 27.2.
 Newer versions of Bitcoin Core may be used, but have not been extensively tested.
 
 This version introduces a new coin selection algorithm called  [CoinGrinder](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-27.0.md#wallet) that will reduce on-chain transaction costs when feerates are high.

--- a/eclair-core/pom.xml
+++ b/eclair-core/pom.xml
@@ -88,9 +88,9 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-27.1/bitcoin-27.1-x86_64-linux-gnu.tar.gz</bitcoind.url>
-                <bitcoind.md5>3253eaa3b0b9b612d39db667699712ac</bitcoind.md5>
-                <bitcoind.sha1>8e37ee39b60d02cdb2934913e5bed756eb0b7107</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-27.2/bitcoin-27.2-x86_64-linux-gnu.tar.gz</bitcoind.url>
+                <bitcoind.md5>c6dcec7ce5c43dafa48fe459911a8049</bitcoind.md5>
+                <bitcoind.sha1>4342a03bbcc98d81fca2c4fb404f96d5dbae4e10</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -101,9 +101,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-27.1/bitcoin-27.1-x86_64-apple-darwin.tar.gz</bitcoind.url>
-                <bitcoind.md5>a741eb0bb55877b8bc05bf1928ed1f10</bitcoind.md5>
-                <bitcoind.sha1>4d67a36c11d0ff3e6b5148d808c439f99a53c7c5</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-27.2/bitcoin-27.2-x86_64-apple-darwin.tar.gz</bitcoind.url>
+                <bitcoind.md5>25857522febc428160bc4eedf46eb6db</bitcoind.md5>
+                <bitcoind.sha1>574d753359ef2b5c1bc0ef1e028d516da86392af</bitcoind.sha1>
             </properties>
         </profile>
         <profile>
@@ -114,9 +114,9 @@
                 </os>
             </activation>
             <properties>
-                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-27.1/bitcoin-27.1-win64.zip</bitcoind.url>
-                <bitcoind.md5>8102305fed89d99291a65b3ee2e649f2</bitcoind.md5>
-                <bitcoind.sha1>0ead7bd39f7ba72717ad3721f617beb84c8d5382</bitcoind.sha1>
+                <bitcoind.url>https://bitcoincore.org/bin/bitcoin-core-27.2/bitcoin-27.2-win64.zip</bitcoind.url>
+                <bitcoind.md5>1a05b7880a01c0437e5e0b7e13a02635</bitcoind.md5>
+                <bitcoind.sha1>84c0b8d1a02d3c024881a180e8a3c670c1e0073a</bitcoind.sha1>
             </properties>
         </profile>
     </profiles>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -188,7 +188,7 @@ class Setup(val datadir: File,
       await(getBitcoinStatus(bitcoinClient), 30 seconds, "bitcoind did not respond after 30 seconds")
     }
     logger.info(s"bitcoind version=${bitcoinStatus.version}")
-    assert(bitcoinStatus.version >= 270100, "Eclair requires Bitcoin Core 27.1 or higher")
+    assert(bitcoinStatus.version >= 270200, "Eclair requires Bitcoin Core 27.2 or higher")
     bitcoinStatus.unspentAddresses.foreach { address =>
       val isSegwit = addressToPublicKeyScript(bitcoinStatus.chainHash, address).map(script => Script.isNativeWitnessScript(script)).getOrElse(false)
       assert(isSegwit, s"Your wallet contains non-segwit UTXOs (e.g. address=$address). You must send those UTXOs to a segwit address to use Eclair (check out our README for more details).")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -62,7 +62,7 @@ trait BitcoindService extends Logging {
 
   val PATH_BITCOIND = sys.env.get("BITCOIND_DIR") match {
     case Some(customBitcoinDir) => new File(customBitcoinDir, "bitcoind")
-    case None => new File(TestUtils.BUILD_DIRECTORY, "bitcoin-27.1/bin/bitcoind")
+    case None => new File(TestUtils.BUILD_DIRECTORY, "bitcoin-27.2/bin/bitcoind")
   }
   logger.info(s"using bitcoind: $PATH_BITCOIND")
   val PATH_BITCOIND_DATADIR = new File(INTEGRATION_TMP_DIR, "datadir-bitcoin")


### PR DESCRIPTION
Bitcoin Core 27.2 is out with some bug fixes. None of the bugs fixed seem to impact us, but there's always a possibility that a security issue was also fixed, so it's better to upgrade!