### PR TITLE
Migrate closed channels to a dedicated DB table

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -11,6 +11,15 @@
 We remove the code used to deserialize channel data from versions of eclair prior to v0.13.
 Node operators running a version of `eclair` older than v0.13 must first upgrade to v0.13 to migrate their channel data, and then upgrade to the latest version.
 
+### Move closed channels to dedicated database table
+
+We previously kept closed channels in the same database table as active channels, with a flag indicating that it was closed.
+This creates performance issues for nodes with a large history of channels, and creates backwards-compatibility issues when changing the channel data format.
+
+We now store closed channels in a dedicated table, where we only keep relevant information regarding the channel.
+When restarting your node, the channels table will automatically be cleaned up and closed channels will move to the new table.
+This may take some time depending on your channels history, but will only happen once.
+
 ### Update minimal version of Bitcoin Core
 
 With this release, eclair requires using Bitcoin Core 29.1.
@@ -22,7 +31,7 @@ Newer versions of Bitcoin Core may be used, but have not been extensively tested
 
 ### API changes
 
-<insert changes>
+- the `closedchannels` API now returns human-readable channel data
 
 ### Miscellaneous improvements and bug fixes
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -47,7 +47,6 @@ import fr.acinq.eclair.payment.send.PaymentInitiator._
 import fr.acinq.eclair.payment.send.{ClearRecipient, OfferPayment, PaymentIdentifier}
 import fr.acinq.eclair.router.Router
 import fr.acinq.eclair.router.Router._
-import fr.acinq.eclair.transactions.Transactions.CommitmentFormat
 import fr.acinq.eclair.wire.protocol.OfferTypes.Offer
 import fr.acinq.eclair.wire.protocol._
 import grizzled.slf4j.Logging
@@ -117,7 +116,7 @@ trait Eclair {
 
   def channelInfo(channel: ApiTypes.ChannelIdentifier)(implicit timeout: Timeout): Future[CommandResponse[CMD_GET_CHANNEL_INFO]]
 
-  def closedChannels(nodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated])(implicit timeout: Timeout): Future[Iterable[RES_GET_CHANNEL_INFO]]
+  def closedChannels(nodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated])(implicit timeout: Timeout): Future[Iterable[DATA_CLOSED]]
 
   def peers()(implicit timeout: Timeout): Future[Iterable[PeerInfo]]
 
@@ -348,11 +347,9 @@ class EclairImpl(val appKit: Kit) extends Eclair with Logging with SpendFromChan
     sendToChannelTyped(channel = channel, cmdBuilder = CMD_GET_CHANNEL_INFO(_))
   }
 
-  override def closedChannels(nodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated])(implicit timeout: Timeout): Future[Iterable[RES_GET_CHANNEL_INFO]] = {
+  override def closedChannels(nodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated])(implicit timeout: Timeout): Future[Iterable[DATA_CLOSED]] = {
     Future {
-      appKit.nodeParams.db.channels.listClosedChannels(nodeId_opt, paginated_opt).map { data =>
-        RES_GET_CHANNEL_INFO(nodeId = data.remoteNodeId, channelId = data.channelId, channel = ActorRef.noSender, state = CLOSED, data = data)
-      }
+      appKit.nodeParams.db.channels.listClosedChannels(nodeId_opt, paginated_opt)
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
@@ -163,7 +163,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
 
     case Event(e: Error, d: DATA_WAIT_FOR_OPEN_CHANNEL) => handleRemoteError(e, d)
 
-    case Event(INPUT_DISCONNECTED, _) => goto(CLOSED)
+    case Event(INPUT_DISCONNECTED, d: DATA_WAIT_FOR_OPEN_CHANNEL) => goto(CLOSED) using IgnoreClosedData(d)
   })
 
   when(WAIT_FOR_ACCEPT_CHANNEL)(handleExceptions {
@@ -203,11 +203,11 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
 
     case Event(INPUT_DISCONNECTED, d: DATA_WAIT_FOR_ACCEPT_CHANNEL) =>
       d.initFunder.replyTo ! OpenChannelResponse.Disconnected
-      goto(CLOSED)
+      goto(CLOSED) using IgnoreClosedData(d)
 
     case Event(TickChannelOpenTimeout, d: DATA_WAIT_FOR_ACCEPT_CHANNEL) =>
       d.initFunder.replyTo ! OpenChannelResponse.TimedOut
-      goto(CLOSED)
+      goto(CLOSED) using IgnoreClosedData(d)
   })
 
   when(WAIT_FOR_FUNDING_INTERNAL)(handleExceptions {
@@ -264,11 +264,11 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
 
     case Event(INPUT_DISCONNECTED, d: DATA_WAIT_FOR_FUNDING_INTERNAL) =>
       d.replyTo ! OpenChannelResponse.Disconnected
-      goto(CLOSED)
+      goto(CLOSED) using IgnoreClosedData(d)
 
     case Event(TickChannelOpenTimeout, d: DATA_WAIT_FOR_FUNDING_INTERNAL) =>
       d.replyTo ! OpenChannelResponse.TimedOut
-      goto(CLOSED)
+      goto(CLOSED) using IgnoreClosedData(d)
   })
 
   when(WAIT_FOR_FUNDING_CREATED)(handleExceptions {
@@ -346,7 +346,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
 
     case Event(e: Error, d: DATA_WAIT_FOR_FUNDING_CREATED) => handleRemoteError(e, d)
 
-    case Event(INPUT_DISCONNECTED, _) => goto(CLOSED)
+    case Event(INPUT_DISCONNECTED, d: DATA_WAIT_FOR_FUNDING_CREATED) => goto(CLOSED) using IgnoreClosedData(d)
   })
 
   when(WAIT_FOR_FUNDING_SIGNED)(handleExceptions {
@@ -414,13 +414,13 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
       // we rollback the funding tx, it will never be published
       wallet.rollback(d.fundingTx)
       d.replyTo ! OpenChannelResponse.Disconnected
-      goto(CLOSED)
+      goto(CLOSED) using IgnoreClosedData(d)
 
     case Event(TickChannelOpenTimeout, d: DATA_WAIT_FOR_FUNDING_SIGNED) =>
       // we rollback the funding tx, it will never be published
       wallet.rollback(d.fundingTx)
       d.replyTo ! OpenChannelResponse.TimedOut
-      goto(CLOSED)
+      goto(CLOSED) using IgnoreClosedData(d)
   })
 
   when(WAIT_FOR_FUNDING_CONFIRMED)(handleExceptions {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonHandlers.scala
@@ -59,7 +59,7 @@ trait CommonHandlers {
           nodeParams.db.channels.addOrUpdateChannel(d)
           context.system.eventStream.publish(ChannelPersisted(self, remoteNodeId, d.channelId, d))
           state
-        case _: TransientChannelData =>
+        case _: TransientChannelData | _: ClosedData =>
           log.error(s"can't store data=${state.stateData} in state=${state.stateName}")
           state
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/DualFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/DualFundingHandlers.scala
@@ -110,7 +110,7 @@ trait DualFundingHandlers extends CommonFundingHandlers {
     if (fundingTxIds.subsetOf(e.fundingTxIds)) {
       log.warning("{} funding attempts have been double-spent, forgetting channel", fundingTxIds.size)
       d.allFundingTxs.map(_.sharedTx.tx.buildUnsignedTx()).foreach(tx => wallet.rollback(tx))
-      goto(CLOSED) sending Error(d.channelId, FundingTxDoubleSpent(d.channelId).getMessage)
+      goto(CLOSED) using IgnoreClosedData(d) sending Error(d.channelId, FundingTxDoubleSpent(d.channelId).getMessage)
     } else {
       // Not all funding attempts have been double-spent, the channel may still confirm.
       // For example, we may have published an RBF attempt while we were checking if funding attempts were double-spent.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/ChannelsDb.scala
@@ -18,7 +18,7 @@ package fr.acinq.eclair.db
 
 import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.eclair.channel.PersistentChannelData
+import fr.acinq.eclair.channel.{DATA_CLOSED, PersistentChannelData}
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.{CltvExpiry, Paginated}
 
@@ -30,8 +30,13 @@ trait ChannelsDb {
 
   def updateChannelMeta(channelId: ByteVector32, event: ChannelEvent.EventType): Unit
 
-  /** Mark a channel as closed, but keep it in the DB. */
-  def removeChannel(channelId: ByteVector32): Unit
+  /**
+   * Remove a channel from our DB.
+   *
+   * @param channelId ID of the channel that should be removed.
+   * @param data_opt  if provided, closing data will be stored in a dedicated table.
+   */
+  def removeChannel(channelId: ByteVector32, data_opt: Option[DATA_CLOSED]): Unit
 
   /** Mark revoked HTLC information as obsolete. It will be removed from the DB once [[removeHtlcInfos]] is called. */
   def markHtlcInfosForRemoval(channelId: ByteVector32, beforeCommitIndex: Long): Unit
@@ -41,9 +46,10 @@ trait ChannelsDb {
 
   def listLocalChannels(): Seq[PersistentChannelData]
 
-  def listClosedChannels(remoteNodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated]): Seq[PersistentChannelData]
+  def listClosedChannels(remoteNodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated]): Seq[DATA_CLOSED]
 
   def addHtlcInfo(channelId: ByteVector32, commitmentNumber: Long, paymentHash: ByteVector32, cltvExpiry: CltvExpiry): Unit
 
   def listHtlcInfos(channelId: ByteVector32, commitmentNumber: Long): Seq[(ByteVector32, CltvExpiry)]
+
 }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/Databases.scala
@@ -214,9 +214,8 @@ object Databases extends Logging {
               maxAge = initChecks.localChannelsMaxAge,
               sqlQuery =
                 """
-                  |SELECT MAX(GREATEST(created_timestamp, last_payment_sent_timestamp, last_payment_received_timestamp, last_connected_timestamp, closed_timestamp))
-                  |FROM local.channels
-                  |WHERE NOT is_closed""".stripMargin)
+                  |SELECT MAX(GREATEST(created_timestamp, last_payment_sent_timestamp, last_payment_received_timestamp, last_connected_timestamp))
+                  |FROM local.channels""".stripMargin)
 
             checkMaxAge(name = "network node",
               maxAge = initChecks.networkNodesMaxAge,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgChannelsDb.scala
@@ -17,26 +17,26 @@
 package fr.acinq.eclair.db.pg
 
 import com.zaxxer.hikari.util.IsolationLevel
-import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.eclair.channel.PersistentChannelData
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, TxId}
+import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.ChannelsDb
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db.Monitoring.Tags.DbBackends
 import fr.acinq.eclair.db.pg.PgUtils.PgLock
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecs.channelDataCodec
-import fr.acinq.eclair.{CltvExpiry, Paginated}
+import fr.acinq.eclair.{CltvExpiry, MilliSatoshi, Paginated}
 import grizzled.slf4j.Logging
 import scodec.bits.BitVector
 
-import java.sql.{Connection, Timestamp}
+import java.sql.{Connection, Statement, Timestamp}
 import java.time.Instant
 import javax.sql.DataSource
 
 object PgChannelsDb {
   val DB_NAME = "channels"
-  val CURRENT_VERSION = 11
+  val CURRENT_VERSION = 12
 }
 
 class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb with Logging {
@@ -49,12 +49,95 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
 
   inTransaction { pg =>
     using(pg.createStatement()) { statement =>
+      /**
+       * Before version 12, closed channels were directly kept in the local_channels table with an is_closed flag set to true.
+       * We move them to a dedicated table, where we keep minimal channel information.
+       */
+      def migration1112(statement: Statement): Unit = {
+        // We start by dropping for foreign key constraint on htlc_infos, otherwise we won't be able to move recently
+        // closed channels to a different table.
+        statement.executeQuery("SELECT conname FROM pg_catalog.pg_constraint WHERE contype = 'f'").map(rs => rs.getString("conname")).headOption match {
+          case Some(foreignKeyConstraint) => statement.executeUpdate(s"ALTER TABLE local.htlc_infos DROP CONSTRAINT $foreignKeyConstraint")
+          case None => logger.warn("couldn't find foreign key constraint for htlc_infos table: DB migration may fail")
+        }
+        // We can now move closed channels to a dedicated table.
+        statement.executeUpdate("CREATE TABLE local.channels_closed (channel_id TEXT NOT NULL PRIMARY KEY, remote_node_id TEXT NOT NULL, funding_txid TEXT NOT NULL, funding_output_index BIGINT NOT NULL, funding_tx_index BIGINT NOT NULL, funding_key_path TEXT NOT NULL, channel_features TEXT NOT NULL, is_channel_opener BOOLEAN NOT NULL, commitment_format TEXT NOT NULL, announced BOOLEAN NOT NULL, capacity_satoshis BIGINT NOT NULL, closing_txid TEXT NOT NULL, closing_type TEXT NOT NULL, closing_script TEXT NOT NULL, local_balance_msat BIGINT NOT NULL, remote_balance_msat BIGINT NOT NULL, closing_amount_satoshis BIGINT NOT NULL, created_at TIMESTAMP WITH TIME ZONE NOT NULL, closed_at TIMESTAMP WITH TIME ZONE NOT NULL)")
+        statement.executeUpdate("CREATE INDEX channels_closed_remote_node_id_idx ON local.channels_closed(remote_node_id)")
+        // We migrate closed channels from the local_channels table to the new channels_closed table, whenever possible.
+        val insertStatement = pg.prepareStatement("INSERT INTO local.channels_closed VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        val batchSize = 50
+        using(pg.prepareStatement("SELECT channel_id, data, is_closed, created_timestamp, closed_timestamp FROM local.channels WHERE is_closed=TRUE")) { queryStatement =>
+          val rs = queryStatement.executeQuery()
+          var inserted = 0
+          var batchCount = 0
+          while (rs.next()) {
+            val channelId = rs.getByteVector32FromHex("channel_id")
+            val data_opt = channelDataCodec.decode(BitVector(rs.getBytes("data"))).require.value match {
+              case d: DATA_NEGOTIATING_SIMPLE =>
+                // We didn't store which closing transaction actually confirmed, so we select the most likely one.
+                // The simple_close feature wasn't widely supported before this migration, so this shouldn't affect a lot of channels.
+                val closingTx = d.publishedClosingTxs.lastOption.getOrElse(d.proposedClosingTxs.last.preferred_opt.get)
+                Some(DATA_CLOSED(d, closingTx))
+              case d: DATA_CLOSING =>
+                Helpers.Closing.isClosingTypeAlreadyKnown(d) match {
+                  case Some(closingType) => Some(DATA_CLOSED(d, closingType))
+                  // If the closing type cannot be inferred from the stored data, it must be a mutual close.
+                  // In that case, we didn't store which closing transaction actually confirmed, so we select the most likely one.
+                  case None if d.mutualClosePublished.nonEmpty => Some(DATA_CLOSED(d, Helpers.Closing.MutualClose(d.mutualClosePublished.last)))
+                  case None =>
+                    logger.warn(s"cannot move channel_id=$channelId to the channels_closed table, unknown closing_type")
+                    None
+                }
+              case d =>
+                logger.warn(s"cannot move channel_id=$channelId to the channels_closed table (state=${d.getClass.getSimpleName})")
+                None
+            }
+            data_opt match {
+              case Some(data) =>
+                insertStatement.setString(1, channelId.toHex)
+                insertStatement.setString(2, data.remoteNodeId.toHex)
+                insertStatement.setString(3, data.fundingTxId.value.toHex)
+                insertStatement.setLong(4, data.fundingOutputIndex)
+                insertStatement.setLong(5, data.fundingTxIndex)
+                insertStatement.setString(6, data.fundingKeyPath)
+                insertStatement.setString(7, data.channelFeatures)
+                insertStatement.setBoolean(8, data.isChannelOpener)
+                insertStatement.setString(9, data.commitmentFormat)
+                insertStatement.setBoolean(10, data.announced)
+                insertStatement.setLong(11, data.capacity.toLong)
+                insertStatement.setString(12, data.closingTxId.value.toHex)
+                insertStatement.setString(13, data.closingType)
+                insertStatement.setString(14, data.closingScript.toHex)
+                insertStatement.setLong(15, data.localBalance.toLong)
+                insertStatement.setLong(16, data.remoteBalance.toLong)
+                insertStatement.setLong(17, data.closingAmount.toLong)
+                insertStatement.setTimestamp(18, rs.getTimestampNullable("created_timestamp").getOrElse(Timestamp.from(Instant.ofEpochMilli(0))))
+                insertStatement.setTimestamp(19, rs.getTimestampNullable("closed_timestamp").getOrElse(Timestamp.from(Instant.ofEpochMilli(0))))
+                insertStatement.addBatch()
+                batchCount = batchCount + 1
+                if (batchCount % batchSize == 0) {
+                  inserted = inserted + insertStatement.executeBatch().sum
+                  batchCount = 0
+                }
+              case None => ()
+            }
+          }
+          inserted = inserted + insertStatement.executeBatch().sum
+          logger.info(s"moved $inserted channels to the channels_closed table")
+        }
+        // We can now clean-up the active channels table.
+        statement.executeUpdate("DELETE FROM local.channels WHERE is_closed=TRUE")
+        statement.executeUpdate("ALTER TABLE local.channels DROP COLUMN is_closed")
+        statement.executeUpdate("ALTER TABLE local.channels DROP COLUMN closed_timestamp")
+      }
+
       getVersion(statement, DB_NAME) match {
         case None =>
           statement.executeUpdate("CREATE SCHEMA IF NOT EXISTS local")
 
-          statement.executeUpdate("CREATE TABLE local.channels (channel_id TEXT NOT NULL PRIMARY KEY, remote_node_id TEXT NOT NULL, data BYTEA NOT NULL, json JSONB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT FALSE, created_timestamp TIMESTAMP WITH TIME ZONE, last_payment_sent_timestamp TIMESTAMP WITH TIME ZONE, last_payment_received_timestamp TIMESTAMP WITH TIME ZONE, last_connected_timestamp TIMESTAMP WITH TIME ZONE, closed_timestamp TIMESTAMP WITH TIME ZONE)")
-          statement.executeUpdate("CREATE TABLE local.htlc_infos (channel_id TEXT NOT NULL, commitment_number BIGINT NOT NULL, payment_hash TEXT NOT NULL, cltv_expiry BIGINT NOT NULL, FOREIGN KEY(channel_id) REFERENCES local.channels(channel_id))")
+          statement.executeUpdate("CREATE TABLE local.channels (channel_id TEXT NOT NULL PRIMARY KEY, remote_node_id TEXT NOT NULL, data BYTEA NOT NULL, json JSONB NOT NULL, created_timestamp TIMESTAMP WITH TIME ZONE, last_payment_sent_timestamp TIMESTAMP WITH TIME ZONE, last_payment_received_timestamp TIMESTAMP WITH TIME ZONE, last_connected_timestamp TIMESTAMP WITH TIME ZONE)")
+          statement.executeUpdate("CREATE TABLE local.channels_closed (channel_id TEXT NOT NULL PRIMARY KEY, remote_node_id TEXT NOT NULL, funding_txid TEXT NOT NULL, funding_output_index BIGINT NOT NULL, funding_tx_index BIGINT NOT NULL, funding_key_path TEXT NOT NULL, channel_features TEXT NOT NULL, is_channel_opener BOOLEAN NOT NULL, commitment_format TEXT NOT NULL, announced BOOLEAN NOT NULL, capacity_satoshis BIGINT NOT NULL, closing_txid TEXT NOT NULL, closing_type TEXT NOT NULL, closing_script TEXT NOT NULL, local_balance_msat BIGINT NOT NULL, remote_balance_msat BIGINT NOT NULL, closing_amount_satoshis BIGINT NOT NULL, created_at TIMESTAMP WITH TIME ZONE NOT NULL, closed_at TIMESTAMP WITH TIME ZONE NOT NULL)")
+          statement.executeUpdate("CREATE TABLE local.htlc_infos (channel_id TEXT NOT NULL, commitment_number BIGINT NOT NULL, payment_hash TEXT NOT NULL, cltv_expiry BIGINT NOT NULL)")
           statement.executeUpdate("CREATE TABLE local.htlc_infos_to_remove (channel_id TEXT NOT NULL PRIMARY KEY, before_commitment_number BIGINT NOT NULL)")
 
           statement.executeUpdate("CREATE INDEX local_channels_type_idx ON local.channels ((json->>'type'))")
@@ -63,7 +146,11 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
           // This is more efficient because we're writing a lot to this table but only reading when a channel is force-closed.
           statement.executeUpdate("CREATE INDEX htlc_infos_channel_id_idx ON local.htlc_infos(channel_id)")
           statement.executeUpdate("CREATE INDEX htlc_infos_commitment_number_idx ON local.htlc_infos(commitment_number)")
+          statement.executeUpdate("CREATE INDEX channels_closed_remote_node_id_idx ON local.channels_closed(remote_node_id)")
         case Some(v) if v < 11 => throw new RuntimeException("You are updating from a version of eclair older than v0.13: please update to the v0.13 release first to migrate your channel data, and afterwards you'll be able to update to the latest version.")
+        case Some(v@11) =>
+          logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
+          if (v < 12) migration1112(statement)
         case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
         case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
       }
@@ -91,8 +178,8 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
       val encoded = channelDataCodec.encode(data).require.toByteArray
       using(pg.prepareStatement(
         """
-          | INSERT INTO local.channels (channel_id, remote_node_id, data, json, created_timestamp, last_connected_timestamp, is_closed)
-          | VALUES (?, ?, ?, ?::JSONB, ?, ?, FALSE)
+          | INSERT INTO local.channels (channel_id, remote_node_id, data, json, created_timestamp, last_connected_timestamp)
+          | VALUES (?, ?, ?, ?::JSONB, ?, ?)
           | ON CONFLICT (channel_id)
           | DO UPDATE SET data = EXCLUDED.data, json = EXCLUDED.json ;
           | """.stripMargin)) { statement =>
@@ -109,7 +196,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
 
   override def getChannel(channelId: ByteVector32): Option[PersistentChannelData] = withMetrics("channels/get-channel", DbBackends.Postgres) {
     withLock { pg =>
-      using(pg.prepareStatement("SELECT data FROM local.channels WHERE channel_id=? AND is_closed=FALSE")) { statement =>
+      using(pg.prepareStatement("SELECT data FROM local.channels WHERE channel_id=?")) { statement =>
         statement.setString(1, channelId.toHex)
         statement.executeQuery.mapCodec(channelDataCodec).lastOption
       }
@@ -137,7 +224,7 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
     timestampColumn_opt.foreach(updateChannelMetaTimestampColumn(channelId, _))
   }
 
-  override def removeChannel(channelId: ByteVector32): Unit = withMetrics("channels/remove-channel", DbBackends.Postgres) {
+  override def removeChannel(channelId: ByteVector32, data_opt: Option[DATA_CLOSED]): Unit = withMetrics("channels/remove-channel", DbBackends.Postgres) {
     withLock { pg =>
       using(pg.prepareStatement("DELETE FROM local.pending_settlement_commands WHERE channel_id=?")) { statement =>
         statement.setString(1, channelId.toHex)
@@ -148,9 +235,39 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
       // We instead run an asynchronous job to clean up that data in small batches.
       markHtlcInfosForRemoval(channelId, Long.MaxValue)
 
-      using(pg.prepareStatement("UPDATE local.channels SET is_closed=TRUE, closed_timestamp=? WHERE channel_id=?")) { statement =>
-        statement.setTimestamp(1, Timestamp.from(Instant.now()))
-        statement.setString(2, channelId.toHex)
+      // If we have useful closing data for this channel, we keep it in a dedicated table.
+      data_opt.foreach(data => {
+        val createdAt_opt = using(pg.prepareStatement("SELECT created_timestamp FROM local.channels WHERE channel_id=?")) { statement =>
+          statement.setString(1, channelId.toHex)
+          statement.executeQuery().flatMap(rs => rs.getTimestampNullable("created_timestamp")).headOption
+        }
+        using(pg.prepareStatement("INSERT INTO local.channels_closed VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT DO NOTHING")) { statement =>
+          statement.setString(1, channelId.toHex)
+          statement.setString(2, data.remoteNodeId.toHex)
+          statement.setString(3, data.fundingTxId.value.toHex)
+          statement.setLong(4, data.fundingOutputIndex)
+          statement.setLong(5, data.fundingTxIndex)
+          statement.setString(6, data.fundingKeyPath)
+          statement.setString(7, data.channelFeatures)
+          statement.setBoolean(8, data.isChannelOpener)
+          statement.setString(9, data.commitmentFormat)
+          statement.setBoolean(10, data.announced)
+          statement.setLong(11, data.capacity.toLong)
+          statement.setString(12, data.closingTxId.value.toHex)
+          statement.setString(13, data.closingType)
+          statement.setString(14, data.closingScript.toHex)
+          statement.setLong(15, data.localBalance.toLong)
+          statement.setLong(16, data.remoteBalance.toLong)
+          statement.setLong(17, data.closingAmount.toLong)
+          statement.setTimestamp(18, createdAt_opt.getOrElse(Timestamp.from(Instant.ofEpochMilli(0))))
+          statement.setTimestamp(19, Timestamp.from(Instant.now()))
+          statement.executeUpdate()
+        }
+      })
+
+      // We can now remove this channel from the active channels table.
+      using(pg.prepareStatement("DELETE FROM local.channels WHERE channel_id=?")) { statement =>
+        statement.setString(1, channelId.toHex)
         statement.executeUpdate()
       }
     }
@@ -199,21 +316,40 @@ class PgChannelsDb(implicit ds: DataSource, lock: PgLock) extends ChannelsDb wit
   override def listLocalChannels(): Seq[PersistentChannelData] = withMetrics("channels/list-local-channels", DbBackends.Postgres) {
     withLock { pg =>
       using(pg.createStatement) { statement =>
-        statement.executeQuery("SELECT data FROM local.channels WHERE is_closed=FALSE")
+        statement.executeQuery("SELECT data FROM local.channels")
           .mapCodec(channelDataCodec).toSeq
       }
     }
   }
 
-  override def listClosedChannels(remoteNodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated]): Seq[PersistentChannelData] = withMetrics("channels/list-closed-channels", DbBackends.Postgres) {
+  override def listClosedChannels(remoteNodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated]): Seq[DATA_CLOSED] = withMetrics("channels/list-closed-channels", DbBackends.Postgres) {
     val sql = remoteNodeId_opt match {
-      case None => "SELECT data FROM local.channels WHERE is_closed=TRUE ORDER BY closed_timestamp DESC"
-      case Some(remoteNodeId) => s"SELECT data FROM local.channels WHERE is_closed=TRUE AND remote_node_id = '${remoteNodeId.toHex}' ORDER BY closed_timestamp DESC"
+      case Some(remoteNodeId) => s"SELECT * FROM local.channels_closed WHERE remote_node_id = '${remoteNodeId.toHex}' ORDER BY closed_at DESC"
+      case None => "SELECT * FROM local.channels_closed ORDER BY closed_at DESC"
     }
     withLock { pg =>
       using(pg.prepareStatement(limited(sql, paginated_opt))) { statement =>
-        statement.executeQuery()
-          .mapCodec(channelDataCodec).toSeq
+        statement.executeQuery().map { rs =>
+          DATA_CLOSED(
+            channelId = rs.getByteVector32FromHex("channel_id"),
+            remoteNodeId = PublicKey(rs.getByteVectorFromHex("remote_node_id")),
+            fundingTxId = TxId(rs.getByteVector32FromHex("funding_txid")),
+            fundingOutputIndex = rs.getLong("funding_output_index"),
+            fundingTxIndex = rs.getLong("funding_tx_index"),
+            fundingKeyPath = rs.getString("funding_key_path"),
+            channelFeatures = rs.getString("channel_features"),
+            isChannelOpener = rs.getBoolean("is_channel_opener"),
+            commitmentFormat = rs.getString("commitment_format"),
+            announced = rs.getBoolean("announced"),
+            capacity = Satoshi(rs.getLong("capacity_satoshis")),
+            closingTxId = TxId(rs.getByteVector32FromHex("closing_txid")),
+            closingType = rs.getString("closing_type"),
+            closingScript = rs.getByteVectorFromHex("closing_script"),
+            localBalance = MilliSatoshi(rs.getLong("local_balance_msat")),
+            remoteBalance = MilliSatoshi(rs.getLong("remote_balance_msat")),
+            closingAmount = Satoshi(rs.getLong("closing_amount_satoshis"))
+          )
+        }.toSeq
       }
     }
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPendingCommandsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/pg/PgPendingCommandsDb.scala
@@ -56,7 +56,6 @@ class PgPendingCommandsDb(implicit ds: DataSource, lock: PgLock) extends Pending
       getVersion(statement, DB_NAME) match {
         case None =>
           statement.executeUpdate("CREATE SCHEMA IF NOT EXISTS local")
-          // note: should we use a foreign key to local_channels table here?
           statement.executeUpdate("CREATE TABLE local.pending_settlement_commands (channel_id TEXT NOT NULL, htlc_id BIGINT NOT NULL, data BYTEA NOT NULL, PRIMARY KEY(channel_id, htlc_id))")
         case Some(v@(1 | 2)) =>
           logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqliteChannelsDb.scala
@@ -16,22 +16,23 @@
 
 package fr.acinq.eclair.db.sqlite
 
-import fr.acinq.bitcoin.scalacompat.ByteVector32
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.eclair.channel.PersistentChannelData
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, Satoshi, TxId}
+import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.ChannelsDb
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.db.Monitoring.Metrics.withMetrics
 import fr.acinq.eclair.db.Monitoring.Tags.DbBackends
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecs.channelDataCodec
-import fr.acinq.eclair.{CltvExpiry, Paginated, TimestampMilli}
+import fr.acinq.eclair.{CltvExpiry, MilliSatoshi, Paginated, TimestampMilli}
 import grizzled.slf4j.Logging
+import scodec.bits.BitVector
 
-import java.sql.Connection
+import java.sql.{Connection, Statement}
 
 object SqliteChannelsDb {
   val DB_NAME = "channels"
-  val CURRENT_VERSION = 7
+  val CURRENT_VERSION = 8
 }
 
 class SqliteChannelsDb(val sqlite: Connection) extends ChannelsDb with Logging {
@@ -49,17 +50,106 @@ class SqliteChannelsDb(val sqlite: Connection) extends ChannelsDb with Logging {
     statement.execute("PRAGMA foreign_keys = ON")
   }
 
+  /**
+   * Before version 8, closed channels were directly kept in the local_channels table with an is_closed flag set to true.
+   * We move them to a dedicated table, where we keep minimal channel information.
+   */
+  def migration78(statement: Statement): Unit = {
+    // We start by dropping for foreign key constraint on htlc_infos, otherwise we won't be able to move recently
+    // closed channels to a different table. The only option for that in sqlite is to re-create the table.
+    statement.executeUpdate("ALTER TABLE htlc_infos RENAME TO htlc_infos_old")
+    statement.executeUpdate("CREATE TABLE htlc_infos (channel_id BLOB NOT NULL, commitment_number INTEGER NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL)")
+    statement.executeUpdate("INSERT INTO htlc_infos(channel_id, commitment_number, payment_hash, cltv_expiry) SELECT channel_id, commitment_number, payment_hash, cltv_expiry FROM htlc_infos_old")
+    statement.executeUpdate("DROP TABLE htlc_infos_old")
+    statement.executeUpdate("CREATE INDEX htlc_infos_channel_id_idx ON htlc_infos(channel_id)")
+    statement.executeUpdate("CREATE INDEX htlc_infos_commitment_number_idx ON htlc_infos(commitment_number)")
+    // We can now move closed channels to a dedicated table.
+    statement.executeUpdate("CREATE TABLE local_channels_closed (channel_id TEXT NOT NULL PRIMARY KEY, remote_node_id TEXT NOT NULL, funding_txid TEXT NOT NULL, funding_output_index INTEGER NOT NULL, funding_tx_index INTEGER NOT NULL, funding_key_path TEXT NOT NULL, channel_features TEXT NOT NULL, is_channel_opener BOOLEAN NOT NULL, commitment_format TEXT NOT NULL, announced BOOLEAN NOT NULL, capacity_satoshis INTEGER NOT NULL, closing_txid TEXT NOT NULL, closing_type TEXT NOT NULL, closing_script TEXT NOT NULL, local_balance_msat INTEGER NOT NULL, remote_balance_msat INTEGER NOT NULL, closing_amount_satoshis INTEGER NOT NULL, created_at INTEGER NOT NULL, closed_at INTEGER NOT NULL)")
+    statement.executeUpdate("CREATE INDEX local_channels_closed_remote_node_id_idx ON local_channels_closed(remote_node_id)")
+    // We migrate closed channels from the local_channels table to the new local_channels_closed table, whenever possible.
+    val insertStatement = sqlite.prepareStatement("INSERT INTO local_channels_closed VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+    val batchSize = 50
+    using(sqlite.prepareStatement("SELECT channel_id, data, is_closed, created_timestamp, closed_timestamp FROM local_channels WHERE is_closed=1")) { queryStatement =>
+      val rs = queryStatement.executeQuery()
+      var inserted = 0
+      var batchCount = 0
+      while (rs.next()) {
+        val channelId = rs.getByteVector32("channel_id")
+        val data_opt = channelDataCodec.decode(BitVector(rs.getBytes("data"))).require.value match {
+          case d: DATA_NEGOTIATING_SIMPLE =>
+            // We didn't store which closing transaction actually confirmed, so we select the most likely one.
+            // The simple_close feature wasn't widely supported before this migration, so this shouldn't affect a lot of channels.
+            val closingTx = d.publishedClosingTxs.lastOption.getOrElse(d.proposedClosingTxs.last.preferred_opt.get)
+            Some(DATA_CLOSED(d, closingTx))
+          case d: DATA_CLOSING =>
+            Helpers.Closing.isClosingTypeAlreadyKnown(d) match {
+              case Some(closingType) => Some(DATA_CLOSED(d, closingType))
+              // If the closing type cannot be inferred from the stored data, it must be a mutual close.
+              // In that case, we didn't store which closing transaction actually confirmed, so we select the most likely one.
+              case None if d.mutualClosePublished.nonEmpty => Some(DATA_CLOSED(d, Helpers.Closing.MutualClose(d.mutualClosePublished.last)))
+              case None =>
+                logger.warn(s"cannot move channel_id=$channelId to the local_channels_closed table, unknown closing_type")
+                None
+            }
+          case d =>
+            logger.warn(s"cannot move channel_id=$channelId to the local_channels_closed table (state=${d.getClass.getSimpleName})")
+            None
+        }
+        data_opt match {
+          case Some(data) =>
+            insertStatement.setString(1, channelId.toHex)
+            insertStatement.setString(2, data.remoteNodeId.toHex)
+            insertStatement.setString(3, data.fundingTxId.value.toHex)
+            insertStatement.setLong(4, data.fundingOutputIndex)
+            insertStatement.setLong(5, data.fundingTxIndex)
+            insertStatement.setString(6, data.fundingKeyPath)
+            insertStatement.setString(7, data.channelFeatures)
+            insertStatement.setBoolean(8, data.isChannelOpener)
+            insertStatement.setString(9, data.commitmentFormat)
+            insertStatement.setBoolean(10, data.announced)
+            insertStatement.setLong(11, data.capacity.toLong)
+            insertStatement.setString(12, data.closingTxId.value.toHex)
+            insertStatement.setString(13, data.closingType)
+            insertStatement.setString(14, data.closingScript.toHex)
+            insertStatement.setLong(15, data.localBalance.toLong)
+            insertStatement.setLong(16, data.remoteBalance.toLong)
+            insertStatement.setLong(17, data.closingAmount.toLong)
+            insertStatement.setLong(18, rs.getLongNullable("created_timestamp").getOrElse(0))
+            insertStatement.setLong(19, rs.getLongNullable("closed_timestamp").getOrElse(0))
+            insertStatement.addBatch()
+            batchCount = batchCount + 1
+            if (batchCount % batchSize == 0) {
+              inserted = inserted + insertStatement.executeBatch().sum
+              batchCount = 0
+            }
+          case None => ()
+        }
+      }
+      inserted = inserted + insertStatement.executeBatch().sum
+      logger.info(s"moved $inserted channels to the local_channels_closed table")
+    }
+    // We can now clean-up the active channels table.
+    statement.executeUpdate("DELETE FROM local_channels WHERE is_closed=1")
+    statement.executeUpdate("ALTER TABLE local_channels DROP COLUMN is_closed")
+    statement.executeUpdate("ALTER TABLE local_channels DROP COLUMN closed_timestamp")
+  }
+
   using(sqlite.createStatement(), inTransaction = true) { statement =>
     getVersion(statement, DB_NAME) match {
       case None =>
-        statement.executeUpdate("CREATE TABLE local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT 0, created_timestamp INTEGER, last_payment_sent_timestamp INTEGER, last_payment_received_timestamp INTEGER, last_connected_timestamp INTEGER, closed_timestamp INTEGER)")
-        statement.executeUpdate("CREATE TABLE htlc_infos (channel_id BLOB NOT NULL, commitment_number INTEGER NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
+        statement.executeUpdate("CREATE TABLE local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, created_timestamp INTEGER, last_payment_sent_timestamp INTEGER, last_payment_received_timestamp INTEGER, last_connected_timestamp INTEGER)")
+        statement.executeUpdate("CREATE TABLE local_channels_closed (channel_id TEXT NOT NULL PRIMARY KEY, remote_node_id TEXT NOT NULL, funding_txid TEXT NOT NULL, funding_output_index INTEGER NOT NULL, funding_tx_index INTEGER NOT NULL, funding_key_path TEXT NOT NULL, channel_features TEXT NOT NULL, is_channel_opener BOOLEAN NOT NULL, commitment_format TEXT NOT NULL, announced BOOLEAN NOT NULL, capacity_satoshis INTEGER NOT NULL, closing_txid TEXT NOT NULL, closing_type TEXT NOT NULL, closing_script TEXT NOT NULL, local_balance_msat INTEGER NOT NULL, remote_balance_msat INTEGER NOT NULL, closing_amount_satoshis INTEGER NOT NULL, created_at INTEGER NOT NULL, closed_at INTEGER NOT NULL)")
+        statement.executeUpdate("CREATE TABLE htlc_infos (channel_id BLOB NOT NULL, commitment_number INTEGER NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL)")
         statement.executeUpdate("CREATE TABLE htlc_infos_to_remove (channel_id BLOB NOT NULL PRIMARY KEY, before_commitment_number INTEGER NOT NULL)")
         // Note that we use two distinct indices instead of a composite index on (channel_id, commitment_number).
         // This is more efficient because we're writing a lot to this table but only reading when a channel is force-closed.
         statement.executeUpdate("CREATE INDEX htlc_infos_channel_id_idx ON htlc_infos(channel_id)")
         statement.executeUpdate("CREATE INDEX htlc_infos_commitment_number_idx ON htlc_infos(commitment_number)")
+        statement.executeUpdate("CREATE INDEX local_channels_closed_remote_node_id_idx ON local_channels_closed(remote_node_id)")
       case Some(v) if v < 7 => throw new RuntimeException("You are updating from a version of eclair older than v0.13: please update to the v0.13 release first to migrate your channel data, and afterwards you'll be able to update to the latest version.")
+      case Some(v@7) =>
+        logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")
+        if (v < 8) migration78(statement)
       case Some(CURRENT_VERSION) => () // table is up-to-date, nothing to do
       case Some(unknownVersion) => throw new RuntimeException(s"Unknown version of DB $DB_NAME found, version=$unknownVersion")
     }
@@ -72,7 +162,7 @@ class SqliteChannelsDb(val sqlite: Connection) extends ChannelsDb with Logging {
       update.setBytes(1, encoded)
       update.setBytes(2, data.channelId.toArray)
       if (update.executeUpdate() == 0) {
-        using(sqlite.prepareStatement("INSERT INTO local_channels (channel_id, data, created_timestamp, last_connected_timestamp, is_closed) VALUES (?, ?, ?, ?, 0)")) { statement =>
+        using(sqlite.prepareStatement("INSERT INTO local_channels (channel_id, data, created_timestamp, last_connected_timestamp) VALUES (?, ?, ?, ?)")) { statement =>
           statement.setBytes(1, data.channelId.toArray)
           statement.setBytes(2, encoded)
           statement.setLong(3, TimestampMilli.now().toLong)
@@ -84,7 +174,7 @@ class SqliteChannelsDb(val sqlite: Connection) extends ChannelsDb with Logging {
   }
 
   override def getChannel(channelId: ByteVector32): Option[PersistentChannelData] = withMetrics("channels/get-channel", DbBackends.Sqlite) {
-    using(sqlite.prepareStatement("SELECT data FROM local_channels WHERE channel_id=? AND is_closed=0")) { statement =>
+    using(sqlite.prepareStatement("SELECT data FROM local_channels WHERE channel_id=?")) { statement =>
       statement.setBytes(1, channelId.toArray)
       statement.executeQuery.mapCodec(channelDataCodec).lastOption
     }
@@ -111,7 +201,7 @@ class SqliteChannelsDb(val sqlite: Connection) extends ChannelsDb with Logging {
     timestampColumn_opt.foreach(updateChannelMetaTimestampColumn(channelId, _))
   }
 
-  override def removeChannel(channelId: ByteVector32): Unit = withMetrics("channels/remove-channel", DbBackends.Sqlite) {
+  override def removeChannel(channelId: ByteVector32, data_opt: Option[DATA_CLOSED]): Unit = withMetrics("channels/remove-channel", DbBackends.Sqlite) {
     using(sqlite.prepareStatement("DELETE FROM pending_settlement_commands WHERE channel_id=?")) { statement =>
       statement.setBytes(1, channelId.toArray)
       statement.executeUpdate()
@@ -121,9 +211,39 @@ class SqliteChannelsDb(val sqlite: Connection) extends ChannelsDb with Logging {
     // We instead run an asynchronous job to clean up that data in small batches.
     markHtlcInfosForRemoval(channelId, Long.MaxValue)
 
-    using(sqlite.prepareStatement("UPDATE local_channels SET is_closed=1, closed_timestamp=? WHERE channel_id=?")) { statement =>
-      statement.setLong(1, TimestampMilli.now().toLong)
-      statement.setBytes(2, channelId.toArray)
+    // If we have useful closing data for this channel, we keep it in a dedicated table.
+    data_opt.foreach(data => {
+      val createdAt_opt = using(sqlite.prepareStatement("SELECT created_timestamp FROM local_channels WHERE channel_id=?")) { statement =>
+        statement.setBytes(1, channelId.toArray)
+        statement.executeQuery().flatMap(rs => rs.getLongNullable("created_timestamp")).headOption
+      }
+      using(sqlite.prepareStatement("INSERT OR IGNORE INTO local_channels_closed VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")) { statement =>
+        statement.setString(1, channelId.toHex)
+        statement.setString(2, data.remoteNodeId.toHex)
+        statement.setString(3, data.fundingTxId.value.toHex)
+        statement.setLong(4, data.fundingOutputIndex)
+        statement.setLong(5, data.fundingTxIndex)
+        statement.setString(6, data.fundingKeyPath)
+        statement.setString(7, data.channelFeatures)
+        statement.setBoolean(8, data.isChannelOpener)
+        statement.setString(9, data.commitmentFormat)
+        statement.setBoolean(10, data.announced)
+        statement.setLong(11, data.capacity.toLong)
+        statement.setString(12, data.closingTxId.value.toHex)
+        statement.setString(13, data.closingType)
+        statement.setString(14, data.closingScript.toHex)
+        statement.setLong(15, data.localBalance.toLong)
+        statement.setLong(16, data.remoteBalance.toLong)
+        statement.setLong(17, data.closingAmount.toLong)
+        statement.setLong(18, createdAt_opt.getOrElse(0))
+        statement.setLong(19, TimestampMilli.now().toLong)
+        statement.executeUpdate()
+      }
+    })
+
+    // We can now remove this channel from the active channels table.
+    using(sqlite.prepareStatement("DELETE FROM local_channels WHERE channel_id=?")) { statement =>
+      statement.setBytes(1, channelId.toArray)
       statement.executeUpdate()
     }
   }
@@ -172,29 +292,39 @@ class SqliteChannelsDb(val sqlite: Connection) extends ChannelsDb with Logging {
 
   override def listLocalChannels(): Seq[PersistentChannelData] = withMetrics("channels/list-local-channels", DbBackends.Sqlite) {
     using(sqlite.createStatement) { statement =>
-      statement.executeQuery("SELECT data FROM local_channels WHERE is_closed=0")
+      statement.executeQuery("SELECT data FROM local_channels")
         .mapCodec(channelDataCodec).toSeq
     }
   }
 
-
-  override def listClosedChannels(remoteNodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated]): Seq[PersistentChannelData] = withMetrics("channels/list-closed-channels", DbBackends.Sqlite) {
-    val sql = "SELECT data FROM local_channels WHERE is_closed=1 ORDER BY closed_timestamp DESC"
-    remoteNodeId_opt match {
-      case None =>
-        using(sqlite.prepareStatement(limited(sql, paginated_opt))) { statement =>
-          statement.executeQuery().mapCodec(channelDataCodec).toSeq
-        }
-      case Some(nodeId) =>
-        using(sqlite.prepareStatement(sql)) { statement =>
-          val filtered = statement.executeQuery()
-            .mapCodec(channelDataCodec).filter(_.remoteNodeId == nodeId)
-          val limited = paginated_opt match {
-            case None => filtered
-            case Some(p) => filtered.slice(p.skip, p.skip + p.count)
-          }
-          limited.toSeq
-        }
+  override def listClosedChannels(remoteNodeId_opt: Option[PublicKey], paginated_opt: Option[Paginated]): Seq[DATA_CLOSED] = withMetrics("channels/list-closed-channels", DbBackends.Sqlite) {
+    val sql = remoteNodeId_opt match {
+      case Some(_) => "SELECT * FROM local_channels_closed WHERE remote_node_id=? ORDER BY closed_at DESC"
+      case None => "SELECT * FROM local_channels_closed ORDER BY closed_at DESC"
+    }
+    using(sqlite.prepareStatement(limited(sql, paginated_opt))) { statement =>
+      remoteNodeId_opt.foreach(remoteNodeId => statement.setString(1, remoteNodeId.toHex))
+      statement.executeQuery().map { rs =>
+        DATA_CLOSED(
+          channelId = rs.getByteVector32FromHex("channel_id"),
+          remoteNodeId = PublicKey(rs.getByteVectorFromHex("remote_node_id")),
+          fundingTxId = TxId(rs.getByteVector32FromHex("funding_txid")),
+          fundingOutputIndex = rs.getLong("funding_output_index"),
+          fundingTxIndex = rs.getLong("funding_tx_index"),
+          fundingKeyPath = rs.getString("funding_key_path"),
+          channelFeatures = rs.getString("channel_features"),
+          isChannelOpener = rs.getBoolean("is_channel_opener"),
+          commitmentFormat = rs.getString("commitment_format"),
+          announced = rs.getBoolean("announced"),
+          capacity = Satoshi(rs.getLong("capacity_satoshis")),
+          closingTxId = TxId(rs.getByteVector32FromHex("closing_txid")),
+          closingType = rs.getString("closing_type"),
+          closingScript = rs.getByteVectorFromHex("closing_script"),
+          localBalance = MilliSatoshi(rs.getLong("local_balance_msat")),
+          remoteBalance = MilliSatoshi(rs.getLong("remote_balance_msat")),
+          closingAmount = Satoshi(rs.getLong("closing_amount_satoshis"))
+        )
+      }.toSeq
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingCommandsDb.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/db/sqlite/SqlitePendingCommandsDb.scala
@@ -45,7 +45,6 @@ class SqlitePendingCommandsDb(val sqlite: Connection) extends PendingCommandsDb 
 
     getVersion(statement, DB_NAME) match {
       case None =>
-        // note: should we use a foreign key to local_channels table here?
         statement.executeUpdate("CREATE TABLE pending_settlement_commands (channel_id BLOB NOT NULL, htlc_id INTEGER NOT NULL, data BLOB NOT NULL, PRIMARY KEY(channel_id, htlc_id))")
       case Some(v@1) =>
         logger.warn(s"migrating db $DB_NAME, found version=$v current=$CURRENT_VERSION")

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/OpenChannelInterceptor.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/OpenChannelInterceptor.scala
@@ -255,6 +255,7 @@ private class OpenChannelInterceptor(peer: ActorRef[Any],
       case _: DATA_NEGOTIATING_SIMPLE => true
       case _: DATA_CLOSING => true
       case _: DATA_WAIT_FOR_REMOTE_PUBLISH_FUTURE_COMMITMENT => true
+      case _: ClosedData => true
     }
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestDatabases.scala
@@ -110,7 +110,6 @@ object TestDatabases {
   }
 
   case class TestPgDatabases() extends TestDatabases {
-
     val datasource: DataSource = getNewDatabase()
     val hikariConfig = new HikariConfig
     hikariConfig.setDataSource(datasource)
@@ -165,8 +164,7 @@ object TestDatabases {
                      initializeTables: Connection => Unit,
                      dbName: String,
                      targetVersion: Int,
-                     postCheck: Connection => Unit
-                    ): Unit = {
+                     postCheck: Connection => Unit): Unit = {
     val connection = dbs.connection
     // initialize the database to a previous version and populate data
     initializeTables(connection)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingSignedStateSpec.scala
@@ -153,9 +153,10 @@ class WaitForFundingSignedStateSpec extends TestKitBaseClass with FixtureAnyFunS
   test("recv CMD_CLOSE") { f =>
     import f._
     val sender = TestProbe()
+    val channelId = alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_SIGNED].channelId
     val c = CMD_CLOSE(sender.ref, None, None)
     alice ! c
-    sender.expectMsg(RES_SUCCESS(c, alice.stateData.asInstanceOf[DATA_WAIT_FOR_FUNDING_SIGNED].channelId))
+    sender.expectMsg(RES_SUCCESS(c, channelId))
     awaitCond(alice.stateName == CLOSED)
     aliceOpenReplyTo.expectMsg(OpenChannelResponse.Cancelled)
     listener.expectMsgType[ChannelAborted]

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/ChannelsDbSpec.scala
@@ -17,26 +17,32 @@
 package fr.acinq.eclair.db
 
 import com.softwaremill.quicklens._
-import fr.acinq.bitcoin.scalacompat.ByteVector32
-import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
-import fr.acinq.eclair.TestDatabases.{TestPgDatabases, TestSqliteDatabases}
+import fr.acinq.bitcoin.scalacompat.Crypto.PrivateKey
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, OutPoint, SatoshiLong, Script, Transaction, TxIn, TxOut}
+import fr.acinq.eclair.TestDatabases.{TestPgDatabases, TestSqliteDatabases, migrationCheck}
+import fr.acinq.eclair.TestUtils.randomTxId
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
+import fr.acinq.eclair.channel._
 import fr.acinq.eclair.db.ChannelsDbSpec.getTimestamp
 import fr.acinq.eclair.db.DbEventHandler.ChannelEvent
 import fr.acinq.eclair.db.jdbc.JdbcUtils.using
 import fr.acinq.eclair.db.pg.PgChannelsDb
+import fr.acinq.eclair.db.pg.PgUtils.setVersion
 import fr.acinq.eclair.db.sqlite.SqliteChannelsDb
 import fr.acinq.eclair.db.sqlite.SqliteUtils.ExtendedResultSet._
+import fr.acinq.eclair.json.JsonSerializers
+import fr.acinq.eclair.transactions.Transactions.{ClosingTx, InputInfo}
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecs.channelDataCodec
 import fr.acinq.eclair.wire.internal.channel.ChannelCodecsSpec
-import fr.acinq.eclair.{Alias, CltvExpiry, TestDatabases, randomBytes32, randomKey, randomLong}
+import fr.acinq.eclair.wire.protocol.Shutdown
+import fr.acinq.eclair.{Alias, BlockHeight, CltvExpiry, MilliSatoshiLong, TestDatabases, randomBytes32, randomKey, randomLong}
 import org.scalatest.funsuite.AnyFunSuite
-import scodec.bits.ByteVector
+import scodec.bits.{ByteVector, HexStringSyntax}
 
-import java.sql.{Connection, SQLException}
+import java.sql.Connection
 import java.util.concurrent.Executors
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
-import scala.util.Random
 
 class ChannelsDbSpec extends AnyFunSuite {
 
@@ -67,8 +73,6 @@ class ChannelsDbSpec extends AnyFunSuite {
       val paymentHash2 = ByteVector32(ByteVector.fill(32)(1))
       val cltvExpiry2 = CltvExpiry(656)
 
-      intercept[SQLException](db.addHtlcInfo(channel1.channelId, commitNumber, paymentHash1, cltvExpiry1)) // no related channel
-
       assert(db.listLocalChannels().isEmpty)
       db.addOrUpdateChannel(channel1)
       db.addOrUpdateChannel(channel1)
@@ -88,16 +92,19 @@ class ChannelsDbSpec extends AnyFunSuite {
       assert(db.listHtlcInfos(channel1.channelId, commitNumber + 1).isEmpty)
 
       assert(db.listClosedChannels(None, None).isEmpty)
-      db.removeChannel(channel1.channelId)
+      val closed1 = DATA_CLOSED(channel1.channelId, channel1.remoteNodeId, randomTxId(), 3, 2, channel1.channelParams.localParams.fundingKeyPath.toString(), channel1.channelParams.channelFeatures.toString, isChannelOpener = true, "anchor_outputs", announced = true, 100_000 sat, randomTxId(), "local-close", hex"deadbeef", 61_000_500 msat, 40_000_000 msat, 60_000 sat)
+      db.removeChannel(channel1.channelId, Some(closed1))
       assert(db.getChannel(channel1.channelId).isEmpty)
       assert(db.listLocalChannels() == List(channel2b))
-      assert(db.listClosedChannels(None, None) == List(channel1))
-      assert(db.listClosedChannels(Some(channel1.remoteNodeId), None) == List(channel1))
+      assert(db.listClosedChannels(None, None) == List(closed1))
+      assert(db.listClosedChannels(Some(channel1.remoteNodeId), None) == List(closed1))
       assert(db.listClosedChannels(Some(PrivateKey(randomBytes32()).publicKey), None).isEmpty)
 
-      db.removeChannel(channel2b.channelId)
+      // If no closing data is provided, the channel won't be backed-up in the closed_channels table.
+      db.removeChannel(channel2b.channelId, None)
       assert(db.getChannel(channel2b.channelId).isEmpty)
       assert(db.listLocalChannels().isEmpty)
+      assert(db.listClosedChannels(None, None) == Seq(closed1))
     }
   }
 
@@ -120,7 +127,7 @@ class ChannelsDbSpec extends AnyFunSuite {
       db.markHtlcInfosForRemoval(channel1.channelId, commitNumberSplice1)
       db.addHtlcInfo(channel1.channelId, 51, randomBytes32(), CltvExpiry(561))
       db.addHtlcInfo(channel1.channelId, 52, randomBytes32(), CltvExpiry(561))
-      db.removeChannel(channel1.channelId)
+      db.removeChannel(channel1.channelId, None)
 
       // The second channel has two splice transactions.
       db.addHtlcInfo(channel2.channelId, 48, randomBytes32(), CltvExpiry(561))
@@ -191,7 +198,6 @@ class ChannelsDbSpec extends AnyFunSuite {
       assert(getTimestamp(dbs, channel1.channelId, "last_payment_sent_timestamp").isEmpty)
       assert(getTimestamp(dbs, channel1.channelId, "last_payment_received_timestamp").isEmpty)
       assert(getTimestamp(dbs, channel1.channelId, "last_connected_timestamp").nonEmpty)
-      assert(getTimestamp(dbs, channel1.channelId, "closed_timestamp").isEmpty)
 
       db.updateChannelMeta(channel1.channelId, ChannelEvent.EventType.Created)
       assert(getTimestamp(dbs, channel1.channelId, "created_timestamp").nonEmpty)
@@ -205,14 +211,156 @@ class ChannelsDbSpec extends AnyFunSuite {
       db.updateChannelMeta(channel1.channelId, ChannelEvent.EventType.Connected)
       assert(getTimestamp(dbs, channel1.channelId, "last_connected_timestamp").nonEmpty)
 
-      db.removeChannel(channel1.channelId)
-      assert(getTimestamp(dbs, channel1.channelId, "closed_timestamp").nonEmpty)
+      db.removeChannel(channel1.channelId, None)
 
       assert(getTimestamp(dbs, channel2.channelId, "created_timestamp").nonEmpty)
       assert(getTimestamp(dbs, channel2.channelId, "last_payment_sent_timestamp").isEmpty)
       assert(getTimestamp(dbs, channel2.channelId, "last_payment_received_timestamp").isEmpty)
       assert(getTimestamp(dbs, channel2.channelId, "last_connected_timestamp").nonEmpty)
-      assert(getTimestamp(dbs, channel2.channelId, "closed_timestamp").isEmpty)
+    }
+  }
+
+  test("migrate closed channels to dedicated table") {
+    def createCommitments(): Commitments = {
+      ChannelCodecsSpec.normal.commitments
+        .modify(_.channelParams.channelId).setTo(randomBytes32())
+        .modify(_.channelParams.remoteParams.nodeId).setTo(randomKey().publicKey)
+    }
+
+    def closingTx(): ClosingTx = {
+      val input = InputInfo(OutPoint(randomTxId(), 3), TxOut(300_000 sat, Script.pay2wpkh(randomKey().publicKey)))
+      val tx = Transaction(2, Seq(TxIn(input.outPoint, Nil, 0)), Seq(TxOut(120_000 sat, Script.pay2wpkh(randomKey().publicKey)), TxOut(175_000 sat, Script.pay2tr(randomKey().xOnlyPublicKey()))), 0)
+      ClosingTx(input, tx, Some(1))
+    }
+
+    val paymentHash1 = randomBytes32()
+    val paymentHash2 = randomBytes32()
+    // The next two channels are closed and should be migrated to the closed_channels table.
+    // We haven't yet removed their corresponding htlc_infos, because it is done asynchronously for performance reasons.
+    val closed1 = DATA_CLOSING(createCommitments(), BlockHeight(750_000), hex"deadbeef", closingTx() :: Nil, closingTx() :: Nil)
+    val closed2 = DATA_NEGOTIATING_SIMPLE(createCommitments(), FeeratePerKw(2500 sat), hex"deadbeef", hex"beefdead", Nil, closingTx() :: Nil)
+    val htlcInfos = Map(
+      closed1.channelId -> Seq(
+        (7, paymentHash1, CltvExpiry(800_000)),
+        (7, paymentHash2, CltvExpiry(795_000)),
+        (8, paymentHash1, CltvExpiry(800_000)),
+      ),
+      closed2.channelId -> Seq(
+        (13, paymentHash1, CltvExpiry(801_000)),
+        (14, paymentHash2, CltvExpiry(801_000)),
+      )
+    )
+    // The following channel is closed, but was never confirmed and thus doesn't need to be migrated to the closed_channels table.
+    val closed3 = DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED(createCommitments(), 0 msat, 0 msat, BlockHeight(775_000), BlockHeight(780_000), DualFundingStatus.WaitingForConfirmations, None)
+    // The following channels aren't closed, and must stay in the channels table after the migration.
+    val notClosed1 = DATA_CLOSING(createCommitments(), BlockHeight(800_000), hex"deadbeef", closingTx() :: Nil, closingTx() :: Nil)
+    val notClosed2 = DATA_SHUTDOWN(createCommitments(), Shutdown(randomBytes32(), hex"deadbeef"), Shutdown(randomBytes32(), hex"beefdead"), CloseStatus.Initiator(Some(ClosingFeerates(FeeratePerKw(1500 sat), FeeratePerKw(1000 sat), FeeratePerKw(2500 sat)))))
+
+    def postCheck(db: ChannelsDb): Unit = {
+      // The closed channels have been migrated to a dedicated DB.
+      assert(db.listClosedChannels(None, None).map(_.channelId).toSet == Set(closed1.channelId, closed2.channelId))
+      // The remaining channels are still active.
+      assert(db.listLocalChannels().toSet == Set(notClosed1, notClosed2))
+      // The corresponding htlc_infos hasn't been removed.
+      assert(db.listHtlcInfos(closed1.channelId, 7).toSet == Set((paymentHash1, CltvExpiry(800_000)), (paymentHash2, CltvExpiry(795_000))))
+      assert(db.listHtlcInfos(closed1.channelId, 8).toSet == Set((paymentHash1, CltvExpiry(800_000))))
+      assert(db.listHtlcInfos(closed2.channelId, 13).toSet == Set((paymentHash1, CltvExpiry(801_000))))
+      assert(db.listHtlcInfos(closed2.channelId, 14).toSet == Set((paymentHash2, CltvExpiry(801_000))))
+    }
+
+    forAllDbs {
+      case dbs: TestPgDatabases =>
+        migrationCheck(
+          dbs = dbs,
+          initializeTables = connection => {
+            // We initialize a v11 database, where closed channels were kept inside the channels table with an is_closed flag.
+            using(connection.createStatement()) { statement =>
+              statement.executeUpdate("CREATE SCHEMA IF NOT EXISTS local")
+              statement.executeUpdate("CREATE TABLE local.channels (channel_id TEXT NOT NULL PRIMARY KEY, remote_node_id TEXT NOT NULL, data BYTEA NOT NULL, json JSONB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT FALSE, created_timestamp TIMESTAMP WITH TIME ZONE, last_payment_sent_timestamp TIMESTAMP WITH TIME ZONE, last_payment_received_timestamp TIMESTAMP WITH TIME ZONE, last_connected_timestamp TIMESTAMP WITH TIME ZONE, closed_timestamp TIMESTAMP WITH TIME ZONE)")
+              statement.executeUpdate("CREATE TABLE local.htlc_infos (channel_id TEXT NOT NULL, commitment_number BIGINT NOT NULL, payment_hash TEXT NOT NULL, cltv_expiry BIGINT NOT NULL, FOREIGN KEY(channel_id) REFERENCES local.channels(channel_id))")
+              statement.executeUpdate("CREATE INDEX htlc_infos_channel_id_idx ON local.htlc_infos(channel_id)")
+              statement.executeUpdate("CREATE INDEX htlc_infos_commitment_number_idx ON local.htlc_infos(commitment_number)")
+              setVersion(statement, PgChannelsDb.DB_NAME, 11)
+            }
+            // We insert some channels in our DB and htc info related to those channels.
+            Seq(closed1, closed2, closed3).foreach { c =>
+              using(connection.prepareStatement("INSERT INTO local.channels (channel_id, remote_node_id, data, json, is_closed) VALUES (?, ?, ?, ?::JSONB, TRUE)")) { statement =>
+                statement.setString(1, c.channelId.toHex)
+                statement.setString(2, c.remoteNodeId.toHex)
+                statement.setBytes(3, channelDataCodec.encode(c).require.toByteArray)
+                statement.setString(4, JsonSerializers.serialization.write(c)(JsonSerializers.formats))
+                statement.executeUpdate()
+              }
+            }
+            Seq(notClosed1, notClosed2).foreach { c =>
+              using(connection.prepareStatement("INSERT INTO local.channels (channel_id, remote_node_id, data, json, is_closed) VALUES (?, ?, ?, ?::JSONB, FALSE)")) { statement =>
+                statement.setString(1, c.channelId.toHex)
+                statement.setString(2, c.remoteNodeId.toHex)
+                statement.setBytes(3, channelDataCodec.encode(c).require.toByteArray)
+                statement.setString(4, JsonSerializers.serialization.write(c)(JsonSerializers.formats))
+                statement.executeUpdate()
+              }
+            }
+            htlcInfos.foreach { case (channelId, infos) =>
+              infos.foreach { case (commitmentNumber, paymentHash, expiry) =>
+                using(connection.prepareStatement("INSERT INTO local.htlc_infos VALUES (?, ?, ?, ?)")) { statement =>
+                  statement.setString(1, channelId.toHex)
+                  statement.setLong(2, commitmentNumber)
+                  statement.setString(3, paymentHash.toHex)
+                  statement.setLong(4, expiry.toLong)
+                  statement.executeUpdate()
+                }
+              }
+            }
+          },
+          dbName = PgChannelsDb.DB_NAME,
+          targetVersion = PgChannelsDb.CURRENT_VERSION,
+          postCheck = _ => postCheck(dbs.channels)
+        )
+      case dbs: TestSqliteDatabases =>
+        migrationCheck(
+          dbs = dbs,
+          initializeTables = connection => {
+            // We initialize a v7 database, where closed channels were kept inside the channels table with an is_closed flag.
+            using(connection.createStatement()) { statement =>
+              statement.execute("PRAGMA foreign_keys = ON")
+              statement.executeUpdate("CREATE TABLE local_channels (channel_id BLOB NOT NULL PRIMARY KEY, data BLOB NOT NULL, is_closed BOOLEAN NOT NULL DEFAULT 0, created_timestamp INTEGER, last_payment_sent_timestamp INTEGER, last_payment_received_timestamp INTEGER, last_connected_timestamp INTEGER, closed_timestamp INTEGER)")
+              statement.executeUpdate("CREATE TABLE htlc_infos (channel_id BLOB NOT NULL, commitment_number INTEGER NOT NULL, payment_hash BLOB NOT NULL, cltv_expiry INTEGER NOT NULL, FOREIGN KEY(channel_id) REFERENCES local_channels(channel_id))")
+              statement.executeUpdate("CREATE INDEX htlc_infos_channel_id_idx ON htlc_infos(channel_id)")
+              statement.executeUpdate("CREATE INDEX htlc_infos_commitment_number_idx ON htlc_infos(commitment_number)")
+              setVersion(statement, SqliteChannelsDb.DB_NAME, 7)
+            }
+            // We insert some channels in our DB and htc info related to those channels.
+            Seq(closed1, closed2, closed3).foreach { c =>
+              using(connection.prepareStatement("INSERT INTO local_channels (channel_id, data, is_closed) VALUES (?, ?, 1)")) { statement =>
+                statement.setBytes(1, c.channelId.toArray)
+                statement.setBytes(2, channelDataCodec.encode(c).require.toByteArray)
+                statement.executeUpdate()
+              }
+            }
+            Seq(notClosed1, notClosed2).foreach { c =>
+              using(connection.prepareStatement("INSERT INTO local_channels (channel_id, data, is_closed) VALUES (?, ?, 0)")) { statement =>
+                statement.setBytes(1, c.channelId.toArray)
+                statement.setBytes(2, channelDataCodec.encode(c).require.toByteArray)
+                statement.executeUpdate()
+              }
+            }
+            htlcInfos.foreach { case (channelId, infos) =>
+              infos.foreach { case (commitmentNumber, paymentHash, expiry) =>
+                using(connection.prepareStatement("INSERT INTO htlc_infos VALUES (?, ?, ?, ?)")) { statement =>
+                  statement.setBytes(1, channelId.toArray)
+                  statement.setLong(2, commitmentNumber)
+                  statement.setBytes(3, paymentHash.toArray)
+                  statement.setLong(4, expiry.toLong)
+                  statement.executeUpdate()
+                }
+              }
+            }
+          },
+          dbName = SqliteChannelsDb.DB_NAME,
+          targetVersion = SqliteChannelsDb.CURRENT_VERSION,
+          postCheck = _ => postCheck(dbs.channels)
+        )
     }
   }
 
@@ -232,38 +380,6 @@ class ChannelsDbSpec extends AnyFunSuite {
 }
 
 object ChannelsDbSpec {
-
-  case class TestCase(channelId: ByteVector32,
-                      remoteNodeId: PublicKey,
-                      data: ByteVector,
-                      isClosed: Boolean,
-                      createdTimestamp: Option[Long],
-                      lastPaymentSentTimestamp: Option[Long],
-                      lastPaymentReceivedTimestamp: Option[Long],
-                      lastConnectedTimestamp: Option[Long],
-                      closedTimestamp: Option[Long],
-                      commitmentNumbers: Seq[Int])
-
-  val testCases: Seq[TestCase] = for (_ <- 0 until 10) yield {
-    val channelId = randomBytes32()
-    val remoteNodeId = randomKey().publicKey
-    val channel = ChannelCodecsSpec.normal
-      .modify(_.commitments.channelParams.channelId).setTo(channelId)
-      .modify(_.commitments.channelParams.remoteParams.nodeId).setTo(remoteNodeId)
-    val data = channelDataCodec.encode(channel).require.bytes
-    TestCase(
-      channelId = channelId,
-      remoteNodeId = remoteNodeId,
-      data = data,
-      isClosed = Random.nextBoolean(),
-      createdTimestamp = if (Random.nextBoolean()) Some(Random.nextInt(Int.MaxValue)) else None,
-      lastPaymentSentTimestamp = if (Random.nextBoolean()) Some(Random.nextInt(Int.MaxValue)) else None,
-      lastPaymentReceivedTimestamp = if (Random.nextBoolean()) Some(Random.nextInt(Int.MaxValue)) else None,
-      lastConnectedTimestamp = if (Random.nextBoolean()) Some(Random.nextInt(Int.MaxValue)) else None,
-      closedTimestamp = if (Random.nextBoolean()) Some(Random.nextInt(Int.MaxValue)) else None,
-      commitmentNumbers = for (_ <- 0 until Random.nextInt(10)) yield Random.nextInt(5) // there will be repetitions, on purpose
-    )
-  }
 
   def getTimestamp(dbs: TestDatabases, channelId: ByteVector32, columnName: String): Option[Long] = {
     dbs match {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/RevokedHtlcInfoCleanerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/RevokedHtlcInfoCleanerSpec.scala
@@ -38,7 +38,7 @@ class RevokedHtlcInfoCleanerSpec extends ScalaTestWithActorTestKit(ConfigFactory
     channelsDb.addHtlcInfo(channelId, 17, randomBytes32(), CltvExpiry(561))
     channelsDb.addHtlcInfo(channelId, 19, randomBytes32(), CltvExpiry(1105))
     channelsDb.addHtlcInfo(channelId, 23, randomBytes32(), CltvExpiry(1729))
-    channelsDb.removeChannel(channelId)
+    channelsDb.removeChannel(channelId, None)
     assert(channelsDb.listHtlcInfos(channelId, 17).nonEmpty)
     assert(channelsDb.listHtlcInfos(channelId, 19).nonEmpty)
     assert(channelsDb.listHtlcInfos(channelId, 23).nonEmpty)


### PR DESCRIPTION
We create a dedicated table to store minimal information about closed channels. We migrate the existing closed channels to this new table. Note that we need to remove the foreign key constraint on `htlc_infos` because that table is asynchronously cleaned up, which may happen *after* we moved the channel to the closed table (which is fine).

There are several benefits to using a dedicated table and data class for closed channels. First of all, this is good for performance, because it doesn't impact the active channels table, and we only keep relevant data (the rest can be re-computed using the blockchain if necessary). Also, this is useful to allow removing data from `Commitments` in the future, without needing to care for backwards-compatibility with very old channels (for example, removing supporting for the `DefaultCommitmentFormat` in favor of anchor outputs).