### PR TITLE
Avoid negative on-the-fly funding fee

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/OnTheFlyFunding.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/relay/OnTheFlyFunding.scala
@@ -91,7 +91,7 @@ object OnTheFlyFunding {
   /** An on-the-fly funding proposal sent to our peer. */
   case class Proposal(htlc: WillAddHtlc, upstream: Upstream.Hot, onionSharedSecrets: Seq[Sphinx.SharedSecret]) {
     /** Maximum fees that can be collected from this HTLC. */
-    def maxFees(htlcMinimum: MilliSatoshi): MilliSatoshi = htlc.amount - htlcMinimum
+    def maxFees(htlcMinimum: MilliSatoshi): MilliSatoshi = (htlc.amount - htlcMinimum).max(0 msat)
 
     /** Create commands to fail all upstream HTLCs. */
     def createFailureCommands(failure_opt: Option[FailureReason])(implicit log: LoggingAdapter): Seq[(ByteVector32, CMD_FAIL_HTLC)] = upstream match {


### PR DESCRIPTION
Since we don't have access to channel params in the `Peer` actor, we don't know the remote `htlc_minimum` when receiving a splice. This may lead to cases where we later fail because we end up with a negative funding fee, which doesn't make any sense.

To avoid those failures, we hard-code the `htlc_minimum` value used by Phoenix (which is the only consumer of this protocol so far) and use the max with our local `htlc_minimum`.