### PR TITLE
(Minor) Use helpers for feerates conversions

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -245,7 +245,7 @@ class EclairImpl(val appKit: Kit) extends Eclair with Logging with SpendFromChan
         fundingAmount = fundingAmount,
         channelType_opt = channelType_opt,
         pushAmount_opt = pushAmount_opt,
-        fundingTxFeerate_opt = fundingFeerate_opt.map(FeeratePerKw(_)),
+        fundingTxFeerate_opt = fundingFeerate_opt.map(_.perKw),
         fundingTxFeeBudget_opt = Some(fundingFeeBudget),
         requestFunding_opt = None,
         channelFlags_opt = announceChannel_opt.map(announceChannel => ChannelFlags(announceChannel = announceChannel)),
@@ -441,7 +441,7 @@ class EclairImpl(val appKit: Kit) extends Eclair with Logging with SpendFromChan
         if (blocks < 3) appKit.nodeParams.currentBitcoinCoreFeerates.fast
         else if (blocks > 6) appKit.nodeParams.currentBitcoinCoreFeerates.slow
         else appKit.nodeParams.currentBitcoinCoreFeerates.medium
-      case Right(feeratePerByte) => FeeratePerKw(feeratePerByte)
+      case Right(feeratePerByte) => feeratePerByte.perKw
     }
     appKit.wallet match {
       case w: BitcoinCoreClient =>
@@ -455,7 +455,7 @@ class EclairImpl(val appKit: Kit) extends Eclair with Logging with SpendFromChan
 
   override def cpfpBumpFees(targetFeeratePerByte: FeeratePerByte, outpoints: Set[OutPoint]): Future[TxId] = {
     appKit.wallet match {
-      case w: BitcoinCoreClient => w.cpfp(outpoints, FeeratePerKw(targetFeeratePerByte)).map(_.txid)
+      case w: BitcoinCoreClient => w.cpfp(outpoints, targetFeeratePerByte.perKw).map(_.txid)
       case _ => Future.failed(new IllegalArgumentException("this call is only available with a bitcoin core backend"))
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -608,7 +608,7 @@ object NodeParams extends Logging {
       ),
       onChainFeeConf = OnChainFeeConf(
         feeTargets = feeTargets,
-        maxClosingFeerate = FeeratePerKw(FeeratePerByte(Satoshi(config.getLong("on-chain-fees.max-closing-feerate")))),
+        maxClosingFeerate = FeeratePerByte(Satoshi(config.getLong("on-chain-fees.max-closing-feerate"))).perKw,
         safeUtxosThreshold = config.getInt("on-chain-fees.safe-utxos-threshold"),
         spendAnchorWithoutHtlcs = config.getBoolean("on-chain-fees.spend-anchor-without-htlcs"),
         anchorWithoutHtlcsMaxFee = Satoshi(config.getLong("on-chain-fees.anchor-without-htlcs-max-fee-satoshis")),
@@ -617,7 +617,7 @@ object NodeParams extends Logging {
         defaultFeerateTolerance = FeerateTolerance(
           config.getDouble("on-chain-fees.feerate-tolerance.ratio-low"),
           config.getDouble("on-chain-fees.feerate-tolerance.ratio-high"),
-          FeeratePerKw(FeeratePerByte(Satoshi(config.getLong("on-chain-fees.feerate-tolerance.anchor-output-max-commit-feerate")))),
+          FeeratePerByte(Satoshi(config.getLong("on-chain-fees.feerate-tolerance.anchor-output-max-commit-feerate"))).perKw,
           DustTolerance(
             Satoshi(config.getLong("on-chain-fees.feerate-tolerance.dust-tolerance.max-exposure-satoshis")),
             config.getBoolean("on-chain-fees.feerate-tolerance.dust-tolerance.close-on-update-fee-overflow")
@@ -628,7 +628,7 @@ object NodeParams extends Logging {
           val tolerance = FeerateTolerance(
             e.getDouble("feerate-tolerance.ratio-low"),
             e.getDouble("feerate-tolerance.ratio-high"),
-            FeeratePerKw(FeeratePerByte(Satoshi(e.getLong("feerate-tolerance.anchor-output-max-commit-feerate")))),
+            FeeratePerByte(Satoshi(e.getLong("feerate-tolerance.anchor-output-max-commit-feerate"))).perKw,
             DustTolerance(
               Satoshi(e.getLong("feerate-tolerance.dust-tolerance.max-exposure-satoshis")),
               e.getBoolean("feerate-tolerance.dust-tolerance.close-on-update-fee-overflow")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -237,11 +237,11 @@ class Setup(val datadir: File,
 
       defaultFeerates = {
         val confDefaultFeerates = FeeratesPerKB(
-          minimum = FeeratePerKB(FeeratePerByte(Satoshi(config.getLong("on-chain-fees.default-feerates.minimum")))),
-          slow = FeeratePerKB(FeeratePerByte(Satoshi(config.getLong("on-chain-fees.default-feerates.slow")))),
-          medium = FeeratePerKB(FeeratePerByte(Satoshi(config.getLong("on-chain-fees.default-feerates.medium")))),
-          fast = FeeratePerKB(FeeratePerByte(Satoshi(config.getLong("on-chain-fees.default-feerates.fast")))),
-          fastest = FeeratePerKB(FeeratePerByte(Satoshi(config.getLong("on-chain-fees.default-feerates.fastest")))),
+          minimum = FeeratePerByte(Satoshi(config.getLong("on-chain-fees.default-feerates.minimum"))).perKB,
+          slow = FeeratePerByte(Satoshi(config.getLong("on-chain-fees.default-feerates.slow"))).perKB,
+          medium = FeeratePerByte(Satoshi(config.getLong("on-chain-fees.default-feerates.medium"))).perKB,
+          fast = FeeratePerByte(Satoshi(config.getLong("on-chain-fees.default-feerates.fast"))).perKB,
+          fastest = FeeratePerByte(Satoshi(config.getLong("on-chain-fees.default-feerates.fastest"))).perKB,
         )
         feeratesPerKw.set(FeeratesPerKw(confDefaultFeerates))
         confDefaultFeerates

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -1061,7 +1061,7 @@ case class Commitments(channelParams: ChannelParams,
       active.map(_.canSendFee(cmd.feeratePerKw, channelParams, changes1, feeConf))
         .collectFirst { case Left(f) => Left(f) }
         .getOrElse {
-          Metrics.LocalFeeratePerByte.withTag(Tags.CommitmentFormat, active.head.commitmentFormat.toString).record(FeeratePerByte(cmd.feeratePerKw).feerate.toLong)
+          Metrics.LocalFeeratePerByte.withTag(Tags.CommitmentFormat, active.head.commitmentFormat.toString).record(cmd.feeratePerKw.perByte.feerate.toLong)
           Right(copy(changes = changes1), fee)
         }
     }
@@ -1080,7 +1080,7 @@ case class Commitments(channelParams: ChannelParams,
       active.map(_.canReceiveFee(fee.feeratePerKw, channelParams, changes1, feerates, feeConf))
         .collectFirst { case Left(f) => Left(f) }
         .getOrElse {
-          Metrics.RemoteFeeratePerByte.withTag(Tags.CommitmentFormat, active.head.commitmentFormat.toString).record(FeeratePerByte(fee.feeratePerKw).feerate.toLong)
+          Metrics.RemoteFeeratePerByte.withTag(Tags.CommitmentFormat, active.head.commitmentFormat.toString).record(fee.feeratePerKw.perByte.feerate.toLong)
           Right(copy(changes = changes1))
         }
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/DustExposure.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/DustExposure.scala
@@ -36,7 +36,7 @@ object DustExposure {
    * However, this cannot fully protect us if the feerate increases too much (in which case we may have to force-close).
    */
   def feerateForDustExposure(currentFeerate: FeeratePerKw): FeeratePerKw = {
-    (currentFeerate * 1.25).max(currentFeerate + FeeratePerKw(FeeratePerByte(10 sat)))
+    (currentFeerate * 1.25).max(currentFeerate + FeeratePerByte(10 sat).perKw)
   }
 
   /** Test whether the given HTLC contributes to our dust exposure with the default dust feerate calculation. */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -1246,7 +1246,7 @@ object Helpers {
        */
       private def claimIncomingHtlcOutputs(commitKeys: RemoteCommitmentKeys, commitTx: Transaction, outputs: Seq[CommitmentOutput], commitment: FullCommitment, remoteCommit: RemoteCommit, finalScriptPubKey: ByteVector)(implicit log: LoggingAdapter): (Map[OutPoint, Long], Seq[ClaimHtlcSuccessTx]) = {
         // The feerate will be set by the publisher actor based on the HTLC expiry, we don't care which feerate is used here.
-        val feerate = FeeratePerKw(FeeratePerByte(1 sat))
+        val feerate = FeeratePerByte(1 sat).perKw
         // We collect all the preimages available.
         val preimages = (commitment.changes.localChanges.all ++ commitment.changes.remoteChanges.all).collect {
           case u: UpdateFulfillHtlc => Crypto.sha256(u.paymentPreimage) -> u.paymentPreimage
@@ -1292,7 +1292,7 @@ object Helpers {
        */
       private def claimOutgoingHtlcOutputs(commitKeys: RemoteCommitmentKeys, commitTx: Transaction, outputs: Seq[CommitmentOutput], commitment: FullCommitment, remoteCommit: RemoteCommit, finalScriptPubKey: ByteVector)(implicit log: LoggingAdapter): (Map[OutPoint, Long], Seq[ClaimHtlcTimeoutTx]) = {
         // The feerate will be set by the publisher actor based on the HTLC expiry, we don't care which feerate is used here.
-        val feerate = FeeratePerKw(FeeratePerByte(1 sat))
+        val feerate = FeeratePerByte(1 sat).perKw
         // Remember we are looking at the remote commitment so IN for them is really OUT for us and vice versa.
         val outgoingHtlcs = remoteCommit.spec.htlcs.collect {
           case IncomingHtlc(add: UpdateAddHtlc) =>
@@ -1312,7 +1312,7 @@ object Helpers {
       def claimHtlcsWithPreimage(channelKeys: ChannelKeys, commitKeys: RemoteCommitmentKeys, remoteCommitPublished: RemoteCommitPublished, commitment: FullCommitment, remoteCommit: RemoteCommit, preimage: ByteVector32, finalScriptPubKey: ByteVector)(implicit log: LoggingAdapter): Seq[ClaimHtlcSuccessTx] = {
         val outputs = makeRemoteCommitTxOutputs(channelKeys, commitKeys, commitment, remoteCommit)
         // The feerate will be set by the publisher actor based on the HTLC expiry, we don't care which feerate is used here.
-        val feerate = FeeratePerKw(FeeratePerByte(1 sat))
+        val feerate = FeeratePerByte(1 sat).perKw
         remoteCommit.spec.htlcs.collect {
           // Remember we are looking at the remote commitment so IN for them is really OUT for us and vice versa.
           case OutgoingHtlc(add: UpdateAddHtlc) if add.paymentHash == Crypto.sha256(preimage) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/StartupSpec.scala
@@ -340,9 +340,9 @@ class StartupSpec extends AnyFunSuite {
     )
 
     val nodeParams = makeNodeParamsWithDefaults(perNodeConf.withFallback(defaultConf))
-    assert(nodeParams.onChainFeeConf.feerateToleranceFor(PublicKey(hex"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f")) == FeerateTolerance(0.1, 15.0, FeeratePerKw(FeeratePerByte(15 sat)), DustTolerance(25_000 sat, closeOnUpdateFeeOverflow = true)))
-    assert(nodeParams.onChainFeeConf.feerateToleranceFor(PublicKey(hex"03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b")) == FeerateTolerance(0.75, 5.0, FeeratePerKw(FeeratePerByte(5 sat)), DustTolerance(40_000 sat, closeOnUpdateFeeOverflow = false)))
-    assert(nodeParams.onChainFeeConf.feerateToleranceFor(PublicKey(hex"0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f7")) == FeerateTolerance(0.5, 10.0, FeeratePerKw(FeeratePerByte(10 sat)), DustTolerance(50_000 sat, closeOnUpdateFeeOverflow = false)))
+    assert(nodeParams.onChainFeeConf.feerateToleranceFor(PublicKey(hex"031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f")) == FeerateTolerance(0.1, 15.0, FeeratePerByte(15 sat).perKw, DustTolerance(25_000 sat, closeOnUpdateFeeOverflow = true)))
+    assert(nodeParams.onChainFeeConf.feerateToleranceFor(PublicKey(hex"03462779ad4aad39514614751a71085f2f10e1c7a593e4e030efb5b8721ce55b0b")) == FeerateTolerance(0.75, 5.0, FeeratePerByte(5 sat).perKw, DustTolerance(40_000 sat, closeOnUpdateFeeOverflow = false)))
+    assert(nodeParams.onChainFeeConf.feerateToleranceFor(PublicKey(hex"0362c0a046dacce86ddd0343c6d3c7c79c2208ba0d9c9cf24a6d046d21d21f90f7")) == FeerateTolerance(0.5, 10.0, FeeratePerByte(10 sat).perKw, DustTolerance(50_000 sat, closeOnUpdateFeeOverflow = false)))
   }
 
   test("NodeParams should fail if htlc-minimum-msat is set to 0") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -106,7 +106,7 @@ trait BitcoindService extends Logging {
           .appendedAll(defaultAddressType_opt.map(addressType => s"addresstype=$addressType\n").getOrElse(""))
           .appendedAll(changeAddressType_opt.map(addressType => s"changetype=$addressType\n").getOrElse(""))
           .appendedAll(mempoolSize_opt.map(mempoolSize => s"maxmempool=$mempoolSize\n").getOrElse(""))
-          .appendedAll(mempoolMinFeerate_opt.map(mempoolMinFeerate => s"minrelaytxfee=${FeeratePerKB(mempoolMinFeerate).feerate.toBtc.toBigDecimal}\n").getOrElse(""))
+          .appendedAll(mempoolMinFeerate_opt.map(mempoolMinFeerate => s"minrelaytxfee=${mempoolMinFeerate.perKB.feerate.toBtc.toBigDecimal}\n").getOrElse(""))
         if (useCookie) {
           defaultConf
             .replace("rpcuser=foo", "")
@@ -248,7 +248,7 @@ trait BitcoindService extends Logging {
     val tx = Transaction(version = 2, Nil, TxOut(amountSat, addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, address).toOption.get) :: Nil, lockTime = 0)
     val client = makeBitcoinCoreClient()
     val f = for {
-      funded <- client.fundTransaction(tx, FeeratePerKw(FeeratePerByte(Satoshi(10))), replaceable = true)
+      funded <- client.fundTransaction(tx, FeeratePerByte(Satoshi(10)).perKw, replaceable = true)
       signed <- client.signPsbt(new Psbt(funded.tx), funded.tx.txIn.indices, Nil)
       txid <- client.publishTransaction(signed.finalTx_opt.toOption.get)
       tx <- client.getTransaction(txid)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FeeProviderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/fee/FeeProviderSpec.scala
@@ -26,14 +26,14 @@ class FeeProviderSpec extends AnyFunSuite {
     assert(FeeratePerByte(FeeratePerKw(2000 sat)) == FeeratePerByte(8 sat))
     assert(FeeratePerKB(FeeratePerByte(10 sat)) == FeeratePerKB(10000 sat))
     assert(FeeratePerKB(FeeratePerKw(25 sat)) == FeeratePerKB(100 sat))
-    assert(FeeratePerKw(FeeratePerKB(10000 sat)) == FeeratePerKw(2500 sat))
-    assert(FeeratePerKw(FeeratePerByte(10 sat)) == FeeratePerKw(2500 sat))
+    assert(FeeratePerKB(10000 sat).perKw == FeeratePerKw(2500 sat))
+    assert(FeeratePerByte(10 sat).perKw == FeeratePerKw(2500 sat))
   }
 
   test("enforce a minimum feerate-per-kw") {
-    assert(FeeratePerKw(FeeratePerKB(1000 sat)) == MinimumFeeratePerKw)
-    assert(FeeratePerKw(FeeratePerKB(500 sat)) == MinimumFeeratePerKw)
-    assert(FeeratePerKw(FeeratePerByte(1 sat)) == MinimumFeeratePerKw)
+    assert(FeeratePerKB(1000 sat).perKw == MinimumFeeratePerKw)
+    assert(FeeratePerKB(500 sat).perKw == MinimumFeeratePerKw)
+    assert(FeeratePerByte(1 sat).perKw == MinimumFeeratePerKw)
   }
 
   test("compare feerates") {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/DustExposureSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/DustExposureSpec.scala
@@ -42,7 +42,7 @@ class DustExposureSpec extends AnyFunSuiteLike {
         IncomingHtlc(createHtlc(3, 500.sat.toMilliSatoshi)),
         OutgoingHtlc(createHtlc(3, 500.sat.toMilliSatoshi)),
       )
-      val spec = CommitmentSpec(htlcs, FeeratePerKw(FeeratePerByte(50 sat)), 50000 msat, 75000 msat)
+      val spec = CommitmentSpec(htlcs, FeeratePerByte(50 sat).perKw, 50000 msat, 75000 msat)
       assert(DustExposure.computeExposure(spec, 450 sat, Transactions.ZeroFeeHtlcTxAnchorOutputsCommitmentFormat) == 898.sat.toMilliSatoshi)
       assert(DustExposure.computeExposure(spec, 500 sat, Transactions.ZeroFeeHtlcTxAnchorOutputsCommitmentFormat) == 2796.sat.toMilliSatoshi)
       assert(DustExposure.computeExposure(spec, 500 sat, Transactions.UnsafeLegacyAnchorOutputsCommitmentFormat) == 3796.sat.toMilliSatoshi)
@@ -50,7 +50,7 @@ class DustExposureSpec extends AnyFunSuiteLike {
     {
       // Low feerate: buffer adds 10 sat/byte
       val dustLimit = 500.sat
-      val feerate = FeeratePerKw(FeeratePerByte(10 sat))
+      val feerate = FeeratePerByte(10 sat).perKw
       assert(Transactions.receivedHtlcTrimThreshold(dustLimit, feerate, Transactions.DefaultCommitmentFormat) == 2257.sat)
       assert(Transactions.offeredHtlcTrimThreshold(dustLimit, feerate, Transactions.DefaultCommitmentFormat) == 2157.sat)
       assert(Transactions.receivedHtlcTrimThreshold(dustLimit, feerate * 2, Transactions.DefaultCommitmentFormat) == 4015.sat)
@@ -81,7 +81,7 @@ class DustExposureSpec extends AnyFunSuiteLike {
     {
       // High feerate: buffer adds 25%
       val dustLimit = 1000.sat
-      val feerate = FeeratePerKw(FeeratePerByte(80 sat))
+      val feerate = FeeratePerByte(80 sat).perKw
       assert(Transactions.receivedHtlcTrimThreshold(dustLimit, feerate, Transactions.UnsafeLegacyAnchorOutputsCommitmentFormat) == 15120.sat)
       assert(Transactions.offeredHtlcTrimThreshold(dustLimit, feerate, Transactions.UnsafeLegacyAnchorOutputsCommitmentFormat) == 14320.sat)
       assert(Transactions.receivedHtlcTrimThreshold(dustLimit, feerate * 1.25, Transactions.UnsafeLegacyAnchorOutputsCommitmentFormat) == 18650.sat)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
@@ -68,7 +68,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
     val tx = Transaction(version = 2, Nil, TxOut(amount, addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, walletAddress).toOption.get) :: Nil, lockTime = 0)
     val client = makeBitcoinCoreClient()
     val f = for {
-      funded <- client.fundTransaction(tx, FeeratePerKw(FeeratePerByte(10.sat)))
+      funded <- client.fundTransaction(tx, FeeratePerByte(10.sat).perKw)
       signed <- client.signPsbt(new Psbt(funded.tx), funded.tx.txIn.indices, Nil)
       txid <- client.publishTransaction(signed.finalTx_opt.toOption.get)
     } yield txid
@@ -2188,7 +2188,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       // Bob's available utxo is unconfirmed.
       val probe = TestProbe()
       walletB.getP2wpkhPubkey().pipeTo(probe.ref)
-      walletB.sendToPubkeyScript(Script.write(Script.pay2wpkh(probe.expectMsgType[PublicKey])), 75_000 sat, FeeratePerKw(FeeratePerByte(1.sat))).pipeTo(probe.ref)
+      walletB.sendToPubkeyScript(Script.write(Script.pay2wpkh(probe.expectMsgType[PublicKey])), 75_000 sat, FeeratePerByte(1.sat).perKw).pipeTo(probe.ref)
       probe.expectMsgType[TxId]
 
       alice ! Start(alice2bob.ref)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -2458,7 +2458,7 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     assert(initialState.commitments.latest.localCommit.spec.commitTxFeerate == TestConstants.anchorOutputsFeeratePerKw)
     val add = UpdateAddHtlc(ByteVector32.Zeroes, 0, 2500000 msat, randomBytes32(), CltvExpiryDelta(144).toCltvExpiry(currentBlockHeight), TestConstants.emptyOnionPacket, None, Reputation.maxEndorsement, None)
     alice2bob.send(bob, add)
-    val fee = UpdateFee(initialState.channelId, FeeratePerKw(FeeratePerByte(2 sat)))
+    val fee = UpdateFee(initialState.channelId, FeeratePerByte(2 sat).perKw)
     alice2bob.send(bob, fee)
     awaitCond(bob.stateData == initialState
       .modify(_.commitments.changes.remoteChanges.proposed).using(_ :+ add :+ fee)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version4/ChannelCodecs4Spec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/internal/channel/version4/ChannelCodecs4Spec.scala
@@ -111,7 +111,7 @@ class ChannelCodecs4Spec extends AnyFunSuite {
         remoteFundingPubKey = PrivateKey(ByteVector.fromValidHex("01" * 32)).publicKey,
         localOutputs = Nil,
         commitmentFormat = ZeroFeeHtlcTxAnchorOutputsCommitmentFormat,
-        lockTime = 0, dustLimit = 330.sat, targetFeerate = FeeratePerKw(FeeratePerByte(3.sat)), requireConfirmedInputs = RequireConfirmedInputs(forLocal = false, forRemote = false)),
+        lockTime = 0, dustLimit = 330.sat, targetFeerate = FeeratePerByte(3.sat).perKw, requireConfirmedInputs = RequireConfirmedInputs(forLocal = false, forRemote = false)),
       liquidityPurchase_opt = None
     )
     assert(decoded == dualFundedUnconfirmedFundingTx)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/LiquidityAdsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/LiquidityAdsSpec.scala
@@ -31,11 +31,11 @@ class LiquidityAdsSpec extends AnyFunSuite {
     assert(nodeKey.publicKey == PublicKey(hex"03ca9b880627d2d4e3b33164f66946349f820d26aa9572fe0e525e534850cbd413"))
 
     val fundingRate = LiquidityAds.FundingRate(100_000 sat, 1_000_000 sat, 500, 100, 10 sat, 1000 sat)
-    assert(fundingRate.fees(FeeratePerKw(FeeratePerByte(5 sat)), 500_000 sat, 500_000 sat, isChannelCreation = false).total == 5635.sat)
-    assert(fundingRate.fees(FeeratePerKw(FeeratePerByte(5 sat)), 500_000 sat, 600_000 sat, isChannelCreation = false).total == 5635.sat)
-    assert(fundingRate.fees(FeeratePerKw(FeeratePerByte(5 sat)), 500_000 sat, 600_000 sat, isChannelCreation = true).total == 6635.sat)
-    assert(fundingRate.fees(FeeratePerKw(FeeratePerByte(5 sat)), 500_000 sat, 400_000 sat, isChannelCreation = false).total == 4635.sat)
-    assert(fundingRate.fees(FeeratePerKw(FeeratePerByte(10 sat)), 500_000 sat, 500_000 sat, isChannelCreation = false).total == 6260.sat)
+    assert(fundingRate.fees(FeeratePerByte(5 sat).perKw, 500_000 sat, 500_000 sat, isChannelCreation = false).total == 5635.sat)
+    assert(fundingRate.fees(FeeratePerByte(5 sat).perKw, 500_000 sat, 600_000 sat, isChannelCreation = false).total == 5635.sat)
+    assert(fundingRate.fees(FeeratePerByte(5 sat).perKw, 500_000 sat, 600_000 sat, isChannelCreation = true).total == 6635.sat)
+    assert(fundingRate.fees(FeeratePerByte(5 sat).perKw, 500_000 sat, 400_000 sat, isChannelCreation = false).total == 4635.sat)
+    assert(fundingRate.fees(FeeratePerByte(10 sat).perKw, 500_000 sat, 500_000 sat, isChannelCreation = false).total == 6260.sat)
 
     val fundingRates = LiquidityAds.WillFundRates(fundingRate :: Nil, Set(LiquidityAds.PaymentType.FromChannelBalance))
     val Some(request) = LiquidityAds.requestFunding(500_000 sat, LiquidityAds.PaymentDetails.FromChannelBalance, fundingRates)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Channel.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Channel.scala
@@ -74,7 +74,7 @@ trait Channel {
 
   val rbfOpen: Route = postRequest("rbfopen") { implicit f =>
     formFields(channelIdFormParam, "targetFeerateSatByte".as[FeeratePerByte], "fundingFeeBudgetSatoshis".as[Satoshi], "lockTime".as[Long].?) {
-      (channelId, targetFeerateSatByte, fundingFeeBudget, lockTime_opt) => complete(eclairApi.rbfOpen(channelId, FeeratePerKw(targetFeerateSatByte), fundingFeeBudget, lockTime_opt))
+      (channelId, targetFeerateSatByte, fundingFeeBudget, lockTime_opt) => complete(eclairApi.rbfOpen(channelId, targetFeerateSatByte.perKw, fundingFeeBudget, lockTime_opt))
     }
   }
 
@@ -95,7 +95,7 @@ trait Channel {
 
   val rbfSplice: Route = postRequest("rbfsplice") { implicit f =>
     formFields(channelIdFormParam, "targetFeerateSatByte".as[FeeratePerByte], "fundingFeeBudgetSatoshis".as[Satoshi], "lockTime".as[Long].?) {
-      (channelId, targetFeerateSatByte, fundingFeeBudget, lockTime_opt) => complete(eclairApi.rbfSplice(channelId, FeeratePerKw(targetFeerateSatByte), fundingFeeBudget, lockTime_opt))
+      (channelId, targetFeerateSatByte, fundingFeeBudget, lockTime_opt) => complete(eclairApi.rbfSplice(channelId, targetFeerateSatByte.perKw, fundingFeeBudget, lockTime_opt))
     }
   }
 
@@ -104,9 +104,9 @@ trait Channel {
       formFields("scriptPubKey".as[ByteVector](bytesUnmarshaller).?, "preferredFeerateSatByte".as[FeeratePerByte].?, "minFeerateSatByte".as[FeeratePerByte].?, "maxFeerateSatByte".as[FeeratePerByte].?) {
         (scriptPubKey_opt, preferredFeerate_opt, minFeerate_opt, maxFeerate_opt) =>
           val closingFeerates = preferredFeerate_opt.map(preferredPerByte => {
-            val preferredFeerate = FeeratePerKw(preferredPerByte)
-            val minFeerate = minFeerate_opt.map(feerate => FeeratePerKw(feerate)).getOrElse(preferredFeerate / 2)
-            val maxFeerate = maxFeerate_opt.map(feerate => FeeratePerKw(feerate)).getOrElse(preferredFeerate * 2)
+            val preferredFeerate = preferredPerByte.perKw
+            val minFeerate = minFeerate_opt.map(feerate => feerate.perKw).getOrElse(preferredFeerate / 2)
+            val maxFeerate = maxFeerate_opt.map(feerate => feerate.perKw).getOrElse(preferredFeerate * 2)
             ClosingFeerates(preferredFeerate, minFeerate, maxFeerate)
           })
           if (scriptPubKey_opt.forall(Script.isNativeWitnessScript)) {
@@ -121,7 +121,7 @@ trait Channel {
   val forceClose: Route = postRequest("forceclose") { implicit t =>
     withChannelsIdentifier { channels =>
       formFields("maxClosingFeerateSatByte".as[FeeratePerByte].?) { maxClosingFeerate_opt =>
-        complete(eclairApi.forceClose(channels, maxClosingFeerate_opt.map(FeeratePerKw(_))))
+        complete(eclairApi.forceClose(channels, maxClosingFeerate_opt.map(_.perKw)))
       }
     }
   }

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Control.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Control.scala
@@ -57,7 +57,7 @@ trait Control {
   val spendFromChannelAddressPrep: Route = postRequest("spendfromchanneladdressprep") { implicit t =>
     formFields("t".as[ByteVector32], "o".as[Int], "kp", "fi".as[Int], "address", "f".as[FeeratePerByte]) {
       (txId, outputIndex, keyPath, fundingTxIndex, address, feerate) =>
-        complete(eclairApi.spendFromChannelAddressPrep(OutPoint(TxId(txId), outputIndex), KeyPath(keyPath), fundingTxIndex, address, FeeratePerKw(feerate)))
+        complete(eclairApi.spendFromChannelAddressPrep(OutPoint(TxId(txId), outputIndex), KeyPath(keyPath), fundingTxIndex, address, feerate.perKw))
     }
   }
 


### PR DESCRIPTION
It saves tedious double parentheses, especially in tests: `FeeratePerKw(FeeratePerByte(1 sat))` -> `FeeratePerByte(1 sat).perKw`.

Just a scratch that was hitching for a long time.