### PR TITLE
Add bitcoin rpc call to check wether an address belongs to our wallet

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/OnChainWallet.scala
@@ -111,6 +111,12 @@ trait OnChainChannelFunder {
    */
   def doubleSpent(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean]
 
+  /**
+   * @param address bitcoin address to check
+   * @return true if address belongs to our wallet
+   */
+  def isMine(address: String)(implicit ec: ExecutionContext): Future[Boolean]
+
 }
 
 /** This trait lets users generate on-chain addresses and public keys. */

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -684,6 +684,13 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
     }
   }
 
+  def isMine(address: String)(implicit ec: ExecutionContext): Future[Boolean] = {
+    for {
+      addressInfo <- rpcClient.invoke("getaddressinfo", address)
+      JBool(isMine) = addressInfo \ "ismine"
+    } yield isMine
+  }
+  
   //------------------------- MEMPOOL  -------------------------//
 
   def getMempool()(implicit ec: ExecutionContext): Future[Seq[Transaction]] =

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/DummyOnChainWallet.scala
@@ -21,7 +21,7 @@ import fr.acinq.bitcoin.psbt.{KeyPathWithMaster, Psbt, TaprootBip32DerivationPat
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
 import fr.acinq.bitcoin.scalacompat.Crypto.TaprootTweak.KeyPathTweak
 import fr.acinq.bitcoin.scalacompat.DeterministicWallet.KeyPath
-import fr.acinq.bitcoin.scalacompat.{Block, ByteVector64, KotlinUtils, OutPoint, Satoshi, SatoshiLong, Script, ScriptElt, ScriptWitness, Transaction, TxId, TxIn, TxOut}
+import fr.acinq.bitcoin.scalacompat.{Block, ByteVector64, KotlinUtils, OutPoint, Satoshi, SatoshiLong, Script, ScriptElt, ScriptWitness, Transaction, TxId, TxIn, TxOut, addressFromPublicKeyScript}
 import fr.acinq.eclair.TestUtils.randomTxId
 import fr.acinq.eclair.blockchain.OnChainWallet.{FundTransactionResponse, MakeFundingTxResponse, OnChainBalance, ProcessPsbtResponse}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.AddressType
@@ -92,6 +92,12 @@ class DummyOnChainWallet extends OnChainWallet with OnChainAddressCache {
   override def doubleSpent(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean] = Future.successful(false)
 
   override def getReceivePublicKeyScript(renew: Boolean): Seq[ScriptElt] = Script.pay2tr(dummyReceivePubkey.xOnly, KeyPathTweak)
+
+  override def isMine(address: String)(implicit ec: ExecutionContext): Future[Boolean] = Future.successful {
+    if (Right(address) == addressFromPublicKeyScript(Block.RegtestGenesisBlock.hash, Script.pay2wpkh(dummyReceivePubkey))) true
+    else if (Right(address) == addressFromPublicKeyScript(Block.RegtestGenesisBlock.hash, Script.pay2tr(dummyReceivePubkey.xOnly, KeyPathTweak))) true
+    else false
+  }
 }
 
 class SingleKeyOnChainWallet extends OnChainWallet with OnChainAddressCache {
@@ -227,6 +233,12 @@ class SingleKeyOnChainWallet extends OnChainWallet with OnChainAddressCache {
   override def doubleSpent(tx: Transaction)(implicit ec: ExecutionContext): Future[Boolean] = Future.successful(doubleSpent.contains(tx.txid))
 
   override def getReceivePublicKeyScript(renew: Boolean): Seq[ScriptElt] = p2trScript
+
+  override def isMine(address: String)(implicit ec: ExecutionContext): Future[Boolean] = Future.successful {
+    if (Right(address) == addressFromPublicKeyScript(Block.RegtestGenesisBlock.hash, p2wpkhScript)) true
+    else if (Right(address) == addressFromPublicKeyScript(Block.RegtestGenesisBlock.hash, p2trScript)) true
+    else false
+  }
 }
 
 /** A wallet that blocks when called to fund transactions (useful to test events happening while funding). */

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
@@ -123,6 +123,25 @@ class BitcoinCoreClientSpec extends TestKitBaseClass with BitcoindService with A
     assert(addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, address2).map(Script.isPay2tr).contains(true))
   }
 
+  test("check whether an address belongs to our wallet") {
+    val sender = TestProbe()
+    val bitcoinClient = makeBitcoinCoreClient()
+
+    bitcoinClient.getReceiveAddress(None).pipeTo(sender.ref)
+    val address = sender.expectMsgType[String]
+    bitcoinClient.isMine(address).pipeTo(sender.ref)
+    sender.expectMsg(true)
+
+    bitcoinClient.getChangeAddress(None).pipeTo(sender.ref)
+    val changeAddress = sender.expectMsgType[String]
+    bitcoinClient.isMine(changeAddress).pipeTo(sender.ref)
+    sender.expectMsg(true)
+
+    val randomAddress = computeBIP84Address(randomKey().publicKey, Block.RegtestGenesisBlock.hash)
+    bitcoinClient.isMine(randomAddress).pipeTo(sender.ref)
+    sender.expectMsg(false)
+  }
+
   test("fund transactions") {
     val sender = TestProbe()
     val bitcoinClient = makeBitcoinCoreClient()
@@ -2123,5 +2142,24 @@ class BitcoinCoreClientWithEclairSignerSpec extends BitcoinCoreClientSpec {
     val signedTx: Transaction = signedPsbt.extract().getRight
     wallet.publishTransaction(signedTx).pipeTo(sender.ref)
     sender.expectMsg(signedTx.txid)
+  }
+
+  test("check whether an address belongs to our wallet (private keys managed by eclair)") {
+    val sender = TestProbe()
+    val bitcoinClient = makeBitcoinCoreClient()
+
+    bitcoinClient.getReceiveAddress(None).pipeTo(sender.ref)
+    val address = sender.expectMsgType[String]
+    bitcoinClient.isMine(address).pipeTo(sender.ref)
+    sender.expectMsg(true)
+
+    bitcoinClient.getChangeAddress(None).pipeTo(sender.ref)
+    val changeAddress = sender.expectMsgType[String]
+    bitcoinClient.isMine(changeAddress).pipeTo(sender.ref)
+    sender.expectMsg(true)
+
+    val randomAddress = computeBIP84Address(randomKey().publicKey, Block.RegtestGenesisBlock.hash)
+    bitcoinClient.isMine(randomAddress).pipeTo(sender.ref)
+    sender.expectMsg(false)
   }
 }


### PR DESCRIPTION
We use the "ismine" property that is returned by the "getaddressinfo" RPC call.