### PR TITLE
Don't try reconnecting automatically to mobile wallets

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -88,11 +88,11 @@ class Peer(val nodeParams: NodeParams,
         channel ! INPUT_RESTORED(state)
         FinalChannelId(state.channelId) -> channel
       }.toMap
-      val isMobileWallet = init.storedChannels.exists(_.channelParams.remoteParams.initFeatures.hasFeature(Features.WakeUpNotificationClient))
+      val autoReconnect = init.storedChannels.isEmpty || init.storedChannels.exists(c => !c.channelParams.remoteParams.initFeatures.hasFeature(Features.WakeUpNotificationClient))
       context.system.eventStream.publish(PeerCreated(self, remoteNodeId))
       // When we restart, we will attempt to reconnect right away, but then we'll wait.
       // We don't fetch our peer's features from the DB: if the connection succeeds, we will get them from their init message, which saves a DB call.
-      goto(DISCONNECTED) using DisconnectedData(channels, activeChannels = Set.empty, peerStorage = PeerStorage.Uninitialized, remoteFeatures_opt = None, isMobileWallet = isMobileWallet)
+      goto(DISCONNECTED) using DisconnectedData(channels, activeChannels = Set.empty, peerStorage = PeerStorage.Uninitialized, remoteFeatures_opt = None, autoReconnect = autoReconnect)
   }
 
   when(DISCONNECTED) {
@@ -554,8 +554,8 @@ class Peer(val nodeParams: NodeParams,
         } else {
           d.channels.values.toSet[ActorRef].foreach(_ ! INPUT_DISCONNECTED) // we deduplicate with toSet because there might be two entries per channel (tmp id and final id)
           val lastRemoteFeatures = LastRemoteFeatures(d.remoteFeatures, d.remoteFeaturesWritten)
-          val isMobileWallet = lastRemoteFeatures.features.hasFeature(Features.WakeUpNotificationClient)
-          goto(DISCONNECTED) using DisconnectedData(d.channels.collect { case (k: FinalChannelId, v) => (k, v) }, d.activeChannels, d.peerStorage, Some(lastRemoteFeatures), isMobileWallet)
+          val autoReconnect = !lastRemoteFeatures.features.hasFeature(Features.WakeUpNotificationClient)
+          goto(DISCONNECTED) using DisconnectedData(d.channels.collect { case (k: FinalChannelId, v) => (k, v) }, d.activeChannels, d.peerStorage, Some(lastRemoteFeatures), autoReconnect)
         }
 
       case Event(ChannelTerminated(actor), d: ConnectedData) =>
@@ -1105,7 +1105,7 @@ object Peer {
     override def activeChannels: Set[ByteVector32] = Set.empty
     override def peerStorage: PeerStorage = PeerStorage.Uninitialized
   }
-  case class DisconnectedData(channels: Map[FinalChannelId, ActorRef], activeChannels: Set[ByteVector32], peerStorage: PeerStorage, remoteFeatures_opt: Option[LastRemoteFeatures], isMobileWallet: Boolean) extends Data
+  case class DisconnectedData(channels: Map[FinalChannelId, ActorRef], activeChannels: Set[ByteVector32], peerStorage: PeerStorage, remoteFeatures_opt: Option[LastRemoteFeatures], autoReconnect: Boolean) extends Data
   case class ConnectedData(address: NodeAddress, peerConnection: ActorRef, localInit: protocol.Init, remoteInit: protocol.Init, channels: Map[ChannelId, ActorRef], activeChannels: Set[ByteVector32], currentFeerates: RecommendedFeerates, previousFeerates_opt: Option[RecommendedFeerates], peerStorage: PeerStorage, remoteFeaturesWritten: Boolean) extends Data {
     val connectionInfo: ConnectionInfo = ConnectionInfo(address, peerConnection, localInit, remoteInit)
     def localFeatures: Features[InitFeature] = localInit.features

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -88,7 +88,8 @@ class Peer(val nodeParams: NodeParams,
         channel ! INPUT_RESTORED(state)
         FinalChannelId(state.channelId) -> channel
       }.toMap
-      val autoReconnect = init.storedChannels.isEmpty || init.storedChannels.exists(c => !c.channelParams.remoteParams.initFeatures.hasFeature(Features.WakeUpNotificationClient))
+      // We only connect to nodes with whom we have a channel, which aren't mobile wallets.
+      val autoReconnect = init.storedChannels.exists(c => !c.channelParams.remoteParams.initFeatures.hasFeature(Features.WakeUpNotificationClient))
       context.system.eventStream.publish(PeerCreated(self, remoteNodeId))
       // When we restart, we will attempt to reconnect right away, but then we'll wait.
       // We don't fetch our peer's features from the DB: if the connection succeeds, we will get them from their init message, which saves a DB call.
@@ -554,7 +555,8 @@ class Peer(val nodeParams: NodeParams,
         } else {
           d.channels.values.toSet[ActorRef].foreach(_ ! INPUT_DISCONNECTED) // we deduplicate with toSet because there might be two entries per channel (tmp id and final id)
           val lastRemoteFeatures = LastRemoteFeatures(d.remoteFeatures, d.remoteFeaturesWritten)
-          val autoReconnect = !lastRemoteFeatures.features.hasFeature(Features.WakeUpNotificationClient)
+          // We only reconnect if our peer is not a mobile wallet, and we now have a channel with them.
+          val autoReconnect = d.channels.nonEmpty && !d.remoteFeatures.hasFeature(Features.WakeUpNotificationClient)
           goto(DISCONNECTED) using DisconnectedData(d.channels.collect { case (k: FinalChannelId, v) => (k, v) }, d.activeChannels, d.peerStorage, Some(lastRemoteFeatures), autoReconnect)
         }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/Peer.scala
@@ -88,10 +88,11 @@ class Peer(val nodeParams: NodeParams,
         channel ! INPUT_RESTORED(state)
         FinalChannelId(state.channelId) -> channel
       }.toMap
+      val isMobileWallet = init.storedChannels.exists(_.channelParams.remoteParams.initFeatures.hasFeature(Features.WakeUpNotificationClient))
       context.system.eventStream.publish(PeerCreated(self, remoteNodeId))
       // When we restart, we will attempt to reconnect right away, but then we'll wait.
       // We don't fetch our peer's features from the DB: if the connection succeeds, we will get them from their init message, which saves a DB call.
-      goto(DISCONNECTED) using DisconnectedData(channels, activeChannels = Set.empty, peerStorage = PeerStorage.Uninitialized, remoteFeatures_opt = None)
+      goto(DISCONNECTED) using DisconnectedData(channels, activeChannels = Set.empty, peerStorage = PeerStorage.Uninitialized, remoteFeatures_opt = None, isMobileWallet = isMobileWallet)
   }
 
   when(DISCONNECTED) {
@@ -553,7 +554,8 @@ class Peer(val nodeParams: NodeParams,
         } else {
           d.channels.values.toSet[ActorRef].foreach(_ ! INPUT_DISCONNECTED) // we deduplicate with toSet because there might be two entries per channel (tmp id and final id)
           val lastRemoteFeatures = LastRemoteFeatures(d.remoteFeatures, d.remoteFeaturesWritten)
-          goto(DISCONNECTED) using DisconnectedData(d.channels.collect { case (k: FinalChannelId, v) => (k, v) }, d.activeChannels, d.peerStorage, Some(lastRemoteFeatures))
+          val isMobileWallet = lastRemoteFeatures.features.hasFeature(Features.WakeUpNotificationClient)
+          goto(DISCONNECTED) using DisconnectedData(d.channels.collect { case (k: FinalChannelId, v) => (k, v) }, d.activeChannels, d.peerStorage, Some(lastRemoteFeatures), isMobileWallet)
         }
 
       case Event(ChannelTerminated(actor), d: ConnectedData) =>
@@ -1103,7 +1105,7 @@ object Peer {
     override def activeChannels: Set[ByteVector32] = Set.empty
     override def peerStorage: PeerStorage = PeerStorage.Uninitialized
   }
-  case class DisconnectedData(channels: Map[FinalChannelId, ActorRef], activeChannels: Set[ByteVector32], peerStorage: PeerStorage, remoteFeatures_opt: Option[LastRemoteFeatures]) extends Data
+  case class DisconnectedData(channels: Map[FinalChannelId, ActorRef], activeChannels: Set[ByteVector32], peerStorage: PeerStorage, remoteFeatures_opt: Option[LastRemoteFeatures], isMobileWallet: Boolean) extends Data
   case class ConnectedData(address: NodeAddress, peerConnection: ActorRef, localInit: protocol.Init, remoteInit: protocol.Init, channels: Map[ChannelId, ActorRef], activeChannels: Set[ByteVector32], currentFeerates: RecommendedFeerates, previousFeerates_opt: Option[RecommendedFeerates], peerStorage: PeerStorage, remoteFeaturesWritten: Boolean) extends Data {
     val connectionInfo: ConnectionInfo = ConnectionInfo(address, peerConnection, localInit, remoteInit)
     def localFeatures: Features[InitFeature] = localInit.features

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
@@ -80,7 +80,11 @@ class ReconnectionTask(nodeParams: NodeParams, remoteNodeId: PublicKey) extends 
 
   when(IDLE) {
     case Event(Peer.Transition(previousPeerData, nextPeerData: Peer.DisconnectedData), d: IdleData) =>
-      if (nodeParams.autoReconnect && nextPeerData.channels.nonEmpty) { // we only reconnect if nodeParams explicitly instructs us to or there are existing channels
+      // We only reconnect automatically if:
+      //  - auto-reconnection is enabled in our node params (which is the default behavior)
+      //  - and there are existing channels
+      //  - and our peer is not a mobile wallet (which is likely to be offline and will initiate the connection themselves)
+      if (nodeParams.autoReconnect && nextPeerData.channels.nonEmpty && !nextPeerData.isMobileWallet) {
         val (initialDelay, firstNextReconnectionDelay) = (previousPeerData, d.previousData) match {
           case (Peer.Nothing, _) =>
             // When restarting, we add some randomization before the first reconnection attempt to avoid herd effect

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/ReconnectionTask.scala
@@ -84,7 +84,7 @@ class ReconnectionTask(nodeParams: NodeParams, remoteNodeId: PublicKey) extends 
       //  - auto-reconnection is enabled in our node params (which is the default behavior)
       //  - and there are existing channels
       //  - and our peer is not a mobile wallet (which is likely to be offline and will initiate the connection themselves)
-      if (nodeParams.autoReconnect && nextPeerData.channels.nonEmpty && !nextPeerData.isMobileWallet) {
+      if (nodeParams.autoReconnect && nextPeerData.autoReconnect && nextPeerData.channels.nonEmpty) {
         val (initialDelay, firstNextReconnectionDelay) = (previousPeerData, d.previousData) match {
           case (Peer.Nothing, _) =>
             // When restarting, we add some randomization before the first reconnection attempt to avoid herd effect

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerSpec.scala
@@ -50,6 +50,10 @@ class PeerSpec extends FixtureSpec {
   import PeerSpec._
   import akka.actor.typed.scaladsl.adapter._
 
+  private val autoReconnect = "auto_reconnect"
+  private val fastReconnectDelay = "fast_reconnect_delay"
+  private val withNodeAnn = "with_node_announcements"
+
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = 30 seconds, interval = 1 second)
 
   case class FixtureParam(nodeParams: NodeParams, remoteNodeId: PublicKey, system: ActorSystem, peer: TestFSMRef[Peer.State, Peer.Data, Peer], peerConnection: TestProbe, channel: TestProbe, switchboard: TestProbe, register: TestProbe, mockLimiter: ActorRef) {
@@ -75,9 +79,11 @@ class PeerSpec extends FixtureSpec {
       .modify(_.channelConf.maxHtlcValueInFlightMsat).setToIf(testData.tags.contains("max-htlc-value-in-flight-percent"))(100_000_000 msat)
       .modify(_.channelConf.maxHtlcValueInFlightPercent).setToIf(testData.tags.contains("max-htlc-value-in-flight-percent"))(25)
       .modify(_.channelConf.channelFundingTimeout).setToIf(testData.tags.contains("channel_funding_timeout"))(100 millis)
-      .modify(_.autoReconnect).setToIf(testData.tags.contains("auto_reconnect"))(true)
+      .modify(_.autoReconnect).setToIf(testData.tags.contains(autoReconnect))(true)
+      .modify(_.maxReconnectInterval).setToIf(testData.tags.contains(fastReconnectDelay))(10 millis)
+      .modify(_.initialRandomReconnectDelay).setToIf(testData.tags.contains(fastReconnectDelay))(1 millis)
 
-    if (testData.tags.contains("with_node_announcement")) {
+    if (testData.tags.contains(withNodeAnn)) {
       val bobAnnouncement = NodeAnnouncement(randomBytes64(), Features.empty, 1 unixsec, Bob.nodeParams.nodeId, Color(100.toByte, 200.toByte, 300.toByte), "node-alias", fakeIPAddress :: Nil)
       aliceParams.db.network.addNode(bobAnnouncement)
     }
@@ -196,7 +202,7 @@ class PeerSpec extends FixtureSpec {
     probe.expectMsgType[PeerConnection.ConnectionResult.ConnectionFailed]
   }
 
-  test("successfully reconnect to peer at startup when there are existing channels", Tag("auto_reconnect")) { f =>
+  test("successfully reconnect to peer at startup when there are existing channels", Tag(autoReconnect)) { f =>
     import f._
 
     spawnClientSpawner(f)
@@ -217,6 +223,23 @@ class PeerSpec extends FixtureSpec {
       assert(mockServer.accept() != null)
     }
     mockServer.close()
+  }
+
+  test("don't reconnect to mobile wallets", Tag(autoReconnect), Tag(fastReconnectDelay)) { f =>
+    import f._
+
+    val monitor = TestProbe()
+    val reconnectionTask = peer.underlyingActor.context.child("reconnection-task").get
+    monitor.send(reconnectionTask, FSM.SubscribeTransitionCallBack(monitor.ref))
+    monitor.expectMsg(FSM.CurrentState(reconnectionTask, ReconnectionTask.IDLE))
+
+    val probe = TestProbe()
+    val localInit = protocol.Init(peer.underlyingActor.nodeParams.features.initFeatures())
+    val remoteInit = protocol.Init(peer.underlyingActor.nodeParams.features.initFeatures().add(Features.WakeUpNotificationClient, FeatureSupport.Optional))
+    val mobileWalletChannel = ChannelCodecsSpec.normal.copy(commitments = ChannelCodecsSpec.normal.commitments.updateInitFeatures(localInit, remoteInit))
+    probe.send(peer, Peer.Init(Set(mobileWalletChannel), Map.empty))
+    // the reconnection task will stay in the idle state
+    monitor.expectNoMessage(100 millis)
   }
 
   test("reject connection attempts in state CONNECTED") { f =>
@@ -306,7 +329,7 @@ class PeerSpec extends FixtureSpec {
     }
   }
 
-  test("send state transitions to child reconnection actor", Tag("auto_reconnect"), Tag("with_node_announcement")) { f =>
+  test("send state transitions to child reconnection actor", Tag(autoReconnect), Tag(withNodeAnn)) { f =>
     import f._
 
     // monitor state changes of child reconnection task

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
@@ -23,7 +23,7 @@ import fr.acinq.eclair._
 import fr.acinq.eclair.io.Peer.{ChannelId, PeerStorage}
 import fr.acinq.eclair.io.ReconnectionTask.WaitingData
 import fr.acinq.eclair.tor.Socks5ProxyParams
-import fr.acinq.eclair.wire.protocol.{Color, NodeAddress, NodeAnnouncement, NodeInfo, RecommendedFeerates}
+import fr.acinq.eclair.wire.protocol.{Color, NodeAddress, NodeAnnouncement, RecommendedFeerates}
 import org.mockito.IdiomaticMockito.StubbingOps
 import org.mockito.MockitoSugar.mock
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
@@ -33,12 +33,15 @@ import scala.concurrent.duration._
 
 class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with ParallelTestExecution {
 
+  private val autoReconnect = "auto_reconnect"
+  private val withNodeAnn = "with_node_announcements"
+
   private val fakeIPAddress = NodeAddress.fromParts("1.2.3.4", 42000).get
   private val channels = Map(Peer.FinalChannelId(randomBytes32()) -> system.deadLetters)
   private val recommendedFeerates = RecommendedFeerates(Block.RegtestGenesisBlock.hash, TestConstants.feeratePerKw, TestConstants.anchorOutputsFeeratePerKw)
 
   private val PeerNothingData = Peer.Nothing
-  private val PeerDisconnectedData = Peer.DisconnectedData(channels, activeChannels = Set.empty, PeerStorage.Empty, remoteFeatures_opt = None)
+  private val PeerDisconnectedData = Peer.DisconnectedData(channels, activeChannels = Set.empty, PeerStorage.Empty, remoteFeatures_opt = None, isMobileWallet = false)
   private val PeerConnectedData = Peer.ConnectedData(fakeIPAddress, system.deadLetters, null, null, channels.map { case (k: ChannelId, v) => (k, v) }, activeChannels = Set.empty, recommendedFeerates, None, PeerStorage.Empty, remoteFeaturesWritten = true)
 
   case class FixtureParam(nodeParams: NodeParams, remoteNodeId: PublicKey, reconnectionTask: TestFSMRef[ReconnectionTask.State, ReconnectionTask.Data, ReconnectionTask], monitor: TestProbe)
@@ -50,9 +53,9 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
 
     import com.softwaremill.quicklens._
     val aliceParams = TestConstants.Alice.nodeParams
-      .modify(_.autoReconnect).setToIf(test.tags.contains("auto_reconnect"))(true)
+      .modify(_.autoReconnect).setToIf(test.tags.contains(autoReconnect))(true)
 
-    if (test.tags.contains("with_node_announcements")) {
+    if (test.tags.contains(withNodeAnn)) {
       val bobAnnouncement = NodeAnnouncement(randomBytes64(), Features.empty, 1 unixsec, remoteNodeId, Color(100.toByte, 200.toByte, 300.toByte), "node-alias", fakeIPAddress :: Nil)
       aliceParams.db.network.addNode(bobAnnouncement)
     }
@@ -70,23 +73,31 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     withFixture(test.toNoArgTest(FixtureParam(aliceParams, remoteNodeId, reconnectionTask, monitor)))
   }
 
-  test("stay idle at startup if auto-reconnect is disabled", Tag("with_node_announcements")) { f =>
+  test("stay idle at startup if auto-reconnect is disabled", Tag(withNodeAnn)) { f =>
     import f._
 
     val peer = TestProbe()
     peer.send(reconnectionTask, Peer.Transition(PeerNothingData, PeerDisconnectedData))
-    monitor.expectNoMessage()
+    monitor.expectNoMessage(100 millis)
   }
 
-  test("stay idle at startup if there are no channels", Tag("auto_reconnect"), Tag("with_node_announcements")) { f =>
+  test("stay idle at startup for mobile wallets", Tag(autoReconnect), Tag(withNodeAnn)) { f =>
     import f._
 
     val peer = TestProbe()
-    peer.send(reconnectionTask, Peer.Transition(PeerNothingData, Peer.DisconnectedData(Map.empty, activeChannels = Set.empty, PeerStorage.Empty, None)))
-    monitor.expectNoMessage()
+    peer.send(reconnectionTask, Peer.Transition(PeerNothingData, Peer.DisconnectedData(Map.empty, activeChannels = Set.empty, PeerStorage.Empty, None, isMobileWallet = true)))
+    monitor.expectNoMessage(100 millis)
   }
 
-  test("only try to connect once at startup if auto-reconnect is enabled but there are no known address", Tag("auto_reconnect")) { f =>
+  test("stay idle at startup if there are no channels", Tag(autoReconnect), Tag(withNodeAnn)) { f =>
+    import f._
+
+    val peer = TestProbe()
+    peer.send(reconnectionTask, Peer.Transition(PeerNothingData, Peer.DisconnectedData(Map.empty, activeChannels = Set.empty, PeerStorage.Empty, None, isMobileWallet = false)))
+    monitor.expectNoMessage(100 millis)
+  }
+
+  test("only try to connect once at startup if auto-reconnect is enabled but there are no known address", Tag(autoReconnect)) { f =>
     import f._
 
     val peer = TestProbe()
@@ -95,7 +106,7 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     val TransitionWithData(ReconnectionTask.WAITING, ReconnectionTask.IDLE, _, _) = monitor.expectMsgType[TransitionWithData]
   }
 
-  test("initiate reconnection at startup if auto-reconnect is enabled", Tag("auto_reconnect"), Tag("with_node_announcements")) { f =>
+  test("initiate reconnection at startup if auto-reconnect is enabled", Tag(autoReconnect), Tag(withNodeAnn)) { f =>
     import f._
 
     val peer = TestProbe()
@@ -107,7 +118,7 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(expectedNextReconnectionDelayInterval contains connectingData.nextReconnectionDelay.toSeconds) // we only reconnect once
   }
 
-  test("reconnect with increasing delays", Tag("auto_reconnect")) { f =>
+  test("reconnect with increasing delays", Tag(autoReconnect)) { f =>
     import f._
 
     val probe = TestProbe()
@@ -157,7 +168,7 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(waitingData3.nextReconnectionDelay == (waitingData0.nextReconnectionDelay * 8))
   }
 
-  test("all kind of connection failures should be caught by the reconnection task", Tag("auto_reconnect")) { f =>
+  test("all kind of connection failures should be caught by the reconnection task", Tag(autoReconnect)) { f =>
     import f._
 
     val peer = TestProbe()
@@ -185,7 +196,7 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     }
   }
 
-  test("concurrent incoming/outgoing reconnection", Tag("auto_reconnect")) { f =>
+  test("concurrent incoming/outgoing reconnection", Tag(autoReconnect)) { f =>
     import f._
 
     val peer = TestProbe()

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/ReconnectionTaskSpec.scala
@@ -41,7 +41,7 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
   private val recommendedFeerates = RecommendedFeerates(Block.RegtestGenesisBlock.hash, TestConstants.feeratePerKw, TestConstants.anchorOutputsFeeratePerKw)
 
   private val PeerNothingData = Peer.Nothing
-  private val PeerDisconnectedData = Peer.DisconnectedData(channels, activeChannels = Set.empty, PeerStorage.Empty, remoteFeatures_opt = None, isMobileWallet = false)
+  private val PeerDisconnectedData = Peer.DisconnectedData(channels, activeChannels = Set.empty, PeerStorage.Empty, remoteFeatures_opt = None, autoReconnect = true)
   private val PeerConnectedData = Peer.ConnectedData(fakeIPAddress, system.deadLetters, null, null, channels.map { case (k: ChannelId, v) => (k, v) }, activeChannels = Set.empty, recommendedFeerates, None, PeerStorage.Empty, remoteFeaturesWritten = true)
 
   case class FixtureParam(nodeParams: NodeParams, remoteNodeId: PublicKey, reconnectionTask: TestFSMRef[ReconnectionTask.State, ReconnectionTask.Data, ReconnectionTask], monitor: TestProbe)
@@ -73,7 +73,7 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     withFixture(test.toNoArgTest(FixtureParam(aliceParams, remoteNodeId, reconnectionTask, monitor)))
   }
 
-  test("stay idle at startup if auto-reconnect is disabled", Tag(withNodeAnn)) { f =>
+  test("stay idle at startup if auto-reconnect is disabled for all peers", Tag(withNodeAnn)) { f =>
     import f._
 
     val peer = TestProbe()
@@ -81,11 +81,11 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     monitor.expectNoMessage(100 millis)
   }
 
-  test("stay idle at startup for mobile wallets", Tag(autoReconnect), Tag(withNodeAnn)) { f =>
+  test("stay idle at startup if auto-reconnect is disabled for this peer", Tag(autoReconnect), Tag(withNodeAnn)) { f =>
     import f._
 
     val peer = TestProbe()
-    peer.send(reconnectionTask, Peer.Transition(PeerNothingData, Peer.DisconnectedData(Map.empty, activeChannels = Set.empty, PeerStorage.Empty, None, isMobileWallet = true)))
+    peer.send(reconnectionTask, Peer.Transition(PeerNothingData, Peer.DisconnectedData(Map.empty, activeChannels = Set.empty, PeerStorage.Empty, None, autoReconnect = false)))
     monitor.expectNoMessage(100 millis)
   }
 
@@ -93,7 +93,7 @@ class ReconnectionTaskSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     import f._
 
     val peer = TestProbe()
-    peer.send(reconnectionTask, Peer.Transition(PeerNothingData, Peer.DisconnectedData(Map.empty, activeChannels = Set.empty, PeerStorage.Empty, None, isMobileWallet = false)))
+    peer.send(reconnectionTask, Peer.Transition(PeerNothingData, Peer.DisconnectedData(Map.empty, activeChannels = Set.empty, PeerStorage.Empty, None, autoReconnect = true)))
     monitor.expectNoMessage(100 millis)
   }
 


### PR DESCRIPTION
It's useless as they will always have a different IP address, and they will be offline most of the time anyway. They will initiate connections either when the app is started or when they receive a push notification so we never need to initiate connections from the server side.