### PR TITLE
Add outgoing reputation

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -149,6 +149,9 @@ sealed trait Upstream { def amountIn: MilliSatoshi }
 object Upstream {
   /** We haven't restarted and have full information about the upstream parent(s). */
   sealed trait Hot extends Upstream {
+    /**
+     * Occupancy of the incoming channel (both slot and value occupancy combined) that will be compared to the outgoing confidence.
+     */
     def incomingChannelOccupancy: Double
   }
   object Hot {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -148,14 +148,16 @@ case class INPUT_RESTORED(data: PersistentChannelData)
 sealed trait Upstream { def amountIn: MilliSatoshi }
 object Upstream {
   /** We haven't restarted and have full information about the upstream parent(s). */
-  sealed trait Hot extends Upstream
+  sealed trait Hot extends Upstream {
+    def incomingChannelOccupancy: Double
+  }
   object Hot {
     /** Our node is forwarding a single incoming HTLC. */
-    case class Channel(add: UpdateAddHtlc, receivedAt: TimestampMilli, receivedFrom: PublicKey) extends Hot {
+    case class Channel(add: UpdateAddHtlc, receivedAt: TimestampMilli, receivedFrom: PublicKey, incomingChannelOccupancy: Double) extends Hot {
       override val amountIn: MilliSatoshi = add.amountMsat
       val expiryIn: CltvExpiry = add.cltvExpiry
 
-      override def toString: String = s"Channel(amountIn=$amountIn, receivedAt=${receivedAt.toLong}, receivedFrom=${receivedFrom.toHex}, endorsement=${add.endorsement})"
+      override def toString: String = s"Channel(amountIn=$amountIn, receivedAt=${receivedAt.toLong}, receivedFrom=${receivedFrom.toHex}, endorsement=${add.endorsement}, incomingChannelOccupancy=$incomingChannelOccupancy)"
     }
     /** Our node is forwarding a payment based on a set of HTLCs from potentially multiple upstream channels. */
     case class Trampoline(received: List[Channel]) extends Hot {
@@ -163,6 +165,8 @@ object Upstream {
       // We must use the lowest expiry of the incoming HTLC set.
       val expiryIn: CltvExpiry = received.map(_.add.cltvExpiry).min
       val receivedAt: TimestampMilli = received.map(_.receivedAt).max
+
+      override def incomingChannelOccupancy: Double = received.map(_.incomingChannelOccupancy).max
 
       override def toString: String = s"Trampoline(${received.map(_.toString).mkString(",")})"
     }
@@ -173,7 +177,7 @@ object Upstream {
   object Cold {
     def apply(hot: Hot): Cold = hot match {
       case Local(id) => Local(id)
-      case Hot.Channel(add, _, _) => Cold.Channel(add.channelId, add.id, add.amountMsat)
+      case Hot.Channel(add, _, _, _) => Cold.Channel(add.channelId, add.id, add.amountMsat)
       case Hot.Trampoline(received) => Cold.Trampoline(received.map(r => Cold.Channel(r.add.channelId, r.add.id, r.add.amountMsat)))
     }
 
@@ -188,7 +192,10 @@ object Upstream {
   }
 
   /** Our node is the origin of the payment: there are no matching upstream HTLCs. */
-  case class Local(id: UUID) extends Hot with Cold { override val amountIn: MilliSatoshi = 0 msat }
+  case class Local(id: UUID) extends Hot with Cold {
+    override val amountIn: MilliSatoshi = 0 msat
+    override def incomingChannelOccupancy: Double = 0.0
+  }
 }
 
 /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelExceptions.scala
@@ -152,5 +152,6 @@ case class ForbiddenDuringSplice                   (override val channelId: Byte
 case class ForbiddenDuringQuiescence               (override val channelId: ByteVector32, command: String) extends ChannelException(channelId, s"cannot process $command while quiescent")
 case class ConcurrentRemoteSplice                  (override val channelId: ByteVector32) extends ChannelException(channelId, "splice attempt canceled, remote initiated splice before us")
 case class TooManySmallHtlcs                       (override val channelId: ByteVector32, number: Long, below: MilliSatoshi) extends ChannelJammingException(channelId, s"too many small htlcs: $number HTLCs below $below")
-case class ConfidenceTooLow                        (override val channelId: ByteVector32, confidence: Double, occupancy: Double) extends ChannelJammingException(channelId, s"confidence too low: confidence=$confidence occupancy=$occupancy")
+case class IncomingConfidenceTooLow                (override val channelId: ByteVector32, confidence: Double, occupancy: Double) extends ChannelJammingException(channelId, s"incoming confidence too low: confidence=$confidence occupancy=$occupancy")
+case class OutgoingConfidenceTooLow                (override val channelId: ByteVector32, confidence: Double, occupancy: Double) extends ChannelJammingException(channelId, s"outgoing confidence too low: confidence=$confidence occupancy=$occupancy")
 // @formatter:on

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -951,16 +951,6 @@ case class Commitments(channelParams: ChannelParams,
       .getOrElse(Right(copy(changes = changes1)))
   }
 
-  def incomingOccupancy: Double = {
-    active.map(commitment => {
-      val incomingHtlcs = commitment.localCommit.spec.htlcs.collect(DirectedHtlc.incoming)
-      val slotsOccupancy = incomingHtlcs.size.toDouble / (channelParams.localCommitParams.maxAcceptedHtlcs min channelParams.remoteCommitParams.maxAcceptedHtlcs)
-      val htlcValueInFlight = incomingHtlcs.toSeq.map(_.amountMsat).sum
-      val valueOccupancy = htlcValueInFlight.toLong.toDouble / channelParams.maxHtlcValueInFlight.toLong.toDouble
-      slotsOccupancy max valueOccupancy
-    }).max
-  }
-
   def sendFulfill(cmd: CMD_FULFILL_HTLC, nodeSecret: PrivateKey, useAttributionData: Boolean): Either[ChannelException, (Commitments, UpdateFulfillHtlc)] =
     getIncomingHtlcCrossSigned(cmd.id) match {
       case Some(htlc) if CommitmentChanges.alreadyProposed(changes.localChanges.proposed, htlc.id) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -453,7 +453,7 @@ case class Commitment(fundingTxIndex: Long,
     localCommit.spec.htlcs.collect(DirectedHtlc.incoming).filter(nearlyExpired)
   }
 
-  def canSendAdd(amount: MilliSatoshi, params: ChannelParams, changes: CommitmentChanges, feerates: FeeratesPerKw, feeConf: OnChainFeeConf, confidence: Double): Either[ChannelException, Unit] = {
+  def canSendAdd(amount: MilliSatoshi, params: ChannelParams, changes: CommitmentChanges, feerates: FeeratesPerKw, feeConf: OnChainFeeConf, reputationScore: Reputation.Score): Either[ChannelException, Unit] = {
     // we allowed mismatches between our feerates and our remote's as long as commitments didn't contain any HTLC at risk
     // we need to verify that we're not disagreeing on feerates anymore before offering new HTLCs
     // NB: there may be a pending update_fee that hasn't been applied yet that needs to be taken into account
@@ -531,7 +531,7 @@ case class Commitment(fundingTxIndex: Long,
 
     // Jamming protection
     // Must be the last checks so that they can be ignored for shadow deployment.
-    Reputation.checkChannelOccupancy(outgoingHtlcs.toSeq, params, confidence)
+    reputationScore.checkOutgoingChannelOccupancy(outgoingHtlcs.toSeq, params)
   }
 
   def canReceiveAdd(amount: MilliSatoshi, params: ChannelParams, changes: CommitmentChanges, feerates: FeeratesPerKw, feeConf: OnChainFeeConf): Either[ChannelException, Unit] = {
@@ -907,7 +907,10 @@ case class Commitments(channelParams: ChannelParams,
     val changes1 = changes.addLocalProposal(add).copy(localNextHtlcId = changes.localNextHtlcId + 1)
     val originChannels1 = originChannels + (add.id -> cmd.origin)
     // we verify that this htlc is allowed in every active commitment
-    val failures = active.map(_.canSendAdd(add.amountMsat, channelParams, changes1, feerates, feeConf, cmd.reputationScore.incomingConfidence)).collect { case Left(f) => f }
+    val failures =
+      (active.map(_.canSendAdd(add.amountMsat, channelParams, changes1, feerates, feeConf, cmd.reputationScore))
+        :+ cmd.reputationScore.checkIncomingChannelOccupancy(cmd.origin.upstream.incomingChannelOccupancy, channelId))
+      .collect { case Left(f) => f }
     if (failures.isEmpty) {
       Right(copy(changes = changes1, originChannels = originChannels1), add)
     } else if (failures.forall(_.isInstanceOf[ChannelJammingException])) {
@@ -916,7 +919,8 @@ case class Commitments(channelParams: ChannelParams,
       Metrics.dropHtlc(failure, Tags.Directions.Outgoing)
       failure match {
         case f: TooManySmallHtlcs => log.info("TooManySmallHtlcs: {} outgoing HTLCs are below {}", f.number, f.below)
-        case f: ConfidenceTooLow => log.info("ConfidenceTooLow: confidence is {}% while channel is {}% full", (100 * f.confidence).toInt, (100 * f.occupancy).toInt)
+        case f: IncomingConfidenceTooLow => log.info("IncomingConfidenceTooLow: confidence is {}% while channel is {}% full", (100 * f.confidence).toInt, (100 * f.occupancy).toInt)
+        case f: OutgoingConfidenceTooLow => log.info("OutgoingConfidenceTooLow: confidence is {}% while channel is {}% full", (100 * f.confidence).toInt, (100 * f.occupancy).toInt)
         case _ => ()
       }
       Right(copy(changes = changes1, originChannels = originChannels1), add)
@@ -945,6 +949,16 @@ case class Commitments(channelParams: ChannelParams,
     active.map(_.canReceiveAdd(add.amountMsat, channelParams, changes1, feerates, feeConf))
       .collectFirst { case Left(f) => Left(f) }
       .getOrElse(Right(copy(changes = changes1)))
+  }
+
+  def incomingOccupancy: Double = {
+    active.map(commitment => {
+      val incomingHtlcs = commitment.localCommit.spec.htlcs.collect(DirectedHtlc.incoming)
+      val slotsOccupancy = incomingHtlcs.size.toDouble / (channelParams.localCommitParams.maxAcceptedHtlcs min channelParams.remoteCommitParams.maxAcceptedHtlcs)
+      val htlcValueInFlight = incomingHtlcs.toSeq.map(_.amountMsat).sum
+      val valueOccupancy = htlcValueInFlight.toLong.toDouble / channelParams.maxHtlcValueInFlight.toLong.toDouble
+      slotsOccupancy max valueOccupancy
+    }).max
   }
 
   def sendFulfill(cmd: CMD_FULFILL_HTLC, nodeSecret: PrivateKey, useAttributionData: Boolean): Either[ChannelException, (Commitments, UpdateFulfillHtlc)] =

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -720,7 +720,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
           actions.foreach {
             case PostRevocationAction.RelayHtlc(add) =>
               log.debug("forwarding incoming htlc {} to relayer", add)
-              relayer ! Relayer.RelayForward(add, remoteNodeId)
+              relayer ! Relayer.RelayForward(add, remoteNodeId, commitments1.incomingOccupancy)
             case PostRevocationAction.RejectHtlc(add) =>
               log.debug("rejecting incoming htlc {}", add)
               // NB: we don't set commit = true, we will sign all updates at once afterwards.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -47,6 +47,7 @@ import fr.acinq.eclair.io.Peer
 import fr.acinq.eclair.io.Peer.LiquidityPurchaseSigned
 import fr.acinq.eclair.payment.relay.Relayer
 import fr.acinq.eclair.payment.{Bolt11Invoice, PaymentSettlingOnChain}
+import fr.acinq.eclair.reputation.Reputation
 import fr.acinq.eclair.router.Announcements
 import fr.acinq.eclair.transactions.Transactions.ClosingTx
 import fr.acinq.eclair.transactions._
@@ -720,7 +721,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
           actions.foreach {
             case PostRevocationAction.RelayHtlc(add) =>
               log.debug("forwarding incoming htlc {} to relayer", add)
-              relayer ! Relayer.RelayForward(add, remoteNodeId, commitments1.incomingOccupancy)
+              relayer ! Relayer.RelayForward(add, remoteNodeId, Reputation.incomingOccupancy(commitments1))
             case PostRevocationAction.RejectHtlc(add) =>
               log.debug("rejecting incoming htlc {}", add)
               // NB: we don't set commit = true, we will sign all updates at once afterwards.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/NodeRelay.scala
@@ -58,7 +58,7 @@ object NodeRelay {
 
   // @formatter:off
   sealed trait Command
-  case class Relay(nodeRelayPacket: IncomingPaymentPacket.NodeRelayPacket, originNode: PublicKey) extends Command
+  case class Relay(nodeRelayPacket: IncomingPaymentPacket.NodeRelayPacket, originNode: PublicKey, incomingChannelOccupancy: Double) extends Command
   case object Stop extends Command
   private case class WrappedMultiPartExtraPaymentReceived(mppExtraReceived: MultiPartPaymentFSM.ExtraPaymentReceived[HtlcPart]) extends Command
   private case class WrappedMultiPartPaymentFailed(mppFailed: MultiPartPaymentFSM.MultiPartPaymentFailed) extends Command
@@ -223,11 +223,11 @@ class NodeRelay private(nodeParams: NodeParams,
    */
   private def receiving(htlcs: Queue[Upstream.Hot.Channel], nextPayload: IntermediatePayload.NodeRelay, nextPacket_opt: Option[OnionRoutingPacket], handler: ActorRef): Behavior[Command] =
     Behaviors.receiveMessagePartial {
-      case Relay(packet: IncomingPaymentPacket.NodeRelayPacket, originNode) =>
+      case Relay(packet: IncomingPaymentPacket.NodeRelayPacket, originNode, incomingChannelOccupancy) =>
         require(packet.outerPayload.paymentSecret == paymentSecret, "payment secret mismatch")
         context.log.debug("forwarding incoming htlc #{} from channel {} to the payment FSM", packet.add.id, packet.add.channelId)
         handler ! MultiPartPaymentFSM.HtlcPart(packet.outerPayload.totalAmount, packet.add, packet.receivedAt)
-        receiving(htlcs :+ Upstream.Hot.Channel(packet.add.removeUnknownTlvs(), packet.receivedAt, originNode), nextPayload, nextPacket_opt, handler)
+        receiving(htlcs :+ Upstream.Hot.Channel(packet.add.removeUnknownTlvs(), packet.receivedAt, originNode, incomingChannelOccupancy), nextPayload, nextPacket_opt, handler)
       case WrappedMultiPartPaymentFailed(MultiPartPaymentFSM.MultiPartPaymentFailed(_, failure, parts)) =>
         context.log.warn("could not complete incoming multi-part payment (parts={} paidAmount={} failure={})", parts.size, parts.map(_.amount).sum, failure)
         Metrics.recordPaymentRelayFailed(failure.getClass.getSimpleName, Tags.RelayType.Trampoline)
@@ -465,7 +465,7 @@ class NodeRelay private(nodeParams: NodeParams,
   }
 
   private def rejectExtraHtlcPartialFunction: PartialFunction[Command, Behavior[Command]] = {
-    case Relay(nodeRelayPacket, _) =>
+    case Relay(nodeRelayPacket, _, _) =>
       rejectExtraHtlc(nodeRelayPacket.add, nodeRelayPacket.receivedAt)
       Behaviors.same
     // NB: this message would be sent from the payment FSM which we stopped before going to this state, but all this is asynchronous.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/PaymentLifecycle.scala
@@ -77,10 +77,10 @@ class PaymentLifecycle(nodeParams: NodeParams, cfg: SendPaymentConfig, router: A
     case Event(RouteResponse(route +: _), WaitingForRoute(request, failures, ignore)) =>
       log.info(s"route found: attempt=${failures.size + 1}/${request.maxAttempts} route=${route.printNodes()} channels=${route.printChannels()}")
       reputationRecorder_opt match {
-        case Some(reputationRecorder) => reputationRecorder ! GetConfidence(self, cfg.upstream, route.hops.head.fee(request.amount))
+        case Some(reputationRecorder) => reputationRecorder ! GetConfidence(self, cfg.upstream, Some(route.hops.head.nextNodeId), route.hops.head.fee(request.amount))
         case None =>
           val endorsement = cfg.upstream match {
-            case Hot.Channel(add, _, _) => add.endorsement
+            case Hot.Channel(add, _, _, _) => add.endorsement
             case Hot.Trampoline(received) => received.map(_.add.endorsement).min
             case Upstream.Local(_) => Reputation.maxEndorsement
           }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/reputation/Reputation.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/reputation/Reputation.scala
@@ -17,7 +17,7 @@
 package fr.acinq.eclair.reputation
 
 import fr.acinq.bitcoin.scalacompat.ByteVector32
-import fr.acinq.eclair.channel.{ChannelJammingException, ChannelParams, ConfidenceTooLow, TooManySmallHtlcs}
+import fr.acinq.eclair.channel.{ChannelJammingException, ChannelParams, IncomingConfidenceTooLow, OutgoingConfidenceTooLow, TooManySmallHtlcs}
 import fr.acinq.eclair.wire.protocol.UpdateAddHtlc
 import fr.acinq.eclair.{MilliSatoshi, TimestampMilli}
 
@@ -118,40 +118,47 @@ object Reputation {
   /**
    * @param incomingConfidence Confidence that the outgoing HTLC will succeed given the reputation of the incoming peer
    */
-  case class Score(incomingConfidence: Double) {
+  case class Score(incomingConfidence: Double, outgoingConfidence: Double) {
     val endorsement = toEndorsement(incomingConfidence)
+
+    def checkOutgoingChannelOccupancy(outgoingHtlcs: Seq[UpdateAddHtlc], params: ChannelParams): Either[ChannelJammingException, Unit] = {
+      val maxAcceptedHtlcs = Seq(params.localCommitParams.maxAcceptedHtlcs, params.remoteCommitParams.maxAcceptedHtlcs).min
+
+      for ((amountMsat, i) <- outgoingHtlcs.map(_.amountMsat).sorted.zipWithIndex) {
+        // We want to allow some small HTLCs but still keep slots for larger ones.
+        // We never want to reject HTLCs of size above `maxHtlcAmount / maxAcceptedHtlcs` as too small because we want to allow filling all the slots with HTLCs of equal sizes.
+        // We use exponentially spaced thresholds in between.
+        if (amountMsat.toLong < 1 || amountMsat.toLong.toDouble < math.pow(params.maxHtlcValueInFlight.toLong.toDouble / maxAcceptedHtlcs, i / maxAcceptedHtlcs)) {
+          return Left(TooManySmallHtlcs(params.channelId, number = i + 1, below = amountMsat))
+        }
+      }
+
+      val htlcValueInFlight = outgoingHtlcs.map(_.amountMsat).sum
+      val slotsOccupancy = outgoingHtlcs.size.toDouble / maxAcceptedHtlcs
+      val valueOccupancy = htlcValueInFlight.toLong.toDouble / params.maxHtlcValueInFlight.toLong.toDouble
+      val occupancy = slotsOccupancy max valueOccupancy
+      // Because there are only 8 endorsement levels, the highest endorsement corresponds to a confidence between 87.5% and 100%.
+      // So even for well-behaved peers setting the highest endorsement we still expect a confidence of less than 93.75%.
+      // To compensate for that we add a tolerance of 10% that's also useful for nodes without history.
+      if (incomingConfidence + 0.1 < occupancy) {
+        return Left(IncomingConfidenceTooLow(params.channelId, incomingConfidence, occupancy))
+      }
+
+      Right(())
+    }
+
+    def checkIncomingChannelOccupancy(incomingChannelOccupancy: Double, outgoingChannelId: ByteVector32): Either[ChannelJammingException, Unit] = {
+      if (outgoingConfidence + 0.1 < incomingChannelOccupancy) {
+        return Left(OutgoingConfidenceTooLow(outgoingChannelId, incomingConfidence, incomingChannelOccupancy))
+      }
+      Right(())
+    }
   }
 
   case object Score {
-    val max = Score(1.0)
+    val max = Score(1.0, 1.0)
 
-    def fromEndorsement(endorsement: Int): Score = Score((endorsement + 0.5) / 8)
-  }
-
-  def checkChannelOccupancy(outgoingHtlcs: Seq[UpdateAddHtlc], params: ChannelParams, confidence: Double): Either[ChannelJammingException, Unit] = {
-    val maxAcceptedHtlcs = Seq(params.localCommitParams.maxAcceptedHtlcs, params.remoteCommitParams.maxAcceptedHtlcs).min
-
-    for ((amountMsat, i) <- outgoingHtlcs.map(_.amountMsat).sorted.zipWithIndex) {
-      // We want to allow some small HTLCs but still keep slots for larger ones.
-      // We never want to reject HTLCs of size above `maxHtlcAmount / maxAcceptedHtlcs` as too small because we want to allow filling all the slots with HTLCs of equal sizes.
-      // We use exponentially spaced thresholds in between.
-      if (amountMsat.toLong < 1 || amountMsat.toLong.toDouble < math.pow(params.maxHtlcValueInFlight.toLong.toDouble / maxAcceptedHtlcs, i / maxAcceptedHtlcs)) {
-        return Left(TooManySmallHtlcs(params.channelId, number = i + 1, below = amountMsat))
-      }
-    }
-
-    val htlcValueInFlight = outgoingHtlcs.map(_.amountMsat).sum
-    val slotsOccupancy = outgoingHtlcs.size.toDouble / maxAcceptedHtlcs
-    val valueOccupancy = htlcValueInFlight.toLong.toDouble / params.maxHtlcValueInFlight.toLong.toDouble
-    val occupancy = slotsOccupancy max valueOccupancy
-    // Because there are only 8 endorsement levels, the highest endorsement corresponds to a confidence between 87.5% and 100%.
-    // So even for well-behaved peers setting the highest endorsement we still expect a confidence of less than 93.75%.
-    // To compensate for that we add a tolerance of 10% that's also useful for nodes without history.
-    if (confidence + 0.1 < occupancy) {
-      return Left(ConfidenceTooLow(params.channelId, confidence, occupancy))
-    }
-
-    Right(())
+    def fromEndorsement(endorsement: Int): Score = Score((endorsement + 0.5) / 8, 1.0)
   }
 
   def toEndorsement(confidence: Double): Int = (confidence * endorsementLevels).toInt.min(maxEndorsement)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalQuiescentStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalQuiescentStateSpec.scala
@@ -311,7 +311,7 @@ class NormalQuiescentStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteL
     import f._
     val (preimage, add) = addHtlc(50_000_000 msat, bob, alice, bob2alice, alice2bob)
     crossSign(bob, alice, bob2alice, alice2bob)
-    alice2relayer.expectMsg(RelayForward(add, TestConstants.Bob.nodeParams.nodeId))
+    alice2relayer.expectMsg(RelayForward(add, TestConstants.Bob.nodeParams.nodeId, 0.1))
     initiateQuiescence(f, sendInitialStfu = true)
     val forbiddenMsg = UpdateFulfillHtlc(channelId(bob), add.id, preimage)
     // both parties will respond to a forbidden msg while quiescent with a warning (and disconnect)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -118,7 +118,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     val sender = TestProbe()
     val h = randomBytes32()
     val originHtlc = UpdateAddHtlc(channelId = randomBytes32(), id = 5656, amountMsat = 50000000 msat, cltvExpiry = CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), paymentHash = h, onionRoutingPacket = TestConstants.emptyOnionPacket, pathKey_opt = None, endorsement = Reputation.maxEndorsement, fundingFee_opt = None)
-    val origin = Origin.Hot(sender.ref, Upstream.Hot.Channel(originHtlc, TimestampMilli.now(), randomKey().publicKey))
+    val origin = Origin.Hot(sender.ref, Upstream.Hot.Channel(originHtlc, TimestampMilli.now(), randomKey().publicKey, 0.1))
     val cmd = CMD_ADD_HTLC(sender.ref, originHtlc.amountMsat - 10_000.msat, h, originHtlc.cltvExpiry - CltvExpiryDelta(7), TestConstants.emptyOnionPacket, None, Reputation.Score.max, None, origin)
     alice ! cmd
     sender.expectMsgType[RES_SUCCESS[CMD_ADD_HTLC]]
@@ -137,7 +137,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     val h = randomBytes32()
     val originHtlc1 = UpdateAddHtlc(randomBytes32(), 47, 30000000 msat, h, CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, None, Reputation.maxEndorsement, None)
     val originHtlc2 = UpdateAddHtlc(randomBytes32(), 32, 20000000 msat, h, CltvExpiryDelta(160).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, None, Reputation.maxEndorsement, None)
-    val origin = Origin.Hot(sender.ref, Upstream.Hot.Trampoline(List(originHtlc1, originHtlc2).map(htlc => Upstream.Hot.Channel(htlc, TimestampMilli.now(), randomKey().publicKey))))
+    val origin = Origin.Hot(sender.ref, Upstream.Hot.Trampoline(List(originHtlc1, originHtlc2).map(htlc => Upstream.Hot.Channel(htlc, TimestampMilli.now(), randomKey().publicKey, 0.1))))
     val cmd = CMD_ADD_HTLC(sender.ref, originHtlc1.amountMsat + originHtlc2.amountMsat - 10000.msat, h, originHtlc2.cltvExpiry - CltvExpiryDelta(7), TestConstants.emptyOnionPacket, None, Reputation.Score.max, None, origin)
     alice ! cmd
     sender.expectMsgType[RES_SUCCESS[CMD_ADD_HTLC]]
@@ -1421,9 +1421,9 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
 
     // Alice forwards HTLCs that fit in the dust exposure.
     alice2relayer.expectMsgAllOf(
-      RelayForward(nonDust, TestConstants.Bob.nodeParams.nodeId),
-      RelayForward(almostTrimmed, TestConstants.Bob.nodeParams.nodeId),
-      RelayForward(trimmed2, TestConstants.Bob.nodeParams.nodeId),
+      RelayForward(nonDust, TestConstants.Bob.nodeParams.nodeId, 6.0 / 30),
+      RelayForward(almostTrimmed, TestConstants.Bob.nodeParams.nodeId, 6.0 / 30),
+      RelayForward(trimmed2, TestConstants.Bob.nodeParams.nodeId, 6.0 / 30),
     )
     alice2relayer.expectNoMessage(100 millis)
     // And instantly fails the others.
@@ -1468,7 +1468,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     bob2alice.forward(alice)
 
     // Alice forwards HTLCs that fit in the dust exposure and instantly fails the others.
-    alice2relayer.expectMsg(RelayForward(acceptedHtlc, TestConstants.Bob.nodeParams.nodeId))
+    alice2relayer.expectMsg(RelayForward(acceptedHtlc, TestConstants.Bob.nodeParams.nodeId, 4.0 / 30))
     alice2relayer.expectNoMessage(100 millis)
     assert(alice2bob.expectMsgType[UpdateFailHtlc].id == rejectedHtlc.id)
     alice2bob.expectMsgType[CommitSig]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/LiquidityDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/LiquidityDbSpec.scala
@@ -71,10 +71,10 @@ class LiquidityDbSpec extends AnyFunSuite {
       val paymentHash1 = randomBytes32()
       val paymentHash2 = randomBytes32()
       val upstream = Seq(
-        Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), 7, 25_000_000 msat, paymentHash1, CltvExpiry(750_000), randomOnion(), None, Reputation.maxEndorsement, None), TimestampMilli(0), randomKey().publicKey),
-        Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), 0, 1 msat, paymentHash1, CltvExpiry(750_000), randomOnion(), Some(randomKey().publicKey), Reputation.maxEndorsement, None), TimestampMilli.now(), randomKey().publicKey),
-        Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), 561, 100_000_000 msat, paymentHash2, CltvExpiry(799_999), randomOnion(), None, Reputation.maxEndorsement, None), TimestampMilli.now(), randomKey().publicKey),
-        Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), 1105, 100_000_000 msat, paymentHash2, CltvExpiry(799_999), randomOnion(), None, Reputation.maxEndorsement, None), TimestampMilli.now(), randomKey().publicKey),
+        Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), 7, 25_000_000 msat, paymentHash1, CltvExpiry(750_000), randomOnion(), None, Reputation.maxEndorsement, None), TimestampMilli(0), randomKey().publicKey, 0.1),
+        Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), 0, 1 msat, paymentHash1, CltvExpiry(750_000), randomOnion(), Some(randomKey().publicKey), Reputation.maxEndorsement, None), TimestampMilli.now(), randomKey().publicKey, 0.1),
+        Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), 561, 100_000_000 msat, paymentHash2, CltvExpiry(799_999), randomOnion(), None, Reputation.maxEndorsement, None), TimestampMilli.now(), randomKey().publicKey, 0.1),
+        Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), 1105, 100_000_000 msat, paymentHash2, CltvExpiry(799_999), randomOnion(), None, Reputation.maxEndorsement, None), TimestampMilli.now(), randomKey().publicKey, 0.1),
       )
       val pendingAlice = Seq(
         OnTheFlyFunding.Pending(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PaymentPacketSpec.scala
@@ -292,7 +292,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
 
     // c forwards the trampoline payment to e through d.
     val recipient_e = ClearRecipient(e, Features.empty, inner_c.amountToForward, inner_c.outgoingCltv, randomBytes32(), nextTrampolineOnion_opt = Some(trampolinePacket_e))
-    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b)))), paymentHash, Route(inner_c.amountToForward, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
+    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b, 0.1)))), paymentHash, Route(inner_c.amountToForward, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
     assert(payment_e.outgoingChannel == channelUpdate_cd.shortChannelId)
     assert(payment_e.cmd.amount == amount_cd)
     assert(payment_e.cmd.cltvExpiry == expiry_cd)
@@ -363,7 +363,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
 
     // c forwards the trampoline payment to e through d.
     val recipient_e = ClearRecipient(e, Features.empty, inner_c.amountToForward, inner_c.outgoingCltv, inner_c.paymentSecret, invoice.extraEdges, inner_c.paymentMetadata)
-    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b)))), paymentHash, Route(inner_c.amountToForward, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
+    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b, 0.1)))), paymentHash, Route(inner_c.amountToForward, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
     assert(payment_e.outgoingChannel == channelUpdate_cd.shortChannelId)
     assert(payment_e.cmd.amount == amount_cd)
     assert(payment_e.cmd.cltvExpiry == expiry_cd)
@@ -425,7 +425,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
 
     // c forwards the trampoline payment to e through d.
     val recipient_e = ClearRecipient(e, Features.empty, inner_c.amountToForward, inner_c.outgoingCltv, inner_c.paymentSecret, invoice.extraEdges, inner_c.paymentMetadata)
-    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b)))), paymentHash, Route(inner_c.amountToForward, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
+    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b, 0.1)))), paymentHash, Route(inner_c.amountToForward, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
     assert(payment_e.outgoingChannel == channelUpdate_cd.shortChannelId)
     assert(payment_e.cmd.amount == amount_cd)
     assert(payment_e.cmd.cltvExpiry == expiry_cd)
@@ -478,7 +478,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
 
     // c forwards an invalid trampoline onion to e through d.
     val recipient_e = ClearRecipient(e, Features.empty, inner_c.amountToForward, inner_c.outgoingCltv, randomBytes32(), nextTrampolineOnion_opt = Some(trampolinePacket_e.copy(payload = trampolinePacket_e.payload.reverse)))
-    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b)))), paymentHash, Route(inner_c.amountToForward, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
+    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b, 0.1)))), paymentHash, Route(inner_c.amountToForward, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
     assert(payment_e.outgoingChannel == channelUpdate_cd.shortChannelId)
     val add_d = UpdateAddHtlc(randomBytes32(), 3, payment_e.cmd.amount, paymentHash, payment_e.cmd.cltvExpiry, payment_e.cmd.onion, None, Reputation.maxEndorsement, None)
     val Right(ChannelRelayPacket(_, _, packet_e, _)) = decrypt(add_d, priv_d.privateKey, Features.empty)
@@ -603,7 +603,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     // c forwards an invalid amount to e through (the outer total amount doesn't match the inner amount).
     val invalidTotalAmount = inner_c.amountToForward - 1.msat
     val recipient_e = ClearRecipient(e, Features.empty, invalidTotalAmount, inner_c.outgoingCltv, randomBytes32(), nextTrampolineOnion_opt = Some(trampolinePacket_e))
-    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b)))), paymentHash, Route(invalidTotalAmount, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
+    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b, 0.1)))), paymentHash, Route(invalidTotalAmount, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
     val add_d = UpdateAddHtlc(randomBytes32(), 3, payment_e.cmd.amount, paymentHash, payment_e.cmd.cltvExpiry, payment_e.cmd.onion, None, Reputation.maxEndorsement, None)
     val Right(ChannelRelayPacket(_, payload_d, packet_e, _)) = decrypt(add_d, priv_d.privateKey, Features.empty)
 
@@ -619,7 +619,7 @@ class PaymentPacketSpec extends AnyFunSuite with BeforeAndAfterAll {
     // c forwards an invalid amount to e through (the outer expiry doesn't match the inner expiry).
     val invalidExpiry = inner_c.outgoingCltv - CltvExpiryDelta(12)
     val recipient_e = ClearRecipient(e, Features.empty, inner_c.amountToForward, invalidExpiry, randomBytes32(), nextTrampolineOnion_opt = Some(trampolinePacket_e))
-    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b)))), paymentHash, Route(inner_c.amountToForward, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
+    val Right(payment_e) = buildOutgoingPayment(Origin.Hot(ActorRef.noSender, Upstream.Hot.Trampoline(List(Upstream.Hot.Channel(add_c, TimestampMilli(1687345927000L), b, 0.1)))), paymentHash, Route(inner_c.amountToForward, afterTrampolineChannelHops, None), recipient_e, Reputation.Score.max)
     val add_d = UpdateAddHtlc(randomBytes32(), 3, payment_e.cmd.amount, paymentHash, payment_e.cmd.cltvExpiry, payment_e.cmd.onion, None, Reputation.maxEndorsement, None)
     val Right(ChannelRelayPacket(_, payload_d, packet_e, _)) = decrypt(add_d, priv_d.privateKey, Features.empty)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/PostRestartHtlcCleanerSpec.scala
@@ -173,9 +173,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
     )
 
     // The HTLCs were not relayed yet, but they match pending on-the-fly funding proposals.
-    val upstreamChannel = Upstream.Hot.Channel(htlc_ab_1.head.add, TimestampMilli.now(), a)
+    val upstreamChannel = Upstream.Hot.Channel(htlc_ab_1.head.add, TimestampMilli.now(), a, 0.1)
     val downstreamChannel = OnTheFlyFunding.Pending(Seq(OnTheFlyFunding.Proposal(createWillAdd(100_000 msat, channelPaymentHash, CltvExpiry(500)), upstreamChannel, Nil)), createStatus())
-    val upstreamTrampoline = Upstream.Hot.Trampoline(List(htlc_ab_1.last, htlc_ab_2.head).map(htlc => Upstream.Hot.Channel(htlc.add, TimestampMilli.now(), a)))
+    val upstreamTrampoline = Upstream.Hot.Trampoline(List(htlc_ab_1.last, htlc_ab_2.head).map(htlc => Upstream.Hot.Channel(htlc.add, TimestampMilli.now(), a, 0.1)))
     val downstreamTrampoline = OnTheFlyFunding.Pending(Seq(OnTheFlyFunding.Proposal(createWillAdd(100_000 msat, trampolinePaymentHash, CltvExpiry(500)), upstreamTrampoline, Nil)), createStatus())
     nodeParams.db.liquidity.addPendingOnTheFlyFunding(randomKey().publicKey, downstreamChannel)
     nodeParams.db.liquidity.addPendingOnTheFlyFunding(randomKey().publicKey, downstreamTrampoline)
@@ -374,9 +374,9 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
     val htlc_upstream_1 = Seq(buildHtlcIn(0, channelId_ab_1, paymentHash1), buildHtlcIn(5, channelId_ab_1, paymentHash2))
     val htlc_upstream_2 = Seq(buildHtlcIn(7, channelId_ab_2, paymentHash1), buildHtlcIn(9, channelId_ab_2, paymentHash2))
     val htlc_upstream_3 = Seq(buildHtlcIn(11, randomBytes32(), paymentHash3))
-    val upstream_1 = Upstream.Hot.Trampoline(Upstream.Hot.Channel(htlc_upstream_1.head.add, TimestampMilli(1687345927000L), a) :: Upstream.Hot.Channel(htlc_upstream_2.head.add, TimestampMilli(1687345967000L), a) :: Nil)
-    val upstream_2 = Upstream.Hot.Trampoline(Upstream.Hot.Channel(htlc_upstream_1(1).add, TimestampMilli(1687345902000L), a) :: Upstream.Hot.Channel(htlc_upstream_2(1).add, TimestampMilli(1687345999000L), a) :: Nil)
-    val upstream_3 = Upstream.Hot.Trampoline(Upstream.Hot.Channel(htlc_upstream_3.head.add, TimestampMilli(1687345980000L), a) :: Nil)
+    val upstream_1 = Upstream.Hot.Trampoline(Upstream.Hot.Channel(htlc_upstream_1.head.add, TimestampMilli(1687345927000L), a, 0.1) :: Upstream.Hot.Channel(htlc_upstream_2.head.add, TimestampMilli(1687345967000L), a, 0.2) :: Nil)
+    val upstream_2 = Upstream.Hot.Trampoline(Upstream.Hot.Channel(htlc_upstream_1(1).add, TimestampMilli(1687345902000L), a, 0.3) :: Upstream.Hot.Channel(htlc_upstream_2(1).add, TimestampMilli(1687345999000L), a, 0.4) :: Nil)
+    val upstream_3 = Upstream.Hot.Trampoline(Upstream.Hot.Channel(htlc_upstream_3.head.add, TimestampMilli(1687345980000L), a, 0.5) :: Nil)
     val data_upstream_1 = ChannelCodecsSpec.makeChannelDataNormal(htlc_upstream_1, Map.empty)
     val data_upstream_2 = ChannelCodecsSpec.makeChannelDataNormal(htlc_upstream_2, Map.empty)
     val data_upstream_3 = ChannelCodecsSpec.makeChannelDataNormal(htlc_upstream_3, Map.empty)
@@ -669,7 +669,7 @@ class PostRestartHtlcCleanerSpec extends TestKitBaseClass with FixtureAnyFunSuit
       buildHtlcIn(2, channelId_ab_1, paymentHash2), // trampoline relayed
     )
     // The first upstream HTLC was not relayed but has a pending on-the-fly funding proposal.
-    val downstreamChannel = OnTheFlyFunding.Pending(Seq(OnTheFlyFunding.Proposal(createWillAdd(100_000 msat, paymentHash1, CltvExpiry(500)), Upstream.Hot.Channel(htlc_ab(0).add, TimestampMilli.now(), a), Nil)), createStatus())
+    val downstreamChannel = OnTheFlyFunding.Pending(Seq(OnTheFlyFunding.Proposal(createWillAdd(100_000 msat, paymentHash1, CltvExpiry(500)), Upstream.Hot.Channel(htlc_ab(0).add, TimestampMilli.now(), a, 0.1), Nil)), createStatus())
     nodeParams.db.liquidity.addPendingOnTheFlyFunding(randomKey().publicKey, downstreamChannel)
     // The other two HTLCs were relayed after completing on-the-fly funding.
     val htlc_bc = Seq(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/ChannelRelayerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/ChannelRelayerSpec.scala
@@ -120,7 +120,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(payload)
 
     channelRelayer ! WrappedLocalChannelUpdate(lcu)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
 
     if (success) {
       expectFwdAdd(register, lcu.channelId, outgoingAmount, outgoingExpiry, 7)
@@ -169,7 +169,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(payload, outgoingAmount + u.channelUpdate.feeBaseMsat, outgoingExpiry + u.channelUpdate.cltvExpiryDelta)
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.fromEndorsement(7))
 
     expectFwdAdd(register, channelIds(realScid1), outgoingAmount, outgoingExpiry, 7)
@@ -185,7 +185,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       val r = createValidIncomingPacket(payload, outgoingAmount + u.channelUpdate.feeBaseMsat, outgoingExpiry + u.channelUpdate.cltvExpiryDelta)
 
       channelRelayer ! WrappedLocalChannelUpdate(u)
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.fromEndorsement(6))
 
       // We try to wake-up the next node.
@@ -209,7 +209,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(payload, outgoingAmount + u.channelUpdate.feeBaseMsat, outgoingExpiry + u.channelUpdate.cltvExpiryDelta)
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.fromEndorsement(5))
 
     // We try to wake-up the next node.
@@ -241,7 +241,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val payload = createBlindedPayload(Left(outgoingNodeId), u.channelUpdate, isIntroduction = false)
     val r = createValidIncomingPacket(payload, outgoingAmount + u.channelUpdate.feeBaseMsat, outgoingExpiry + u.channelUpdate.cltvExpiryDelta)
 
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     // We try to wake-up the next node.
@@ -265,7 +265,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val payload = createBlindedPayload(Left(outgoingNodeId), u.channelUpdate, isIntroduction = false)
     val r = createValidIncomingPacket(payload, outgoingAmount + u.channelUpdate.feeBaseMsat, outgoingExpiry + u.channelUpdate.cltvExpiryDelta)
 
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     // We try to wake-up the next node.
@@ -292,7 +292,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(payload, outgoingAmount + u.channelUpdate.feeBaseMsat, outgoingExpiry + u.channelUpdate.cltvExpiryDelta)
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.fromEndorsement(7))
 
     // We try to wake-up the next node.
@@ -324,7 +324,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val u2 = createLocalUpdate(channelId2, balance = 80_000_000 msat)
     channelRelayer ! WrappedLocalChannelUpdate(u2)
 
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     // first try
@@ -347,7 +347,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val payload = ChannelRelay.Standard(realScid1, outgoingAmount, outgoingExpiry)
     val r = createValidIncomingPacket(payload)
 
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, FailureReason.LocalFailure(UnknownNextPeer()), None, commit = true))
@@ -361,7 +361,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val u = createLocalUpdate(channelId1)
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.fromEndorsement(6))
 
     val fwd = expectFwdAdd(register, channelIds(realScid1), outgoingAmount, outgoingExpiry, 6)
@@ -380,7 +380,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
     channelRelayer ! WrappedLocalChannelDown(d)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, FailureReason.LocalFailure(UnknownNextPeer()), None, commit = true))
@@ -394,7 +394,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val u = createLocalUpdate(channelId1, enabled = false)
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, FailureReason.LocalFailure(ChannelDisabled(u.channelUpdate.messageFlags, u.channelUpdate.channelFlags, Some(u.channelUpdate))), None, commit = true))
@@ -408,7 +408,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val u = createLocalUpdate(channelId1, htlcMinimum = outgoingAmount + 1.msat)
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, FailureReason.LocalFailure(AmountBelowMinimum(outgoingAmount, Some(u.channelUpdate))), None, commit = true))
@@ -423,7 +423,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       val r = createValidIncomingPacket(createBlindedPayload(Right(u.channelUpdate.shortChannelId), u.channelUpdate, isIntroduction), outgoingAmount + u.channelUpdate.feeBaseMsat, outgoingExpiry + u.channelUpdate.cltvExpiryDelta)
 
       channelRelayer ! WrappedLocalChannelUpdate(u)
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.max)
 
       val cmd = register.expectMessageType[Register.Forward[channel.Command]]
@@ -454,7 +454,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(payload, outgoingAmount + u.channelUpdate.feeBaseMsat, outgoingExpiry + u.channelUpdate.cltvExpiryDelta)
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     // We try to wake-up the next node, but we timeout before they connect.
@@ -474,7 +474,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(payload, expiryIn = outgoingExpiry + u.channelUpdate.cltvExpiryDelta + CltvExpiryDelta(1))
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     expectFwdAdd(register, channelIds(realScid1), r.amountToForward, r.outgoingCltv, 7).message
@@ -488,7 +488,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val r = createValidIncomingPacket(payload, expiryIn = outgoingExpiry + u.channelUpdate.cltvExpiryDelta - CltvExpiryDelta(1))
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, FailureReason.LocalFailure(IncorrectCltvExpiry(r.outgoingCltv, Some(u.channelUpdate))), None, commit = true))
@@ -502,7 +502,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val u = createLocalUpdate(channelId1)
 
     channelRelayer ! WrappedLocalChannelUpdate(u)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, FailureReason.LocalFailure(FeeInsufficient(r.add.amountMsat, Some(u.channelUpdate))), None, commit = true))
@@ -516,7 +516,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val u1 = createLocalUpdate(channelId1, timestamp = TimestampSecond.now(), feeBaseMsat = 1 msat, feeProportionalMillionths = 0)
 
     channelRelayer ! WrappedLocalChannelUpdate(u1)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.fromEndorsement(1))
 
     // relay succeeds with current channel update (u1) with lower fees
@@ -525,7 +525,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     val u2 = createLocalUpdate(channelId1, timestamp = TimestampSecond.now() - 530)
 
     channelRelayer ! WrappedLocalChannelUpdate(u2)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.fromEndorsement(2))
 
     // relay succeeds because the current update (u2) with higher fees occurred less than 10 minutes ago
@@ -535,7 +535,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
 
     channelRelayer ! WrappedLocalChannelUpdate(u1)
     channelRelayer ! WrappedLocalChannelUpdate(u3)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.max)
 
     // relay fails because the current update (u3) with higher fees occurred more than 10 minutes ago
@@ -565,7 +565,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
 
     testCases.foreach { testCase =>
       channelRelayer ! WrappedLocalChannelUpdate(u)
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.max)
       val fwd = expectFwdAdd(register, channelIds(realScid1), outgoingAmount, outgoingExpiry, 7)
       fwd.message.replyTo ! RES_ADD_FAILED(fwd.message, testCase.exc, Some(testCase.update))
@@ -602,7 +602,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
     {
       val payload = ChannelRelay.Standard(ShortChannelId(12345), 998900 msat, CltvExpiry(60))
       val r = createValidIncomingPacket(payload, 1000000 msat, CltvExpiry(70), endorsementIn = 5)
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.fromEndorsement(5))
       // select the channel to the same node, with the lowest capacity and balance but still high enough to handle the payment
       val cmd1 = expectFwdAdd(register, channelUpdates(ShortChannelId(22223)).channelId, r.amountToForward, r.outgoingCltv, 5).message
@@ -623,7 +623,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       // higher amount payment (have to increased incoming htlc amount for fees to be sufficient)
       val payload = ChannelRelay.Standard(ShortChannelId(12345), 50000000 msat, CltvExpiry(60))
       val r = createValidIncomingPacket(payload, 60000000 msat, CltvExpiry(70), endorsementIn = 0)
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.fromEndorsement(0))
       expectFwdAdd(register, channelUpdates(ShortChannelId(11111)).channelId, r.amountToForward, r.outgoingCltv, 0).message
     }
@@ -631,7 +631,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       // lower amount payment
       val payload = ChannelRelay.Standard(ShortChannelId(12345), 1000 msat, CltvExpiry(60))
       val r = createValidIncomingPacket(payload, 60000000 msat, CltvExpiry(70), endorsementIn = 6)
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.fromEndorsement(6))
       expectFwdAdd(register, channelUpdates(ShortChannelId(33333)).channelId, r.amountToForward, r.outgoingCltv, 6).message
     }
@@ -639,7 +639,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       // payment too high, no suitable channel found, we keep the requested one
       val payload = ChannelRelay.Standard(ShortChannelId(12345), 1000000000 msat, CltvExpiry(60))
       val r = createValidIncomingPacket(payload, 1010000000 msat, CltvExpiry(70))
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.fromEndorsement(7))
       expectFwdAdd(register, channelUpdates(ShortChannelId(12345)).channelId, r.amountToForward, r.outgoingCltv, 7).message
     }
@@ -647,7 +647,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       // cltv expiry larger than our requirements
       val payload = ChannelRelay.Standard(ShortChannelId(12345), 998900 msat, CltvExpiry(50))
       val r = createValidIncomingPacket(payload, 1000000 msat, CltvExpiry(70))
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.fromEndorsement(7))
       expectFwdAdd(register, channelUpdates(ShortChannelId(22223)).channelId, r.amountToForward, r.outgoingCltv, 7).message
     }
@@ -655,7 +655,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       // cltv expiry too small, no suitable channel found
       val payload = ChannelRelay.Standard(ShortChannelId(12345), 998900 msat, CltvExpiry(61))
       val r = createValidIncomingPacket(payload, 1000000 msat, CltvExpiry(70))
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.fromEndorsement(4))
       expectFwdFail(register, r.add.channelId, CMD_FAIL_HTLC(r.add.id, FailureReason.LocalFailure(IncorrectCltvExpiry(CltvExpiry(61), Some(channelUpdates(ShortChannelId(12345)).channelUpdate))), None, commit = true))
     }
@@ -682,7 +682,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
 
     testCases.foreach { testCase =>
       channelRelayer ! WrappedLocalChannelUpdate(u)
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.max)
       val fwd = expectFwdAdd(register, channelIds(realScid1), outgoingAmount, outgoingExpiry, 7)
       fwd.message.replyTo ! RES_SUCCESS(fwd.message, channelId1)
@@ -709,7 +709,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
       testCases.foreach { htlcResult =>
         val r = createValidIncomingPacket(createBlindedPayload(Right(u.channelUpdate.shortChannelId), u.channelUpdate, isIntroduction), outgoingAmount + u.channelUpdate.feeBaseMsat, outgoingExpiry + u.channelUpdate.cltvExpiryDelta, endorsementIn = 0)
         channelRelayer ! WrappedLocalChannelUpdate(u)
-        channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+        channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
         receiveConfidence(Reputation.Score.fromEndorsement(0))
         val fwd = expectFwdAdd(register, channelId1, outgoingAmount, outgoingExpiry, 0)
         fwd.message.replyTo ! RES_SUCCESS(fwd.message, channelId1)
@@ -753,7 +753,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
 
     testCases.foreach { testCase =>
       channelRelayer ! WrappedLocalChannelUpdate(u)
-      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+      channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
       receiveConfidence(Reputation.Score.fromEndorsement(3))
 
       val fwd1 = expectFwdAdd(register, channelIds(realScid1), outgoingAmount, outgoingExpiry, 3)
@@ -779,7 +779,7 @@ class ChannelRelayerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("a
 
     val payload = ChannelRelay.Standard(realScid1, outgoingAmount, outgoingExpiry)
     val r = createValidIncomingPacket(payload, endorsementIn = 3)
-    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId)
+    channelRelayer ! Relay(r, TestConstants.Alice.nodeParams.nodeId, 0.1)
     receiveConfidence(Reputation.Score.fromEndorsement(3))
     val fwd1 = expectFwdAdd(register, channelIds(realScid1), outgoingAmount, outgoingExpiry, 3)
     fwd1.message.replyTo ! RES_SUCCESS(fwd1.message, channelId1)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/OnTheFlyFundingSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/relay/OnTheFlyFundingSpec.scala
@@ -1237,7 +1237,7 @@ object OnTheFlyFundingSpec {
   def upstreamChannel(amountIn: MilliSatoshi, expiryIn: CltvExpiry, paymentHash: ByteVector32 = randomBytes32(), blinded: Boolean = false): Upstream.Hot.Channel = {
     val pathKey = if (blinded) Some(randomKey().publicKey) else None
     val add = UpdateAddHtlc(randomBytes32(), randomHtlcId(), amountIn, paymentHash, expiryIn, TestConstants.emptyOnionPacket, pathKey, Reputation.maxEndorsement, None)
-    Upstream.Hot.Channel(add, TimestampMilli.now(), randomKey().publicKey)
+    Upstream.Hot.Channel(add, TimestampMilli.now(), randomKey().publicKey, 0.01)
   }
 
   def createWillAdd(amount: MilliSatoshi, paymentHash: ByteVector32, expiry: CltvExpiry, pathKey_opt: Option[PublicKey] = None): WillAddHtlc = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/reputation/ReputationRecorderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/reputation/ReputationRecorderSpec.scala
@@ -44,10 +44,10 @@ class ReputationRecorderSpec extends ScalaTestWithActorTestKit(ConfigFactory.loa
   }
 
   def makeChannelUpstream(nodeId: PublicKey, endorsement: Int, amount: MilliSatoshi = 1000000 msat): Upstream.Hot.Channel =
-    Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), randomLong(), amount, randomBytes32(), CltvExpiry(1234), null, TlvStream(UpdateAddHtlcTlv.Endorsement(endorsement))), TimestampMilli.now(), nodeId)
+    Upstream.Hot.Channel(UpdateAddHtlc(randomBytes32(), randomLong(), amount, randomBytes32(), CltvExpiry(1234), null, TlvStream(UpdateAddHtlcTlv.Endorsement(endorsement))), TimestampMilli.now(), nodeId, 0.25)
 
-  def makeOutgoingHtlcAdded(upstream: Upstream.Hot, fee: MilliSatoshi): OutgoingHtlcAdded =
-    OutgoingHtlcAdded(UpdateAddHtlc(randomBytes32(), randomLong(), 100000 msat, randomBytes32(), CltvExpiry(456), null, TlvStream.empty), randomKey().publicKey, upstream, fee)
+  def makeOutgoingHtlcAdded(upstream: Upstream.Hot, downstream: PublicKey, fee: MilliSatoshi): OutgoingHtlcAdded =
+    OutgoingHtlcAdded(UpdateAddHtlc(randomBytes32(), randomLong(), 100000 msat, randomBytes32(), CltvExpiry(456), null, TlvStream.empty), downstream, upstream, fee)
 
   def makeOutgoingHtlcFulfilled(add: UpdateAddHtlc): OutgoingHtlcFulfilled =
     OutgoingHtlcFulfilled(UpdateFulfillHtlc(add.channelId, add.id, randomBytes32(), TlvStream.empty))
@@ -58,115 +58,194 @@ class ReputationRecorderSpec extends ScalaTestWithActorTestKit(ConfigFactory.loa
   test("channel relay") { f =>
     import f._
 
+    val (nextA, nextB) = (randomKey().publicKey, randomKey().publicKey)
+
     val upstream1 = makeChannelUpstream(originNode, 7)
-    reputationRecorder ! GetConfidence(replyTo.ref, upstream1, 2000 msat)
-    assert(replyTo.expectMessageType[Reputation.Score].incomingConfidence == 0)
-    val added1 = makeOutgoingHtlcAdded(upstream1, 2000 msat)
+    reputationRecorder ! GetConfidence(replyTo.ref, upstream1, Some(nextA), 2000 msat)
+    replyTo.expectMessage(Reputation.Score(0.0, 0.0))
+    val added1 = makeOutgoingHtlcAdded(upstream1, nextA, 2000 msat)
     testKit.system.eventStream ! EventStream.Publish(added1)
     testKit.system.eventStream ! EventStream.Publish(makeOutgoingHtlcFulfilled(added1.add))
     val upstream2 = makeChannelUpstream(originNode, 7)
     awaitCond({
-      reputationRecorder ! GetConfidence(replyTo.ref, upstream2, 1000 msat)
-      replyTo.expectMessageType[Reputation.Score].incomingConfidence === (2.0 / 4) +- 0.001
+      reputationRecorder ! GetConfidence(replyTo.ref, upstream2, Some(nextB), 1000 msat)
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence === (2.0 / 4) +- 0.001 && score.outgoingConfidence == 0.0
     }, max = 60 seconds)
-    val added2 = makeOutgoingHtlcAdded(upstream2, 1000 msat)
+    val added2 = makeOutgoingHtlcAdded(upstream2, nextB, 1000 msat)
     testKit.system.eventStream ! EventStream.Publish(added2)
     awaitCond({
-      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, 7), 3000 msat)
-      replyTo.expectMessageType[Reputation.Score].incomingConfidence === (2.0 / 10) +- 0.001
+      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, 7), Some(nextA), 3000 msat)
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence === (2.0 / 10) +- 0.001 && score.outgoingConfidence === (2.0 / 8) +- 0.001
     }, max = 60 seconds)
     val upstream3 = makeChannelUpstream(originNode, 7)
-    reputationRecorder ! GetConfidence(replyTo.ref, upstream3, 1000 msat)
-    assert(replyTo.expectMessageType[Reputation.Score].incomingConfidence === (2.0 / 6) +- 0.001)
-    val added3 = makeOutgoingHtlcAdded(upstream3, 1000 msat)
+    reputationRecorder ! GetConfidence(replyTo.ref, upstream3, Some(nextB), 1000 msat)
+    assert({
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence === (2.0 / 6) +- 0.001 && score.outgoingConfidence == 0.0
+    })
+    val added3 = makeOutgoingHtlcAdded(upstream3, nextB, 1000 msat)
     testKit.system.eventStream ! EventStream.Publish(added3)
     testKit.system.eventStream ! EventStream.Publish(makeOutgoingHtlcFulfilled(added3.add))
     testKit.system.eventStream ! EventStream.Publish(makeOutgoingHtlcFailed(added2.add))
     // Not endorsed
     awaitCond({
-      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, 0), 1000 msat)
-      replyTo.expectMessageType[Reputation.Score].incomingConfidence == 0
+      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, 0), Some(nextA), 1000 msat)
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence == 0.0 && score.outgoingConfidence === (2.0 / 4) +- 0.001
     }, max = 60 seconds)
     // Different origin node
-    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(randomKey().publicKey, 7), 1000 msat)
-    assert(replyTo.expectMessageType[Reputation.Score].incomingConfidence == 0)
+    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(randomKey().publicKey, 7), Some(randomKey().publicKey), 1000 msat)
+    assert({
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence == 0.0 && score.outgoingConfidence == 0.0
+    })
     // Very large HTLC
-    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, 7), 100000000 msat)
-    assert(replyTo.expectMessageType[Reputation.Score].incomingConfidence === 0.0 +- 0.001)
+    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, 7), Some(nextA), 100000000 msat)
+    assert({
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence === 0.0 +- 0.001 && score.outgoingConfidence === 0.0 +- 0.001
+    })
   }
 
   test("trampoline relay") { f =>
     import f._
 
     val (a, b, c) = (randomKey().publicKey, randomKey().publicKey, randomKey().publicKey)
+    val (d, e) = (randomKey().publicKey, randomKey().publicKey)
 
     val upstream1 = Upstream.Hot.Trampoline(makeChannelUpstream(a, 7, 20000 msat) :: makeChannelUpstream(b, 7, 40000 msat) :: makeChannelUpstream(c, 0, 10000 msat) :: makeChannelUpstream(c, 2, 20000 msat) :: makeChannelUpstream(c, 2, 30000 msat) :: Nil)
-    reputationRecorder ! GetConfidence(replyTo.ref, upstream1, 12000 msat)
-    assert(replyTo.expectMessageType[Reputation.Score].incomingConfidence == 0)
-    val added1 = makeOutgoingHtlcAdded(upstream1, 6000 msat)
+    reputationRecorder ! GetConfidence(replyTo.ref, upstream1, Some(d), 12000 msat)
+    assert({
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence == 0.0 && score.outgoingConfidence == 0.0
+    })
+    val added1 = makeOutgoingHtlcAdded(upstream1, d, 6000 msat)
     testKit.system.eventStream ! EventStream.Publish(added1)
     testKit.system.eventStream ! EventStream.Publish(makeOutgoingHtlcFulfilled(added1.add))
     val upstream2 = Upstream.Hot.Trampoline(makeChannelUpstream(a, 7, 10000 msat) :: makeChannelUpstream(c, 0, 10000 msat) :: Nil)
     awaitCond({
-      reputationRecorder ! GetConfidence(replyTo.ref, upstream2, 2000 msat)
-      replyTo.expectMessageType[Reputation.Score].incomingConfidence === (1.0 / 3) +- 0.001
+      reputationRecorder ! GetConfidence(replyTo.ref, upstream2, Some(d), 2000 msat)
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence === (1.0 / 3) +- 0.001 && score.outgoingConfidence === (6.0 / 10) +- 0.001
     }, max = 60 seconds)
-    val added2 = makeOutgoingHtlcAdded(upstream2, 2000 msat)
+    val added2 = makeOutgoingHtlcAdded(upstream2, d, 2000 msat)
     testKit.system.eventStream ! EventStream.Publish(added2)
     val upstream3 = Upstream.Hot.Trampoline(makeChannelUpstream(a, 0, 10000 msat) :: makeChannelUpstream(b, 7, 15000 msat) :: makeChannelUpstream(b, 7, 5000 msat) :: Nil)
     awaitCond({
-      reputationRecorder ! GetConfidence(replyTo.ref, upstream3, 3000 msat)
-      replyTo.expectMessageType[Reputation.Score].incomingConfidence == 0
+      reputationRecorder ! GetConfidence(replyTo.ref, upstream3, Some(e), 3000 msat)
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence == 0.0 && score.outgoingConfidence == 0.0
     }, max = 60 seconds)
-    val added3 = makeOutgoingHtlcAdded(upstream3, 3000 msat)
+    val added3 = makeOutgoingHtlcAdded(upstream3, e, 3000 msat)
     testKit.system.eventStream ! EventStream.Publish(added3)
     testKit.system.eventStream ! EventStream.Publish(makeOutgoingHtlcFailed(added2.add))
     testKit.system.eventStream ! EventStream.Publish(makeOutgoingHtlcFulfilled(added3.add))
 
     awaitCond({
-      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(a, 7), 1000 msat)
-      replyTo.expectMessageType[Reputation.Score].incomingConfidence === (2.0 / 4) +- 0.001
+      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(a, 7), Some(d), 1000 msat)
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence === (2.0 / 4) +- 0.001 && score.outgoingConfidence === (6.0 / 8) +- 0.001
     }, max = 60 seconds)
-    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(a, 0), 1000 msat)
-    assert(replyTo.expectMessageType[Reputation.Score].incomingConfidence === (1.0 / 3) +- 0.001)
-    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(b, 7), 1000 msat)
-    assert(replyTo.expectMessageType[Reputation.Score].incomingConfidence === (4.0 / 6) +- 0.001)
-    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(b, 0), 1000 msat)
-    assert(replyTo.expectMessageType[Reputation.Score].incomingConfidence == 0.0)
-    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(c, 0), 1000 msat)
-    assert(replyTo.expectMessageType[Reputation.Score].incomingConfidence === (3.0 / 5) +- 0.001)
+    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(a, 0), Some(d), 1000 msat)
+    assert({
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence === (1.0 / 3) +- 0.001 && score.outgoingConfidence === (6.0 / 8) +- 0.001
+    })
+    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(b, 7), Some(d), 1000 msat)
+    assert({
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence === (4.0 / 6) +- 0.001 && score.outgoingConfidence === (6.0 / 8) +- 0.001
+    })
+    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(b, 0), Some(e), 1000 msat)
+    assert({
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence == 0.0 && score.outgoingConfidence === (3.0 / 5) +- 0.001
+    })
+    reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(c, 0), Some(e), 1000 msat)
+    assert({
+      val score = replyTo.expectMessageType[Reputation.Score]
+      score.incomingConfidence === (3.0 / 5) +- 0.001 && score.outgoingConfidence === (3.0 / 5) +- 0.001
+    })
   }
 
   test("basic attack") { f =>
     import f._
 
+    val nextNode = randomKey().publicKey
+
     // Our peer builds a good reputation by sending successful endorsed payments
     for (_ <- 1 to 200) {
       val upstream = makeChannelUpstream(originNode, 7)
-      val added = makeOutgoingHtlcAdded(upstream, 10000 msat)
+      val added = makeOutgoingHtlcAdded(upstream, nextNode, 10000 msat)
       testKit.system.eventStream ! EventStream.Publish(added)
       testKit.system.eventStream ! EventStream.Publish(makeOutgoingHtlcFulfilled(added.add))
     }
     awaitCond({
-      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, 7), 10000 msat)
-      replyTo.expectMessageType[Reputation.Score].incomingConfidence === 1.0 +- 0.01
+      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, 7), Some(nextNode), 10000 msat)
+      val score = replyTo.expectMessageType[Reputation.Score]
+      (score.incomingConfidence === 1.0 +- 0.01) && (score.outgoingConfidence === 1.0 +- 0.01)
     }, max = 60 seconds)
 
     // HTLCs with lower endorsement don't benefit from this high reputation.
     for (endorsement <- 0 to 6) {
-      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, endorsement), 10000 msat)
+      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, endorsement), Some(nextNode), 10000 msat)
       assert(replyTo.expectMessageType[Reputation.Score].incomingConfidence == 0.0)
     }
 
     // The attack starts, HTLCs stay pending.
     for (_ <- 1 to 100) {
       val upstream = makeChannelUpstream(originNode, 7)
-      val added = makeOutgoingHtlcAdded(upstream, 10000 msat)
+      val added = makeOutgoingHtlcAdded(upstream, nextNode, 10000 msat)
       testKit.system.eventStream ! EventStream.Publish(added)
     }
     awaitCond({
-      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, 7), 10000 msat)
+      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(originNode, 7), Some(nextNode), 10000 msat)
       replyTo.expectMessageType[Reputation.Score].incomingConfidence < 1.0 / 2
+    }, max = 60 seconds)
+  }
+
+  test("sink attack") {f =>
+    import f._
+
+    val (a, b, c) = (randomKey().publicKey, randomKey().publicKey, randomKey().publicKey)
+    val attacker = randomKey().publicKey
+
+    // A, B and C are good nodes with a good reputation.
+    for (node <- Seq(a, b, c)) {
+      val upstream = makeChannelUpstream(node, 7)
+      val added = makeOutgoingHtlcAdded(upstream, randomKey().publicKey, 10000000 msat)
+      testKit.system.eventStream ! EventStream.Publish(added)
+      testKit.system.eventStream ! EventStream.Publish(makeOutgoingHtlcFulfilled(added.add))
+      awaitCond({
+        reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(node, 7), Some(attacker), 10000 msat)
+        val score = replyTo.expectMessageType[Reputation.Score]
+        score.incomingConfidence > 0.9 && score.outgoingConfidence == 0.0
+      }, max = 60 seconds)
+    }
+
+    // The attacker attracts payments by setting low fees and builds its outgoing reputation.
+    for (node <- Seq(a, b, c)) {
+      for (_ <- 1 to 100) {
+        val upstream = makeChannelUpstream(node, 7)
+        val added = makeOutgoingHtlcAdded(upstream, attacker, 10000 msat)
+        testKit.system.eventStream ! EventStream.Publish(added)
+        testKit.system.eventStream ! EventStream.Publish(makeOutgoingHtlcFulfilled(added.add))
+      }
+    }
+
+    // When the attack starts, the outgoing confidence goes down quickly.
+    for (node <- Seq(a, b, c)) {
+      for (_ <- 1 to 50) {
+        val upstream = makeChannelUpstream(node, 7)
+        val added = makeOutgoingHtlcAdded(upstream, attacker, 10000 msat)
+        testKit.system.eventStream ! EventStream.Publish(added)
+      }
+    }
+    awaitCond({
+      reputationRecorder ! GetConfidence(replyTo.ref, makeChannelUpstream(a, 7), Some(attacker), 10000 msat)
+      replyTo.expectMessageType[Reputation.Score].outgoingConfidence < 1.0 / 2
     }, max = 60 seconds)
   }
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version1/ChannelCodecs1Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version1/ChannelCodecs1Spec.scala
@@ -130,7 +130,7 @@ class ChannelCodecs1Spec extends AnyFunSuite {
     assert(originCodec.decodeValue(originCodec.encode(localCold).require).require == localCold)
 
     val add = UpdateAddHtlc(randomBytes32(), 4324, 11000000 msat, randomBytes32(), CltvExpiry(400000), TestConstants.emptyOnionPacket, None, Reputation.maxEndorsement, None)
-    val relayedHot = Origin.Hot(replyTo, Upstream.Hot.Channel(add, TimestampMilli(0), randomKey().publicKey))
+    val relayedHot = Origin.Hot(replyTo, Upstream.Hot.Channel(add, TimestampMilli(0), randomKey().publicKey, 0.12))
     val relayedCold = Origin.Cold(Upstream.Cold.Channel(add.channelId, add.id, add.amountMsat))
     assert(originCodec.decodeValue(originCodec.encode(relayedHot).require).require == relayedCold)
     assert(originCodec.decodeValue(originCodec.encode(relayedCold).require).require == relayedCold)
@@ -140,7 +140,7 @@ class ChannelCodecs1Spec extends AnyFunSuite {
       UpdateAddHtlc(randomBytes32(), 1L, 2000 msat, randomBytes32(), CltvExpiry(400000), TestConstants.emptyOnionPacket, None, Reputation.maxEndorsement, None),
       UpdateAddHtlc(randomBytes32(), 2L, 3000 msat, randomBytes32(), CltvExpiry(400000), TestConstants.emptyOnionPacket, None, Reputation.maxEndorsement, None),
     )
-    val trampolineRelayedHot = Origin.Hot(replyTo, Upstream.Hot.Trampoline(adds.map(add => Upstream.Hot.Channel(add, TimestampMilli(0), randomKey().publicKey)).toList))
+    val trampolineRelayedHot = Origin.Hot(replyTo, Upstream.Hot.Trampoline(adds.map(add => Upstream.Hot.Channel(add, TimestampMilli(0), randomKey().publicKey, 0.38)).toList))
     // We didn't encode the incoming HTLC amount.
     val trampolineRelayed = Origin.Cold(Upstream.Cold.Trampoline(adds.map(add => Upstream.Cold.Channel(add.channelId, add.id, 0 msat)).toList))
     assert(originCodec.decodeValue(originCodec.encode(trampolineRelayedHot).require).require == trampolineRelayed)


### PR DESCRIPTION
Add an outgoing reputation in addition to the incoming reputation. It should protect against the "sink attack".