### PR TITLE
Reject incoming HTLCs with a high `cltv_expiry`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -902,10 +902,19 @@ case class Commitments(channelParams: ChannelParams,
     if (cmd.cltvExpiry < minExpiry) {
       return Left(ExpiryTooSmall(channelId, minimum = minExpiry, actual = cmd.cltvExpiry, blockHeight = currentHeight))
     }
-    // we don't want to use too high a refund timeout, because our funds will be locked during that time if the payment is never fulfilled
+    // We don't want to use too high a refund timeout, because our funds will be locked during that time if the payment
+    // is never fulfilled.
+    // We apply the same expiry limits to the corresponding incoming HTLCs: we do it here instead of inside receiveAdd,
+    // because returning a failure in receiveAdd would force-close the channel, whereas it is harmless to accept the
+    // HTLC and then fail it (like we do for dust exposure limits).
     val maxExpiry = channelConf.maxExpiryDelta.toCltvExpiry(currentHeight)
-    if (cmd.cltvExpiry >= maxExpiry) {
-      return Left(ExpiryTooBig(channelId, maximum = maxExpiry, actual = cmd.cltvExpiry, blockHeight = currentHeight))
+    val expiry = cmd.origin.upstream match {
+      case _: Upstream.Local => cmd.cltvExpiry
+      case u: Upstream.Hot.Channel => Seq(cmd.cltvExpiry, u.expiryIn).max
+      case u: Upstream.Hot.Trampoline => (cmd.cltvExpiry +: u.received.map(_.expiryIn)).max
+    }
+    if (expiry >= maxExpiry) {
+      return Left(ExpiryTooBig(channelId, maximum = maxExpiry, actual = expiry, blockHeight = currentHeight))
     }
 
     // even if remote advertises support for 0 msat htlc, we limit ourselves to values strictly positive, hence the max(1 msat)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/receive/MultiPartHandler.scala
@@ -439,8 +439,12 @@ object MultiPartHandler {
 
   private def validatePaymentCltv(nodeParams: NodeParams, add: UpdateAddHtlc, payload: FinalPayload)(implicit log: LoggingAdapter): Boolean = {
     val minExpiry = nodeParams.channelConf.minFinalExpiryDelta.toCltvExpiry(nodeParams.currentBlockHeight)
+    val maxExpiry = nodeParams.channelConf.maxExpiryDelta.toCltvExpiry(nodeParams.currentBlockHeight)
     if (add.cltvExpiry < minExpiry) {
-      log.warning("received payment with expiry too small for amount={} totalAmount={}", add.amountMsat, payload.totalAmount)
+      log.warning("received payment with expiry too small for amount={} totalAmount={} (expiry={})", add.amountMsat, payload.totalAmount, add.cltvExpiry)
+      false
+    } else if (add.cltvExpiry >= maxExpiry) {
+      log.warning("received payment with expiry too big for amount={} totalAmount={} (expiry={})", add.amountMsat, payload.totalAmount, add.cltvExpiry)
       false
     } else {
       true

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -49,6 +49,7 @@ import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 import org.scalatest.{Outcome, Tag}
 import scodec.bits._
 
+import java.util.UUID
 import scala.concurrent.duration._
 
 /**
@@ -166,11 +167,25 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     val sender = TestProbe()
     val initialState = alice.stateData.asInstanceOf[DATA_NORMAL]
     val maxAllowedExpiryDelta = alice.underlyingActor.nodeParams.channelConf.maxExpiryDelta
+    val validExpiry = CltvExpiryDelta(36).toCltvExpiry(currentBlockHeight)
     val expiryTooBig = (maxAllowedExpiryDelta + 1).toCltvExpiry(currentBlockHeight)
-    val add = CMD_ADD_HTLC(sender.ref, 500000000 msat, randomBytes32(), expiryTooBig, TestConstants.emptyOnionPacket, None, Reputation.Score.max(accountable = false), None, localOrigin(sender.ref))
-    alice ! add
-    val error = ExpiryTooBig(channelId(alice), maximum = maxAllowedExpiryDelta.toCltvExpiry(currentBlockHeight), actual = expiryTooBig, blockHeight = currentBlockHeight)
-    sender.expectMsg(RES_ADD_FAILED(add, error, Some(initialState.channelUpdate)))
+    val incoming = UpdateAddHtlc(randomBytes32(), 7, 500_000_000 msat, randomBytes32(), validExpiry, TestConstants.emptyOnionPacket, None, accountable = true, None)
+    val cmd = CMD_ADD_HTLC(sender.ref, 500_000_000 msat, randomBytes32(), validExpiry, TestConstants.emptyOnionPacket, None, Reputation.Score.max(accountable = false), None, localOrigin(sender.ref))
+    val testCases = Seq(
+      // HTLC for which we're the sender.
+      cmd.copy(cltvExpiry = expiryTooBig, origin = Origin.Hot(sender.ref, Upstream.Local(UUID.randomUUID()))),
+      // HTLC relayed with a valid incoming HTLC expiry.
+      cmd.copy(cltvExpiry = expiryTooBig, origin = Origin.Hot(sender.ref, Upstream.Hot.Channel(incoming, 0 unixms, randomKey().publicKey, 0.5))),
+      // HTLC relayed with the incoming HTLC having a high expiry.
+      cmd.copy(cltvExpiry = validExpiry, origin = Origin.Hot(sender.ref, Upstream.Hot.Channel(incoming.copy(cltvExpiry = expiryTooBig), 0 unixms, randomKey().publicKey, 0.5))),
+      // HTLC relayed using trampoline, with one of the incoming HTLCs having a high expiry.
+      cmd.copy(cltvExpiry = validExpiry, origin = Origin.Hot(sender.ref, Upstream.Hot.Trampoline(Upstream.Hot.Channel(incoming, 0 unixms, randomKey().publicKey, 0.5) :: Upstream.Hot.Channel(incoming.copy(cltvExpiry = expiryTooBig), 0 unixms, randomKey().publicKey, 0.5) :: Nil))),
+    )
+    testCases.foreach(cmd => {
+      alice ! cmd
+      val error = ExpiryTooBig(channelId(alice), maximum = maxAllowedExpiryDelta.toCltvExpiry(currentBlockHeight), actual = expiryTooBig, blockHeight = currentBlockHeight)
+      sender.expectMsg(RES_ADD_FAILED(cmd, error, Some(initialState.channelUpdate)))
+    })
     alice2bob.expectNoMessage(100 millis)
   }
 

--- a/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/payment/MultiPartHandlerSpec.scala
@@ -367,7 +367,7 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
     assert(nodeParams.db.payments.getIncomingPayment(invoice.paymentHash).get.status == IncomingPaymentStatus.Pending)
   }
 
-  test("PaymentHandler should reject incoming multi-part payment with an invalid expiry") { f =>
+  test("PaymentHandler should reject incoming multi-part payment with an invalid expiry (expiry too small)") { f =>
     import f._
 
     sender.send(handlerWithMpp, ReceiveStandardPayment(sender.ref, Some(1000 msat), Left("multi-part invalid expiry")))
@@ -376,6 +376,21 @@ class MultiPartHandlerSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike 
 
     val lowCltvExpiry = nodeParams.channelConf.fulfillSafetyBeforeTimeout.toCltvExpiry(nodeParams.currentBlockHeight)
     val add = UpdateAddHtlc(ByteVector32.One, 0, 800 msat, invoice.paymentHash, lowCltvExpiry, TestConstants.emptyOnionPacket, None, accountable = false, None)
+    sender.send(handlerWithMpp, ReceivePacket(IncomingPaymentPacket.FinalPacket(add, FinalPayload.Standard.createPayload(add.amountMsat, 1000 msat, add.cltvExpiry, invoice.paymentSecret, invoice.paymentMetadata, upgradeAccountability = false), TimestampMilli.now()), randomKey().publicKey))
+    val cmd = register.expectMsgType[Register.Forward[CMD_FAIL_HTLC]].message
+    assert(cmd.reason == FailureReason.LocalFailure(IncorrectOrUnknownPaymentDetails(1000 msat, nodeParams.currentBlockHeight)))
+    assert(nodeParams.db.payments.getIncomingPayment(invoice.paymentHash).get.status == IncomingPaymentStatus.Pending)
+  }
+
+  test("PaymentHandler should reject incoming multi-part payment with an invalid expiry (expiry too big)") { f =>
+    import f._
+
+    sender.send(handlerWithMpp, ReceiveStandardPayment(sender.ref, Some(1000 msat), Left("multi-part invalid expiry")))
+    val invoice = sender.expectMsgType[Bolt11Invoice]
+    assert(invoice.features.hasFeature(BasicMultiPartPayment))
+
+    val highCltvExpiry = (nodeParams.channelConf.maxExpiryDelta + 1).toCltvExpiry(nodeParams.currentBlockHeight)
+    val add = UpdateAddHtlc(ByteVector32.One, 0, 800 msat, invoice.paymentHash, highCltvExpiry, TestConstants.emptyOnionPacket, None, accountable = false, None)
     sender.send(handlerWithMpp, ReceivePacket(IncomingPaymentPacket.FinalPacket(add, FinalPayload.Standard.createPayload(add.amountMsat, 1000 msat, add.cltvExpiry, invoice.paymentSecret, invoice.paymentMetadata, upgradeAccountability = false), TimestampMilli.now()), randomKey().publicKey))
     val cmd = register.expectMsgType[Register.Forward[CMD_FAIL_HTLC]].message
     assert(cmd.reason == FailureReason.LocalFailure(IncorrectOrUnknownPaymentDetails(1000 msat, nodeParams.currentBlockHeight)))


### PR DESCRIPTION
We currently reject HTLCs with a `cltv_expiry` higher than 2 weeks in the future when sending them (in the `sendAdd` method). That's because they would lock up our funds for a long period of time if our peer decided to force-close. Also, a large `cltv_expiry` makes slow jamming easier.

We now apply the same limits to incoming HTLCs for consistency (since they may differ by `cltv_expiry_delta`). Note that we don't do it in the `receiveAdd` function, which would trigger a force-close. We just accept those HTLCs and then fail them, since it is harmless to have them only temporarily in our commitment as long as we don't relay.