### PR TITLE
Remove obsolete `WatchFundingConfirmed` when using RBF

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonFundingHandlers.scala
@@ -96,10 +96,13 @@ trait CommonFundingHandlers extends CommonHandlers {
         // Children splice transactions may already spend that confirmed funding transaction.
         val spliceSpendingTxs = commitments1.all.collect { case c if c.fundingTxIndex == commitment.fundingTxIndex + 1 => c.fundingTxId }
         watchFundingSpent(commitment, additionalKnownSpendingTxs = spliceSpendingTxs.toSet, None)
-        // in the dual-funding case we can forget all other transactions, they have been double spent by the tx that just confirmed
-        rollbackDualFundingTxs(d.commitments.active // note how we use the unpruned original commitments
+        // In the dual-funding/splicing case we can forget all other transactions (RBF attempts), they have been
+        // double-spent by the tx that just confirmed.
+        val conflictingTxs = d.commitments.active // note how we use the unpruned original commitments
           .filter(c => c.fundingTxIndex == commitment.fundingTxIndex && c.fundingTxId != commitment.fundingTxId)
-          .map(_.localFundingStatus).collect { case fundingTx: DualFundedUnconfirmedFundingTx => fundingTx.sharedTx })
+          .map(_.localFundingStatus).collect { case fundingTx: DualFundedUnconfirmedFundingTx => fundingTx.sharedTx }
+        conflictingTxs.foreach(tx => blockchain ! UnwatchTxConfirmed(tx.txId))
+        rollbackDualFundingTxs(conflictingTxs)
         (commitments1, commitment)
     }
   }


### PR DESCRIPTION
When using RBF for a dual-funded channel or a splice, we set multiple `WatchFundingConfirmed` for conflicting transactions. When one of those transactions confirms, the others will never confirm: it is wasteful to keep watching for their confirmation.

The watcher doesn't have enough information on its own to efficiently detect that some watches are double-spent: we instead rely on the consumer of the watch to tell the watcher to stop watching the RBF attempts.

Fixes #2954