### PR TITLE
Select `channel_type` for automatic channel creation

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelFeatures.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelFeatures.scala
@@ -116,7 +116,6 @@ object ChannelTypes {
     override def commitmentFormat: CommitmentFormat = PhoenixSimpleTaprootChannelCommitmentFormat
     override def toString: String = "phoenix_simple_taproot_channel"
   }
-
   // @formatter:on
 
   private val features2ChannelType: Map[Features[_ <: InitFeature], SupportedChannelType] = Set(
@@ -147,6 +146,15 @@ object ChannelTypes {
     // We ensure that we support the features necessary for this channel type.
     case Some(proposedChannelType: SupportedChannelType) if proposedChannelType.features.forall(f => localFeatures.hasFeature(f)) => Right(proposedChannelType)
     case Some(proposedChannelType: SupportedChannelType) => Left(InvalidChannelType(channelId, proposedChannelType))
+  }
+
+  /** Returns our preferred channel type for public channels, if supported by our peer. */
+  def preferredForPublicChannels(localFeatures: Features[InitFeature], remoteFeatures: Features[InitFeature]): Option[SupportedChannelType] = {
+    if (Features.canUseFeature(localFeatures, remoteFeatures, Features.AnchorOutputsZeroFeeHtlcTx)) {
+      Some(AnchorOutputsZeroFeeHtlcTx(scidAlias = Features.canUseFeature(localFeatures, remoteFeatures, Features.ScidAlias)))
+    } else {
+      None
+    }
   }
 
 }


### PR DESCRIPTION
When creating channels automatically, we don't necessarily have access to our peer's features. It is useful to automatically select the channel type based on local and remote features. We now allow this behavior in the `OpenChannelInterceptor`.

Note that when we add official support for taproot channels and 0-fee commitments, we will hard-code in `eclair` which type of channels we think is best. If node operators want to override this order, they will need to explicitly provide the `channel_type` parameter (which can be done when using the API).