### PR TITLE
Fix comparison of utxos in the balance

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/BalanceActor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/BalanceActor.scala
@@ -106,10 +106,10 @@ private class BalanceActor(context: ActorContext[Command],
             case Some(previousBalance) =>
               // On-chain metrics:
               log.info("on-chain diff={}", balance.onChain.total - previousBalance.onChain.total)
-              val utxosBefore = previousBalance.onChain.utxos.toSet
-              val utxosAfter = balance.onChain.utxos.toSet
-              val utxosAdded = utxosAfter -- utxosBefore
-              val utxosRemoved = utxosBefore -- utxosAfter
+              val utxosBefore = previousBalance.onChain.utxos.map(utxo => utxo.outPoint -> utxo).toMap
+              val utxosAfter = balance.onChain.utxos.map(utxo => utxo.outPoint -> utxo).toMap
+              val utxosAdded = (utxosAfter -- utxosBefore.keys).values
+              val utxosRemoved = (utxosBefore -- utxosAfter.keys).values
               utxosAdded
                 .toList.sortBy(_.amount)
                 .foreach(utxo => log.info("+ utxo={} amount={}", utxo.outPoint, utxo.amount))


### PR DESCRIPTION
The `Utxo` case class has many fields, for comparison we must use the `outPoint`.