### PR TITLE
Add `CommitSigBatch` codec

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecs.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecs.scala
@@ -278,6 +278,10 @@ object LightningMessageCodecs {
       ("htlcSignatures" | listofsignatures) ::
       ("tlvStream" | CommitSigTlv.commitSigTlvCodec)).as[CommitSig]
 
+  // This isn't a "real" lightning codec, as we send each commit_sig individually to our peers.
+  // But it's necessary to send CommitSigBatch objects to front machines when the cluster mode is used.
+  val commitSigBatchCodec: Codec[CommitSigBatch] = listOfN(uint16, lengthDelimited(commitSigCodec)).xmap(sigs => CommitSigBatch(sigs.toSeq), batch => batch.messages.toList)
+
   val revokeAndAckCodec: Codec[RevokeAndAck] = (
     ("channelId" | bytes32) ::
       ("perCommitmentSecret" | privateKey) ::
@@ -567,7 +571,7 @@ object LightningMessageCodecs {
     //
     .typecase(39409, recommendedFeeratesCodec)
   //
-
+    .typecase(53011, commitSigBatchCodec)
   //
 
   //

--- a/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/wire/protocol/LightningMessageCodecsSpec.scala
@@ -27,7 +27,7 @@ import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.ChannelSpendSignature.{IndividualSignature, PartialSignatureWithNonce}
 import fr.acinq.eclair.channel.ChannelTypes.SimpleTaprootChannelsPhoenix
-import fr.acinq.eclair.channel.{ChannelFlags, ChannelTypes}
+import fr.acinq.eclair.channel.{ChannelFlags, ChannelSpendSignature, ChannelTypes}
 import fr.acinq.eclair.json.JsonSerializers
 import fr.acinq.eclair.reputation.Reputation
 import fr.acinq.eclair.router.Announcements
@@ -694,6 +694,18 @@ class LightningMessageCodecsSpec extends AnyFunSuite {
       val reEncoded = lightningMessageCodec.encode(decoded).require.bytes
       assert(reEncoded == encoded)
     }
+  }
+
+  test("encode/decode commit_sig batch") {
+    val channelId = randomBytes32()
+    val batch = CommitSigBatch(Seq(
+      CommitSig(channelId, ChannelSpendSignature.IndividualSignature(randomBytes64()), Nil, batchSize = 3),
+      CommitSig(channelId, ChannelSpendSignature.IndividualSignature(randomBytes64()), Nil, batchSize = 3),
+      CommitSig(channelId, ChannelSpendSignature.IndividualSignature(randomBytes64()), Nil, batchSize = 3),
+    ))
+    val encoded = lightningMessageCodec.encode(batch).require
+    val decoded = lightningMessageCodec.decode(encoded).require.value
+    assert(decoded == batch)
   }
 
   test("unknown messages") {


### PR DESCRIPTION
While we send `commit_sig` messages individually on the wire, we need a codec for the batch object when using the cluster mode, where peer connection actors live on remote machines.