### PR TITLE
Allow remote `dust_limit_satoshis` up to 5000 sats

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -120,7 +120,7 @@ eclair {
     dust-limit-satoshis = 546
     // Starting with anchor outputs channels, the on-chain feerate is not taken into account when trimming outputs.
     // We must thus use a high enough dust limit to ensure that the outputs can economically be spent on-chain.
-    max-remote-dust-limit-satoshis = 10000
+    max-remote-dust-limit-satoshis = 5000
     htlc-minimum-msat = 1
     // The following parameters apply to each HTLC direction (incoming or outgoing), which means that the maximum amount in flight will be at most twice what is set here.
     // Note that our peer may use a lower value than ours, which would reduce the maximum amount in flight.


### PR DESCRIPTION
Set allow remote `dust_limit_satoshis` up to 5000 sats, which means that HTLC outputs should be claimable at feerates lower than `25 sat/kw` (see https://github.com/lightning/bolts/pull/1301 for more details).

Given that our default `dust-tolerance` is set to 50 000 sats, this allows at least 10 pending dust HTLCs before we start failing dust HTLCs back instead of relaying them.