### PR TITLE
Fix #1652: Add an option to disable server in cluster mode

### DIFF
--- a/eclair-core/src/main/resources/reference.conf
+++ b/eclair-core/src/main/resources/reference.conf
@@ -4,6 +4,7 @@ eclair {
   chain = "mainnet" // "regtest" for regtest, "testnet" for testnet, "mainnet" for mainnet, "signet" for signet
 
   server {
+    enabled = true
     public-ips = [] // external ips, will be announced on the network
     binding-ip = "0.0.0.0"
     port = 9735

--- a/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/Setup.scala
@@ -128,7 +128,9 @@ class Setup(val datadir: File,
   val serverBindingAddress = new InetSocketAddress(config.getString("server.binding-ip"), config.getInt("server.port"))
 
   // early checks
-  PortChecker.checkAvailable(serverBindingAddress)
+  if (config.getBoolean("server.enabled")) {
+    PortChecker.checkAvailable(serverBindingAddress)
+  }
 
   // load on onchain key manager if an `eclair-signer.conf` is found in Eclair's data directory
   val onChainKeyManager_opt = LocalOnChainKeyManager.load(datadir, NodeParams.hashFromChain(chain))
@@ -395,7 +397,12 @@ class Setup(val datadir: File,
       switchboard = system.actorOf(SimpleSupervisor.props(Switchboard.props(nodeParams, peerFactory), "switchboard", SupervisorStrategy.Resume))
       _ = switchboard ! Switchboard.Init(channels)
       clientSpawner = system.actorOf(SimpleSupervisor.props(ClientSpawner.props(nodeParams.keyPair, nodeParams.socksProxy_opt, nodeParams.peerConnectionConf, switchboard, router), "client-spawner", SupervisorStrategy.Restart))
-      server = system.actorOf(SimpleSupervisor.props(Server.props(nodeParams.keyPair, nodeParams.peerConnectionConf, switchboard, router, serverBindingAddress, Some(tcpBound)), "server", SupervisorStrategy.Restart))
+      server = if (config.getBoolean("server.enabled")) {
+        system.actorOf(SimpleSupervisor.props(Server.props(nodeParams.keyPair, nodeParams.peerConnectionConf, switchboard, router, serverBindingAddress, Some(tcpBound)), "server", SupervisorStrategy.Restart))
+      } else {
+        tcpBound.success(Done)
+        system.deadLetters
+      }
       paymentInitiator = system.actorOf(SimpleSupervisor.props(PaymentInitiator.props(nodeParams, PaymentInitiator.SimplePaymentFactory(nodeParams, router, register)), "payment-initiator", SupervisorStrategy.Restart))
 
       _ = for (i <- 0 until config.getInt("autoprobe-count")) yield system.actorOf(SimpleSupervisor.props(Autoprobe.props(nodeParams, router, paymentInitiator), s"payment-autoprobe-$i", SupervisorStrategy.Restart))


### PR DESCRIPTION
Added server.enabled = true default to reference.conf, and conditionally skipped PortChecker and Server actor initialization in Setup.scala when set to false.