### PR TITLE
Use `min_final_expiry_delta` in trampoline test handler

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/TrampolinePaymentLifecycle.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/payment/send/TrampolinePaymentLifecycle.scala
@@ -193,7 +193,11 @@ class TrampolinePaymentLifecycle private(nodeParams: NodeParams,
         case _ => None
       }
     })
-    val expiry = CltvExpiry(nodeParams.currentBlockHeight) + CltvExpiryDelta(36)
+    val minFinalExpiryDelta = cmd.invoice match {
+      case invoice: Bolt11Invoice => invoice.minFinalCltvExpiryDelta
+      case _ => CltvExpiryDelta(42)
+    }
+    val expiry = CltvExpiry(nodeParams.currentBlockHeight + 1) + minFinalExpiryDelta
     if (filtered.isEmpty) {
       context.log.warn("no usable channel with trampoline node {}", cmd.trampolineNodeId)
       cmd.replyTo ! PaymentFailed(cmd.paymentId, paymentHash, LocalFailure(totalAmount, Nil, new RuntimeException("no usable channel with trampoline node")) :: Nil, startedAt, settledAt = TimestampMilli.now())


### PR DESCRIPTION
We use the invoice's `min_final_expiry_delta` in the test trampoline payment FSM (which isn't used for any real payment, it is only there to allow cross-compat tests with other implementations).

When not using Bolt11, we increase the fallback value to 42, which is what LDK uses by default.

We also add 1 block in case we're late in our view of the blockchain.

Fixes #3347