### PR TITLE
Use channel_reestablish tlv when sending channel_ready

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -2356,12 +2356,12 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
       }
 
     case Event(_: ChannelReestablish, d: DATA_WAIT_FOR_CHANNEL_READY) =>
-      log.debug("re-sending channelReady")
+      log.debug("re-sending channel_ready")
       val channelReady = createChannelReady(d.aliases, d.commitments.params)
       goto(WAIT_FOR_CHANNEL_READY) sending channelReady
 
     case Event(_: ChannelReestablish, d: DATA_WAIT_FOR_DUAL_FUNDING_READY) =>
-      log.debug("re-sending channelReady")
+      log.debug("re-sending channel_ready")
       val channelReady = createChannelReady(d.aliases, d.commitments.params)
       goto(WAIT_FOR_DUAL_FUNDING_READY) sending channelReady
 
@@ -2492,7 +2492,7 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
           // BOLT 2: A node if it has sent a previous shutdown MUST retransmit shutdown.
           d.localShutdown.foreach {
             localShutdown =>
-              log.debug("re-sending localShutdown")
+              log.debug("re-sending local_shutdown")
               sendQueue = sendQueue :+ localShutdown
           }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -2384,12 +2384,12 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
               val notReceivedByRemote = remoteSpliceSupport && channelReestablish.yourLastFundingLocked_opt.isEmpty
               // If next_local_commitment_number is 1 in both the channel_reestablish it sent and received, then the node
               // MUST retransmit channel_ready, otherwise it MUST NOT
-              val notReceivedByRemote_legacy = !remoteSpliceSupport && channelReestablish.nextLocalCommitmentNumber == 1 && c.localCommit.index == 0
+              val notReceivedByRemoteLegacy = !remoteSpliceSupport && channelReestablish.nextLocalCommitmentNumber == 1 && c.localCommit.index == 0
               // If this is a public channel and we haven't announced the channel, we retransmit our channel_ready and
               // will also send announcement_signatures.
               val notAnnouncedYet = d.commitments.announceChannel && c.shortChannelId_opt.nonEmpty && d.lastAnnouncement_opt.isEmpty
-              if (notAnnouncedYet || notReceivedByRemote || notReceivedByRemote_legacy) {
-                log.debug("re-sending channelReady")
+              if (notAnnouncedYet || notReceivedByRemote || notReceivedByRemoteLegacy) {
+                log.debug("re-sending channel_ready")
                 val channelKeyPath = keyManager.keyPath(d.commitments.params.localParams, d.commitments.params.channelConfig)
                 val nextPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 1)
                 sendQueue = sendQueue :+ ChannelReady(d.commitments.channelId, nextPerCommitmentPoint)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -2373,15 +2373,37 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
           var sendQueue = Queue.empty[LightningMessage]
           // normal case, our data is up-to-date
 
-          // re-send channel_ready if necessary
-          if (d.commitments.latest.fundingTxIndex == 0 && channelReestablish.nextLocalCommitmentNumber == 1 && d.commitments.localCommitIndex == 0) {
-            // If next_local_commitment_number is 1 in both the channel_reestablish it sent and received, then the node MUST retransmit channel_ready, otherwise it MUST NOT
-            // TODO: when the remote node enables option_splice we can use your_last_funding_locked to detect they did not receive our channel_ready.
-            log.debug("re-sending channelReady")
-            val channelKeyPath = keyManager.keyPath(d.commitments.params.localParams, d.commitments.params.channelConfig)
-            val nextPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 1)
-            val channelReady = ChannelReady(d.commitments.channelId, nextPerCommitmentPoint)
-            sendQueue = sendQueue :+ channelReady
+          // re-send channel_ready and announcement_signatures if necessary
+          d.commitments.lastLocalLocked_opt match {
+            case None => ()
+            // We only send channel_ready for initial funding transactions.
+            case Some(c) if c.fundingTxIndex != 0 => ()
+            case Some(c) =>
+              val remoteSpliceSupport = d.commitments.params.remoteParams.initFeatures.hasFeature(Features.SplicePrototype)
+              // If our peer has not received our channel_ready, we retransmit it.
+              val notReceivedByRemote = remoteSpliceSupport && channelReestablish.yourLastFundingLocked_opt.isEmpty
+              // If next_local_commitment_number is 1 in both the channel_reestablish it sent and received, then the node
+              // MUST retransmit channel_ready, otherwise it MUST NOT
+              val notReceivedByRemote_legacy = !remoteSpliceSupport && channelReestablish.nextLocalCommitmentNumber == 1 && c.localCommit.index == 0
+              // If this is a public channel and we haven't announced the channel, we retransmit our channel_ready and
+              // will also send announcement_signatures.
+              val notAnnouncedYet = d.commitments.announceChannel && c.shortChannelId_opt.nonEmpty && d.lastAnnouncement_opt.isEmpty
+              if (notAnnouncedYet || notReceivedByRemote || notReceivedByRemote_legacy) {
+                log.debug("re-sending channelReady")
+                val channelKeyPath = keyManager.keyPath(d.commitments.params.localParams, d.commitments.params.channelConfig)
+                val nextPerCommitmentPoint = keyManager.commitmentPoint(channelKeyPath, 1)
+                sendQueue = sendQueue :+ ChannelReady(d.commitments.channelId, nextPerCommitmentPoint)
+              }
+              if (notAnnouncedYet) {
+                // The funding transaction is confirmed, so we've already sent our announcement_signatures.
+                // We haven't announced the channel yet, which means we haven't received our peer's announcement_signatures.
+                // We retransmit our announcement_signatures to let our peer know that we're ready to announce the channel.
+                val localAnnSigs = c.signAnnouncement(nodeParams, d.commitments.params)
+                localAnnSigs.foreach(annSigs => {
+                  announcementSigsSent += annSigs.shortChannelId
+                  sendQueue = sendQueue :+ annSigs
+                })
+              }
           }
 
           // resume splice signing session if any
@@ -2432,10 +2454,10 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
             // We then clean up unsigned updates that haven't been received before the disconnection.
             .discardUnsignedUpdates()
 
-          val spliceLocked_opt = commitments1.lastLocalLocked_opt match {
-            case None => None
+          commitments1.lastLocalLocked_opt match {
+            case None => ()
             // We only send splice_locked for splice transactions.
-            case Some(c) if c.fundingTxIndex == 0 => None
+            case Some(c) if c.fundingTxIndex == 0 => ()
             case Some(c) =>
               // If our peer has not received our splice_locked, we retransmit it.
               val notReceivedByRemote = !channelReestablish.yourLastFundingLocked_opt.contains(c.fundingTxId)
@@ -2443,15 +2465,14 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
               // will exchange announcement_signatures afterwards.
               val notAnnouncedYet = commitments1.announceChannel && d.lastAnnouncement_opt.forall(ann => !c.shortChannelId_opt.contains(ann.shortChannelId))
               if (notReceivedByRemote || notAnnouncedYet) {
+                // Retransmission of local announcement_signatures for splices are done when receiving splice_locked, no need
+                // to retransmit here.
                 log.debug("re-sending splice_locked for fundingTxId={}", c.fundingTxId)
                 spliceLockedSent += (c.fundingTxId -> c.fundingTxIndex)
                 trimSpliceLockedSentIfNeeded()
-                Some(SpliceLocked(d.channelId, c.fundingTxId))
-              } else {
-                None
+                sendQueue = sendQueue :+ SpliceLocked(d.channelId, c.fundingTxId)
               }
           }
-          sendQueue = sendQueue ++ spliceLocked_opt.toSeq
 
           // we may need to retransmit updates and/or commit_sig and/or revocation
           sendQueue = sendQueue ++ syncSuccess.retransmit
@@ -2473,19 +2494,6 @@ class Channel(val nodeParams: NodeParams, val wallet: OnChainChannelFunder with 
             localShutdown =>
               log.debug("re-sending localShutdown")
               sendQueue = sendQueue :+ localShutdown
-          }
-
-          // Retransmission of local announcement_signatures for splices are done when receiving splice_locked, no need
-          // to retransmit here.
-          d.commitments.all.find(_.fundingTxIndex == 0) match {
-            case Some(c) if d.commitments.announceChannel && c.shortChannelId_opt.nonEmpty && d.lastAnnouncement_opt.isEmpty =>
-              // The funding transaction is confirmed, so we've already sent our announcement_signatures.
-              // We haven't announced the channel yet, which means we haven't received our peer's announcement_signatures.
-              // We retransmit our announcement_signatures to let our peer know that we're ready to announce the channel.
-              val localAnnSigs_opt = c.signAnnouncement(nodeParams, d.commitments.params)
-              localAnnSigs_opt.foreach(annSigs => announcementSigsSent += annSigs.shortChannelId)
-              sendQueue = sendQueue ++ localAnnSigs_opt.toSeq
-            case _ => ()
           }
 
           if (d.commitments.announceChannel) {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/RestoreSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/RestoreSpec.scala
@@ -11,7 +11,7 @@ import fr.acinq.eclair.channel.fsm.Channel
 import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
 import fr.acinq.eclair.channel.states.ChannelStateTestsBase.FakeTxPublisherFactory
 import fr.acinq.eclair.router.Announcements
-import fr.acinq.eclair.wire.protocol.{ChannelReestablish, ChannelUpdate, CommitSig, Error, RevokeAndAck}
+import fr.acinq.eclair.wire.protocol.{ChannelReestablish, ChannelUpdate, CommitSig, Error, Init, RevokeAndAck}
 import fr.acinq.eclair.{TestKitBaseClass, _}
 import org.scalatest.{Outcome, Tag}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
@@ -29,6 +29,10 @@ class RestoreSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Chan
       withFixture(test.toNoArgTest(setup))
     }
   }
+
+  private def aliceInit = Init(Alice.nodeParams.features.initFeatures())
+
+  private def bobInit = Init(Bob.nodeParams.features.initFeatures())
 
   test("use funding pubkeys from publish commitment to spend our output", Tag(ChannelStateTestsTags.StaticRemoteKey)) { f =>
     import f._

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/RestoreSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/RestoreSpec.scala
@@ -4,21 +4,14 @@ import akka.actor.ActorRef
 import akka.actor.typed.scaladsl.adapter.actorRefAdapter
 import akka.testkit.{TestActor, TestFSMRef, TestProbe}
 import com.softwaremill.quicklens.ModifyPimp
-import fr.acinq.bitcoin
-import fr.acinq.bitcoin.ScriptFlags
-import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat._
 import fr.acinq.eclair.TestConstants.{Alice, Bob}
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.WatchFundingSpentTriggered
 import fr.acinq.eclair.channel.fsm.Channel
 import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
 import fr.acinq.eclair.channel.states.ChannelStateTestsBase.FakeTxPublisherFactory
-import fr.acinq.eclair.crypto.Generators
-import fr.acinq.eclair.crypto.keymanager.ChannelKeyManager
 import fr.acinq.eclair.router.Announcements
-import fr.acinq.eclair.transactions.Scripts
-import fr.acinq.eclair.transactions.Transactions.{ClaimP2WPKHOutputTx, DefaultCommitmentFormat, InputInfo, TxOwner}
-import fr.acinq.eclair.wire.protocol.{ChannelReady, ChannelReestablish, ChannelUpdate, CommitSig, Error, Init, RevokeAndAck}
+import fr.acinq.eclair.wire.protocol.{ChannelReestablish, ChannelUpdate, CommitSig, Error, RevokeAndAck}
 import fr.acinq.eclair.{TestKitBaseClass, _}
 import org.scalatest.{Outcome, Tag}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
@@ -36,10 +29,6 @@ class RestoreSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Chan
       withFixture(test.toNoArgTest(setup))
     }
   }
-
-  private def aliceInit = Init(Alice.nodeParams.features.initFeatures())
-
-  private def bobInit = Init(Bob.nodeParams.features.initFeatures())
 
   test("use funding pubkeys from publish commitment to spend our output", Tag(ChannelStateTestsTags.StaticRemoteKey)) { f =>
     import f._
@@ -177,7 +166,7 @@ class RestoreSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Chan
     // and we terminate Alice
     alice.stop()
 
-    // there should ne no pending messages
+    // there should be no pending messages
     alice2bob.expectNoMessage()
     bob2alice.expectNoMessage()
 
@@ -207,10 +196,6 @@ class RestoreSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with Chan
       bob ! INPUT_RECONNECTED(bob2alice.ref, bobInit, aliceInit)
       alice2bob.expectMsgType[ChannelReestablish]
       bob2alice.expectMsgType[ChannelReestablish]
-      alice2bob.forward(bob)
-      bob2alice.forward(newAlice)
-      alice2bob.expectMsgType[ChannelReady]
-      bob2alice.expectMsgType[ChannelReady]
       alice2bob.forward(bob)
       bob2alice.forward(newAlice)
       alice2bob.expectMsgType[ChannelUpdate]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
@@ -146,7 +146,8 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
     systemB.eventStream.subscribe(channelUpdateListener.ref, classOf[LocalChannelUpdate])
     systemB.eventStream.subscribe(channelUpdateListener.ref, classOf[LocalChannelDown])
     val router = TestProbe()
-    val finalNodeParamsA = nodeParamsA
+    val (nodeParamsA1, nodeParamsB1) = computeInitFeature(nodeParamsA, nodeParamsB, tags)
+    val finalNodeParamsA = nodeParamsA1
       .modify(_.channelConf.dustLimit).setToIf(tags.contains(ChannelStateTestsTags.HighDustLimitDifferenceAliceBob))(5000 sat)
       .modify(_.channelConf.dustLimit).setToIf(tags.contains(ChannelStateTestsTags.HighDustLimitDifferenceBobAlice))(1000 sat)
       .modify(_.channelConf.maxRemoteDustLimit).setToIf(tags.contains(ChannelStateTestsTags.HighDustLimitDifferenceAliceBob))(10000 sat)
@@ -155,7 +156,7 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
       .modify(_.onChainFeeConf.defaultFeerateTolerance.ratioHigh).setToIf(tags.contains(ChannelStateTestsTags.HighFeerateMismatchTolerance))(1000000)
       .modify(_.onChainFeeConf.spendAnchorWithoutHtlcs).setToIf(tags.contains(ChannelStateTestsTags.DontSpendAnchorWithoutHtlcs))(false)
       .modify(_.channelConf.balanceThresholds).setToIf(tags.contains(ChannelStateTestsTags.AdaptMaxHtlcAmount))(Seq(Channel.BalanceThreshold(1_000 sat, 0 sat), Channel.BalanceThreshold(5_000 sat, 1_000 sat), Channel.BalanceThreshold(10_000 sat, 5_000 sat)))
-    val finalNodeParamsB = nodeParamsB
+    val finalNodeParamsB = nodeParamsB1
       .modify(_.channelConf.dustLimit).setToIf(tags.contains(ChannelStateTestsTags.HighDustLimitDifferenceAliceBob))(1000 sat)
       .modify(_.channelConf.dustLimit).setToIf(tags.contains(ChannelStateTestsTags.HighDustLimitDifferenceBobAlice))(5000 sat)
       .modify(_.channelConf.maxRemoteDustLimit).setToIf(tags.contains(ChannelStateTestsTags.HighDustLimitDifferenceAliceBob))(10000 sat)
@@ -181,10 +182,8 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
     SetupFixture(alice, bob, aliceOpenReplyTo, alice2bob, bob2alice, alice2blockchain, bob2blockchain, router, alice2relayer, bob2relayer, channelUpdateListener, wallet, alicePeer, bobPeer)
   }
 
-  def computeFeatures(setup: SetupFixture, tags: Set[String], channelFlags: ChannelFlags): (LocalParams, LocalParams, SupportedChannelType) = {
-    import setup._
-
-    val aliceInitFeatures = Alice.nodeParams.features
+  def computeInitFeature(nodeParamsA: NodeParams, nodeParamsB: NodeParams, tags: Set[String]): (NodeParams, NodeParams) = {
+    (nodeParamsA.copy(features = nodeParamsA.features
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.DisableWumbo))(_.removed(Features.Wumbo))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.StaticRemoteKey))(_.updated(Features.StaticRemoteKey, FeatureSupport.Optional))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.AnchorOutputs))(_.updated(Features.StaticRemoteKey, FeatureSupport.Optional).updated(Features.AnchorOutputs, FeatureSupport.Optional))
@@ -195,9 +194,8 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.ZeroConf))(_.updated(Features.ZeroConf, FeatureSupport.Optional))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.ScidAlias))(_.updated(Features.ScidAlias, FeatureSupport.Optional))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.DualFunding))(_.updated(Features.DualFunding, FeatureSupport.Optional))
-      .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.SimpleClose))(_.updated(Features.SimpleClose, FeatureSupport.Optional))
-      .initFeatures()
-    val bobInitFeatures = Bob.nodeParams.features
+      .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.SimpleClose))(_.updated(Features.SimpleClose, FeatureSupport.Optional))),
+    nodeParamsB.copy(features = nodeParamsB.features
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.DisableWumbo))(_.removed(Features.Wumbo))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.StaticRemoteKey))(_.updated(Features.StaticRemoteKey, FeatureSupport.Optional))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.AnchorOutputs))(_.updated(Features.StaticRemoteKey, FeatureSupport.Optional).updated(Features.AnchorOutputs, FeatureSupport.Optional))
@@ -210,7 +208,15 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.DualFunding))(_.updated(Features.DualFunding, FeatureSupport.Optional))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.SimpleClose))(_.updated(Features.SimpleClose, FeatureSupport.Optional))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.DisableSplice))(_.removed(Features.SplicePrototype))
-      .initFeatures()
+      ))
+  }
+
+  def computeFeatures(setup: SetupFixture, tags: Set[String], channelFlags: ChannelFlags): (LocalParams, LocalParams, SupportedChannelType) = {
+    import setup._
+
+    val (nodeParamsA, nodeParamsB) = computeInitFeature(TestConstants.Alice.nodeParams, TestConstants.Bob.nodeParams, tags)
+    val aliceInitFeatures = nodeParamsA.features.initFeatures()
+    val bobInitFeatures = nodeParamsB.features.initFeatures()
 
     val channelType = ChannelTypes.defaultFromFeatures(aliceInitFeatures, bobInitFeatures, announceChannel = channelFlags.announceChannel)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
@@ -117,9 +117,7 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
                           channelUpdateListener: TestProbe,
                           wallet: OnChainWallet with OnchainPubkeyCache,
                           alicePeer: TestProbe,
-                          bobPeer: TestProbe,
-                          aliceInit: Init,
-                          bobInit: Init) {
+                          bobPeer: TestProbe) {
     def currentBlockHeight: BlockHeight = alice.underlyingActor.nodeParams.currentBlockHeight
   }
 
@@ -180,10 +178,7 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
       implicit val system: ActorSystem = systemB
       TestFSMRef(new Channel(finalNodeParamsB, wallet, finalNodeParamsA.nodeId, bob2blockchain.ref, bob2relayer.ref, FakeTxPublisherFactory(bob2blockchain)), bobPeer.ref)
     }
-    val aliceInit = Init(Alice.nodeParams.features.initFeatures())
-    val bobInit = Init(Bob.nodeParams.features.initFeatures().modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.DisableSplice))(_.removed(Features.SplicePrototype)).initFeatures())
-
-    SetupFixture(alice, bob, aliceOpenReplyTo, alice2bob, bob2alice, alice2blockchain, bob2blockchain, router, alice2relayer, bob2relayer, channelUpdateListener, wallet, alicePeer, bobPeer, aliceInit, bobInit)
+    SetupFixture(alice, bob, aliceOpenReplyTo, alice2bob, bob2alice, alice2blockchain, bob2blockchain, router, alice2relayer, bob2relayer, channelUpdateListener, wallet, alicePeer, bobPeer)
   }
 
   def computeFeatures(setup: SetupFixture, tags: Set[String], channelFlags: ChannelFlags): (LocalParams, LocalParams, SupportedChannelType) = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
@@ -146,7 +146,7 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
     systemB.eventStream.subscribe(channelUpdateListener.ref, classOf[LocalChannelUpdate])
     systemB.eventStream.subscribe(channelUpdateListener.ref, classOf[LocalChannelDown])
     val router = TestProbe()
-    val (nodeParamsA1, nodeParamsB1) = computeInitFeature(nodeParamsA, nodeParamsB, tags)
+    val (nodeParamsA1, nodeParamsB1) = updateInitFeatures(nodeParamsA, nodeParamsB, tags)
     val finalNodeParamsA = nodeParamsA1
       .modify(_.channelConf.dustLimit).setToIf(tags.contains(ChannelStateTestsTags.HighDustLimitDifferenceAliceBob))(5000 sat)
       .modify(_.channelConf.dustLimit).setToIf(tags.contains(ChannelStateTestsTags.HighDustLimitDifferenceBobAlice))(1000 sat)
@@ -182,7 +182,7 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
     SetupFixture(alice, bob, aliceOpenReplyTo, alice2bob, bob2alice, alice2blockchain, bob2blockchain, router, alice2relayer, bob2relayer, channelUpdateListener, wallet, alicePeer, bobPeer)
   }
 
-  def computeInitFeature(nodeParamsA: NodeParams, nodeParamsB: NodeParams, tags: Set[String]): (NodeParams, NodeParams) = {
+  def updateInitFeatures(nodeParamsA: NodeParams, nodeParamsB: NodeParams, tags: Set[String]): (NodeParams, NodeParams) = {
     (nodeParamsA.copy(features = nodeParamsA.features
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.DisableWumbo))(_.removed(Features.Wumbo))
       .modify(_.activated).usingIf(tags.contains(ChannelStateTestsTags.StaticRemoteKey))(_.updated(Features.StaticRemoteKey, FeatureSupport.Optional))
@@ -214,7 +214,7 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
   def computeFeatures(setup: SetupFixture, tags: Set[String], channelFlags: ChannelFlags): (LocalParams, LocalParams, SupportedChannelType) = {
     import setup._
 
-    val (nodeParamsA, nodeParamsB) = computeInitFeature(TestConstants.Alice.nodeParams, TestConstants.Bob.nodeParams, tags)
+    val (nodeParamsA, nodeParamsB) = updateInitFeatures(alice.underlyingActor.nodeParams, bob.underlyingActor.nodeParams, tags)
     val aliceInitFeatures = nodeParamsA.features.initFeatures()
     val bobInitFeatures = nodeParamsB.features.initFeatures()
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
@@ -244,14 +244,13 @@ class WaitForDualFundingReadyStateSpec extends TestKitBaseClass with FixtureAnyF
     alice2bob.forward(bob)
     bob2alice.expectMsgType[ChannelReestablish]
     bob2alice.forward(alice)
-    bob2alice.expectMsgType[ChannelReady]
-    bob2alice.forward(alice)
+    // Bob does not retransmit channel_ready and announcement_signatures because Alice already sent them.
     bob2alice.expectNoMessage(100 millis)
-    // When receiving channel_ready, Bob retransmits announcement_signatures.
     alice2bob.expectMsgType[ChannelReady]
     alice2bob.forward(bob)
     alice2bob.expectMsgType[AnnouncementSignatures]
     alice2bob.forward(bob)
+    // When receiving channel_ready, Bob retransmits announcement_signatures.
     bob2alice.expectMsgType[AnnouncementSignatures]
     bob2alice.forward(alice)
     awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].lastAnnouncement_opt.nonEmpty)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
@@ -244,13 +244,14 @@ class WaitForDualFundingReadyStateSpec extends TestKitBaseClass with FixtureAnyF
     alice2bob.forward(bob)
     bob2alice.expectMsgType[ChannelReestablish]
     bob2alice.forward(alice)
-    // Bob does not retransmit channel_ready and announcement_signatures because Alice already sent them.
+    // Bob does not retransmit channel_ready and announcement_signatures because he has already received both of them from Alice.
     bob2alice.expectNoMessage(100 millis)
+    // Alice has already received Bob's channel_ready, but not its announcement_signatures.
+    // She retransmits channel_ready and Bob will retransmit its announcement_signatures in response.
     alice2bob.expectMsgType[ChannelReady]
     alice2bob.forward(bob)
     alice2bob.expectMsgType[AnnouncementSignatures]
     alice2bob.forward(bob)
-    // When receiving channel_ready, Bob retransmits announcement_signatures.
     bob2alice.expectMsgType[AnnouncementSignatures]
     bob2alice.forward(alice)
     awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].lastAnnouncement_opt.nonEmpty)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -87,14 +87,14 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     r2s.expectMsgType[TxComplete]
     r2s.forward(s)
     if (spliceIn_opt.isDefined) {
-      s2r.expectMsgType[TxAddInput]
-      s2r.forward(r)
-      r2s.expectMsgType[TxComplete]
-      r2s.forward(s)
-      s2r.expectMsgType[TxAddOutput]
-      s2r.forward(r)
-      r2s.expectMsgType[TxComplete]
-      r2s.forward(s)
+        s2r.expectMsgType[TxAddInput]
+        s2r.forward(r)
+        r2s.expectMsgType[TxComplete]
+        r2s.forward(s)
+        s2r.expectMsgType[TxAddOutput]
+        s2r.forward(r)
+        r2s.expectMsgType[TxComplete]
+        r2s.forward(s)
     }
     if (spliceOut_opt.isDefined) {
       s2r.expectMsgType[TxAddOutput]
@@ -366,7 +366,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
   }
 
   test("recv CMD_SPLICE (splice-in, non dual-funded channel)") { () =>
-    val f = init(tags = Set(ChannelStateTestsTags.DualFunding))
+    val f = init(tags = Set.empty, wallet_opt = Some(new SingleKeyOnChainWallet()))
     import f._
 
     reachNormal(f, tags = Set.empty) // we open a non dual-funded channel

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -913,16 +913,8 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
   }
 
   def reconnect(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], alice2bob: TestProbe, bob2alice: TestProbe): (PublicKey, PublicKey) = {
-    val aliceInit = Init(alice.stateData match {
-      case d: ChannelDataWithoutCommitments => d.channelParams.localParams.initFeatures
-      case d: ChannelDataWithCommitments => d.commitments.params.localParams.initFeatures
-      case _ => Alice.nodeParams.initFeaturesFor(Bob.nodeParams.nodeId)
-    })
-    val bobInit = Init(bob.stateData match {
-      case d: ChannelDataWithoutCommitments => d.channelParams.localParams.initFeatures
-      case d: ChannelDataWithCommitments => d.commitments.params.localParams.initFeatures
-      case _ => Bob.nodeParams.initFeaturesFor(Alice.nodeParams.nodeId)
-    })
+    val aliceInit = Init(alice.nodeParams.initFeaturesFor(bob.nodeParams.nodeId))
+    val bobInit = Init(bob.nodeParams.initFeaturesFor(alice.nodeParams.nodeId))
 
     alice ! INPUT_RECONNECTED(alice2bob.ref, aliceInit, bobInit)
     bob ! INPUT_RECONNECTED(bob2alice.ref, bobInit, aliceInit)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/OfflineStateSpec.scala
@@ -77,7 +77,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     import f._
 
     disconnect(alice, bob)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     val channelId = alice2bob.expectMsgType[ChannelReestablish].channelId
     alice2bob.forward(bob)
     bob2alice.expectMsgType[ChannelReestablish]
@@ -117,7 +117,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     // bob doesn't receive the sig
     disconnect(alice, bob)
 
-    val (aliceCurrentPerCommitmentPoint, bobCurrentPerCommitmentPoint) = reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    val (aliceCurrentPerCommitmentPoint, bobCurrentPerCommitmentPoint) = reconnect(alice, bob, alice2bob, bob2alice)
     val reestablishA = alice2bob.expectMsg(ChannelReestablish(htlc.channelId, 1, 0, PrivateKey(ByteVector32.Zeroes), aliceCurrentPerCommitmentPoint, TlvStream(lastFundingLockedTlvs(alice.stateData.asInstanceOf[DATA_NORMAL].commitments))))
     val reestablishB = bob2alice.expectMsg(ChannelReestablish(htlc.channelId, 1, 0, PrivateKey(ByteVector32.Zeroes), bobCurrentPerCommitmentPoint, TlvStream(lastFundingLockedTlvs(bob.stateData.asInstanceOf[DATA_NORMAL].commitments))))
     alice2bob.forward(bob, reestablishA)
@@ -172,7 +172,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     bob2alice.expectNoMessage(500 millis)
 
     disconnect(alice, bob)
-    val (aliceCurrentPerCommitmentPoint, bobCurrentPerCommitmentPoint) = reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    val (aliceCurrentPerCommitmentPoint, bobCurrentPerCommitmentPoint) = reconnect(alice, bob, alice2bob, bob2alice)
     val reestablishA = alice2bob.expectMsg(ChannelReestablish(htlc.channelId, 1, 0, PrivateKey(ByteVector32.Zeroes), aliceCurrentPerCommitmentPoint, TlvStream(lastFundingLockedTlvs(alice.stateData.asInstanceOf[DATA_NORMAL].commitments))))
     val reestablishB = bob2alice.expectMsg(ChannelReestablish(htlc.channelId, 2, 0, PrivateKey(ByteVector32.Zeroes), bobCurrentPerCommitmentPoint, TlvStream(lastFundingLockedTlvs(bob.stateData.asInstanceOf[DATA_NORMAL].commitments))))
     alice2bob.forward(bob, reestablishA)
@@ -220,7 +220,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     disconnect(alice, bob)
 
     {
-      val (aliceCurrentPerCommitmentPoint, bobCurrentPerCommitmentPoint) = reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+      val (aliceCurrentPerCommitmentPoint, bobCurrentPerCommitmentPoint) = reconnect(alice, bob, alice2bob, bob2alice)
       val reestablishA = alice2bob.expectMsg(ChannelReestablish(htlc.channelId, 1, 1, revB.perCommitmentSecret, aliceCurrentPerCommitmentPoint, TlvStream(lastFundingLockedTlvs(alice.stateData.asInstanceOf[DATA_NORMAL].commitments))))
       val reestablishB = bob2alice.expectMsg(ChannelReestablish(htlc.channelId, 2, 0, PrivateKey(ByteVector32.Zeroes), bobCurrentPerCommitmentPoint, TlvStream(lastFundingLockedTlvs(bob.stateData.asInstanceOf[DATA_NORMAL].commitments))))
       alice2bob.forward(bob, reestablishA)
@@ -251,8 +251,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     disconnect(alice, bob)
 
     {
-      val (aliceCurrentPerCommitmentPoint, bobCurrentPerCommitmentPoint) = reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
-      val fundingTxId = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.fundingTxId
+      val (aliceCurrentPerCommitmentPoint, bobCurrentPerCommitmentPoint) = reconnect(alice, bob, alice2bob, bob2alice)
       val reestablishA = alice2bob.expectMsg(ChannelReestablish(htlc.channelId, 2, 1, revB.perCommitmentSecret, aliceCurrentPerCommitmentPoint,TlvStream(lastFundingLockedTlvs(alice.stateData.asInstanceOf[DATA_NORMAL].commitments))))
       val reestablishB = bob2alice.expectMsg(ChannelReestablish(htlc.channelId, 2, 0, PrivateKey(ByteVector32.Zeroes), bobCurrentPerCommitmentPoint,TlvStream(lastFundingLockedTlvs(bob.stateData.asInstanceOf[DATA_NORMAL].commitments))))
       alice2bob.forward(bob, reestablishA)
@@ -289,7 +288,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     bob2alice.expectMsgType[CommitSig]
     disconnect(alice, bob)
 
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     val reestablishA = alice2bob.expectMsgType[ChannelReestablish]
     assert(reestablishA.nextLocalCommitmentNumber == 4)
     assert(reestablishA.nextRemoteRevocationNumber == 3)
@@ -338,7 +337,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     alice.setState(OFFLINE, oldStateData)
 
     // then we reconnect them
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
 
     // peers exchange channel_reestablish messages
     val reestablishA = alice2bob.expectMsgType[ChannelReestablish]
@@ -388,7 +387,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     alice.setState(OFFLINE, oldStateData)
 
     // then we reconnect them
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
 
     val reestablishA = alice2bob.expectMsgType[ChannelReestablish]
     val reestablishB = bob2alice.expectMsgType[ChannelReestablish]
@@ -428,7 +427,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
 
     // we simulate a disconnection followed by a reconnection
     disconnect(alice, bob)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     // bob sends an invalid channel_reestablish
     alice2bob.expectMsgType[ChannelReestablish]
     val invalidReestablish = bob2alice.expectMsgType[ChannelReestablish].copy(nextRemoteRevocationNumber = 42)
@@ -463,7 +462,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
 
     // we simulate a disconnection followed by a reconnection
     disconnect(alice, bob)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     // bob sends an invalid channel_reestablish
     alice2bob.expectMsgType[ChannelReestablish]
     val invalidReestablish = bob2alice.expectMsgType[ChannelReestablish].copy(nextLocalCommitmentNumber = 42)
@@ -506,7 +505,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     channelUpdateListener.expectNoMessage(300 millis)
 
     // then we reconnect them
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
 
     // peers exchange channel_reestablish messages
     alice2bob.expectMsgType[ChannelReestablish]
@@ -554,7 +553,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     bob.underlyingActor.nodeParams.db.pendingCommands.addSettlementCommand(initialState.channelId, CMD_FULFILL_HTLC(htlc.id, r, commit = true))
 
     // then we reconnect them
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
 
     // peers exchange channel_reestablish messages
     alice2bob.expectMsgType[ChannelReestablish]
@@ -585,7 +584,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     bob.underlyingActor.nodeParams.db.pendingCommands.addSettlementCommand(initialState.channelId, CMD_FULFILL_HTLC(htlc.id, r, commit = true))
 
     // then we reconnect them
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
 
     // peers exchange channel_reestablish messages
     alice2bob.expectMsgType[ChannelReestablish]
@@ -737,7 +736,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     alice2bob.expectNoMessage(100 millis)
 
     // then we reconnect them; Alice should send the feerate changes to Bob
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
 
     // peers exchange channel_reestablish messages
     alice2bob.expectMsgType[ChannelReestablish]
@@ -818,7 +817,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
 
     // We simulate a disconnection / reconnection.
     disconnect(alice, bob)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
 
     // Alice and Bob exchange channel_reestablish and channel_ready again.
     alice2bob.expectMsgType[ChannelReestablish]
@@ -850,7 +849,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     disconnect(alice, bob)
     // we wait 1s so the new channel_update doesn't have the same timestamp
     TestUtils.waitFor(1 second)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     alice2bob.expectMsgType[ChannelReestablish]
     bob2alice.expectMsgType[ChannelReestablish]
     bob2alice.forward(alice)
@@ -870,7 +869,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     disconnect(alice, bob)
     // we wait 1s so the new channel_update doesn't have the same timestamp
     TestUtils.waitFor(1 second)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     alice2bob.expectMsgType[ChannelReestablish]
     bob2alice.expectMsgType[ChannelReestablish]
     bob2alice.forward(alice)
@@ -886,7 +885,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     disconnect(alice, bob)
     // we wait 1s so the new channel_update doesn't have the same timestamp
     TestUtils.waitFor(1 second)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     alice2bob.expectMsgType[ChannelReestablish]
     bob2alice.expectMsgType[ChannelReestablish]
     bob2alice.forward(alice)
@@ -913,7 +912,18 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     awaitCond(bob.stateName == OFFLINE)
   }
 
-  def reconnect(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], alice2bob: TestProbe, bob2alice: TestProbe, aliceInit: Init, bobInit: Init): (PublicKey, PublicKey) = {
+  def reconnect(alice: TestFSMRef[ChannelState, ChannelData, Channel], bob: TestFSMRef[ChannelState, ChannelData, Channel], alice2bob: TestProbe, bob2alice: TestProbe): (PublicKey, PublicKey) = {
+    val aliceInit = Init(alice.stateData match {
+      case d: ChannelDataWithoutCommitments => d.channelParams.localParams.initFeatures
+      case d: ChannelDataWithCommitments => d.commitments.params.localParams.initFeatures
+      case _ => Alice.nodeParams.initFeaturesFor(Bob.nodeParams.nodeId)
+    })
+    val bobInit = Init(bob.stateData match {
+      case d: ChannelDataWithoutCommitments => d.channelParams.localParams.initFeatures
+      case d: ChannelDataWithCommitments => d.commitments.params.localParams.initFeatures
+      case _ => Bob.nodeParams.initFeaturesFor(Alice.nodeParams.nodeId)
+    })
+
     alice ! INPUT_RECONNECTED(alice2bob.ref, aliceInit, bobInit)
     bob ! INPUT_RECONNECTED(bob2alice.ref, bobInit, aliceInit)
 
@@ -935,13 +945,13 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
 
     // we simulate a disconnection / reconnection
     disconnect(alice, bob)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     alice2bob.expectMsgType[ChannelReestablish]
     bob2alice.expectMsgType[ChannelReestablish]
     bob2alice.forward(alice)
     alice2bob.forward(bob)
 
-    // Alice will resend her channel_ready at reconnection because there are no channel updates (pre-splice behavior).
+    // Alice will resend her channel_ready on reconnection because the channel hasn't been used for any payment yet (pre-splice behavior).
     alice2bob.expectMsgType[ChannelReady]
     alice2bob.expectNoMessage(100 millis)
 
@@ -951,13 +961,13 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
 
     // we simulate a disconnection / reconnection
     disconnect(alice, bob)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     alice2bob.expectMsgType[ChannelReestablish]
     bob2alice.expectMsgType[ChannelReestablish]
     bob2alice.forward(alice)
     alice2bob.forward(bob)
 
-    // Alice will NOT resend her channel_ready at reconnection because there are channel updates (pre-splice behavior).
+    // Alice will NOT resend her channel_ready on reconnection because the channel has been used for a payment (pre-splice behavior).
     alice2bob.expectNoMessage(100 millis)
   }
 
@@ -966,7 +976,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
 
     // we simulate a disconnection / reconnection
     disconnect(alice, bob)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     alice2bob.expectMsgType[ChannelReestablish]
     bob2alice.expectMsgType[ChannelReestablish]
     bob2alice.forward(alice)
@@ -987,13 +997,13 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
 
     // we simulate a disconnection / reconnection
     disconnect(alice, bob)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     alice2bob.expectMsgType[ChannelReestablish]
     bob2alice.expectMsgType[ChannelReestablish]
     bob2alice.forward(alice)
     alice2bob.forward(bob)
 
-    // Alice will resend her channel_ready and announcement_signatures at reconnection after a channel update because
+    // Alice will resend her channel_ready and announcement_signatures on reconnection, even though the channel has already been used, because
     // she still has not received announcement_signatures from bob (pre-splice behavior).
     alice2bob.expectMsgType[ChannelReady]
     alice2bob.forward(bob)
@@ -1008,7 +1018,7 @@ class OfflineStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
 
     // we simulate a disconnection / reconnection
     disconnect(alice, bob)
-    reconnect(alice, bob, alice2bob, bob2alice, aliceInit, bobInit)
+    reconnect(alice, bob, alice2bob, bob2alice)
     alice2bob.expectMsgType[ChannelReestablish]
     bob2alice.expectMsgType[ChannelReestablish]
     bob2alice.forward(alice)


### PR DESCRIPTION
When the remote node supports the `your_last_funding_locked` tlv we do not need to always resend `channel_ready` when there are no channel updates. The tlv removes the ambiguity about whether our last `channel_ready` was received.