### PR TITLE
use File.toURI for more stable URI creation

### DIFF
--- a/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/Plugin.scala
@@ -58,7 +58,7 @@ object Plugin extends Logging {
   }
 
   def openJar(jar: File): Option[JarURLConnection] =
-    Try(URI.create(s"jar:file:${jar.getCanonicalPath}!/").toURL.openConnection().asInstanceOf[JarURLConnection]) match {
+    Try(URI.create(s"jar:${jar.toURI}!/").toURL.openConnection().asInstanceOf[JarURLConnection]) match {
       case Success(url) => Some(url)
       case Failure(t) => logger.error(s"unable to load plugin file:${jar.getAbsolutePath} ", t); None
     }


### PR DESCRIPTION
The use of File.toURI should produce more stable URI than the use of File.getCanonicalPath and then concat manually.

fixes https://github.com/ACINQ/eclair/issues/3041