### PR TITLE
Configure bitcoind test instances to use bech32m addresses

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -89,8 +89,8 @@ trait BitcoindService extends Logging {
   val onChainKeyManager = new LocalOnChainKeyManager("eclair", MnemonicCode.toSeed(mnemonics, passphrase), TimestampSecond.now(), Block.RegtestGenesisBlock.hash)
 
   def startBitcoind(useCookie: Boolean = false,
-                    defaultAddressType_opt: Option[String] = None,
-                    changeAddressType_opt: Option[String] = None,
+                    defaultAddressType_opt: Option[String] = Some("bech32m"),
+                    changeAddressType_opt: Option[String] = Some("bech32m"),
                     mempoolSize_opt: Option[Int] = None, // mempool size in MB
                     mempoolMinFeerate_opt: Option[FeeratePerByte] = None, // transactions below this feerate won't be accepted in the mempool
                     startupFlags: String = ""): Unit = {
@@ -199,7 +199,7 @@ trait BitcoindService extends Logging {
     val addressToUse = address match {
       case Some(addr) => addr
       case None =>
-        sender.send(bitcoincli, BitcoinReq("getnewaddress", "", "bech32"))
+        sender.send(bitcoincli, BitcoinReq("getnewaddress", "", "bech32m"))
         val JString(address) = sender.expectMsgType[JValue](timeout)
         address
     }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/InteractiveTxBuilderSpec.scala
@@ -77,7 +77,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
   }
 
   private def createInput(channelId: ByteVector32, serialId: UInt64, amount: Satoshi): TxAddInput = {
-    val changeScript = Script.write(Script.pay2wpkh(randomKey().publicKey))
+    val changeScript = Script.write(Script.pay2tr(randomKey().publicKey.xOnly))
     val previousTx = Transaction(2, Nil, Seq(TxOut(amount, changeScript), TxOut(amount, changeScript), TxOut(amount, changeScript)), 0)
     TxAddInput(channelId, serialId, Some(previousTx), 1, 0)
   }
@@ -1463,7 +1463,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
   }
 
   test("fund transaction with previous inputs (with new inputs)") {
-    val targetFeerate = FeeratePerKw(10_000 sat)
+    val targetFeerate = FeeratePerKw(11_000 sat)
     val fundingA = 100_000 sat
     val utxosA = Seq(55_000 sat, 55_000 sat, 55_000 sat)
     withFixture(ChannelTypes.AnchorOutputsZeroFeeHtlcTx(), fundingA, utxosA, 0 sat, Nil, targetFeerate, 660 sat, 0, RequireConfirmedInputs(forLocal = false, forRemote = false)) { f =>
@@ -1576,7 +1576,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       val successA1 = alice2bob.expectMsgType[Succeeded]
       val successB1 = bob2alice.expectMsgType[Succeeded]
       val (txA1, commitmentA1, txB1, commitmentB1) = fixtureParams.exchangeSigsBobFirst(bobParams, successA1, successB1)
-      assert(initialFeerate * 0.9 <= txA1.feerate && txA1.feerate <= initialFeerate * 1.25)
+      assert(initialFeerate * 0.9 <= txA1.feerate && txA1.feerate <= initialFeerate * 1.3)
       val probe = TestProbe()
       walletA.publishTransaction(txA1.signedTx).pipeTo(probe.ref)
       probe.expectMsg(txA1.txId)
@@ -1919,7 +1919,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       val successA1 = alice2bob.expectMsgType[Succeeded]
       val successB1 = bob2alice.expectMsgType[Succeeded]
       val (txA1, commitmentA1, _, commitmentB1) = fixtureParams.exchangeSigsBobFirst(bobParams, successA1, successB1)
-      assert(targetFeerate * 0.9 <= txA1.feerate && txA1.feerate <= targetFeerate * 1.25)
+      assert(targetFeerate * 0.9 <= txA1.feerate && txA1.feerate <= targetFeerate * 1.35)
       walletA.publishTransaction(txA1.signedTx).pipeTo(probe.ref)
       probe.expectMsg(txA1.txId)
 
@@ -1970,7 +1970,7 @@ class InteractiveTxBuilderSpec extends TestKitBaseClass with AnyFunSuiteLike wit
       val (spliceTxA1, commitmentA2, _, commitmentB2) = fixtureParams.exchangeSigsBobFirst(fundingParamsB1, successA2, successB2)
       assert(commitmentA2.localCommit.spec.toLocal == commitmentA1.localCommit.spec.toLocal - spliceFeeA - purchase.fees.total)
       assert(commitmentB2.localCommit.spec.toLocal == commitmentB1.localCommit.spec.toLocal + fundingB + purchase.fees.total)
-      assert(targetFeerate * 0.9 <= spliceTxA1.feerate && spliceTxA1.feerate <= targetFeerate * 1.25)
+      assert(targetFeerate * 0.9 <= spliceTxA1.feerate && spliceTxA1.feerate <= targetFeerate * 1.35)
       walletA.publishTransaction(spliceTxA1.signedTx).pipeTo(probe.ref)
       probe.expectMsg(spliceTxA1.txId)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/ReplaceableTxPublisherSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/publish/ReplaceableTxPublisherSpec.scala
@@ -455,7 +455,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
 
       val targetFee = Transactions.weight2fee(targetFeerate, mempoolTxs.map(_.weight).sum.toInt)
       val actualFee = mempoolTxs.map(_.fees).sum
-      assert(targetFee * 0.9 <= actualFee && actualFee <= targetFee * 1.1, s"actualFee=$actualFee targetFee=$targetFee")
+      assert(targetFee * 0.9 <= actualFee && actualFee <= targetFee * 1.3, s"actualFee=$actualFee targetFee=$targetFee")
 
       generateBlocks(6)
       system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
@@ -500,7 +500,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
 
     val targetFee = Transactions.weight2fee(targetFeerate, mempoolTxs.map(_.weight).sum.toInt)
     val actualFee = mempoolTxs.map(_.fees).sum
-    assert(targetFee * 0.9 <= actualFee && actualFee <= targetFee * 1.1, s"actualFee=$actualFee targetFee=$targetFee")
+    assert(targetFee * 0.9 <= actualFee && actualFee <= targetFee * 1.2, s"actualFee=$actualFee targetFee=$targetFee")
 
     generateBlocks(6)
     system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
@@ -595,7 +595,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
 
       val targetFee = Transactions.weight2fee(targetFeerate, mempoolTxs.map(_.weight).sum.toInt)
       val actualFee = mempoolTxs.map(_.fees).sum
-      assert(targetFee * 0.9 <= actualFee && actualFee <= targetFee * 1.1, s"actualFee=$actualFee targetFee=$targetFee")
+      assert(targetFee * 0.9 <= actualFee && actualFee <= targetFee * 1.3, s"actualFee=$actualFee targetFee=$targetFee")
 
       generateBlocks(6)
       system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
@@ -628,7 +628,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
 
       val targetFee = Transactions.weight2fee(targetFeerate, mempoolTxs.map(_.weight).sum.toInt)
       val actualFee = mempoolTxs.map(_.fees).sum
-      assert(targetFee * 0.9 <= actualFee && actualFee <= targetFee * 1.1, s"actualFee=$actualFee targetFee=$targetFee")
+      assert(targetFee * 0.9 <= actualFee && actualFee <= targetFee * 1.3, s"actualFee=$actualFee targetFee=$targetFee")
 
       generateBlocks(6)
       system.eventStream.publish(CurrentBlockHeight(currentBlockHeight(probe)))
@@ -870,7 +870,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
       assert(mempoolAnchorTx1.txid == anchorTxId1)
       val targetFee1 = Transactions.weight2fee(feerateLow, mempoolTxs1.map(_.weight).sum.toInt)
       val actualFee1 = mempoolTxs1.map(_.fees).sum
-      assert(targetFee1 * 0.9 <= actualFee1 && actualFee1 <= targetFee1 * 1.1, s"actualFee=$actualFee1 targetFee=$targetFee1")
+      assert(targetFee1 * 0.9 <= actualFee1 && actualFee1 <= targetFee1 * 1.3, s"actualFee=$actualFee1 targetFee=$targetFee1")
 
       // The confirmation target has changed (probably because we learnt a payment preimage).
       // We should now use the high feerate, which corresponds to that new target.
@@ -1147,7 +1147,7 @@ class ReplaceableTxPublisherSpec extends TestKitBaseClass with AnyFunSuiteLike w
     setFeerate(targetFeerate) // the feerate is higher than what it was when the channel force-closed
     val htlcTimeoutTx = getMempoolTxs(1).head
     val htlcTimeoutTargetFee = Transactions.weight2fee(targetFeerate, htlcTimeoutTx.weight.toInt)
-    assert(htlcTimeoutTargetFee * 0.9 <= htlcTimeoutTx.fees && htlcTimeoutTx.fees <= htlcTimeoutTargetFee * 1.2, s"actualFee=${htlcTimeoutTx.fees} targetFee=$htlcTimeoutTargetFee")
+    assert(htlcTimeoutTargetFee * 0.9 <= htlcTimeoutTx.fees && htlcTimeoutTx.fees <= htlcTimeoutTargetFee * 1.3, s"actualFee=${htlcTimeoutTx.fees} targetFee=$htlcTimeoutTargetFee")
     assert(htlcTimeoutTx.fees <= htlcTimeout.txInfo.amountIn)
 
     generateBlocks(6)


### PR DESCRIPTION
When addres type or change type is not specified, bitcoind will start with addresstype=bech32m and changetype=bech32m.