### PR TITLE
Reject offers with amount set to `0`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/OfferTypes.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/wire/protocol/OfferTypes.scala
@@ -314,6 +314,7 @@ object OfferTypes {
 
     def validate(records: TlvStream[OfferTlv]): Either[InvalidTlvPayload, Offer] = {
       if (records.get[OfferDescription].isEmpty && records.get[OfferAmount].nonEmpty) return Left(MissingRequiredTlv(UInt64(10)))
+      if (records.get[OfferAmount].exists(_.amount == 0)) return Left(ForbiddenTlv(UInt64(10)))
       if (records.get[OfferNodeId].isEmpty && records.get[OfferPaths].isEmpty) return Left(MissingRequiredTlv(UInt64(22)))
       if (records.get[OfferCurrency].nonEmpty && records.get[OfferAmount].isEmpty) return Left(MissingRequiredTlv(UInt64(8)))
       if (records.unknown.exists(!isOfferTlv(_))) return Left(ForbiddenTlv(records.unknown.find(!isOfferTlv(_)).get.tag))

--- a/eclair-core/src/test/resources/offers-test.json
+++ b/eclair-core/src/test/resources/offers-test.json
@@ -584,6 +584,57 @@
     "bolt12": "lno1qcp4256ypgx9getnwss8vetrw3hhyuckyypwa3eyt44h6txtxquqh7lz5djge4afgfjn7k4rgrkuag0jsd5xvxg"
   },
   {
+    "description": "Invalid: zero offer_amount",
+    "valid": false,
+    "bolt12": "lno1pqqq5qqkyyp4he0fg7pqje62jmnq78cr0ashv4q06qql58tyd9rhp3t2wuyugtq",
+    "field info": "offer_amount is 0",
+    "fields": [
+      {
+        "type": 8,
+        "length": 0,
+        "hex": ""
+      },
+      {
+        "type": 10,
+        "length": 0,
+        "hex": ""
+      },
+      {
+        "type": 22,
+        "length": 33,
+        "hex": "035be5e9478209674a96e60f1f037f6176540fd001fa1d64694770c56a7709c42c"
+      }
+    ]
+  },
+  {
+    "description": "Invalid: zero offer_amount with currency",
+    "valid": false,
+    "bolt12": "lno1qcp4256ypqqq5qqkyyp4he0fg7pqje62jmnq78cr0ashv4q06qql58tyd9rhp3t2wuyugtq",
+    "field info": "offer_amount is 0, offer_currency is USD",
+    "fields": [
+      {
+        "type": 6,
+        "length": 3,
+        "hex": "555344"
+      },
+      {
+        "type": 8,
+        "length": 0,
+        "hex": ""
+      },
+      {
+        "type": 10,
+        "length": 0,
+        "hex": ""
+      },
+      {
+        "type": 22,
+        "length": 33,
+        "hex": "035be5e9478209674a96e60f1f037f6176540fd001fa1d64694770c56a7709c42c"
+      }
+    ]
+  },
+  {
     "description": "Missing offer_issuer_id and no offer_path",
     "valid": false,
     "bolt12": "lno1pgx9getnwss8vetrw3hhyuc"


### PR DESCRIPTION
This doesn't make any sense, the field should be omitted if any amount is acceptable: setting it to `0` is confusing.

See https://github.com/lightning/bolts/pull/1316