### PR TITLE
fixup! Add API methods to spend funds sent to taproot channel addresses (#3220)

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/SpendFromChannelAddress.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/SpendFromChannelAddress.scala
@@ -31,7 +31,7 @@ trait SpendFromChannelAddress {
       Right(pubKeyScript) = addressToPublicKeyScript(appKit.nodeParams.chainHash, address).map(Script.write)
       channelKeys = appKit.nodeParams.channelKeyManager.channelKeys(ChannelConfig.standard, fundingKeyPath)
       localFundingPubkey = channelKeys.fundingKey(fundingTxIndex).publicKey
-      isTaproot = Script.isPay2tr(Script.parse(pubKeyScript))
+      isTaproot = Script.isPay2tr(Script.parse(inputTx.txOut(outPoint.index.toInt).publicKeyScript))
       (localNonce_opt, dummyWitness) = if (isTaproot) {
         val serverNonce = Musig2.generateNonce(randomBytes32(), Right(localFundingPubkey), Seq(localFundingPubkey), None, None)
         nonces.put(serverNonce.publicNonce, serverNonce)


### PR DESCRIPTION
It is the parent script that matters when considering the signature scheme, not the output script.