### PR TITLE
Fix flaky GossipIntegrationSpec test

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/channel/GossipIntegrationSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/channel/GossipIntegrationSpec.scala
@@ -84,8 +84,15 @@ class GossipIntegrationSpec extends FixtureSpec with IntegrationPatience {
 
       // Alice creates a channel_announcement for the splice transaction and updates the graph.
       val spliceAnn = inside(getRouterData(alice)) { routerData =>
-        assert(routerData.channels.keys == Set(splice_scid_ab, scid_bc))
-        assert(routerData.spentChannels.isEmpty)
+        routerData.spentChannels match {
+          case spentChannels if spentChannels.isEmpty =>
+            assert(routerData.channels.keys == Set(splice_scid_ab, scid_bc))
+          case spentChannels =>
+            // Handle the special case where Alice receives ExternalChannelSpent after validating the local channel update
+            // for the splice and treating it as a new channel; the original splice will be removed when the splice tx confirms.
+            assert(spentChannels.contains(spliceTxId) && spentChannels(spliceTxId) == Set(scid_ab))
+            assert(routerData.channels.keys == Set(splice_scid_ab, scid_bc, scid_ab))
+        }
         val channel_ab = routerData.channels(splice_scid_ab)
         assert(channel_ab.capacity == 200_000.sat)
         assert(channel_ab.update_1_opt.nonEmpty && channel_ab.update_2_opt.nonEmpty)


### PR DESCRIPTION
If Alice receives `ExternalChannelSpentTriggered` after validating the local channel update for the splice, then the original funding tx will not be in the `spentChannels` list and the splice will be added to the routing graph as a new channel.

When `ExternalChannelSpentTriggered` is received, it will add Alice's funding tx to `spentChannels` and cause the assert in issue #3033 .

This is unlikely to occur in the wild and if it does, the original funding tx will be removed when the splice tx that spends it confirms.