### PR TITLE
Increase default revocation timeout

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -374,10 +374,10 @@ eclair {
   }
 
   peer-connection {
-    auth-timeout = 15 seconds // will disconnect if connection authentication doesn't happen within that timeframe
-    init-timeout = 15 seconds // will disconnect if initialization doesn't happen within that timeframe
+    auth-timeout = 30 seconds // will disconnect if connection authentication doesn't happen within that timeframe
+    init-timeout = 30 seconds // will disconnect if initialization doesn't happen within that timeframe
     ping-interval = 30 seconds
-    ping-timeout = 20 seconds // will disconnect if peer takes longer than that to respond
+    ping-timeout = 60 seconds // will disconnect if peer takes longer than that to respond
     ping-disconnect = true // disconnect if no answer to our pings
     // When enabled, if we receive an incoming connection, we will echo the source IP address in our init message.
     // This should be disabled if your node is behind a load balancer that doesn't preserve source IP addresses.


### PR DESCRIPTION
We increase the delay after which we disconnect peers that don't send their revocation (which can indicate malicious behavior or a known lnd bug). The previous 20 seconds delay was too aggressive for Tor nodes, or nodes that have large blocking file backups.

Fixes #3081