### PR TITLE
Emit `ChannelPersisted` event at channel creation

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -338,7 +338,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
       case InteractiveTxBuilder.Succeeded(status, commitSig, liquidityPurchase_opt, nextRemoteCommitNonce_opt) =>
         nextRemoteCommitNonce_opt.foreach { case (txId, nonce) => remoteNextCommitNonces = remoteNextCommitNonces + (txId -> nonce) }
         val d1 = DATA_WAIT_FOR_DUAL_FUNDING_SIGNED(d.channelParams, d.secondRemotePerCommitmentPoint, d.localPushAmount, d.remotePushAmount, status)
-        nodeParams.db.channels.addChannel(d1) match {
+        store(d1) match {
           case None =>
             d.deferred.foreach(self ! _)
             d.replyTo_opt.foreach(_ ! OpenChannelResponse.Created(d.channelId, status.fundingTx.txId, status.fundingTx.tx.localFees.truncateToSatoshi))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenSingleFunded.scala
@@ -341,7 +341,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
                   val d1 = DATA_WAIT_FOR_FUNDING_CONFIRMED(commitments, nodeParams.currentBlockHeight, None, Right(fundingSigned))
                   nodeParams.addChannelIdIfAbsent(channelId, remoteNodeId) match {
                     case None =>
-                      nodeParams.db.channels.addChannel(d1) match {
+                      store(d1) match {
                         case None =>
                           peer ! ChannelIdAssigned(self, remoteNodeId, temporaryChannelId, channelId) // we notify the peer asap so it knows how to route messages
                           txPublisher ! SetChannelId(remoteNodeId, channelId)
@@ -415,7 +415,7 @@ trait ChannelOpenSingleFunded extends SingleFundingHandlers with ErrorHandlers {
             originChannels = Map.empty)
           val blockHeight = nodeParams.currentBlockHeight
           val d1 = DATA_WAIT_FOR_FUNDING_CONFIRMED(commitments, blockHeight, None, Left(d.lastSent))
-          nodeParams.db.channels.addChannel(d1) match {
+          store(d1) match {
             case None =>
               context.system.eventStream.publish(ChannelSignatureReceived(self, commitments))
               context.system.eventStream.publish(ChannelFundingCreated(self, d.channelId, remoteNodeId, Right(d.fundingTx), commitment.fundingTxIndex, commitments))

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/CommonHandlers.scala
@@ -48,6 +48,21 @@ trait CommonHandlers {
   implicit def state2mystate(state: FSM.State[ChannelState, ChannelData]): MyState = MyState(state)
 
   /**
+   * This is only to be used the first time the channel is persisted in db.
+   * Will return an error if the same channel_id is already present.
+   */
+  def store(d: PersistentChannelData): Option[Throwable] = {
+    log.debug("inserting database record for channelId={}", d.channelId)
+    nodeParams.db.channels.addChannel(d) match {
+      case None =>
+        context.system.eventStream.publish(ChannelPersisted(self, remoteNodeId, d.channelId, d))
+        None
+      case Some(t) =>
+        Some(t)
+    }
+  }
+
+  /**
    * We wrap the FSM state to add some utility functions that can be called on state transitions.
    */
   case class MyState(state: FSM.State[ChannelState, ChannelData]) {


### PR DESCRIPTION
Since #3337 we are calling directly `db.addChannel` for the initial storage in db. But the `storing()` method that we were previously using also emitted a `ChannelPersisted`.

This caused the `BalanceActor` to not be aware of the newly created channel and resulted in a temporary balance glitch.

Found by Claude.