### PR TITLE
Notify peer actor when aborting a liquidity purchase

### DIFF
--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/Channel.scala
@@ -715,10 +715,12 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
             case batch: CommitSigBatch =>
               log.warning("we're expecting a single commit_sig for splice with txId={} but received a batch of commit_sig for txIds={}", signingSession.fundingTxId, batch.messages.flatMap(_.fundingTxId_opt).mkString(","))
               rollbackFundingAttempt(signingSession.fundingTx.tx, Nil)
+              reportLiquidityPurchaseAborted(d.channelId, signingSession)
               handleLocalError(CommitSigCountMismatch(d.channelId, 1, batch.batchSize), d, Some(commit))
             case _: CommitSig if !signingSession.isConsistentWith(d.commitments) =>
               log.warning("aborting splice: commitment number mismatch")
               rollbackFundingAttempt(signingSession.fundingTx.tx, Nil)
+              reportLiquidityPurchaseAborted(d.channelId, signingSession)
               handleLocalError(InvalidCommitmentNumber(d.channelId, signingSession.fundingTxId), d, Some(commit))
             case sig: CommitSig =>
               signingSession.receiveCommitSig(d.commitments.channelParams, channelKeys, sig, nodeParams.currentBlockHeight) match {
@@ -1529,6 +1531,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
             case SpliceStatus.SpliceWaitingForSigs(signingSession) if !signingSession.isConsistentWith(d.commitments) =>
               log.warning("aborting splice RBF: commitment number mismatch")
               rollbackFundingAttempt(signingSession.fundingTx.tx, previousTxs = Seq.empty) // no splice rbf yet
+              reportLiquidityPurchaseAborted(d.channelId, signingSession)
               handleLocalError(InvalidCommitmentNumber(d.channelId, signingSession.fundingTxId), d, Some(msg))
             case SpliceStatus.SpliceWaitingForSigs(signingSession) =>
               // we have not yet sent our tx_signatures
@@ -2721,6 +2724,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
                   // commitment numbers that we have already revoked.
                   log.warning("aborting rbf attempt: commitment number mismatch")
                   rollbackRbfAttempt(signingSession, d)
+                  reportLiquidityPurchaseAborted(d.channelId, signingSession)
                   goto(WAIT_FOR_DUAL_FUNDING_CONFIRMED) using d.copy(status = DualFundingStatus.RbfAborted) sending TxAbort(d.channelId, InvalidCommitmentNumber(d.channelId, signingSession.fundingTxId).getMessage)
                 case DualFundingStatus.RbfWaitingForSigs(signingSession) if signingSession.fundingTx.txId == fundingTxId =>
                   if (retransmitCommitSig) {
@@ -3609,6 +3613,7 @@ class Channel(val nodeParams: NodeParams, val channelKeys: ChannelKeys, val wall
             // we have already revoked. We abort the splice attempt instead.
             log.warning("aborting splice attempt: commitment number mismatch")
             rollbackFundingAttempt(signingSession.fundingTx.tx, previousTxs = Seq.empty) // no splice rbf yet
+            reportLiquidityPurchaseAborted(d.channelId, signingSession)
             sendQueue = sendQueue :+ TxAbort(d.channelId, InvalidCommitmentNumber(d.channelId, signingSession.fundingTxId).getMessage)
             SpliceStatus.SpliceAborted
           case SpliceStatus.SpliceWaitingForSigs(signingSession) if signingSession.fundingTx.txId == fundingTxId =>

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/ChannelOpenDualFunded.scala
@@ -498,6 +498,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
             case DualFundingStatus.RbfWaitingForSigs(signingSession) if !signingSession.isConsistentWith(d.commitments) =>
               log.warning("aborting RBF attempt: commitment number mismatch")
               rollbackRbfAttempt(signingSession, d)
+              reportLiquidityPurchaseAborted(d.channelId, signingSession)
               handleLocalError(InvalidCommitmentNumber(d.channelId, signingSession.fundingTxId), d, Some(txSigs))
             case DualFundingStatus.RbfWaitingForSigs(signingSession) =>
               signingSession.receiveTxSigs(channelKeys, txSigs, nodeParams.currentBlockHeight) match {
@@ -687,6 +688,7 @@ trait ChannelOpenDualFunded extends DualFundingHandlers with ErrorHandlers {
         case DualFundingStatus.RbfWaitingForSigs(signingSession) if !signingSession.isConsistentWith(d.commitments) =>
           log.warning("aborting RBF attempt: commitment number mismatch")
           rollbackRbfAttempt(signingSession, d)
+          reportLiquidityPurchaseAborted(d.channelId, signingSession)
           handleLocalError(InvalidCommitmentNumber(d.channelId, signingSession.fundingTxId), d, Some(commitSig))
         case DualFundingStatus.RbfWaitingForSigs(signingSession) =>
           signingSession.receiveCommitSig(d.commitments.channelParams, channelKeys, commitSig, nodeParams.currentBlockHeight) match {

--- a/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/DualFundingHandlers.scala
+++ b/eclair-core/src/main/scala/fr/acinq/eclair/channel/fsm/DualFundingHandlers.scala
@@ -16,7 +16,7 @@
 
 package fr.acinq.eclair.channel.fsm
 
-import fr.acinq.bitcoin.scalacompat.{Transaction, TxIn}
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, Transaction, TxIn}
 import fr.acinq.eclair.NotificationsLogger
 import fr.acinq.eclair.NotificationsLogger.NotifyNodeOperator
 import fr.acinq.eclair.blockchain.{CurrentBlockHeight, NewTransaction}
@@ -26,6 +26,7 @@ import fr.acinq.eclair.channel._
 import fr.acinq.eclair.channel.fsm.Channel.BITCOIN_FUNDING_DOUBLE_SPENT
 import fr.acinq.eclair.channel.fund.InteractiveTxBuilder._
 import fr.acinq.eclair.channel.fund.{InteractiveTxBuilder, InteractiveTxSigningSession}
+import fr.acinq.eclair.io.Peer.LiquidityPurchaseAborted
 import fr.acinq.eclair.wire.protocol.{ChannelReady, Error}
 
 import scala.concurrent.Future
@@ -142,6 +143,17 @@ trait DualFundingHandlers extends CommonFundingHandlers {
 
   def rollbackRbfAttempt(signingSession: InteractiveTxSigningSession.WaitingForSigs, d: DATA_WAIT_FOR_DUAL_FUNDING_CONFIRMED): Unit = {
     rollbackFundingAttempt(signingSession.fundingTx.tx, d.allFundingTxs.map(_.sharedTx))
+  }
+
+  /**
+   * When we abort a funding attempt for which we were selling liquidity, we must tell our peer actor: we have already
+   * told it that the purchase was signed, so it is waiting for a funding transaction that will never exist. This lets
+   * it fail the corresponding upstream HTLCs instead of holding them until they expire.
+   */
+  def reportLiquidityPurchaseAborted(channelId: ByteVector32, signingSession: InteractiveTxSigningSession.WaitingForSigs): Unit = {
+    signingSession.liquidityPurchase_opt.collect {
+      case _ if !signingSession.fundingParams.isInitiator => peer ! LiquidityPurchaseAborted(channelId, signingSession.fundingTx.txId, signingSession.fundingTxIndex)
+    }
   }
 
   def reportRbfFailure(fundingStatus: DualFundingStatus, f: Throwable): Unit = {

--- a/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
+++ b/eclair-core/src/test/scala/fr/acinq/eclair/channel/states/e/NormalSplicesStateSpec.scala
@@ -2081,6 +2081,56 @@ class NormalSplicesStateSpec extends TestKitBaseClass with FixtureAnyFunSuiteLik
     assert(alice.stateData.asInstanceOf[DATA_NORMAL].commitments.active.size == 1)
   }
 
+  test("reconnect with an inconsistent splice signing session (liquidity purchase)") { f =>
+    import f._
+
+    // Alice buys liquidity from Bob while splicing in.
+    val sender = TestProbe()
+    val fundingRequest = LiquidityAds.RequestFunding(400_000 sat, TestConstants.defaultLiquidityRates.fundingRates.head, LiquidityAds.PaymentDetails.FromChannelBalance)
+    alice ! CMD_SPLICE(sender.ref, Some(SpliceIn(500_000 sat)), None, Some(fundingRequest), None)
+    exchangeStfu(alice, bob, alice2bob, bob2alice)
+    assert(alice2bob.expectMsgType[SpliceInit].requestFunding_opt.nonEmpty)
+    alice2bob.forward(bob)
+    assert(bob2alice.expectMsgType[SpliceAck].willFund_opt.nonEmpty)
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAddInput]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[TxAddInput]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAddInput]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[TxAddOutput]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAddOutput]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[TxComplete]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxAddOutput]
+    alice2bob.forward(bob)
+    bob2alice.expectMsgType[TxComplete]
+    bob2alice.forward(alice)
+    alice2bob.expectMsgType[TxComplete]
+    alice2bob.forward(bob)
+
+    // Bob signed that liquidity purchase: his peer actor is now waiting for the funding transaction.
+    val purchase = bobPeer.fishForSpecificMessage() { case l: LiquidityPurchaseSigned => l }
+    assert(purchase.fundingTxIndex == 1)
+    alice2bob.expectMsgType[CommitSig] // we don't forward it
+    bob2alice.expectMsgType[CommitSig] // we don't forward it
+
+    // Bob's signing session isn't consistent with his commitments anymore: he aborts the splice on reconnection, and
+    // must tell his peer actor so that it fails the corresponding upstream HTLCs instead of holding them.
+    val signingSession = desynchronizeSpliceSigningSession(bob)
+    disconnect(f)
+    reconnect(f)
+
+    val txAbort = bob2alice.fishForSpecificMessage() { case msg: TxAbort => msg }
+    assert(txAbort.toAscii == InvalidCommitmentNumber(channelId(bob), signingSession.fundingTxId).getMessage)
+    val aborted = bobPeer.fishForSpecificMessage() { case l: LiquidityPurchaseAborted => l }
+    assert(aborted.txId == purchase.txId)
+    assert(aborted.fundingTxIndex == purchase.fundingTxIndex)
+  }
+
   test("recv CommitSigBatch including the parent commitment while signing a splice") { f =>
     import f._
 


### PR DESCRIPTION
When we were selling liquidity and abort the funding attempt after telling our peer actor that the purchase was signed, we must send it a LiquidityPurchaseAborted event. Otherwise the payment stays in the Funded state, pointing at a funding transaction that will never exist: we hold the upstream HTLCs until they expire, at which point we force-close a channel that we aborted the splice on ourselves.