### PR TITLE
Enable detailed monitoring for singleton actors

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -326,14 +326,14 @@ class Setup(val datadir: File,
       }
 
       watcher = {
-        system.actorOf(SimpleSupervisor.props(Props(new ZMQActor(config.getString("bitcoind.zmqblock"), ZMQActor.Topics.HashBlock, Some(zmqBlockConnected))), "zmqblock", SupervisorStrategy.Restart))
-        system.actorOf(SimpleSupervisor.props(Props(new ZMQActor(config.getString("bitcoind.zmqtx"), ZMQActor.Topics.RawTx, Some(zmqTxConnected))), "zmqtx", SupervisorStrategy.Restart))
+        system.actorOf(SimpleSupervisor.props(Props(new ZMQActor(config.getString("bitcoind.zmqblock"), ZMQActor.Topics.HashBlock, Some(zmqBlockConnected))), "zmq-block", SupervisorStrategy.Restart))
+        system.actorOf(SimpleSupervisor.props(Props(new ZMQActor(config.getString("bitcoind.zmqtx"), ZMQActor.Topics.RawTx, Some(zmqTxConnected))), "zmq-tx", SupervisorStrategy.Restart))
         val watcherBitcoinClient = if (config.getBoolean("bitcoind.batch-watcher-requests")) {
           new BitcoinCoreClient(new BatchingBitcoinJsonRPCClient(bitcoin), nodeParams.liquidityAdsConfig.lockUtxos)
         } else {
           new BitcoinCoreClient(bitcoin, nodeParams.liquidityAdsConfig.lockUtxos)
         }
-        system.spawn(Behaviors.supervise(ZmqWatcher(nodeParams, blockHeight, watcherBitcoinClient)).onFailure(typed.SupervisorStrategy.resume), "watcher")
+        system.spawn(Behaviors.supervise(ZmqWatcher(nodeParams, blockHeight, watcherBitcoinClient)).onFailure(typed.SupervisorStrategy.resume), "zmq-watcher")
       }
 
       router = system.actorOf(SimpleSupervisor.props(Router.props(nodeParams, watcher, Some(routerInitialized)), "router", SupervisorStrategy.Resume))

--- a/eclair-node/src/main/resources/application.conf
+++ b/eclair-node/src/main/resources/application.conf
@@ -34,6 +34,32 @@ akka {
 kamon.instrumentation.akka {
   filters {
     actors {
+      # Decides which actors will have metric tracking enabled. Beware that most of the time what you really need is to
+      # track Actor groups instead of individual actors because wildly targetting actors can lead to cardinality issues.
+      #
+      track {
+        includes = ${?kamon.instrumentation.akka.filters.actors.track.includes} [
+        "**/blockchain-watchdog",
+        "**/zmq-block",
+        "**/zmq-tx",
+        "**/zmq-watcher",
+        "**/router",
+        "**/front-router",
+        "**/db-event-handler",
+        "**/register",
+        "**/payment-handler",
+        "**/relayer",
+        "**/switchboard",
+        "**/client-spawner",
+        "**/server",
+        "**/payment-initiator",
+        "**/autoprobe-count",
+        "**/batching-client",
+        "**/post-restart-htlc-cleaner"
+        ]
+        excludes = [ "*/system/**", "*/user/IO-**" ]
+      }
+
       # Decides which actors generate Spans for the messages they process, given that there is already an ongoing trace
       # in the Context of the processed message (i.e. there is a Sampled Span in the Context).
       trace {


### PR DESCRIPTION
This allows tracking the `mailbox-size` for those actors, while existing group-level monitoring only tracks `time-in-mailbox`.