### PR TITLE
[test] latest-bitcoind: build output location has moved to bin/

### DIFF
--- a/.github/workflows/latest-bitcoind.yml
+++ b/.github/workflows/latest-bitcoind.yml
@@ -48,5 +48,5 @@ jobs:
         run: echo "fs.file-max = 1024000" | sudo tee -a /etc/sysctl.conf
 
       - name: Run eclair tests
-        run: BITCOIND_DIR=$GITHUB_WORKSPACE/bitcoin/build/src ./mvnw test
+        run: BITCOIND_DIR=$GITHUB_WORKSPACE/bitcoin/build/bin ./mvnw test
         working-directory: ./eclair


### PR DESCRIPTION
See https://github.com/bitcoin/bitcoin/pull/31161

I think this is why you're getting [failures in this test](https://github.com/ACINQ/eclair/actions/runs/14287089451/job/40043441144#step:9:24169)