### PR TITLE
Better documentation for remote `bitcoind`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ rpcworkqueue=128
 rpcclienttimeout=30
 ```
 
+:warning: We recommend running bitcoind on the same machine as your eclair node.
+:warning: If you run bitcoind on a remote machine, you MUST use a secure tunnel between bitcoind and eclair: the RPC and ZMQ events must be encrypted and authenticated.
+
+Note that bitcoind does not provide a built-in mechanism for using TLS (or another encryption protocol): it is up to the node operator to setup a secure tunnel (e.g. using ssh or wireguard).
+
 ### Installing Eclair
 
 Eclair is developed in [Scala](https://www.scala-lang.org/), a powerful functional language that runs on the JVM, and is packaged as a ZIP archive.

--- a/docs/release-notes/eclair-vnext.md
+++ b/docs/release-notes/eclair-vnext.md
@@ -2,6 +2,8 @@
 
 <insert here a high-level description of the release>
 
+We explicitly document that bitcoind should run on the same machine as eclair, or that a secure tunnel (providing encryption and authentication) must be setup between eclair and bitcoind.
+
 ## Major changes
 
 <insert changes>


### PR DESCRIPTION
Our documentation didn't make it clear enough that `bitcoind` should ideally run on the same machine as `eclair`. If that's not possible, since `bitcoind` doesn't provide support for TLS for its RPC and ZMQ endpoints, the node operator MUST setup a secure tunnel (providing encryption and authentication) between `eclair` and `bitcoind`. If that isn't provided, a network attacker may drop or alter messages between `eclair` and `bitcoind`, which can lead to a loss of funds.