### PR TITLE
More aggressive peer scorer idle channels management

### DIFF
--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -119,6 +119,8 @@ eclair.peer-scoring {
     max-feerate-sat-per-byte = 5
     // Rate-limit the number of funding transactions we make per day (on average).
     max-funding-tx-per-day = 6
+    // If true, we will occasionally try to fund idle large capacity peers that have most funds on their side.
+    revive-old-peers = false
     // Minimum time between funding the same peer, to evaluate whether the previous funding was effective.
     funding-cooldown = 72 hours
   }

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -113,6 +113,8 @@ eclair.peer-scoring {
     local-balance-closing-threshold-satoshis = 10000000 // 0.1 btc
     // We won't close channels where the remote balance exceeds this amount.
     remote-balance-closing-threshold-satoshis = 5000000 // 0.05 btc
+    // We won't close channels if this percentage of the channel capacity has been used during the past week.
+    idle-channel-closing-threshold-percent = 0.075 // 7.5%
     // We stop funding channels if our on-chain balance is below this amount.
     min-on-chain-balance-satoshis = 50000000 // 0.5 btc
     // We stop funding channels if the on-chain feerate is above this value.

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -704,6 +704,8 @@ eclair {
       max-feerate-sat-per-byte = 5
       // Rate-limit the number of funding transactions we make per day (on average).
       max-funding-tx-per-day = 6
+      // If true, we will occasionally try to fund idle large capacity peers that have most funds on their side.
+      revive-old-peers = false
       // Minimum time between funding the same peer, to evaluate whether the previous funding was effective.
       funding-cooldown = 72 hours
     }

--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -698,6 +698,8 @@ eclair {
       local-balance-closing-threshold-satoshis = 10000000 // 0.1 btc
       // We won't close channels where the remote balance exceeds this amount.
       remote-balance-closing-threshold-satoshis = 5000000 // 0.05 btc
+      // We won't close channels if this percentage of the channel capacity has been used during the past week.
+      idle-channel-closing-threshold-percent = 0.075 // 7.5%
       // We stop funding channels if our on-chain balance is below this amount.
       min-on-chain-balance-satoshis = 50000000 // 0.5 btc
       // We stop funding channels if the on-chain feerate is above this value.

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Eclair.scala
@@ -216,7 +216,7 @@ trait Eclair {
 
   def spendFromChannelAddress(fundingKeyPath: DeterministicWallet.KeyPath, fundingTxIndex: Long, remoteFundingPubkey: PublicKey, localNonce_opt: Option[IndividualNonce], remoteSig: ChannelSpendSignature, unsignedTx: Transaction): Future[SpendFromChannelResult]
 
-  def configurePeerScorer(cfg: PeerScorer.ConfigOverrides)(implicit timeout: Timeout): Future[Boolean]
+  def configurePeerScorer(cfg: PeerScorer.ConfigOverrides)(implicit timeout: Timeout): Future[String]
 
 }
 
@@ -855,10 +855,10 @@ class EclairImpl(val appKit: Kit) extends Eclair with Logging with SpendFromChan
     }
   }
 
-  override def configurePeerScorer(cfg: PeerScorer.ConfigOverrides)(implicit timeout: Timeout): Future[Boolean] = {
+  override def configurePeerScorer(cfg: PeerScorer.ConfigOverrides)(implicit timeout: Timeout): Future[String] = {
     appKit.peerScorer_opt match {
-      case Some(scorer) => scorer.ask((ref: typed.ActorRef[Boolean]) => PeerScorer.UpdateConfig(ref, cfg))
-      case None => Future.successful(false)
+      case Some(scorer) => scorer.ask((ref: typed.ActorRef[Boolean]) => PeerScorer.UpdateConfig(ref, cfg)).map(res => if (res) "ok" else "could not update config: please retry")
+      case None => Future.successful("peer scorer is disabled: you should enable it first")
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -736,6 +736,7 @@ object NodeParams extends Logging {
           maxFundingTxPerDay = config.getInt("peer-scoring.liquidity.max-funding-tx-per-day"),
           minOnChainBalance = config.getLong("peer-scoring.liquidity.min-on-chain-balance-satoshis").sat,
           maxFeerate = FeeratePerByte(config.getLong("peer-scoring.liquidity.max-feerate-sat-per-byte").sat).perKw,
+          reviveOldPeers = config.getBoolean("peer-scoring.liquidity.revive-old-peers"),
           fundingCooldown = FiniteDuration(config.getDuration("peer-scoring.liquidity.funding-cooldown").getSeconds, TimeUnit.SECONDS),
         ),
         relayFees = PeerScorer.RelayFeesConfig(

--- a/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/NodeParams.scala
@@ -733,6 +733,7 @@ object NodeParams extends Logging {
           maxPerPeerCapacity = config.getLong("peer-scoring.liquidity.max-per-peer-capacity-satoshis").sat,
           localBalanceClosingThreshold = config.getLong("peer-scoring.liquidity.local-balance-closing-threshold-satoshis").sat,
           remoteBalanceClosingThreshold = config.getLong("peer-scoring.liquidity.remote-balance-closing-threshold-satoshis").sat,
+          idleChannelClosingThresholdPct = config.getDouble("peer-scoring.liquidity.idle-channel-closing-threshold-percent"),
           maxFundingTxPerDay = config.getInt("peer-scoring.liquidity.max-funding-tx-per-day"),
           minOnChainBalance = config.getLong("peer-scoring.liquidity.min-on-chain-balance-satoshis").sat,
           maxFeerate = FeeratePerByte(config.getLong("peer-scoring.liquidity.max-feerate-sat-per-byte").sat).perKw,

--- a/eclair-core/src/main/scala/fr/acinq/eclair/profit/PeerScorer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/profit/PeerScorer.scala
@@ -73,6 +73,7 @@ object PeerScorer {
    * @param remoteBalanceClosingThreshold we won't close channels where the remote balance exceeds this amount.
    * @param minOnChainBalance             we stop funding channels if our on-chain balance is below this amount.
    * @param maxFeerate                    we stop funding channels if the on-chain feerate is above this value.
+   * @param reviveOldPeers                if true, we will occasionally try to fund idle large capacity peers that have most funds on their side.
    * @param fundingCooldown               minimum time between funding the same peer, to evaluate effectiveness.
    */
   case class LiquidityConfig(autoFund: Boolean,
@@ -85,6 +86,7 @@ object PeerScorer {
                              remoteBalanceClosingThreshold: Satoshi,
                              minOnChainBalance: Satoshi,
                              maxFeerate: FeeratePerKw,
+                             reviveOldPeers: Boolean,
                              fundingCooldown: FiniteDuration)
 
   /**
@@ -113,6 +115,7 @@ object PeerScorer {
                              remoteBalanceClosingThresholdOverride_opt: Option[Satoshi],
                              minOnChainBalanceOverride_opt: Option[Satoshi],
                              maxFeerateOverride_opt: Option[FeeratePerKw],
+                             reviveOldPeersOverride_opt: Option[Boolean],
                              fundingCooldownOverride_opt: Option[FiniteDuration])
 
   private case class FundingProposal(peer: PeerInfo, fundingAmount: Satoshi) {
@@ -186,6 +189,7 @@ private class PeerScorer(nodeParams: NodeParams, wallet: OnChainBalanceChecker, 
             remoteBalanceClosingThreshold = cfg.remoteBalanceClosingThresholdOverride_opt.getOrElse(config.liquidity.remoteBalanceClosingThreshold),
             minOnChainBalance = cfg.minOnChainBalanceOverride_opt.getOrElse(config.liquidity.minOnChainBalance),
             maxFeerate = cfg.maxFeerateOverride_opt.getOrElse(config.liquidity.maxFeerate),
+            reviveOldPeers = cfg.reviveOldPeersOverride_opt.getOrElse(config.liquidity.reviveOldPeers),
             fundingCooldown = cfg.fundingCooldownOverride_opt.getOrElse(config.liquidity.fundingCooldown),
           ),
           relayFees = config.relayFees.copy(
@@ -547,7 +551,7 @@ private class PeerScorer(nodeParams: NodeParams, wallet: OnChainBalanceChecker, 
       }
       val toReviveNotAlreadySelected = toRevive.filterNot(p => bestPeers.exists(_.remoteNodeId == p.remoteNodeId) || smallPeerToFund_opt.exists(_.remoteNodeId == p.remoteNodeId) || p.peer.capacity >= config.liquidity.maxPerPeerCapacity)
       val toRevive_opt = toReviveNotAlreadySelected.headOption match {
-        case Some(_) if Random.nextDouble() <= (1.0 / (scoringPerDay * 5)) => Random.shuffle(toReviveNotAlreadySelected.take(3)).headOption
+        case Some(_) if config.liquidity.reviveOldPeers && Random.nextDouble() <= (1.0 / (scoringPerDay * 5)) => Random.shuffle(toReviveNotAlreadySelected.take(3)).headOption
         case _ => None
       }
       (bestPeersToFund ++ toRevive_opt ++ smallPeerToFund_opt).distinctBy(_.remoteNodeId)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/profit/PeerScorer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/profit/PeerScorer.scala
@@ -346,7 +346,7 @@ private class PeerScorer(nodeParams: NodeParams, wallet: OnChainBalanceChecker, 
       // We only close channels for which liquidity is idle.
       .filter(p => p.stats.map(_.totalAmountOut).sum <= p.capacity * 0.05 && p.stats.map(_.totalAmountIn).sum <= p.capacity * 0.05)
       // And relay fees have been minimal for long enough to give a chance for routing to catch up.
-      .filter(p => p.latestUpdate_opt.exists(u => u.relayFees.feeProportionalMillionths <= config.relayFees.minRelayFees.feeProportionalMillionths && u.timestamp <= TimestampSecond.now() - 5.days))
+      .filter(p => p.latestUpdate_opt.exists(u => u.relayFees.feeProportionalMillionths <= config.relayFees.minRelayFees.feeProportionalMillionths && u.timestamp <= TimestampSecond.now() - 1.day))
       .foreach(p => {
         // We keep the best channel and close the others.
         val toClose = sortChannelsToClose(p.channels).tail
@@ -491,13 +491,13 @@ private class PeerScorer(nodeParams: NodeParams, wallet: OnChainBalanceChecker, 
   private def decreaseIdleChannelsRelayFeesIfNeeded(peers: Seq[PeerInfo], history: DecisionHistory): DecisionHistory = {
     val feeDecreases = peers
       // We're only interested in channels for which liquidity is idle.
-      // We ignore peers for which more than 75% of the funds are on their side: they have a higher incentive than us to
+      // We ignore peers for which more than 80% of the funds are on their side: they have a higher incentive than us to
       // close those channels if they aren't useful, so we'll wait for them to do so.
-      .filter(p => p.stats.map(_.totalAmountOut).sum <= p.capacity * 0.05 && p.stats.map(_.totalAmountIn).sum <= p.capacity * 0.05 && p.canSend >= p.capacity * 0.25)
+      .filter(p => p.stats.map(_.totalAmountOut).sum <= p.capacity * 0.05 && p.stats.map(_.totalAmountIn).sum <= p.capacity * 0.05 && p.canSend >= p.capacity * 0.2)
       // And relay fees aren't already minimal.
       .filter(p => p.latestUpdate_opt.exists(u => u.relayFees.feeProportionalMillionths > config.relayFees.minRelayFees.feeProportionalMillionths))
       // And relay fees haven't been updated recently.
-      .filter(p => p.latestUpdate_opt.exists(u => u.timestamp <= TimestampSecond.now() - 1.day))
+      .filter(p => p.latestUpdate_opt.exists(u => u.timestamp <= TimestampSecond.now() - 12.hours))
       .flatMap(p => {
         p.latestUpdate_opt match {
           case Some(u) =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/profit/PeerScorer.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/profit/PeerScorer.scala
@@ -63,18 +63,19 @@ object PeerScorer {
                     relayFees: RelayFeesConfig)
 
   /**
-   * @param autoFund                      if true, we will automatically fund channels.
-   * @param autoClose                     if true, we will automatically close unused channels to reclaim liquidity.
-   * @param minFundingAmount              we always fund channels with at least this amount.
-   * @param maxFundingAmount              we never fund channels with more than this amount.
-   * @param maxPerPeerCapacity            maximum total capacity (across all channels) per peer.
-   * @param maxFundingTxPerDay            we rate-limit the number of transactions we make per day (on average).
-   * @param localBalanceClosingThreshold  we won't close channels if our local balance is below this amount.
-   * @param remoteBalanceClosingThreshold we won't close channels where the remote balance exceeds this amount.
-   * @param minOnChainBalance             we stop funding channels if our on-chain balance is below this amount.
-   * @param maxFeerate                    we stop funding channels if the on-chain feerate is above this value.
-   * @param reviveOldPeers                if true, we will occasionally try to fund idle large capacity peers that have most funds on their side.
-   * @param fundingCooldown               minimum time between funding the same peer, to evaluate effectiveness.
+   * @param autoFund                       if true, we will automatically fund channels.
+   * @param autoClose                      if true, we will automatically close unused channels to reclaim liquidity.
+   * @param minFundingAmount               we always fund channels with at least this amount.
+   * @param maxFundingAmount               we never fund channels with more than this amount.
+   * @param maxPerPeerCapacity             maximum total capacity (across all channels) per peer.
+   * @param maxFundingTxPerDay             we rate-limit the number of transactions we make per day (on average).
+   * @param localBalanceClosingThreshold   we won't close channels if our local balance is below this amount.
+   * @param remoteBalanceClosingThreshold  we won't close channels where the remote balance exceeds this amount.
+   * @param idleChannelClosingThresholdPct we won't close channels if this percentage of the channel capacity has been used during the past week.
+   * @param minOnChainBalance              we stop funding channels if our on-chain balance is below this amount.
+   * @param maxFeerate                     we stop funding channels if the on-chain feerate is above this value.
+   * @param reviveOldPeers                 if true, we will occasionally try to fund idle large capacity peers that have most funds on their side.
+   * @param fundingCooldown                minimum time between funding the same peer, to evaluate effectiveness.
    */
   case class LiquidityConfig(autoFund: Boolean,
                              autoClose: Boolean,
@@ -84,10 +85,13 @@ object PeerScorer {
                              maxFundingTxPerDay: Int,
                              localBalanceClosingThreshold: Satoshi,
                              remoteBalanceClosingThreshold: Satoshi,
+                             idleChannelClosingThresholdPct: Double,
                              minOnChainBalance: Satoshi,
                              maxFeerate: FeeratePerKw,
                              reviveOldPeers: Boolean,
-                             fundingCooldown: FiniteDuration)
+                             fundingCooldown: FiniteDuration) {
+    require(0.0 <= idleChannelClosingThresholdPct && idleChannelClosingThresholdPct <= 0.5, "idle-channel-closing-threshold-pct cannot be greater than 50% of the channel capacity")
+  }
 
   /**
    * @param autoUpdate                         if true, we will automatically update our relay fees.
@@ -113,6 +117,7 @@ object PeerScorer {
                              maxFundingTxPerDayOverride_opt: Option[Int],
                              localBalanceClosingThresholdOverride_opt: Option[Satoshi],
                              remoteBalanceClosingThresholdOverride_opt: Option[Satoshi],
+                             idleChannelClosingThresholdPctOverride_opt: Option[Double],
                              minOnChainBalanceOverride_opt: Option[Satoshi],
                              maxFeerateOverride_opt: Option[FeeratePerKw],
                              reviveOldPeersOverride_opt: Option[Boolean],
@@ -187,6 +192,7 @@ private class PeerScorer(nodeParams: NodeParams, wallet: OnChainBalanceChecker, 
             maxFundingTxPerDay = cfg.maxFundingTxPerDayOverride_opt.getOrElse(config.liquidity.maxFundingTxPerDay),
             localBalanceClosingThreshold = cfg.localBalanceClosingThresholdOverride_opt.getOrElse(config.liquidity.localBalanceClosingThreshold),
             remoteBalanceClosingThreshold = cfg.remoteBalanceClosingThresholdOverride_opt.getOrElse(config.liquidity.remoteBalanceClosingThreshold),
+            idleChannelClosingThresholdPct = cfg.idleChannelClosingThresholdPctOverride_opt.getOrElse(config.liquidity.idleChannelClosingThresholdPct),
             minOnChainBalance = cfg.minOnChainBalanceOverride_opt.getOrElse(config.liquidity.minOnChainBalance),
             maxFeerate = cfg.maxFeerateOverride_opt.getOrElse(config.liquidity.maxFeerate),
             reviveOldPeers = cfg.reviveOldPeersOverride_opt.getOrElse(config.liquidity.reviveOldPeers),
@@ -327,7 +333,7 @@ private class PeerScorer(nodeParams: NodeParams, wallet: OnChainBalanceChecker, 
       // We only close channels when we have more than one.
       .filter(_.channels.size > 1)
       // We only close channels for which most of the liquidity is idle on our side.
-      .filter(p => p.canSend >= p.capacity * 0.8 && p.stats.map(_.totalAmountOut).sum <= p.capacity * 0.05)
+      .filter(p => p.canSend >= p.capacity * 0.8 && p.stats.map(_.totalAmountOut).sum <= p.capacity * config.liquidity.idleChannelClosingThresholdPct)
       .foreach(p => {
         val channels = sortChannelsToClose(p.channels)
         // We keep the best channel and close the others, unless their balance doesn't match our thresholds.
@@ -348,7 +354,7 @@ private class PeerScorer(nodeParams: NodeParams, wallet: OnChainBalanceChecker, 
       // We only close channels when we have more than one.
       .filter(_.channels.size > 1)
       // We only close channels for which liquidity is idle.
-      .filter(p => p.stats.map(_.totalAmountOut).sum <= p.capacity * 0.05 && p.stats.map(_.totalAmountIn).sum <= p.capacity * 0.05)
+      .filter(p => p.stats.map(_.totalAmountOut).sum <= p.capacity * config.liquidity.idleChannelClosingThresholdPct && p.stats.map(_.totalAmountIn).sum <= p.capacity * config.liquidity.idleChannelClosingThresholdPct)
       // And relay fees have been minimal for long enough to give a chance for routing to catch up.
       .filter(p => p.latestUpdate_opt.exists(u => u.relayFees.feeProportionalMillionths <= config.relayFees.minRelayFees.feeProportionalMillionths && u.timestamp <= TimestampSecond.now() - 1.day))
       .foreach(p => {
@@ -497,7 +503,7 @@ private class PeerScorer(nodeParams: NodeParams, wallet: OnChainBalanceChecker, 
       // We're only interested in channels for which liquidity is idle.
       // We ignore peers for which more than 80% of the funds are on their side: they have a higher incentive than us to
       // close those channels if they aren't useful, so we'll wait for them to do so.
-      .filter(p => p.stats.map(_.totalAmountOut).sum <= p.capacity * 0.05 && p.stats.map(_.totalAmountIn).sum <= p.capacity * 0.05 && p.canSend >= p.capacity * 0.2)
+      .filter(p => p.canSend >= p.capacity * 0.2 && p.stats.map(_.totalAmountOut).sum <= p.capacity * config.liquidity.idleChannelClosingThresholdPct && p.stats.map(_.totalAmountIn).sum <= p.capacity * config.liquidity.idleChannelClosingThresholdPct)
       // And relay fees aren't already minimal.
       .filter(p => p.latestUpdate_opt.exists(u => u.relayFees.feeProportionalMillionths > config.relayFees.minRelayFees.feeProportionalMillionths))
       // And relay fees haven't been updated recently.

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -280,6 +280,7 @@ object TestConstants {
           remoteBalanceClosingThreshold = 1_000_000 sat, // 0.01 BTC
           maxFeerate = FeeratePerByte(100 sat).perKw,
           maxFundingTxPerDay = 100,
+          reviveOldPeers = false,
           fundingCooldown = 72 hours,
         ),
         relayFees = PeerScorer.RelayFeesConfig(
@@ -500,6 +501,7 @@ object TestConstants {
           remoteBalanceClosingThreshold = 1_000_000 sat, // 0.01 BTC
           maxFeerate = FeeratePerByte(100 sat).perKw,
           maxFundingTxPerDay = 100,
+          reviveOldPeers = false,
           fundingCooldown = 72 hours,
         ),
         relayFees = PeerScorer.RelayFeesConfig(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/TestConstants.scala
@@ -278,6 +278,7 @@ object TestConstants {
           minOnChainBalance = 5_000_000 sat, // 0.05 BTC
           localBalanceClosingThreshold = 1_000_000 sat, // 0.01 BTC
           remoteBalanceClosingThreshold = 1_000_000 sat, // 0.01 BTC
+          idleChannelClosingThresholdPct = 0.1, // 10%
           maxFeerate = FeeratePerByte(100 sat).perKw,
           maxFundingTxPerDay = 100,
           reviveOldPeers = false,
@@ -499,6 +500,7 @@ object TestConstants {
           minOnChainBalance = 5_000_000 sat, // 0.05 BTC
           localBalanceClosingThreshold = 1_000_000 sat, // 0.01 BTC
           remoteBalanceClosingThreshold = 1_000_000 sat, // 0.01 BTC
+          idleChannelClosingThresholdPct = 0.1, // 10%
           maxFeerate = FeeratePerByte(100 sat).perKw,
           maxFundingTxPerDay = 100,
           reviveOldPeers = false,

--- a/eclair-core/src/test/scala/fr/acinq/eclair/profit/PeerScorerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/profit/PeerScorerSpec.scala
@@ -607,15 +607,15 @@ class PeerScorerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appli
       val c1b = channelInfo(canSend = 0.5 btc, canReceive = 0.5 btc)
       val c2a = channelInfo(canSend = 1 btc, canReceive = 1 btc)
       val c2b = channelInfo(canSend = 0.5 btc, canReceive = 0.5 btc)
-      val c3a = channelInfo(canSend = 0.2 btc, canReceive = 0.8 btc)
-      val c3b = channelInfo(canSend = 0.2 btc, canReceive = 0.8 btc)
+      val c3a = channelInfo(canSend = 0.2 btc, canReceive = 0.9 btc)
+      val c3b = channelInfo(canSend = 0.2 btc, canReceive = 0.9 btc)
 
       // Our first peer's channels have very low volume and the last channel update already used our minimum fees: we should close it.
       val peerInfo1 = PeerInfo(
         remoteNodeId = remoteNodeId1,
         stats = Seq.fill(weeklyBuckets)(peerStats(totalAmountOut = 1_000 sat, totalAmountIn = 1_000 sat, relayFeeEarned = 10 sat)),
         channels = Seq(c1a, c1b),
-        latestUpdate_opt = Some(channelUpdate(c1a.capacity, RelayFees(1 msat, 600), TimestampSecond.now() - 6.days)),
+        latestUpdate_opt = Some(channelUpdate(c1a.capacity, RelayFees(1 msat, 600), TimestampSecond.now() - 2.days)),
         hasPendingChannel = false
       )
       // Our second peer's channels have very low volume, but we're not yet using our minimum fees: we should decrease them.
@@ -623,15 +623,15 @@ class PeerScorerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appli
         remoteNodeId = remoteNodeId2,
         stats = Seq.fill(weeklyBuckets)(peerStats(totalAmountOut = 1_000 sat, totalAmountIn = 1_000 sat, relayFeeEarned = 10 sat)),
         channels = Seq(c2a, c2b),
-        latestUpdate_opt = Some(channelUpdate(c2a.capacity, RelayFees(1 msat, 750), TimestampSecond.now() - 4.days)),
+        latestUpdate_opt = Some(channelUpdate(c2a.capacity, RelayFees(1 msat, 750), TimestampSecond.now() - 1.day)),
         hasPendingChannel = false
       )
-      // Our last peer's channels have very low volume, but we have less than 25% of the funds: we shouldn't do anything yet.
+      // Our last peer's channels have very low volume, but we have less than 20% of the funds: we shouldn't do anything yet.
       val peerInfo3 = PeerInfo(
         remoteNodeId = remoteNodeId3,
         stats = Seq.fill(weeklyBuckets)(peerStats(totalAmountOut = 1_000 sat, totalAmountIn = 1_000 sat, relayFeeEarned = 10 sat)),
         channels = Seq(c3a, c3b),
-        latestUpdate_opt = Some(channelUpdate(c3a.capacity, RelayFees(1 msat, 750), TimestampSecond.now() - 4.days)),
+        latestUpdate_opt = Some(channelUpdate(c3a.capacity, RelayFees(1 msat, 750), TimestampSecond.now() - 1.day)),
         hasPendingChannel = false
       )
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/profit/PeerScorerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/profit/PeerScorerSpec.scala
@@ -47,6 +47,7 @@ class PeerScorerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appli
       remoteBalanceClosingThreshold = 20_000_000 sat, // 0.2 BTC
       maxFeerate = FeeratePerByte(100 sat).perKw,
       maxFundingTxPerDay = 100,
+      reviveOldPeers = true,
       fundingCooldown = 72 hours,
     ),
     relayFees = PeerScorer.RelayFeesConfig(

--- a/eclair-core/src/test/scala/fr/acinq/eclair/profit/PeerScorerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/profit/PeerScorerSpec.scala
@@ -45,6 +45,7 @@ class PeerScorerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("appli
       maxPerPeerCapacity = 1_000_000_000 sat, // 10 BTC
       localBalanceClosingThreshold = 10_000_000 sat, // 0.1 BTC
       remoteBalanceClosingThreshold = 20_000_000 sat, // 0.2 BTC
+      idleChannelClosingThresholdPct = 0.05, // 5%
       maxFeerate = FeeratePerByte(100 sat).perKw,
       maxFundingTxPerDay = 100,
       reviveOldPeers = true,

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Control.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Control.scala
@@ -85,8 +85,8 @@ trait Control {
   }
 
   val configurePeerScorer: Route = postRequest("configurepeerscorer") { implicit t =>
-    formFields("autoFund".as[Boolean] ?, "autoClose".as[Boolean] ?, "autoUpdateFees".as[Boolean] ?, "addWhitelistedPeers".as[List[PublicKey]](pubkeyListUnmarshaller).?, "removeWhitelistedPeers".as[List[PublicKey]](pubkeyListUnmarshaller).?, "minFundingAmount".as[Satoshi] ?, "maxFundingAmount".as[Satoshi] ?, "maxPerPeerCapacity".as[Satoshi] ?, "maxFundingTxPerDay".as[Int] ?, "localBalanceClosingThreshold".as[Satoshi] ?, "remoteBalanceClosingThreshold".as[Satoshi] ?, "minOnChainBalance".as[Satoshi] ?, "maxFeerate".as[FeeratePerByte] ?, "fundingCooldown".as[Int] ?) {
-      (autoFund_opt, autoClose_opt, autoUpdateFees_opt, addWhitelistedPeers_opt, removeWhitelistedPeers_opt, minFundingAmount_opt, maxFundingAmount_opt, maxPerPeerCapacity_opt, maxFundingTxPerDay_opt, localBalanceClosingThreshold_opt, remoteBalanceClosingThreshold_opt, minOnChainBalance_opt, maxFeerate_opt, fundingCooldown_opt) =>
+    formFields("autoFund".as[Boolean] ?, "autoClose".as[Boolean] ?, "autoUpdateFees".as[Boolean] ?, "addWhitelistedPeers".as[List[PublicKey]](pubkeyListUnmarshaller).?, "removeWhitelistedPeers".as[List[PublicKey]](pubkeyListUnmarshaller).?, "minFundingAmount".as[Satoshi] ?, "maxFundingAmount".as[Satoshi] ?, "maxPerPeerCapacity".as[Satoshi] ?, "maxFundingTxPerDay".as[Int] ?, "localBalanceClosingThreshold".as[Satoshi] ?, "remoteBalanceClosingThreshold".as[Satoshi] ?, "minOnChainBalance".as[Satoshi] ?, "maxFeerate".as[FeeratePerByte] ?, "reviveOldPeers".as[Boolean] ?, "fundingCooldown".as[Int] ?) {
+      (autoFund_opt, autoClose_opt, autoUpdateFees_opt, addWhitelistedPeers_opt, removeWhitelistedPeers_opt, minFundingAmount_opt, maxFundingAmount_opt, maxPerPeerCapacity_opt, maxFundingTxPerDay_opt, localBalanceClosingThreshold_opt, remoteBalanceClosingThreshold_opt, minOnChainBalance_opt, maxFeerate_opt, reviveOldPeers_opt, fundingCooldown_opt) =>
         val cfg = PeerScorer.ConfigOverrides(
           autoFundOverride_opt = autoFund_opt,
           autoCloseOverride_opt = autoClose_opt,
@@ -101,6 +101,7 @@ trait Control {
           remoteBalanceClosingThresholdOverride_opt = remoteBalanceClosingThreshold_opt,
           minOnChainBalanceOverride_opt = minOnChainBalance_opt,
           maxFeerateOverride_opt = maxFeerate_opt.map(_.perKw),
+          reviveOldPeersOverride_opt = reviveOldPeers_opt,
           fundingCooldownOverride_opt = fundingCooldown_opt.map(hours => FiniteDuration(hours, TimeUnit.HOURS)),
         )
         complete(eclairApi.configurePeerScorer(cfg))

--- a/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Control.scala
+++ b/eclair-node/src/main/scala/fr/acinq/eclair/api/handlers/Control.scala
@@ -85,8 +85,8 @@ trait Control {
   }
 
   val configurePeerScorer: Route = postRequest("configurepeerscorer") { implicit t =>
-    formFields("autoFund".as[Boolean] ?, "autoClose".as[Boolean] ?, "autoUpdateFees".as[Boolean] ?, "addWhitelistedPeers".as[List[PublicKey]](pubkeyListUnmarshaller).?, "removeWhitelistedPeers".as[List[PublicKey]](pubkeyListUnmarshaller).?, "minFundingAmount".as[Satoshi] ?, "maxFundingAmount".as[Satoshi] ?, "maxPerPeerCapacity".as[Satoshi] ?, "maxFundingTxPerDay".as[Int] ?, "localBalanceClosingThreshold".as[Satoshi] ?, "remoteBalanceClosingThreshold".as[Satoshi] ?, "minOnChainBalance".as[Satoshi] ?, "maxFeerate".as[FeeratePerByte] ?, "reviveOldPeers".as[Boolean] ?, "fundingCooldown".as[Int] ?) {
-      (autoFund_opt, autoClose_opt, autoUpdateFees_opt, addWhitelistedPeers_opt, removeWhitelistedPeers_opt, minFundingAmount_opt, maxFundingAmount_opt, maxPerPeerCapacity_opt, maxFundingTxPerDay_opt, localBalanceClosingThreshold_opt, remoteBalanceClosingThreshold_opt, minOnChainBalance_opt, maxFeerate_opt, reviveOldPeers_opt, fundingCooldown_opt) =>
+    formFields("autoFund".as[Boolean] ?, "autoClose".as[Boolean] ?, "autoUpdateFees".as[Boolean] ?, "addWhitelistedPeers".as[List[PublicKey]](pubkeyListUnmarshaller).?, "removeWhitelistedPeers".as[List[PublicKey]](pubkeyListUnmarshaller).?, "minFundingAmount".as[Satoshi] ?, "maxFundingAmount".as[Satoshi] ?, "maxPerPeerCapacity".as[Satoshi] ?, "maxFundingTxPerDay".as[Int] ?, "localBalanceClosingThreshold".as[Satoshi] ?, "remoteBalanceClosingThreshold".as[Satoshi] ?, "idleChannelClosingThresholdPercent".as[Double]?, "minOnChainBalance".as[Satoshi] ?, "maxFeerate".as[FeeratePerByte] ?, "reviveOldPeers".as[Boolean] ?, "fundingCooldown".as[Int] ?) {
+      (autoFund_opt, autoClose_opt, autoUpdateFees_opt, addWhitelistedPeers_opt, removeWhitelistedPeers_opt, minFundingAmount_opt, maxFundingAmount_opt, maxPerPeerCapacity_opt, maxFundingTxPerDay_opt, localBalanceClosingThreshold_opt, remoteBalanceClosingThreshold_opt, idleChannelClosingThresholdPct_opt, minOnChainBalance_opt, maxFeerate_opt, reviveOldPeers_opt, fundingCooldown_opt) =>
         val cfg = PeerScorer.ConfigOverrides(
           autoFundOverride_opt = autoFund_opt,
           autoCloseOverride_opt = autoClose_opt,
@@ -99,6 +99,7 @@ trait Control {
           maxFundingTxPerDayOverride_opt = maxFundingTxPerDay_opt,
           localBalanceClosingThresholdOverride_opt = localBalanceClosingThreshold_opt,
           remoteBalanceClosingThresholdOverride_opt = remoteBalanceClosingThreshold_opt,
+          idleChannelClosingThresholdPctOverride_opt = idleChannelClosingThresholdPct_opt,
           minOnChainBalanceOverride_opt = minOnChainBalance_opt,
           maxFeerateOverride_opt = maxFeerate_opt.map(_.perKw),
           reviveOldPeersOverride_opt = reviveOldPeers_opt,


### PR DESCRIPTION
We previously lowered fees from idle channels only if our latest update was from more than 24 hours ago, and closed them if our latest update was more than 5 days ago and using our minimal fees.

The issue is that our channel update may have been refreshed without changing the relay fees, for example if our peer disconnected. We don't track when our relay fees reached the minimum amount, so we may have a recent channel update even though we reached our minimum relay fees weeks ago.

We use smaller durations for those thresholds to see if that helps reclaim liquidity more aggressively.

We also disable old peers revival by default: this feature is useful when feerates have been high for a while and funding was thus put on hold, but when feerates are frequently below our feerate threshold, this is wasting liquidity. It should be enabled after a high-fee period.