### PR TITLE
Add `ChannelFundingCreated` event

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -15,8 +15,12 @@ Eclair emits several events during a channel lifecycle, which can be received by
 We reworked these events to be compatible with splicing and consistent with 0-conf:
 
 - we removed the `channel-opened` event
+- we introduced a `channel-funding-created` event
 - we introduced a `channel-confirmed` event
 - we introduced a `channel-ready` event
+
+The `channel-funding-created` event is emitted when the funding transaction or a splice transaction has been signed and can be published.
+Listeners can use the `fundingTxIndex` to detect whether this is the initial channel funding (`fundingTxIndex = 0`) or a splice (`fundingTxIndex > 0`).
 
 The `channel-confirmed` event is emitted when the funding transaction or a splice transaction has enough confirmations.
 Listeners can use the `fundingTxIndex` to detect whether this is the initial channel funding (`fundingTxIndex = 0`) or a splice (`fundingTxIndex > 0`).
@@ -46,7 +50,7 @@ eclair.relay.reserved-for-accountable = 0.0
 ### API changes
 
 - `findroute`, `findroutetonode` and `findroutebetweennodes` now include a `maxCltvExpiryDelta` parameter (#3234)
-- `channel-opened` was removed from the websocket in favor of `channel-confirmed` and `channel-ready` (#3237)
+- `channel-opened` was removed from the websocket in favor of `channel-funding-created`, `channel-confirmed` and `channel-ready` (#3237 and #3256)
 
 ### Miscellaneous improvements and bug fixes
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/ChannelEvents.scala
@@ -52,6 +52,11 @@ case class ShortChannelIdAssigned(channel: ActorRef, channelId: ByteVector32, an
 /** This event will be sent if a channel was aborted before completing the opening flow. */
 case class ChannelAborted(channel: ActorRef, remoteNodeId: PublicKey, channelId: ByteVector32) extends ChannelEvent
 
+/** This event is sent once a funding transaction (channel creation or splice) is ready to be published. */
+case class ChannelFundingCreated(channel: ActorRef, channelId: ByteVector32, remoteNodeId: PublicKey, fundingTx: Either[TxId, Transaction], fundingTxIndex: Long, commitments: Commitments) extends ChannelEvent {
+  val fundingTxId: TxId = fundingTx.fold(txId => txId, tx => tx.txid)
+}
+
 /** This event is sent once a funding transaction (channel creation or splice) has been confirmed. */
 case class ChannelFundingConfirmed(channel: ActorRef, channelId: ByteVector32, remoteNodeId: PublicKey, fundingTxId: TxId, fundingTxIndex: Long, blockHeight: BlockHeight, commitments: Commitments) extends ChannelEvent
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -685,6 +685,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
                 val minDepth_opt = d.commitments.channelParams.minDepth(nodeParams.channelConf.minDepth)
                 watchFundingConfirmed(signingSession.fundingTx.txId, minDepth_opt, delay_opt = None)
                 val commitments1 = d.commitments.add(signingSession1.commitment)
+                context.system.eventStream.publish(ChannelFundingCreated(self, d.channelId, remoteNodeId, Right(signingSession1.fundingTx.signedTx_opt.getOrElse(signingSession1.fundingTx.sharedTx.tx.buildUnsignedTx())), signingSession1.commitment.fundingTxIndex, commitments1))
                 val d1 = d.copy(commitments = commitments1, spliceStatus = SpliceStatus.NoSplice)
                 stay() using d1 storing() sending signingSession1.localSigs calling endQuiescence(d1)
             }
@@ -1457,6 +1458,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
                   val minDepth_opt = d.commitments.channelParams.minDepth(nodeParams.channelConf.minDepth)
                   watchFundingConfirmed(signingSession.fundingTx.txId, minDepth_opt, delay_opt = None)
                   val commitments1 = d.commitments.add(signingSession1.commitment)
+                  context.system.eventStream.publish(ChannelFundingCreated(self, d.channelId, remoteNodeId, Right(signingSession1.fundingTx.signedTx_opt.getOrElse(signingSession1.fundingTx.sharedTx.tx.buildUnsignedTx())), signingSession1.commitment.fundingTxIndex, commitments1))
                   val d1 = d.copy(commitments = commitments1, spliceStatus = SpliceStatus.NoSplice)
                   log.info("publishing funding tx for channelId={} fundingTxId={}", d.channelId, signingSession1.fundingTx.sharedTx.txId)
                   Metrics.recordSplice(signingSession1.fundingTx.fundingParams, signingSession1.fundingTx.sharedTx.tx)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
@@ -334,6 +334,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
                   txPublisher ! SetChannelId(remoteNodeId, channelId)
                   context.system.eventStream.publish(ChannelIdAssigned(self, remoteNodeId, temporaryChannelId, channelId))
                   context.system.eventStream.publish(ChannelSignatureReceived(self, commitments))
+                  context.system.eventStream.publish(ChannelFundingCreated(self, channelId, remoteNodeId, Left(commitment.fundingTxId), commitment.fundingTxIndex, commitments))
                   // NB: we don't send a ChannelSignatureSent for the first commit
                   log.info("waiting for them to publish the funding tx for channelId={} fundingTxid={}", channelId, commitment.fundingTxId)
                   watchFundingConfirmed(commitment.fundingTxId, d.channelParams.minDepth(nodeParams.channelConf.minDepth), delay_opt = None)
@@ -391,6 +392,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
             originChannels = Map.empty)
           val blockHeight = nodeParams.currentBlockHeight
           context.system.eventStream.publish(ChannelSignatureReceived(self, commitments))
+          context.system.eventStream.publish(ChannelFundingCreated(self, d.channelId, remoteNodeId, Right(d.fundingTx), commitment.fundingTxIndex, commitments))
           log.info("publishing funding tx fundingTxId={}", commitment.fundingTxId)
           watchFundingConfirmed(commitment.fundingTxId, d.channelParams.minDepth(nodeParams.channelConf.minDepth), delay_opt = None)
           // we will publish the funding tx only after the channel state has been written to disk because we want to

--- a/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/json/JsonSerializers.scala
@@ -560,6 +560,13 @@ object ChannelEventSerializer extends MinimalSerializer({
     JField("commitTxFeeratePerKw", JLong(e.commitTxFeerate.toLong)),
     JField("fundingTxFeeratePerKw", e.fundingTxFeerate.map(f => JLong(f.toLong)).getOrElse(JNothing))
   )
+  case e: ChannelFundingCreated => JObject(
+    JField("type", JString("channel-funding-created")),
+    JField("remoteNodeId", JString(e.remoteNodeId.toString())),
+    JField("channelId", JString(e.channelId.toHex)),
+    JField("fundingTxId", JString(e.fundingTxId.value.toHex)),
+    JField("fundingTxIndex", JLong(e.fundingTxIndex)),
+  )
   case e: ChannelFundingConfirmed => JObject(
     JField("type", JString("channel-confirmed")),
     JField("remoteNodeId", JString(e.remoteNodeId.toString())),

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -1394,6 +1394,7 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     systemA.eventStream.subscribe(aliceEvents.ref, classOf[AvailableBalanceChanged])
     systemA.eventStream.subscribe(aliceEvents.ref, classOf[LocalChannelUpdate])
     systemA.eventStream.subscribe(aliceEvents.ref, classOf[LocalChannelDown])
+    systemA.eventStream.subscribe(aliceEvents.ref, classOf[ChannelFundingCreated])
     systemB.eventStream.subscribe(bobEvents.ref, classOf[ForgetHtlcInfos])
     systemB.eventStream.subscribe(bobEvents.ref, classOf[AvailableBalanceChanged])
     systemB.eventStream.subscribe(bobEvents.ref, classOf[LocalChannelUpdate])
@@ -1402,6 +1403,10 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     val fundingInput = alice.commitments.latest.fundingInput
     val fundingTx1 = initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat)))
     checkWatchConfirmed(f, fundingTx1)
+    inside(aliceEvents.expectMsgType[ChannelFundingCreated]) { e =>
+      assert(e.fundingTx == Right(fundingTx1))
+      assert(e.fundingTxIndex == 1)
+    }
 
     bob ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
     bob2blockchain.expectMsgTypeHaving[WatchFundingSpent](_.txId == fundingTx1.txid)
@@ -1413,6 +1418,10 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
 
     val fundingTx2 = initiateSplice(f, spliceIn_opt = Some(SpliceIn(500_000 sat)))
     checkWatchConfirmed(f, fundingTx2)
+    inside(aliceEvents.expectMsgType[ChannelFundingCreated]) { e =>
+      assert(e.fundingTx == Right(fundingTx2))
+      assert(e.fundingTxIndex == 2)
+    }
 
     alice ! WatchFundingConfirmedTriggered(BlockHeight(400000), 42, fundingTx1)
     alice2bob.expectMsgType[SpliceLocked]

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/WebSocket.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/WebSocket.scala
@@ -52,6 +52,7 @@ trait WebSocket {
       override def preStart(): Unit = {
         context.system.eventStream.subscribe(self, classOf[PaymentEvent])
         context.system.eventStream.subscribe(self, classOf[ChannelCreated])
+        context.system.eventStream.subscribe(self, classOf[ChannelFundingCreated])
         context.system.eventStream.subscribe(self, classOf[ChannelFundingConfirmed])
         context.system.eventStream.subscribe(self, classOf[ChannelReadyForPayments])
         context.system.eventStream.subscribe(self, classOf[ChannelStateChanged])
@@ -62,6 +63,7 @@ trait WebSocket {
       def receive: Receive = {
         case message: PaymentEvent => flowInput.offer(serialization.write(message))
         case message: ChannelCreated => flowInput.offer(serialization.write(message))
+        case message: ChannelFundingCreated => flowInput.offer(serialization.write(message))
         case message: ChannelFundingConfirmed => flowInput.offer(serialization.write(message))
         case message: ChannelReadyForPayments => flowInput.offer(serialization.write(message))
         case message: ChannelStateChanged =>

--- a/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
+++ b/eclair-node/src/test/scala/fr/acinq/eclair/api/ApiServiceSpec.scala
@@ -1160,6 +1160,12 @@ class ApiServiceSpec extends AnyFunSuite with ScalatestRouteTest with IdiomaticM
         system.eventStream.publish(chcr)
         wsClient.expectMessage(expectedSerializedChcr)
 
+        val chfcr = ChannelFundingCreated(system.deadLetters, ByteVector32.One, bobNodeId, Left(fundingTxId), 0, null)
+        val expectedSerializedChfcr = """{"type":"channel-funding-created","remoteNodeId":"039dc0e0b1d25905e44fdf6f8e89755a5e219685840d0bc1d28d3308f9628a3585","channelId":"0100000000000000000000000000000000000000000000000000000000000000","fundingTxId":"9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692","fundingTxIndex":0}"""
+        assert(serialization.write(chfcr) == expectedSerializedChfcr)
+        system.eventStream.publish(chfcr)
+        wsClient.expectMessage(expectedSerializedChfcr)
+
         val chfc = ChannelFundingConfirmed(system.deadLetters, ByteVector32.One, bobNodeId, fundingTxId, 0, BlockHeight(900000), null)
         val expectedSerializedChfc = """{"type":"channel-confirmed","remoteNodeId":"039dc0e0b1d25905e44fdf6f8e89755a5e219685840d0bc1d28d3308f9628a3585","channelId":"0100000000000000000000000000000000000000000000000000000000000000","fundingTxId":"9fcd45bbaa09c60c991ac0425704163c3f3d2d683c789fa409455b9c97792692","fundingTxIndex":0,"blockHeight":900000}"""
         assert(serialization.write(chfc) == expectedSerializedChfc)


### PR DESCRIPTION
We add a `ChannelFundingCreated` event that is emitted when the funding transaction or a splice transaction has been signed and can now be published, either by us or by our peer (depending on who funds).

This can be handy to detect peers that are using black-listed inputs and immediately close the channel before it confirms and can be used.

I've created the following plugin to show how this can be used: https://github.com/ACINQ/eclair-plugins/pull/18

I've also added a mechanism to extend the `interactive-tx` validation to eagerly reject transactions before signing them, which complements this PR. See #3258 for more details.