### PR TITLE
Rework channel lifecyle events

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -9,6 +9,23 @@
 We remove the code used to support legacy channels that don't use anchor outputs or taproot.
 If you still have such channels, eclair won't start: you will need to close those channels, and will only be able to update eclair once they have been successfully closed.
 
+### Channel lifecyle events rework
+
+Eclair emits several events during a channel lifecycle, which can be received by plugins or through the websocket.
+We reworked these events to be compatible with splicing and consistent with 0-conf:
+
+- we removed the `channel-opened` event
+- we introduced a `channel-confirmed` event
+- we introduced a `channel-ready` event
+
+The `channel-confirmed` event is emitted when the funding transaction or a splice transaction has enough confirmations.
+Listeners can use the `fundingTxIndex` to detect whether this is the initial channel funding (`fundingTxIndex = 0`) or a splice (`fundingTxIndex > 0`).
+
+The `channel-ready` event is emitted when the channel is ready to process payments, which generally happens after the `channel-confirmed` event.
+However, when using zero-conf, this event may be emitted before the `channel-confirmed` event.
+
+See #3237 for more details.
+
 ### Channel jamming accountability
 
 We update our channel jamming mitigation to match the latest draft of the [spec](https://github.com/lightning/bolts/pull/1280).
@@ -29,6 +46,7 @@ eclair.relay.reserved-for-accountable = 0.0
 ### API changes
 
 - `findroute`, `findroutetonode` and `findroutebetweennodes` now include a `maxCltvExpiryDelta` parameter (#3234)
+- `channel-opened` was removed from the websocket in favor of `channel-confirmed` and `channel-ready` (#3237)
 
 ### Miscellaneous improvements and bug fixes
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelData.scala
@@ -765,14 +765,7 @@ object DATA_CLOSED {
     commitmentFormat = d.commitments.latest.commitmentFormat.toString,
     announced = d.commitments.latest.channelParams.announceChannel,
     capacity = d.commitments.latest.capacity,
-    closingTxId = closingType match {
-      case Closing.MutualClose(closingTx) => closingTx.tx.txid
-      case Closing.LocalClose(_, localCommitPublished) => localCommitPublished.commitTx.txid
-      case Closing.CurrentRemoteClose(_, remoteCommitPublished) => remoteCommitPublished.commitTx.txid
-      case Closing.NextRemoteClose(_, remoteCommitPublished) => remoteCommitPublished.commitTx.txid
-      case Closing.RecoveryClose(remoteCommitPublished) => remoteCommitPublished.commitTx.txid
-      case Closing.RevokedClose(revokedCommitPublished) => revokedCommitPublished.commitTx.txid
-    },
+    closingTxId = closingType.closingTxId,
     closingType = closingType.toString,
     closingScript = d.finalScriptPubKey,
     localBalance = closingType match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -30,6 +30,7 @@ import fr.acinq.eclair.{BlockHeight, Features, MilliSatoshi, RealShortChannelId,
 
 trait ChannelEvent
 
+/** This event is sent when a channel has been created: however, it may not be ready to process payments yet (see [[ChannelReadyForPayments]]). */
 case class ChannelCreated(channel: ActorRef, peer: ActorRef, remoteNodeId: PublicKey, isOpener: Boolean, temporaryChannelId: ByteVector32, commitTxFeerate: FeeratePerKw, fundingTxFeerate: Option[FeeratePerKw]) extends ChannelEvent
 
 // This trait can be used by non-standard channels to inject themselves into Register actor and thus make them usable for routing
@@ -50,11 +51,11 @@ case class ShortChannelIdAssigned(channel: ActorRef, channelId: ByteVector32, an
 /** This event will be sent if a channel was aborted before completing the opening flow. */
 case class ChannelAborted(channel: ActorRef, remoteNodeId: PublicKey, channelId: ByteVector32) extends ChannelEvent
 
-/** This event will be sent once a channel has been successfully opened and is ready to process payments. */
-case class ChannelOpened(channel: ActorRef, remoteNodeId: PublicKey, channelId: ByteVector32) extends ChannelEvent
+/** This event is sent once a funding transaction (channel creation or splice) has been confirmed. */
+case class ChannelFundingConfirmed(channel: ActorRef, channelId: ByteVector32, remoteNodeId: PublicKey, fundingTxId: TxId, fundingTxIndex: Long, blockHeight: BlockHeight, commitments: Commitments) extends ChannelEvent
 
-/** This event is sent once channel_ready or splice_locked have been exchanged. */
-case class ChannelReadyForPayments(channel: ActorRef, remoteNodeId: PublicKey, channelId: ByteVector32, fundingTxIndex: Long) extends ChannelEvent
+/** This event is sent once channel_ready or splice_locked have been exchanged: the channel is ready to process payments. */
+case class ChannelReadyForPayments(channel: ActorRef, remoteNodeId: PublicKey, channelId: ByteVector32, fundingTxId: TxId, fundingTxIndex: Long) extends ChannelEvent
 
 case class LocalChannelUpdate(channel: ActorRef, channelId: ByteVector32, aliases: ShortIdAliases, remoteNodeId: PublicKey, announcement_opt: Option[AnnouncedCommitment], channelUpdate: ChannelUpdate, commitments: Commitments) extends ChannelEvent {
   /**
@@ -103,7 +104,7 @@ case class ChannelPersisted(channel: ActorRef, remoteNodeId: PublicKey, channelI
 
 case class LocalCommitConfirmed(channel: ActorRef, remoteNodeId: PublicKey, channelId: ByteVector32, refundAtBlock: BlockHeight) extends ChannelEvent
 
-case class ChannelClosed(channel: ActorRef, channelId: ByteVector32, closingType: ClosingType, commitments: Commitments) extends ChannelEvent
+case class ChannelClosed(channel: ActorRef, channelId: ByteVector32, closingType: ClosingType, closingTxId: TxId, commitments: Commitments) extends ChannelEvent
 
 case class OutgoingHtlcAdded(add: UpdateAddHtlc, remoteNodeId: PublicKey, fee: MilliSatoshi)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -603,14 +603,30 @@ object Helpers {
   object Closing {
 
     // @formatter:off
-    sealed trait ClosingType
-    case class MutualClose(tx: ClosingTx) extends ClosingType { override def toString: String = "mutual-close" }
-    case class LocalClose(localCommit: LocalCommit, localCommitPublished: LocalCommitPublished) extends ClosingType { override def toString: String = "local-close" }
-    sealed trait RemoteClose extends ClosingType { def remoteCommit: RemoteCommit; def remoteCommitPublished: RemoteCommitPublished }
+    sealed trait ClosingType { def closingTxId: TxId }
+    case class MutualClose(tx: ClosingTx) extends ClosingType {
+      override def closingTxId: TxId = tx.tx.txid
+      override def toString: String = "mutual-close"
+    }
+    case class LocalClose(localCommit: LocalCommit, localCommitPublished: LocalCommitPublished) extends ClosingType {
+      override def closingTxId: TxId = localCommitPublished.commitTx.txid
+      override def toString: String = "local-close"
+    }
+    sealed trait RemoteClose extends ClosingType {
+      def remoteCommit: RemoteCommit
+      def remoteCommitPublished: RemoteCommitPublished
+      override def closingTxId: TxId = remoteCommitPublished.commitTx.txid
+    }
     case class CurrentRemoteClose(remoteCommit: RemoteCommit, remoteCommitPublished: RemoteCommitPublished) extends RemoteClose { override def toString: String = "remote-close" }
     case class NextRemoteClose(remoteCommit: RemoteCommit, remoteCommitPublished: RemoteCommitPublished) extends RemoteClose { override def toString: String = "next-remote-close" }
-    case class RecoveryClose(remoteCommitPublished: RemoteCommitPublished) extends ClosingType { override def toString: String = "recovery-close" }
-    case class RevokedClose(revokedCommitPublished: RevokedCommitPublished) extends ClosingType { override def toString: String = "revoked-close" }
+    case class RecoveryClose(remoteCommitPublished: RemoteCommitPublished) extends ClosingType {
+      override def closingTxId: TxId = remoteCommitPublished.commitTx.txid
+      override def toString: String = "recovery-close"
+    }
+    case class RevokedClose(revokedCommitPublished: RevokedCommitPublished) extends ClosingType {
+      override def closingTxId: TxId = revokedCommitPublished.commitTx.txid
+      override def toString: String = "revoked-close"
+    }
     // @formatter:on
 
     /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Monitoring.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Monitoring.scala
@@ -94,6 +94,7 @@ object Monitoring {
 
     object Events {
       val Created = "created"
+      val Spliced = "spliced"
       val Closing = "closing"
       val Closed = "closed"
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/IncomingConnectionsTracker.scala
@@ -6,8 +6,8 @@ import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.actor.typed.{ActorRef, Behavior}
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.eclair.Logs.LogCategory
+import fr.acinq.eclair.channel.ChannelReadyForPayments
 import fr.acinq.eclair.{Logs, NodeParams}
-import fr.acinq.eclair.channel.ChannelOpened
 import fr.acinq.eclair.io.IncomingConnectionsTracker.Command
 import fr.acinq.eclair.io.Monitoring.Metrics
 import fr.acinq.eclair.io.Peer.{Disconnect, DisconnectResponse}
@@ -46,7 +46,7 @@ object IncomingConnectionsTracker {
     Behaviors.setup { context =>
       Behaviors.withMdc(Logs.mdc(category_opt = Some(LogCategory.CONNECTION))) {
         context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[PeerDisconnected](c => ForgetIncomingConnection(c.nodeId)))
-        context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelOpened](c => ForgetIncomingConnection(c.remoteNodeId)))
+        context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelReadyForPayments](c => ForgetIncomingConnection(c.remoteNodeId)))
         new IncomingConnectionsTracker(nodeParams, switchboard, context).tracking(Map.empty)
       }
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PendingChannelsRateLimiter.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PendingChannelsRateLimiter.scala
@@ -40,7 +40,7 @@ object PendingChannelsRateLimiter {
   def apply(nodeParams: NodeParams, router: ActorRef[Router.GetNode], channels: Seq[PersistentChannelData]): Behavior[Command] = {
     Behaviors.setup { context =>
       context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelIdAssigned](c => ReplaceChannelId(c.remoteNodeId, c.temporaryChannelId, c.channelId)))
-      context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelOpened](c => RemoveChannelId(c.remoteNodeId, c.channelId)))
+      context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelReadyForPayments](c => RemoveChannelId(c.remoteNodeId, c.channelId)))
       context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelClosed](c => RemoveChannelId(c.commitments.remoteNodeId, c.channelId)))
       context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[ChannelAborted](c => RemoveChannelId(c.remoteNodeId, c.channelId)))
       val pendingChannels = filterPendingChannels(nodeParams, channels)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -553,10 +553,20 @@ object ChannelEventSerializer extends MinimalSerializer({
     JField("commitTxFeeratePerKw", JLong(e.commitTxFeerate.toLong)),
     JField("fundingTxFeeratePerKw", e.fundingTxFeerate.map(f => JLong(f.toLong)).getOrElse(JNothing))
   )
-  case e: ChannelOpened => JObject(
-    JField("type", JString("channel-opened")),
+  case e: ChannelFundingConfirmed => JObject(
+    JField("type", JString("channel-confirmed")),
     JField("remoteNodeId", JString(e.remoteNodeId.toString())),
     JField("channelId", JString(e.channelId.toHex)),
+    JField("fundingTxId", JString(e.fundingTxId.value.toHex)),
+    JField("fundingTxIndex", JLong(e.fundingTxIndex)),
+    JField("blockHeight", JLong(e.blockHeight.toLong)),
+  )
+  case e: ChannelReadyForPayments => JObject(
+    JField("type", JString("channel-ready")),
+    JField("remoteNodeId", JString(e.remoteNodeId.toString())),
+    JField("channelId", JString(e.channelId.toHex)),
+    JField("fundingTxId", JString(e.fundingTxId.value.toHex)),
+    JField("fundingTxIndex", JLong(e.fundingTxIndex)),
   )
   case e: ChannelStateChanged => JObject(
     JField("type", JString("channel-state-changed")),
@@ -568,7 +578,8 @@ object ChannelEventSerializer extends MinimalSerializer({
   case e: ChannelClosed => JObject(
     JField("type", JString("channel-closed")),
     JField("channelId", JString(e.channelId.toHex)),
-    JField("closingType", JString(e.closingType.getClass.getSimpleName))
+    JField("closingType", JString(e.closingType.getClass.getSimpleName)),
+    JField("closingTxId", JString(e.closingTxId.value.toHex)),
   )
 })
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForChannelReadyStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForChannelReadyStateSpec.scala
@@ -108,10 +108,10 @@ class WaitForChannelReadyStateSpec extends TestKitBaseClass with FixtureAnyFunSu
     val channelReady = bob2alice.expectMsgType[ChannelReady]
     assert(channelReady.alias_opt.contains(bobIds.localAlias))
     val listener = TestProbe()
-    alice.underlying.system.eventStream.subscribe(listener.ref, classOf[ChannelOpened])
+    alice.underlying.system.eventStream.subscribe(listener.ref, classOf[ChannelReadyForPayments])
     bob2alice.forward(alice)
     awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.head.remoteFundingStatus == RemoteFundingStatus.Locked)
-    listener.expectMsg(ChannelOpened(alice, bob.underlyingActor.nodeParams.nodeId, channelId(alice)))
+    assert(listener.expectMsgType[ChannelReadyForPayments].channelId == channelId(alice))
     val initialChannelUpdate = alice.stateData.asInstanceOf[DATA_NORMAL].channelUpdate
     assert(initialChannelUpdate.shortChannelId == aliceIds.localAlias)
     assert(initialChannelUpdate.feeBaseMsat == relayFees.feeBase)
@@ -156,9 +156,9 @@ class WaitForChannelReadyStateSpec extends TestKitBaseClass with FixtureAnyFunSu
     val channelReady = bob2alice.expectMsgType[ChannelReady]
     assert(channelReady.alias_opt.contains(bobIds.localAlias))
     val listener = TestProbe()
-    alice.underlying.system.eventStream.subscribe(listener.ref, classOf[ChannelOpened])
+    alice.underlying.system.eventStream.subscribe(listener.ref, classOf[ChannelReadyForPayments])
     bob2alice.forward(alice)
-    listener.expectMsg(ChannelOpened(alice, bob.underlyingActor.nodeParams.nodeId, channelId(alice)))
+    assert(listener.expectMsgType[ChannelReadyForPayments].channelId == channelId(alice))
     awaitCond(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.head.remoteFundingStatus == RemoteFundingStatus.Locked)
     val initialChannelUpdate = alice.stateData.asInstanceOf[DATA_NORMAL].channelUpdate
     assert(initialChannelUpdate.shortChannelId == aliceIds.localAlias)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/c/WaitForDualFundingReadyStateSpec.scala
@@ -114,18 +114,18 @@ class WaitForDualFundingReadyStateSpec extends TestKitBaseClass with FixtureAnyF
     bob.underlyingActor.nodeParams.db.peers.addOrUpdateRelayFees(alice.underlyingActor.nodeParams.nodeId, RelayFees(25 msat, 90))
 
     val listenerA = TestProbe()
-    alice.underlying.system.eventStream.subscribe(listenerA.ref, classOf[ChannelOpened])
+    alice.underlying.system.eventStream.subscribe(listenerA.ref, classOf[ChannelReadyForPayments])
     val listenerB = TestProbe()
-    bob.underlying.system.eventStream.subscribe(listenerB.ref, classOf[ChannelOpened])
+    bob.underlying.system.eventStream.subscribe(listenerB.ref, classOf[ChannelReadyForPayments])
 
     val aliceChannelReady = alice2bob.expectMsgType[ChannelReady]
     alice2bob.forward(bob, aliceChannelReady)
-    listenerB.expectMsg(ChannelOpened(bob, alice.underlyingActor.nodeParams.nodeId, channelId(bob)))
+    assert(listenerB.expectMsgType[ChannelReadyForPayments].channelId == channelId(bob))
     awaitCond(bob.stateName == NORMAL)
     assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.head.remoteFundingStatus == RemoteFundingStatus.Locked)
     val bobChannelReady = bob2alice.expectMsgType[ChannelReady]
     bob2alice.forward(alice, bobChannelReady)
-    listenerA.expectMsg(ChannelOpened(alice, bob.underlyingActor.nodeParams.nodeId, channelId(alice)))
+    assert(listenerA.expectMsgType[ChannelReadyForPayments].channelId == channelId(alice))
     awaitCond(alice.stateName == NORMAL)
     assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.head.remoteFundingStatus == RemoteFundingStatus.Locked)
 
@@ -172,18 +172,18 @@ class WaitForDualFundingReadyStateSpec extends TestKitBaseClass with FixtureAnyF
     import f._
 
     val listenerA = TestProbe()
-    alice.underlying.system.eventStream.subscribe(listenerA.ref, classOf[ChannelOpened])
+    alice.underlying.system.eventStream.subscribe(listenerA.ref, classOf[ChannelReadyForPayments])
     val listenerB = TestProbe()
-    bob.underlying.system.eventStream.subscribe(listenerB.ref, classOf[ChannelOpened])
+    bob.underlying.system.eventStream.subscribe(listenerB.ref, classOf[ChannelReadyForPayments])
 
     val aliceChannelReady = alice2bob.expectMsgType[ChannelReady]
     alice2bob.forward(bob, aliceChannelReady)
-    listenerB.expectMsg(ChannelOpened(bob, alice.underlyingActor.nodeParams.nodeId, channelId(bob)))
+    assert(listenerB.expectMsgType[ChannelReadyForPayments].channelId == channelId(bob))
     awaitCond(bob.stateName == NORMAL)
     assert(bob.stateData.asInstanceOf[DATA_NORMAL].commitments.active.head.remoteFundingStatus == RemoteFundingStatus.Locked)
     val bobChannelReady = bob2alice.expectMsgType[ChannelReady]
     bob2alice.forward(alice, bobChannelReady)
-    listenerA.expectMsg(ChannelOpened(alice, bob.underlyingActor.nodeParams.nodeId, channelId(alice)))
+    assert(listenerA.expectMsgType[ChannelReadyForPayments].channelId == channelId(alice))
     awaitCond(alice.stateName == NORMAL)
     assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.head.remoteFundingStatus == RemoteFundingStatus.Locked)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/db/AuditDbSpec.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.db
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.{Block, ByteVector32, SatoshiLong, Script, Transaction, TxOut}
 import fr.acinq.eclair.TestDatabases.{TestPgDatabases, TestSqliteDatabases}
+import fr.acinq.eclair.TestUtils.randomTxId
 import fr.acinq.eclair._
 import fr.acinq.eclair.channel.Helpers.Closing.MutualClose
 import fr.acinq.eclair.channel._
@@ -75,7 +76,7 @@ class AuditDbSpec extends AnyFunSuite {
       val e5 = PaymentSent(UUID.randomUUID(), randomBytes32(), randomBytes32(), 84100 msat, randomKey().publicKey, pp5a :: pp5b :: Nil, None)
       val pp6 = PaymentSent.PartialPayment(UUID.randomUUID(), 42000 msat, 1000 msat, randomBytes32(), None, timestamp = now + 10.minutes)
       val e6 = PaymentSent(UUID.randomUUID(), randomBytes32(), randomBytes32(), 42000 msat, randomKey().publicKey, pp6 :: Nil, None)
-      val e7 = ChannelEvent(randomBytes32(), randomKey().publicKey, 456123000 sat, isChannelOpener = true, isPrivate = false, ChannelEvent.EventType.Closed(MutualClose(null)))
+      val e7 = ChannelEvent(randomBytes32(), randomKey().publicKey, randomTxId(), 456123000 sat, isChannelOpener = true, isPrivate = false, ChannelEvent.EventType.Closed(MutualClose(null)))
       val e10 = TrampolinePaymentRelayed(randomBytes32(),
         Seq(
           PaymentRelayed.IncomingPart(20000 msat, randomBytes32(), now - 7.seconds),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/IncomingConnectionsTrackerSpec.scala
@@ -23,7 +23,8 @@ import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
 import com.typesafe.config.ConfigFactory
 import fr.acinq.bitcoin.scalacompat.Crypto
 import fr.acinq.eclair.TestConstants.Alice.nodeParams
-import fr.acinq.eclair.channel.ChannelOpened
+import fr.acinq.eclair.TestUtils.randomTxId
+import fr.acinq.eclair.channel.ChannelReadyForPayments
 import fr.acinq.eclair.io.Peer.Disconnect
 import fr.acinq.eclair.{randomBytes32, randomKey}
 import org.scalatest.Outcome
@@ -96,7 +97,7 @@ class IncomingConnectionsTrackerSpec extends ScalaTestWithActorTestKit(ConfigFac
     }
 
     // Untrack a node when a channel with it is confirmed on-chain.
-    system.eventStream ! EventStream.Publish(ChannelOpened(system.deadLetters.toClassic, connection1, randomBytes32()))
+    system.eventStream ! EventStream.Publish(ChannelReadyForPayments(system.deadLetters.toClassic, connection1, randomBytes32(), randomTxId(), 0))
     eventually {
       tracker ! IncomingConnectionsTracker.CountIncomingConnections(probe.ref)
       probe.expectMessage(1)

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/WebSocket.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/WebSocket.scala
@@ -52,7 +52,8 @@ trait WebSocket {
       override def preStart(): Unit = {
         context.system.eventStream.subscribe(self, classOf[PaymentEvent])
         context.system.eventStream.subscribe(self, classOf[ChannelCreated])
-        context.system.eventStream.subscribe(self, classOf[ChannelOpened])
+        context.system.eventStream.subscribe(self, classOf[ChannelFundingConfirmed])
+        context.system.eventStream.subscribe(self, classOf[ChannelReadyForPayments])
         context.system.eventStream.subscribe(self, classOf[ChannelStateChanged])
         context.system.eventStream.subscribe(self, classOf[ChannelClosed])
         context.system.eventStream.subscribe(self, classOf[OnionMessages.ReceiveMessage])
@@ -61,7 +62,8 @@ trait WebSocket {
       def receive: Receive = {
         case message: PaymentEvent => flowInput.offer(serialization.write(message))
         case message: ChannelCreated => flowInput.offer(serialization.write(message))
-        case message: ChannelOpened => flowInput.offer(serialization.write(message))
+        case message: ChannelFundingConfirmed => flowInput.offer(serialization.write(message))
+        case message: ChannelReadyForPayments => flowInput.offer(serialization.write(message))
         case message: ChannelStateChanged =>
           if (message.previousState != WAIT_FOR_INIT_INTERNAL) {
             flowInput.offer(serialization.write(message))


### PR DESCRIPTION
We emit several events during the channel lifecycle, which have become a bit of a mess over the years, especially with the addition of 0-conf, splicing and on-the-fly funding.

We now use the following events:

- `ChannelCreated` once the funding transaction is created
- `ChannelFundingConfirmed` once the funding transaction is confirmed, which is also emitted for splice transactions
- `ChannelReadyForPayments` once the channel is ready for payments, after exchanging `channel_ready` for the channel creation or `splice_locked` for splice transactions

The order between `ChannelFundingConfirmed` and `ChannelReadyForPayments` depends on whether 0-conf is used or not.

We remove `ChannelOpened`, which was actually a subset of the existing `ChannelReadyForPayments` event (which was added afterwards).

We add a few fields to existing channel events, which we don't yet store in the DB to avoid modifying it, but will store later when we modify the schema of the `AuditDb`.

We now store an entry in the `AuditDb` whenever a splice transaction confirms, which allows tracking the full history of a channel's changes.