### PR TITLE
Catch close commands in `Offline(WaitForDualFundingSigned)`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -2862,14 +2862,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
       val error = ChannelUnavailable(d.channelId)
       handleAddHtlcCommandError(c, error, None) // we don't provide a channel_update: this will be a permanent channel failure
 
-    case Event(c: CMD_CLOSE, d) =>
-        d match {
-          case data: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED =>
-            rollbackFundingAttempt(data.signingSession.fundingTx.tx, Nil)
-            handleFastClose(c, d.channelId)
-          case _ =>
-            handleCommandError(CommandUnavailableInThisState(d.channelId, "close", stateName), c)
-        }
+    case Event(c: CMD_CLOSE, d) => handleCommandError(CommandUnavailableInThisState(d.channelId, "close", stateName), c)
 
     case Event(c: CMD_FORCECLOSE, d) =>
       d match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -2536,6 +2536,10 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
 
     case Event(c: CMD_UPDATE_RELAY_FEE, d: DATA_NORMAL) => handleUpdateRelayFeeDisconnected(c, d)
 
+    case Event(c: CloseCommand, d: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED) =>
+      rollbackFundingAttempt(d.signingSession.fundingTx.tx, Nil)
+      handleFastClose(c, d.channelId)
+
     case Event(getTxResponse: GetTxWithMetaResponse, d: DATA_WAIT_FOR_FUNDING_CONFIRMED) if getTxResponse.txid == d.commitments.latest.fundingTxId => handleGetFundingTx(getTxResponse, d.waitingSince, d.fundingTx_opt)
 
     case Event(BITCOIN_FUNDING_PUBLISH_FAILED, d: DATA_WAIT_FOR_FUNDING_CONFIRMED) => handleFundingPublishFailed(d)
@@ -2765,6 +2769,10 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
     case Event(_: CMD_UPDATE_FEE, _) => stay()
 
     case Event(c: CMD_UPDATE_RELAY_FEE, d: DATA_NORMAL) => handleUpdateRelayFeeDisconnected(c, d)
+
+    case Event(c: CloseCommand, d: DATA_WAIT_FOR_DUAL_FUNDING_SIGNED) =>
+      rollbackFundingAttempt(d.signingSession.fundingTx.tx, Nil)
+      handleFastClose(c, d.channelId) sending Error(d.channelId, DualFundingAborted(d.channelId).getMessage)
 
     case Event(channelReestablish: ChannelReestablish, d: DATA_SHUTDOWN) =>
       Helpers.Syncing.checkCommitNonces(channelReestablish, d.commitments, None) match {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForDualFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForDualFundingSignedStateSpec.scala
@@ -364,7 +364,7 @@ class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAny
     awaitCond(bob.stateName == CLOSED)
   }
 
-  test("recv CMD_CLOSE (offline)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
+  test("recv CMD_FORCECLOSE (offline)", Tag(ChannelStateTestsTags.DualFunding)) { f =>
     import f._
 
     alice ! INPUT_DISCONNECTED
@@ -374,7 +374,7 @@ class WaitForDualFundingSignedStateSpec extends TestKitBaseClass with FixtureAny
 
     val finalChannelId = channelId(alice)
     val sender = TestProbe()
-    val c = CMD_CLOSE(sender.ref, None, None)
+    val c = CMD_FORCECLOSE(sender.ref)
 
     alice ! c
     sender.expectMsg(RES_SUCCESS(c, finalChannelId))


### PR DESCRIPTION
They were previously ignored because we don't yet have a commitment.