### PR TITLE
`OutgoingNodeId` in a blinded path may not be a wallet

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelay.scala
@@ -34,7 +34,7 @@ import fr.acinq.eclair.payment.{ChannelPaymentRelayed, IncomingPaymentPacket}
 import fr.acinq.eclair.wire.protocol.FailureMessageCodecs.createBadOnionFailure
 import fr.acinq.eclair.wire.protocol.PaymentOnion.IntermediatePayload
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{Features, InitFeature, Logs, NodeParams, TimestampMilli, TimestampSecond, channel, nodeFee}
+import fr.acinq.eclair.{EncodedNodeId, Features, InitFeature, Logs, NodeParams, TimestampMilli, TimestampSecond, channel, nodeFee}
 
 import java.util.UUID
 import java.util.concurrent.TimeUnit
@@ -142,7 +142,8 @@ class ChannelRelay private(nodeParams: NodeParams,
   }
 
   private val (requestedShortChannelId_opt, walletNodeId_opt) = r.payload.outgoing match {
-    case Left(walletNodeId) => (None, Some(walletNodeId))
+    case Left(EncodedNodeId.WithPublicKey.Wallet(walletNodeId)) => (None, Some(walletNodeId))
+    case Left(_) => (None, None)
     case Right(shortChannelId) => (Some(shortChannelId), None)
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelayer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/ChannelRelayer.scala
@@ -71,7 +71,7 @@ object ChannelRelayer {
           case Relay(channelRelayPacket, originNode) =>
             val relayId = UUID.randomUUID()
             val nextNodeId_opt: Option[PublicKey] = channelRelayPacket.payload.outgoing match {
-              case Left(walletNodeId) => Some(walletNodeId)
+              case Left(outgoingNodeId) => Some(outgoingNodeId.publicKey)
               case Right(outgoingChannelId) => scid2channels.get(outgoingChannelId) match {
                 case Some(channelId) => channels.get(channelId).map(_.nextNodeId)
                 case None => None

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/BlindedPathsResolver.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/BlindedPathsResolver.scala
@@ -112,8 +112,7 @@ private class BlindedPathsResolver(nodeParams: NodeParams,
                   )
                   paymentRelayData.outgoing match {
                     case Left(outgoingNodeId) =>
-                      // The next node seems to be a wallet node directly connected to us.
-                      validateRelay(EncodedNodeId.WithPublicKey.Wallet(outgoingNodeId), nextPaymentInfo, paymentRelayData, nextPathKey, paymentRoute.route.subsequentNodes, toResolve.tail, resolved)
+                      validateRelay(outgoingNodeId, nextPaymentInfo, paymentRelayData, nextPathKey, paymentRoute.route.subsequentNodes, toResolve.tail, resolved)
                     case Right(outgoingChannelId) =>
                       register ! Register.GetNextNodeId(context.messageAdapter(WrappedNodeId), outgoingChannelId)
                       waitForNextNodeId(outgoingChannelId, nextPaymentInfo, paymentRelayData, nextPathKey, paymentRoute.route.subsequentNodes, toResolve.tail, resolved)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -23,7 +23,7 @@ import fr.acinq.eclair.wire.protocol.BlindedRouteData.PaymentRelayData
 import fr.acinq.eclair.wire.protocol.CommonCodecs._
 import fr.acinq.eclair.wire.protocol.OnionRoutingCodecs.{ForbiddenTlv, InvalidTlvPayload, MissingRequiredTlv}
 import fr.acinq.eclair.wire.protocol.TlvCodecs._
-import fr.acinq.eclair.{CltvExpiry, Features, MilliSatoshi, ShortChannelId, UInt64}
+import fr.acinq.eclair.{CltvExpiry, EncodedNodeId, Features, MilliSatoshi, ShortChannelId, UInt64}
 import scodec.bits.{BitVector, ByteVector}
 
 /**
@@ -228,7 +228,7 @@ object PaymentOnion {
     sealed trait ChannelRelay extends IntermediatePayload {
       // @formatter:off
       /** The outgoing channel, or the nodeId of one of our peers. */
-      def outgoing: Either[PublicKey, ShortChannelId]
+      def outgoing: Either[EncodedNodeId.WithPublicKey, ShortChannelId]
       def amountToForward(incomingAmount: MilliSatoshi): MilliSatoshi
       def outgoingCltv(incomingCltv: CltvExpiry): CltvExpiry
       // @formatter:on

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/PaymentOnionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/PaymentOnionSpec.scala
@@ -128,7 +128,8 @@ class PaymentOnionSpec extends AnyFunSuite {
         RouteBlindingEncryptedDataTlv.PaymentConstraints(CltvExpiry(1500), 1 msat),
       )
       val Right(payload) = IntermediatePayload.ChannelRelay.Blinded.validate(TlvStream(EncryptedRecipientData(hex"deadbeef")), blindedTlvs, randomKey().publicKey)
-      assert(payload.outgoing == Left(nextNodeId))
+      val Left(nodeId) = payload.outgoing
+      assert(nodeId.publicKey == nextNodeId)
       assert(payload.amountToForward(10_000 msat) == 9990.msat)
       assert(payload.outgoingCltv(CltvExpiry(1000)) == CltvExpiry(856))
       assert(payload.paymentRelayData.allowedFeatures.isEmpty)


### PR DESCRIPTION
`OutgoingNodeId` was assumed to be a wallet. While it probably shouldn't cause problems, it's better to keep both cases distinct.