### PR TITLE
Rework closing channel balance computation

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -398,7 +398,7 @@ class Setup(val datadir: File,
 
       _ = for (i <- 0 until config.getInt("autoprobe-count")) yield system.actorOf(SimpleSupervisor.props(Autoprobe.props(nodeParams, router, paymentInitiator), s"payment-autoprobe-$i", SupervisorStrategy.Restart))
 
-      balanceActor = system.spawn(BalanceActor(nodeParams.db, bitcoinClient, channelsListener, nodeParams.balanceCheckInterval), name = "balance-actor")
+      balanceActor = system.spawn(BalanceActor(bitcoinClient, nodeParams.channelConf.minDepth, channelsListener, nodeParams.balanceCheckInterval), name = "balance-actor")
 
       postman = system.spawn(Behaviors.supervise(Postman(nodeParams, switchboard, router.toTyped, register, offerManager)).onFailure(typed.SupervisorStrategy.restart), name = "postman")
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/BalanceActor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/BalanceActor.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.acinq.eclair.balance
 
 import akka.actor.typed.eventstream.EventStream
@@ -7,12 +23,11 @@ import fr.acinq.bitcoin.scalacompat.{Btc, ByteVector32, SatoshiLong}
 import fr.acinq.eclair.NotificationsLogger
 import fr.acinq.eclair.NotificationsLogger.NotifyNodeOperator
 import fr.acinq.eclair.balance.BalanceActor._
-import fr.acinq.eclair.balance.CheckBalance.{GlobalBalance, computeOffChainBalance}
+import fr.acinq.eclair.balance.CheckBalance.{GlobalBalance, OffChainBalance}
 import fr.acinq.eclair.balance.Monitoring.{Metrics, Tags}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.Utxo
 import fr.acinq.eclair.channel.PersistentChannelData
-import fr.acinq.eclair.db.Databases
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -29,11 +44,11 @@ object BalanceActor {
   private final case class WrappedGlobalBalanceWithChannels(wrapped: Try[GlobalBalance], channelsCount: Int) extends Command
   // @formatter:on
 
-  def apply(db: Databases, bitcoinClient: BitcoinCoreClient, channelsListener: ActorRef[ChannelsListener.GetChannels], interval: FiniteDuration)(implicit ec: ExecutionContext): Behavior[Command] = {
+  def apply(bitcoinClient: BitcoinCoreClient, minDepth: Int, channelsListener: ActorRef[ChannelsListener.GetChannels], interval: FiniteDuration)(implicit ec: ExecutionContext): Behavior[Command] = {
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
         timers.startTimerWithFixedDelay(TickBalance, interval)
-        new BalanceActor(context, db, bitcoinClient, channelsListener).apply(refBalance_opt = None, previousBalance_opt = None)
+        new BalanceActor(context, bitcoinClient, minDepth, channelsListener).apply(refBalance_opt = None, previousBalance_opt = None)
       }
     }
   }
@@ -41,14 +56,14 @@ object BalanceActor {
 }
 
 private class BalanceActor(context: ActorContext[Command],
-                           db: Databases,
                            bitcoinClient: BitcoinCoreClient,
+                           minDepth: Int,
                            channelsListener: ActorRef[ChannelsListener.GetChannels])(implicit ec: ExecutionContext) {
 
   private val log = context.log
 
   /**
-   * @param refBalance_opt the reference balance computed once at startup, useful for telling if we are making or losing money overall
+   * @param refBalance_opt      the reference balance computed once at startup, useful for telling if we are making or losing money overall
    * @param previousBalance_opt the last computed balance, it is useful to make a detailed diff between two successive balance checks
    * @return
    */
@@ -65,7 +80,7 @@ private class BalanceActor(context: ActorContext[Command],
       Behaviors.same
     case WrappedChannels(res) =>
       val channelsCount = res.channels.size
-      context.pipeToSelf(CheckBalance.computeGlobalBalance(res.channels, db, bitcoinClient))(b => WrappedGlobalBalanceWithChannels(b, channelsCount))
+      context.pipeToSelf(CheckBalance.computeGlobalBalance(res.channels, bitcoinClient, minDepth))(b => WrappedGlobalBalanceWithChannels(b, channelsCount))
       Behaviors.same
     case WrappedGlobalBalanceWithChannels(res, channelsCount) =>
       res match {
@@ -89,44 +104,45 @@ private class BalanceActor(context: ActorContext[Command],
           }
           previousBalance_opt match {
             case Some(previousBalance) =>
+              // On-chain metrics:
               log.info("on-chain diff={}", balance.onChain.total - previousBalance.onChain.total)
-              val utxosBefore = previousBalance.onChain.confirmed ++ previousBalance.onChain.unconfirmed
-              val utxosAfter = balance.onChain.confirmed ++ balance.onChain.unconfirmed
-              val utxosAdded = utxosAfter -- utxosBefore.keys
-              val utxosRemoved = utxosBefore -- utxosAfter.keys
+              val utxosBefore = previousBalance.onChain.utxos.toSet
+              val utxosAfter = balance.onChain.utxos.toSet
+              val utxosAdded = utxosAfter -- utxosBefore
+              val utxosRemoved = utxosBefore -- utxosAfter
               utxosAdded
-                .toList.sortBy(-_._2)
-                .foreach { case (outPoint, amount) => log.info("+ utxo={} amount={}", outPoint, amount) }
+                .toList.sortBy(_.amount)
+                .foreach(utxo => log.info("+ utxo={} amount={}", utxo.outPoint, utxo.amount))
               utxosRemoved
-                .toList.sortBy(-_._2)
-                .foreach { case (outPoint, amount) => log.info("- utxo={} amount={}", outPoint, amount) }
-
+                .toList.sortBy(_.amount)
+                .foreach(utxo => log.info("- utxo={} amount={}", utxo.outPoint, utxo.amount))
+              // Off-chain metrics:
               log.info("off-chain diff={}", balance.offChain.total - previousBalance.offChain.total)
-              val offchainBalancesBefore = previousBalance.channels.view.mapValues(computeOffChainBalance(previousBalance.knownPreimages, _).total)
-              val offchainBalancesAfter = balance.channels.view.mapValues(computeOffChainBalance(balance.knownPreimages, _).total)
-              offchainBalancesAfter
-                .map { case (channelId, balanceAfter) => (channelId, balanceAfter - offchainBalancesBefore.getOrElse(channelId, Btc(0))) }
+              val offChainBalancesBefore = previousBalance.channels.view.mapValues(channel => OffChainBalance().addChannelBalance(channel).total)
+              val offChainBalancesAfter = balance.channels.view.mapValues(channel => OffChainBalance().addChannelBalance(channel).total)
+              offChainBalancesAfter
+                .map { case (channelId, balanceAfter) => (channelId, balanceAfter - offChainBalancesBefore.getOrElse(channelId, Btc(0))) }
                 .filter { case (_, balanceDiff) => balanceDiff > 0.sat }
                 .toList.sortBy(-_._2)
                 .foreach { case (channelId, balanceDiff) => log.info("+ channelId={} amount={}", channelId, balanceDiff) }
-              offchainBalancesBefore
-                .map { case (channelId, balanceBefore) => (channelId, balanceBefore - offchainBalancesAfter.getOrElse(channelId, Btc(0))) }
+              offChainBalancesBefore
+                .map { case (channelId, balanceBefore) => (channelId, balanceBefore - offChainBalancesAfter.getOrElse(channelId, Btc(0))) }
                 .filter { case (_, balanceDiff) => balanceDiff > 0.sat }
                 .toList.sortBy(-_._2)
                 .foreach { case (channelId, balanceDiff) => log.info("- channelId={} amount={}", channelId, balanceDiff) }
             case None => ()
           }
-
-          log.info("current balance: total={} onchain.confirmed={} onchain.unconfirmed={} offchain={}", balance.total.toDouble, balance.onChain.totalConfirmed.toDouble, balance.onChain.totalUnconfirmed.toDouble, balance.offChain.total.toDouble)
+          log.info("current balance: total={} onchain.deeply-confirmed={} onchain.recently-confirmed={} onchain.unconfirmed={} offchain={}", balance.total.toDouble, balance.onChain.totalDeeplyConfirmed.toDouble, balance.onChain.totalRecentlyConfirmed.toDouble, balance.onChain.totalUnconfirmed.toDouble, balance.offChain.total.toDouble)
           log.debug("current balance details: {}", balance)
           // This is a very rough estimation of the fee we would need to pay for a force-close with 5 pending HTLCs at 100 sat/byte.
           val perChannelFeeBumpingReserve = 50_000.sat
           // Instead of scaling this linearly with the number of channels we have, we use sqrt(channelsCount) to reflect
           // the fact that if you have channels with many peers, only a subset of these peers will likely be malicious.
           val estimatedFeeBumpingReserve = perChannelFeeBumpingReserve * Math.sqrt(channelsCount)
-          if (balance.onChain.totalConfirmed < estimatedFeeBumpingReserve) {
+          val totalConfirmedBalance = balance.onChain.totalDeeplyConfirmed + balance.onChain.totalRecentlyConfirmed
+          if (totalConfirmedBalance < estimatedFeeBumpingReserve) {
             val message =
-              s"""On-chain confirmed balance is low (${balance.onChain.totalConfirmed.toMilliBtc}): eclair may not be able to guarantee funds safety in case channels force-close.
+              s"""On-chain confirmed balance is low (${totalConfirmedBalance.toMilliBtc}): eclair may not be able to guarantee funds safety in case channels force-close.
                  |You have $channelsCount channels, which could cost $estimatedFeeBumpingReserve in fees if some of these channels are malicious.
                  |Please note that the value above is a very arbitrary estimation: the real cost depends on the feerate and the number of malicious channels.
                  |You should add more utxos to your bitcoin wallet to guarantee funds safety.
@@ -134,16 +150,15 @@ private class BalanceActor(context: ActorContext[Command],
             context.system.eventStream ! EventStream.Publish(NotifyNodeOperator(NotificationsLogger.Warning, message))
           }
           Metrics.GlobalBalance.withoutTags().update(balance.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OnchainConfirmed).update(balance.onChain.totalConfirmed.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OnchainUnconfirmed).update(balance.onChain.totalUnconfirmed.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.waitForFundingConfirmed).update(balance.offChain.waitForFundingConfirmed.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.waitForChannelReady).update(balance.offChain.waitForChannelReady.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.normal).update(balance.offChain.normal.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.shutdown).update(balance.offChain.shutdown.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.closingLocal).update(balance.offChain.closing.localCloseBalance.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.closingRemote).update(balance.offChain.closing.remoteCloseBalance.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.closingUnknown).update(balance.offChain.closing.unknownCloseBalance.total.toMilliBtc.toDouble)
-          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.Offchain).withTag(Tags.OffchainState, Tags.OffchainStates.waitForPublishFutureCommitment).update(balance.offChain.waitForPublishFutureCommitment.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OnChainDeeplyConfirmed).update(balance.onChain.totalDeeplyConfirmed.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OnChainRecentlyConfirmed).update(balance.onChain.totalRecentlyConfirmed.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OnChainUnconfirmed).update(balance.onChain.totalUnconfirmed.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OffChain).withTag(Tags.OffChainState, Tags.OffChainStates.waitForFundingConfirmed).update(balance.offChain.waitForFundingConfirmed.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OffChain).withTag(Tags.OffChainState, Tags.OffChainStates.waitForChannelReady).update(balance.offChain.waitForChannelReady.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OffChain).withTag(Tags.OffChainState, Tags.OffChainStates.normal).update(balance.offChain.normal.total.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OffChain).withTag(Tags.OffChainState, Tags.OffChainStates.shutdown).update(balance.offChain.shutdown.total.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OffChain).withTag(Tags.OffChainState, Tags.OffChainStates.closing).update(balance.offChain.closing.total.toMilliBtc.toDouble)
+          Metrics.GlobalBalanceDetailed.withTag(Tags.BalanceType, Tags.BalanceTypes.OffChain).withTag(Tags.OffChainState, Tags.OffChainStates.waitForPublishFutureCommitment).update(balance.offChain.waitForPublishFutureCommitment.toMilliBtc.toDouble)
           refBalance_opt match {
             case Some(refBalance) =>
               val normalizedValue = 100 + (if (refBalance.total.toSatoshi.toLong > 0) (balance.total.toSatoshi.toLong - refBalance.total.toSatoshi.toLong) * 1000D / refBalance.total.toSatoshi.toLong else 0)
@@ -162,7 +177,7 @@ private class BalanceActor(context: ActorContext[Command],
           Behaviors.same
       }
     case GetGlobalBalance(replyTo, channels) =>
-      CheckBalance.computeGlobalBalance(channels, db, bitcoinClient) onComplete (replyTo ! _)
+      CheckBalance.computeGlobalBalance(channels, bitcoinClient, minDepth) onComplete (replyTo ! _)
       Behaviors.same
   }
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
@@ -1,76 +1,162 @@
+/*
+ * Copyright 2024 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fr.acinq.eclair.balance
 
-import fr.acinq.bitcoin.scalacompat.{Btc, ByteVector32, OutPoint, Satoshi, SatoshiLong, Script, TxId}
+import fr.acinq.bitcoin.scalacompat.{Btc, ByteVector32, OutPoint, Satoshi, SatoshiLong}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.Utxo
 import fr.acinq.eclair.channel.Helpers.Closing
-import fr.acinq.eclair.channel.Helpers.Closing.{CurrentRemoteClose, LocalClose, NextRemoteClose, RemoteClose}
+import fr.acinq.eclair.channel.Helpers.Closing._
 import fr.acinq.eclair.channel._
-import fr.acinq.eclair.db.Databases
-import fr.acinq.eclair.transactions.DirectedHtlc.{incoming, outgoing}
-import fr.acinq.eclair.transactions.Transactions
-import fr.acinq.eclair.transactions.Transactions._
-import fr.acinq.eclair.wire.protocol.{UpdateAddHtlc, UpdateFulfillHtlc}
+import fr.acinq.eclair.transactions.DirectedHtlc.incoming
+import fr.acinq.eclair.transactions.Transactions.{ClaimHtlcSuccessTx, HtlcSuccessTx, HtlcTimeoutTx}
+import fr.acinq.eclair.wire.protocol.UpdateAddHtlc
 
 import scala.concurrent.{ExecutionContext, Future}
 
 object CheckBalance {
 
   /**
-   * Helper to avoid accidental deduplication caused by the [[Set]]
-   * Amounts are truncated to the [[Satoshi]] because that is what would happen on-chain.
+   * Helper to avoid accidental deduplication caused by the [[Set]].
+   * Amounts are truncated to [[Satoshi]] because that is what would happen on-chain.
    */
   implicit class HtlcsWithSum(htlcs: Set[UpdateAddHtlc]) {
     def sumAmount: Satoshi = htlcs.toList.map(_.amountMsat.truncateToSatoshi).sum
   }
 
-  /** if local has preimage of an incoming htlc, then we know it will get the funds */
-  private def localHasPreimage(c: CommitmentChanges, htlcId: Long): Boolean = {
-    c.localChanges.all.collectFirst { case u: UpdateFulfillHtlc if u.id == htlcId => true }.isDefined
-  }
-
-  /** if remote proved it had the preimage of an outgoing htlc, then we know it won't timeout */
-  private def remoteHasPreimage(c: CommitmentChanges, htlcId: Long): Boolean = {
-    c.remoteChanges.all.collectFirst { case u: UpdateFulfillHtlc if u.id == htlcId => true }.isDefined
-  }
+  private def mainBalance(commit: LocalCommit): Satoshi = commit.spec.toLocal.truncateToSatoshi
 
   /**
-   * For more fine-grained analysis, we count the in-flight amounts separately from the main amounts.
+   * For more fine-grained analysis, we count the in-flight HTLC amounts separately from the main amounts.
    *
-   * The base assumption regarding htlcs is that they will all timeout. That means that we ignore incoming htlcs (except
-   * if we know the preimage), and we count outgoing htlcs in our balance.
+   * We assume that pending htlcs will all be fulfilled and thus count incoming HTLCs in our balance.
+   * When HTLCs are relayed, the upstream and downstream channels will cancel each other, because the HTLC is added to
+   * our balance in the upstream channel and deduced from our balance in the downstream channel (minus fees).
+   *
+   * If an HTLC is failed downstream, the failure is immediately propagated to the upstream channel (even if it is in
+   * the middle of a force-close): the HTLC amount is thus added back to our balance in the downstream channel and
+   * removed from the upstream channel, so it correctly cancels itself in the global balance. If the downstream channel
+   * is force-closing, the HTLC will be considered failed only when the HTLC-timeout transaction is confirmed, at which
+   * point we relay the failure upstream: the HTLC amount is removed from the upstream channel and is added to our
+   * on-chain balance in the closing downstream channel.
    */
-  case class MainAndHtlcBalance(toLocal: Btc = 0.sat, htlcs: Btc = 0.sat) {
+  case class MainAndHtlcBalance(toLocal: Btc = 0 sat, htlcs: Btc = 0 sat) {
     val total: Btc = toLocal + htlcs
-  }
 
-  /**
-   * In the closing state some transactions may be published or even confirmed. They will be taken into account if we
-   * do a `bitcoin-cli getbalance` and we don't want to count them twice.
-   *
-   * That's why we keep track of the id of each transaction that pays us any amount. It allows us to double check from
-   * bitcoin core and remove any published transaction.
-   */
-  case class PossiblyPublishedMainBalance(toLocal: Map[OutPoint, Btc] = Map.empty) {
-    val total: Btc = toLocal.values.map(_.toSatoshi).sum
-  }
+    def addChannelBalance(commitments: Commitments): MainAndHtlcBalance = {
+      // We take the last commitment into account: it's the most likely to (eventually) confirm.
+      MainAndHtlcBalance(
+        toLocal = this.toLocal + mainBalance(commitments.latest.localCommit),
+        htlcs = commitments.latest.localCommit.spec.htlcs.collect(incoming).sumAmount
+      )
+    }
 
-  case class PossiblyPublishedMainAndHtlcBalance(toLocal: Map[OutPoint, Btc] = Map.empty, htlcs: Map[OutPoint, Btc] = Map.empty, htlcsUnpublished: Btc = 0.sat) {
-    private val totalToLocal: Btc = toLocal.values.map(_.toSatoshi).sum
-    private val totalHtlcs: Btc = htlcs.values.map(_.toSatoshi).sum
-    val total: Btc = totalToLocal + totalHtlcs + htlcsUnpublished
-  }
+    /** Add our balance for a confirmed local close. */
+    def addLocalClose(lcp: LocalCommitPublished): MainAndHtlcBalance = {
+      // If our main transaction isn't deeply confirmed yet, we count it in our off-chain balance.
+      // Once it confirms, it will be included in our on-chain balance, so we ignore it in our off-chain balance.
+      val additionalToLocal = lcp.claimMainDelayedOutputTx.map(_.input.outPoint) match {
+        case Some(outpoint) if !lcp.irrevocablySpent.contains(outpoint) => lcp.commitTx.txOut(outpoint.index.toInt).amount
+        case _ => 0 sat
+      }
+      val additionalHtlcs = lcp.htlcTxs.map {
+        case (outpoint, htlcTx_opt) =>
+          val htlcAmount = lcp.commitTx.txOut(outpoint.index.toInt).amount
+          lcp.irrevocablySpent.get(outpoint) match {
+            case Some(spendingTx) =>
+              // If the HTLC was spent by us, there will be an entry in our 3rd-stage transactions.
+              // Otherwise it was spent by the remote and we don't have anything to add to our balance.
+              val delayedHtlcOutpoint = OutPoint(spendingTx.txid, 0)
+              val htlcSpentByUs = lcp.claimHtlcDelayedTxs.map(_.input.outPoint).contains(delayedHtlcOutpoint)
+              // If our 3rd-stage transaction isn't confirmed yet, we should count it in our off-chain balance.
+              // Once confirmed, we should ignore it since it will appear in our on-chain balance.
+              val htlcDelayedPending = !lcp.irrevocablySpent.contains(delayedHtlcOutpoint)
+              if (htlcSpentByUs && htlcDelayedPending) htlcAmount else 0 sat
+            case None =>
+              // We assume that HTLCs will be fulfilled, so we only count incoming HTLCs in our off-chain balance.
+              htlcTx_opt match {
+                case Some(_: HtlcSuccessTx) => htlcAmount
+                case Some(_: HtlcTimeoutTx) => 0 sat
+                case None => htlcAmount // incoming HTLC for which we don't have the preimage yet
+              }
+          }
+      }.sum
+      MainAndHtlcBalance(toLocal = toLocal + additionalToLocal, htlcs = htlcs + additionalHtlcs)
+    }
 
-  /**
-   * Unless they got evicted, mutual close transactions will also appear in the on-chain balance and will disappear
-   * from here after on pruning.
-   */
-  case class ClosingBalance(localCloseBalance: PossiblyPublishedMainAndHtlcBalance = PossiblyPublishedMainAndHtlcBalance(),
-                            remoteCloseBalance: PossiblyPublishedMainAndHtlcBalance = PossiblyPublishedMainAndHtlcBalance(),
-                            mutualCloseBalance: PossiblyPublishedMainBalance = PossiblyPublishedMainBalance(),
-                            unknownCloseBalance: MainAndHtlcBalance = MainAndHtlcBalance()) {
+    /** Add our balance for a confirmed remote close. */
+    def addRemoteClose(rcp: RemoteCommitPublished): MainAndHtlcBalance = {
+      // If our main transaction isn't deeply confirmed yet, we count it in our off-chain balance.
+      // Once it confirms, it will be included in our on-chain balance, so we ignore it in our off-chain balance.
+      val additionalToLocal = rcp.claimMainOutputTx.map(_.input.outPoint) match {
+        case Some(outpoint) if !rcp.irrevocablySpent.contains(outpoint) => rcp.commitTx.txOut(outpoint.index.toInt).amount
+        case _ => 0 sat
+      }
+      // If HTLC transactions are confirmed, they will appear in our on-chain balance if we were the one to claim them.
+      // We only need to include incoming HTLCs that haven't been claimed yet (since we assume that they will be fulfilled).
+      // Note that it is their commitment, so incoming/outgoing are inverted.
+      val additionalHtlcs = rcp.claimHtlcTxs.map {
+        case (outpoint, Some(_: ClaimHtlcSuccessTx)) if !rcp.irrevocablySpent.contains(outpoint) => rcp.commitTx.txOut(outpoint.index.toInt).amount
+        case (outpoint, None) if !rcp.irrevocablySpent.contains(outpoint) => rcp.commitTx.txOut(outpoint.index.toInt).amount // incoming HTLC for which we don't have the preimage yet
+        case _ => 0 sat
+      }.sum
+      MainAndHtlcBalance(toLocal = toLocal + additionalToLocal, htlcs = htlcs + additionalHtlcs)
+    }
 
-    val total: Btc = localCloseBalance.total + remoteCloseBalance.total + mutualCloseBalance.total + unknownCloseBalance.total
+    /** Add our balance for a confirmed revoked close. */
+    def addRevokedClose(rvk: RevokedCommitPublished): MainAndHtlcBalance = {
+      // If our main transaction isn't deeply confirmed yet, we count it in our off-chain balance.
+      // Once it confirms, it will be included in our on-chain balance, so we ignore it in our off-chain balance.
+      // We do the same thing for our main penalty transaction claiming their main output.
+      val additionalToLocal = rvk.claimMainOutputTx.map(_.input.outPoint) match {
+        case Some(outpoint) if !rvk.irrevocablySpent.contains(outpoint) => rvk.commitTx.txOut(outpoint.index.toInt).amount
+        case _ => 0 sat
+      }
+      val additionalToRemote = rvk.mainPenaltyTx.map(_.input.outPoint) match {
+        case Some(outpoint) if !rvk.irrevocablySpent.contains(outpoint) => rvk.commitTx.txOut(outpoint.index.toInt).amount
+        case _ => 0 sat
+      }
+      val additionalHtlcs = rvk.htlcPenaltyTxs.map(_.input.outPoint).map(htlcOutpoint => {
+        val htlcAmount = rvk.commitTx.txOut(htlcOutpoint.index.toInt).amount
+        rvk.irrevocablySpent.get(htlcOutpoint) match {
+          case Some(spendingTx) =>
+            // The spending transaction may claim a batch of HTLCs at once, we only look at the current one.
+            spendingTx.txIn.zipWithIndex.collectFirst { case (txIn, i) if txIn.outPoint == htlcOutpoint => i } match {
+              case Some(outputIndex) =>
+                // If they managed to get their HTLC transaction confirmed, we published an HTLC-delayed penalty transaction.
+                val delayedHtlcOutpoint = OutPoint(spendingTx.txid, outputIndex)
+                val htlcSpentByThem = rvk.claimHtlcDelayedPenaltyTxs.map(_.input.outPoint).contains(delayedHtlcOutpoint)
+                // If our 3rd-stage transaction isn't confirmed yet, we should count it in our off-chain balance.
+                // Once confirmed, we should ignore it since it will appear in our on-chain balance.
+                val htlcDelayedPending = !rvk.irrevocablySpent.contains(delayedHtlcOutpoint)
+                // Note that if the HTLC output was spent by us, it should appear in our on-chain balance, so we don't
+                // count it here.
+                if (htlcSpentByThem && htlcDelayedPending) htlcAmount else 0 sat
+              case None =>
+                // This should never happen unless our data is corrupted.
+                0 sat
+            }
+          case None =>
+            // We assume that our penalty transaction will confirm before their HTLC transaction.
+            htlcAmount
+        }
+      }).sum
+      MainAndHtlcBalance(toLocal = toLocal + additionalToLocal + additionalToRemote, htlcs = htlcs + additionalHtlcs)
+    }
   }
 
   /**
@@ -80,248 +166,96 @@ object CheckBalance {
                              waitForChannelReady: Btc = 0.sat,
                              normal: MainAndHtlcBalance = MainAndHtlcBalance(),
                              shutdown: MainAndHtlcBalance = MainAndHtlcBalance(),
-                             negotiating: Btc = 0.sat,
-                             closing: ClosingBalance = ClosingBalance(),
+                             negotiating: MainAndHtlcBalance = MainAndHtlcBalance(),
+                             closing: MainAndHtlcBalance = MainAndHtlcBalance(),
                              waitForPublishFutureCommitment: Btc = 0.sat) {
-    val total: Btc = waitForFundingConfirmed + waitForChannelReady + normal.total + shutdown.total + negotiating + closing.total + waitForPublishFutureCommitment
-  }
+    val total: Btc = waitForFundingConfirmed + waitForChannelReady + normal.total + shutdown.total + negotiating.total + closing.total + waitForPublishFutureCommitment
 
-  private def updateMainBalance(current: Btc, localCommit: LocalCommit): Btc = {
-    val toLocal = localCommit.spec.toLocal.truncateToSatoshi
-    current + toLocal
-  }
-
-  private def updateMainAndHtlcBalance(current: MainAndHtlcBalance, c: Commitments, knownPreimages: Set[(ByteVector32, Long)]): MainAndHtlcBalance = {
-    // We take the last commitment into account: it's the most likely to (eventually) confirm.
-    val commitment = c.latest
-    val toLocal = commitment.localCommit.spec.toLocal.truncateToSatoshi
-    // we only count htlcs in if we know the preimage
-    val htlcIn = commitment.localCommit.spec.htlcs.collect(incoming)
-      .filter(add => knownPreimages.contains((add.channelId, add.id)) || localHasPreimage(c.changes, add.id))
-      .sumAmount
-    val htlcOut = commitment.localCommit.spec.htlcs.collect(outgoing).sumAmount
-    current.copy(
-      toLocal = current.toLocal + toLocal,
-      htlcs = current.htlcs + htlcIn + htlcOut
-    )
-  }
-
-  private def updatePossiblyPublishedBalance(current: PossiblyPublishedMainAndHtlcBalance, b1: PossiblyPublishedMainAndHtlcBalance): PossiblyPublishedMainAndHtlcBalance = {
-    current.copy(
-      toLocal = current.toLocal ++ b1.toLocal,
-      htlcs = current.htlcs ++ b1.htlcs,
-      htlcsUnpublished = current.htlcsUnpublished + b1.htlcsUnpublished
-    )
-  }
-
-  def computeLocalCloseBalance(changes: CommitmentChanges, l: LocalClose, originChannels: Map[Long, Origin], knownPreimages: Set[(ByteVector32, Long)]): PossiblyPublishedMainAndHtlcBalance = {
-    import l._
-    val toLocal = localCommitPublished.claimMainDelayedOutputTx.toSeq.map(c => OutPoint(c.tx.txid, 0) -> c.tx.txOut.head.amount.toBtc).toMap
-    // incoming htlcs for which we have a preimage and the to-local delay has expired: we have published a claim tx that pays directly to our wallet
-    val htlcsInOnChain = localCommitPublished.htlcTxs.values.flatten.collect { case htlcTx: HtlcSuccessTx => htlcTx }
-      .filter(htlcTx => localCommitPublished.claimHtlcDelayedTxs.exists(_.input.outPoint.txid == htlcTx.tx.txid))
-      .map(_.htlcId)
-      .toSet
-    // outgoing htlcs that have timed out and the to-local delay has expired: we have published a claim tx that pays directly to our wallet
-    val htlcsOutOnChain = localCommitPublished.htlcTxs.values.flatten.collect { case htlcTx: HtlcTimeoutTx => htlcTx }
-      .filter(htlcTx => localCommitPublished.claimHtlcDelayedTxs.exists(_.input.outPoint.txid == htlcTx.tx.txid))
-      .map(_.htlcId)
-      .toSet
-    // incoming htlcs for which we have a preimage but we are still waiting for the to-local delay
-    val htlcIn = localCommit.spec.htlcs.collect(incoming)
-      .filterNot(htlc => htlcsInOnChain.contains(htlc.id)) // we filter the htlc that already pay us on-chain
-      .filter(add => knownPreimages.contains((add.channelId, add.id)) || localHasPreimage(changes, add.id))
-      .sumAmount
-    // outgoing htlcs for which remote didn't prove it had the preimage are expected to time out if they were relayed,
-    // and succeed if they were sent from this node
-    val htlcOut = localCommit.spec.htlcs.collect(outgoing)
-      .filterNot(htlc => htlcsOutOnChain.contains(htlc.id)) // we filter the htlc that already pay us on-chain
-      .filterNot(htlc => originChannels.get(htlc.id).exists(_.upstream.isInstanceOf[Upstream.Local]))
-      .filterNot(htlc => remoteHasPreimage(changes, htlc.id))
-      .sumAmount
-    // all claim txs have possibly been published
-    val htlcs = localCommitPublished.claimHtlcDelayedTxs
-      .map(c => OutPoint(c.tx.txid, 0) -> c.tx.txOut.head.amount.toBtc).toMap
-    PossiblyPublishedMainAndHtlcBalance(
-      toLocal = toLocal,
-      htlcs = htlcs,
-      htlcsUnpublished = htlcIn + htlcOut
-    )
-  }
-
-  def computeRemoteCloseBalance(c: Commitments, r: RemoteClose, knownPreimages: Set[(ByteVector32, Long)]): PossiblyPublishedMainAndHtlcBalance = {
-    import r._
-    val toLocal = if (c.params.channelFeatures.paysDirectlyToWallet) {
-      // If static remote key is enabled, the commit tx directly pays to our wallet
-      // We use the pubkeyscript to retrieve our output
-      val finalScriptPubKey = Script.write(Script.pay2wpkh(c.params.localParams.walletStaticPaymentBasepoint.get))
-      Transactions.findPubKeyScriptIndex(remoteCommitPublished.commitTx, finalScriptPubKey) match {
-        case Right(outputIndex) => Map(OutPoint(remoteCommitPublished.commitTx.txid, outputIndex) -> remoteCommitPublished.commitTx.txOut(outputIndex).amount.toBtc)
-        case _ => Map.empty[OutPoint, Btc] // either we don't have an output (below dust), or we have used a non-default pubkey script
-      }
-    } else {
-      remoteCommitPublished.claimMainOutputTx.toSeq.map(c => OutPoint(c.tx.txid, 0) -> c.tx.txOut.head.amount.toBtc).toMap
+    def addChannelBalance(channel: PersistentChannelData): OffChainBalance = channel match {
+      case d: DATA_WAIT_FOR_FUNDING_CONFIRMED => this.copy(waitForFundingConfirmed = this.waitForFundingConfirmed + mainBalance(d.commitments.latest.localCommit))
+      case d: DATA_WAIT_FOR_CHANNEL_READY => this.copy(waitForChannelReady = this.waitForChannelReady + mainBalance(d.commitments.latest.localCommit))
+      case _: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED => this // we ignore our balance from unsigned commitments
+      case d: DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED => this.copy(waitForFundingConfirmed = this.waitForFundingConfirmed + mainBalance(d.commitments.latest.localCommit))
+      case d: DATA_WAIT_FOR_DUAL_FUNDING_READY => this.copy(waitForChannelReady = this.waitForChannelReady + mainBalance(d.commitments.latest.localCommit))
+      case d: DATA_NORMAL => this.copy(normal = this.normal.addChannelBalance(d.commitments))
+      case d: DATA_SHUTDOWN => this.copy(shutdown = this.shutdown.addChannelBalance(d.commitments))
+      case d: DATA_NEGOTIATING => this.copy(negotiating = this.negotiating.addChannelBalance(d.commitments))
+      case d: DATA_NEGOTIATING_SIMPLE => this.copy(negotiating = this.negotiating.addChannelBalance(d.commitments))
+      case d: DATA_CLOSING =>
+        Closing.isClosingTypeAlreadyKnown(d) match {
+          // A mutual close transaction is confirmed: the channel should transition to the CLOSED state.
+          // We can ignore it as our channel balance should appear in our on-chain balance.
+          case Some(_: MutualClose) => this
+          // A commitment transaction is confirmed: we compute the channel balance that we expect to get back on-chain.
+          case Some(c: LocalClose) => this.copy(closing = this.closing.addLocalClose(c.localCommitPublished))
+          case Some(c: CurrentRemoteClose) => this.copy(closing = this.closing.addRemoteClose(c.remoteCommitPublished))
+          case Some(c: NextRemoteClose) => this.copy(closing = this.closing.addRemoteClose(c.remoteCommitPublished))
+          case Some(c: RevokedClose) => this.copy(closing = this.closing.addRevokedClose(c.revokedCommitPublished))
+          // In the recovery case, we can only claim our main output, HTLC outputs are lost.
+          // Once our main transaction confirms, the channel will transition to the CLOSED state and our channel funds
+          // will appear in our on-chain balance (minus on-chain fees).
+          case Some(c: RecoveryClose) => c.remoteCommitPublished.claimMainOutputTx.map(_.input.outPoint) match {
+            case Some(localOutput) =>
+              val localBalance = c.remoteCommitPublished.commitTx.txOut(localOutput.index.toInt).amount
+              this.copy(closing = this.closing.copy(toLocal = this.closing.toLocal + localBalance))
+            case None => this
+          }
+          // We don't know yet which type of closing will confirm on-chain, so we use our default off-chain balance.
+          case None => this.copy(closing = this.closing.addChannelBalance(d.commitments))
+        }
+      case d: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT => this.copy(waitForPublishFutureCommitment = this.waitForPublishFutureCommitment + mainBalance(d.commitments.latest.localCommit))
     }
-    // incoming htlcs for which we have a preimage: we have published a claim tx that pays directly to our wallet
-    val htlcsInOnChain = remoteCommitPublished.claimHtlcTxs.values.flatten.collect { case htlcTx: ClaimHtlcSuccessTx => htlcTx }
-      .map(_.htlcId)
-      .toSet
-    // outgoing htlcs that have timed out: we have published a claim tx that pays directly to our wallet
-    val htlcsOutOnChain = remoteCommitPublished.claimHtlcTxs.values.flatten.collect { case htlcTx: ClaimHtlcTimeoutTx => htlcTx }
-      .map(_.htlcId)
-      .toSet
-    // incoming htlcs for which we have a preimage
-    val htlcIn = remoteCommit.spec.htlcs.collect(outgoing)
-      .filter(add => knownPreimages.contains((add.channelId, add.id)) || localHasPreimage(c.changes, add.id))
-      .filterNot(htlc => htlcsInOnChain.contains(htlc.id)) // we filter the htlc that already pay us on-chain
-      .sumAmount
-    // all outgoing htlcs for which remote didn't prove it had the preimage are expected to time out
-    val htlcOut = remoteCommit.spec.htlcs.collect(incoming)
-      .filterNot(htlc => htlcsOutOnChain.contains(htlc.id)) // we filter the htlc that already pay us on-chain
-      .filterNot(htlc => remoteHasPreimage(c.changes, htlc.id))
-      .sumAmount
-    // all claim txs have possibly been published
-    val htlcs = remoteCommitPublished.claimHtlcTxs.values.flatten
-      .map(c => OutPoint(c.tx.txid, 0) -> c.tx.txOut.head.amount.toBtc).toMap
-    PossiblyPublishedMainAndHtlcBalance(
-      toLocal = toLocal,
-      htlcs = htlcs,
-      htlcsUnpublished = htlcIn + htlcOut
-    )
-  }
-
-  def computeOffChainBalance(knownPreimages: Set[(ByteVector32, Long)]): (OffChainBalance, PersistentChannelData) => OffChainBalance = {
-    case (r, d: DATA_WAIT_FOR_FUNDING_CONFIRMED) => r.copy(waitForFundingConfirmed = updateMainBalance(r.waitForFundingConfirmed, d.commitments.latest.localCommit))
-    case (r, d: DATA_WAIT_FOR_CHANNEL_READY) => r.copy(waitForChannelReady = updateMainBalance(r.waitForChannelReady, d.commitments.latest.localCommit))
-    case (r, _: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED) => r // we ignore our balance from unsigned commitments
-    case (r, d: DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED) => r.copy(waitForFundingConfirmed = updateMainBalance(r.waitForFundingConfirmed, d.commitments.latest.localCommit))
-    case (r, d: DATA_WAIT_FOR_DUAL_FUNDING_READY) => r.copy(waitForChannelReady = updateMainBalance(r.waitForChannelReady, d.commitments.latest.localCommit))
-    case (r, d: DATA_NORMAL) => r.copy(normal = updateMainAndHtlcBalance(r.normal, d.commitments, knownPreimages))
-    case (r, d: DATA_SHUTDOWN) => r.copy(shutdown = updateMainAndHtlcBalance(r.shutdown, d.commitments, knownPreimages))
-    case (r, d: DATA_NEGOTIATING) => r.copy(negotiating = updateMainBalance(r.negotiating, d.commitments.latest.localCommit))
-    case (r, d: DATA_NEGOTIATING_SIMPLE) => r.copy(negotiating = updateMainBalance(r.negotiating, d.commitments.latest.localCommit))
-    case (r, d: DATA_CLOSING) =>
-      Closing.isClosingTypeAlreadyKnown(d) match {
-        case None if d.mutualClosePublished.nonEmpty && d.localCommitPublished.isEmpty && d.remoteCommitPublished.isEmpty && d.nextRemoteCommitPublished.isEmpty && d.revokedCommitPublished.isEmpty =>
-          // There can be multiple mutual close transactions for the same channel, but most of the time there will
-          // only be one. We use the last one in the list, which should be the one we have seen last in our local
-          // mempool. In the worst case scenario, there are several mutual closes and the one that made it to the
-          // mempool or the chain isn't the one we are keeping track of here. As a consequence the transaction won't
-          // be pruned and we will count twice the amount in the global (onChain + offChain) balance, until the
-          // mutual close tx gets deeply confirmed and the channel is removed.
-          val mutualClose = d.mutualClosePublished.last
-          val outputIndex_opt = mutualClose.toLocalOutputIndex_opt match {
-            case Some(outputIndex) => Some(outputIndex)
-            case None =>
-              // Normally this would mean that we don't actually have an output, but due to a migration
-              // the data might not be accurate, see [[ChannelTypes0.migrateClosingTx]]
-              // As a (hackish) workaround, we use the pubkeyscript to retrieve our output
-              Transactions.findPubKeyScriptIndex(mutualClose.tx, d.finalScriptPubKey).map(_.toLong).toOption
-          }
-          outputIndex_opt match {
-            case Some(index) => r.copy(closing = r.closing.copy(mutualCloseBalance = r.closing.mutualCloseBalance.copy(toLocal = r.closing.mutualCloseBalance.toLocal + (OutPoint(mutualClose.tx.txid, index) -> mutualClose.tx.txOut(index.toInt).amount))))
-            case None => r
-          }
-        case Some(localClose: LocalClose) => r.copy(closing = r.closing.copy(localCloseBalance = updatePossiblyPublishedBalance(r.closing.localCloseBalance, computeLocalCloseBalance(d.commitments.changes, localClose, d.commitments.originChannels, knownPreimages))))
-        case _ if d.remoteCommitPublished.nonEmpty || d.nextRemoteCommitPublished.nonEmpty =>
-          // We have seen the remote commit, it may or may not have been confirmed. We may have published our own
-          // local commit too, which may take precedence. But if we are aware of the remote commit, it means that
-          // our bitcoin core has already seen it (since it's the one who told us about it) and we make
-          // the assumption that the remote commit won't be replaced by our local commit.
-          val remoteClose = if (d.remoteCommitPublished.isDefined) {
-            CurrentRemoteClose(d.commitments.latest.remoteCommit, d.remoteCommitPublished.get)
-          } else {
-            NextRemoteClose(d.commitments.latest.nextRemoteCommit_opt.get.commit, d.nextRemoteCommitPublished.get)
-          }
-          r.copy(closing = r.closing.copy(remoteCloseBalance = updatePossiblyPublishedBalance(r.closing.remoteCloseBalance, computeRemoteCloseBalance(d.commitments, remoteClose, knownPreimages))))
-        case _ => r.copy(closing = r.closing.copy(unknownCloseBalance = updateMainAndHtlcBalance(r.closing.unknownCloseBalance, d.commitments, knownPreimages)))
-      }
-    case (r, d: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT) => r.copy(waitForPublishFutureCommitment = updateMainBalance(r.waitForPublishFutureCommitment, d.commitments.latest.localCommit))
-  }
-
-  def computeOffChainBalance(knownPreimages: Set[(ByteVector32, Long)], channel: PersistentChannelData): OffChainBalance = {
-    computeOffChainBalance(knownPreimages)(OffChainBalance(), channel)
   }
 
   /**
-   * Compute the overall balance a list of channels.
+   * Compute the overall balance for a list of channels.
    *
    * Assumptions:
-   * - If the commitment transaction hasn't been published, we simply take our local amount (and htlc amount in states
-   * where they may exist, namely [[NORMAL]] and [[SHUTDOWN]]).
-   * - In [[CLOSING]] state:
-   *   - If we know for sure we are in a mutual close scenario, then we don't count the amount, because the tx will
-   *     already have been published.
-   *   - If we know for sure we are in a local, then we take the amounts based on the outputs of
-   *     the transactions, whether delayed or not. This ensures that mining fees are taken into account.
-   *   - If we have detected that a remote commit was published, then we assume the closing type will be remote, even
-   *     it is not yet confirmed. Like for local commits, we take amounts based on outputs of transactions.
-   *   - In the other cases, we simply take our local amount
-   *   - TODO?: we disregard anchor outputs
+   * - If the funding transaction isn't confirmed yet, we simply take our (future) local amount into account.
+   * - If the funding transaction is confirmed, we take our main balance and pending HTLCs into account.
+   * - In the [[CLOSING]] state: while closing transactions are unconfirmed, we use the channel amounts, which don't
+   * take on-chain fees into account. Once closing transactions confirm, we ignore the corresponding channel amounts,
+   * the final amounts are included in our on-chain balance, which takes into account the on-chain fees paid.
    */
-  def computeOffChainBalance(channels: Iterable[PersistentChannelData], knownPreimages: Set[(ByteVector32, Long)]): OffChainBalance = {
-    channels.foldLeft(OffChainBalance()) {
-      computeOffChainBalance(knownPreimages)
-    }
+  def computeOffChainBalance(channels: Iterable[PersistentChannelData]): OffChainBalance = {
+    channels.foldLeft(OffChainBalance()) { case (balance, channel) => balance.addChannelBalance(channel) }
   }
 
-  /**
-   * Query bitcoin core to prune all amounts related to transactions that have already been published
-   */
-  def prunePublishedTransactions(br: OffChainBalance, bitcoinClient: BitcoinCoreClient)(implicit ec: ExecutionContext): Future[OffChainBalance] = {
-    for {
-      txs: Iterable[Option[(TxId, Int)]] <- Future.sequence((br.closing.localCloseBalance.toLocal.keys ++
-        br.closing.localCloseBalance.htlcs.keys ++
-        br.closing.remoteCloseBalance.toLocal.keys ++
-        br.closing.remoteCloseBalance.htlcs.keys ++
-        br.closing.mutualCloseBalance.toLocal.keys)
-        .map(outPoint => bitcoinClient.getTxConfirmations(outPoint.txid).map(_ map { confirmations => outPoint.txid -> confirmations })))
-      txMap: Map[TxId, Int] = txs.flatten.toMap
-    } yield {
-      br.copy(closing = br.closing.copy(
-        localCloseBalance = br.closing.localCloseBalance.copy(
-          toLocal = br.closing.localCloseBalance.toLocal.filterNot { case (outPoint, _) => txMap.contains(outPoint.txid) },
-          htlcs = br.closing.localCloseBalance.htlcs.filterNot { case (outPoint, _) => txMap.contains(outPoint.txid) },
-        ),
-        remoteCloseBalance = br.closing.remoteCloseBalance.copy(
-          toLocal = br.closing.remoteCloseBalance.toLocal.filterNot { case (outPoint, _) => txMap.contains(outPoint.txid) },
-          htlcs = br.closing.remoteCloseBalance.htlcs.filterNot { case (outPoint, _) => txMap.contains(outPoint.txid) },
-        ),
-        mutualCloseBalance = br.closing.mutualCloseBalance.copy(
-          toLocal = br.closing.mutualCloseBalance.toLocal.filterNot { case (outPoint, _) => txMap.contains(outPoint.txid) },
-        )
-      ))
-    }
-  }
-
-  case class DetailedOnChainBalance(confirmed: Map[OutPoint, Btc] = Map.empty, unconfirmed: Map[OutPoint, Btc] = Map.empty, utxos: Seq[Utxo]) {
-    val totalConfirmed: Btc = confirmed.values.map(_.toSatoshi).sum
+  case class DetailedOnChainBalance(deeplyConfirmed: Map[OutPoint, Btc] = Map.empty, recentlyConfirmed: Map[OutPoint, Btc] = Map.empty, unconfirmed: Map[OutPoint, Btc] = Map.empty, utxos: Seq[Utxo]) {
+    val totalDeeplyConfirmed: Btc = deeplyConfirmed.values.map(_.toSatoshi).sum
+    val totalRecentlyConfirmed: Btc = recentlyConfirmed.values.map(_.toSatoshi).sum
     val totalUnconfirmed: Btc = unconfirmed.values.map(_.toSatoshi).sum
-    val total: Btc = totalConfirmed + totalUnconfirmed
+    val total: Btc = totalDeeplyConfirmed + totalRecentlyConfirmed + totalUnconfirmed
   }
 
   /**
-   * Returns the on-chain balance, but discards the unconfirmed incoming swap-in transactions, because they may be RBF-ed.
-   * Confirmed swap-in transactions are counted, because we can spend them, but we keep track of what we still owe to our
-   * users.
+   * Compute our on-chain balance: we distinguish unconfirmed transactions (which may be RBF-ed or even double-spent),
+   * recently confirmed transactions (which aren't yet settled in our off-chain balance until they've reached min-depth)
+   * and deeply confirmed transactions (which are settled in our off-chain balance).
+   *
+   * Note that this may create temporary glitches when doing 0-conf splices, which will appear in the off-chain balance
+   * immediately but will only be correctly accounted for in our on-chain balance after being deeply confirmed. Those
+   * cases can be detected by looking at the unconfirmed and recently confirmed on-chain balance.
+   *
+   * During force-close, closing transactions that haven't reached min-depth are counted in our off-chain balance and
+   * should thus be ignored from our on-chain balance, where they will be tracked as unconfirmed or recently confirmed.
    */
-  private def computeOnChainBalance(bitcoinClient: BitcoinCoreClient)(implicit ec: ExecutionContext): Future[DetailedOnChainBalance] = for {
+  private def computeOnChainBalance(bitcoinClient: BitcoinCoreClient, minDepth: Int)(implicit ec: ExecutionContext): Future[DetailedOnChainBalance] = for {
     utxos <- bitcoinClient.listUnspent()
     detailed = utxos.foldLeft(DetailedOnChainBalance(utxos = utxos)) {
       case (total, utxo) if utxo.confirmations == 0 => total.copy(unconfirmed = total.unconfirmed + (utxo.outPoint -> utxo.amount))
-      case (total, utxo) => total.copy(confirmed = total.confirmed + (utxo.outPoint -> utxo.amount))
+      case (total, utxo) if utxo.confirmations < minDepth => total.copy(recentlyConfirmed = total.recentlyConfirmed + (utxo.outPoint -> utxo.amount))
+      case (total, utxo) => total.copy(deeplyConfirmed = total.deeplyConfirmed + (utxo.outPoint -> utxo.amount))
     }
   } yield detailed
 
-  case class GlobalBalance(onChain: DetailedOnChainBalance, offChain: OffChainBalance, channels: Map[ByteVector32, PersistentChannelData], knownPreimages: Set[(ByteVector32, Long)]) {
+  case class GlobalBalance(onChain: DetailedOnChainBalance, offChain: OffChainBalance, channels: Map[ByteVector32, PersistentChannelData]) {
     val total: Btc = onChain.total + offChain.total
   }
 
-  def computeGlobalBalance(channels: Map[ByteVector32, PersistentChannelData], db: Databases, bitcoinClient: BitcoinCoreClient)(implicit ec: ExecutionContext): Future[GlobalBalance] = for {
-    onChain <- CheckBalance.computeOnChainBalance(bitcoinClient)
-    knownPreimages = db.pendingCommands.listSettlementCommands().collect { case (channelId, cmd: CMD_FULFILL_HTLC) => (channelId, cmd.id) }.toSet
-    offChainRaw = CheckBalance.computeOffChainBalance(channels.values, knownPreimages)
-    offChainPruned <- CheckBalance.prunePublishedTransactions(offChainRaw, bitcoinClient)
-  } yield GlobalBalance(onChain, offChainPruned, channels, knownPreimages)
+  def computeGlobalBalance(channels: Map[ByteVector32, PersistentChannelData], bitcoinClient: BitcoinCoreClient, minDepth: Int)(implicit ec: ExecutionContext): Future[GlobalBalance] = for {
+    onChain <- CheckBalance.computeOnChainBalance(bitcoinClient, minDepth)
+    offChain = CheckBalance.computeOffChainBalance(channels.values)
+  } yield GlobalBalance(onChain, offChain, channels)
 
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/Monitoring.scala
@@ -32,25 +32,24 @@ object Monitoring {
 
   object Tags {
     val BalanceType = "type"
-    val OffchainState = "state"
+    val OffChainState = "state"
     val DiffSign = "sign"
     val UtxoStatus = "status"
 
     object BalanceTypes {
-      val OnchainConfirmed = "onchain.confirmed"
-      val OnchainUnconfirmed = "onchain.unconfirmed"
-      val Offchain = "offchain"
+      val OnChainDeeplyConfirmed = "onchain.deeply-confirmed"
+      val OnChainRecentlyConfirmed = "onchain.recently-confirmed"
+      val OnChainUnconfirmed = "onchain.unconfirmed"
+      val OffChain = "offchain"
     }
 
-    object OffchainStates {
+    object OffChainStates {
       val waitForFundingConfirmed = "waitForFundingConfirmed"
       val waitForChannelReady = "waitForChannelReady"
       val normal = "normal"
       val shutdown = "shutdown"
       val negotiating = "negotiating"
-      val closingLocal = "closing-local"
-      val closingRemote = "closing-remote"
-      val closingUnknown = "closing-unknown"
+      val closing = "closing"
       val waitForPublishFutureCommitment = "waitForPublishFutureCommitment"
     }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -571,8 +571,8 @@ object CommitmentSerializer extends ConvertClassSerializer[Commitment](c => Comm
 // @formatter:on
 
 // @formatter:off
-private case class DetailedOnChainBalanceJson(total: Btc, confirmed: Map[OutPoint, Btc], unconfirmed: Map[OutPoint, Btc])
-object DetailedOnChainBalanceSerializer extends ConvertClassSerializer[DetailedOnChainBalance](b => DetailedOnChainBalanceJson(b.total, confirmed = b.confirmed, unconfirmed = b.unconfirmed))
+private case class DetailedOnChainBalanceJson(total: Btc, deeplyConfirmed: Map[OutPoint, Btc], recentlyConfirmed: Map[OutPoint, Btc], unconfirmed: Map[OutPoint, Btc])
+object DetailedOnChainBalanceSerializer extends ConvertClassSerializer[DetailedOnChainBalance](b => DetailedOnChainBalanceJson(b.total, deeplyConfirmed = b.deeplyConfirmed, recentlyConfirmed = b.recentlyConfirmed, unconfirmed = b.unconfirmed))
 private case class GlobalBalanceJson(total: Btc, onChain: DetailedOnChainBalance, offChain: OffChainBalance)
 object GlobalBalanceSerializer extends ConvertClassSerializer[GlobalBalance](b => GlobalBalanceJson(b.total, b.onChain, b.offChain))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/balance/CheckBalanceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/balance/CheckBalanceSpec.scala
@@ -1,32 +1,26 @@
 package fr.acinq.eclair.balance
 
-import akka.pattern.pipe
-import akka.testkit.TestProbe
-import fr.acinq.bitcoin.scalacompat.{ByteVector32, OutPoint, SatoshiLong, TxId}
-import fr.acinq.eclair.TestUtils.randomTxId
-import fr.acinq.eclair.balance.CheckBalance.{ClosingBalance, MainAndHtlcBalance, OffChainBalance, PossiblyPublishedMainAndHtlcBalance, PossiblyPublishedMainBalance}
+import fr.acinq.bitcoin.scalacompat.SatoshiLong
+import fr.acinq.eclair.balance.CheckBalance.{MainAndHtlcBalance, OffChainBalance}
 import fr.acinq.eclair.blockchain.bitcoind.ZmqWatcher.{apply => _, _}
-import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient
-import fr.acinq.eclair.channel.Helpers.Closing.{CurrentRemoteClose, LocalClose}
-import fr.acinq.eclair.channel.publish.TxPublisher.{PublishFinalTx, PublishReplaceableTx}
-import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
 import fr.acinq.eclair.channel._
+import fr.acinq.eclair.channel.publish.TxPublisher.{PublishFinalTx, PublishReplaceableTx}
+import fr.acinq.eclair.channel.publish.{ReplaceableClaimHtlcTimeout, ReplaceableRemoteCommitAnchor}
+import fr.acinq.eclair.channel.states.{ChannelStateTestsBase, ChannelStateTestsTags}
 import fr.acinq.eclair.db.jdbc.JdbcUtils.ExtendedResultSet._
 import fr.acinq.eclair.db.pg.PgUtils.using
 import fr.acinq.eclair.testutils.PimpTestProbe.convert
+import fr.acinq.eclair.transactions.Transactions.{ClaimHtlcSuccessTx, ClaimHtlcTimeoutTx, HtlcSuccessTx}
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecs.channelDataCodec
-import fr.acinq.eclair.wire.protocol.{CommitSig, Error, RevokeAndAck, TlvStream, UpdateAddHtlc, UpdateAddHtlcTlv}
-import fr.acinq.eclair.{BlockHeight, CltvExpiry, CltvExpiryDelta, MilliSatoshiLong, TestConstants, TestKitBaseClass, TimestampMilli, ToMilliSatoshiConversion, randomBytes32}
+import fr.acinq.eclair.wire.protocol.{CommitSig, RevokeAndAck}
+import fr.acinq.eclair.{BlockHeight, MilliSatoshiLong, TestConstants, TestKitBaseClass, ToMilliSatoshiConversion}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.{Outcome, Tag}
 import org.sqlite.SQLiteConfig
 
 import java.io.File
 import java.sql.DriverManager
-import scala.collection.immutable.Queue
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.DurationInt
-import scala.concurrent.{ExecutionContext, Future}
 
 class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ChannelStateTestsBase {
 
@@ -43,18 +37,24 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
   test("do not deduplicate htlc amounts") { f =>
     import f._
 
-    // We add 3 identical htlcs Alice -> Bob
+    // We add 3 identical outgoing htlcs Alice -> Bob.
     addHtlc(10_000_000 msat, alice, bob, alice2bob, bob2alice)
     addHtlc(10_000_000 msat, alice, bob, alice2bob, bob2alice)
     addHtlc(10_000_000 msat, alice, bob, alice2bob, bob2alice)
     crossSign(alice, bob, alice2bob, bob2alice)
-
-    assert(CheckBalance.computeOffChainBalance(Seq(alice.stateData.asInstanceOf[DATA_NORMAL]), knownPreimages = Set.empty).normal ==
-      MainAndHtlcBalance(
-        toLocal = (TestConstants.fundingSatoshis - TestConstants.initiatorPushAmount - 30_000_000.msat).truncateToSatoshi,
-        htlcs = 30_000.sat
-      )
+    val expected1 = MainAndHtlcBalance(
+      toLocal = (TestConstants.fundingSatoshis - TestConstants.initiatorPushAmount - 30_000_000.msat).truncateToSatoshi,
+      htlcs = 0 sat, // outgoing HTLCs are considered paid
     )
+    assert(CheckBalance.computeOffChainBalance(Seq(alice.stateData.asInstanceOf[DATA_NORMAL])).normal == expected1)
+
+    // We add 3 identical incoming htlcs Bob -> Alice.
+    addHtlc(20_000_000 msat, bob, alice, bob2alice, alice2bob)
+    addHtlc(20_000_000 msat, bob, alice, bob2alice, alice2bob)
+    addHtlc(20_000_000 msat, bob, alice, bob2alice, alice2bob)
+    crossSign(bob, alice, bob2alice, alice2bob)
+    val expected2 = expected1.copy(htlcs = 60_000 sat)
+    assert(CheckBalance.computeOffChainBalance(Seq(alice.stateData.asInstanceOf[DATA_NORMAL])).normal == expected2)
   }
 
   test("take in-flight signed fulfills into account") { f =>
@@ -66,163 +66,165 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     bob ! CMD_SIGN()
     bob2alice.expectMsgType[CommitSig]
 
-    assert(CheckBalance.computeOffChainBalance(Seq(bob.stateData.asInstanceOf[DATA_NORMAL]), knownPreimages = Set.empty).normal ==
-      MainAndHtlcBalance(
-        toLocal = TestConstants.initiatorPushAmount.truncateToSatoshi,
-        htlcs = htlc.amountMsat.truncateToSatoshi
-      )
+    val expected = MainAndHtlcBalance(
+      toLocal = TestConstants.initiatorPushAmount.truncateToSatoshi,
+      htlcs = htlc.amountMsat.truncateToSatoshi
     )
+    assert(CheckBalance.computeOffChainBalance(Seq(bob.stateData.asInstanceOf[DATA_NORMAL])).normal == expected)
   }
 
-  test("take published remote commit tx into account", Tag(ChannelStateTestsTags.StaticRemoteKey), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
+  test("channel closed with remote commit tx", Tag(ChannelStateTestsTags.StaticRemoteKey), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
     import f._
 
     // We add 3 htlcs Alice -> Bob (one of them below dust) and 2 htlcs Bob -> Alice
-    addHtlc(250000000 msat, alice, bob, alice2bob, bob2alice)
-    val (ra2, htlca2) = addHtlc(100000000 msat, alice, bob, alice2bob, bob2alice)
-    val (_, htlca3) = addHtlc(10000 msat, alice, bob, alice2bob, bob2alice)
-    val (rb1, htlcb1) = addHtlc(50000000 msat, bob, alice, bob2alice, alice2bob)
-    val (_, htlcb2) = addHtlc(55000000 msat, bob, alice, bob2alice, alice2bob)
+    addHtlc(250_000_000 msat, alice, bob, alice2bob, bob2alice)
+    val (ra, htlca) = addHtlc(100_000_000 msat, alice, bob, alice2bob, bob2alice)
+    addHtlc(10_000 msat, alice, bob, alice2bob, bob2alice)
+    val (rb, htlcb) = addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
+    addHtlc(55_000_000 msat, bob, alice, bob2alice, alice2bob)
     crossSign(alice, bob, alice2bob, bob2alice)
-    // And fulfill one htlc in each direction without signing a new commit tx
-    fulfillHtlc(htlca2.id, ra2, bob, alice, bob2alice, alice2bob)
-    fulfillHtlc(htlcb1.id, rb1, alice, bob, alice2bob, bob2alice)
+    // And fulfill one htlc in each direction without signing a new commit tx.
+    fulfillHtlc(htlca.id, ra, bob, alice, bob2alice, alice2bob)
+    fulfillHtlc(htlcb.id, rb, alice, bob, alice2bob, bob2alice)
 
-    // bob publishes his current commit tx
+    // Bob publishes his current commit tx.
     val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.latest.localCommit.commitTxAndRemoteSig.commitTx.tx
     assert(bobCommitTx.txOut.size == 8) // two anchor outputs, two main outputs and 4 pending htlcs
     alice ! WatchFundingSpentTriggered(bobCommitTx)
-    // in response to that, alice publishes her claim txs
+    // In response to that, alice publishes her claim txs.
     alice2blockchain.expectMsgType[PublishReplaceableTx] // claim-anchor
-    alice2blockchain.expectMsgType[PublishFinalTx] // claim-main
-    val claimHtlcTxs = (1 to 3).map(_ => alice2blockchain.expectMsgType[PublishReplaceableTx].tx.txInfo.tx)
+    val claimMain = alice2blockchain.expectMsgType[PublishFinalTx] // claim-main
+    val claimHtlcTxs = (1 to 3).map(_ => alice2blockchain.expectMsgType[PublishReplaceableTx].tx.txInfo)
+    assert(claimHtlcTxs.collect { case tx: ClaimHtlcSuccessTx => tx }.size == 1)
+    assert(claimHtlcTxs.collect { case tx: ClaimHtlcTimeoutTx => tx }.size == 2)
+    alice ! WatchTxConfirmedTriggered(BlockHeight(600_000), 5, bobCommitTx)
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.exists(_.isConfirmed))
 
-    val commitments = alice.stateData.asInstanceOf[DATA_CLOSING].commitments
-    val remoteCommitPublished = alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.get
-    val knownPreimages = Set((commitments.channelId, htlcb1.id))
-    assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(commitments.active.last.remoteCommit, remoteCommitPublished), knownPreimages) ==
-      PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(OutPoint(remoteCommitPublished.claimMainOutputTx.get.tx.txid, 0) -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
-        htlcs = claimHtlcTxs.map(claimTx => OutPoint(claimTx.txid, 0) -> claimTx.txOut.head.amount.toBtc).toMap,
-        htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi
-      ))
-    // assuming alice gets the preimage for the 2nd htlc
-    val knownPreimages1 = Set((commitments.channelId, htlcb1.id), (commitments.channelId, htlcb2.id))
-    assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(commitments.active.last.remoteCommit, remoteCommitPublished), knownPreimages1) ==
-      PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(OutPoint(remoteCommitPublished.claimMainOutputTx.get.tx.txid, 0) -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
-        htlcs = claimHtlcTxs.map(claimTx => OutPoint(claimTx.txid, 0) -> claimTx.txOut.head.amount.toBtc).toMap,
-        htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi + htlcb2.amountMsat.truncateToSatoshi
-      ))
+    // We already have an off-chain balance from other channels.
+    val balance = OffChainBalance(
+      normal = MainAndHtlcBalance(toLocal = 100_000_000 sat, htlcs = 250_000 sat),
+      closing = MainAndHtlcBalance(toLocal = 50_000_000 sat, htlcs = 100_000 sat),
+    )
+    // We add our main balance and the amount of the incoming HTLCs.
+    val expected1 = balance.copy(closing = MainAndHtlcBalance(toLocal = 50_000_000.sat + claimMain.amount, htlcs = 100_000.sat + 50_000.sat + 55_000.sat))
+    val balance1 = balance.addChannelBalance(alice.stateData.asInstanceOf[DATA_CLOSING])
+    assert(balance1 == expected1)
+    // When our HTLC transaction confirms, we stop including it in our off-chain balance: it appears in our on-chain balance.
+    alice ! WatchTxConfirmedTriggered(BlockHeight(601_000), 2, claimHtlcTxs.collectFirst { case tx: ClaimHtlcSuccessTx => tx }.get.tx)
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].remoteCommitPublished.get.irrevocablySpent.size == 2)
+    val expected2 = balance.copy(closing = MainAndHtlcBalance(toLocal = 50_000_000.sat + claimMain.amount, htlcs = 100_000.sat + 55_000.sat))
+    val balance2 = balance.addChannelBalance(alice.stateData.asInstanceOf[DATA_CLOSING])
+    assert(balance2 == expected2)
   }
 
-  test("take published next remote commit tx into account", Tag(ChannelStateTestsTags.StaticRemoteKey), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
+  test("channel closed with next remote commit tx", Tag(ChannelStateTestsTags.StaticRemoteKey), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
     import f._
 
-    // We add 3 htlcs Alice -> Bob (one of them below dust) and 2 htlcs Bob -> Alice
-    addHtlc(250000000 msat, alice, bob, alice2bob, bob2alice)
-    val (ra2, htlca2) = addHtlc(100000000 msat, alice, bob, alice2bob, bob2alice)
-    val (_, htlca3) = addHtlc(10000 msat, alice, bob, alice2bob, bob2alice)
-    val (rb1, htlcb1) = addHtlc(50000000 msat, bob, alice, bob2alice, alice2bob)
-    val (_, htlcb2) = addHtlc(55000000 msat, bob, alice, bob2alice, alice2bob)
+    // We add 3 htlcs Alice -> Bob (one of them below dust) and 2 htlcs Bob -> Alice.
+    addHtlc(250_000_000 msat, alice, bob, alice2bob, bob2alice)
+    addHtlc(100_000_000 msat, alice, bob, alice2bob, bob2alice)
+    addHtlc(10_000 msat, alice, bob, alice2bob, bob2alice)
+    addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
+    val (_, htlcb) = addHtlc(55_000_000 msat, bob, alice, bob2alice, alice2bob)
     crossSign(alice, bob, alice2bob, bob2alice)
-    // And fulfill one htlc in each direction
-    fulfillHtlc(htlca2.id, ra2, bob, alice, bob2alice, alice2bob)
-    fulfillHtlc(htlcb1.id, rb1, alice, bob, alice2bob, bob2alice)
-    // alice signs but we intercept bob's revocation
+    // Alice fails one of her incoming htlcs.
+    failHtlc(htlcb.id, alice, bob, alice2bob, bob2alice)
+    // Alice signs but we intercept bob's revocation.
     alice ! CMD_SIGN()
     alice2bob.expectMsgType[CommitSig]
     alice2bob.forward(bob)
     bob2alice.expectMsgType[RevokeAndAck]
 
-    // as far as alice knows, bob currently has two valid unrevoked commitment transactions
-    // bob publishes his current commit tx
+    // Bob publishes his next commit tx.
     val bobCommitTx = bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.last.localCommit.commitTxAndRemoteSig.commitTx.tx
     assert(bobCommitTx.txOut.size == 7) // two anchor outputs, two main outputs and 3 pending htlcs
     alice ! WatchFundingSpentTriggered(bobCommitTx)
+    // In response to that, alice publishes her claim txs
+    alice2blockchain.expectReplaceableTxPublished[ReplaceableRemoteCommitAnchor]
+    val claimMain = alice2blockchain.expectFinalTxPublished("remote-main-delayed")
+    (1 to 2).map(_ => alice2blockchain.expectReplaceableTxPublished[ReplaceableClaimHtlcTimeout].txInfo)
+    alice ! WatchTxConfirmedTriggered(BlockHeight(600_000), 5, bobCommitTx)
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.exists(_.isConfirmed))
 
-    // in response to that, alice publishes her claim txs
-    alice2blockchain.expectMsgType[PublishReplaceableTx] // claim-anchor
-    alice2blockchain.expectMsgType[PublishFinalTx] // claim-main
-    val claimHtlcTxs = (1 to 2).map(_ => alice2blockchain.expectMsgType[PublishReplaceableTx].tx.txInfo.tx)
-
-    val commitments = alice.stateData.asInstanceOf[DATA_CLOSING].commitments
-    val remoteCommitPublished = alice.stateData.asInstanceOf[DATA_CLOSING].nextRemoteCommitPublished.get
-    val knownPreimages = Set((commitments.channelId, htlcb1.id))
-    assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(commitments.active.last.nextRemoteCommit_opt.get.commit, remoteCommitPublished), knownPreimages) ==
-      PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(OutPoint(remoteCommitPublished.claimMainOutputTx.get.tx.txid, 0) -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
-        htlcs = claimHtlcTxs.map(claimTx => OutPoint(claimTx.txid, 0) -> claimTx.txOut.head.amount.toBtc).toMap,
-        htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi
-      ))
-    // assuming alice gets the preimage for the 2nd htlc
-    val knownPreimages1 = Set((commitments.channelId, htlcb1.id), (commitments.channelId, htlcb2.id))
-    assert(CheckBalance.computeRemoteCloseBalance(commitments, CurrentRemoteClose(commitments.active.last.nextRemoteCommit_opt.get.commit, remoteCommitPublished), knownPreimages1) ==
-      PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(OutPoint(remoteCommitPublished.claimMainOutputTx.get.tx.txid, 0) -> remoteCommitPublished.claimMainOutputTx.get.tx.txOut.head.amount),
-        htlcs = claimHtlcTxs.map(claimTx => OutPoint(claimTx.txid, 0) -> claimTx.txOut.head.amount.toBtc).toMap,
-        htlcsUnpublished = htlca3.amountMsat.truncateToSatoshi + htlcb2.amountMsat.truncateToSatoshi
-      ))
+    // We already have an off-chain balance from other channels.
+    val balance = OffChainBalance(
+      negotiating = MainAndHtlcBalance(toLocal = 200_000_000 sat, htlcs = 150_000 sat),
+      closing = MainAndHtlcBalance(toLocal = 20_000_000 sat, htlcs = 0 sat),
+    )
+    // We add our main balance and the amount of the remaining incoming HTLC.
+    val expected1 = balance.copy(closing = MainAndHtlcBalance(toLocal = 20_000_000.sat + claimMain.amount, htlcs = 50_000.sat))
+    val balance1 = balance.addChannelBalance(alice.stateData.asInstanceOf[DATA_CLOSING])
+    assert(balance1 == expected1)
   }
 
-  test("take published local commit tx into account") { f =>
+  test("channel closed with local commit tx") { f =>
     import f._
 
-    // We add 4 htlcs Alice -> Bob (one of them below dust) and 2 htlcs Bob -> Alice
-    addHtlc(250_000_000 msat, alice, bob, alice2bob, bob2alice)
-    val (ra2, htlca2) = addHtlc(100_000_000 msat, alice, bob, alice2bob, bob2alice)
-    addHtlc(10_000 msat, alice, bob, alice2bob, bob2alice)
-    // for this one we set a non-local upstream to simulate a relayed payment
-    val (_, htlca4) = addHtlc(30_000_000 msat, CltvExpiryDelta(144), alice, bob, alice2bob, bob2alice, upstream = Upstream.Hot.Trampoline(Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), 42, 30_003_000 msat, randomBytes32(), CltvExpiry(144), TestConstants.emptyOnionPacket, TlvStream.empty[UpdateAddHtlcTlv]), TimestampMilli(1687345927000L), TestConstants.Alice.nodeParams.nodeId) :: Nil), replyTo = TestProbe().ref)
-    val (rb1, htlcb1) = addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
-    addHtlc(55_000_000 msat, bob, alice, bob2alice, alice2bob)
+    // We add 2 htlcs Alice -> Bob and 4 htlcs Bob -> Alice (one of them below dust).
+    addHtlc(50_000_000 msat, alice, bob, alice2bob, bob2alice)
+    addHtlc(60_000_000 msat, alice, bob, alice2bob, bob2alice)
+    val (_, htlcb1) = addHtlc(35_000_000 msat, bob, alice, bob2alice, alice2bob)
+    val (rb1, htlcb2) = addHtlc(30_000_000 msat, bob, alice, bob2alice, alice2bob)
+    addHtlc(50_000 msat, bob, alice, bob2alice, alice2bob)
+    val (rb2, htlcb3) = addHtlc(25_000_000 msat, bob, alice, bob2alice, alice2bob)
     crossSign(alice, bob, alice2bob, bob2alice)
-    // And fulfill one htlc in each direction without signing a new commit tx
-    fulfillHtlc(htlca2.id, ra2, bob, alice, bob2alice, alice2bob)
-    fulfillHtlc(htlcb1.id, rb1, alice, bob, alice2bob, bob2alice)
+    // Alice has the preimage for 2 of her incoming HTLCs.
+    fulfillHtlc(htlcb2.id, rb1, alice, bob, alice2bob, bob2alice)
+    fulfillHtlc(htlcb3.id, rb2, alice, bob, alice2bob, bob2alice)
 
-    // alice publishes her commit tx
-    val aliceCommitTx = alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.last.localCommit.commitTxAndRemoteSig.commitTx.tx
-    alice ! Error(ByteVector32.Zeroes, "oops")
-    alice2blockchain.expectFinalTxPublished(aliceCommitTx.txid)
-    assert(aliceCommitTx.txOut.size == 7) // two main outputs and 5 pending htlcs (one is dust)
-    awaitCond(alice.stateName == CLOSING)
-    assert(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.isDefined)
-    val commitments = alice.stateData.asInstanceOf[DATA_CLOSING].commitments
-    val localCommitPublished = alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.get
-    val knownPreimages = Set((commitments.channelId, htlcb1.id))
-    assert(CheckBalance.computeLocalCloseBalance(commitments.changes, LocalClose(commitments.active.last.localCommit, localCommitPublished), commitments.originChannels, knownPreimages) ==
-      PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(OutPoint(localCommitPublished.claimMainDelayedOutputTx.get.tx.txid, 0) -> localCommitPublished.claimMainDelayedOutputTx.get.tx.txOut.head.amount),
-        htlcs = Map.empty,
-        htlcsUnpublished = htlca4.amountMsat.truncateToSatoshi + htlcb1.amountMsat.truncateToSatoshi
-      ))
+    // Alice publishes her commit tx.
+    val (localCommitPublished, localClosingTxs) = localClose(alice, alice2blockchain, htlcSuccessCount = 2, htlcTimeoutCount = 2)
+    alice ! WatchTxConfirmedTriggered(BlockHeight(750_000), 1, localCommitPublished.commitTx)
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.exists(_.isConfirmed))
+    val mainTx = localClosingTxs.mainTx_opt.get
+    val mainBalance = localCommitPublished.claimMainDelayedOutputTx.map(_.amountIn).get
 
-    val mainTx = alice2blockchain.expectFinalTxPublished("local-main-delayed")
-    val htlcTx1 = alice2blockchain.expectFinalTxPublished("htlc-timeout")
-    val htlcTx2 = alice2blockchain.expectFinalTxPublished("htlc-success")
-    val htlcTx3 = alice2blockchain.expectFinalTxPublished("htlc-timeout")
-    val htlcTx4 = alice2blockchain.expectFinalTxPublished("htlc-timeout")
-    alice2blockchain.expectWatchTxConfirmed(aliceCommitTx.txid)
-    alice2blockchain.expectWatchOutputsSpent(mainTx.input +: localCommitPublished.htlcTxs.keys.toSeq)
+    // We already have an off-chain balance from other channels.
+    val balance = OffChainBalance(
+      waitForChannelReady = 500_000 sat,
+      shutdown = MainAndHtlcBalance(toLocal = 100_000_000 sat, htlcs = 0 sat),
+      closing = MainAndHtlcBalance(toLocal = 250_000 sat, htlcs = 50_000 sat),
+    )
+    // We add our main balance and the amount of the incoming HTLCs.
+    val expected1 = balance.copy(closing = MainAndHtlcBalance(toLocal = 250_000.sat + mainBalance, htlcs = 50_000.sat + 35_000.sat + 30_000.sat + 25_000.sat))
+    val balance1 = balance.addChannelBalance(alice.stateData.asInstanceOf[DATA_CLOSING])
+    assert(balance1 == expected1)
 
-    // 3rd-stage txs are published when htlc transactions confirm
-    val htlcDelayedTxs = Seq(htlcTx1, htlcTx2, htlcTx3, htlcTx4).map { htlcTx =>
-      alice ! WatchOutputSpentTriggered(htlcTx.amount, htlcTx.tx)
-      alice2blockchain.expectWatchTxConfirmed(htlcTx.tx.txid)
-      alice ! WatchTxConfirmedTriggered(BlockHeight(2701), 3, htlcTx.tx)
+    // The incoming HTLCs for which Alice has the preimage confirm: we keep including them until the 3rd-stage transaction confirms.
+    assert(localClosingTxs.htlcSuccessTxs.size == 2)
+    val htlcDelayedTxs = localClosingTxs.htlcSuccessTxs.map(tx => {
+      alice ! WatchTxConfirmedTriggered(BlockHeight(760_000), 3, tx)
       val htlcDelayedTx = alice2blockchain.expectFinalTxPublished("htlc-delayed")
       alice2blockchain.expectWatchOutputSpent(htlcDelayedTx.input)
       htlcDelayedTx
-    }
-    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.get.claimHtlcDelayedTxs.length == 4)
+    })
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.exists(_.claimHtlcDelayedTxs.size == 2))
+    assert(balance.addChannelBalance(alice.stateData.asInstanceOf[DATA_CLOSING]) == expected1)
 
-    assert(CheckBalance.computeLocalCloseBalance(commitments.changes, LocalClose(commitments.active.last.localCommit, alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.get), commitments.originChannels, knownPreimages) ==
-      PossiblyPublishedMainAndHtlcBalance(
-        toLocal = Map(OutPoint(localCommitPublished.claimMainDelayedOutputTx.get.tx.txid, 0) -> localCommitPublished.claimMainDelayedOutputTx.get.tx.txOut.head.amount),
-        htlcs = htlcDelayedTxs.map(claimTx => OutPoint(claimTx.tx.txid, 0) -> claimTx.tx.txOut.head.amount.toBtc).toMap,
-        htlcsUnpublished = 0.sat
-      ))
+    // Bob claims the remaining incoming HTLC using his HTLC-timeout transaction: we remove it from our balance.
+    val (remoteCommitPublished, remoteClosingTxs) = remoteClose(localCommitPublished.commitTx, bob, bob2blockchain, htlcTimeoutCount = 3)
+    val bobHtlcTimeoutTx = remoteCommitPublished.claimHtlcTxs
+      .collectFirst { case (outpoint, Some(txInfo: ClaimHtlcTimeoutTx)) if txInfo.htlcId == htlcb1.id => outpoint }
+      .flatMap(outpoint => remoteClosingTxs.htlcTimeoutTxs.find(_.txIn.head.outPoint == outpoint))
+      .get
+    alice ! WatchTxConfirmedTriggered(BlockHeight(760_010), 0, bobHtlcTimeoutTx)
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.exists(_.irrevocablySpent.contains(bobHtlcTimeoutTx.txIn.head.outPoint)))
+    val expected2 = balance.copy(closing = MainAndHtlcBalance(toLocal = 250_000.sat + mainBalance, htlcs = 50_000.sat + 30_000.sat + 25_000.sat))
+    val balance2 = balance.addChannelBalance(alice.stateData.asInstanceOf[DATA_CLOSING])
+    assert(balance2 == expected2)
+
+    // Alice's 3rd-stage transactions confirm: we stop including them in our off-chain balance, they will appear in our on-chain balance.
+    htlcDelayedTxs.foreach(txInfo => alice ! WatchTxConfirmedTriggered(BlockHeight(765_000), 3, txInfo.tx))
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.exists(lcp => htlcDelayedTxs.map(_.input).forall(o => lcp.irrevocablySpent.contains(o))))
+    val expected3 = balance.copy(closing = MainAndHtlcBalance(toLocal = 250_000.sat + mainBalance, htlcs = 50_000.sat))
+    val balance3 = balance.addChannelBalance(alice.stateData.asInstanceOf[DATA_CLOSING])
+    assert(balance3 == expected3)
+
+    // Alice's main transaction confirms: we stop including it in our off-chain balance, it will appear in our on-chain balance.
+    alice ! WatchTxConfirmedTriggered(BlockHeight(765_100), 2, mainTx)
+    awaitCond(alice.stateData.asInstanceOf[DATA_CLOSING].localCommitPublished.exists(_.irrevocablySpent.contains(mainTx.txIn.head.outPoint)))
+    val balance4 = balance.addChannelBalance(alice.stateData.asInstanceOf[DATA_CLOSING])
+    assert(balance4 == balance)
   }
 
   ignore("compute from eclair.sqlite") { _ =>
@@ -234,88 +236,9 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
       statement.executeQuery("SELECT data FROM local_channels WHERE is_closed=0")
         .mapCodec(channelDataCodec)
     }
-    val knownPreimages: Set[(ByteVector32, Long)] = using(sqlite.prepareStatement("SELECT channel_id, htlc_id FROM pending_relay")) { statement =>
-      val rs = statement.executeQuery()
-      var q: Queue[(ByteVector32, Long)] = Queue()
-      while (rs.next()) {
-        q = q :+ (rs.getByteVector32("channel_id"), rs.getLong("htlc_id"))
-      }
-      q.toSet
-    }
-    val res = CheckBalance.computeOffChainBalance(channels, knownPreimages)
+    val res = CheckBalance.computeOffChainBalance(channels)
     println(res)
     println(res.total)
-  }
-
-  test("tx pruning") { () =>
-    val outPoints = (for (_ <- 0 until 20) yield OutPoint(randomTxId(), 0)).toList
-    val knownTxids = Set(outPoints(1).txid, outPoints(3).txid, outPoints(4).txid, outPoints(6).txid, outPoints(9).txid, outPoints(12).txid, outPoints(13).txid)
-
-    val bitcoinClient = new BitcoinCoreClient(null) {
-      /** Get the number of confirmations of a given transaction. */
-      override def getTxConfirmations(txid: TxId)(implicit ec: ExecutionContext): Future[Option[Int]] =
-        Future.successful(if (knownTxids.contains(txid)) Some(42) else None)
-    }
-
-    val bal1 = OffChainBalance(
-      closing = ClosingBalance(
-        localCloseBalance = PossiblyPublishedMainAndHtlcBalance(
-          toLocal = Map(
-            outPoints(0) -> 1000.sat,
-            outPoints(1) -> 1000.sat,
-            outPoints(2) -> 1000.sat),
-          htlcs = Map(
-            outPoints(3) -> 1000.sat,
-            outPoints(4) -> 1000.sat,
-            outPoints(5) -> 1000.sat)
-        ),
-        remoteCloseBalance = PossiblyPublishedMainAndHtlcBalance(
-          toLocal = Map(
-            outPoints(6) -> 1000.sat,
-            outPoints(7) -> 1000.sat,
-            outPoints(8) -> 1000.sat,
-            outPoints(9) -> 1000.sat),
-          htlcs = Map(
-            outPoints(10) -> 1000.sat,
-            outPoints(11) -> 1000.sat,
-            outPoints(12) -> 1000.sat),
-        ),
-        mutualCloseBalance = PossiblyPublishedMainBalance(
-          toLocal = Map(
-            outPoints(13) -> 1000.sat,
-            outPoints(14) -> 1000.sat
-          )
-        )
-      )
-    )
-
-    val sender = TestProbe()
-    CheckBalance.prunePublishedTransactions(bal1, bitcoinClient).pipeTo(sender.ref)
-    val bal2 = sender.expectMsgType[OffChainBalance]
-
-    assert(bal2 == OffChainBalance(
-      closing = ClosingBalance(
-        localCloseBalance = PossiblyPublishedMainAndHtlcBalance(
-          toLocal = Map(
-            outPoints(0) -> 1000.sat,
-            outPoints(2) -> 1000.sat),
-          htlcs = Map(
-            outPoints(5) -> 1000.sat)
-        ),
-        remoteCloseBalance = PossiblyPublishedMainAndHtlcBalance(
-          toLocal = Map(
-            outPoints(7) -> 1000.sat,
-            outPoints(8) -> 1000.sat),
-          htlcs = Map(
-            outPoints(10) -> 1000.sat,
-            outPoints(11) -> 1000.sat),
-        ),
-        mutualCloseBalance = PossiblyPublishedMainBalance(
-          toLocal = Map(
-            outPoints(14) -> 1000.sat
-          )
-        )))
-    )
   }
 
 }


### PR DESCRIPTION
We re-work the channel balance computation (`CheckBalance.scala`) used to continuously monitor the overall balance of the node. We previously assumed that all pending HTLCs would timeout on-chain, and monitored our mempool to deduplicate unconfirmed transactions and RBF attempts. But it is actually simpler to assume that all pending HTLCs will be fulfilled, and keep counting them in our off-chain balance until the spending transaction reaches `min-depth`.

We introduce a distinction between recently confirmed transactions and deeply confirmed transactions in our on-chain balance: there will be cases where we don't know yet whether we'll be able to gets funds back and the information of pending on-chain funds lets us verify that our overall balance is looking good. It always eventually converges to be in our on-chain balance.

Fixes #3085