### PR TITLE
Improve defenses against malicious bitcoin RPC endpoint

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BasicBitcoinJsonRPCClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BasicBitcoinJsonRPCClient.scala
@@ -49,10 +49,12 @@ class BasicBitcoinJsonRPCClient(override val chainHash: BlockHash, rpcAuthMethod
   private val credentials = new AtomicReference[BitcoinJsonRPCCredentials](rpcAuthMethod.credentials)
   implicit val serialization: JacksonSerialization = Serialization
 
-  override def invoke(method: String, params: Any*)(implicit ec: ExecutionContext): Future[JValue] =
-    invoke(Seq(JsonRPCRequest(method = method, params = params))).map(l => jsonResponse2Exception(l.head).result)
+  override def invoke(method: String, params: Any*)(implicit ec: ExecutionContext): Future[JValue] = {
+    val request = JsonRPCRequest(id = JsonRPCRequest.nextRequestId(), method = method, params = params)
+    invoke(Seq(request)).map(l => jsonResponse2Exception(l.head).result)
+  }
 
-  def jsonResponse2Exception(jsonRPCResponse: JsonRPCResponse): JsonRPCResponse = jsonRPCResponse match {
+  private def jsonResponse2Exception(jsonRPCResponse: JsonRPCResponse): JsonRPCResponse = jsonRPCResponse match {
     case JsonRPCResponse(_, Some(error), _) => throw JsonRPCError(error)
     case o => o
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BatchingBitcoinJsonRPCClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BatchingBitcoinJsonRPCClient.scala
@@ -28,16 +28,19 @@ import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 class BatchingBitcoinJsonRPCClient(rpcClient: BasicBitcoinJsonRPCClient)(implicit system: ActorSystem, ec: ExecutionContext) extends BitcoinJsonRPCClient {
+  // @formatter:off
   override def chainHash: BlockHash = rpcClient.chainHash
   override def wallet: Option[String] = rpcClient.wallet
+  // @formatter:on
 
   implicit val timeout: Timeout = Timeout(1 hour)
 
-  val batchingClient = system.actorOf(Props(new BatchingClient(rpcClient)), name = "batching-client")
+  private val batchingClient = system.actorOf(Props(new BatchingClient(rpcClient)), name = "batching-client")
 
   override def invoke(method: String, params: Any*)(implicit ec: ExecutionContext): Future[JsonAST.JValue] = {
     KamonExt.timeFuture(Metrics.RpcBatchInvokeDuration.withoutTags()) {
-      (batchingClient ? JsonRPCRequest(method = method, params = params)).mapTo[JsonAST.JValue]
+      val request = JsonRPCRequest(id = JsonRPCRequest.nextRequestId(), method = method, params = params)
+      (batchingClient ? request).mapTo[JsonAST.JValue]
     }
   }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BatchingClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BatchingClient.scala
@@ -37,32 +37,36 @@ class BatchingClient(rpcClient: BasicBitcoinJsonRPCClient) extends Actor with Ac
       // there is already a batch in flight, just add this request to the queue
       context become waiting(queue :+ Pending(request, sender()), processing)
 
-    case responses: Seq[JsonRPCResponse]@unchecked =>
+    case responses: Seq[JsonRPCResponse] @unchecked =>
       log.debug("got {} responses", responses.size)
-      // let's send back answers to the requestors
-      require(responses.size == processing.size, s"responses=${responses.size} != processing=${processing.size}")
-      responses.zip(processing).foreach {
-        case (JsonRPCResponse(result, None, _), Pending(_, requestor)) => requestor ! result
-        case (JsonRPCResponse(_, Some(error), _), Pending(_, requestor)) => requestor ! Status.Failure(JsonRPCError(error))
-      }
+      val keyedResponses = responses.map(r => r.id -> r).toMap
+      processing.foreach(pending => keyedResponses.get(pending.request.id) match {
+        case Some(response) => response.error match {
+          case None => pending.requestor ! response.result
+          case Some(error) => pending.requestor ! Status.Failure(JsonRPCError(error))
+        }
+        case None =>
+          log.warning("response missing for requestId={} method={}", pending.request.id, pending.request.method)
+          pending.requestor ! Status.Failure(new RuntimeException("no response from bitcoind"))
+      })
       process(queue)
 
     case s@Status.Failure(t) =>
-      log.error(t, s"got exception for batch of ${processing.size} requests")
-      // let's fail all requests
+      log.error(s"got exception for batch of ${processing.size} requests: ${t.getMessage}")
+      // We don't know what caused the failure at that point, and we cannot figure our which requests succeeded (if any)
+      // and which failed. We tell requestors that all requests in the batch have failed, but it may be misleading.
       processing.foreach { case Pending(_, requestor) => requestor ! s }
       process(queue)
   }
 
   def process(queue: Queue[Pending]): Unit = {
-    // do we have queued requests?
     if (queue.isEmpty) {
       log.debug("no more requests, going back to idle")
       context become receive
     } else {
       val (batch, rest) = queue.splitAt(BatchingClient.BATCH_SIZE)
       log.debug(s"sending {} request(s): {} (queue={})", batch.size, batch.groupBy(_.request.method).map(e => e._1 + "=" + e._2.size).mkString(" "), queue.size)
-      rpcClient.invoke(batch.map(_.request)) pipeTo self
+      rpcClient.invoke(batch.map(_.request)).pipeTo(self)
       context become waiting(rest, batch)
     }
   }
@@ -71,7 +75,7 @@ class BatchingClient(rpcClient: BasicBitcoinJsonRPCClient) extends Actor with Ac
 
 object BatchingClient {
 
-  val BATCH_SIZE = 50
+  private val BATCH_SIZE = 50
 
   case class Pending(request: JsonRPCRequest, requestor: ActorRef)
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -66,7 +66,14 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
   //------------------------- TRANSACTIONS  -------------------------//
 
   def getTransaction(txid: TxId)(implicit ec: ExecutionContext): Future[Transaction] =
-    getRawTransaction(txid).map(raw => Transaction.read(raw))
+    getRawTransaction(txid).flatMap(raw => {
+      val tx = Transaction.read(raw)
+      if (tx.txid != txid) {
+        Future.failed(new RuntimeException(s"received transaction doesn't match the request: ${tx.txid} != $txid"))
+      } else {
+        Future.successful(tx)
+      }
+    })
 
   private def getRawTransaction(txid: TxId)(implicit ec: ExecutionContext): Future[String] =
     rpcClient.invoke("getrawtransaction", txid).collect {
@@ -83,7 +90,12 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
   /** Get the number of confirmations of a given transaction. */
   def getTxConfirmations(txid: TxId)(implicit ec: ExecutionContext): Future[Option[Int]] =
     rpcClient.invoke("getrawtransaction", txid, 1 /* verbose output is needed to get the number of confirmations */)
-      .map(json => Some((json \ "confirmations").extractOrElse[Int](0)))
+      .flatMap(json => {
+        json \ "txid" match {
+          case JString(txid1) if TxId.fromValidHex(txid1) != txid => Future.failed(new RuntimeException(s"received transaction doesn't match the request: $txid1 != $txid"))
+          case _ => Future.successful(Some((json \ "confirmations").extractOrElse[Int](0)))
+        }
+      })
       .recover {
         case t: JsonRPCError if t.error.code == -5 => None // Invalid or non-wallet transaction id (code: -5)
       }
@@ -487,8 +499,9 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
    * @return the transaction id (txid)
    */
   def publishTransaction(tx: Transaction)(implicit ec: ExecutionContext): Future[TxId] =
-    rpcClient.invoke("sendrawtransaction", tx.toString()).collect {
-      case JString(txid) => TxId.fromValidHex(txid)
+    rpcClient.invoke("sendrawtransaction", tx.toString()).flatMap {
+      case JString(txid) if TxId.fromValidHex(txid) == tx.txid => Future.successful(tx.txid)
+      case _ => Future.failed(new RuntimeException("failed to publish transaction or incorrect txid returned"))
     }.recoverWith {
       case JsonRPCError(Error(-27, _)) =>
         // "transaction already in block chain (code: -27)"
@@ -663,7 +676,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
       actualFeerate = Transactions.fee2rate(actualFees, signedTx.weight())
       maxFeerate = feeratePerKw * 1.5
       _ = require(actualFeerate < maxFeerate, s"actual feerate $actualFeerate is more than 50% above requested feerate $feeratePerKw")
-      txid <-  unlockIfFails(lockedOutputs)(publishTransaction(signedTx))
+      txid <- unlockIfFails(lockedOutputs)(publishTransaction(signedTx))
     } yield txid
   }
 
@@ -690,7 +703,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
       JBool(isMine) = addressInfo \ "ismine"
     } yield isMine
   }
-  
+
   //------------------------- MEMPOOL  -------------------------//
 
   def getMempool()(implicit ec: ExecutionContext): Future[Seq[Transaction]] =
@@ -753,7 +766,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
         val JArray(txs) = json \ "tx"
         TxId.fromValidHex(txs(txIndex).extract[String])
       }.getOrElse(TxId(ByteVector32.Zeroes)))
-      tx <- getRawTransaction(txid)
+      tx <- getTransaction(txid)
       unspent <- isTransactionOutputSpendable(txid, outputIndex, includeMempool = true)
       fundingTxStatus <- if (unspent) {
         Future.successful(UtxoStatus.Unspent)
@@ -761,7 +774,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
         // if this returns true, it means that the spending tx is *not* in the blockchain
         isTransactionOutputSpendable(txid, outputIndex, includeMempool = false).map(res => UtxoStatus.Spent(spendingTxConfirmed = !res))
       }
-    } yield ValidateResult(c, Right((Transaction.read(tx), fundingTxStatus)))
+    } yield ValidateResult(c, Right((tx, fundingTxStatus)))
   } recover {
     case t: Throwable => ValidateResult(c, Left(t))
   }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinCoreClient.scala
@@ -61,12 +61,14 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
     require(rpcClient.wallet.contains(keyManager.walletName), s"eclair-backed bitcoin wallet mismatch: eclair-signer.conf uses wallet=${keyManager.walletName}, but eclair.conf uses wallet=${rpcClient.wallet.getOrElse("")}")
   }
 
-  val useEclairSigner = onChainKeyManager_opt.nonEmpty
+  val useEclairSigner: Boolean = onChainKeyManager_opt.nonEmpty
 
   //------------------------- TRANSACTIONS  -------------------------//
 
   def getTransaction(txid: TxId)(implicit ec: ExecutionContext): Future[Transaction] =
-    getRawTransaction(txid).flatMap(raw => {
+    rpcClient.invoke("getrawtransaction", txid).collect {
+      case JString(raw) => raw
+    }.flatMap(raw => {
       val tx = Transaction.read(raw)
       if (tx.txid != txid) {
         Future.failed(new RuntimeException(s"received transaction doesn't match the request: ${tx.txid} != $txid"))
@@ -74,11 +76,6 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
         Future.successful(tx)
       }
     })
-
-  private def getRawTransaction(txid: TxId)(implicit ec: ExecutionContext): Future[String] =
-    rpcClient.invoke("getrawtransaction", txid).collect {
-      case JString(raw) => raw
-    }
 
   def getTransactionMeta(txid: TxId)(implicit ec: ExecutionContext): Future[GetTxWithMetaResponse] =
     for {
@@ -119,6 +116,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
       JInt(height) = json \ "height"
       JArray(txs) = json \ "tx"
       index = txs.indexOf(JString(txid.value.toHex))
+      _ = require(index >= 0, "transaction not found in block: bitcoin core may be malicious")
     } yield (BlockHeight(height.toInt), index)
 
   /**
@@ -255,7 +253,6 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
       val JDecimal(fee) = json \ "fee"
       val fundedTx = Transaction.read(hex)
       val changePos_opt = if (changePos >= 0) Some(changePos.intValue) else None
-
       val walletInputs = fundedTx.txIn.map(_.outPoint).toSet -- tx.txIn.map(_.outPoint).toSet
       val addedOutputs = fundedTx.txOut.size - tx.txOut.size
       val feeSat = toSatoshi(fee)
@@ -264,7 +261,6 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
         require(addedOutputs == 0 || changePos >= 0, "change output added, but position not returned")
         require(options.changePosition.isEmpty || changePos_opt.isEmpty || changePos_opt == options.changePosition, "change output added at wrong position")
         feeBudget_opt.foreach(feeBudget => require(feeSat <= feeBudget, s"mining fee is higher than budget ($feeSat > $feeBudget)"))
-
         FundTransactionResponse(fundedTx, feeSat, changePos_opt)
       } match {
         case Success(response) => Future.successful(response)
@@ -500,7 +496,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
    */
   def publishTransaction(tx: Transaction)(implicit ec: ExecutionContext): Future[TxId] =
     rpcClient.invoke("sendrawtransaction", tx.toString()).flatMap {
-      case JString(txid) if TxId.fromValidHex(txid) == tx.txid => Future.successful(tx.txid)
+      case JString(txid) if Try(TxId.fromValidHex(txid)).toOption.contains(tx.txid) => Future.successful(tx.txid)
       case _ => Future.failed(new RuntimeException("failed to publish transaction or incorrect txid returned"))
     }.recoverWith {
       case JsonRPCError(Error(-27, _)) =>
@@ -508,7 +504,7 @@ class BitcoinCoreClient(val rpcClient: BitcoinJsonRPCClient, val lockUtxos: Bool
         Future.successful(tx.txid)
       case e@JsonRPCError(Error(-25, _)) =>
         // "missing inputs (code: -25)": it may be that the tx has already been published and its output spent.
-        getRawTransaction(tx.txid).map(_ => tx.txid).recoverWith { case _ => Future.failed(e) }
+        getTransaction(tx.txid).map(_ => tx.txid).recoverWith { case _ => Future.failed(e) }
     }
 
   /**

--- a/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinJsonRPCClient.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/blockchain/bitcoind/rpc/BitcoinJsonRPCClient.scala
@@ -20,6 +20,7 @@ import fr.acinq.bitcoin.scalacompat.BlockHash
 import org.json4s.JsonAST.JValue
 
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicLong
 import scala.concurrent.{ExecutionContext, Future}
 
 trait BitcoinJsonRPCClient {
@@ -30,9 +31,17 @@ trait BitcoinJsonRPCClient {
   // @formatter:on
 }
 
+case class JsonRPCRequest(jsonrpc: String = "1.0", id: String, method: String, params: Seq[Any])
+
+object JsonRPCRequest {
+  private val nextId = new AtomicLong(0)
+
+  /** Generate a unique request ID. */
+  def nextRequestId(): String = s"scala-client-${nextId.incrementAndGet()}"
+}
+
 // @formatter:off
-case class JsonRPCRequest(jsonrpc: String = "1.0", id: String = "scala-client", method: String, params: Seq[Any])
-case class Error(code: Int, message: String)
 case class JsonRPCResponse(result: JValue, error: Option[Error], id: String)
+case class Error(code: Int, message: String)
 case class JsonRPCError(error: Error) extends IOException(s"${error.message} (code: ${error.code})")
 // @formatter:on

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
@@ -221,6 +221,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
         case Left(ex) => handleLocalError(ex, d, None)
         case Right((localSpec, localCommitTx, remoteSpec, remoteCommitTx)) =>
           require(fundingTx.txOut(fundingTxOutputIndex).publicKeyScript == localCommitTx.input.txOut.publicKeyScript, "pubkey script mismatch!")
+          require(fundingTx.txOut(fundingTxOutputIndex).amount == localCommitTx.input.txOut.amount, "funding amount mismatch!")
           val remoteCommit = RemoteCommit(0, remoteSpec, remoteCommitTx.tx.txid, d.remoteFirstPerCommitmentPoint)
           val localSigOfRemoteTx = d.commitmentFormat match {
             case _: SimpleTaprootChannelCommitmentFormat =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fund/InteractiveTxBuilder.scala
@@ -790,10 +790,13 @@ private class InteractiveTxBuilder(replyTo: ActorRef[InteractiveTxBuilder.Respon
       return Left(InvalidCompleteInteractiveTx(fundingParams.channelId, "funding script included multiple times"))
     }
     val sharedOutput = sharedOutputs.headOption match {
-      case Some(output) => output
       case None =>
         log.warn("invalid interactive tx: funding outpoint not included")
         return Left(InvalidCompleteInteractiveTx(fundingParams.channelId, "funding outpoint not included"))
+      case Some(output) if output.amount != fundingParams.fundingAmount =>
+        log.warn("invalid interactive tx: funding amount doesn't match ({} != {})", sharedOutputs.map(_.amount).sum, fundingParams.fundingAmount)
+        return Left(InvalidCompleteInteractiveTx(fundingParams.channelId, "funding amount mismatch"))
+      case Some(output) => output
     }
 
     val sharedInput_opt = fundingParams.sharedInput_opt.map(sharedInput => {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BatchingClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BatchingClientSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.blockchain.bitcoind
+
+import akka.actor.Props
+import akka.testkit.TestProbe
+import fr.acinq.bitcoin.scalacompat.Block
+import fr.acinq.eclair.TestKitBaseClass
+import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinJsonRPCAuthMethod.UserPassword
+import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, BatchingClient, JsonRPCRequest, JsonRPCResponse}
+import org.json4s.JsonAST.JString
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
+import scala.concurrent.{ExecutionContext, Future, Promise}
+
+class BatchingClientSpec extends TestKitBaseClass with AnyFunSuiteLike {
+
+  test("match reordered batch responses by request id") {
+    val invocations = new LinkedBlockingQueue[Seq[JsonRPCRequest]]()
+    val completions = new LinkedBlockingQueue[Promise[Seq[JsonRPCResponse]]]()
+    val rpcClient = new BasicBitcoinJsonRPCClient(
+      Block.RegtestGenesisBlock.hash,
+      rpcAuthMethod = UserPassword("", ""),
+      host = "localhost",
+      port = 0)(sb = null) {
+      override def invoke(requests: Seq[JsonRPCRequest])(implicit ec: ExecutionContext): Future[Seq[JsonRPCResponse]] = {
+        invocations.add(requests)
+        val completion = Promise[Seq[JsonRPCResponse]]()
+        completions.add(completion)
+        completion.future
+      }
+    }
+    val client = system.actorOf(Props(new BatchingClient(rpcClient)))
+    val blocker = TestProbe()
+    val requestorA = TestProbe()
+    val requestorB = TestProbe()
+
+    blocker.send(client, JsonRPCRequest(id = "blocker", method = "getblockcount", params = Nil))
+    assert(invocations.poll(3, TimeUnit.SECONDS).map(_.id) == Seq("blocker"))
+
+    requestorA.send(client, JsonRPCRequest(id = "request-a", method = "getrawtransaction", params = Seq("tx-a")))
+    requestorB.send(client, JsonRPCRequest(id = "request-b", method = "getrawtransaction", params = Seq("tx-b")))
+    Thread.sleep(200)
+    completions.poll(3, TimeUnit.SECONDS).success(Seq(JsonRPCResponse(JString("blocker-result"), None, "blocker")))
+    blocker.expectMsg(JString("blocker-result"))
+
+    val batchedRequests = invocations.poll(3, TimeUnit.SECONDS)
+    assert(batchedRequests.map(_.id) == Seq("request-a", "request-b"))
+    completions.poll(3, TimeUnit.SECONDS).success(Seq(
+      JsonRPCResponse(JString("result-b"), None, "request-b"),
+      JsonRPCResponse(JString("result-a"), None, "request-a")))
+
+    requestorA.expectMsg(JString("result-a"))
+    requestorB.expectMsg(JString("result-b"))
+  }
+
+}

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoinCoreClientSpec.scala
@@ -33,7 +33,7 @@ import fr.acinq.eclair.blockchain.bitcoind.BitcoindService.{BitcoinReq, SignTran
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient.AddressType.{P2tr, P2wpkh}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinCoreClient._
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinJsonRPCAuthMethod.UserPassword
-import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, BitcoinCoreClient, BitcoinJsonRPCClient, JsonRPCError}
+import fr.acinq.eclair.blockchain.bitcoind.rpc._
 import fr.acinq.eclair.blockchain.fee.{FeeratePerByte, FeeratePerKw}
 import fr.acinq.eclair.crypto.keymanager.LocalOnChainKeyManager
 import fr.acinq.eclair.transactions.Transactions.ZeroFeeHtlcTxAnchorOutputsCommitmentFormat
@@ -1999,6 +1999,22 @@ class BitcoinCoreClientSpec extends TestKitBaseClass with BitcoindService with A
     }
     wallet.fundTransaction(txNotFunded, FeeratePerKw(5000 sat), replaceable = true).pipeTo(sender.ref)
     sender.expectMsgType[FundTransactionResponse]
+  }
+
+  test("check that batching client correctly maps responses to request ids") {
+    val sender = TestProbe()
+    val rpcClient = new BasicBitcoinJsonRPCClient(Block.RegtestGenesisBlock.hash, rpcAuthMethod = bitcoinrpcauthmethod, host = "localhost", port = bitcoindRpcPort, wallet = Some(defaultWallet))
+    val batchingClient = new BatchingBitcoinJsonRPCClient(rpcClient)
+    val bitcoinClient = new BitcoinCoreClient(batchingClient, false)
+    bitcoinClient.getReceiveAddress(None).pipeTo(sender.ref)
+    val address = sender.expectMsgType[String]
+    val txs = (1 to 10).map(_ => sendToAddress(address, 100_000 sat))
+    generateBlocks(1)
+    // We send many concurrent requests that try to fetch transactions and verify that the returned transaction matches,
+    // indicating that the response was correctly mapped to the right request.
+    val checks = (1 to 200).map(i => bitcoinClient.getTransaction(txs(i % 10).txid).map(tx => tx == txs(i % 10)))
+    Future.sequence(checks).pipeTo(sender.ref)
+    sender.expectMsg(Vector.fill(200)(true))
   }
 
 }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/blockchain/bitcoind/BitcoindService.scala
@@ -24,7 +24,7 @@ import fr.acinq.bitcoin.scalacompat.Crypto.PrivateKey
 import fr.acinq.bitcoin.scalacompat.{Block, Btc, BtcAmount, MilliBtc, MnemonicCode, Satoshi, Transaction, TxOut, addressToPublicKeyScript, computeP2WpkhAddress}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.BitcoinJsonRPCAuthMethod.{SafeCookie, UserPassword}
 import fr.acinq.eclair.blockchain.bitcoind.rpc.{BasicBitcoinJsonRPCClient, BitcoinCoreClient, BitcoinJsonRPCAuthMethod, BitcoinJsonRPCClient}
-import fr.acinq.eclair.blockchain.fee.{FeeratePerByte, FeeratePerKB, FeeratePerKw}
+import fr.acinq.eclair.blockchain.fee.FeeratePerByte
 import fr.acinq.eclair.crypto.keymanager.{LocalOnChainKeyManager, OnChainKeyManager}
 import fr.acinq.eclair.integration.IntegrationSpec
 import fr.acinq.eclair.{BlockHeight, TestUtils, TimestampSecond, randomKey}
@@ -248,7 +248,8 @@ trait BitcoindService extends Logging {
     val tx = Transaction(version = 2, Nil, TxOut(amountSat, addressToPublicKeyScript(Block.RegtestGenesisBlock.hash, address).toOption.get) :: Nil, lockTime = 0)
     val client = makeBitcoinCoreClient()
     val f = for {
-      funded <- client.fundTransaction(tx, FeeratePerByte(Satoshi(10)).perKw, replaceable = true)
+      minFee <- client.mempoolMinFee()
+      funded <- client.fundTransaction(tx, minFee.perKw * 2, replaceable = true)
       signed <- client.signPsbt(new Psbt(funded.tx), funded.tx.txIn.indices, Nil)
       txid <- client.publishTransaction(signed.finalTx_opt.toOption.get)
       tx <- client.getTransaction(txid)

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingInternalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/b/WaitForFundingInternalStateSpec.scala
@@ -29,7 +29,7 @@ import fr.acinq.eclair.channel.states.ChannelStateTestsBase
 import fr.acinq.eclair.io.Peer.OpenChannelResponse
 import fr.acinq.eclair.transactions.Scripts
 import fr.acinq.eclair.wire.protocol._
-import fr.acinq.eclair.{TestConstants, TestKitBaseClass, randomKey, toLongId}
+import fr.acinq.eclair.{TestConstants, TestKitBaseClass, toLongId}
 import org.scalatest.Outcome
 import org.scalatest.funsuite.FixtureAnyFunSuiteLike
 
@@ -69,7 +69,7 @@ class WaitForFundingInternalStateSpec extends TestKitBaseClass with FixtureAnyFu
     val fundingTx = Transaction(
       version = 2,
       txIn = Seq(TxIn(OutPoint(randomTxId(), 3), Nil, 0)),
-      txOut = Seq(TxOut(100_000 sat, Script.pay2wsh(Scripts.multiSig2of2(localFundingPubKey, remoteFundingPubKey)))),
+      txOut = Seq(TxOut(TestConstants.fundingSatoshis, Script.pay2wsh(Scripts.multiSig2of2(localFundingPubKey, remoteFundingPubKey)))),
       lockTime = 0
     )
     val channelId = toLongId(fundingTx.txid, 0)


### PR DESCRIPTION
This PR contains three independent commits that improve security in case the bitcoin RPC endpoint is malicious. Note that this isn't foolproof: a fully compromised Bitcoin Core client is hard to protect against, and eclair isn't yet fully secure if that happens. But we're taking steps towards that goal with incremental improvements.

Reported by AI scanning from @rob1ham :pray: 