### PR TITLE
Remove deprecated `bip125 replaceable` field in MempoolTx

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -709,10 +709,9 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
       val JDecimal(fees) = json \ "fees" \ "base"
       val JDecimal(ancestorFees) = json \ "fees" \ "ancestor"
       val JDecimal(descendantFees) = json \ "fees" \ "descendant"
-      val JBool(replaceable) = json \ "bip125-replaceable"
       val unconfirmedParents = (json \ "depends").extract[List[String]].map(TxId.fromValidHex).toSet
       // NB: bitcoind counts the transaction itself as its own ancestor and descendant, which is confusing: we fix that by decrementing these counters.
-      MempoolTx(txid, vsize.toLong, weight.toLong, replaceable, toSatoshi(fees), ancestorCount.toInt - 1, toSatoshi(ancestorFees), descendantCount.toInt - 1, toSatoshi(descendantFees), unconfirmedParents)
+      MempoolTx(txid, vsize.toLong, weight.toLong, toSatoshi(fees), ancestorCount.toInt - 1, toSatoshi(ancestorFees), descendantCount.toInt - 1, toSatoshi(descendantFees), unconfirmedParents)
     })
   }
 
@@ -816,7 +815,6 @@ object BitcoinCoreClient {
    * @param txid               transaction id.
    * @param vsize              virtual transaction size as defined in BIP 141.
    * @param weight             transaction weight as defined in BIP 141.
-   * @param replaceable        Whether this transaction could be replaced with RBF (BIP125).
    * @param fees               transaction fees.
    * @param ancestorCount      number of unconfirmed parent transactions.
    * @param ancestorFees       transactions fees for the package consisting of this transaction and its unconfirmed parents.
@@ -824,7 +822,7 @@ object BitcoinCoreClient {
    * @param descendantFees     transactions fees for the package consisting of this transaction and its unconfirmed children (without its unconfirmed parents).
    * @param unconfirmedParents unconfirmed transactions used as inputs for this transaction.
    */
-  case class MempoolTx(txid: TxId, vsize: Long, weight: Long, replaceable: Boolean, fees: Satoshi, ancestorCount: Int, ancestorFees: Satoshi, descendantCount: Int, descendantFees: Satoshi, unconfirmedParents: Set[TxId])
+  case class MempoolTx(txid: TxId, vsize: Long, weight: Long, fees: Satoshi, ancestorCount: Int, ancestorFees: Satoshi, descendantCount: Int, descendantFees: Satoshi, unconfirmedParents: Set[TxId])
 
   case class WalletTx(address: String, amount: Satoshi, fees: Satoshi, blockId_opt: Option[BlockId], confirmations: Long, txid: TxId, timestamp: Long)
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
@@ -1396,7 +1396,6 @@ class BitcoinCoreClientSpec extends TestKitBaseClass with BitcoindService with A
     assert(mempoolCpfpTx.ancestorFees == mempoolCpfpTx.fees + mempoolTx.fees)
     val expectedFees = Transactions.weight2fee(targetFeerate, tx.weight() + cpfpTx.weight())
     assert(expectedFees * 0.95 <= mempoolCpfpTx.ancestorFees && mempoolCpfpTx.ancestorFees <= expectedFees * 1.05)
-    assert(mempoolCpfpTx.replaceable)
 
     generateBlocks(1)
   }
@@ -1452,7 +1451,6 @@ class BitcoinCoreClientSpec extends TestKitBaseClass with BitcoindService with A
     val packageWeight = fundingTx.weight() + mutualCloseTx.weight() + cpfpTx.weight()
     val expectedFees = Transactions.weight2fee(targetFeerate, packageWeight)
     assert(expectedFees * 0.95 <= mempoolCpfpTx.ancestorFees && mempoolCpfpTx.ancestorFees <= expectedFees * 1.05)
-    assert(mempoolCpfpTx.replaceable)
 
     generateBlocks(1)
   }
@@ -1547,7 +1545,6 @@ class BitcoinCoreClientSpec extends TestKitBaseClass with BitcoindService with A
     val packageWeight = txA1.weight() + txA2.weight() + txA3.weight() + txA4.weight() + txA5.weight() + txA6.weight() + txB1.weight() + txB2.weight() + txB3.weight() + cpfpTx.weight()
     val expectedFees = Transactions.weight2fee(targetFeerate, packageWeight)
     assert(expectedFees * 0.95 <= mempoolCpfpTx.ancestorFees && mempoolCpfpTx.ancestorFees <= expectedFees * 1.05)
-    assert(mempoolCpfpTx.replaceable)
 
     generateBlocks(1)
   }


### PR DESCRIPTION
Full RBF has been the default policy since v28, `bip125-replaceable` field in Bitcoin Core RPC had been deprecated since v29 and has been removed in https://github.com/bitcoin/bitcoin/pull/34911 (which broke our `Latest Bitcoin Core` tests, see https://github.com/ACINQ/eclair/actions/runs/27658085695 for example, this PR should fix them).
