### PR TITLE
Don't store duplicate settlement messages

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -987,6 +987,10 @@ case class Commitments(channelParams: ChannelParams,
   def receiveFulfill(fulfill: UpdateFulfillHtlc): Either[ChannelException, (Commitments, Origin, UpdateAddHtlc)] =
     getOutgoingHtlcCrossSigned(fulfill.id) match {
       case Some(htlc) if htlc.paymentHash == Crypto.sha256(fulfill.paymentPreimage) => originChannels.get(fulfill.id) match {
+        case Some(origin) if CommitmentChanges.alreadyProposed(changes.remoteChanges.proposed, htlc.id) =>
+          // We've already received a fail/fulfill for this HTLC, so we don't need to add it again to the remote changes.
+          // If it differs from the previous settlement message, our peer is buggy and we will force-close when exchanging commit_sig.
+          Right(this, origin, htlc)
         case Some(origin) =>
           payment.Monitoring.Metrics.recordOutgoingPaymentDistribution(remoteNodeId, htlc.amountMsat)
           Right(copy(changes = changes.addRemoteProposal(fulfill)), origin, htlc)
@@ -1027,6 +1031,7 @@ case class Commitments(channelParams: ChannelParams,
   def receiveFail(fail: UpdateFailHtlc): Either[ChannelException, (Commitments, Origin, UpdateAddHtlc)] =
     getOutgoingHtlcCrossSigned(fail.id) match {
       case Some(htlc) => originChannels.get(fail.id) match {
+        case Some(origin) if CommitmentChanges.alreadyProposed(changes.remoteChanges.proposed, htlc.id) => Right(this, origin, htlc)
         case Some(origin) => Right(copy(changes = changes.addRemoteProposal(fail)), origin, htlc)
         case None => Left(UnknownHtlcId(channelId, fail.id))
       }
@@ -1040,6 +1045,7 @@ case class Commitments(channelParams: ChannelParams,
     } else {
       getOutgoingHtlcCrossSigned(fail.id) match {
         case Some(htlc) => originChannels.get(fail.id) match {
+          case Some(origin) if CommitmentChanges.alreadyProposed(changes.remoteChanges.proposed, htlc.id) => Right(this, origin, htlc)
           case Some(origin) => Right(copy(changes = changes.addRemoteProposal(fail)), origin, htlc)
           case None => Left(UnknownHtlcId(channelId, fail.id))
         }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -1853,6 +1853,29 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     alice2blockchain.expectWatchTxConfirmed(tx.txid)
   }
 
+  test("recv UpdateFulfillHtlc (duplicate)") { f =>
+    import f._
+
+    val (r, htlc) = addHtlc(50_000_000 msat, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    bob ! CMD_FULFILL_HTLC(htlc.id, r, None)
+    val fulfill = bob2alice.expectMsgType[UpdateFulfillHtlc]
+    bob2alice.forward(alice, fulfill)
+    awaitCond(alice.commitments.changes.remoteChanges.proposed.contains(fulfill))
+    alice2relayer.expectMsgType[RES_ADD_SETTLED[Origin, HtlcResult.RemoteFulfill]]
+    val remoteChanges = alice.commitments.changes.remoteChanges
+
+    // We relay fulfill commands (which are ignored downstream since they are duplicates) and ignore failures.
+    // We don't store the duplicate/conflicting message.
+    bob2alice.forward(alice, fulfill)
+    alice2relayer.expectMsgType[RES_ADD_SETTLED[Origin, HtlcResult.RemoteFulfill]]
+    assert(alice.commitments.changes.remoteChanges == remoteChanges)
+    val fail = UpdateFailHtlc(fulfill.channelId, fulfill.id, randomBytes(292))
+    bob2alice.forward(alice, fail)
+    alice2relayer.expectNoMessage(100 millis)
+    assert(alice.commitments.changes.remoteChanges == remoteChanges)
+  }
+
   private def testCmdFailHtlc(f: FixtureParam, commitmentFormat: CommitmentFormat): Unit = {
     import f._
 
@@ -2094,6 +2117,28 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     alice2blockchain.expectReplaceableTxPublished[ClaimLocalAnchorTx]
     alice2blockchain.expectFinalTxPublished("local-main-delayed")
     alice2blockchain.expectWatchTxConfirmed(tx.txid)
+  }
+
+  test("recv UpdateFailHtlc (duplicate)") { f =>
+    import f._
+
+    val (r, htlc) = addHtlc(27_000_000 msat, alice, bob, alice2bob, bob2alice)
+    crossSign(alice, bob, alice2bob, bob2alice)
+    bob ! CMD_FAIL_HTLC(htlc.id, FailureReason.LocalFailure(PermanentChannelFailure()), None)
+    val fail = bob2alice.expectMsgType[UpdateFailHtlc]
+    bob2alice.forward(alice, fail)
+    awaitCond(alice.commitments.changes.remoteChanges.proposed.contains(fail))
+    alice2relayer.expectNoMessage(100 millis)
+    val remoteChanges = alice.commitments.changes.remoteChanges
+
+    // We ignore duplicate failures, but if we receive a fulfill we relay it downstream.
+    bob2alice.forward(alice, fail)
+    alice2relayer.expectNoMessage(100 millis)
+    assert(alice.commitments.changes.remoteChanges == remoteChanges)
+    val fulfill = UpdateFulfillHtlc(fail.channelId, fail.id, r)
+    bob2alice.forward(alice, fulfill)
+    alice2relayer.expectMsgType[RES_ADD_SETTLED[Origin, HtlcResult.RemoteFulfill]]
+    assert(alice.commitments.changes.remoteChanges == remoteChanges)
   }
 
   test("recv UpdateFailHtlc (onion error bigger than recommended value)") { f =>


### PR DESCRIPTION
If our peer is buggy, or if we have a bug in our message queue, we may receive duplicate settlement messages for pending HTLCs. It is fine to handle them and relay the settlement downstream (instead of immediately force-closing), but we shouldn't store the duplicate settlement in the remote changes, otherwise it will trigger a force-close when exchanging `commit_sig`.