### PR TITLE
Add claude files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ DeleteMe*.*
 jdbcUrlFile_*.tmp
 
 .DS_Store
+
+.claude*


### PR DESCRIPTION
Claude adds a `.claude` dir at the root of the project. In a sandboxing setup we may want to use other custom claude-related directories, hence the wildcard.