### PR TITLE
Add `GossipTimestampFilter` buffer during gossip queries to fix flaky tests

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Sync.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Sync.scala
@@ -31,6 +31,7 @@ import shapeless.HNil
 import scala.annotation.tailrec
 import scala.collection.SortedSet
 import scala.collection.immutable.SortedMap
+import scala.concurrent.duration.DurationInt
 import scala.util.Random
 
 object Sync {
@@ -55,10 +56,11 @@ object Sync {
       s.to ! query
 
       // we also set a pass-all filter for now (we can update it later) for the future gossip messages, by setting
-      // the first_timestamp field to the current date/time and timestamp_range to the maximum value
+      // the first_timestamp field to the current date/time minus one minute and timestamp_range to the maximum value
+      // the one minute buffer ensures that we don't miss recent gossip that hasn't reached our peer yet
       // NB: we can't just set firstTimestamp to 0, because in that case peer would send us all past messages matching
       // that (i.e. the whole routing table)
-      val filter = GossipTimestampFilter(s.chainHash, firstTimestamp = TimestampSecond.now(), timestampRange = Int.MaxValue)
+      val filter = GossipTimestampFilter(s.chainHash, firstTimestamp = TimestampSecond.now() - 1.minute, timestampRange = Int.MaxValue)
       s.to ! filter
 
       // reset our sync state for this peer: we create an entry to ensure we reject duplicate queries and unsolicited reply_channel_range

--- a/eclair-core/src/main/scala/fr/acinq/eclair/router/Sync.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/router/Sync.scala
@@ -57,10 +57,9 @@ object Sync {
 
       // we also set a pass-all filter for now (we can update it later) for the future gossip messages, by setting
       // the first_timestamp field to the current date/time minus one minute and timestamp_range to the maximum value
-      // the one minute buffer ensures that we don't miss recent gossip that hasn't reached our peer yet
       // NB: we can't just set firstTimestamp to 0, because in that case peer would send us all past messages matching
       // that (i.e. the whole routing table)
-      val filter = GossipTimestampFilter(s.chainHash, firstTimestamp = TimestampSecond.now() - 1.minute, timestampRange = Int.MaxValue)
+      val filter = GossipTimestampFilter(s.chainHash, firstTimestamp = TimestampSecond.now() - 1.minute, timestampRange = Int.MaxValue) // the one minute buffer ensures that we don't miss recent gossip that hasn't reached our peer yet
       s.to ! filter
 
       // reset our sync state for this peer: we create an entry to ensure we reject duplicate queries and unsolicited reply_channel_range


### PR DESCRIPTION
In a network Alice -- Bob - Carol, we could have
- Alice creates a channel update, Bob and Carol do not know it yet.
- Carol syncs with Bob and sends a `GossipTimestampFilter` with the current timestamp
- Bob receives the channel update from Alice but does not propagate it to Carol because it is too old for the `GossipTimestampFilter`

To prevent this from happening, we add a buffer of one minute to allow gossip to propagate.

This is unlikely to happen in real life but was making some tests flaky.