### PR TITLE
Fix Bolt12 path fee hiding

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -734,11 +734,10 @@ eclair {
   offers {
     // Minimum length of an offer blinded path when hiding our real node id
     message-path-min-length = 2
-
     // Number of payment paths to put in Bolt12 invoices when hiding our real node id
     payment-path-count = 2
     // Length of payment paths to put in Bolt12 invoices when hiding our real node id
-    payment-path-length = 4
+    payment-path-length = 2
     // Expiry delta of payment paths to put in Bolt12 invoices when hiding our real node id
     payment-path-expiry-delta = 500
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/offer/OfferManager.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/offer/OfferManager.scala
@@ -285,7 +285,7 @@ object OfferManager {
             val minimalInvoice = MinimalBolt12Invoice(offer, nodeParams.chainHash, metadata.amount, metadata.quantity, Crypto.sha256(metadata.preimage), metadata.payerKey, metadata.createdAt, additionalTlvs, customTlvs)
             val incomingPayment = IncomingBlindedPayment(minimalInvoice, metadata.preimage, PaymentType.Blinded, TimestampMilli.now(), IncomingPaymentStatus.Pending)
             // We may be deducing some of the blinded path fees from the received amount.
-            val maxRecipientPathFees = nodeFee(metadata.recipientPathFees, amount)
+            val maxRecipientPathFees = nodeFee(metadata.recipientPathFees, Seq(amount, metadata.amount).max)
             replyTo ! MultiPartHandler.GetIncomingPaymentActor.ProcessPayment(incomingPayment, maxRecipientPathFees)
             Behaviors.stopped
           case RejectPayment(reason) =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/payment/OfferPaymentSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/integration/basic/payment/OfferPaymentSpec.scala
@@ -783,7 +783,7 @@ class OfferPaymentSpec extends FixtureSpec with IntegrationPatience {
     assert(offer.nodeId.isEmpty)
     assert(offer.contactInfos.size == 1)
     assert(offer.contactInfos.head.asInstanceOf[BlindedPath].route.firstNodeId == EncodedNodeId.WithPublicKey.Plain(carol.nodeId))
-    assert(offer.contactInfos.head.asInstanceOf[BlindedPath].route.length == carol.nodeParams.offersConfig.messagePathMinLength)
+    assert(offer.contactInfos.head.asInstanceOf[BlindedPath].route.length >= carol.nodeParams.offersConfig.messagePathMinLength)
     assert(offer.description.contains("test offer"))
     assert(offer.amount.contains(amount))
 
@@ -801,7 +801,7 @@ class OfferPaymentSpec extends FixtureSpec with IntegrationPatience {
     assert(offer.nodeId.isEmpty)
     assert(offer.contactInfos.size == 1)
     assert(offer.contactInfos.head.asInstanceOf[BlindedPath].route.firstNodeId == EncodedNodeId.WithPublicKey.Plain(bob.nodeId))
-    assert(offer.contactInfos.head.asInstanceOf[BlindedPath].route.length == carol.nodeParams.offersConfig.messagePathMinLength)
+    assert(offer.contactInfos.head.asInstanceOf[BlindedPath].route.length >= carol.nodeParams.offersConfig.messagePathMinLength)
     assert(offer.description.contains("test offer"))
     assert(offer.amount.contains(amount))
 
@@ -825,7 +825,7 @@ class OfferPaymentSpec extends FixtureSpec with IntegrationPatience {
     val offer = createOffer(carol, description_opt = Some("test offer"), amount_opt = Some(amount), issuer_opt = None, blindedPathsFirstNodeId_opt = Some(alice.nodeId))
     assert(offer.nodeId.isEmpty)
     assert(offer.contactInfos.head.asInstanceOf[BlindedPath].route.firstNodeId == EncodedNodeId.WithPublicKey.Plain(alice.nodeId))
-    assert(offer.contactInfos.head.asInstanceOf[BlindedPath].route.length == carol.nodeParams.offersConfig.messagePathMinLength)
+    assert(offer.contactInfos.head.asInstanceOf[BlindedPath].route.length >= carol.nodeParams.offersConfig.messagePathMinLength)
     assert(offer.description.contains("test offer"))
     assert(offer.amount.contains(amount))
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/offer/OfferManagerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/offer/OfferManagerSpec.scala
@@ -33,7 +33,7 @@ import fr.acinq.eclair.router.Router.ChannelHop
 import fr.acinq.eclair.wire.protocol.OfferTypes.{InvoiceRequest, Offer}
 import fr.acinq.eclair.wire.protocol.RouteBlindingEncryptedDataCodecs.RouteBlindingDecryptedData
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshi, MilliSatoshiLong, NodeParams, TestConstants, amountAfterFee, randomBytes32, randomKey}
+import fr.acinq.eclair.{CltvExpiry, CltvExpiryDelta, Features, MilliSatoshi, MilliSatoshiLong, NodeParams, TestConstants, amountAfterFee, nodeFee, randomBytes32, randomKey}
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.{Outcome, Tag}
 import scodec.bits.{ByteVector, HexStringSyntax}
@@ -332,6 +332,7 @@ class OfferManagerSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("app
     assert(Crypto.sha256(incomingPayment.paymentPreimage) == invoice.paymentHash)
     assert(incomingPayment.invoice.nodeId == nodeParams.nodeId)
     assert(incomingPayment.invoice.paymentHash == invoice.paymentHash)
-    assert(maxRecipientPathFees == paymentPayload.amount - amountReceived)
+    assert(maxRecipientPathFees >= paymentPayload.amount - amountReceived)
+    assert(maxRecipientPathFees == nodeFee(1000 msat, 200, amount))
   }
 }


### PR DESCRIPTION
When using blinded paths in our Bolt12 invoices, we may use a feature where instead of making the payer pay the fees for the blinded path, we deduce them from the amount we wish to receive (the recipient pays for the privacy it gains from using blinded paths, instead of making the payer pay for something that they didn't opt into). See #2993 for more details.

The constraint on path fees was wrong in some rounding cases, so we fix that, otherwise we would unnecessarily reject some payments. This was found by testing blinded trampoline payments.