### PR TITLE
Add an option to specify a custom signet tx to check

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,11 +284,12 @@ eclair.chain = "regtest"
 eclair.bitcoind.rpcport=18443
 ```
 
-For signet, add `signet=1` in `bitcoin.conf` or start with `-signet`, and modify `eclair.conf`:
+For signet, add `signet=1` in `bitcoin.conf` or start with `-signet`, and modify `eclair.conf` as follows. The `signet-check-tx` config parameter should be the txid of a transaction that exists in your signet, "" to skip this check, or if not specified, the default signet txid value will be used.
 
 ```conf
 eclair.chain = "signet"
 eclair.bitcoind.rpcport=38332
+eclair.bitcoind.signet-check-tx=<txid of signet tx>
 ```
 
 You may also want to take advantage of the new configuration sections in `bitcoin.conf` to manage parameters that are network specific,

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -22,6 +22,8 @@ This removes the need for increasing the commitment feerate based on mempool con
 
 - The default for `eclair.features.option_channel_type` is now  `mandatory` instead of `optional`. This change prepares nodes to always assume the behavior of `option_channel_type` from peers when Bolts PR [#1232](https://github.com/lightning/bolts/pull/1232) is adopted. Until [#1232](https://github.com/lightning/bolts/pull/1232) is adopted you can still set `option_channel_type` to `optional` in your `eclair.conf` file for specific peers that do not yet support this option, see `Configure.md` for more information.
 
+- We added a configuration parameter to facilitate custom signet use. The parameter `eclair.bitcoind.signet-check-tx` should be set to the txid of a transaction that exists in your signet or set to "" to skip this check. See issue [#3079](https://github.com/ACINQ/eclair/issues/3078) for details.
+
 ### Miscellaneous improvements and bug fixes
 
 #### Remove confirmation scaling based on funding amount

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -42,6 +42,8 @@ eclair {
     final-pubkey-refresh-delay = 3 seconds
     // If true, eclair will poll bitcoind for 30 seconds at start-up before giving up.
     wait-for-bitcoind-up = true
+    // The txid of a transaction that exists in your custom signet network or "" to skip this check.
+    signet-check-tx = "ff1027486b628b2d160859205a3401fb2ee379b43527153b0b50a92c17ee7955" // coinbase of block #5000 of default signet
   }
 
   node-alias = "eclair"

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -98,6 +98,13 @@ class Setup(val datadir: File,
   val config = system.settings.config.getConfig("eclair")
   val Seeds(nodeSeed, channelSeed) = seeds_opt.getOrElse(NodeParams.getSeeds(datadir))
   val chain = config.getString("chain")
+  val chain_check_tx = chain match {
+    case "mainnet" => Some("2157b554dcfda405233906e461ee593875ae4b1b97615872db6a25130ecc1dd6") // coinbase of #500000
+    case "testnet" => Some("8f38a0dd41dc0ae7509081e262d791f8d53ed6f884323796d5ec7b0966dd3825") // coinbase of #1500000
+    case "testnet4" => Some("5c50d460b3b98ea0c70baa0f50d1f0cc6ffa553788b4a7e23918bcdd558828fa") // coinbase of #40000
+    case "signet" => if (config.hasPath("bitcoind.signet-check-tx") && config.getString("bitcoind.signet-check-tx").nonEmpty) Some(config.getString("bitcoind.signet-check-tx")) else None
+    case "regtest" => None
+  }
 
   val chaindir = new File(datadir, chain)
   chaindir.mkdirs()
@@ -157,12 +164,9 @@ class Setup(val datadir: File,
             .filter(value => (value \ "spendable").extract[Boolean])
             .map(value => (value \ "address").extract[String])
         }
-      _ <- chain match {
-        case "mainnet" => bitcoinClient.invoke("getrawtransaction", "2157b554dcfda405233906e461ee593875ae4b1b97615872db6a25130ecc1dd6") // coinbase of #500000
-        case "testnet" => bitcoinClient.invoke("getrawtransaction", "8f38a0dd41dc0ae7509081e262d791f8d53ed6f884323796d5ec7b0966dd3825") // coinbase of #1500000
-        case "testnet4" => bitcoinClient.invoke("getrawtransaction", "5c50d460b3b98ea0c70baa0f50d1f0cc6ffa553788b4a7e23918bcdd558828fa") // coinbase of #40000
-        case "signet" => bitcoinClient.invoke("getrawtransaction", "ff1027486b628b2d160859205a3401fb2ee379b43527153b0b50a92c17ee7955") // coinbase of #5000
-        case "regtest" => Future.successful(())
+      _ <- chain_check_tx match {
+        case Some(txid) => bitcoinClient.invoke("getrawtransaction", txid)
+        case None =>Future.successful(())
       }
     } yield BitcoinStatus(bitcoinVersion, chainHash, ibd, progress, blocks, headers, unspentAddresses)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -98,7 +98,7 @@ class Setup(val datadir: File,
   val config = system.settings.config.getConfig("eclair")
   val Seeds(nodeSeed, channelSeed) = seeds_opt.getOrElse(NodeParams.getSeeds(datadir))
   val chain = config.getString("chain")
-  val chain_check_tx = chain match {
+  val chainCheckTx = chain match {
     case "mainnet" => Some("2157b554dcfda405233906e461ee593875ae4b1b97615872db6a25130ecc1dd6") // coinbase of #500000
     case "testnet" => Some("8f38a0dd41dc0ae7509081e262d791f8d53ed6f884323796d5ec7b0966dd3825") // coinbase of #1500000
     case "testnet4" => Some("5c50d460b3b98ea0c70baa0f50d1f0cc6ffa553788b4a7e23918bcdd558828fa") // coinbase of #40000
@@ -164,9 +164,9 @@ class Setup(val datadir: File,
             .filter(value => (value \ "spendable").extract[Boolean])
             .map(value => (value \ "address").extract[String])
         }
-      _ <- chain_check_tx match {
+      _ <- chainCheckTx match {
         case Some(txid) => bitcoinClient.invoke("getrawtransaction", txid)
-        case None =>Future.successful(())
+        case None => Future.successful(())
       }
     } yield BitcoinStatus(bitcoinVersion, chainHash, ibd, progress, blocks, headers, unspentAddresses)
 


### PR DESCRIPTION
This change enables custom signets by allowing the user to specify the txid of a transaction to check or "" to skip this check for signet. Fixes issue #3078.