### PR TITLE
Make wallet resolution independent of wake-up config in `NodeRelay`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -301,7 +301,7 @@ class NodeRelay private(nodeParams: NodeParams,
           }
           walletNodeId_opt match {
             case Some(walletNodeId) if nodeParams.peerWakeUpConfig.enabled => attemptWakeUp(upstream, walletNodeId, recipient, nextPayload, nextPacket_opt)
-            case _ => relay(upstream, recipient, None, None, nextPayload, nextPacket_opt)
+            case _ => relay(upstream, recipient, walletNodeId_opt, None, nextPayload, nextPacket_opt)
           }
       }
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -75,7 +75,7 @@ object NodeRelay {
   }
 
   case class SimpleOutgoingPaymentFactory(nodeParams: NodeParams, router: ActorRef, register: ActorRef) extends OutgoingPaymentFactory {
-    val paymentFactory = PaymentInitiator.SimplePaymentFactory(nodeParams, router, register)
+    val paymentFactory: PaymentInitiator.SimplePaymentFactory = PaymentInitiator.SimplePaymentFactory(nodeParams, router, register)
 
     override def spawnOutgoingPayFSM(context: ActorContext[Command], cfg: SendPaymentConfig, multiPart: Boolean): ActorRef = {
       if (multiPart) {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -66,7 +66,7 @@ object NodeRelay {
   private case class WrappedPaymentFailed(paymentFailed: PaymentFailed) extends Command
   private case class WrappedPeerReadyResult(result: PeerReadyNotifier.Result) extends Command
   private case class WrappedResolvedPaths(resolved: Seq[ResolvedPath]) extends Command
-  private case class WrappedPeerInfo(isPeer: Boolean, remoteFeatures_opt: Option[Features[InitFeature]]) extends Command
+  private case class WrappedPeerInfo(remoteFeatures_opt: Option[Features[InitFeature]]) extends Command
   private case class WrappedOnTheFlyFundingResponse(result: Peer.ProposeOnTheFlyFundingResponse) extends Command
   // @formatter:on
 
@@ -285,16 +285,16 @@ class NodeRelay private(nodeParams: NodeParams,
 
   /** The next node may be a mobile wallet directly connected to us: in that case, we'll need to wake them up before relaying the payment. */
   private def attemptWakeUpIfRecipientIsWallet(upstream: Upstream.Hot.Trampoline, recipient: Recipient, nextPayload: IntermediatePayload.NodeRelay, nextPacket_opt: Option[OnionRoutingPacket]): Behavior[Command] = {
-    val forwardNodeIdFailureAdapter = context.messageAdapter[Register.ForwardNodeIdFailure[Peer.GetPeerInfo]](_ => WrappedPeerInfo(isPeer = false, remoteFeatures_opt = None))
+    val forwardNodeIdFailureAdapter = context.messageAdapter[Register.ForwardNodeIdFailure[Peer.GetPeerInfo]](_ => WrappedPeerInfo(remoteFeatures_opt = None))
     val peerInfoAdapter = context.messageAdapter[Peer.PeerInfoResponse] {
-      case _: Peer.PeerNotFound => WrappedPeerInfo(isPeer = false, remoteFeatures_opt = None)
-      case info: Peer.PeerInfo => WrappedPeerInfo(isPeer = true, info.features)
+      case _: Peer.PeerNotFound => WrappedPeerInfo(remoteFeatures_opt = None)
+      case info: Peer.PeerInfo => WrappedPeerInfo(remoteFeatures_opt = info.features)
     }
     register ! Register.ForwardNodeId(forwardNodeIdFailureAdapter, recipient.nodeId, Peer.GetPeerInfo(Some(peerInfoAdapter)))
     Behaviors.receiveMessagePartial {
       rejectExtraHtlcPartialFunction orElse {
         case info: WrappedPeerInfo =>
-          val walletNodeId_opt = if (info.isPeer && info.remoteFeatures_opt.exists(_.hasFeature(Features.WakeUpNotificationClient))) {
+          val walletNodeId_opt = if (info.remoteFeatures_opt.exists(_.hasFeature(Features.WakeUpNotificationClient))) {
             Some(recipient.nodeId)
           } else {
             None

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -285,25 +285,25 @@ class NodeRelay private(nodeParams: NodeParams,
 
   /** The next node may be a mobile wallet directly connected to us: in that case, we'll need to wake them up before relaying the payment. */
   private def attemptWakeUpIfRecipientIsWallet(upstream: Upstream.Hot.Trampoline, recipient: Recipient, nextPayload: IntermediatePayload.NodeRelay, nextPacket_opt: Option[OnionRoutingPacket]): Behavior[Command] = {
-    if (nodeParams.peerWakeUpConfig.enabled) {
-      val forwardNodeIdFailureAdapter = context.messageAdapter[Register.ForwardNodeIdFailure[Peer.GetPeerInfo]](_ => WrappedPeerInfo(isPeer = false, remoteFeatures_opt = None))
-      val peerInfoAdapter = context.messageAdapter[Peer.PeerInfoResponse] {
-        case _: Peer.PeerNotFound => WrappedPeerInfo(isPeer = false, remoteFeatures_opt = None)
-        case info: Peer.PeerInfo => WrappedPeerInfo(isPeer = true, info.features)
+    val forwardNodeIdFailureAdapter = context.messageAdapter[Register.ForwardNodeIdFailure[Peer.GetPeerInfo]](_ => WrappedPeerInfo(isPeer = false, remoteFeatures_opt = None))
+    val peerInfoAdapter = context.messageAdapter[Peer.PeerInfoResponse] {
+      case _: Peer.PeerNotFound => WrappedPeerInfo(isPeer = false, remoteFeatures_opt = None)
+      case info: Peer.PeerInfo => WrappedPeerInfo(isPeer = true, info.features)
+    }
+    register ! Register.ForwardNodeId(forwardNodeIdFailureAdapter, recipient.nodeId, Peer.GetPeerInfo(Some(peerInfoAdapter)))
+    Behaviors.receiveMessagePartial {
+      rejectExtraHtlcPartialFunction orElse {
+        case info: WrappedPeerInfo =>
+          val walletNodeId_opt = if (info.isPeer && info.remoteFeatures_opt.exists(_.hasFeature(Features.WakeUpNotificationClient))) {
+            Some(recipient.nodeId)
+          } else {
+            None
+          }
+          walletNodeId_opt match {
+            case Some(walletNodeId) if nodeParams.peerWakeUpConfig.enabled => attemptWakeUp(upstream, walletNodeId, recipient, nextPayload, nextPacket_opt)
+            case _ => relay(upstream, recipient, None, None, nextPayload, nextPacket_opt)
+          }
       }
-      register ! Register.ForwardNodeId(forwardNodeIdFailureAdapter, recipient.nodeId, Peer.GetPeerInfo(Some(peerInfoAdapter)))
-      Behaviors.receiveMessagePartial {
-        rejectExtraHtlcPartialFunction orElse {
-          case info: WrappedPeerInfo =>
-            if (info.isPeer && info.remoteFeatures_opt.exists(_.hasFeature(Features.WakeUpNotificationClient))) {
-              attemptWakeUp(upstream, recipient.nodeId, recipient, nextPayload, nextPacket_opt)
-            } else {
-              relay(upstream, recipient, None, None, nextPayload, nextPacket_opt)
-            }
-        }
-      }
-    } else {
-      relay(upstream, recipient, None, None, nextPayload, nextPacket_opt)
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/NodeRelayerSpec.scala
@@ -259,6 +259,8 @@ class NodeRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appl
     assert(fwd.channelId == extra.add.channelId)
     val failure = FailureReason.LocalFailure(IncorrectOrUnknownPaymentDetails(extra.add.amountMsat, nodeParams.currentBlockHeight))
     assert(fwd.message == CMD_FAIL_HTLC(extra.add.id, failure, commit = true))
+
+    register.expectNoMessage(100 millis)
   }
 
   test("fail all additional incoming HTLCs once already relayed out") { f =>


### PR DESCRIPTION
They are logically independent.