### PR TITLE
Add more tolerance in tests

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/transactions/TransactionsSpec.scala
@@ -152,8 +152,8 @@ class TransactionsSpec extends AnyFunSuite with Logging {
       case _: SimpleTaprootChannelCommitmentFormat => assert(actual == expected)
       case _: AnchorOutputsCommitmentFormat =>
         // ECDSA signatures are der-encoded, which creates some variability in signature size compared to the baseline.
-        assert(actual <= expected + 2)
-        assert(actual >= expected - 2)
+        assert(actual <= expected + 3)
+        assert(actual >= expected - 3)
     }
   }
 


### PR DESCRIPTION
DER encoding size can vary by +- 3 bytes, not  +- 2.