### PR TITLE
Stop sending `update_fee` for mobile wallets

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -2736,7 +2736,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
               if (d.commitments.localChannelParams.paysCommitTxFees && !shutdownInProgress) {
                 val currentFeeratePerKw = d.commitments.latest.localCommit.spec.commitTxFeerate
                 val networkFeeratePerKw = nodeParams.onChainFeeConf.getCommitmentFeerate(nodeParams.currentBitcoinCoreFeerates, remoteNodeId, d.commitments.latest.commitmentFormat)
-                if (nodeParams.onChainFeeConf.shouldUpdateFee(currentFeeratePerKw, networkFeeratePerKw)) {
+                if (nodeParams.onChainFeeConf.shouldUpdateFee(currentFeeratePerKw, networkFeeratePerKw, d.commitments.latest.commitmentFormat)) {
                   self ! CMD_UPDATE_FEE(networkFeeratePerKw, commit = true)
                 }
               }
@@ -3219,7 +3219,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
     val commitments = d.commitments.latest
     val networkFeeratePerKw = nodeParams.onChainFeeConf.getCommitmentFeerate(nodeParams.currentBitcoinCoreFeerates, remoteNodeId, d.commitments.latest.commitmentFormat)
     val currentFeeratePerKw = commitments.localCommit.spec.commitTxFeerate
-    val shouldUpdateFee = d.commitments.localChannelParams.paysCommitTxFees && nodeParams.onChainFeeConf.shouldUpdateFee(currentFeeratePerKw, networkFeeratePerKw)
+    val shouldUpdateFee = d.commitments.localChannelParams.paysCommitTxFees && nodeParams.onChainFeeConf.shouldUpdateFee(currentFeeratePerKw, networkFeeratePerKw, d.commitments.latest.commitmentFormat)
     if (shouldUpdateFee) {
       self ! CMD_UPDATE_FEE(networkFeeratePerKw, commit = true)
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -53,6 +53,7 @@ object TestConstants {
   val nonInitiatorPushAmount: MilliSatoshi = 100_000_000L msat
   val feeratePerKw: FeeratePerKw = FeeratePerKw(10_000 sat)
   val anchorOutputsFeeratePerKw: FeeratePerKw = FeeratePerKw(2_500 sat)
+  val phoenixCommitFeeratePerKw: FeeratePerKw = FeeratePerByte(1 sat).perKw
   val defaultLiquidityRates: LiquidityAds.WillFundRates = LiquidityAds.WillFundRates(
     fundingRates = LiquidityAds.FundingRate(100_000 sat, 10_000_000 sat, 500, 100, 100 sat, 1000 sat) :: Nil,
     paymentTypes = Set(LiquidityAds.PaymentType.FromChannelBalance)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/ChannelStateTestsHelperMethods.scala
@@ -140,7 +140,10 @@ trait ChannelStateTestsBase extends Assertions with Eventually {
         temporaryChannelId = ByteVector32.Zeroes,
         fundingAmount = fundingAmount,
         dualFunded = dualFunded,
-        commitTxFeerate = TestConstants.anchorOutputsFeeratePerKw,
+        commitTxFeerate = channelType match {
+          case _: ChannelTypes.AnchorOutputs | ChannelTypes.SimpleTaprootChannelsPhoenix => TestConstants.phoenixCommitFeeratePerKw
+          case _ => TestConstants.anchorOutputsFeeratePerKw
+        },
         fundingTxFeerate = TestConstants.feeratePerKw,
         fundingTxFeeBudget_opt = None,
         pushAmount_opt = pushAmount_opt,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -547,7 +547,7 @@ class PeerSpec extends FixtureSpec {
     assert(init.channelType == ChannelTypes.AnchorOutputs())
     assert(!init.dualFunded)
     assert(init.fundingAmount == 15000.sat)
-    assert(init.commitTxFeerate == TestConstants.anchorOutputsFeeratePerKw)
+    assert(init.commitTxFeerate == TestConstants.phoenixCommitFeeratePerKw)
     assert(init.fundingTxFeerate == nodeParams.onChainFeeConf.getFundingFeerate(nodeParams.currentFeeratesForFundingClosing))
   }
 


### PR DESCRIPTION
We stop sending `update_fee` and set the feerate to `1 sat/byte` for channels with mobile wallet users. This removes edge cases around `update_fee` handling in tricky cases (splicing, shutdown, etc) while still allowing channels to force-close thanks to package relay.

Note that mobile wallets that don't have an on-chain wallet to use CPFP on the commit transaction may not be able to get their commit tx confirmed, but that was already the case before that change since the LSP decides the commit feerate. This will get better with v3 txs and https://delvingbitcoin.org/t/zero-fee-commitments-for-mobile-wallets/1453