### PR TITLE
Add router support for batched splices

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Validation.scala
@@ -113,7 +113,14 @@ object Validation {
             log.debug("validation successful for shortChannelId={}", c.shortChannelId)
             remoteOrigins.foreach(o => sendDecision(o.peerConnection, GossipDecision.Accepted(c)))
             val capacity = tx.txOut(outputIndex).amount
-            d0.spentChannels.get(tx.txid) match {
+            val parentScid = d0.spentChannels.get(tx.txid).flatMap { parentScids =>
+              parentScids.find { parentScid =>
+                d0.channels.get(parentScid).exists { parent =>
+                  Set(c.nodeId1, c.nodeId2) == Set(parent.nodeId1, parent.nodeId2)
+                }
+              }
+            }
+            parentScid match {
               case Some(parentScid) =>
                 d0.channels.get(parentScid) match {
                   case Some(parentChannel) =>
@@ -191,9 +198,12 @@ object Validation {
     // we need to update the graph because the edge identifiers and capacity change from the parent scid to the new splice scid
     log.debug("updating the graph for shortChannelId={}", newPubChan.shortChannelId)
     val graph1 = d.graphWithBalances.updateChannel(ChannelDesc(parentChannel.shortChannelId, parentChannel.nodeId1, parentChannel.nodeId2), ann.shortChannelId, capacity)
-    val spendingTxs = d.spentChannels.filter(_._2 == parentChannel.shortChannelId).keySet
-    spendingTxs.foreach(txId => watcher ! UnwatchTxConfirmed(txId))
-    val spentChannels1 = d.spentChannels -- spendingTxs
+    val spentChannels1 = d.spentChannels.collect {
+      case (txId, parentScids) if (parentScids - parentChannel.shortChannelId).nonEmpty =>
+        txId -> (parentScids - parentChannel.shortChannelId)
+    }
+    (d.spentChannels -- spentChannels1.keys).keys.foreach(txId => watcher ! UnwatchTxConfirmed(txId))
+
     d.copy(
       // we also add the splice scid -> channelId and remove the parent scid -> channelId mappings
       channels = d.channels + (newPubChan.shortChannelId -> newPubChan) - parentChannel.shortChannelId,
@@ -267,34 +277,41 @@ object Validation {
     } else d1
   }
 
-  def handleChannelSpent(d: Data, watcher: typed.ActorRef[ZmqWatcher.Command], db: NetworkDb, spendingTxId: TxId, shortChannelId: RealShortChannelId)(implicit ctx: ActorContext, log: LoggingAdapter): Data = {
+  def handleChannelSpent(d: Data, watcher: typed.ActorRef[ZmqWatcher.Command], db: NetworkDb, spendingTxId: TxId, shortChannelIds: Set[RealShortChannelId])(implicit ctx: ActorContext, log: LoggingAdapter): Data = {
     implicit val sender: ActorRef = ctx.self // necessary to preserve origin when sending messages to other actors
-    val lostChannel = d.channels.get(shortChannelId).orElse(d.prunedChannels.get(shortChannelId)).get
-    log.info("funding tx for channelId={} was spent", shortChannelId)
+
+    val lostChannels = shortChannelIds.map(shortChannelId => d.channels.get(shortChannelId).orElse(d.prunedChannels.get(shortChannelId)).get)
+    log.info("funding tx for channelIds={} was spent", shortChannelIds)
     // we need to remove nodes that aren't tied to any channels anymore
-    val channels1 = d.channels - shortChannelId
-    val prunedChannels1 = d.prunedChannels - shortChannelId
-    val lostNodes = Seq(lostChannel.nodeId1, lostChannel.nodeId2).filterNot(nodeId => hasChannels(nodeId, channels1.values))
+    val channels1 = d.channels -- shortChannelIds
+    val prunedChannels1 = d.prunedChannels -- shortChannelIds
+    val lostNodes = lostChannels.flatMap(lostChannel => Seq(lostChannel.nodeId1, lostChannel.nodeId2).filterNot(nodeId => hasChannels(nodeId, channels1.values)))
     // let's clean the db and send the events
-    log.info("pruning shortChannelId={} (spent)", shortChannelId)
-    db.removeChannel(shortChannelId) // NB: this also removes channel updates
+    log.info("pruning shortChannelIds={} (spent)", shortChannelIds)
+    shortChannelIds.foreach(db.removeChannel(_)) // NB: this also removes channel updates
     // we also need to remove updates from the graph
-    val graphWithBalances1 = d.graphWithBalances
-      .removeChannel(ChannelDesc(lostChannel.shortChannelId, lostChannel.nodeId1, lostChannel.nodeId2))
+    val graphWithBalances1 = lostChannels.foldLeft(d.graphWithBalances) { (graph, lostChannel) =>
+      graph.removeChannel(ChannelDesc(lostChannel.shortChannelId, lostChannel.nodeId1, lostChannel.nodeId2))
+    }
     // we notify front nodes
-    ctx.system.eventStream.publish(ChannelLost(shortChannelId))
+    shortChannelIds.foreach(shortChannelId => ctx.system.eventStream.publish(ChannelLost(shortChannelId)))
     lostNodes.foreach {
       nodeId =>
         log.info("pruning nodeId={} (spent)", nodeId)
         db.removeNode(nodeId)
         ctx.system.eventStream.publish(NodeLost(nodeId))
     }
-    // we no longer need to track this or alternative transactions that spent the parent channel
-    // either this channel was really closed, or it was spliced and the announcement was not received in time
-    // we will re-add a spliced channel as a new channel later when we receive the announcement
-    watcher ! UnwatchExternalChannelSpent(lostChannel.fundingTxId, outputIndex(lostChannel.ann.shortChannelId))
-    val spendingTxs = d.spentChannels.filter(_._2 == shortChannelId).keySet
-    // stop watching the spending txs that will never confirm, we already got confirmations for this spending tx
+    lostChannels.foreach {
+      lostChannel =>
+        // we no longer need to track this or alternative transactions that spent the parent channel
+        // either this channel was really closed, or it was spliced and the announcement was not received in time
+        // we will re-add a spliced channel as a new channel later when we receive the announcement
+        watcher ! UnwatchExternalChannelSpent(lostChannel.fundingTxId, outputIndex(lostChannel.ann.shortChannelId))
+    }
+
+    // We do not need to track other spending txs if one or more of their inputs have been spent by this spending tx
+    val spendingTxs = d.spentChannels.filter(_._2.intersect(shortChannelIds).nonEmpty).keySet
+    // stop watching the spending txs that will never confirm because this alternate spending tx confirmed
     (spendingTxs - spendingTxId).foreach(txId => watcher ! UnwatchTxConfirmed(txId))
     val spentChannels1 = d.spentChannels -- spendingTxs
     d.copy(nodes = d.nodes -- lostNodes, channels = channels1, prunedChannels = prunedChannels1, graphWithBalances = graphWithBalances1, spentChannels = spentChannels1)
@@ -599,7 +616,14 @@ object Validation {
             log.debug("this is a known pruned local channel, processing channel_update for channelId={} scid={}", lcu.channelId, ann.shortChannelId)
             handleChannelUpdate(d, db, nodeParams.currentBlockHeight, Left(lcu))
           case Some(ann) =>
-            val d1 = d.spentChannels.get(ann.fundingTxId).flatMap(parentScid => d.channels.get(parentScid)) match {
+            // A single transaction may splice multiple channels (batching), in which case we have multiple parent
+            // channels. We cannot know which parent channel this announcement corresponds to, but it doesn't matter.
+            // We only need to update one of the parent channels between the same set of nodes to correctly update
+            // our graph.
+            val d1 = d.spentChannels
+              .getOrElse(ann.fundingTxId, Set.empty)
+              .flatMap(d.channels.get)
+              .find(parent => parent.nodeId1 == ann.announcement.nodeId1 && parent.nodeId2 == ann.announcement.nodeId2) match {
               case Some(parentChannel) =>
                 // This is a splice for which we haven't processed the (local) channel_announcement yet.
                 log.debug("processing channel_announcement for local splice with fundingTxId={} channelId={} scid={} (previous={})", ann.fundingTxId, lcu.channelId, ann.shortChannelId, parentChannel.shortChannelId)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/channel/GossipIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/channel/GossipIntegrationSpec.scala
@@ -52,13 +52,19 @@ class GossipIntegrationSpec extends FixtureSpec with IntegrationPatience {
     val channels = getPeerChannels(alice, bob.nodeId) ++ getPeerChannels(bob, carol.nodeId)
     assert(channels.map(_.data.channelId).toSet == Set(channelId_ab, channelId_bc))
 
-    eventually {
+    val scid_ab = eventually {
       assert(getChannelData(alice, channelId_ab).asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.isInstanceOf[LocalFundingStatus.ConfirmedFundingTx])
       assert(getChannelData(bob, channelId_bc).asInstanceOf[DATA_NORMAL].commitments.latest.localFundingStatus.isInstanceOf[LocalFundingStatus.ConfirmedFundingTx])
+      val scid_ab = getChannelData(alice, channelId_ab).asInstanceOf[DATA_NORMAL].commitments.latest.shortChannelId_opt.get
+      // Wait for Alice to receive both initial local channel updates.
+      inside(getRouterData(alice)) { routerData =>
+        val channel_ab = routerData.channels(scid_ab)
+        Seq(channel_ab.update_1_opt, channel_ab.update_2_opt).flatten.foreach(u => assert(u.shortChannelId == scid_ab))
+      }
+      scid_ab
     }
 
     // We splice in to increase the capacity of the alice->bob channel.
-    val scid_ab = getChannelData(alice, channelId_ab).asInstanceOf[DATA_NORMAL].commitments.latest.shortChannelId_opt.get
     val spliceTxId = spliceIn(alice, channelId_ab, 100_000 sat, None).asInstanceOf[RES_SPLICE].fundingTxId
 
     // The announcement for the splice transaction and the corresponding channel updates are broadcast.
@@ -73,10 +79,12 @@ class GossipIntegrationSpec extends FixtureSpec with IntegrationPatience {
       val splice_scid_ab = channelData_alice.commitments.latest.shortChannelId_opt.get
       assert(splice_scid_ab != scid_ab)
       assert(channelData_bob.commitments.latest.shortChannelId_opt.contains(splice_scid_ab))
+      val scid_bc = getChannelData(bob, channelId_bc).asInstanceOf[DATA_NORMAL].commitments.latest.shortChannelId_opt.get
 
       // Alice creates a channel_announcement for the splice transaction and updates the graph.
       val spliceAnn = inside(getRouterData(alice)) { routerData =>
-        assert(routerData.channels.contains(splice_scid_ab))
+        assert(routerData.channels.keys == Set(splice_scid_ab, scid_bc))
+        assert(routerData.spentChannels.isEmpty)
         val channel_ab = routerData.channels(splice_scid_ab)
         assert(channel_ab.capacity == 200_000.sat)
         assert(channel_ab.update_1_opt.nonEmpty && channel_ab.update_2_opt.nonEmpty)
@@ -91,6 +99,8 @@ class GossipIntegrationSpec extends FixtureSpec with IntegrationPatience {
 
       // Bob also creates a channel_announcement for the splice transaction and updates the graph.
       inside(getRouterData(bob)) { routerData =>
+        assert(routerData.channels.keys == Set(splice_scid_ab, scid_bc))
+        assert(routerData.spentChannels.isEmpty)
         assert(routerData.channels.get(splice_scid_ab).map(_.ann).contains(spliceAnn))
         routerData.channels.get(splice_scid_ab).foreach(c => {
           assert(c.capacity == 200_000.sat)
@@ -106,6 +116,8 @@ class GossipIntegrationSpec extends FixtureSpec with IntegrationPatience {
 
       // The channel_announcement for the splice propagates to Carol.
       inside(getRouterData(carol)) { routerData =>
+        assert(routerData.channels.keys == Set(splice_scid_ab, scid_bc))
+        assert(routerData.spentChannels.isEmpty)
         assert(routerData.channels.get(splice_scid_ab).map(_.ann).contains(spliceAnn))
         routerData.channels.get(splice_scid_ab).foreach(c => {
           assert(c.capacity == 200_000.sat)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/channel/GossipIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/channel/GossipIntegrationSpec.scala
@@ -59,7 +59,8 @@ class GossipIntegrationSpec extends FixtureSpec with IntegrationPatience {
       // Wait for Alice to receive both initial local channel updates.
       inside(getRouterData(alice)) { routerData =>
         val channel_ab = routerData.channels(scid_ab)
-        Seq(channel_ab.update_1_opt, channel_ab.update_2_opt).flatten.foreach(u => assert(u.shortChannelId == scid_ab))
+        val receivedUpdates = Seq(channel_ab.update_1_opt, channel_ab.update_2_opt).flatten
+        assert(receivedUpdates.count(_.shortChannelId == scid_ab) == 2)
       }
       scid_ab
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/BaseRouterSpec.scala
@@ -231,6 +231,42 @@ abstract class BaseRouterSpec extends TestKitBaseClass with FixtureAnyFunSuiteLi
     }
   }
 
+  def addChannel(router: ActorRef, watcher: TestProbe, scid: RealShortChannelId, priv1: PrivateKey, priv2: PrivateKey, priv_funding1: PrivateKey, priv_funding2: PrivateKey): (ChannelAnnouncement, ChannelUpdate, ChannelUpdate) = {
+    val channelAnnoucement = channelAnnouncement(scid, priv1, priv2, priv_funding1, priv_funding2)
+    val pub1 = priv1.publicKey
+    val pub2 = priv2.publicKey
+    val update1 = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv1, pub2, scid, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = htlcMaximum)
+    val update2 = makeChannelUpdate(Block.RegtestGenesisBlock.hash, priv2, pub1, scid, CltvExpiryDelta(7), htlcMinimumMsat = 0 msat, feeBaseMsat = 10 msat, feeProportionalMillionths = 10, htlcMaximumMsat = htlcMaximum)
+    val pub_funding1 = priv_funding1.publicKey
+    val pub_funding2 = priv_funding2.publicKey
+    assert(ChannelDesc(update1, channelAnnoucement) == ChannelDesc(channelAnnoucement.shortChannelId, pub1, pub2))
+    val sender1 = TestProbe()
+    val peerConnection = TestProbe()
+    peerConnection.ignoreMsg { case _: TransportHandler.ReadAck => true }
+    peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, channelAnnoucement))
+    peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, update1))
+    peerConnection.send(router, PeerRoutingMessage(peerConnection.ref, remoteNodeId, update2))
+    assert(watcher.expectMsgType[ValidateRequest].ann == channelAnnoucement)
+    watcher.send(router, ValidateResult(channelAnnoucement, Right((Transaction(version = 0, txIn = Nil, txOut = TxOut(publicChannelCapacity, write(pay2wsh(Scripts.multiSig2of2(pub_funding1, pub_funding2)))) :: Nil, lockTime = 0), UtxoStatus.Unspent))))
+    assert(watcher.expectMsgType[WatchExternalChannelSpent].shortChannelId == scid)
+    peerConnection.expectMsgAllOf(
+      GossipDecision.Accepted(channelAnnoucement),
+      GossipDecision.Accepted(update1),
+      GossipDecision.Accepted(update2)
+    )
+    peerConnection.expectNoMessage()
+    awaitCond({
+      sender1.send(router, GetNodes)
+      val nodes = sender1.expectMsgType[Iterable[NodeAnnouncement]]
+      sender1.send(router, GetChannels)
+      val channels = sender1.expectMsgType[Iterable[ChannelAnnouncement]]
+      sender1.send(router, GetChannelUpdates)
+      val updates = sender1.expectMsgType[Iterable[ChannelUpdate]]
+      nodes.size == 8 && channels.size == 6 && updates.size == 14
+    }, max = 10 seconds, interval = 1 second)
+    (channelAnnoucement, update1, update2)
+  }
+
 }
 
 object BaseRouterSpec {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -1345,8 +1345,7 @@ class RouterSpec extends BaseRouterSpec {
           assert(routerData.spentChannels(spliceTx_bc.txid) == Set(scid_bc))
           assert(routerData.spentChannels(batchSpliceTx.txid) == Set(scid_bc))
           assert(routerData.spentChannels(batchSpliceTx_RBF.txid) == Set(scid_bc))
-        }
-        else {
+        } else {
           assert(routerData.spentChannels.contains(spliceTx_bc2.txid))
           assert(routerData.spentChannels(spliceTx_bc2.txid) == Set(scid_bc2))
           assert(routerData.spentChannels(batchSpliceTx.txid) == Set(scid_bc2))
@@ -1370,7 +1369,11 @@ class RouterSpec extends BaseRouterSpec {
     eventListener.expectNoMessage(100 millis)
 
     // Alternative spending transactions in the mempool are now unspendable and need not be watched.
-    assert((1 to 2).map(_ => watcher.expectMsgType[UnwatchTxConfirmed].txId).toSet == Set(spliceTx_bc2.txid, batchSpliceTx.txid))
+    val unwatchedTxs = Set(
+      watcher.expectMsgType[UnwatchTxConfirmed].txId,
+      watcher.expectMsgType[UnwatchTxConfirmed].txId,
+    )
+    assert(unwatchedTxs == Set(spliceTx_bc2.txid, batchSpliceTx.txid))
     watcher.expectNoMessage(100 millis)
 
     // The router no longer tracks the parent scids.

--- a/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/router/RouterSpec.scala
@@ -1300,16 +1300,16 @@ class RouterSpec extends BaseRouterSpec {
 
     // The router tracks the possible spending txs for channels ab, bc and bc2.
     val sender = TestProbe()
-    sender.send(router, GetRouterData)
-    inside(sender.expectMsgType[Data]) { routerData =>
-      awaitAssert({
+    awaitAssert({
+      sender.send(router, GetRouterData)
+      inside(sender.expectMsgType[Data]) { routerData =>
         assert(routerData.spentChannels(spliceTx_ab.txid) == Set(scid_ab))
         assert(routerData.spentChannels(spliceTx_bc.txid) == Set(scid_bc))
         assert(routerData.spentChannels(spliceTx_bc2.txid) == Set(scid_bc2))
         assert(routerData.spentChannels(batchSpliceTx.txid) == Set(scid_ab, scid_bc, scid_bc2))
         assert(routerData.spentChannels(batchSpliceTx_RBF.txid) == Set(scid_ab, scid_bc, scid_bc2))
-      })
-    }
+      }
+    })
 
     // The splice of channel ab is announced, verified and added to the graph; the parent channel is removed from the graph.
     val spliceScid_ab = RealShortChannelId(BlockHeight(450000), 1, 0)
@@ -1318,17 +1318,17 @@ class RouterSpec extends BaseRouterSpec {
     assert(watcher.expectMsgType[UnwatchTxConfirmed].txId == spliceTx_ab.txid)
 
     // The router still tracks the possible spending txs for channels bc and bc2.
-    sender.send(router, GetRouterData)
-    inside(sender.expectMsgType[Data]) { routerData =>
-      awaitAssert({
-          assert(!routerData.spentChannels.contains(spliceTx_ab.txid))
-          assert(routerData.spentChannels.contains(spliceTx_bc.txid))
-          assert(routerData.spentChannels.contains(spliceTx_bc2.txid))
-          assert(routerData.spentChannels(spliceTx_bc.txid) == Set(scid_bc))
-          assert(routerData.spentChannels(batchSpliceTx.txid) == Set(scid_bc, scid_bc2))
-          assert(routerData.spentChannels(batchSpliceTx_RBF.txid) == Set(scid_bc, scid_bc2))
-      })
-    }
+    awaitAssert({
+      sender.send(router, GetRouterData)
+      inside(sender.expectMsgType[Data]) { routerData =>
+        assert(!routerData.spentChannels.contains(spliceTx_ab.txid))
+        assert(routerData.spentChannels.contains(spliceTx_bc.txid))
+        assert(routerData.spentChannels.contains(spliceTx_bc2.txid))
+        assert(routerData.spentChannels(spliceTx_bc.txid) == Set(scid_bc))
+        assert(routerData.spentChannels(batchSpliceTx.txid) == Set(scid_bc, scid_bc2))
+        assert(routerData.spentChannels(batchSpliceTx_RBF.txid) == Set(scid_bc, scid_bc2))
+      }
+    })
 
     // The splice of channel bc is announced, verified and added to the graph; the parent channel is removed from the graph.
     val spliceScid_bc = RealShortChannelId(BlockHeight(450000), 1, 1)
@@ -1337,10 +1337,10 @@ class RouterSpec extends BaseRouterSpec {
     assert(watcher.expectMsgType[UnwatchTxConfirmed].txId == spliceTx_bc.txid)
 
     // The router still tracks the possible spending txs for channel bc or bc2 - either could be considered the parent of scid_bc.
-    sender.send(router, GetRouterData)
-    inside(sender.expectMsgType[Data]) { routerData =>
-      awaitAssert({
-         if (routerData.spentChannels.contains(spliceTx_bc.txid)) {
+    awaitAssert({
+      sender.send(router, GetRouterData)
+      inside(sender.expectMsgType[Data]) { routerData =>
+        if (routerData.spentChannels.contains(spliceTx_bc.txid)) {
           assert(!routerData.spentChannels.contains(spliceTx_bc2.txid))
           assert(routerData.spentChannels(spliceTx_bc.txid) == Set(scid_bc))
           assert(routerData.spentChannels(batchSpliceTx.txid) == Set(scid_bc))
@@ -1351,8 +1351,8 @@ class RouterSpec extends BaseRouterSpec {
           assert(routerData.spentChannels(batchSpliceTx.txid) == Set(scid_bc2))
           assert(routerData.spentChannels(batchSpliceTx_RBF.txid) == Set(scid_bc2))
         }
-      })
-    }
+      }
+    })
 
     // Splice channel updates received for ab and bc add new channels to and remove the parent channels from the graph.
     eventListener.expectMsg(ChannelsDiscovered(SingleChannelDiscovered(spliceAnn_ab, newCapacity_ab_RBF, None, None) :: Nil))
@@ -1377,17 +1377,17 @@ class RouterSpec extends BaseRouterSpec {
     watcher.expectNoMessage(100 millis)
 
     // The router no longer tracks the parent scids.
-    sender.send(router, GetRouterData)
-    inside(sender.expectMsgType[Data]) { routerData =>
-      awaitAssert({
+    awaitAssert({
+      sender.send(router, GetRouterData)
+      inside(sender.expectMsgType[Data]) { routerData =>
         assert(routerData.spentChannels.isEmpty)
         assert(!routerData.channels.contains(scid_ab))
         assert(!routerData.channels.contains(scid_bc))
         assert(!routerData.channels.contains(scid_bc2))
         assert(routerData.channels.contains(spliceScid_ab))
         assert(routerData.channels.contains(spliceScid_bc))
-      })
-    }
+      }
+    })
   }
 
 }


### PR DESCRIPTION
A splice tx could involve more than one parent channel. The Router must track the set of channels spent by a given tx until matching channel announcements are received that splice the parent channels or the spend tx is deeply buried.

If a splice tx spends more than one parent channel between the same nodes, then there's no way to know which new channel announcement corresponds to which parent channel. We simply update the first one found.