### PR TITLE
Add test vector for Bolt12 invalid bech32 padding

### DIFF
--- a/eclair-core/src/test/resources/offers-test.json
+++ b/eclair-core/src/test/resources/offers-test.json
@@ -592,5 +592,10 @@
     "description": "Second offer_path is empty",
     "valid": false,
     "bolt12": "lno1pgx9getnwss8vetrw3hhyucsespjgef743p5fzqq9nqxh0ah7y87rzv3ud0eleps9kl2d5348hq2k8qzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgqpqqqqqqqqqqqqqqqqqqqqqqqqqqqzqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqzq3zyg3zyg3zygszqqqqyqqqqsqqvpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqsq"
+  },
+  {
+    "description": "Bech32 padding exceeds 4-bit limit",
+    "valid": false,
+    "bolt12": "lno1zcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pkseseq"
   }
 ]


### PR DESCRIPTION
See https://github.com/lightning/bolts/pull/1312 for more details.