### PR TITLE
Follow BOLT1 handling for "no reply" pings: ignore, don't warn.

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -243,7 +243,8 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
       case Event(ping@Ping(pongLength, _, _), d: ConnectedData) =>
         d.transport ! TransportHandler.ReadAck(ping)
         if (pongLength <= 65532) {
-          // see BOLT 1: we reply only if requested pong length is acceptable
+          // See BOLT 1: we reply only if requested pong length is acceptable.
+          // Senders may use unacceptable pong length when they don't want a response (to generate cover traffic).
           d.transport ! Pong(ByteVector.fill(pongLength)(0.toByte))
         }
         stay()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -250,11 +250,11 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
   test("ignore malicious ping") { f =>
     import f._
     connect(nodeParams, remoteNodeId, switchboard, router, connection, transport, peerConnection, peer)
-    // huge requested pong length
+    // Huge requested pong length.
     val ping = Ping(Int.MaxValue, randomBytes(127))
     transport.send(peerConnection, ping)
     transport.expectMsg(TransportHandler.ReadAck(ping))
-    assert(transport.expectMsgType[Warning].channelId == Peer.CHANNELID_ZERO)
+    // We simply ignore the message without sending pong back.
     transport.expectNoMessage()
   }
 


### PR DESCRIPTION
These "oversize ping replies" are how we ask for no replies, such as when we're sending dummy traffic.  From the rationale:

    This allows a convenient cutoff for `num_pong_bytes` to indicate that no reply should be sent.
