### PR TITLE
Reject `start_batch` with size <= 1

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -363,9 +363,9 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
               log.debug("ignoring start_batch: we only support batching commit_sig messages")
               d.transport ! Warning(msg.channelId, "invalid start_batch message: we only support batching commit_sig messages")
               stay()
-            } else if (msg.batchSize > 20) {
-              log.debug("ignoring start_batch with batch_size = {} > 20", msg.batchSize)
-              d.transport ! Warning(msg.channelId, "invalid start_batch message: batch_size must not be greater than 20")
+            } else if (msg.batchSize < 1 || msg.batchSize > 20) {
+              log.debug("ignoring start_batch with invalid batch_size = {} (max = 20)", msg.batchSize)
+              d.transport ! Warning(msg.channelId, "invalid start_batch message: batch_size must be greater than 0 and not be greater than 20")
               stay()
             } else {
               log.debug("starting commit_sig batch of size {} for channel_id={}", msg.batchSize, msg.channelId)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/io/PeerConnection.scala
@@ -363,9 +363,9 @@ class PeerConnection(keyPair: KeyPair, conf: PeerConnection.Conf, switchboard: A
               log.debug("ignoring start_batch: we only support batching commit_sig messages")
               d.transport ! Warning(msg.channelId, "invalid start_batch message: we only support batching commit_sig messages")
               stay()
-            } else if (msg.batchSize < 1 || msg.batchSize > 20) {
+            } else if (msg.batchSize <= 1 || msg.batchSize > 20) {
               log.debug("ignoring start_batch with invalid batch_size = {} (max = 20)", msg.batchSize)
-              d.transport ! Warning(msg.channelId, "invalid start_batch message: batch_size must be greater than 0 and not be greater than 20")
+              d.transport ! Warning(msg.channelId, "invalid start_batch message: batch_size must be greater than 1 and not be greater than 20")
               stay()
             } else {
               log.debug("starting commit_sig batch of size {} for channel_id={}", msg.batchSize, msg.channelId)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -559,6 +559,17 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     transport.expectMsg(TransportHandler.ReadAck(commitSig3))
     peer.expectMsg(commitSig3)
     peer.expectNoMessage(100 millis)
+
+    // We receive a batch with size=0: we ignore it.
+    val startBatch4 = StartBatch(channelId, batchSize = 0, TlvStream(StartBatchTlv.MessageType(132)))
+    val commitSig4 = CommitSig(channelId, IndividualSignature(randomBytes64()), Nil, TlvStream(CommitSigTlv.FundingTx(randomTxId())))
+    transport.send(peerConnection, startBatch4)
+    transport.expectMsg(TransportHandler.ReadAck(startBatch4))
+    transport.expectMsgType[Warning]
+    transport.send(peerConnection, commitSig4)
+    transport.expectMsg(TransportHandler.ReadAck(commitSig4))
+    peer.expectMsg(commitSig4)
+    peer.expectNoMessage(100 millis)
   }
 
   test("react to peer's bad behavior") { f =>

--- a/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/io/PeerConnectionSpec.scala
@@ -570,6 +570,17 @@ class PeerConnectionSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike wi
     transport.expectMsg(TransportHandler.ReadAck(commitSig4))
     peer.expectMsg(commitSig4)
     peer.expectNoMessage(100 millis)
+
+    // We receive a batch with size=1: we ignore it.
+    val startBatch5 = StartBatch(channelId, batchSize = 1, TlvStream(StartBatchTlv.MessageType(132)))
+    val commitSig5 = CommitSig(channelId, IndividualSignature(randomBytes64()), Nil, TlvStream(CommitSigTlv.FundingTx(randomTxId())))
+    transport.send(peerConnection, startBatch5)
+    transport.expectMsg(TransportHandler.ReadAck(startBatch5))
+    transport.expectMsgType[Warning]
+    transport.send(peerConnection, commitSig5)
+    transport.expectMsg(TransportHandler.ReadAck(commitSig5))
+    peer.expectMsg(commitSig5)
+    peer.expectNoMessage(100 millis)
   }
 
   test("react to peer's bad behavior") { f =>


### PR DESCRIPTION
Bolt2 specifies that a receiving node:

```
If batch_size is not strictly greater than 1:
- MUST ignore the start_batch message.
- SHOULD send a warning.
```

Thanks @rorp for reporting this!