### PR TITLE
Relax taproot feature dependency

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Features.scala
@@ -416,7 +416,6 @@ object Features {
     KeySend -> (VariableLengthOnion :: Nil),
     SimpleClose -> (ShutdownAnySegwit :: Nil),
     SimpleTaprootChannelsPhoenix -> (ChannelType :: SimpleClose :: Nil),
-    SimpleTaprootChannelsStaging -> (ChannelType :: SimpleClose :: Nil),
     AsyncPaymentPrototype -> (TrampolinePaymentPrototype :: Nil),
     OnTheFlyFunding -> (SplicePrototype :: Nil),
     FundingFeeCredit -> (OnTheFlyFunding :: Nil)


### PR DESCRIPTION
It appears that `lnd` nodes don't set `option_simple_close` when setting `taproot_staging`, which creates disconnection issues.

We will enforce this for the official taproot feature bit, but we should relax it for the staging bit.