### PR TITLE
Use noble docker images instead of alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jdk-alpine as BUILD
+FROM eclipse-temurin:21-jdk-noble as BUILD
 
 # Let's fetch eclair dependencies, so that Docker can cache them
 # This way we won't have to fetch dependencies again if only the source code changes
@@ -23,11 +23,11 @@ COPY . .
 RUN ./mvnw package -pl eclair-node -am -DskipTests -Dgit.commit.id=notag -Dgit.commit.id.abbrev=notag -o
 # It might be good idea to run the tests here, so that the docker build fail if the code is bugged
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:21-jre-noble
 WORKDIR /app
 
 # install jq for eclair-cli
-RUN apk add bash jq curl unzip
+RUN apt-get update && apt-get install bash jq curl unzip
 
 # copy and install eclair-cli executable
 COPY --from=BUILD /usr/src/eclair-core/eclair-cli .


### PR DESCRIPTION
It fixes compatibility issues with alpine (which uses musl and not glibc), and is easier to maintain. 
Note that this makes image about 190 Mb bigger.