### PR TITLE
Increase timeout for flaky onion message tests

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -248,7 +248,7 @@ object TestConstants {
       onionMessageConfig = OnionMessageConfig(
         relayPolicy = RelayAll,
         minIntermediateHops = 9,
-        timeout = 200 millis,
+        timeout = 40 seconds,
         maxAttempts = 2,
       ),
       purgeInvoicesInterval = None,
@@ -439,7 +439,7 @@ object TestConstants {
       onionMessageConfig = OnionMessageConfig(
         relayPolicy = RelayAll,
         minIntermediateHops = 8,
-        timeout = 100 millis,
+        timeout = 30 seconds,
         maxAttempts = 2,
       ),
       purgeInvoicesInterval = None,


### PR DESCRIPTION
The previous timeout of 100ms was creating a lot of tests failures.