### PR TITLE
Compute detailed diff of balance

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/BalanceActor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/BalanceActor.scala
@@ -47,7 +47,7 @@ private class BalanceActor(context: ActorContext[Command],
   private val log = context.log
 
   /**
-   * @param refBalance_opt the reference balance computed once at startup, useful for telling if we are making of losing money overall
+   * @param refBalance_opt the reference balance computed once at startup, useful for telling if we are making or losing money overall
    * @param previousBalance_opt the last computed balance, it is useful to make a detailed diff between two successive balance checks
    * @return
    */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/BalanceActor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/BalanceActor.scala
@@ -3,21 +3,19 @@ package fr.acinq.eclair.balance
 import akka.actor.typed.eventstream.EventStream
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.actor.typed.{ActorRef, Behavior}
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, SatoshiLong, TxId}
+import fr.acinq.bitcoin.scalacompat.{Btc, ByteVector32, SatoshiLong}
 import fr.acinq.eclair.NotificationsLogger
 import fr.acinq.eclair.NotificationsLogger.NotifyNodeOperator
 import fr.acinq.eclair.balance.BalanceActor._
-import fr.acinq.eclair.balance.CheckBalance.GlobalBalance
+import fr.acinq.eclair.balance.CheckBalance.{GlobalBalance, computeOffChainBalance}
 import fr.acinq.eclair.balance.Monitoring.{Metrics, Tags}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.Utxo
 import fr.acinq.eclair.channel.PersistentChannelData
 import fr.acinq.eclair.db.Databases
-import grizzled.slf4j.Logger
-import org.json4s.JsonAST.JInt
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 object BalanceActor {
@@ -28,39 +26,15 @@ object BalanceActor {
   final case class GetGlobalBalance(replyTo: ActorRef[Try[GlobalBalance]], channels: Map[ByteVector32, PersistentChannelData]) extends Command
   private final case class WrappedChannels(wrapped: ChannelsListener.GetChannelsResponse) extends Command
   private final case class WrappedGlobalBalanceWithChannels(wrapped: Try[GlobalBalance], channelsCount: Int) extends Command
-  private final case class WrappedUtxoInfo(wrapped: Try[UtxoInfo]) extends Command
   // @formatter:on
 
   def apply(db: Databases, bitcoinClient: BitcoinCoreClient, channelsListener: ActorRef[ChannelsListener.GetChannels], interval: FiniteDuration)(implicit ec: ExecutionContext): Behavior[Command] = {
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         timers.startTimerWithFixedDelay(TickBalance, interval)
-        new BalanceActor(context, db, bitcoinClient, channelsListener).apply(refBalance_opt = None)
+        new BalanceActor(context, db, bitcoinClient, channelsListener).apply(refBalance_opt = None, previousBalance_opt = None)
       }
     }
-  }
-
-  final case class UtxoInfo(utxos: Seq[Utxo], ancestorCount: Map[TxId, Long])
-
-  def checkUtxos(bitcoinClient: BitcoinCoreClient)(implicit ec: ExecutionContext): Future[UtxoInfo] = {
-
-    def getUnconfirmedAncestorCount(utxo: Utxo): Future[(TxId, Long)] = bitcoinClient.rpcClient.invoke("getmempoolentry", utxo.txid).map(json => {
-      val JInt(ancestorCount) = json \ "ancestorcount"
-      (utxo.txid, ancestorCount.toLong)
-    }).recover {
-      case ex: Throwable =>
-        // a bit hackish but we don't need the actor context for this simple log
-        val log = Logger(classOf[BalanceActor])
-        log.warn(s"could not retrieve unconfirmed ancestor count for txId=${utxo.txid} amount=${utxo.amount}:", ex)
-        (utxo.txid, 0)
-    }
-
-    def getUnconfirmedAncestorCountMap(utxos: Seq[Utxo]): Future[Map[TxId, Long]] = Future.sequence(utxos.filter(_.confirmations == 0).map(getUnconfirmedAncestorCount)).map(_.toMap)
-
-    for {
-      utxos <- bitcoinClient.listUnspent()
-      ancestorCount <- getUnconfirmedAncestorCountMap(utxos)
-    } yield UtxoInfo(utxos, ancestorCount)
   }
 
 }
@@ -72,11 +46,10 @@ private class BalanceActor(context: ActorContext[Command],
 
   private val log = context.log
 
-  def apply(refBalance_opt: Option[GlobalBalance]): Behavior[Command] = Behaviors.receiveMessage {
+  def apply(refBalance_opt: Option[GlobalBalance], previousBalance_opt: Option[GlobalBalance]): Behavior[Command] = Behaviors.receiveMessage {
     case TickBalance =>
       log.debug("checking balance...")
       channelsListener ! ChannelsListener.GetChannels(context.messageAdapter[ChannelsListener.GetChannelsResponse](WrappedChannels))
-      context.pipeToSelf(checkUtxos(bitcoinClient))(WrappedUtxoInfo)
       Behaviors.same
     case WrappedChannels(res) =>
       val channelsCount = res.channels.size
@@ -84,61 +57,14 @@ private class BalanceActor(context: ActorContext[Command],
       Behaviors.same
     case WrappedGlobalBalanceWithChannels(res, channelsCount) =>
       res match {
-        case Success(result) =>
-          log.info("current balance: total={} onchain.confirmed={} onchain.unconfirmed={} offchain={}", result.total.toDouble, result.onChain.confirmed.toDouble, result.onChain.unconfirmed.toDouble, result.offChain.total.toDouble)
-          log.debug("current balance details: {}", result)
-          // This is a very rough estimation of the fee we would need to pay for a force-close with 5 pending HTLCs at 100 sat/byte.
-          val perChannelFeeBumpingReserve = 50_000.sat
-          // Instead of scaling this linearly with the number of channels we have, we use sqrt(channelsCount) to reflect
-          // the fact that if you have channels with many peers, only a subset of these peers will likely be malicious.
-          val estimatedFeeBumpingReserve = perChannelFeeBumpingReserve * Math.sqrt(channelsCount)
-          if (result.onChain.confirmed < estimatedFeeBumpingReserve) {
-            val message =
-              s"""On-chain confirmed balance is low (${result.onChain.confirmed.toMilliBtc}): eclair may not be able to guarantee funds safety in case channels force-close.
-                 |You have $channelsCount channels, which could cost $estimatedFeeBumpingReserve in fees if some of these channels are malicious.
-                 |Please note that the value above is a very arbitrary estimation: the real cost depends on the feerate and the number of malicious channels.
-                 |You should add more utxos to your bitcoin wallet to guarantee funds safety.
-                 |""".stripMargin
-            context.system.eventStream ! EventStream.Publish(NotifyNodeOperator(NotificationsLogger.Warning, message))
-          }
-          Metrics.GlobalBalance.withoutTags().update(result.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OnchainConfirmed).update(result.onChain.confirmed.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OnchainUnconfirmed).update(result.onChain.unconfirmed.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.waitForFundingConfirmed).update(result.offChain.waitForFundingConfirmed.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.waitForChannelReady).update(result.offChain.waitForChannelReady.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.normal).update(result.offChain.normal.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.shutdown).update(result.offChain.shutdown.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.closingLocal).update(result.offChain.closing.localCloseBalance.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.closingRemote).update(result.offChain.closing.remoteCloseBalance.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.closingUnknown).update(result.offChain.closing.unknownCloseBalance.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.waitForPublishFutureCommitment).update(result.offChain.waitForPublishFutureCommitment.toMilliBtc.toDouble)
-          refBalance_opt match {
-            case Some(refBalance) =>
-              val normalizedValue = 100 + (if (refBalance.total.toSatoshi.toLong > 0) (result.total.toSatoshi.toLong - refBalance.total.toSatoshi.toLong) * 1000D / refBalance.total.toSatoshi.toLong else 0)
-              val diffValue = result.total.toSatoshi.toLong - refBalance.total.toSatoshi.toLong
-              log.info("relative balance: current={} reference={} normalized={} diff={}", result.total.toDouble, refBalance.total.toDouble, normalizedValue, diffValue)
-              Metrics.GlobalBalanceNormalized.withoutTags().update(normalizedValue)
-              Metrics.GlobalBalanceDiff.withTag(Tags.DiffSign, Tags.DiffSigns.plus).update(diffValue.max(0).toDouble)
-              Metrics.GlobalBalanceDiff.withTag(Tags.DiffSign, Tags.DiffSigns.minus).update((-diffValue).max(0).toDouble)
-              Behaviors.same
-            case None =>
-              log.info("using balance={} as reference", result.total.toDouble)
-              apply(Some(result))
-          }
-        case Failure(t) =>
-          log.warn("could not compute balance: ", t)
-          Behaviors.same
-      }
-    case GetGlobalBalance(replyTo, channels) =>
-      CheckBalance.computeGlobalBalance(channels, db, bitcoinClient) onComplete (replyTo ! _)
-      Behaviors.same
-    case WrappedUtxoInfo(res) =>
-      res match {
-        case Success(UtxoInfo(utxos, ancestorCount)) =>
+        case Success(balance) =>
+          log.info("--------- balance results --------")
+          // utxos metrics
+          val utxos = balance.onChain.details.utxos
           val filteredByStatus: Map[String, Seq[Utxo]] = Map(
             Monitoring.Tags.UtxoStatuses.Confirmed -> utxos.filter(utxo => utxo.confirmations > 0),
             // We cannot create chains of unconfirmed transactions with more than 25 elements, so we ignore such utxos.
-            Monitoring.Tags.UtxoStatuses.Unconfirmed -> utxos.filter(utxo => utxo.confirmations == 0 && ancestorCount.getOrElse(utxo.txid, 1L) < 25),
+            Monitoring.Tags.UtxoStatuses.Unconfirmed -> utxos.filter(utxo => utxo.confirmations == 0 && utxo.ancestorCount_opt.getOrElse(1) < 25),
             Monitoring.Tags.UtxoStatuses.Safe -> utxos.filter(utxo => utxo.safe),
             Monitoring.Tags.UtxoStatuses.Unsafe -> utxos.filter(utxo => !utxo.safe),
           )
@@ -149,9 +75,77 @@ private class BalanceActor(context: ActorContext[Command],
               Monitoring.Metrics.UtxoCount.withTag(Monitoring.Tags.UtxoStatus, status).update(filteredUtxos.length)
               Monitoring.Metrics.BitcoinBalance.withTag(Monitoring.Tags.UtxoStatus, status).update(amount)
           }
+
+          previousBalance_opt match {
+            case Some(previousBalance) =>
+              log.info("on-chain diff={}", balance.onChain.total - previousBalance.onChain.total)
+              val utxosBefore = previousBalance.onChain.details.confirmed ++ previousBalance.onChain.details.unconfirmed ++ previousBalance.onChain.details.confirmedSwapIn ++ previousBalance.onChain.details.unconfirmedSwapIn
+              val utxosAfter = balance.onChain.details.confirmed ++ balance.onChain.details.unconfirmed ++ balance.onChain.details.confirmedSwapIn ++ balance.onChain.details.unconfirmedSwapIn
+              val utxosAdded = utxosAfter -- utxosBefore.keys
+              val utxosRemoved = utxosBefore -- utxosAfter.keys
+              utxosAdded.foreach { case (outPoint, amount) => log.info("+ utxo={} amount={}", outPoint, amount) }
+              utxosRemoved.foreach { case (outPoint, amount) => log.info("- utxo={} amount={}", outPoint, amount) }
+
+              log.info("off-chain diff={}", balance.offChain.total - previousBalance.offChain.total)
+              val offchainBalancesBefore = previousBalance.channels.view.mapValues(computeOffChainBalance(previousBalance.knownPreimages, _).total)
+              val offchainBalancesAfter = balance.channels.view.mapValues(computeOffChainBalance(balance.knownPreimages, _).total)
+              offchainBalancesAfter
+                .map { case (channelId, balanceAfter) => (channelId, offchainBalancesBefore.getOrElse(channelId, Btc(0)), balanceAfter) }
+                .filter { case (_, balanceBefore, balanceAfter) => balanceAfter > balanceBefore }
+                .foreach { case (channelId, balanceBefore, balanceAfter) => log.info("+ channelId={} amount={}", channelId, balanceAfter - balanceBefore) }
+              offchainBalancesBefore
+                .map { case (channelId, balanceBefore) => (channelId, balanceBefore, offchainBalancesAfter.getOrElse(channelId, Btc(0))) }
+                .filter { case (_, balanceBefore, balanceAfter) => balanceBefore > balanceAfter }
+                .foreach { case (channelId, balanceBefore, balanceAfter) => log.info("- channelId={} amount={}", channelId, balanceBefore - balanceAfter) }
+            case None => ()
+          }
+
+          log.info("current balance: total={} onchain.confirmed={} onchain.unconfirmed={} offchain={}", balance.total.toDouble, balance.onChain.confirmed.toDouble, balance.onChain.unconfirmed.toDouble, balance.offChain.total.toDouble)
+          log.debug("current balance details: {}", balance)
+          // This is a very rough estimation of the fee we would need to pay for a force-close with 5 pending HTLCs at 100 sat/byte.
+          val perChannelFeeBumpingReserve = 50_000.sat
+          // Instead of scaling this linearly with the number of channels we have, we use sqrt(channelsCount) to reflect
+          // the fact that if you have channels with many peers, only a subset of these peers will likely be malicious.
+          val estimatedFeeBumpingReserve = perChannelFeeBumpingReserve * Math.sqrt(channelsCount)
+          if (balance.onChain.confirmed < estimatedFeeBumpingReserve) {
+            val message =
+              s"""On-chain confirmed balance is low (${balance.onChain.confirmed.toMilliBtc}): eclair may not be able to guarantee funds safety in case channels force-close.
+                 |You have $channelsCount channels, which could cost $estimatedFeeBumpingReserve in fees if some of these channels are malicious.
+                 |Please note that the value above is a very arbitrary estimation: the real cost depends on the feerate and the number of malicious channels.
+                 |You should add more utxos to your bitcoin wallet to guarantee funds safety.
+                 |""".stripMargin
+            context.system.eventStream ! EventStream.Publish(NotifyNodeOperator(NotificationsLogger.Warning, message))
+          }
+          Metrics.GlobalBalance.withoutTags().update(balance.total.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OnchainConfirmed).update(balance.onChain.confirmed.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OnchainUnconfirmed).update(balance.onChain.unconfirmed.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.waitForFundingConfirmed).update(balance.offChain.waitForFundingConfirmed.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.waitForChannelReady).update(balance.offChain.waitForChannelReady.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.normal).update(balance.offChain.normal.total.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.shutdown).update(balance.offChain.shutdown.total.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.closingLocal).update(balance.offChain.closing.localCloseBalance.total.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.closingRemote).update(balance.offChain.closing.remoteCloseBalance.total.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.closingUnknown).update(balance.offChain.closing.unknownCloseBalance.total.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.waitForPublishFutureCommitment).update(balance.offChain.waitForPublishFutureCommitment.toMilliBtc.toDouble)
+          refBalance_opt match {
+            case Some(refBalance) =>
+              val normalizedValue = 100 + (if (refBalance.total.toSatoshi.toLong > 0) (balance.total.toSatoshi.toLong - refBalance.total.toSatoshi.toLong) * 1000D / refBalance.total.toSatoshi.toLong else 0)
+              val diffValue = balance.total.toSatoshi.toLong - refBalance.total.toSatoshi.toLong
+              log.info("relative balance: current={} reference={} normalized={} diff={}", balance.total.toDouble, refBalance.total.toDouble, normalizedValue, diffValue)
+              Metrics.GlobalBalanceNormalized.withoutTags().update(normalizedValue)
+              Metrics.GlobalBalanceDiff.withTag(Tags.DiffSign, Tags.DiffSigns.plus).update(diffValue.max(0).toDouble)
+              Metrics.GlobalBalanceDiff.withTag(Tags.DiffSign, Tags.DiffSigns.minus).update((-diffValue).max(0).toDouble)
+              apply(refBalance_opt = Some(refBalance), previousBalance_opt = Some(balance))
+            case None =>
+              log.info("using balance={} as reference", balance.total.toDouble)
+              apply(refBalance_opt = Some(balance), previousBalance_opt = Some(balance))
+          }
         case Failure(t) =>
-          log.warn("could not check utxos: ", t)
+          log.warn("could not compute balance: ", t)
+          Behaviors.same
       }
+    case GetGlobalBalance(replyTo, channels) =>
+      CheckBalance.computeGlobalBalance(channels, db, bitcoinClient) onComplete (replyTo ! _)
       Behaviors.same
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
@@ -286,12 +286,12 @@ object CheckBalance {
   }
 
   case class CorrectedOnChainBalance(details: DetailedOnChainBalance) {
-    val confirmed: Btc = (details.confirmed ++ details.confirmedSwapIn).values.map(_.toSatoshi).sum
+    val confirmed: Btc = details.confirmed.values.map(_.toSatoshi).sum
     val unconfirmed: Btc = details.unconfirmed.values.map(_.toSatoshi).sum
     val total: Btc = confirmed + unconfirmed
   }
 
-  case class DetailedOnChainBalance(confirmed: Map[OutPoint, Btc] = Map.empty, unconfirmed: Map[OutPoint, Btc] = Map.empty, confirmedSwapIn: Map[OutPoint, Btc] = Map.empty, unconfirmedSwapIn: Map[OutPoint, Btc] = Map.empty, utxos: Seq[Utxo])
+  case class DetailedOnChainBalance(confirmed: Map[OutPoint, Btc] = Map.empty, unconfirmed: Map[OutPoint, Btc] = Map.empty, utxos: Seq[Utxo])
 
   /**
    * Returns the on-chain balance, but discards the unconfirmed incoming swap-in transactions, because they may be RBF-ed.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
@@ -1,15 +1,16 @@
 package fr.acinq.eclair.balance
 
 import com.softwaremill.quicklens._
-import fr.acinq.bitcoin.scalacompat.{Btc, ByteVector32, Satoshi, SatoshiLong, Script, TxId}
+import fr.acinq.bitcoin.scalacompat.{Btc, ByteVector32, OutPoint, Satoshi, SatoshiLong, Script, TxId}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
+import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.Utxo
 import fr.acinq.eclair.channel.Helpers.Closing
 import fr.acinq.eclair.channel.Helpers.Closing.{CurrentRemoteClose, LocalClose, NextRemoteClose, RemoteClose}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.Databases
 import fr.acinq.eclair.transactions.DirectedHtlc.{incoming, outgoing}
 import fr.acinq.eclair.transactions.Transactions
-import fr.acinq.eclair.transactions.Transactions.{ClaimHtlcSuccessTx, ClaimHtlcTimeoutTx, HtlcSuccessTx, HtlcTimeoutTx}
+import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.wire.protocol.{UpdateAddHtlc, UpdateFulfillHtlc}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -51,11 +52,11 @@ object CheckBalance {
    * That's why we keep track of the id of each transaction that pays us any amount. It allows us to double check from
    * bitcoin core and remove any published transaction.
    */
-  case class PossiblyPublishedMainBalance(toLocal: Map[TxId, Btc] = Map.empty) {
+  case class PossiblyPublishedMainBalance(toLocal: Map[OutPoint, Btc] = Map.empty) {
     val total: Btc = toLocal.values.map(_.toSatoshi).sum
   }
 
-  case class PossiblyPublishedMainAndHtlcBalance(toLocal: Map[TxId, Btc] = Map.empty, htlcs: Map[TxId, Btc] = Map.empty, htlcsUnpublished: Btc = 0.sat) {
+  case class PossiblyPublishedMainAndHtlcBalance(toLocal: Map[OutPoint, Btc] = Map.empty, htlcs: Map[OutPoint, Btc] = Map.empty, htlcsUnpublished: Btc = 0.sat) {
     val totalToLocal: Btc = toLocal.values.map(_.toSatoshi).sum
     val totalHtlcs: Btc = htlcs.values.map(_.toSatoshi).sum
     val total: Btc = totalToLocal + totalHtlcs + htlcsUnpublished
@@ -112,7 +113,7 @@ object CheckBalance {
 
   def computeLocalCloseBalance(changes: CommitmentChanges, l: LocalClose, originChannels: Map[Long, Origin], knownPreimages: Set[(ByteVector32, Long)]): PossiblyPublishedMainAndHtlcBalance = {
     import l._
-    val toLocal = localCommitPublished.claimMainDelayedOutputTx.toSeq.map(c => c.tx.txid -> c.tx.txOut.head.amount.toBtc).toMap
+    val toLocal = localCommitPublished.claimMainDelayedOutputTx.toSeq.map(c => OutPoint(c.tx.txid, 0) -> c.tx.txOut.head.amount.toBtc).toMap
     // incoming htlcs for which we have a preimage and the to-local delay has expired: we have published a claim tx that pays directly to our wallet
     val htlcsInOnChain = localCommitPublished.htlcTxs.values.flatten.collect { case htlcTx: HtlcSuccessTx => htlcTx }
       .filter(htlcTx => localCommitPublished.claimHtlcDelayedTxs.exists(_.input.outPoint.txid == htlcTx.tx.txid))
@@ -137,7 +138,7 @@ object CheckBalance {
       .sumAmount
     // all claim txs have possibly been published
     val htlcs = localCommitPublished.claimHtlcDelayedTxs
-      .map(c => c.tx.txid -> c.tx.txOut.head.amount.toBtc).toMap
+      .map(c => OutPoint(c.tx.txid, 0) -> c.tx.txOut.head.amount.toBtc).toMap
     PossiblyPublishedMainAndHtlcBalance(
       toLocal = toLocal,
       htlcs = htlcs,
@@ -152,11 +153,11 @@ object CheckBalance {
       // We use the pubkeyscript to retrieve our output
       val finalScriptPubKey = Script.write(Script.pay2wpkh(c.params.localParams.walletStaticPaymentBasepoint.get))
       Transactions.findPubKeyScriptIndex(remoteCommitPublished.commitTx, finalScriptPubKey) match {
-        case Right(outputIndex) => Map(remoteCommitPublished.commitTx.txid -> remoteCommitPublished.commitTx.txOut(outputIndex).amount.toBtc)
-        case _ => Map.empty[TxId, Btc] // either we don't have an output (below dust), or we have used a non-default pubkey script
+        case Right(outputIndex) => Map(OutPoint(remoteCommitPublished.commitTx.txid, outputIndex) -> remoteCommitPublished.commitTx.txOut(outputIndex).amount.toBtc)
+        case _ => Map.empty[OutPoint, Btc] // either we don't have an output (below dust), or we have used a non-default pubkey script
       }
     } else {
-      remoteCommitPublished.claimMainOutputTx.toSeq.map(c => c.tx.txid -> c.tx.txOut.head.amount.toBtc).toMap
+      remoteCommitPublished.claimMainOutputTx.toSeq.map(c => OutPoint(c.tx.txid, 0) -> c.tx.txOut.head.amount.toBtc).toMap
     }
     // incoming htlcs for which we have a preimage: we have published a claim tx that pays directly to our wallet
     val htlcsInOnChain = remoteCommitPublished.claimHtlcTxs.values.flatten.collect { case htlcTx: ClaimHtlcSuccessTx => htlcTx }
@@ -178,12 +179,64 @@ object CheckBalance {
       .sumAmount
     // all claim txs have possibly been published
     val htlcs = remoteCommitPublished.claimHtlcTxs.values.flatten
-      .map(c => c.tx.txid -> c.tx.txOut.head.amount.toBtc).toMap
+      .map(c => OutPoint(c.tx.txid, 0) -> c.tx.txOut.head.amount.toBtc).toMap
     PossiblyPublishedMainAndHtlcBalance(
       toLocal = toLocal,
       htlcs = htlcs,
       htlcsUnpublished = htlcIn + htlcOut
     )
+  }
+
+  def computeOffChainBalance(knownPreimages: Set[(ByteVector32, Long)]): (OffChainBalance, PersistentChannelData) => OffChainBalance = {
+    case (r, d: DATA_WAIT_FOR_FUNDING_CONFIRMED) => r.modify(_.waitForFundingConfirmed).using(updateMainBalance(d.commitments.latest.localCommit))
+    case (r, d: DATA_WAIT_FOR_CHANNEL_READY) => r.modify(_.waitForChannelReady).using(updateMainBalance(d.commitments.latest.localCommit))
+    case (r, _: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED) => r // we ignore our balance from unsigned commitments
+    case (r, d: DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED) => r.modify(_.waitForFundingConfirmed).using(updateMainBalance(d.commitments.latest.localCommit))
+    case (r, d: DATA_WAIT_FOR_DUAL_FUNDING_READY) => r.modify(_.waitForChannelReady).using(updateMainBalance(d.commitments.latest.localCommit))
+    case (r, d: DATA_NORMAL) => r.modify(_.normal).using(updateMainAndHtlcBalance(d.commitments, knownPreimages))
+    case (r, d: DATA_SHUTDOWN) => r.modify(_.shutdown).using(updateMainAndHtlcBalance(d.commitments, knownPreimages))
+    case (r, d: DATA_NEGOTIATING) => r.modify(_.negotiating).using(updateMainBalance(d.commitments.latest.localCommit))
+    case (r, d: DATA_CLOSING) =>
+      Closing.isClosingTypeAlreadyKnown(d) match {
+        case None if d.mutualClosePublished.nonEmpty && d.localCommitPublished.isEmpty && d.remoteCommitPublished.isEmpty && d.nextRemoteCommitPublished.isEmpty && d.revokedCommitPublished.isEmpty =>
+          // There can be multiple mutual close transactions for the same channel, but most of the time there will
+          // only be one. We use the last one in the list, which should be the one we have seen last in our local
+          // mempool. In the worst case scenario, there are several mutual closes and the one that made it to the
+          // mempool or the chain isn't the one we are keeping track of here. As a consequence the transaction won't
+          // be pruned and we will count twice the amount in the global (onChain + offChain) balance, until the
+          // mutual close tx gets deeply confirmed and the channel is removed.
+          val mutualClose = d.mutualClosePublished.last
+          val outputInfo_opt = mutualClose.toLocalOutput match {
+            case Some(outputInfo) => Some(outputInfo)
+            case None =>
+              // Normally this would mean that we don't actually have an output, but due to a migration
+              // the data might not be accurate, see [[ChannelTypes0.migrateClosingTx]]
+              // As a (hackish) workaround, we use the pubkeyscript to retrieve our output
+              Transactions.findPubKeyScriptIndex(mutualClose.tx, d.finalScriptPubKey) match {
+                case Right(outputIndex) => Some(OutputInfo(outputIndex, mutualClose.tx.txOut(outputIndex).amount, d.finalScriptPubKey))
+                case _ => None // either we don't have an output (below dust), or we have used a non-default pubkey script
+              }
+          }
+          r.modify(_.closing.mutualCloseBalance.toLocal).usingIf(outputInfo_opt.isDefined)(_ + (OutPoint(mutualClose.tx.txid, outputInfo_opt.get.index) -> outputInfo_opt.get.amount))
+        case Some(localClose: LocalClose) => r.modify(_.closing.localCloseBalance).using(updatePossiblyPublishedBalance(computeLocalCloseBalance(d.commitments.changes, localClose, d.commitments.originChannels, knownPreimages)))
+        case _ if d.remoteCommitPublished.nonEmpty || d.nextRemoteCommitPublished.nonEmpty =>
+          // We have seen the remote commit, it may or may not have been confirmed. We may have published our own
+          // local commit too, which may take precedence. But if we are aware of the remote commit, it means that
+          // our bitcoin core has already seen it (since it's the one who told us about it) and we make
+          // the assumption that the remote commit won't be replaced by our local commit.
+          val remoteClose = if (d.remoteCommitPublished.isDefined) {
+            CurrentRemoteClose(d.commitments.latest.remoteCommit, d.remoteCommitPublished.get)
+          } else {
+            NextRemoteClose(d.commitments.latest.nextRemoteCommit_opt.get.commit, d.nextRemoteCommitPublished.get)
+          }
+          r.modify(_.closing.remoteCloseBalance).using(updatePossiblyPublishedBalance(computeRemoteCloseBalance(d.commitments, remoteClose, knownPreimages)))
+        case _ => r.modify(_.closing.unknownCloseBalance).using(updateMainAndHtlcBalance(d.commitments, knownPreimages))
+      }
+    case (r, d: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) => r.modify(_.waitForPublishFutureCommitment).using(updateMainBalance(d.commitments.latest.localCommit))
+  }
+
+  def computeOffChainBalance(knownPreimages: Set[(ByteVector32, Long)], channel: PersistentChannelData): OffChainBalance = {
+    computeOffChainBalance(knownPreimages)(OffChainBalance(), channel)
   }
 
   /**
@@ -203,54 +256,9 @@ object CheckBalance {
    *   - TODO?: we disregard anchor outputs
    */
   def computeOffChainBalance(channels: Iterable[PersistentChannelData], knownPreimages: Set[(ByteVector32, Long)]): OffChainBalance = {
-    channels
-      .foldLeft(OffChainBalance()) {
-        case (r, d: DATA_WAIT_FOR_FUNDING_CONFIRMED) => r.modify(_.waitForFundingConfirmed).using(updateMainBalance(d.commitments.latest.localCommit))
-        case (r, d: DATA_WAIT_FOR_CHANNEL_READY) => r.modify(_.waitForChannelReady).using(updateMainBalance(d.commitments.latest.localCommit))
-        case (r, d: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED) => r // we ignore our balance from unsigned commitments
-        case (r, d: DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED) => r.modify(_.waitForFundingConfirmed).using(updateMainBalance(d.commitments.latest.localCommit))
-        case (r, d: DATA_WAIT_FOR_DUAL_FUNDING_READY) => r.modify(_.waitForChannelReady).using(updateMainBalance(d.commitments.latest.localCommit))
-        case (r, d: DATA_NORMAL) => r.modify(_.normal).using(updateMainAndHtlcBalance(d.commitments, knownPreimages))
-        case (r, d: DATA_SHUTDOWN) => r.modify(_.shutdown).using(updateMainAndHtlcBalance(d.commitments, knownPreimages))
-        case (r, d: DATA_NEGOTIATING) => r.modify(_.negotiating).using(updateMainBalance(d.commitments.latest.localCommit))
-        case (r, d: DATA_CLOSING) =>
-          Closing.isClosingTypeAlreadyKnown(d) match {
-            case None if d.mutualClosePublished.nonEmpty && d.localCommitPublished.isEmpty && d.remoteCommitPublished.isEmpty && d.nextRemoteCommitPublished.isEmpty && d.revokedCommitPublished.isEmpty =>
-              // There can be multiple mutual close transactions for the same channel, but most of the time there will
-              // only be one. We use the last one in the list, which should be the one we have seen last in our local
-              // mempool. In the worst case scenario, there are several mutual closes and the one that made it to the
-              // mempool or the chain isn't the one we are keeping track of here. As a consequence the transaction won't
-              // be pruned and we will count twice the amount in the global (onChain + offChain) balance, until the
-              // mutual close tx gets deeply confirmed and the channel is removed.
-              val mutualClose = d.mutualClosePublished.last
-              val amount = mutualClose.toLocalOutput match {
-                case Some(outputInfo) => outputInfo.amount
-                case None =>
-                  // Normally this would mean that we don't actually have an output, but due to a migration
-                  // the data might not be accurate, see [[ChannelTypes0.migrateClosingTx]]
-                  // As a (hackish) workaround, we use the pubkeyscript to retrieve our output
-                  Transactions.findPubKeyScriptIndex(mutualClose.tx, d.finalScriptPubKey) match {
-                    case Right(outputIndex) => mutualClose.tx.txOut(outputIndex).amount
-                    case _ => 0.sat // either we don't have an output (below dust), or we have used a non-default pubkey script
-                  }
-              }
-              r.modify(_.closing.mutualCloseBalance.toLocal).using(_ + (mutualClose.tx.txid -> amount))
-            case Some(localClose: LocalClose) => r.modify(_.closing.localCloseBalance).using(updatePossiblyPublishedBalance(computeLocalCloseBalance(d.commitments.changes, localClose, d.commitments.originChannels, knownPreimages)))
-            case _ if d.remoteCommitPublished.nonEmpty || d.nextRemoteCommitPublished.nonEmpty =>
-              // We have seen the remote commit, it may or may not have been confirmed. We may have published our own
-              // local commit too, which may take precedence. But if we are aware of the remote commit, it means that
-              // our bitcoin core has already seen it (since it's the one who told us about it) and we make
-              // the assumption that the remote commit won't be replaced by our local commit.
-              val remoteClose = if (d.remoteCommitPublished.isDefined) {
-                CurrentRemoteClose(d.commitments.latest.remoteCommit, d.remoteCommitPublished.get)
-              } else {
-                NextRemoteClose(d.commitments.latest.nextRemoteCommit_opt.get.commit, d.nextRemoteCommitPublished.get)
-              }
-              r.modify(_.closing.remoteCloseBalance).using(updatePossiblyPublishedBalance(computeRemoteCloseBalance(d.commitments, remoteClose, knownPreimages)))
-            case _ => r.modify(_.closing.unknownCloseBalance).using(updateMainAndHtlcBalance(d.commitments, knownPreimages))
-          }
-        case (r, d: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) => r.modify(_.waitForPublishFutureCommitment).using(updateMainBalance(d.commitments.latest.localCommit))
-      }
+    channels.foldLeft(OffChainBalance()) {
+      computeOffChainBalance(knownPreimages)
+    }
   }
 
   /**
@@ -263,7 +271,7 @@ object CheckBalance {
         br.closing.remoteCloseBalance.toLocal.keys ++
         br.closing.remoteCloseBalance.htlcs.keys ++
         br.closing.mutualCloseBalance.toLocal.keys)
-        .map(txid => bitcoinClient.getTxConfirmations(txid).map(_ map { confirmations => txid -> confirmations })))
+        .map(outPoint => bitcoinClient.getTxConfirmations(outPoint.txid).map(_ map { confirmations => outPoint.txid -> confirmations })))
       txMap: Map[TxId, Int] = txs.flatten.toMap
     } yield {
       br
@@ -273,15 +281,17 @@ object CheckBalance {
           _.closing.remoteCloseBalance.toLocal,
           _.closing.remoteCloseBalance.htlcs,
           _.closing.mutualCloseBalance.toLocal)
-        .using(map => map.filterNot { case (txid, _) => txMap.contains(txid) })
+        .using(map => map.filterNot { case (outPoint, _) => txMap.contains(outPoint.txid) })
     }
   }
 
-  case class CorrectedOnChainBalance(confirmed: Btc, unconfirmed: Btc) {
+  case class CorrectedOnChainBalance(details: DetailedOnChainBalance) {
+    val confirmed: Btc = (details.confirmed ++ details.confirmedSwapIn).values.map(_.toSatoshi).sum
+    val unconfirmed: Btc = details.unconfirmed.values.map(_.toSatoshi).sum
     val total: Btc = confirmed + unconfirmed
   }
 
-  private case class DetailedBalance(confirmed: Btc = 0.sat, unconfirmed: Btc = 0.sat)
+  case class DetailedOnChainBalance(confirmed: Map[OutPoint, Btc] = Map.empty, unconfirmed: Map[OutPoint, Btc] = Map.empty, confirmedSwapIn: Map[OutPoint, Btc] = Map.empty, unconfirmedSwapIn: Map[OutPoint, Btc] = Map.empty, utxos: Seq[Utxo])
 
   /**
    * Returns the on-chain balance, but discards the unconfirmed incoming swap-in transactions, because they may be RBF-ed.
@@ -290,13 +300,13 @@ object CheckBalance {
    */
   def computeOnChainBalance(bitcoinClient: BitcoinCoreClient)(implicit ec: ExecutionContext): Future[CorrectedOnChainBalance] = for {
     utxos <- bitcoinClient.listUnspent()
-    detailed = utxos.foldLeft(DetailedBalance()) {
-      case (total, utxo) if utxo.confirmations == 0 => total.modify(_.unconfirmed).using(_ + utxo.amount)
-      case (total, utxo) => total.modify(_.confirmed).using(_ + utxo.amount)
+    detailed = utxos.foldLeft(DetailedOnChainBalance(utxos = utxos)) {
+      case (total, utxo) if utxo.confirmations == 0 => total.modify(_.unconfirmed).using(_ + (utxo.outPoint -> utxo.amount))
+      case (total, utxo) => total.modify(_.confirmed).using(_ + (utxo.outPoint -> utxo.amount))
     }
-  } yield CorrectedOnChainBalance(detailed.confirmed, detailed.unconfirmed)
+  } yield CorrectedOnChainBalance(detailed)
 
-  case class GlobalBalance(onChain: CorrectedOnChainBalance, offChain: OffChainBalance) {
+  case class GlobalBalance(onChain: CorrectedOnChainBalance, offChain: OffChainBalance, channels: Map[ByteVector32, PersistentChannelData], knownPreimages: Set[(ByteVector32, Long)]) {
     val total: Btc = onChain.total + offChain.total
   }
 
@@ -305,6 +315,6 @@ object CheckBalance {
     knownPreimages = db.pendingCommands.listSettlementCommands().collect { case (channelId, cmd: CMD_FULFILL_HTLC) => (channelId, cmd.id) }.toSet
     offChainRaw = CheckBalance.computeOffChainBalance(channels.values, knownPreimages)
     offChainPruned <- CheckBalance.prunePublishedTransactions(offChainRaw, bitcoinClient)
-  } yield GlobalBalance(onChain, offChainPruned)
+  } yield GlobalBalance(onChain, offChainPruned, channels, knownPreimages)
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -755,7 +755,7 @@ object BitcoinCoreClient {
   case class OutpointArg(txid: TxId, vout: Long)
 
   case class Utxo(txid: TxId, outputIndex: Long, amount: MilliBtc, ancestorCount_opt: Option[Int], confirmations: Long, safe: Boolean, label_opt: Option[String]) {
-    lazy val outPoint = OutPoint(txid, outputIndex)
+    val outPoint = OutPoint(txid, outputIndex)
   }
 
   def toSatoshi(btcAmount: BigDecimal): Satoshi = Satoshi(btcAmount.bigDecimal.scaleByPowerOfTen(8).longValue)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -692,6 +692,11 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
 
   def listUnspent()(implicit ec: ExecutionContext): Future[Seq[Utxo]] = rpcClient.invoke("listunspent", /* minconf */ 0).collect {
     case JArray(values) => values.map(utxo => {
+      val JInt(vout) = utxo \ "vout"
+      val ancestorcount = utxo \ "ancestorcount" match {
+        case JInt(ancestorcount) => Some(ancestorcount)
+        case _ => None
+      }
       val JInt(confirmations) = utxo \ "confirmations"
       val JBool(safe) = utxo \ "safe"
       val JDecimal(amount) = utxo \ "amount"
@@ -700,7 +705,15 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
         case JString(label) => Some(label)
         case _ => None
       }
-      Utxo(TxId.fromValidHex(txid), (amount.doubleValue * 1000).millibtc, confirmations.toLong, safe, label)
+      Utxo(
+        txid = TxId.fromValidHex(txid),
+        outputIndex = vout.toLong,
+        amount = (amount.doubleValue * 1000).millibtc,
+        ancestorCount_opt = ancestorcount.map(_.toInt),
+        confirmations = confirmations.toLong,
+        safe = safe,
+        label_opt = label
+      )
     })
   }
 
@@ -741,7 +754,9 @@ object BitcoinCoreClient {
   /** Outpoint used as RPC argument. */
   case class OutpointArg(txid: TxId, vout: Long)
 
-  case class Utxo(txid: TxId, amount: MilliBtc, confirmations: Long, safe: Boolean, label_opt: Option[String])
+  case class Utxo(txid: TxId, outputIndex: Long, amount: MilliBtc, ancestorCount_opt: Option[Int], confirmations: Long, safe: Boolean, label_opt: Option[String]) {
+    lazy val outPoint = OutPoint(txid, outputIndex)
+  }
 
   def toSatoshi(btcAmount: BigDecimal): Satoshi = Satoshi(btcAmount.bigDecimal.scaleByPowerOfTen(8).longValue)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -20,7 +20,7 @@ import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.scalacompat.DeterministicWallet.KeyPath
 import fr.acinq.bitcoin.scalacompat.{BlockHash, BlockId, Btc, ByteVector32, ByteVector64, OutPoint, Satoshi, Transaction, TxId}
-import fr.acinq.eclair.balance.CheckBalance.{CorrectedOnChainBalance, GlobalBalance, OffChainBalance}
+import fr.acinq.eclair.balance.CheckBalance.{DetailedOnChainBalance, GlobalBalance, OffChainBalance}
 import fr.acinq.eclair.blockchain.fee.{ConfirmationTarget, FeeratePerKw}
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.{ShaChain, Sphinx}
@@ -564,10 +564,9 @@ object CommitmentSerializer extends ConvertClassSerializer[Commitment](c => Comm
 // @formatter:on
 
 // @formatter:off
-private case class DetailedOnChainBalanceJson(confirmed: Map[OutPoint, Btc], unconfirmed: Map[OutPoint, Btc])
-private case class CorrectedOnChainBalanceJson(total: Btc, details: DetailedOnChainBalanceJson)
-object CorrectedOnChainBalanceSerializer extends ConvertClassSerializer[CorrectedOnChainBalance](b => CorrectedOnChainBalanceJson(b.total, DetailedOnChainBalanceJson(confirmed = b.details.confirmed, unconfirmed = b.details.unconfirmed)))
-private case class GlobalBalanceJson(total: Btc, onChain: CorrectedOnChainBalance, offChain: OffChainBalance)
+private case class DetailedOnChainBalanceJson(total: Btc, confirmed: Map[OutPoint, Btc], unconfirmed: Map[OutPoint, Btc])
+object DetailedOnChainBalanceSerializer extends ConvertClassSerializer[DetailedOnChainBalance](b => DetailedOnChainBalanceJson(b.total, confirmed = b.confirmed, unconfirmed = b.unconfirmed))
+private case class GlobalBalanceJson(total: Btc, onChain: DetailedOnChainBalance, offChain: OffChainBalance)
 object GlobalBalanceSerializer extends ConvertClassSerializer[GlobalBalance](b => GlobalBalanceJson(b.total, b.onChain, b.offChain))
 
 private case class PeerInfoJson(nodeId: PublicKey, state: String, address: Option[String], channels: Int)
@@ -730,7 +729,7 @@ object JsonSerializers {
     OriginSerializer +
     ByteVector32KeySerializer +
     TxIdKeySerializer +
-    CorrectedOnChainBalanceSerializer +
+    DetailedOnChainBalanceSerializer +
     GlobalBalanceSerializer +
     PeerInfoSerializer +
     PaymentFailedSummarySerializer +

--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -20,7 +20,7 @@ import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.scalacompat.DeterministicWallet.KeyPath
 import fr.acinq.bitcoin.scalacompat.{BlockHash, BlockId, Btc, ByteVector32, ByteVector64, OutPoint, Satoshi, Transaction, TxId}
-import fr.acinq.eclair.balance.CheckBalance.{CorrectedOnChainBalance, GlobalBalance, OffChainBalance}
+import fr.acinq.eclair.balance.CheckBalance.{CorrectedOnChainBalance, DetailedOnChainBalance, GlobalBalance, OffChainBalance}
 import fr.acinq.eclair.blockchain.fee.{ConfirmationTarget, FeeratePerKw}
 import fr.acinq.eclair.channel.RemoteSignature.PartialSignatureWithNonce
 import fr.acinq.eclair.channel._
@@ -565,6 +565,10 @@ object CommitmentSerializer extends ConvertClassSerializer[Commitment](c => Comm
 // @formatter:on
 
 // @formatter:off
+private case class DetailedOnChainBalanceJson(confirmed: Map[OutPoint, Btc], unconfirmed: Map[OutPoint, Btc], confirmedSwapIn: Map[OutPoint, Btc], unconfirmedSwapIn: Map[OutPoint, Btc])
+object DetailedOnChainBalanceSerializer extends ConvertClassSerializer[DetailedOnChainBalance](b => DetailedOnChainBalanceJson(confirmed = b.confirmed, unconfirmed = b.unconfirmed, confirmedSwapIn = b.confirmedSwapIn, unconfirmedSwapIn = b.unconfirmedSwapIn))
+private case class CorrectedOnChainBalanceJson(total: Btc, details: DetailedOnChainBalance)
+object CorrectedOnChainBalanceSerializer extends ConvertClassSerializer[CorrectedOnChainBalance](b => CorrectedOnChainBalanceJson(b.total, b.details))
 private case class GlobalBalanceJson(total: Btc, onChain: CorrectedOnChainBalance, offChain: OffChainBalance)
 object GlobalBalanceSerializer extends ConvertClassSerializer[GlobalBalance](b => GlobalBalanceJson(b.total, b.onChain, b.offChain))
 
@@ -728,6 +732,8 @@ object JsonSerializers {
     OriginSerializer +
     ByteVector32KeySerializer +
     TxIdKeySerializer +
+    DetailedOnChainBalanceSerializer +
+    CorrectedOnChainBalanceSerializer +
     GlobalBalanceSerializer +
     PeerInfoSerializer +
     PaymentFailedSummarySerializer +

--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -20,9 +20,8 @@ import com.google.common.net.HostAndPort
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.scalacompat.DeterministicWallet.KeyPath
 import fr.acinq.bitcoin.scalacompat.{BlockHash, BlockId, Btc, ByteVector32, ByteVector64, OutPoint, Satoshi, Transaction, TxId}
-import fr.acinq.eclair.balance.CheckBalance.{CorrectedOnChainBalance, DetailedOnChainBalance, GlobalBalance, OffChainBalance}
+import fr.acinq.eclair.balance.CheckBalance.{CorrectedOnChainBalance, GlobalBalance, OffChainBalance}
 import fr.acinq.eclair.blockchain.fee.{ConfirmationTarget, FeeratePerKw}
-import fr.acinq.eclair.channel.RemoteSignature.PartialSignatureWithNonce
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.crypto.{ShaChain, Sphinx}
 import fr.acinq.eclair.db.FailureType.FailureType
@@ -565,10 +564,9 @@ object CommitmentSerializer extends ConvertClassSerializer[Commitment](c => Comm
 // @formatter:on
 
 // @formatter:off
-private case class DetailedOnChainBalanceJson(confirmed: Map[OutPoint, Btc], unconfirmed: Map[OutPoint, Btc], confirmedSwapIn: Map[OutPoint, Btc], unconfirmedSwapIn: Map[OutPoint, Btc])
-object DetailedOnChainBalanceSerializer extends ConvertClassSerializer[DetailedOnChainBalance](b => DetailedOnChainBalanceJson(confirmed = b.confirmed, unconfirmed = b.unconfirmed, confirmedSwapIn = b.confirmedSwapIn, unconfirmedSwapIn = b.unconfirmedSwapIn))
-private case class CorrectedOnChainBalanceJson(total: Btc, details: DetailedOnChainBalance)
-object CorrectedOnChainBalanceSerializer extends ConvertClassSerializer[CorrectedOnChainBalance](b => CorrectedOnChainBalanceJson(b.total, b.details))
+private case class DetailedOnChainBalanceJson(confirmed: Map[OutPoint, Btc], unconfirmed: Map[OutPoint, Btc])
+private case class CorrectedOnChainBalanceJson(total: Btc, details: DetailedOnChainBalanceJson)
+object CorrectedOnChainBalanceSerializer extends ConvertClassSerializer[CorrectedOnChainBalance](b => CorrectedOnChainBalanceJson(b.total, DetailedOnChainBalanceJson(confirmed = b.details.confirmed, unconfirmed = b.details.unconfirmed)))
 private case class GlobalBalanceJson(total: Btc, onChain: CorrectedOnChainBalance, offChain: OffChainBalance)
 object GlobalBalanceSerializer extends ConvertClassSerializer[GlobalBalance](b => GlobalBalanceJson(b.total, b.onChain, b.offChain))
 
@@ -732,7 +730,6 @@ object JsonSerializers {
     OriginSerializer +
     ByteVector32KeySerializer +
     TxIdKeySerializer +
-    DetailedOnChainBalanceSerializer +
     CorrectedOnChainBalanceSerializer +
     GlobalBalanceSerializer +
     PeerInfoSerializer +

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestBitcoinCoreClient.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestBitcoinCoreClient.scala
@@ -17,7 +17,8 @@
 package fr.acinq.eclair
 
 import akka.actor.ActorSystem
-import fr.acinq.bitcoin.scalacompat.{BlockId, Transaction, TxId}
+import fr.acinq.bitcoin.scalacompat.{Block, BlockId, MilliBtcDouble, Transaction, TxId, computeBIP84Address}
+import fr.acinq.eclair.TestUtils.randomTxId
 import fr.acinq.eclair.blockchain._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinJsonRPCAuthMethod.UserPassword
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, BitcoinCoreClient}
@@ -45,4 +46,7 @@ class TestBitcoinCoreClient()(implicit system: ActorSystem) extends BitcoinCoreC
 
   override def getTransactionShortId(txId: TxId)(implicit ec: ExecutionContext): Future[(BlockHeight, Int)] = Future.successful((BlockHeight(400000), 42))
 
+  override def listUnspent()(implicit ec: ExecutionContext): Future[Seq[BitcoinCoreClient.Utxo]] = Future.successful(Seq(BitcoinCoreClient.Utxo(randomTxId(), outputIndex = 0, 10_000 millibtc, ancestorCount_opt = None, confirmations = 10, safe = true, label_opt = None)))
+
+  override def getReceiveAddress(label: String)(implicit ec: ExecutionContext): Future[String] = Future.successful(computeBIP84Address(randomKey().publicKey, Block.RegtestGenesisBlock.hash))
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/balance/CheckBalanceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/balance/CheckBalanceSpec.scala
@@ -2,7 +2,7 @@ package fr.acinq.eclair.balance
 
 import akka.pattern.pipe
 import akka.testkit.TestProbe
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, SatoshiLong, TxId}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, OutPoint, SatoshiLong, TxId}
 import fr.acinq.eclair.TestUtils.randomTxId
 import fr.acinq.eclair.balance.CheckBalance.{ClosingBalance, MainAndHtlcBalance, OffChainBalance, PossiblyPublishedMainAndHtlcBalance, PossiblyPublishedMainBalance}
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{apply => _, _}
@@ -101,16 +101,16 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val knownPreimages = Set((commitments.channelId, htlcb1.id))
     assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(commitments.active.last.remoteCommit, remoteCommitPublished), knownPreimages) ==
       PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(remoteCommitPublished.claimMainOutputTx.get.tx.txid -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
-        htlcs = claimHtlcTxs.map(claimTx => claimTx.txid -> claimTx.txOut.head.amount.toBtc).toMap,
+        toLocal = Map(OutPoint(remoteCommitPublished.claimMainOutputTx.get.tx.txid, 0) -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
+        htlcs = claimHtlcTxs.map(claimTx => OutPoint(claimTx.txid, 0) -> claimTx.txOut.head.amount.toBtc).toMap,
         htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi
       ))
     // assuming alice gets the preimage for the 2nd htlc
     val knownPreimages1 = Set((commitments.channelId, htlcb1.id), (commitments.channelId, htlcb2.id))
     assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(commitments.active.last.remoteCommit, remoteCommitPublished), knownPreimages1) ==
       PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(remoteCommitPublished.claimMainOutputTx.get.tx.txid -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
-        htlcs = claimHtlcTxs.map(claimTx => claimTx.txid -> claimTx.txOut.head.amount.toBtc).toMap,
+        toLocal = Map(OutPoint(remoteCommitPublished.claimMainOutputTx.get.tx.txid, 0) -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
+        htlcs = claimHtlcTxs.map(claimTx => OutPoint(claimTx.txid, 0) -> claimTx.txOut.head.amount.toBtc).toMap,
         htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi + htlcb2.amountMsat.truncateToSatoshi
       ))
   }
@@ -150,16 +150,16 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val knownPreimages = Set((commitments.channelId, htlcb1.id))
     assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(commitments.active.last.nextRemoteCommit_opt.get.commit, remoteCommitPublished), knownPreimages) ==
       PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(remoteCommitPublished.claimMainOutputTx.get.tx.txid -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
-        htlcs = claimHtlcTxs.map(claimTx => claimTx.txid -> claimTx.txOut.head.amount.toBtc).toMap,
+        toLocal = Map(OutPoint(remoteCommitPublished.claimMainOutputTx.get.tx.txid, 0) -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
+        htlcs = claimHtlcTxs.map(claimTx => OutPoint(claimTx.txid, 0) -> claimTx.txOut.head.amount.toBtc).toMap,
         htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi
       ))
     // assuming alice gets the preimage for the 2nd htlc
     val knownPreimages1 = Set((commitments.channelId, htlcb1.id), (commitments.channelId, htlcb2.id))
     assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(commitments.active.last.nextRemoteCommit_opt.get.commit, remoteCommitPublished), knownPreimages1) ==
       PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(remoteCommitPublished.claimMainOutputTx.get.tx.txid -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
-        htlcs = claimHtlcTxs.map(claimTx => claimTx.txid -> claimTx.txOut.head.amount.toBtc).toMap,
+        toLocal = Map(OutPoint(remoteCommitPublished.claimMainOutputTx.get.tx.txid, 0) -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
+        htlcs = claimHtlcTxs.map(claimTx => OutPoint(claimTx.txid, 0) -> claimTx.txOut.head.amount.toBtc).toMap,
         htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi + htlcb2.amountMsat.truncateToSatoshi
       ))
   }
@@ -192,7 +192,7 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     val knownPreimages = Set((commitments.channelId, htlcb1.id))
     assert(CheckBalance.computeLocalCloseBalance(commitments.changes, LocalClose(commitments.active.last.localCommit, localCommitPublished), commitments.originChannels, knownPreimages) ==
       PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(localCommitPublished.claimMainDelayedOutputTx.get.tx.txid -> localCommitPublished.claimMainDelayedOutputTx.get.tx.txOut.head.amount),
+        toLocal = Map(OutPoint(localCommitPublished.claimMainDelayedOutputTx.get.tx.txid, 0) -> localCommitPublished.claimMainDelayedOutputTx.get.tx.txOut.head.amount),
         htlcs = Map.empty,
         htlcsUnpublished = htlca4.amountMsat.truncateToSatoshi + htlcb1.amountMsat.truncateToSatoshi
       ))
@@ -223,8 +223,8 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
 
     assert(CheckBalance.computeLocalCloseBalance(commitments.changes, LocalClose(commitments.active.last.localCommit, alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.get), commitments.originChannels, knownPreimages) ==
       PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(localCommitPublished.claimMainDelayedOutputTx.get.tx.txid -> localCommitPublished.claimMainDelayedOutputTx.get.tx.txOut.head.amount),
-        htlcs = claimHtlcDelayedTxs.map(claimTx => claimTx.txid -> claimTx.txOut.head.amount.toBtc).toMap,
+        toLocal = Map(OutPoint(localCommitPublished.claimMainDelayedOutputTx.get.tx.txid, 0) -> localCommitPublished.claimMainDelayedOutputTx.get.tx.txOut.head.amount),
+        htlcs = claimHtlcDelayedTxs.map(claimTx => OutPoint(claimTx.txid, 0) -> claimTx.txOut.head.amount.toBtc).toMap,
         htlcsUnpublished = 0.sat
       ))
   }
@@ -252,8 +252,8 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
   }
 
   test("tx pruning") { () =>
-    val txids = (for (_ <- 0 until 20) yield randomTxId()).toList
-    val knownTxids = Set(txids(1), txids(3), txids(4), txids(6), txids(9), txids(12), txids(13))
+    val outPoints = (for (_ <- 0 until 20) yield OutPoint(randomTxId(), 0)).toList
+    val knownTxids = Set(outPoints(1).txid, outPoints(3).txid, outPoints(4).txid, outPoints(6).txid, outPoints(9).txid, outPoints(12).txid, outPoints(13).txid)
 
     val bitcoinClient = new BitcoinCoreClient(null) {
       /** Get the number of confirmations of a given transaction. */
@@ -265,29 +265,29 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
       closing = ClosingBalance(
         localCloseBalance = PossiblyPublishedMainAndHtlcBalance(
           toLocal = Map(
-            txids(0) -> 1000.sat,
-            txids(1) -> 1000.sat,
-            txids(2) -> 1000.sat),
+            outPoints(0) -> 1000.sat,
+            outPoints(1) -> 1000.sat,
+            outPoints(2) -> 1000.sat),
           htlcs = Map(
-            txids(3) -> 1000.sat,
-            txids(4) -> 1000.sat,
-            txids(5) -> 1000.sat)
+            outPoints(3) -> 1000.sat,
+            outPoints(4) -> 1000.sat,
+            outPoints(5) -> 1000.sat)
         ),
         remoteCloseBalance = PossiblyPublishedMainAndHtlcBalance(
           toLocal = Map(
-            txids(6) -> 1000.sat,
-            txids(7) -> 1000.sat,
-            txids(8) -> 1000.sat,
-            txids(9) -> 1000.sat),
+            outPoints(6) -> 1000.sat,
+            outPoints(7) -> 1000.sat,
+            outPoints(8) -> 1000.sat,
+            outPoints(9) -> 1000.sat),
           htlcs = Map(
-            txids(10) -> 1000.sat,
-            txids(11) -> 1000.sat,
-            txids(12) -> 1000.sat),
+            outPoints(10) -> 1000.sat,
+            outPoints(11) -> 1000.sat,
+            outPoints(12) -> 1000.sat),
         ),
         mutualCloseBalance = PossiblyPublishedMainBalance(
           toLocal = Map(
-            txids(13) -> 1000.sat,
-            txids(14) -> 1000.sat
+            outPoints(13) -> 1000.sat,
+            outPoints(14) -> 1000.sat
           )
         )
       )
@@ -301,22 +301,22 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
       closing = ClosingBalance(
         localCloseBalance = PossiblyPublishedMainAndHtlcBalance(
           toLocal = Map(
-            txids(0) -> 1000.sat,
-            txids(2) -> 1000.sat),
+            outPoints(0) -> 1000.sat,
+            outPoints(2) -> 1000.sat),
           htlcs = Map(
-            txids(5) -> 1000.sat)
+            outPoints(5) -> 1000.sat)
         ),
         remoteCloseBalance = PossiblyPublishedMainAndHtlcBalance(
           toLocal = Map(
-            txids(7) -> 1000.sat,
-            txids(8) -> 1000.sat),
+            outPoints(7) -> 1000.sat,
+            outPoints(8) -> 1000.sat),
           htlcs = Map(
-            txids(10) -> 1000.sat,
-            txids(11) -> 1000.sat),
+            outPoints(10) -> 1000.sat,
+            outPoints(11) -> 1000.sat),
         ),
         mutualCloseBalance = PossiblyPublishedMainBalance(
           toLocal = Map(
-            txids(14) -> 1000.sat
+            outPoints(14) -> 1000.sat
           )
         )))
     )

--- a/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
@@ -333,12 +333,10 @@ class JsonSerializersSpec extends TestKitBaseClass with AnyFunSuiteLike with Mat
 
   test("GlobalBalance serializer") {
     val gb = GlobalBalance(
-      onChain = CheckBalance.CorrectedOnChainBalance(
-        details = CheckBalance.DetailedOnChainBalance(
-          confirmed = Map(OutPoint(TxId.fromValidHex("9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692"), 3) -> Btc(1.4)),
-          unconfirmed = Map(OutPoint(TxId.fromValidHex("345b2b05ec046ffe0c14d3b61838c79980713ad1cf8ae7a45c172ce90c9c0b9f"), 1) -> Btc(0.05)),
-          utxos = Seq.empty
-        )
+      onChain = CheckBalance.DetailedOnChainBalance(
+        confirmed = Map(OutPoint(TxId.fromValidHex("9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692"), 3) -> Btc(1.4)),
+        unconfirmed = Map(OutPoint(TxId.fromValidHex("345b2b05ec046ffe0c14d3b61838c79980713ad1cf8ae7a45c172ce90c9c0b9f"), 1) -> Btc(0.05)),
+        utxos = Seq.empty
       ),
       offChain = CheckBalance.OffChainBalance(normal = MainAndHtlcBalance(
         toLocal = Btc(0.2),
@@ -356,7 +354,7 @@ class JsonSerializersSpec extends TestKitBaseClass with AnyFunSuiteLike with Mat
       knownPreimages = Set.empty, // not used by json serializer
 
     )
-    JsonSerializers.serialization.write(gb)(JsonSerializers.formats) shouldBe """{"total":2.0,"onChain":{"total":1.45,"details":{"confirmed":{"9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692:3":1.4},"unconfirmed":{"345b2b05ec046ffe0c14d3b61838c79980713ad1cf8ae7a45c172ce90c9c0b9f:1":0.05}}},"offChain":{"waitForFundingConfirmed":0.0,"waitForChannelReady":0.0,"normal":{"toLocal":0.2,"htlcs":0.05},"shutdown":{"toLocal":0.0,"htlcs":0.0},"negotiating":0.0,"closing":{"localCloseBalance":{"toLocal":{"4d176ad844c363bed59edf81962b008faa6194c3b3757ffcd26ba60f95716db2:0":0.1},"htlcs":{"94b70cec5a98d67d17c6e3de5c7697f8a6cab4f698df91e633ce35efa3574d71:1":0.03,"a844edd41ce8503864f3c95d89d850b177a09d7d35e950a7d27c14abb63adb13:3":0.06},"htlcsUnpublished":0.01},"remoteCloseBalance":{"toLocal":{},"htlcs":{},"htlcsUnpublished":0.0},"mutualCloseBalance":{"toLocal":{"7e3b012534afe0bb8d1f2f09c724b1a10a813ce704e5b9c217ccfdffffff0247:4":0.1}},"unknownCloseBalance":{"toLocal":0.0,"htlcs":0.0}},"waitForPublishFutureCommitment":0.0}}"""
+    JsonSerializers.serialization.write(gb)(JsonSerializers.formats) shouldBe """{"total":2.0,"onChain":{"total":1.45,"confirmed":{"9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692:3":1.4},"unconfirmed":{"345b2b05ec046ffe0c14d3b61838c79980713ad1cf8ae7a45c172ce90c9c0b9f:1":0.05}},"offChain":{"waitForFundingConfirmed":0.0,"waitForChannelReady":0.0,"normal":{"toLocal":0.2,"htlcs":0.05},"shutdown":{"toLocal":0.0,"htlcs":0.0},"negotiating":0.0,"closing":{"localCloseBalance":{"toLocal":{"4d176ad844c363bed59edf81962b008faa6194c3b3757ffcd26ba60f95716db2:0":0.1},"htlcs":{"94b70cec5a98d67d17c6e3de5c7697f8a6cab4f698df91e633ce35efa3574d71:1":0.03,"a844edd41ce8503864f3c95d89d850b177a09d7d35e950a7d27c14abb63adb13:3":0.06},"htlcsUnpublished":0.01},"remoteCloseBalance":{"toLocal":{},"htlcs":{},"htlcsUnpublished":0.0},"mutualCloseBalance":{"toLocal":{"7e3b012534afe0bb8d1f2f09c724b1a10a813ce704e5b9c217ccfdffffff0247:4":0.1}},"unknownCloseBalance":{"toLocal":0.0,"htlcs":0.0}},"waitForPublishFutureCommitment":0.0}}"""
   }
 
   test("type hints") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
@@ -333,20 +333,31 @@ class JsonSerializersSpec extends TestKitBaseClass with AnyFunSuiteLike with Mat
 
   test("GlobalBalance serializer") {
     val gb = GlobalBalance(
-      onChain = CheckBalance.CorrectedOnChainBalance(Btc(0.4), Btc(0.05)),
+      onChain = CheckBalance.CorrectedOnChainBalance(
+        details = CheckBalance.DetailedOnChainBalance(
+          confirmed = Map(OutPoint(TxId.fromValidHex("9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692"), 3) -> Btc(1.4)),
+          unconfirmed = Map(OutPoint(TxId.fromValidHex("345b2b05ec046ffe0c14d3b61838c79980713ad1cf8ae7a45c172ce90c9c0b9f"), 1) -> Btc(0.05)),
+          confirmedSwapIn = Map.empty, unconfirmedSwapIn = Map.empty,
+          utxos = Seq.empty
+        )
+      ),
       offChain = CheckBalance.OffChainBalance(normal = MainAndHtlcBalance(
         toLocal = Btc(0.2),
         htlcs = Btc(0.05)
       ), closing = ClosingBalance(
         localCloseBalance = PossiblyPublishedMainAndHtlcBalance(
-          toLocal = Map(TxId.fromValidHex("4d176ad844c363bed59edf81962b008faa6194c3b3757ffcd26ba60f95716db2") -> Btc(0.1)),
-          htlcs = Map(TxId.fromValidHex("94b70cec5a98d67d17c6e3de5c7697f8a6cab4f698df91e633ce35efa3574d71") -> Btc(0.03), TxId.fromValidHex("a844edd41ce8503864f3c95d89d850b177a09d7d35e950a7d27c14abb63adb13") -> Btc(0.06)),
+          toLocal = Map(OutPoint(TxId.fromValidHex("4d176ad844c363bed59edf81962b008faa6194c3b3757ffcd26ba60f95716db2"), 0) -> Btc(0.1)),
+          htlcs = Map(OutPoint(TxId.fromValidHex("94b70cec5a98d67d17c6e3de5c7697f8a6cab4f698df91e633ce35efa3574d71"), 1) -> Btc(0.03), OutPoint(TxId.fromValidHex("a844edd41ce8503864f3c95d89d850b177a09d7d35e950a7d27c14abb63adb13"), 3) -> Btc(0.06)),
           htlcsUnpublished = Btc(0.01)),
         mutualCloseBalance = PossiblyPublishedMainBalance(
-          toLocal = Map(TxId.fromValidHex("7e3b012534afe0bb8d1f2f09c724b1a10a813ce704e5b9c217ccfdffffff0247") -> Btc(0.1)))
-      ))
+          toLocal = Map(OutPoint(TxId.fromValidHex("7e3b012534afe0bb8d1f2f09c724b1a10a813ce704e5b9c217ccfdffffff0247"), 4) -> Btc(0.1)))
+      )
+      ),
+      channels = Map.empty, // not used by json serializer
+      knownPreimages = Set.empty, // not used by json serializer
+
     )
-    JsonSerializers.serialization.write(gb)(JsonSerializers.formats) shouldBe """{"total":1.0,"onChain":{"confirmed":0.4,"unconfirmed":0.05},"offChain":{"waitForFundingConfirmed":0.0,"waitForChannelReady":0.0,"normal":{"toLocal":0.2,"htlcs":0.05},"shutdown":{"toLocal":0.0,"htlcs":0.0},"negotiating":0.0,"closing":{"localCloseBalance":{"toLocal":{"4d176ad844c363bed59edf81962b008faa6194c3b3757ffcd26ba60f95716db2":0.1},"htlcs":{"94b70cec5a98d67d17c6e3de5c7697f8a6cab4f698df91e633ce35efa3574d71":0.03,"a844edd41ce8503864f3c95d89d850b177a09d7d35e950a7d27c14abb63adb13":0.06},"htlcsUnpublished":0.01},"remoteCloseBalance":{"toLocal":{},"htlcs":{},"htlcsUnpublished":0.0},"mutualCloseBalance":{"toLocal":{"7e3b012534afe0bb8d1f2f09c724b1a10a813ce704e5b9c217ccfdffffff0247":0.1}},"unknownCloseBalance":{"toLocal":0.0,"htlcs":0.0}},"waitForPublishFutureCommitment":0.0}}"""
+    JsonSerializers.serialization.write(gb)(JsonSerializers.formats) shouldBe """{"total":2.0,"onChain":{"total":1.45,"details":{"confirmed":{"9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692:3":1.4},"unconfirmed":{"345b2b05ec046ffe0c14d3b61838c79980713ad1cf8ae7a45c172ce90c9c0b9f:1":0.05},"confirmedSwapIn":{},"unconfirmedSwapIn":{}}},"offChain":{"waitForFundingConfirmed":0.0,"waitForChannelReady":0.0,"normal":{"toLocal":0.2,"htlcs":0.05},"shutdown":{"toLocal":0.0,"htlcs":0.0},"negotiating":0.0,"closing":{"localCloseBalance":{"toLocal":{"4d176ad844c363bed59edf81962b008faa6194c3b3757ffcd26ba60f95716db2:0":0.1},"htlcs":{"94b70cec5a98d67d17c6e3de5c7697f8a6cab4f698df91e633ce35efa3574d71:1":0.03,"a844edd41ce8503864f3c95d89d850b177a09d7d35e950a7d27c14abb63adb13:3":0.06},"htlcsUnpublished":0.01},"remoteCloseBalance":{"toLocal":{},"htlcs":{},"htlcsUnpublished":0.0},"mutualCloseBalance":{"toLocal":{"7e3b012534afe0bb8d1f2f09c724b1a10a813ce704e5b9c217ccfdffffff0247:4":0.1}},"unknownCloseBalance":{"toLocal":0.0,"htlcs":0.0}},"waitForPublishFutureCommitment":0.0}}"""
   }
 
   test("type hints") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/json/JsonSerializersSpec.scala
@@ -337,7 +337,6 @@ class JsonSerializersSpec extends TestKitBaseClass with AnyFunSuiteLike with Mat
         details = CheckBalance.DetailedOnChainBalance(
           confirmed = Map(OutPoint(TxId.fromValidHex("9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692"), 3) -> Btc(1.4)),
           unconfirmed = Map(OutPoint(TxId.fromValidHex("345b2b05ec046ffe0c14d3b61838c79980713ad1cf8ae7a45c172ce90c9c0b9f"), 1) -> Btc(0.05)),
-          confirmedSwapIn = Map.empty, unconfirmedSwapIn = Map.empty,
           utxos = Seq.empty
         )
       ),
@@ -357,7 +356,7 @@ class JsonSerializersSpec extends TestKitBaseClass with AnyFunSuiteLike with Mat
       knownPreimages = Set.empty, // not used by json serializer
 
     )
-    JsonSerializers.serialization.write(gb)(JsonSerializers.formats) shouldBe """{"total":2.0,"onChain":{"total":1.45,"details":{"confirmed":{"9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692:3":1.4},"unconfirmed":{"345b2b05ec046ffe0c14d3b61838c79980713ad1cf8ae7a45c172ce90c9c0b9f:1":0.05},"confirmedSwapIn":{},"unconfirmedSwapIn":{}}},"offChain":{"waitForFundingConfirmed":0.0,"waitForChannelReady":0.0,"normal":{"toLocal":0.2,"htlcs":0.05},"shutdown":{"toLocal":0.0,"htlcs":0.0},"negotiating":0.0,"closing":{"localCloseBalance":{"toLocal":{"4d176ad844c363bed59edf81962b008faa6194c3b3757ffcd26ba60f95716db2:0":0.1},"htlcs":{"94b70cec5a98d67d17c6e3de5c7697f8a6cab4f698df91e633ce35efa3574d71:1":0.03,"a844edd41ce8503864f3c95d89d850b177a09d7d35e950a7d27c14abb63adb13:3":0.06},"htlcsUnpublished":0.01},"remoteCloseBalance":{"toLocal":{},"htlcs":{},"htlcsUnpublished":0.0},"mutualCloseBalance":{"toLocal":{"7e3b012534afe0bb8d1f2f09c724b1a10a813ce704e5b9c217ccfdffffff0247:4":0.1}},"unknownCloseBalance":{"toLocal":0.0,"htlcs":0.0}},"waitForPublishFutureCommitment":0.0}}"""
+    JsonSerializers.serialization.write(gb)(JsonSerializers.formats) shouldBe """{"total":2.0,"onChain":{"total":1.45,"details":{"confirmed":{"9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692:3":1.4},"unconfirmed":{"345b2b05ec046ffe0c14d3b61838c79980713ad1cf8ae7a45c172ce90c9c0b9f:1":0.05}}},"offChain":{"waitForFundingConfirmed":0.0,"waitForChannelReady":0.0,"normal":{"toLocal":0.2,"htlcs":0.05},"shutdown":{"toLocal":0.0,"htlcs":0.0},"negotiating":0.0,"closing":{"localCloseBalance":{"toLocal":{"4d176ad844c363bed59edf81962b008faa6194c3b3757ffcd26ba60f95716db2:0":0.1},"htlcs":{"94b70cec5a98d67d17c6e3de5c7697f8a6cab4f698df91e633ce35efa3574d71:1":0.03,"a844edd41ce8503864f3c95d89d850b177a09d7d35e950a7d27c14abb63adb13:3":0.06},"htlcsUnpublished":0.01},"remoteCloseBalance":{"toLocal":{},"htlcs":{},"htlcsUnpublished":0.0},"mutualCloseBalance":{"toLocal":{"7e3b012534afe0bb8d1f2f09c724b1a10a813ce704e5b9c217ccfdffffff0247:4":0.1}},"unknownCloseBalance":{"toLocal":0.0,"htlcs":0.0}},"waitForPublishFutureCommitment":0.0}}"""
   }
 
   test("type hints") {


### PR DESCRIPTION
This PR:
- uses _outpoints_ instead of _txids_ to track on-chain utxos, the later being insufficient when transactions have more than one output that belongs to us
- prints a detailed diff between two balance checks, by utxos and channels.