### PR TITLE
Update scid when splice funding tx confirms

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -467,7 +467,7 @@ object LocalFundingStatus {
   case class ZeroconfPublishedFundingTx(tx: Transaction, localSigs_opt: Option[TxSignatures], liquidityPurchase_opt: Option[LiquidityAds.PurchaseBasicInfo]) extends UnconfirmedFundingTx with Locked {
     override val signedTx_opt: Option[Transaction] = Some(tx)
   }
-  case class ConfirmedFundingTx(tx: Transaction, localSigs_opt: Option[TxSignatures], liquidityPurchase_opt: Option[LiquidityAds.PurchaseBasicInfo]) extends LocalFundingStatus with Locked {
+  case class ConfirmedFundingTx(tx: Transaction, localSigs_opt: Option[TxSignatures], liquidityPurchase_opt: Option[LiquidityAds.PurchaseBasicInfo], blockHeight: BlockHeight, txIndex: Int) extends LocalFundingStatus with Locked {
     override val signedTx_opt: Option[Transaction] = Some(tx)
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -352,7 +352,8 @@ object Helpers {
 
   def makeAnnouncementSignatures(nodeParams: NodeParams, channelParams: ChannelParams, remoteFundingPubKey: PublicKey, shortChannelId: RealShortChannelId): AnnouncementSignatures = {
     val features = Features.empty[Feature] // empty features for now
-    val fundingPubKey = nodeParams.channelKeyManager.fundingPublicKey(channelParams.localParams.fundingKeyPath, fundingTxIndex = 0) // TODO: public announcements are not yet supported with splices
+    val fundingPubKey = nodeParams.channelKeyManager.fundingPublicKey(channelParams.localParams.fundingKeyPath, fundingTxIndex = 0)
+    // TODO: public announcements are not yet supported with splices
     val witness = Announcements.generateChannelAnnouncementWitness(
       nodeParams.chainHash,
       shortChannelId,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
@@ -82,7 +82,7 @@ trait CommonFundingHandlers extends CommonHandlers {
         }
       case _ => () // in the dual-funding case, we have already verified the funding tx
     }
-    val fundingStatus = ConfirmedFundingTx(w.tx, d.commitments.localFundingSigs(w.tx.txid), d.commitments.liquidityPurchase(w.tx.txid))
+    val fundingStatus = ConfirmedFundingTx(w.tx, d.commitments.localFundingSigs(w.tx.txid), d.commitments.liquidityPurchase(w.tx.txid), w.blockHeight, w.txIndex)
     context.system.eventStream.publish(TransactionConfirmed(d.channelId, remoteNodeId, w.tx))
     // When a splice transaction confirms, it double-spends all the commitment transactions that only applied to the
     // previous funding transaction. Our peer cannot publish the corresponding revoked commitments anymore, so we can

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -1832,7 +1832,8 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     bob2alice.ignoreMsg { case _: ChannelUpdate => true }
 
     disconnect(f)
-    reconnect(f)
+    reconnect(f, interceptFundingDeeplyBuried = false)
+    alice2blockchain.expectMsgType[WatchFundingDeeplyBuried]
 
     // NB: channel_ready are not re-sent because the channel has already been used (for building splices).
     bob2alice.expectMsgTypeHaving[SpliceLocked](_.fundingTxId == fundingTx1.txid)
@@ -1846,7 +1847,8 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     alice2blockchain.expectMsgType[WatchFundingSpent]
 
     disconnect(f)
-    reconnect(f)
+    reconnect(f, interceptFundingDeeplyBuried = false)
+    alice2blockchain.expectMsgType[WatchFundingDeeplyBuried]
 
     alice2bob.expectMsgTypeHaving[SpliceLocked](_.fundingTxId == fundingTx1.txid)
     alice2bob.forward(bob)
@@ -1860,7 +1862,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     alice2blockchain.expectMsgType[WatchFundingSpent]
 
     disconnect(f)
-    reconnect(f)
+    reconnect(f, interceptFundingDeeplyBuried = false)
 
     alice2bob.expectMsgTypeHaving[SpliceLocked](_.fundingTxId == fundingTx2.txid)
     alice2bob.forward(bob)
@@ -1876,7 +1878,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
 
     // NB: we disconnect *before* transmitting the splice_locked to Alice.
     disconnect(f)
-    reconnect(f)
+    reconnect(f, interceptFundingDeeplyBuried = false)
 
     alice2bob.expectMsgTypeHaving[SpliceLocked](_.fundingTxId == fundingTx2.txid)
     alice2bob.forward(bob)
@@ -1887,7 +1889,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     bob2alice.expectNoMessage(100 millis)
 
     disconnect(f)
-    reconnect(f)
+    reconnect(f, interceptFundingDeeplyBuried = false)
 
     alice2bob.expectMsgTypeHaving[SpliceLocked](_.fundingTxId == fundingTx2.txid)
     alice2bob.forward(bob)


### PR DESCRIPTION
This PR addresses a [problem](https://github.com/lightning/bolts/pull/1160#issuecomment-2462954942) found during interop testing of splices with CLN.

A zero conf splice should send splice_locked when funding tx is published, but will not update it's scid until the fund tx confirms.

Channel balances and max htlc amounts will not update until local both sends to and receives from it's remote peer splice_locked.