### PR TITLE
fix comments for feerate-tolerance in reference.conf

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -269,8 +269,8 @@ eclair {
     }
 
     feerate-tolerance {
-      ratio-low = 0.5 // will allow remote fee rates as low as half our local feerate when not using anchor outputs
-      ratio-high = 10.0 // will allow remote fee rates as high as 10 times our local feerate when not using anchor outputs
+      ratio-low = 0.5 // will allow remote fee rates as low as half our local feerate (only enforced when not using anchor outputs)
+      ratio-high = 10.0 // will allow remote fee rates as high as 10 times our local feerate (for all commitment formats)
       // when using anchor outputs, we only need to use a commitment feerate that allows the tx to propagate: we will use CPFP to speed up confirmation if needed.
       // the following value is the maximum feerate we'll use for our commit tx (in sat/byte)
       anchor-output-max-commit-feerate = 10


### PR DESCRIPTION
The "ratio-high" config setting is enforced for all commitment formats, not just the legacy format, unlike what the comment suggests.

See https://github.com/ACINQ/eclair/blob/3d415bc9127cdd25779bda77d90307a42e82e21f/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/fee/OnChainFeeConf.scala#L77-L91

Commit https://github.com/ACINQ/eclair/commit/36a3c8897cae18fe3ef219e24140b8d9c25bf239 invalidated the old comment.