### PR TITLE
Smaller default value for `peer-connection.max-no-channels`

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -405,7 +405,7 @@ eclair {
     // When enabled, if we receive an incoming connection, we will echo the source IP address in our init message.
     // This should be disabled if your node is behind a load balancer that doesn't preserve source IP addresses.
     send-remote-address-init = true
-    max-no-channels = 250 // maximum number of incoming connections from peers that do not have any channels with us
+    max-no-channels = 64 // maximum number of incoming connections from peers that do not have any channels with us
   }
 
   // When relaying payments or messages to mobile peers who are disconnected, we may try to wake them up using a mobile


### PR DESCRIPTION
We previously allowed 250 parallel incoming connections from nodes with whom we don't have any channels yet. While this makes sense for wallet providers, this is too large for standard routing nodes and exposes them to more DoS risk. We reduce the default value to 64 instead, which can of course be overridden by node operators in their `eclair.conf`.