### PR TITLE
Deduplicate closing balance during mutual close

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/balance/CheckBalance.scala
@@ -200,6 +200,10 @@ object CheckBalance {
               this.copy(closing = this.closing.copy(toLocal = this.closing.toLocal + localBalance))
             case None => this
           }
+          // If we have a fully signed mutual close transaction and a closing transaction is in our mempool or recently
+          // confirmed, the channel will most likely end up being mutual-closed (since the feerate is higher than any
+          // force-close transaction). We thus ignore this channel in our off-chain balance to avoid counting it twice.
+          case None if d.mutualClosePublished.nonEmpty && recentlySpentInputs.contains(d.commitments.latest.fundingInput) => this
           // We don't know yet which type of closing will confirm on-chain, so we use our default off-chain balance.
           case None => this.copy(closing = this.closing.addChannelBalance(d.commitments))
         }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/balance/CheckBalanceSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/balance/CheckBalanceSpec.scala
@@ -98,6 +98,16 @@ class CheckBalanceSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with
     assert(CheckBalance.computeOffChainBalance(Seq(alice.stateData.asInstanceOf[DATA_NEGOTIATING_SIMPLE]), recentlySpentInputs = Set(closingTxInput)).negotiating == expected)
   }
 
+  test("channel closing with published closing tx (without option_simple_close)") { f =>
+    import f._
+
+    mutualClose(alice, bob, alice2bob, bob2alice, alice2blockchain, bob2blockchain)
+    assert(alice.stateData.asInstanceOf[DATA_CLOSING].mutualClosePublished.nonEmpty)
+    val closingTxInput = alice.stateData.asInstanceOf[DATA_CLOSING].commitments.latest.fundingInput
+    val expected = MainAndHtlcBalance(toLocal = 0 sat, htlcs = 0 sat)
+    assert(CheckBalance.computeOffChainBalance(Seq(alice.stateData.asInstanceOf[DATA_CLOSING]), recentlySpentInputs = Set(closingTxInput)).closing == expected)
+  }
+
   test("channel closed with remote commit tx", Tag(ChannelStateTestsTags.StaticRemoteKey), Tag(ChannelStateTestsTags.AnchorOutputsZeroFeeHtlcTxs)) { f =>
     import f._
 


### PR DESCRIPTION
When a mutual close transaction is published or recently confirmed, we don't include the corresponding channel in our off-chain balance to avoid counting it twice (which would resolve itself after confirmations but is misleading).

There are degenerate cases where the channel will actually end up being force-closed, even though we started with a mutual close, but that will be very infrequent and will resolve itself after confirmations.