### PR TITLE
Allow override peer storage write delay

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -23,7 +23,7 @@ import fr.acinq.eclair.Setup.Seeds
 import fr.acinq.eclair.blockchain.fee._
 import fr.acinq.eclair.channel.fsm.Channel
 import fr.acinq.eclair.channel.fsm.Channel.{BalanceThreshold, ChannelConf, UnhandledExceptionStrategy}
-import fr.acinq.eclair.channel.{ChannelFlags, ChannelTypes}
+import fr.acinq.eclair.channel.{ChannelFlags, ChannelType, ChannelTypes}
 import fr.acinq.eclair.crypto.Noise.KeyPair
 import fr.acinq.eclair.crypto.keymanager.{ChannelKeyManager, NodeKeyManager, OnChainKeyManager}
 import fr.acinq.eclair.db._
@@ -163,7 +163,12 @@ case class PaymentFinalExpiryConf(min: CltvExpiryDelta, max: CltvExpiryDelta) {
  * @param removalDelay     we keep our peer's data in our DB even after closing all of our channels with them, up to this duration.
  * @param cleanUpFrequency frequency at which we go through the DB to remove unused storage.
  */
-case class PeerStorageConfig(writeDelay: FiniteDuration, removalDelay: FiniteDuration, cleanUpFrequency: FiniteDuration)
+case class PeerStorageConfig(writeDelay: FiniteDuration, removalDelay: FiniteDuration, cleanUpFrequency: FiniteDuration) {
+  // NB: we don't use the arguments here, but they can be used in feature branches to override the default value.
+  def getWriteDelay(nodeId: PublicKey, remoteFeatures_opt: Option[Features[InitFeature]]): FiniteDuration = {
+    writeDelay
+  }
+}
 
 object NodeParams extends Logging {
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -154,7 +154,7 @@ class Peer(val nodeParams: NodeParams,
 
     case Event(e: ChannelReadyForPayments, d: DisconnectedData) =>
       if (!d.peerStorage.written && !isTimerActive(WritePeerStorageTimerKey)) {
-        startSingleTimer(WritePeerStorageTimerKey, WritePeerStorage, nodeParams.peerStorageConfig.writeDelay)
+        startSingleTimer(WritePeerStorageTimerKey, WritePeerStorage, nodeParams.peerStorageConfig.getWriteDelay(remoteNodeId, d.remoteFeatures_opt.map(_.features)))
       }
       val remoteFeatures_opt = d.remoteFeatures_opt match {
         case Some(remoteFeatures) if !remoteFeatures.written =>
@@ -459,7 +459,7 @@ class Peer(val nodeParams: NodeParams,
             }
         }
         if (!d.peerStorage.written && !isTimerActive(WritePeerStorageTimerKey)) {
-          startSingleTimer(WritePeerStorageTimerKey, WritePeerStorage, nodeParams.peerStorageConfig.writeDelay)
+          startSingleTimer(WritePeerStorageTimerKey, WritePeerStorage, nodeParams.peerStorageConfig.getWriteDelay(remoteNodeId, Some(d.remoteFeatures)))
         }
         if (!d.remoteFeaturesWritten) {
           // We have a channel, so we can write to the DB without any DoS risk.
@@ -580,7 +580,7 @@ class Peer(val nodeParams: NodeParams,
           if (d.activeChannels.isEmpty) {
             log.debug("received peer storage from peer with no active channel")
           } else if (!isTimerActive(WritePeerStorageTimerKey)) {
-            startSingleTimer(WritePeerStorageTimerKey, WritePeerStorage, nodeParams.peerStorageConfig.writeDelay)
+            startSingleTimer(WritePeerStorageTimerKey, WritePeerStorage, nodeParams.peerStorageConfig.getWriteDelay(remoteNodeId, Some(d.remoteFeatures)))
           }
           stay() using d.copy(peerStorage = PeerStorage(Some(store.blob), written = false))
         } else {


### PR DESCRIPTION
We provide the remote `node_id` and `init_features` to allow feature branches to override the default write delay used for peer storage.