### PR TITLE
Fix flaky wallet funding tests

### DIFF
--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
@@ -31,7 +31,7 @@ import fr.acinq.eclair.transactions.Transactions
 import fr.acinq.eclair.{TimestampSecond, randomBytes32}
 import scodec.bits._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Random, Success}
 
 /**
@@ -227,6 +227,14 @@ class SingleKeyOnChainWallet extends OnChainWallet with OnChainAddressCache {
   override def doubleSpent(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean] = Future.successful(doubleSpent.contains(tx.txid))
 
   override def getReceivePublicKeyScript(renew: Boolean): Seq[ScriptElt] = p2trScript
+}
+
+/** A wallet that blocks when called to fund transactions (useful to test events happening while funding). */
+class BlockingOnChainWallet extends SingleKeyOnChainWallet {
+  override def makeFundingTx(pubkeyScript: ByteVector, amount: Satoshi, feeRatePerKw: FeeratePerKw, feeBudget_opt: Option[Satoshi])(implicit ec: ExecutionContext): Future[MakeFundingTxResponse] = {
+    // We create a dummy promise that will never be completed.
+    Promise().future
+  }
 }
 
 object DummyOnChainWallet {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingInternalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingInternalStateSpec.scala
@@ -19,6 +19,7 @@ package fr.acinq.eclair.channel.states.b
 import akka.actor.Status
 import akka.testkit.{TestFSMRef, TestProbe}
 import fr.acinq.bitcoin.scalacompat.ByteVector32
+import fr.acinq.eclair.blockchain.BlockingOnChainWallet
 import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.fsm.Channel
 import fr.acinq.eclair.channel.fsm.Channel.TickChannelOpenTimeout
@@ -40,7 +41,8 @@ class WaitForFundingInternalStateSpec extends TestKitBaseClass with FixtureAnyFu
   case class FixtureParam(alice: TestFSMRef[ChannelState, ChannelData, Channel], aliceOpenReplyTo: TestProbe, alice2bob: TestProbe, bob2alice: TestProbe, alice2blockchain: TestProbe, listener: TestProbe)
 
   override def withFixture(test: OneArgTest): Outcome = {
-    val setup = init(tags = test.tags)
+    // Note that we use a dummy wallet that doesn't complete its transaction funding.
+    val setup = init(tags = test.tags, walletA_opt = Some(new BlockingOnChainWallet()))
     import setup._
     val channelParams = computeChannelParams(setup, test.tags)
     val listener = TestProbe()


### PR DESCRIPTION
We fix a few flaky tests in our channel FSM that test scenarios where errors are received while creating funding transactions. The issue was that we used a dummy wallet that could complete its call before our calls to `awaitCond(alice.stateName == WAIT_FOR_FUNDING_INTERNAL)`.

We use a new dummy on-chain wallet that never responds to transaction funding calls to allow tests to inject failure events.