### PR TITLE
Use bitcoin-lib 0.35

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <akka.version>2.6.20</akka.version>
         <akka.http.version>10.2.7</akka.http.version>
         <sttp.version>3.8.16</sttp.version>
-        <bitcoinlib.version>0.34</bitcoinlib.version>
+        <bitcoinlib.version>0.35</bitcoinlib.version>
         <guava.version>32.1.1-jre</guava.version>
         <kamon.version>2.7.3</kamon.version>
     </properties>


### PR DESCRIPTION
`bitcoin-lib` 0.35 uses `bitcoin-kmp` 0.21.0 and `secp256k1-kmp` 0.16.0 which wraps `secp256k1` 0.6.0 (the first official release with musig2 support).