### PR TITLE
Decrypt on-the-fly funding trampoline failures

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
@@ -186,7 +186,8 @@ class ChannelRelay private(nodeParams: NodeParams,
             context.log.info("rejecting htlc reason={}", cmdFail.reason)
             safeSendAndStop(r.add.channelId, cmdFail)
           case RelayNeedsFunding(nextNodeId, cmdFail) =>
-            val cmd = Peer.ProposeOnTheFlyFunding(onTheFlyFundingResponseAdapter, r.amountToForward, r.add.paymentHash, r.outgoingCltv, r.nextPacket, nextPathKey_opt, upstream)
+            // Note that in the channel relay case, we don't have any outgoing onion shared secrets.
+            val cmd = Peer.ProposeOnTheFlyFunding(onTheFlyFundingResponseAdapter, r.amountToForward, r.add.paymentHash, r.outgoingCltv, r.nextPacket, Nil, nextPathKey_opt, upstream)
             register ! Register.ForwardNodeId(forwardNodeIdFailureAdapter, nextNodeId, cmd)
             waitForOnTheFlyFundingResponse(cmdFail)
           case RelaySuccess(selectedChannelId, cmdAdd) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -422,7 +422,7 @@ class NodeRelay private(nodeParams: NodeParams,
       case Right(nextPacket) =>
         val forwardNodeIdFailureAdapter = context.messageAdapter[Register.ForwardNodeIdFailure[Peer.ProposeOnTheFlyFunding]](_ => WrappedOnTheFlyFundingResponse(Peer.ProposeOnTheFlyFundingResponse.NotAvailable("peer not found")))
         val onTheFlyFundingResponseAdapter = context.messageAdapter[Peer.ProposeOnTheFlyFundingResponse](WrappedOnTheFlyFundingResponse)
-        val cmd = Peer.ProposeOnTheFlyFunding(onTheFlyFundingResponseAdapter, amountOut, paymentHash, expiryOut, nextPacket.cmd.onion, nextPacket.cmd.nextPathKey_opt, upstream)
+        val cmd = Peer.ProposeOnTheFlyFunding(onTheFlyFundingResponseAdapter, amountOut, paymentHash, expiryOut, nextPacket.cmd.onion, nextPacket.sharedSecrets, nextPacket.cmd.nextPathKey_opt, upstream)
         register ! Register.ForwardNodeId(forwardNodeIdFailureAdapter, walletNodeId, cmd)
         Behaviors.receiveMessagePartial {
           rejectExtraHtlcPartialFunction orElse {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/OnTheFlyFunding.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/OnTheFlyFunding.scala
@@ -20,6 +20,7 @@ import akka.actor.Cancellable
 import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors, StashBuffer}
 import akka.actor.typed.{ActorRef, Behavior}
+import akka.event.LoggingAdapter
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, Crypto, TxId}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
@@ -87,12 +88,12 @@ object OnTheFlyFunding {
   // @formatter:on
 
   /** An on-the-fly funding proposal sent to our peer. */
-  case class Proposal(htlc: WillAddHtlc, upstream: Upstream.Hot) {
+  case class Proposal(htlc: WillAddHtlc, upstream: Upstream.Hot, onionSharedSecrets: Seq[Sphinx.SharedSecret]) {
     /** Maximum fees that can be collected from this HTLC. */
     def maxFees(htlcMinimum: MilliSatoshi): MilliSatoshi = htlc.amount - htlcMinimum
 
     /** Create commands to fail all upstream HTLCs. */
-    def createFailureCommands(failure_opt: Option[FailureReason]): Seq[(ByteVector32, CMD_FAIL_HTLC)] = upstream match {
+    def createFailureCommands(failure_opt: Option[FailureReason])(implicit log: LoggingAdapter): Seq[(ByteVector32, CMD_FAIL_HTLC)] = upstream match {
       case _: Upstream.Local => Nil
       case u: Upstream.Hot.Channel =>
         val failure = htlc.pathKey_opt match {
@@ -101,11 +102,18 @@ object OnTheFlyFunding {
         }
         Seq(u.add.channelId -> CMD_FAIL_HTLC(u.add.id, failure, commit = true))
       case u: Upstream.Hot.Trampoline =>
-        // In the trampoline case, we currently ignore downstream failures: we should add dedicated failures to the
-        // BOLTs to better handle those cases.
         val failure = failure_opt match {
           case Some(f) => f match {
-            case _: FailureReason.EncryptedDownstreamFailure => FailureReason.LocalFailure(TemporaryNodeFailure())
+            case f: FailureReason.EncryptedDownstreamFailure =>
+              // In the trampoline case, we currently ignore downstream failures: we should add dedicated failures to
+              // the BOLTs to better handle those cases.
+              Sphinx.FailurePacket.decrypt(f.packet, onionSharedSecrets) match {
+                case Left(Sphinx.CannotDecryptFailurePacket(_)) =>
+                  log.warning("couldn't decrypt downstream on-the-fly funding failure")
+                case Right(f) =>
+                  log.warning("downstream on-the-fly funding failure: {}", f.failureMessage.message)
+              }
+              FailureReason.LocalFailure(TemporaryNodeFailure())
             case _: FailureReason.LocalFailure => f
           }
           case None => FailureReason.LocalFailure(UnknownNextPeer())
@@ -131,7 +139,7 @@ object OnTheFlyFunding {
     def maxFees(htlcMinimum: MilliSatoshi): MilliSatoshi = proposed.map(_.maxFees(htlcMinimum)).sum
 
     /** Create commands to fail all upstream HTLCs. */
-    def createFailureCommands(): Seq[(ByteVector32, CMD_FAIL_HTLC)] = proposed.flatMap(_.createFailureCommands(None))
+    def createFailureCommands(implicit log: LoggingAdapter): Seq[(ByteVector32, CMD_FAIL_HTLC)] = proposed.flatMap(_.createFailureCommands(None))
 
     /** Create commands to fulfill all upstream HTLCs. */
     def createFulfillCommands(preimage: ByteVector32): Seq[(ByteVector32, CMD_FULFILL_HTLC)] = proposed.flatMap(_.createFulfillCommands(preimage))
@@ -355,7 +363,13 @@ object OnTheFlyFunding {
       .typecase(0x01, upstreamChannel)
       .typecase(0x02, upstreamTrampoline)
 
-    val proposal: Codec[Proposal] = (("willAddHtlc" | lengthDelimited(willAddHtlcCodec)) :: ("upstream" | upstream)).as[Proposal]
+    val proposal: Codec[Proposal] = (
+      ("willAddHtlc" | lengthDelimited(willAddHtlcCodec)) ::
+        ("upstream" | upstream) ::
+        // We don't need to persist the onion shared secrets: we only persist on-the-fly funding proposals once they
+        // have been funded, at which point we will ignore downstream failures.
+        ("onionSharedSecrets" | provide(Seq.empty[Sphinx.SharedSecret]))
+      ).as[Proposal]
 
     val proposals: Codec[Seq[Proposal]] = listOfN(uint16, proposal).xmap(_.toSeq, _.toList)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/LiquidityDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/LiquidityDbSpec.scala
@@ -78,14 +78,14 @@ class LiquidityDbSpec extends AnyFunSuite {
       val pendingAlice = Seq(
         OnTheFlyFunding.Pending(
           proposed = Seq(
-            OnTheFlyFunding.Proposal(createWillAdd(20_000 msat, paymentHash1, CltvExpiry(500)), upstream(0)),
-            OnTheFlyFunding.Proposal(createWillAdd(1 msat, paymentHash1, CltvExpiry(750), Some(randomKey().publicKey)), upstream(1)),
+            OnTheFlyFunding.Proposal(createWillAdd(20_000 msat, paymentHash1, CltvExpiry(500)), upstream(0), Nil),
+            OnTheFlyFunding.Proposal(createWillAdd(1 msat, paymentHash1, CltvExpiry(750), Some(randomKey().publicKey)), upstream(1), Nil),
           ),
           status = OnTheFlyFunding.Status.Funded(randomBytes32(), TxId(randomBytes32()), 7, 500 msat)
         ),
         OnTheFlyFunding.Pending(
           proposed = Seq(
-            OnTheFlyFunding.Proposal(createWillAdd(195_000_000 msat, paymentHash2, CltvExpiry(1000)), Upstream.Hot.Trampoline(upstream(2) :: upstream(3) :: Nil)),
+            OnTheFlyFunding.Proposal(createWillAdd(195_000_000 msat, paymentHash2, CltvExpiry(1000)), Upstream.Hot.Trampoline(upstream(2) :: upstream(3) :: Nil), Nil),
           ),
           status = OnTheFlyFunding.Status.Funded(randomBytes32(), TxId(randomBytes32()), 3, 0 msat)
         )
@@ -93,13 +93,13 @@ class LiquidityDbSpec extends AnyFunSuite {
       val pendingBob = Seq(
         OnTheFlyFunding.Pending(
           proposed = Seq(
-            OnTheFlyFunding.Proposal(createWillAdd(20_000 msat, paymentHash1, CltvExpiry(42)), upstream(0)),
+            OnTheFlyFunding.Proposal(createWillAdd(20_000 msat, paymentHash1, CltvExpiry(42)), upstream(0), Nil),
           ),
           status = OnTheFlyFunding.Status.Funded(randomBytes32(), TxId(randomBytes32()), 11, 3_500 msat)
         ),
         OnTheFlyFunding.Pending(
           proposed = Seq(
-            OnTheFlyFunding.Proposal(createWillAdd(24_000_000 msat, paymentHash2, CltvExpiry(800_000), Some(randomKey().publicKey)), Upstream.Local(UUID.randomUUID())),
+            OnTheFlyFunding.Proposal(createWillAdd(24_000_000 msat, paymentHash2, CltvExpiry(800_000), Some(randomKey().publicKey)), Upstream.Local(UUID.randomUUID()), Nil),
           ),
           status = OnTheFlyFunding.Status.Funded(randomBytes32(), TxId(randomBytes32()), 0, 10_000 msat)
         )

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/SwitchboardSpec.scala
@@ -43,7 +43,7 @@ class SwitchboardSpec extends TestKitBaseClass with AnyFunSuiteLike {
     val remoteNodeId1 = channel.remoteNodeId
     val paymentHash1 = randomBytes32()
     val pendingOnTheFly1 = OnTheFlyFunding.Pending(
-      proposed = Seq(OnTheFlyFunding.Proposal(OnTheFlyFundingSpec.createWillAdd(10_000_000 msat, paymentHash1, CltvExpiry(600)), Upstream.Local(UUID.randomUUID()))),
+      proposed = Seq(OnTheFlyFunding.Proposal(OnTheFlyFundingSpec.createWillAdd(10_000_000 msat, paymentHash1, CltvExpiry(600)), Upstream.Local(UUID.randomUUID()), Nil)),
       status = OnTheFlyFundingSpec.createStatus()
     )
     nodeParams.db.liquidity.addPendingOnTheFlyFunding(remoteNodeId1, pendingOnTheFly1)
@@ -52,7 +52,7 @@ class SwitchboardSpec extends TestKitBaseClass with AnyFunSuiteLike {
     val remoteNodeId2 = randomKey().publicKey
     val paymentHash2 = randomBytes32()
     val pendingOnTheFly2 = OnTheFlyFunding.Pending(
-      proposed = Seq(OnTheFlyFunding.Proposal(OnTheFlyFundingSpec.createWillAdd(5_000_000 msat, paymentHash2, CltvExpiry(600)), Upstream.Local(UUID.randomUUID()))),
+      proposed = Seq(OnTheFlyFunding.Proposal(OnTheFlyFundingSpec.createWillAdd(5_000_000 msat, paymentHash2, CltvExpiry(600)), Upstream.Local(UUID.randomUUID()), Nil)),
       status = OnTheFlyFundingSpec.createStatus()
     )
     nodeParams.db.liquidity.addPendingOnTheFlyFunding(remoteNodeId2, pendingOnTheFly2)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
@@ -174,9 +174,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
 
     // The HTLCs were not relayed yet, but they match pending on-the-fly funding proposals.
     val upstreamChannel = Upstream.Hot.Channel(htlc_ab_1.head.add, TimestampMilli.now(), a)
-    val downstreamChannel = OnTheFlyFunding.Pending(Seq(OnTheFlyFunding.Proposal(createWillAdd(100_000 msat, channelPaymentHash, CltvExpiry(500)), upstreamChannel)), createStatus())
+    val downstreamChannel = OnTheFlyFunding.Pending(Seq(OnTheFlyFunding.Proposal(createWillAdd(100_000 msat, channelPaymentHash, CltvExpiry(500)), upstreamChannel, Nil)), createStatus())
     val upstreamTrampoline = Upstream.Hot.Trampoline(List(htlc_ab_1.last, htlc_ab_2.head).map(htlc => Upstream.Hot.Channel(htlc.add, TimestampMilli.now(), a)))
-    val downstreamTrampoline = OnTheFlyFunding.Pending(Seq(OnTheFlyFunding.Proposal(createWillAdd(100_000 msat, trampolinePaymentHash, CltvExpiry(500)), upstreamTrampoline)), createStatus())
+    val downstreamTrampoline = OnTheFlyFunding.Pending(Seq(OnTheFlyFunding.Proposal(createWillAdd(100_000 msat, trampolinePaymentHash, CltvExpiry(500)), upstreamTrampoline, Nil)), createStatus())
     nodeParams.db.liquidity.addPendingOnTheFlyFunding(randomKey().publicKey, downstreamChannel)
     nodeParams.db.liquidity.addPendingOnTheFlyFunding(randomKey().publicKey, downstreamTrampoline)
 
@@ -671,7 +671,7 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
       buildHtlcIn(2, channelId_ab_1, paymentHash2), // trampoline relayed
     )
     // The first upstream HTLC was not relayed but has a pending on-the-fly funding proposal.
-    val downstreamChannel = OnTheFlyFunding.Pending(Seq(OnTheFlyFunding.Proposal(createWillAdd(100_000 msat, paymentHash1, CltvExpiry(500)), Upstream.Hot.Channel(htlc_ab(0).add, TimestampMilli.now(), a))), createStatus())
+    val downstreamChannel = OnTheFlyFunding.Pending(Seq(OnTheFlyFunding.Proposal(createWillAdd(100_000 msat, paymentHash1, CltvExpiry(500)), Upstream.Hot.Channel(htlc_ab(0).add, TimestampMilli.now(), a), Nil)), createStatus())
     nodeParams.db.liquidity.addPendingOnTheFlyFunding(randomKey().publicKey, downstreamChannel)
     // The other two HTLCs were relayed after completing on-the-fly funding.
     val htlc_bc = Seq(


### PR DESCRIPTION
Even though we ignore the actual failure and always return a temporary failure upstream, it's useful to decrypt the recipient failure to log it. When we add support for trampoline errors, we will need the decrypted failure to be able to re-wrap it with trampoline onion secrets.