### PR TITLE
Force-close on invalid HTLC `cltv_expiry`

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -1,6 +1,7 @@
 package fr.acinq.eclair.channel
 
 import akka.event.LoggingAdapter
+import fr.acinq.bitcoin.Script.LOCKTIME_THRESHOLD
 import fr.acinq.bitcoin.scalacompat.Crypto.{PrivateKey, PublicKey}
 import fr.acinq.bitcoin.scalacompat.Musig2.IndividualNonce
 import fr.acinq.bitcoin.scalacompat.{ByteVector32, ByteVector64, Crypto, OutPoint, Satoshi, SatoshiLong, Transaction, TxId}
@@ -959,7 +960,7 @@ case class Commitments(channelParams: ChannelParams,
     }
 
     // CLTV expiry values >= 500_000_000 would indicate a time in seconds instead of a block height.
-    if (add.cltvExpiry >= CltvExpiry(500_000_000)) {
+    if (add.cltvExpiry >= CltvExpiry(LOCKTIME_THRESHOLD)) {
       return Left(ExpiryTooBig(channelId, CltvExpiry(500_000_000), add.cltvExpiry, currentBlockHeight))
     }
 

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -961,7 +961,7 @@ case class Commitments(channelParams: ChannelParams,
 
     // CLTV expiry values >= 500_000_000 would indicate a time in seconds instead of a block height.
     if (add.cltvExpiry >= CltvExpiry(LOCKTIME_THRESHOLD)) {
-      return Left(ExpiryTooBig(channelId, CltvExpiry(500_000_000), add.cltvExpiry, currentBlockHeight))
+      return Left(ExpiryTooBig(channelId, CltvExpiry(LOCKTIME_THRESHOLD), add.cltvExpiry, currentBlockHeight))
     }
 
     // we used to not enforce a strictly positive minimum, hence the max(1 msat)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/Commitments.scala
@@ -953,9 +953,14 @@ case class Commitments(channelParams: ChannelParams,
     }
   }
 
-  def receiveAdd(add: UpdateAddHtlc): Either[ChannelException, Commitments] = {
+  def receiveAdd(add: UpdateAddHtlc, currentBlockHeight: BlockHeight): Either[ChannelException, Commitments] = {
     if (add.id != changes.remoteNextHtlcId) {
       return Left(UnexpectedHtlcId(channelId, expected = changes.remoteNextHtlcId, actual = add.id))
+    }
+
+    // CLTV expiry values >= 500_000_000 would indicate a time in seconds instead of a block height.
+    if (add.cltvExpiry >= CltvExpiry(500_000_000)) {
+      return Left(ExpiryTooBig(channelId, CltvExpiry(500_000_000), add.cltvExpiry, currentBlockHeight))
     }
 
     // we used to not enforce a strictly positive minimum, hence the max(1 msat)

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -557,7 +557,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
       }
 
     case Event(add: UpdateAddHtlc, d: DATA_NORMAL) =>
-      d.commitments.receiveAdd(add) match {
+      d.commitments.receiveAdd(add, nodeParams.currentBlockHeight) match {
         case Right(commitments1) => stay() using d.copy(commitments = commitments1)
         case Left(cause) => handleLocalError(cause, d, Some(add))
       }

--- a/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/transactions/Scripts.scala
@@ -26,7 +26,6 @@ import fr.acinq.bitcoin.scalacompat._
 import fr.acinq.eclair.crypto.keymanager.{CommitmentPublicKeys, LocalCommitmentKeys, RemoteCommitmentKeys}
 import fr.acinq.eclair.transactions.Transactions._
 import fr.acinq.eclair.{BlockHeight, CltvExpiry, CltvExpiryDelta}
-import fr.acinq.secp256k1.Secp256k1
 import scodec.bits.ByteVector
 
 import scala.util.{Success, Try}
@@ -100,7 +99,7 @@ object Scripts {
    * @return the block height before which this tx cannot be published.
    */
   def cltvTimeout(tx: Transaction): BlockHeight =
-    if (tx.lockTime <= LOCKTIME_THRESHOLD) {
+    if (tx.lockTime < LOCKTIME_THRESHOLD) {
       // locktime is a number of blocks
       BlockHeight(tx.lockTime)
     } else {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/CommitmentsSpec.scala
@@ -85,7 +85,7 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     assert(ac1.availableBalanceForSend == a - p - htlcOutputFee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
     assert(ac1.availableBalanceForReceive == b)
 
-    val Right(bc1) = bc0.receiveAdd(add)
+    val Right(bc1) = bc0.receiveAdd(add, currentBlockHeight)
     assert(bc1.availableBalanceForSend == b)
     assert(bc1.availableBalanceForReceive == a - p - htlcOutputFee)
 
@@ -170,7 +170,7 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     assert(ac1.availableBalanceForSend == a - p - htlcOutputFee) // as soon as htlc is sent, alice sees its balance decrease (more than the payment amount because of the commitment fees)
     assert(ac1.availableBalanceForReceive == b)
 
-    val Right(bc1) = bc0.receiveAdd(add)
+    val Right(bc1) = bc0.receiveAdd(add, currentBlockHeight)
     assert(bc1.availableBalanceForSend == b)
     assert(bc1.availableBalanceForReceive == a - p - htlcOutputFee)
 
@@ -268,15 +268,15 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     assert(bc1.availableBalanceForSend == b - p3) // bob doesn't pay the fee
     assert(bc1.availableBalanceForReceive == a)
 
-    val Right(bc2) = bc1.receiveAdd(add1)
+    val Right(bc2) = bc1.receiveAdd(add1, currentBlockHeight)
     assert(bc2.availableBalanceForSend == b - p3)
     assert(bc2.availableBalanceForReceive == a - p1 - htlcOutputFee)
 
-    val Right(bc3) = bc2.receiveAdd(add2)
+    val Right(bc3) = bc2.receiveAdd(add2, currentBlockHeight)
     assert(bc3.availableBalanceForSend == b - p3)
     assert(bc3.availableBalanceForReceive == a - p1 - htlcOutputFee - p2 - htlcOutputFee)
 
-    val Right(ac3) = ac2.receiveAdd(add3)
+    val Right(ac3) = ac2.receiveAdd(add3, currentBlockHeight)
     assert(ac3.availableBalanceForSend == a - p1 - htlcOutputFee - p2 - htlcOutputFee)
     assert(ac3.availableBalanceForReceive == b - p3)
 
@@ -409,7 +409,7 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     for (isInitiator <- Seq(true, false)) {
       val c = CommitmentsSpec.makeCommitments(31000000 msat, 702000000 msat, FeeratePerKw(2679 sat), 546 sat, isInitiator)
       val add = UpdateAddHtlc(randomBytes32(), c.changes.remoteNextHtlcId, c.availableBalanceForReceive, randomBytes32(), CltvExpiry(f.currentBlockHeight), TestConstants.emptyOnionPacket, None, accountable = false, None)
-      c.receiveAdd(add)
+      c.receiveAdd(add, f.currentBlockHeight)
     }
   }
 
@@ -432,7 +432,7 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
         val (_, cmdAdd) = makeCmdAdd(amount, randomKey().publicKey, f.currentBlockHeight)
         c.sendAdd(cmdAdd, f.currentBlockHeight, TestConstants.Alice.nodeParams.channelConf, feeConfNoMismatch) match {
           case Right((cc, _)) => c = cc
-          case Left(e) => // we ignore failures (the HTLC amount probably exceeded availableBalanceForSend)
+          case Left(_) => // we ignore failures (the HTLC amount probably exceeded availableBalanceForSend)
         }
       }
       if (c.availableBalanceForSend > 0.msat) {
@@ -460,14 +460,14 @@ class CommitmentsSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
       for (_ <- 1 to t.pendingHtlcs) {
         val amount = Random.nextInt(maxPendingHtlcAmount.toLong.toInt).msat.max(1 msat)
         val add = UpdateAddHtlc(randomBytes32(), c.changes.remoteNextHtlcId, amount, randomBytes32(), CltvExpiry(f.currentBlockHeight), TestConstants.emptyOnionPacket, None, accountable = false, None)
-        c.receiveAdd(add) match {
+        c.receiveAdd(add, f.currentBlockHeight) match {
           case Right(cc) => c = cc
-          case Left(e) => // we ignore failures (the HTLC amount probably exceeded availableBalanceForReceive)
+          case Left(_) => // we ignore failures (the HTLC amount probably exceeded availableBalanceForReceive)
         }
       }
       if (c.availableBalanceForReceive > 0.msat) {
         val add = UpdateAddHtlc(randomBytes32(), c.changes.remoteNextHtlcId, c.availableBalanceForReceive, randomBytes32(), CltvExpiry(f.currentBlockHeight), TestConstants.emptyOnionPacket, None, accountable = false, None)
-        c.receiveAdd(add) match {
+        c.receiveAdd(add, f.currentBlockHeight) match {
           case Right(_) => ()
           case Left(e) => fail(s"$t -> $e")
         }

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalStateSpec.scala
@@ -622,6 +622,19 @@ class NormalStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLike with 
     bob2blockchain.expectWatchTxConfirmed(tx.txid)
   }
 
+  test("recv UpdateAddHtlc (invalid cltv_expiry)") { f =>
+    import f._
+    val tx = bob.signCommitTx()
+    bob ! UpdateAddHtlc(ByteVector32.Zeroes, 0, 150000 msat, randomBytes32(), CltvExpiry(500_000_000), TestConstants.emptyOnionPacket, None, accountable = false, None)
+    val error = bob2alice.expectMsgType[Error]
+    assert(new String(error.data.toArray) == ExpiryTooBig(channelId(bob), CltvExpiry(500_000_000), CltvExpiry(500_000_000), BlockHeight(TestConstants.defaultBlockHeight)).getMessage)
+    awaitCond(bob.stateName == CLOSING)
+    bob2blockchain.expectFinalTxPublished(tx.txid)
+    bob2blockchain.expectReplaceableTxPublished[ClaimLocalAnchorTx]
+    bob2blockchain.expectFinalTxPublished("local-main-delayed")
+    bob2blockchain.expectWatchTxConfirmed(tx.txid)
+  }
+
   test("recv UpdateAddHtlc (value too small)") { f =>
     import f._
     val tx = bob.signCommitTx()


### PR DESCRIPTION
Bolt 2 specifies that if the sending node sets `cltv_expiry` to greater or equal to 500,000,000, we should send a warning and close the connection or send an error and fail the channel. We never implemented that, which was fine because we already rejected large `cltv_expiry` before that threshold (without force-closing), but it's better to explicitly force close if our peer is sending such invalid values.