### PR TITLE
Clarify recipient blinded path fee deduction

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/offer/OfferManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/offer/OfferManager.scala
@@ -24,17 +24,17 @@ import fr.acinq.eclair.EncodedNodeId.ShortChannelIdDir
 import fr.acinq.eclair.crypto.Sphinx.RouteBlinding
 import fr.acinq.eclair.db.{IncomingBlindedPayment, IncomingPaymentStatus, PaymentType}
 import fr.acinq.eclair.message.{OnionMessages, Postman}
-import fr.acinq.eclair.payment.MinimalBolt12Invoice
 import fr.acinq.eclair.payment.offer.OfferPaymentMetadata.MinimalInvoiceData
 import fr.acinq.eclair.payment.receive.MultiPartHandler
 import fr.acinq.eclair.payment.receive.MultiPartHandler.{CreateInvoiceActor, ReceivingRoute}
 import fr.acinq.eclair.payment.relay.Relayer.RelayFees
+import fr.acinq.eclair.payment.{Bolt12Invoice, MinimalBolt12Invoice}
 import fr.acinq.eclair.router.BlindedRouteCreation.aggregatePaymentInfo
 import fr.acinq.eclair.router.Router
 import fr.acinq.eclair.wire.protocol.OfferTypes.{InvoiceRequest, InvoiceTlv, Offer}
 import fr.acinq.eclair.wire.protocol.PaymentOnion.FinalPayload
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{CltvExpiryDelta, Logs, MilliSatoshi, NodeParams, TimestampMilli, TimestampSecond, nodeFee, randomBytes32}
+import fr.acinq.eclair.{CltvExpiryDelta, Logs, MilliSatoshi, MilliSatoshiLong, NodeParams, TimestampMilli, TimestampSecond, nodeFee, randomBytes32}
 import scodec.bits.ByteVector
 
 import scala.concurrent.duration.FiniteDuration
@@ -65,7 +65,7 @@ object OfferManager {
 
   case class RequestInvoice(messagePayload: MessageOnion.InvoiceRequestPayload, blindedKey: PrivateKey, postman: ActorRef[Postman.SendMessage]) extends Command
 
-  case class ReceivePayment(replyTo: ActorRef[MultiPartHandler.GetIncomingPaymentActor.Command], paymentHash: ByteVector32, payload: FinalPayload.Blinded, realAmount: MilliSatoshi) extends Command
+  case class ReceivePayment(replyTo: ActorRef[MultiPartHandler.GetIncomingPaymentActor.Command], paymentHash: ByteVector32, payload: FinalPayload.Blinded) extends Command
 
   /**
    * Offer handlers must be implemented in separate plugins and respond to these two `HandlerCommand`.
@@ -117,16 +117,14 @@ object OfferManager {
             case _ => context.log.debug("offer {} is not registered or invoice request is invalid", messagePayload.invoiceRequest.offer.offerId)
           }
           Behaviors.same
-        case ReceivePayment(replyTo, paymentHash, payload, realAmount) =>
+        case ReceivePayment(replyTo, paymentHash, payload) =>
           MinimalInvoiceData.decode(payload.pathId) match {
             case Some(signed) =>
               registeredOffers.get(signed.offerId) match {
                 case Some(RegisteredOffer(offer, _, _, handler)) =>
                   MinimalInvoiceData.verify(nodeParams.nodeId, signed) match {
-                    case Some(metadata) if realAmount + nodeFee(metadata.hiddenFees, realAmount) < payload.amount =>
-                      replyTo ! MultiPartHandler.GetIncomingPaymentActor.RejectPayment(s"incorrect amount received for offer ${signed.offerId.toHex}: realAmount=$realAmount, hiddenFees=${metadata.hiddenFees}, virtualAmount=${payload.amount}")
                     case Some(metadata) if Crypto.sha256(metadata.preimage) == paymentHash =>
-                      val child = context.spawnAnonymous(PaymentActor(nodeParams, replyTo, offer, metadata, paymentTimeout))
+                      val child = context.spawnAnonymous(PaymentActor(nodeParams, replyTo, offer, metadata, payload, paymentTimeout))
                       handler ! HandlePayment(child, signed.offerId, metadata.pluginData_opt)
                     case Some(_) => replyTo ! MultiPartHandler.GetIncomingPaymentActor.RejectPayment(s"preimage does not match payment hash for offer ${signed.offerId.toHex}")
                     case None => replyTo ! MultiPartHandler.GetIncomingPaymentActor.RejectPayment(s"invalid signature for metadata for offer ${signed.offerId.toHex}")
@@ -151,26 +149,43 @@ object OfferManager {
      *
      * @param amount         Amount for the invoice (must be the same as the invoice request if it contained an amount).
      * @param routes         Routes to use for the payment.
-     * @param hideFees       If true, fees for the blinded route will be hidden to the payer and paid by the recipient.
      * @param pluginData_opt Some data for the handler by the handler. It will be sent to the handler when a payment is attempted.
      * @param additionalTlvs additional TLVs to add to the invoice.
      * @param customTlvs     custom TLVs to add to the invoice.
      */
     case class ApproveRequest(amount: MilliSatoshi,
                               routes: Seq[Route],
-                              hideFees: Boolean,
                               pluginData_opt: Option[ByteVector] = None,
                               additionalTlvs: Set[InvoiceTlv] = Set.empty,
                               customTlvs: Set[GenericTlv] = Set.empty) extends Command
 
-    case class Route(hops: Seq[Router.ChannelHop], maxFinalExpiryDelta: CltvExpiryDelta, shortChannelIdDir_opt: Option[ShortChannelIdDir] = None)
+    /**
+     * @param recipientPaysFees If true, fees for the blinded route will be hidden to the payer and paid by the recipient.
+     */
+    case class Route(hops: Seq[Router.ChannelHop], recipientPaysFees: Boolean, maxFinalExpiryDelta: CltvExpiryDelta, shortChannelIdDir_opt: Option[ShortChannelIdDir] = None) {
+      def finalize(nodePriv: PrivateKey, preimage: ByteVector32, amount: MilliSatoshi, invoiceRequest: InvoiceRequest, minFinalExpiryDelta: CltvExpiryDelta, pluginData_opt: Option[ByteVector]): ReceivingRoute = {
+        val (paymentInfo, metadata) = if (recipientPaysFees) {
+          val realPaymentInfo = aggregatePaymentInfo(amount, hops, minFinalExpiryDelta)
+          val recipientFees = RelayFees(realPaymentInfo.feeBase, realPaymentInfo.feeProportionalMillionths)
+          val metadata = MinimalInvoiceData(preimage, invoiceRequest.payerId, TimestampSecond.now(), invoiceRequest.quantity, amount, recipientFees, pluginData_opt)
+          val paymentInfo = realPaymentInfo.copy(feeBase = 0 msat, feeProportionalMillionths = 0)
+          (paymentInfo, metadata)
+        } else {
+          val paymentInfo = aggregatePaymentInfo(amount, hops, minFinalExpiryDelta)
+          val metadata = MinimalInvoiceData(preimage, invoiceRequest.payerId, TimestampSecond.now(), invoiceRequest.quantity, amount, RelayFees.zero, pluginData_opt)
+          (paymentInfo, metadata)
+        }
+        val pathId = MinimalInvoiceData.encode(nodePriv, invoiceRequest.offer.offerId, metadata)
+        ReceivingRoute(hops, pathId, maxFinalExpiryDelta, paymentInfo, shortChannelIdDir_opt)
+      }
+    }
 
     /**
      * Sent by the offer handler to reject the request. For instance because stock has been exhausted.
      */
     case class RejectRequest(message: String) extends Command
 
-    private case class WrappedInvoiceResponse(response: CreateInvoiceActor.Bolt12InvoiceResponse) extends Command
+    private case class WrappedInvoiceResponse(invoice: Bolt12Invoice) extends Command
 
     private case class WrappedOnionMessageResponse(response: Postman.OnionMessageResponse) extends Command
 
@@ -203,17 +218,10 @@ object OfferManager {
             context.log.debug("offer handler rejected invoice request: {}", error)
             postman ! Postman.SendMessage(OfferTypes.BlindedPath(pathToSender), OnionMessages.RoutingStrategy.FindRoute, TlvStream(OnionMessagePayloadTlv.InvoiceError(TlvStream(OfferTypes.Error(error)))), expectsReply = false, context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse))
             waitForSent()
-          case ApproveRequest(amount, routes, hideFees, pluginData_opt, additionalTlvs, customTlvs) =>
+          case ApproveRequest(amount, routes, pluginData_opt, additionalTlvs, customTlvs) =>
             val preimage = randomBytes32()
-            val receivingRoutes = routes.map(route => {
-              val paymentInfo = aggregatePaymentInfo(amount, route.hops, nodeParams.channelConf.minFinalExpiryDelta)
-              val hiddenFees = if (hideFees) RelayFees(paymentInfo.feeBase, paymentInfo.feeProportionalMillionths) else RelayFees.zero
-              val metadata = MinimalInvoiceData(preimage, invoiceRequest.payerId, TimestampSecond.now(), invoiceRequest.quantity, amount, hiddenFees, pluginData_opt)
-              val pathId = MinimalInvoiceData.encode(nodeParams.privateKey, invoiceRequest.offer.offerId, metadata)
-              val paymentInfo1 = if (hideFees) paymentInfo.copy(feeBase = MilliSatoshi(0), feeProportionalMillionths = 0) else paymentInfo
-              ReceivingRoute(route.hops, pathId, route.maxFinalExpiryDelta, paymentInfo1, route.shortChannelIdDir_opt)
-            })
-            val receivePayment = MultiPartHandler.ReceiveOfferPayment(context.messageAdapter[CreateInvoiceActor.Bolt12InvoiceResponse](WrappedInvoiceResponse), nodeKey, invoiceRequest, receivingRoutes, preimage, additionalTlvs, customTlvs)
+            val receivingRoutes = routes.map(_.finalize(nodeParams.privateKey, preimage, amount, invoiceRequest, nodeParams.channelConf.minFinalExpiryDelta, pluginData_opt))
+            val receivePayment = MultiPartHandler.ReceiveOfferPayment(context.messageAdapter[Bolt12Invoice](WrappedInvoiceResponse), nodeKey, invoiceRequest, receivingRoutes, preimage, additionalTlvs, customTlvs)
             val child = context.spawnAnonymous(CreateInvoiceActor(nodeParams))
             child ! CreateInvoiceActor.CreateBolt12Invoice(receivePayment)
             waitForInvoice()
@@ -222,16 +230,10 @@ object OfferManager {
 
       private def waitForInvoice(): Behavior[Command] = {
         Behaviors.receiveMessagePartial {
-          case WrappedInvoiceResponse(invoiceResponse) =>
-            invoiceResponse match {
-              case CreateInvoiceActor.InvoiceCreated(invoice) =>
-                context.log.debug("invoice created for offerId={} invoice={}", invoice.invoiceRequest.offer.offerId, invoice.toString)
-                postman ! Postman.SendMessage(OfferTypes.BlindedPath(pathToSender), OnionMessages.RoutingStrategy.FindRoute, TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)), expectsReply = false, context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse))
-                waitForSent()
-              case f: CreateInvoiceActor.InvoiceCreationFailed =>
-                context.log.debug("invoice creation failed: {}", f.message)
-                Behaviors.stopped
-            }
+          case WrappedInvoiceResponse(invoice) =>
+            context.log.debug("invoice created for offerId={} invoice={}", invoice.invoiceRequest.offer.offerId, invoice.toString)
+            postman ! Postman.SendMessage(OfferTypes.BlindedPath(pathToSender), OnionMessages.RoutingStrategy.FindRoute, TlvStream(OnionMessagePayloadTlv.Invoice(invoice.records)), expectsReply = false, context.messageAdapter[Postman.OnionMessageResponse](WrappedOnionMessageResponse))
+            waitForSent()
         }
       }
 
@@ -248,7 +250,8 @@ object OfferManager {
     sealed trait Command
 
     /**
-     * Sent by the offer handler. Causes the creation of a dummy invoice that matches as best as possible the actual invoice for this payment (since the actual invoice is not stored) and will be used in the payment handler.
+     * Sent by the offer handler. Causes the creation of a dummy invoice that matches as best as possible the actual
+     * invoice for this payment (since the actual invoice is not stored) and will be used in the payment handler.
      *
      * @param additionalTlvs additional TLVs to add to the dummy invoice. Should be the same as what was used for the actual invoice.
      * @param customTlvs     custom TLVs to add to the dummy invoice. Should be the same as what was used for the actual invoice.
@@ -260,14 +263,21 @@ object OfferManager {
      */
     case class RejectPayment(reason: String) extends Command
 
-    def apply(nodeParams: NodeParams, replyTo: ActorRef[MultiPartHandler.GetIncomingPaymentActor.Command], offer: Offer, metadata: MinimalInvoiceData, timeout: FiniteDuration): Behavior[Command] = {
+    def apply(nodeParams: NodeParams,
+              replyTo: ActorRef[MultiPartHandler.GetIncomingPaymentActor.Command],
+              offer: Offer,
+              metadata: MinimalInvoiceData,
+              payload: FinalPayload.Blinded,
+              timeout: FiniteDuration): Behavior[Command] = {
       Behaviors.setup { context =>
         context.scheduleOnce(timeout, context.self, RejectPayment("plugin timeout"))
         Behaviors.receiveMessage {
           case AcceptPayment(additionalTlvs, customTlvs) =>
             val minimalInvoice = MinimalBolt12Invoice(offer, nodeParams.chainHash, metadata.amount, metadata.quantity, Crypto.sha256(metadata.preimage), metadata.payerKey, metadata.createdAt, additionalTlvs, customTlvs)
             val incomingPayment = IncomingBlindedPayment(minimalInvoice, metadata.preimage, PaymentType.Blinded, TimestampMilli.now(), IncomingPaymentStatus.Pending)
-            replyTo ! MultiPartHandler.GetIncomingPaymentActor.ProcessPayment(incomingPayment)
+            // We may be deducing some of the blinded path fees from the received amount.
+            val recipientPathFees = nodeFee(metadata.recipientPathFees, payload.amount)
+            replyTo ! MultiPartHandler.GetIncomingPaymentActor.ProcessPayment(incomingPayment, recipientPathFees)
             Behaviors.stopped
           case RejectPayment(reason) =>
             replyTo ! MultiPartHandler.GetIncomingPaymentActor.RejectPayment(reason)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/offer/OfferPaymentMetadata.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/offer/OfferPaymentMetadata.scala
@@ -34,23 +34,28 @@ import scodec.bits.ByteVector
  * We instead include payment metadata in the blinded route's path_id field which lets us generate a minimal invoice
  * once we receive the payment, that is similar to the one that was actually sent to the payer. It will not be exactly
  * the same (notably the blinding route will be missing) but it will contain what we need to fulfill the payment.
+ *
+ * Since the recipient is selecting the blinded route to themselves, it may be unfair to the payer if the blinded route
+ * requires a high routing fee. The recipient can instead opt into having some of those routing fees deducted from the
+ * amount they receive by setting [[MinimalInvoiceData.recipientPathFees]] to a non-zero value.
  */
 object OfferPaymentMetadata {
 
   /**
-   * @param preimage       preimage for that payment.
-   * @param payerKey       payer key (from their invoice request).
-   * @param createdAt      creation time of the invoice.
-   * @param quantity       quantity of items requested.
-   * @param amount         amount that must be paid.
-   * @param pluginData_opt optional data from the offer plugin.
+   * @param preimage          preimage for that payment.
+   * @param payerKey          payer key (from their invoice request).
+   * @param createdAt         creation time of the invoice.
+   * @param quantity          quantity of items requested.
+   * @param amount            amount that must be paid.
+   * @param recipientPathFees the payment recipient may choose to pay part of the blinded path relay fees themselves.
+   * @param pluginData_opt    optional data from the offer plugin.
    */
   case class MinimalInvoiceData(preimage: ByteVector32,
                                 payerKey: PublicKey,
                                 createdAt: TimestampSecond,
                                 quantity: Long,
                                 amount: MilliSatoshi,
-                                hiddenFees: RelayFees,
+                                recipientPathFees: RelayFees,
                                 pluginData_opt: Option[ByteVector])
 
   /**
@@ -71,7 +76,7 @@ object OfferPaymentMetadata {
         ("createdAt" | timestampSecond) ::
         ("quantity" | uint64overflow) ::
         ("amount" | millisatoshi) ::
-        ("hiddenFees" | (millisatoshi :: int64).as[RelayFees]) ::
+        ("recipientPathFees" | (millisatoshi :: int64).as[RelayFees]) ::
         ("pluginData" | optional(bitsRemaining, bytes))).as[MinimalInvoiceData]
 
     private val signedDataCodec: Codec[SignedMinimalInvoiceData] =

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartPaymentFSM.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartPaymentFSM.scala
@@ -139,7 +139,7 @@ object MultiPartPaymentFSM {
     override def amount: MilliSatoshi  = htlc.amountMsat
   }
   /** The fee of a blinded route paid by the receiver (us). */
-  case class HiddenFeePart(paymentHash: ByteVector32, amount: MilliSatoshi, totalAmount: MilliSatoshi) extends PaymentPart
+  case class RecipientBlindedPathFeePart(paymentHash: ByteVector32, amount: MilliSatoshi, totalAmount: MilliSatoshi) extends PaymentPart
   /** We successfully received all parts of the payment. */
   case class MultiPartPaymentSucceeded(paymentHash: ByteVector32, parts: Queue[PaymentPart])
   /** We aborted the payment because of an inconsistency in the payment set or because we didn't receive the total amount in reasonable time. */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -338,9 +338,6 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
               // this is most likely a liquidity issue, we remove this edge for our next payment attempt
               data.recipient.extraEdges.filterNot(edge => edge.sourceNodeId == nodeId && edge.targetNodeId == hop.nextNodeId)
           }
-        case _: HopRelayParams.Dummy =>
-          log.error("received an update for a dummy hop, this should never happen")
-          data.recipient.extraEdges
       }
       case None =>
         log.error(s"couldn't find node=$nodeId in the route, this should never happen")


### PR DESCRIPTION
We clarify that the previously named "hiddenFee" is actually the blinded path fee that is being paid by the recipient (by deducing it from the amount it plans on receiving). We thus rename variables and add docs.

We also revert the validation flow: instead of generating a payment part for that fee based on the difference between the paid amount and the onion value, we generate that payment part based on the blinded path fee we recorded in the `path_id` and validate that it matches what the payer is sending.

We revert some of the changes to the `MultiPartHandler` which aren't necessary and do some clean-up of some unused code paths.

This is a PR targeting #2993: I verified that this code compiles, but didn't update the tests.