### PR TITLE
(Minor) Fix capturing logs in tests

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/testutils/MyCapturingAppender.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/testutils/MyCapturingAppender.scala
@@ -19,7 +19,7 @@ class MyCapturingAppender extends AppenderBase[ILoggingEvent] {
 
   /**
    * Flush buffered logging events to the output appenders
-   * Also clears the buffer..
+   * Also clears the buffer.
    */
   def flush(): Unit = synchronized {
     val deferredTestLogger = this.getContext.asInstanceOf[LoggerContext].getLogger("MyCapturingAppenderDelegate")

--- a/eclair-core/src/test/scala/fr/acinq/eclair/testutils/MyContextSelector.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/testutils/MyContextSelector.scala
@@ -2,7 +2,7 @@ package fr.acinq.eclair.testutils
 
 import ch.qos.logback.classic.LoggerContext
 import ch.qos.logback.classic.selector.ContextSelector
-import ch.qos.logback.classic.util.ContextInitializer
+import ch.qos.logback.classic.util.{ContextInitializer, LogbackMDCAdapter}
 
 import java.util
 import scala.jdk.CollectionConverters.SeqHasAsJava
@@ -32,10 +32,11 @@ class MyContextSelector extends ContextSelector {
       val context = contexts.getOrElse(name, {
         val context = new LoggerContext()
         context.setName(name)
+        context.setMDCAdapter(new LogbackMDCAdapter())
         new ContextInitializer(context).autoConfig()
+        contexts = contexts + (name -> context)
         context
       })
-      contexts = contexts + (name -> context)
       context
     }
   }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/testutils/MySlf4jLogger.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/testutils/MySlf4jLogger.scala
@@ -43,6 +43,7 @@ class MySlf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Lo
   private val contextName = context.system.settings.config.getString("akka.logging-context")
 
   val loggerFactory: LoggerContext = MyContextSelector.Singleton.getLoggerContext(contextName)
+  val mdc = loggerFactory.getMDCAdapter
 
   val mdcThreadAttributeName = "sourceThread"
   val mdcActorSystemAttributeName = "sourceActorSystem"
@@ -101,21 +102,21 @@ class MySlf4jLogger extends Actor with SLF4JLogging with RequiresMessageQueue[Lo
       case m: LogEventWithMarker if m.marker ne null =>
         val properties = m.marker.properties
         if (properties.nonEmpty) {
-          properties.foreach { case (k, v) => MDC.put(k, String.valueOf(v)) }
+          properties.foreach { case (k, v) => mdc.put(k, String.valueOf(v)) }
         }
       case _ =>
     }
 
-    MDC.put(mdcAkkaSourceAttributeName, logSource)
-    MDC.put(mdcThreadAttributeName, logEvent.thread.getName)
-    MDC.put(mdcAkkaTimestamp, formatTimestamp(logEvent.timestamp))
-    MDC.put(mdcActorSystemAttributeName, context.system.name)
-    MDC.put(mdcAkkaAddressAttributeName, akkaAddress)
-    logEvent.mdc.foreach { case (k, v) => MDC.put(k, String.valueOf(v)) }
+    mdc.put(mdcAkkaSourceAttributeName, logSource)
+    mdc.put(mdcThreadAttributeName, logEvent.thread.getName)
+    mdc.put(mdcAkkaTimestamp, formatTimestamp(logEvent.timestamp))
+    mdc.put(mdcActorSystemAttributeName, context.system.name)
+    mdc.put(mdcAkkaAddressAttributeName, akkaAddress)
+    logEvent.mdc.foreach { case (k, v) => mdc.put(k, String.valueOf(v)) }
 
     try logStatement
     finally {
-      MDC.clear()
+      mdc.clear()
     }
   }
 


### PR DESCRIPTION
The lack of properly initialized `MDCContext` made `prepareForDeferredProcessing()` crash in `MyCapturingAppender`.