### PR TITLE
Remove duplication around skipping dust transactions

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -881,7 +881,7 @@ object Transactions {
    * @param dummySignedTx the transaction with a witness filled with dummy signatures (to compute its weight).
    * @return the output amount, unless the transaction should be skipped because it's below dust.
    */
-  private def skipTxIfBelowDust[T <: TransactionWithInputInfo](dummySignedTx: T, feerate: FeeratePerKw, dustLimit: Satoshi): Either[TxGenerationSkipped, Satoshi] = {
+  private def skipTxIfBelowDust(dummySignedTx: TransactionWithInputInfo, feerate: FeeratePerKw, dustLimit: Satoshi): Either[TxGenerationSkipped, Satoshi] = {
     val fee = weight2fee(feerate, dummySignedTx.tx.weight())
     val amount = dummySignedTx.input.txOut.amount - fee
     if (amount < dustLimit) {


### PR DESCRIPTION
This is a small refactoring to remove some duplication around skipping transactions whose output is below dust. We had a lot of copy-pasted code, which was a bit error-prone. I don't know if we should go further and try also factoring the part that creates/modifies the dummy signed transaction: it's less obvious how to do that while maintaining readability, and it may be obsolete once we've cleaned up `Transactions.scala` more in depth.