### PR TITLE
Fix links to 'Reaching The Ground With Lightning'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ You can also use Github issues for [feature requests](https://github.com/acinq/e
 
 - [Bitcoin Whitepaper](https://bitcoin.org/bitcoin.pdf)
 - [Lightning Network Whitepaper](https://lightning.network/lightning-network-paper.pdf)
-- [Deployable Lightning](https://github.com/ElementsProject/lightning/raw/master/doc/deployable-lightning.pdf)
+- [Deployable Lightning](https://github.com/ElementsProject/lightning/blob/10b10eb981a2c3f2385c3c9ae2244a1767eeca86/doc/miscellaneous/deployable-lightning.pdf)
 - [Understanding the Lightning Network](https://bitcoinmagazine.com/articles/understanding-the-lightning-network-part-building-a-bidirectional-payment-channel-1464710791)
 - [Lightning Network Specification](https://github.com/lightning/bolts)
 - [High Level Lightning Network Specification](https://medium.com/@rusty_lightning/the-bitcoin-lightning-spec-part-1-8-a7720fb1b4da)

--- a/README.md
+++ b/README.md
@@ -326,4 +326,4 @@ zmqpubrawtx=tcp://127.0.0.1:29001
 ## Resources
 
 * [1] [The Bitcoin Lightning Network: Scalable Off-Chain Instant Payments](https://lightning.network/lightning-network-paper.pdf) by Joseph Poon and Thaddeus Dryja
-* [2] [Reaching The Ground With Lightning](https://github.com/ElementsProject/lightning/raw/master/doc/deployable-lightning.pdf) by Rusty Russell
+* [2] [Reaching The Ground With Lightning](https://github.com/ElementsProject/lightning/blob/10b10eb981a2c3f2385c3c9ae2244a1767eeca86/doc/miscellaneous/deployable-lightning.pdf) by Rusty Russell


### PR DESCRIPTION
Hello!

I noticed that the links to 'Reaching The Ground With Lightning' in README.md and CONTRIBUTING.md were broken because the file was moved in https://github.com/ElementsProject/lightning/commit/9e47c16021f165865841e7f307d4f54f0a783f71.

I now used a permalink so the links will not break again. However, that also means if the PDF gets updated, the links will still point to the old version.

However, since the PDF has not been changed meaningfully in 10 years (last time in https://github.com/ElementsProject/lightning/commit/2ab9e3bd7f3ed3e2423f3f4bc718afae2e91c15c), I don't think that's ever going to happen again.

But _if_ it happens, I think working links are more important anyway.

I also searched for `deployable-lightning.pdf` to check if there's another broken link, but I didn't find any.