### PR TITLE
Remove spurious interactive-tx `commit_sig` retransmission

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -1082,6 +1082,11 @@ object InteractiveTxSigningSession {
                             liquidityPurchase_opt: Option[LiquidityAds.PurchaseBasicInfo]) extends InteractiveTxSigningSession {
     val commitInput: InputInfo = localCommit.fold(_.commitTx.input, _.commitTxAndRemoteSig.commitTx.input)
     val localCommitIndex: Long = localCommit.fold(_.index, _.index)
+    // This value tells our peer whether we need them to retransmit their commit_sig on reconnection or not.
+    val nextLocalCommitmentNumber: Long = localCommit match {
+      case Left(unsignedCommit) => unsignedCommit.index
+      case Right(commit) => commit.index + 1
+    }
 
     def receiveCommitSig(nodeParams: NodeParams, channelParams: ChannelParams, remoteCommitSig: CommitSig)(implicit log: LoggingAdapter): Either[ChannelException, InteractiveTxSigningSession] = {
       localCommit match {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForDualFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForDualFundingSignedStateSpec.scala
@@ -21,7 +21,7 @@ import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, SatoshiLong, TxId}
 import fr.acinq.eclair.TestUtils.randomTxId
 import fr.acinq.eclair.blockchain.SingleKeyOnChainWallet
-import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{WatchFundingConfirmed, WatchPublished}
+import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{WatchFundingConfirmed, WatchPublished, WatchPublishedTriggered}
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.fsm.Channel
@@ -375,15 +375,16 @@ class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAny
     bob ! INPUT_DISCONNECTED
     awaitCond(bob.stateName == OFFLINE)
 
-    reconnect(f, fundingTxId)
+    reconnect(f, fundingTxId, aliceExpectsCommitSig = true, bobExpectsCommitSig = true)
   }
 
-  test("recv INPUT_DISCONNECTED (commit_sig not received, next_commitment_number = 0)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
+  test("recv INPUT_DISCONNECTED (commit_sig received by Alice)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
     import f._
 
     val fundingTxId = alice.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_SIGNED].signingSession.fundingTx.txId
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
     alice2bob.expectMsgType[CommitSig] // Bob doesn't receive Alice's commit_sig
-    bob2alice.expectMsgType[CommitSig] // Alice doesn't receive Bob's commit_sig
     awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_SIGNED)
     awaitCond(bob.stateName == WAIT_FOR_DUAL_FUNDING_SIGNED)
 
@@ -392,10 +393,10 @@ class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAny
     bob ! INPUT_DISCONNECTED
     awaitCond(bob.stateName == OFFLINE)
 
-    reconnect(f, fundingTxId, aliceCommitmentNumber = 0, bobCommitmentNumber = 0)
+    reconnect(f, fundingTxId, aliceExpectsCommitSig = false, bobExpectsCommitSig = true)
   }
 
-  test("recv INPUT_DISCONNECTED (commit_sig partially received)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
+  test("recv INPUT_DISCONNECTED (commit_sig received by Bob)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
     import f._
 
     val fundingTxId = alice.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_SIGNED].signingSession.fundingTx.txId
@@ -411,13 +412,12 @@ class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAny
     bob ! INPUT_DISCONNECTED
     awaitCond(bob.stateName == OFFLINE)
 
-    reconnect(f, fundingTxId)
+    reconnect(f, fundingTxId, aliceExpectsCommitSig = true, bobExpectsCommitSig = false)
   }
 
-  test("recv INPUT_DISCONNECTED (commit_sig partially received, next_commitment_number = 0)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
+  test("recv INPUT_DISCONNECTED (commit_sig received by Bob, zero-conf)", Tag(ChannelStateTestsTags.DualFunding), Tag(ChannelStateTestsTags.ZeroConf), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
     import f._
 
-    val fundingTxId = alice.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_SIGNED].signingSession.fundingTx.txId
     alice2bob.expectMsgType[CommitSig]
     alice2bob.forward(bob)
     bob2alice.expectMsgType[CommitSig] // Alice doesn't receive Bob's commit_sig
@@ -425,12 +425,47 @@ class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAny
     awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_SIGNED)
     awaitCond(bob.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
 
+    // Note that this case can only happen when Bob doesn't need Alice's signatures to publish the transaction (when
+    // Bob was the only one to contribute to the funding transaction).
+    val fundingTx = bob.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED].latestFundingTx.sharedTx.tx.buildUnsignedTx()
+    assert(bob2blockchain.expectMsgType[WatchPublished].txId == fundingTx.txid)
+    bob ! WatchPublishedTriggered(fundingTx)
+    assert(bob2blockchain.expectMsgType[WatchFundingConfirmed].txId == fundingTx.txid)
+    bob2alice.expectMsgType[ChannelReady]
+    awaitCond(bob.stateName == WAIT_FOR_DUAL_FUNDING_READY)
+
     alice ! INPUT_DISCONNECTED
     awaitCond(alice.stateName == OFFLINE)
     bob ! INPUT_DISCONNECTED
     awaitCond(bob.stateName == OFFLINE)
 
-    reconnect(f, fundingTxId, aliceCommitmentNumber = 0)
+    val listener = TestProbe()
+    alice.underlyingActor.context.system.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
+
+    val aliceInit = Init(alice.underlyingActor.nodeParams.features.initFeatures())
+    val bobInit = Init(bob.underlyingActor.nodeParams.features.initFeatures())
+    alice ! INPUT_RECONNECTED(bob, aliceInit, bobInit)
+    bob ! INPUT_RECONNECTED(alice, bobInit, aliceInit)
+    val channelReestablishAlice = alice2bob.expectMsgType[ChannelReestablish]
+    assert(channelReestablishAlice.nextFundingTxId_opt.contains(fundingTx.txid))
+    assert(channelReestablishAlice.nextLocalCommitmentNumber == 0)
+    alice2bob.forward(bob, channelReestablishAlice)
+    val channelReestablishBob = bob2alice.expectMsgType[ChannelReestablish]
+    assert(channelReestablishBob.nextFundingTxId_opt.isEmpty)
+    assert(channelReestablishBob.nextLocalCommitmentNumber == 1)
+    bob2alice.forward(alice, channelReestablishBob)
+
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    bob2alice.expectMsgType[TxSignatures]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxSignatures]
+    alice2bob.forward(bob)
+
+    awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
+    awaitCond(bob.stateName == WAIT_FOR_DUAL_FUNDING_READY)
+    assert(alice2blockchain.expectMsgType[WatchPublished].txId == fundingTx.txid)
+    assert(listener.expectMsgType[TransactionPublished].tx.txid == fundingTx.txid)
   }
 
   test("recv INPUT_DISCONNECTED (commit_sig received)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
@@ -450,7 +485,7 @@ class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAny
     bob ! INPUT_DISCONNECTED
     awaitCond(bob.stateName == OFFLINE)
 
-    reconnect(f, fundingTxId)
+    reconnect(f, fundingTxId, aliceExpectsCommitSig = false, bobExpectsCommitSig = false)
   }
 
   test("recv INPUT_DISCONNECTED (tx_signatures received)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
@@ -466,7 +501,7 @@ class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAny
     bob2alice.forward(alice)
     bob2alice.expectMsgType[TxSignatures]
     bob2alice.forward(alice)
-    alice2bob.expectMsgType[TxSignatures]
+    alice2bob.expectMsgType[TxSignatures] // Bob doesn't receive Alice's tx_signatures
     awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
     awaitCond(bob.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
 
@@ -490,7 +525,52 @@ class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAny
     assert(listener.expectMsgType[TransactionPublished].tx.txid == fundingTxId)
   }
 
-  private def reconnect(f: FixtureParam, fundingTxId: TxId, aliceCommitmentNumber: Long = 1, bobCommitmentNumber: Long = 1): Unit = {
+  test("recv INPUT_DISCONNECTED (tx_signatures received, zero-conf)", Tag(ChannelStateTestsTags.DualFunding), Tag(ChannelStateTestsTags.ZeroConf), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
+    import f._
+
+    val listener = TestProbe()
+    bob.underlyingActor.context.system.eventStream.subscribe(listener.ref, classOf[TransactionPublished])
+
+    alice2bob.expectMsgType[CommitSig]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[CommitSig]
+    bob2alice.forward(alice)
+    bob2alice.expectMsgType[TxSignatures]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxSignatures] // Bob doesn't receive Alice's tx_signatures
+    awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
+    awaitCond(bob.stateName == WAIT_FOR_DUAL_FUNDING_CONFIRMED)
+
+    val fundingTx = alice.stateData.asInstanceOf[DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED].latestFundingTx.signedTx_opt.get
+    assert(alice2blockchain.expectMsgType[WatchPublished].txId == fundingTx.txid)
+    alice ! WatchPublishedTriggered(fundingTx)
+    assert(alice2blockchain.expectMsgType[WatchFundingConfirmed].txId == fundingTx.txid)
+    alice2bob.expectMsgType[ChannelReady]
+    awaitCond(alice.stateName == WAIT_FOR_DUAL_FUNDING_READY)
+
+    alice ! INPUT_DISCONNECTED
+    awaitCond(alice.stateName == OFFLINE)
+    bob ! INPUT_DISCONNECTED
+    awaitCond(bob.stateName == OFFLINE)
+
+    val aliceInit = Init(alice.underlyingActor.nodeParams.features.initFeatures())
+    val bobInit = Init(bob.underlyingActor.nodeParams.features.initFeatures())
+    alice ! INPUT_RECONNECTED(bob, aliceInit, bobInit)
+    bob ! INPUT_RECONNECTED(alice, bobInit, aliceInit)
+
+    assert(alice2bob.expectMsgType[ChannelReestablish].nextFundingTxId_opt.isEmpty)
+    alice2bob.forward(bob)
+    assert(bob2alice.expectMsgType[ChannelReestablish].nextFundingTxId_opt.contains(fundingTx.txid))
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxSignatures]
+    alice2bob.forward(bob)
+    alice2bob.expectMsgType[ChannelReady]
+    alice2bob.forward(bob)
+    assert(bob2blockchain.expectMsgType[WatchPublished].txId == fundingTx.txid)
+    assert(listener.expectMsgType[TransactionPublished].tx.txid == fundingTx.txid)
+  }
+
+  private def reconnect(f: FixtureParam, fundingTxId: TxId, aliceExpectsCommitSig: Boolean, bobExpectsCommitSig: Boolean): Unit = {
     import f._
 
     val listener = TestProbe()
@@ -501,17 +581,24 @@ class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAny
     alice ! INPUT_RECONNECTED(bob, aliceInit, bobInit)
     bob ! INPUT_RECONNECTED(alice, bobInit, aliceInit)
     val channelReestablishAlice = alice2bob.expectMsgType[ChannelReestablish]
+    val nextLocalCommitmentNumberAlice = if (aliceExpectsCommitSig) 0 else 1
     assert(channelReestablishAlice.nextFundingTxId_opt.contains(fundingTxId))
-    assert(channelReestablishAlice.nextLocalCommitmentNumber == 1)
-    alice2bob.forward(bob, channelReestablishAlice.copy(nextLocalCommitmentNumber = aliceCommitmentNumber))
+    assert(channelReestablishAlice.nextLocalCommitmentNumber == nextLocalCommitmentNumberAlice)
+    alice2bob.forward(bob, channelReestablishAlice)
     val channelReestablishBob = bob2alice.expectMsgType[ChannelReestablish]
+    val nextLocalCommitmentNumberBob = if (bobExpectsCommitSig) 0 else 1
     assert(channelReestablishBob.nextFundingTxId_opt.contains(fundingTxId))
-    assert(channelReestablishBob.nextLocalCommitmentNumber == 1)
-    bob2alice.forward(alice, channelReestablishBob.copy(nextLocalCommitmentNumber = bobCommitmentNumber))
-    bob2alice.expectMsgType[CommitSig]
-    bob2alice.forward(alice)
-    alice2bob.expectMsgType[CommitSig]
-    alice2bob.forward(bob)
+    assert(channelReestablishBob.nextLocalCommitmentNumber == nextLocalCommitmentNumberBob)
+    bob2alice.forward(alice, channelReestablishBob)
+
+    if (aliceExpectsCommitSig) {
+      bob2alice.expectMsgType[CommitSig]
+      bob2alice.forward(alice)
+    }
+    if (bobExpectsCommitSig) {
+      alice2bob.expectMsgType[CommitSig]
+      alice2bob.forward(bob)
+    }
     bob2alice.expectMsgType[TxSignatures]
     bob2alice.forward(alice)
     alice2bob.expectMsgType[TxSignatures]


### PR DESCRIPTION
We fully implement https://github.com/lightning/bolts/pull/1214 to stop retransmitting `commit_sig` when our peer has already received it. We also correctly set `next_commitment_number` to let our peer know whether we have received their `commit_sig` or not.

Note that if our peer hasn't upgraded and always sends `next_commitment_number = current_commitment_number + 1` even when they haven't received our `commit_sig`, this won't lead to a force-close: we will simply wait for them to send an `error`, which will never happen. Their channel will be stuck until they upgrade and send `next_commitment_number = current_commitment_number`.

This change must only be merged once:

- we've deployed our node with the changes from #2965
- we've made a Phoenix release that includes https://github.com/ACINQ/lightning-kmp/pull/736 so that users can upgrade to avoid being stuck