### PR TITLE
Keep our closing_complete in the simple close session

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Helpers.scala
@@ -770,7 +770,7 @@ object Helpers {
       }
 
       /** We are the closer: we sign closing transactions for which we pay the fees. */
-      def makeSimpleClosingTx(currentBlockHeight: BlockHeight, channelKeys: ChannelKeys, commitment: FullCommitment, localScriptPubkey: ByteVector, remoteScriptPubkey: ByteVector, feerate: FeeratePerKw, remoteNonce_opt: Option[IndividualNonce]): Either[ChannelException, (ClosingTxs, ClosingComplete, CloserNonces)] = {
+      def makeSimpleClosingTx(currentBlockHeight: BlockHeight, channelKeys: ChannelKeys, commitment: FullCommitment, localScriptPubkey: ByteVector, remoteScriptPubkey: ByteVector, feerate: FeeratePerKw, remoteNonce_opt: Option[IndividualNonce]): Either[ChannelException, (ClosingTxs, ClosingComplete)] = {
         // We must convert the feerate to a fee: we must build dummy transactions to compute their weight.
         val commitInput = commitment.commitInput(channelKeys)
         val closingFee = {
@@ -797,7 +797,6 @@ object Helpers {
           case _ => return Left(CannotGenerateClosingTx(commitment.channelId))
         }
         val localFundingKey = channelKeys.fundingKey(commitment.fundingTxIndex)
-        val localNonces = CloserNonces.generate(localFundingKey.publicKey, commitment.remoteFundingPubKey, commitment.fundingTxId)
         val tlvs: TlvStream[ClosingCompleteTlv] = commitment.commitmentFormat match {
           case _: SimpleTaprootChannelCommitmentFormat =>
             remoteNonce_opt match {
@@ -806,14 +805,15 @@ object Helpers {
                 // If we cannot create our partial signature for one of our closing txs, we just skip it.
                 // It will only happen if our peer sent an invalid nonce, in which case we cannot do anything anyway
                 // apart from eventually force-closing.
-                def localSig(tx: ClosingTx, localNonce: LocalNonce): Option[PartialSignatureWithNonce] = {
+                def localSig(tx: ClosingTx): Option[PartialSignatureWithNonce] = {
+                  val localNonce = NonceGenerator.signingNonce(localFundingKey.publicKey, commitment.remoteFundingPubKey, commitment.fundingTxId)
                   tx.partialSign(localFundingKey, commitment.remoteFundingPubKey, localNonce, Seq(localNonce.publicNonce, remoteNonce)).toOption
                 }
 
                 TlvStream(Set(
-                  closingTxs.localAndRemote_opt.flatMap(tx => localSig(tx, localNonces.localAndRemote)).map(ClosingCompleteTlv.CloserAndCloseeOutputsPartialSignature(_)),
-                  closingTxs.localOnly_opt.flatMap(tx => localSig(tx, localNonces.localOnly)).map(ClosingCompleteTlv.CloserOutputOnlyPartialSignature(_)),
-                  closingTxs.remoteOnly_opt.flatMap(tx => localSig(tx, localNonces.remoteOnly)).map(ClosingCompleteTlv.CloseeOutputOnlyPartialSignature(_)),
+                  closingTxs.localAndRemote_opt.flatMap(tx => localSig(tx)).map(ClosingCompleteTlv.CloserAndCloseeOutputsPartialSignature(_)),
+                  closingTxs.localOnly_opt.flatMap(tx => localSig(tx)).map(ClosingCompleteTlv.CloserOutputOnlyPartialSignature(_)),
+                  closingTxs.remoteOnly_opt.flatMap(tx => localSig(tx)).map(ClosingCompleteTlv.CloseeOutputOnlyPartialSignature(_)),
                 ).flatten[ClosingCompleteTlv])
             }
           case _: AnchorOutputsCommitmentFormat => TlvStream(Set(
@@ -823,7 +823,7 @@ object Helpers {
           ).flatten[ClosingCompleteTlv])
         }
         val closingComplete = ClosingComplete(commitment.channelId, localScriptPubkey, remoteScriptPubkey, closingFee.fee, currentBlockHeight.toLong, tlvs)
-        Right(closingTxs, closingComplete, localNonces)
+        Right(closingTxs, closingComplete)
       }
 
       /**
@@ -853,9 +853,11 @@ object Helpers {
                 closingComplete.closeeOutputOnlyPartialSig_opt.flatMap(remoteSig => closingTxs.localOnly_opt.map(tx => (tx, remoteSig, localSig => ClosingSigTlv.CloseeOutputOnlyPartialSignature(localSig)))),
                 closingComplete.closerOutputOnlyPartialSig_opt.flatMap(remoteSig => closingTxs.remoteOnly_opt.map(tx => (tx, remoteSig, localSig => ClosingSigTlv.CloserOutputOnlyPartialSignature(localSig)))),
               ).flatten
+              val localFundingKey = channelKeys.fundingKey(commitment.fundingTxIndex)
               closingTxsWithSigs.headOption match {
+                case Some((closingTx, remoteSig, _)) if !closingTx.checkRemotePartialSignature(localFundingKey.publicKey, commitment.remoteFundingPubKey, remoteSig, localNonce.publicNonce) =>
+                  Left(InvalidCloseSignature(commitment.channelId, closingTx.tx.txid))
                 case Some((closingTx, remoteSig, sigToTlv)) =>
-                  val localFundingKey = channelKeys.fundingKey(commitment.fundingTxIndex)
                   val signedClosingTx_opt = for {
                     localSig <- closingTx.partialSign(localFundingKey, commitment.remoteFundingPubKey, localNonce, Seq(localNonce.publicNonce, remoteSig.nonce)).toOption
                     signedTx <- closingTx.aggregateSigs(localFundingKey.publicKey, commitment.remoteFundingPubKey, localSig, remoteSig).toOption
@@ -906,7 +908,7 @@ object Helpers {
        * sent another closing_complete before receiving their closing_sig, which is now obsolete: we ignore it and wait
        * for their next closing_sig that will match our latest closing_complete.
        */
-      def receiveSimpleClosingSig(channelKeys: ChannelKeys, commitment: FullCommitment, closingTxs: ClosingTxs, closingSig: ClosingSig, localNonces_opt: Option[CloserNonces], remoteNonce_opt: Option[IndividualNonce]): Either[ChannelException, ClosingTx] = {
+      def receiveSimpleClosingSig(channelKeys: ChannelKeys, commitment: FullCommitment, closingTxs: ClosingTxs, closingSig: ClosingSig, localClosingComplete_opt: Option[ClosingComplete], remoteNonce_opt: Option[IndividualNonce]): Either[ChannelException, ClosingTx] = {
         val closingTxsWithSig = Seq(
           closingSig.closerAndCloseeOutputsSig_opt.flatMap(sig => closingTxs.localAndRemote_opt.map(tx => (tx, IndividualSignature(sig)))),
           closingSig.closerAndCloseeOutputsPartialSig_opt.flatMap(sig => remoteNonce_opt.flatMap(nonce => closingTxs.localAndRemote_opt.map(tx => (tx, PartialSignatureWithNonce(sig, nonce))))),
@@ -924,14 +926,14 @@ object Helpers {
                 val signedTx = closingTx.aggregateSigs(localFundingKey.publicKey, commitment.remoteFundingPubKey, localSig, remoteSig)
                 Some(closingTx.copy(tx = signedTx))
               case remoteSig: PartialSignatureWithNonce =>
-                val localNonce = localNonces_opt match {
-                  case Some(localNonces) if closingTx.tx.txOut.size == 2 => localNonces.localAndRemote
-                  case Some(localNonces) if closingTx.toLocalOutput_opt.nonEmpty => localNonces.localOnly
-                  case Some(localNonces) => localNonces.remoteOnly
+                val localSig_opt = localClosingComplete_opt match {
+                  case Some(closingComplete) if closingTx.tx.txOut.size == 2 => closingComplete.closerAndCloseeOutputsPartialSig_opt
+                  case Some(closingComplete) if closingTx.toLocalOutput_opt.nonEmpty => closingComplete.closerOutputOnlyPartialSig_opt
+                  case Some(closingComplete) => closingComplete.closeeOutputOnlyPartialSig_opt
                   case None => return Left(InvalidCloseSignature(commitment.channelId, closingTx.tx.txid))
                 }
                 for {
-                  localSig <- closingTx.partialSign(localFundingKey, commitment.remoteFundingPubKey, localNonce, Seq(localNonce.publicNonce, remoteSig.nonce)).toOption
+                  localSig <- localSig_opt
                   signedTx <- closingTx.aggregateSigs(localFundingKey.publicKey, commitment.remoteFundingPubKey, localSig, remoteSig).toOption
                 } yield closingTx.copy(tx = signedTx)
             }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -227,8 +227,8 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
   // Closee nonces are first exchanged in shutdown messages, and replaced by a new nonce after each closing_sig.
   var localCloseeNonce_opt: Option[LocalNonce] = None
   var remoteCloseeNonce_opt: Option[IndividualNonce] = None
-  // Closer nonces are randomly generated when sending our closing_complete.
-  var localCloserNonces_opt: Option[CloserNonces] = None
+  // our closing_complete message, that includes partial musig2 signatures generated with random nonces.
+  var localClosingComplete_opt: Option[ClosingComplete] = None
 
   // we pass these to helpers classes so that they have the logging context
   implicit def implicitLog: akka.event.DiagnosticLoggingAdapter = diagLog
@@ -1923,9 +1923,9 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
       } else {
         MutualClose.makeSimpleClosingTx(nodeParams.currentBlockHeight, channelKeys, d.commitments.latest, localScript, d.remoteScriptPubKey, closingFeerate, remoteCloseeNonce_opt) match {
           case Left(f) => handleCommandError(f, c)
-          case Right((closingTxs, closingComplete, closerNonces)) =>
+          case Right((closingTxs, closingComplete)) =>
             log.debug("signing local mutual close transactions: {}", closingTxs)
-            localCloserNonces_opt = Some(closerNonces)
+            localClosingComplete_opt = Some(closingComplete)
             handleCommandSuccess(c, d.copy(lastClosingFeerate = closingFeerate, localScriptPubKey = localScript, proposedClosingTxs = d.proposedClosingTxs :+ closingTxs)) storing() sending closingComplete
         }
       }
@@ -1954,7 +1954,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
       // Note that if we sent two closing_complete in a row, without waiting for their closing_sig for the first one,
       // this will fail because we only care about our latest closing_complete. This is fine, we should receive their
       // closing_sig for the last closing_complete afterwards.
-      MutualClose.receiveSimpleClosingSig(channelKeys, d.commitments.latest, d.proposedClosingTxs.last, closingSig, localCloserNonces_opt, remoteCloseeNonce_opt) match {
+      MutualClose.receiveSimpleClosingSig(channelKeys, d.commitments.latest, d.proposedClosingTxs.last, closingSig, localClosingComplete_opt, remoteCloseeNonce_opt) match {
         case Left(f) =>
           log.warning("invalid closing_sig: {}", f.getMessage)
           remoteCloseeNonce_opt = closingSig.nextCloseeNonce_opt
@@ -3208,7 +3208,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
       remoteNextCommitNonces = Map.empty
       localCloseeNonce_opt = None
       remoteCloseeNonce_opt = None
-      localCloserNonces_opt = None
+      localClosingComplete_opt = None
   }
 
   /*

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonHandlers.scala
@@ -156,9 +156,9 @@ trait CommonHandlers {
         log.warning("cannot create local closing txs, waiting for remote closing_complete: {}", f.getMessage)
         val d = DATA_NEGOTIATING_SIMPLE(commitments, closingFeerate, localScript, remoteScript, Nil, Nil)
         (d, None)
-      case Right((closingTxs, closingComplete, closerNonces)) =>
+      case Right((closingTxs, closingComplete)) =>
         log.debug("signing local mutual close transactions: {}", closingTxs)
-        localCloserNonces_opt = Some(closerNonces)
+        localClosingComplete_opt = Some(closingComplete)
         val d = DATA_NEGOTIATING_SIMPLE(commitments, closingFeerate, localScript, remoteScript, closingTxs :: Nil, Nil)
         (d, Some(closingComplete))
     }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Transactions.scala
@@ -28,7 +28,6 @@ import fr.acinq.eclair._
 import fr.acinq.eclair.blockchain.fee.FeeratePerKw
 import fr.acinq.eclair.channel.ChannelSpendSignature
 import fr.acinq.eclair.channel.ChannelSpendSignature._
-import fr.acinq.eclair.crypto.NonceGenerator
 import fr.acinq.eclair.crypto.keymanager.{CommitmentPublicKeys, LocalCommitmentKeys, RemoteCommitmentKeys}
 import fr.acinq.eclair.transactions.CommitmentOutput._
 import fr.acinq.eclair.transactions.Scripts.Taproot.NUMS_POINT
@@ -1464,21 +1463,6 @@ object Transactions {
     case class PaidByThem(fee: Satoshi) extends SimpleClosingTxFee
   }
   // @formatter:on
-
-  /**
-   * When sending [[fr.acinq.eclair.wire.protocol.ClosingComplete]], we use a different nonce for each closing transaction we create.
-   * We generate nonces for all variants of the closing transaction for simplicity, even though we never use them all.
-   */
-  case class CloserNonces(localAndRemote: LocalNonce, localOnly: LocalNonce, remoteOnly: LocalNonce)
-
-  object CloserNonces {
-    /** Generate a set of random signing nonces for our closing transactions. */
-    def generate(localFundingKey: PublicKey, remoteFundingKey: PublicKey, fundingTxId: TxId): CloserNonces = CloserNonces(
-      NonceGenerator.signingNonce(localFundingKey, remoteFundingKey, fundingTxId),
-      NonceGenerator.signingNonce(localFundingKey, remoteFundingKey, fundingTxId),
-      NonceGenerator.signingNonce(localFundingKey, remoteFundingKey, fundingTxId),
-    )
-  }
 
   /** Each closing attempt can result in multiple potential closing transactions, depending on which outputs are included. */
   case class ClosingTxs(localAndRemote_opt: Option[ClosingTx], localOnly_opt: Option[ClosingTx], remoteOnly_opt: Option[ClosingTx]) {


### PR DESCRIPTION
In the simple close session, which is never persisted, we just need to remember our closing_complete and the partial signatures it contains, instead of keeping our musig2 nonces and generating our partial signatures a second time to build the final closing tx when we receive our peer's partial signatures. 

We also check our peer's partial signature and fail early if they're not valid, instead of building a fully sign closing tx and then verify that it is correct.
