### PR TITLE
Allow high remote `dust_limit_satoshis`

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -118,7 +118,9 @@ eclair {
     }
 
     dust-limit-satoshis = 546
-    max-remote-dust-limit-satoshis = 600
+    // Starting with anchor outputs channels, the on-chain feerate is not taken into account when trimming outputs.
+    // We must thus use a high enough dust limit to ensure that the outputs can economically be spent on-chain.
+    max-remote-dust-limit-satoshis = 10000
     htlc-minimum-msat = 1
     // The following parameters apply to each HTLC direction (incoming or outgoing), which means that the maximum amount in flight will be at most twice what is set here.
     // Note that our peer may use a lower value than ours, which would reduce the maximum amount in flight.


### PR DESCRIPTION
Now that we only accept anchor output channels and beyong, we should let our peers use high `dust_limit_satoshis` values to ensure that the transaction outputs are economically spendable.

We can't yet raise our `dust_limit_satoshis`: we must first accept high values, and in the next release (and once other implementations support it as well), then we'll be able to increase our default value.