### PR TITLE
Optional `payment_secret` in trampoline outer payload

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/PaymentOnion.scala
@@ -532,6 +532,22 @@ object PaymentOnion {
     }
   }
 
+  /**
+   * A payload used when creating test payments to a first trampoline node without using MPP, since the spec allows it.
+   * We never use this class to decode incoming payments though: we will instead insert a dummy [[PaymentData]] entry
+   * when decrypting the onion to avoid duplicating code and data. This class is thus only used to allow creating such
+   * payloads.
+   */
+  case class TrampolineWithoutMppPayload(records: TlvStream[OnionPaymentPayloadTlv]) extends PerHopPayload {
+    require(records.get[TrampolineOnion].nonEmpty, "trampoline onion must be included")
+  }
+
+  object TrampolineWithoutMppPayload {
+    def create(amount: MilliSatoshi, expiry: CltvExpiry, trampolinePacket: OnionRoutingPacket): TrampolineWithoutMppPayload = {
+      TrampolineWithoutMppPayload(TlvStream(AmountToForward(amount), OutgoingCltv(expiry), TrampolineOnion(trampolinePacket)))
+    }
+  }
+
 }
 
 object PaymentOnionCodecs {


### PR DESCRIPTION
If a payer or intermediate trampoline node doesn't need MPP to reach the next trampoline node, they may omit the `payment_secret` field from the outer onion payload and send a single HTLC.

We made `payment_secret` mandatory for final packets, since we set `payment_secret` as required in our Bolt 11 invoices. This lets us use the same code when receiving a payment and when receiving a trampoline relay request. Making the `payment_secret` field optional in `PaymentOnion.FinalPayload.Standard` has too much of an impact on the codebase: I instead chose a somewhat hacky version where we simply insert a dummy `payment_secret` in the trampoline case when it is not provided.