### PR TITLE
Use fallback feerates on testnets

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -270,11 +270,11 @@ eclair {
     smoothing-window = 6 // 1 = no smoothing
 
     default-feerates { // the following values are in satoshis per byte
-      minimum = 5
-      slow = 5
-      medium = 10
-      fast = 20
-      fastest = 30
+      minimum = 1
+      slow = 2
+      medium = 5
+      fast = 10
+      fastest = 20
     }
 
     // confirmation priority for each transaction type, can be slow/medium/fast


### PR DESCRIPTION
When using testnet3 or testnet4, Bitcoin Core may fail to estimate fees because there isn't enough block data. We now use the configured default feerates when that happens to make it easier to run on testnets.

We also update the default feerates to better match current values.

Fixes #3105